### PR TITLE
[core][jsi] Zero-copy NativeArrayBuffer for native-backed data

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
+- `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
@@ -173,4 +173,105 @@ class ArrayBufferConversionTest {
     Truth.assertThat(originalBuffer.readByte(0)).isEqualTo(1.toByte())
     Truth.assertThat(copiedBuffer.readByte(0)).isEqualTo(0x42.toByte())
   }
+
+  @Test
+  fun native_array_buffer_arg_should_share_native_backed_array_buffer() = withJSIInterop(
+    nativeBackedArrayBufferModule()
+  ) {
+    val result = evaluateScript(
+      """
+        const buffer = expo.modules.TestModule.createNative(4);
+        const view = new Uint8Array(buffer);
+        view.fill(1);
+        const processedBuffer = expo.modules.TestModule.fillNativeBuffer(buffer, 0x42);
+        [Array.from(view), Array.from(new Uint8Array(processedBuffer))]
+      """.trimIndent()
+    ).getArray()
+
+    Truth.assertThat(result[0].getArray().map { it.getInt() }).containsExactly(0x42, 0x42, 0x42, 0x42).inOrder()
+    Truth.assertThat(result[1].getArray().map { it.getInt() }).containsExactly(0x42, 0x42, 0x42, 0x42).inOrder()
+  }
+
+  @Test
+  fun returned_native_backed_array_buffer_should_outlive_native_argument_wrapper() = withJSIInterop(
+    nativeBackedArrayBufferModule()
+  ) {
+    evaluateScript(
+      """
+        globalThis.retainedBuffer = (() => {
+          const sourceBuffer = expo.modules.TestModule.createNative(4);
+          new Uint8Array(sourceBuffer).set([1, 2, 3, 4]);
+          return expo.modules.TestModule.fillNativeBuffer(sourceBuffer, 0x42);
+        })();
+      """.trimIndent()
+    )
+
+    forceGc()
+
+    val result = evaluateScript("Array.from(new Uint8Array(globalThis.retainedBuffer))").getArray()
+    Truth.assertThat(result.map { it.getInt() }).containsExactly(0x42, 0x42, 0x42, 0x42).inOrder()
+  }
+
+  @Test
+  fun native_array_buffer_typed_array_arg_should_share_native_backed_view_range() = withJSIInterop(
+    nativeBackedArrayBufferModule()
+  ) {
+    val result = evaluateScript(
+      """
+        const buffer = expo.modules.TestModule.createNative(5);
+        const fullView = new Uint8Array(buffer);
+        fullView.set([1, 2, 3, 4, 5]);
+        const partialView = new Uint8Array(buffer, 1, 2);
+        const processedBuffer = expo.modules.TestModule.fillNativeBuffer(partialView, 0x42);
+        [Array.from(fullView), Array.from(new Uint8Array(processedBuffer))]
+      """.trimIndent()
+    ).getArray()
+
+    Truth.assertThat(result[0].getArray().map { it.getInt() }).containsExactly(1, 0x42, 0x42, 4, 5).inOrder()
+    Truth.assertThat(result[1].getArray().map { it.getInt() }).containsExactly(0x42, 0x42).inOrder()
+  }
+
+  @Test
+  fun native_array_buffer_typed_array_arg_should_copy_js_allocated_view() = withJSIInterop(
+    nativeBackedArrayBufferModule()
+  ) {
+    val result = evaluateScript(
+      """
+        const buffer = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+        const fullView = new Uint8Array(buffer);
+        const partialView = new Uint8Array(buffer, 1, 2);
+        const processedBuffer = expo.modules.TestModule.fillNativeBuffer(partialView, 0x42);
+        [Array.from(fullView), Array.from(new Uint8Array(processedBuffer))]
+      """.trimIndent()
+    ).getArray()
+
+    Truth.assertThat(result[0].getArray().map { it.getInt() }).containsExactly(1, 2, 3, 4, 5).inOrder()
+    Truth.assertThat(result[1].getArray().map { it.getInt() }).containsExactly(0x42, 0x42).inOrder()
+  }
+
+  private fun nativeBackedArrayBufferModule() = inlineModule {
+    Name("TestModule")
+
+    Function("createNative") { size: Int ->
+      NativeArrayBuffer.allocate(size)
+    }
+
+    Function("fillNativeBuffer") { buffer: NativeArrayBuffer, value: Int ->
+      buffer.toDirectBuffer().apply {
+        rewind()
+        while (hasRemaining()) {
+          put(value.toByte())
+        }
+      }
+      buffer
+    }
+  }
+
+  private fun forceGc() {
+    repeat(5) {
+      System.gc()
+      System.runFinalization()
+      Thread.sleep(10)
+    }
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.cpp
@@ -9,6 +9,14 @@ ByteBufferJSIWrapper::ByteBufferJSIWrapper(const jni::alias_ref<jni::JByteBuffer
   _byteBuffer->order(jni::JByteOrder::nativeOrder());
 }
 
+ByteBufferJSIWrapper::ByteBufferJSIWrapper(
+  const jni::alias_ref<jni::JByteBuffer> &byteBuffer,
+  std::shared_ptr<jsi::MutableBuffer> retainedBuffer
+) : _byteBuffer(jni::make_global(byteBuffer)),
+    _retainedBuffer(std::move(retainedBuffer)) {
+  _byteBuffer->order(jni::JByteOrder::nativeOrder());
+}
+
 ByteBufferJSIWrapper::~ByteBufferJSIWrapper() {
   // Destruction can happen on JS thread
   jni::ThreadScope::WithClassLoader([&] { _byteBuffer.reset(); });
@@ -49,6 +57,15 @@ NativeArrayBuffer::initHybrid(jni::alias_ref<JavaPart::javaobject>,
 jni::local_ref<NativeArrayBuffer::javaobject>
 NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
                                jsi::ArrayBuffer &arrayBuffer) {
+  auto mutableBuffer = arrayBuffer.tryGetMutableBuffer(runtime);
+  if (mutableBuffer) {
+    auto byteBuffer = jni::JByteBuffer::wrapBytes(mutableBuffer->data(), mutableBuffer->size());
+    byteBuffer->order(jni::JByteOrder::nativeOrder());
+    auto value = NativeArrayBuffer::newObjectCxxArgs(byteBuffer, std::move(mutableBuffer));
+    jsiContext->jniDeallocator->addReference(value);
+    return value;
+  }
+
   size_t size = arrayBuffer.size(runtime);
   auto byteBuffer = jni::JByteBuffer::allocateDirect(size);
   byteBuffer->order(jni::JByteOrder::nativeOrder());
@@ -62,8 +79,19 @@ NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
 jni::local_ref<NativeArrayBuffer::javaobject>
 NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
                                expo::TypedArray& typedArray) {
-
   size_t size = typedArray.byteLength(runtime);
+
+  auto backingBuffer = typedArray.getBuffer(runtime);
+  auto mutableBuffer = backingBuffer.tryGetMutableBuffer(runtime);
+  if (mutableBuffer) {
+    size_t offset = typedArray.byteOffset(runtime);
+    auto byteBuffer = jni::JByteBuffer::wrapBytes(
+      mutableBuffer->data() + offset, size);
+    byteBuffer->order(jni::JByteOrder::nativeOrder());
+    auto value = NativeArrayBuffer::newObjectCxxArgs(byteBuffer, std::move(mutableBuffer));
+    jsiContext->jniDeallocator->addReference(value);
+    return value;
+  }
 
   auto byteBuffer = jni::JByteBuffer::allocateDirect(static_cast<jint>(size));
   byteBuffer->order(jni::JByteOrder::nativeOrder());
@@ -76,6 +104,11 @@ NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
 
 NativeArrayBuffer::NativeArrayBuffer(const jni::alias_ref<jni::JByteBuffer> &byteBuffer)
   : buffer(std::make_shared<ByteBufferJSIWrapper>(byteBuffer)) { }
+
+NativeArrayBuffer::NativeArrayBuffer(
+  const jni::alias_ref<jni::JByteBuffer> &byteBuffer,
+  std::shared_ptr<jsi::MutableBuffer> retainedBuffer
+) : buffer(std::make_shared<ByteBufferJSIWrapper>(byteBuffer, std::move(retainedBuffer))) { }
 
 int NativeArrayBuffer::size() {
   return (int) buffer->size();

--- a/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
@@ -23,6 +23,11 @@ class ByteBufferJSIWrapper: public jsi::MutableBuffer {
 public:
   explicit ByteBufferJSIWrapper(const jni::alias_ref<jni::JByteBuffer>& byteBuffer);
 
+  ByteBufferJSIWrapper(
+    const jni::alias_ref<jni::JByteBuffer>& byteBuffer,
+    std::shared_ptr<jsi::MutableBuffer> retainedBuffer
+  );
+
   ~ByteBufferJSIWrapper() override;
 
   [[nodiscard]] uint8_t* data() override;
@@ -33,6 +38,7 @@ public:
 
 private:
   jni::global_ref<jni::JByteBuffer> _byteBuffer;
+  std::shared_ptr<jsi::MutableBuffer> _retainedBuffer;
 };
 
 class NativeArrayBuffer : public jni::HybridClass<NativeArrayBuffer, Destructible> {
@@ -49,7 +55,8 @@ public:
   );
 
   /**
-   * Allocates a new NativeArrayBuffer by copying the contents of the given ArrayBuffer.
+   * Creates a NativeArrayBuffer from the given ArrayBuffer. Uses zero-copy when the
+   * buffer is native-backed (tryGetMutableBuffer), otherwise copies the data.
    */
   static jni::local_ref<NativeArrayBuffer::javaobject> newInstance(
     JSIContext *jsiContext,
@@ -58,8 +65,8 @@ public:
   );
 
   /**
-   * Allocates a new NativeArrayBuffer by copying only the bytes within the typed array's
-   * view range — not the entire backing buffer.
+   * Creates a NativeArrayBuffer from the typed array's view range. Uses zero-copy
+   * when the backing buffer is native-backed, otherwise copies only the viewed bytes.
    */
   static jni::local_ref<NativeArrayBuffer::javaobject> newInstance(
     JSIContext *jsiContext,
@@ -68,6 +75,11 @@ public:
   );
 
   explicit NativeArrayBuffer(const jni::alias_ref<jni::JByteBuffer>& byteBuffer);
+
+  NativeArrayBuffer(
+    const jni::alias_ref<jni::JByteBuffer>& byteBuffer,
+    std::shared_ptr<jsi::MutableBuffer> retainedBuffer
+  );
 
   [[nodiscard]] int size();
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
@@ -16,9 +16,7 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
     return false
   }
 
-  /**
-   Converts JS array buffer to its native representation.
-   */
+  /// Converts JS array buffer to its native representation.
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     if jsValue.isTypedArray() {
       let typedArray = jsValue.getTypedArray()
@@ -30,6 +28,15 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
       return try typedArray.withUnsafeBytes { bytes in
         switch innerType {
         case is NativeArrayBuffer.Type:
+          let backingBuffer = typedArray.getArrayBuffer()
+          if let borrowed = backingBuffer.tryBorrowMutableBuffer() {
+            return NativeArrayBuffer(
+              wrapping: UnsafeMutableRawPointer(borrowed.data.advanced(by: typedArray.byteOffset)),
+              count: count,
+              cleanup: {
+                _ = borrowed
+              })
+          }
           return NativeArrayBuffer.copy(of: bytes.baseAddress!, count: count)
         default:
           // Copy the TypedArray's view (respecting its `byteOffset` and `byteLength`) into a
@@ -52,6 +59,14 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
 
     switch innerType {
     case is NativeArrayBuffer.Type:
+      if let borrowed = jsArrayBuffer.tryBorrowMutableBuffer() {
+        return NativeArrayBuffer(
+          wrapping: UnsafeMutableRawPointer(borrowed.data),
+          count: borrowed.size,
+          cleanup: {
+            _ = borrowed
+          })
+      }
       return NativeArrayBuffer.copy(of: UnsafeRawPointer(jsArrayBuffer.data()), count: jsArrayBuffer.size)
     default:
       return ArrayBuffer(jsArrayBuffer)

--- a/packages/expo-modules-core/ios/Tests/NativeArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/NativeArrayBufferTests.swift
@@ -150,7 +150,8 @@ struct NativeArrayBufferTests {
     @Test
     func `creates ArrayBuffer from JavaScript`() throws {
       let jsArrayBuffer = try runtime.eval("new ArrayBuffer(16)").asArrayBuffer()
-      let arrayBuffer = try runtime.eval("expo.modules.ArrayBufferTests.createFromJS(new ArrayBuffer(16))").asArrayBuffer()
+      let arrayBuffer = try runtime.eval("expo.modules.ArrayBufferTests.createFromJS(new ArrayBuffer(16))")
+        .asArrayBuffer()
 
       #expect(jsArrayBuffer.byteLength == 16)
       #expect(arrayBuffer.byteLength == 16)
@@ -160,7 +161,7 @@ struct NativeArrayBufferTests {
     func `ArrayBuffer argument accepts full typed arrays`() throws {
       let result = try runtime.eval([
         "typedArray = new Uint8Array([42, 84])",
-        "expo.modules.ArrayBufferTests.readBytesAsArray(typedArray, 2)"
+        "expo.modules.ArrayBufferTests.readBytesAsArray(typedArray, 2)",
       ]).asArray()
 
       #expect(try result.getValue(at: 0).asInt() == 42)
@@ -172,7 +173,7 @@ struct NativeArrayBufferTests {
       let result = try runtime.eval([
         "arrayBuffer = new Uint8Array([1,2,3,4,5]).buffer",
         "view = new Uint8Array(arrayBuffer, 1, 2)",
-        "expo.modules.ArrayBufferTests.readBytesAsArray(view, 2)"
+        "expo.modules.ArrayBufferTests.readBytesAsArray(view, 2)",
       ]).asArray()
 
       #expect(try result.getValue(at: 0).asInt() == 2)
@@ -183,7 +184,7 @@ struct NativeArrayBufferTests {
     func `NativeArrayBuffer accepts partial typed array view`() throws {
       let result = try runtime.eval([
         "view = new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)",
-        "expo.modules.ArrayBufferTests.readNativeBufferBytesAsArray(view, 2)"
+        "expo.modules.ArrayBufferTests.readNativeBufferBytesAsArray(view, 2)",
       ]).asArray()
 
       #expect(try result.getValue(at: 0).asInt() == 2)
@@ -205,7 +206,7 @@ struct NativeArrayBufferTests {
         "view = new Uint8Array(buffer)",
         "view[0] = 42",
         "view[1] = 84",
-        "buffer"
+        "buffer",
       ]).asArrayBuffer()
 
       // Read back the data we wrote
@@ -221,14 +222,14 @@ struct NativeArrayBufferTests {
       // Create buffer and fill with pattern from native
       let buffer = try runtime.eval([
         "buffer = expo.modules.ArrayBufferTests.createNative(5)",
-        "expo.modules.ArrayBufferTests.fillWithPattern(buffer, 170)", // 10101010 in binary
-        "buffer"
+        "expo.modules.ArrayBufferTests.fillWithPattern(buffer, 170)",  // 10101010 in binary
+        "buffer",
       ]).asArrayBuffer()
 
       // Read back through JavaScript
       let values = try runtime.eval([
         "view = new Uint8Array(buffer)",
-        "Array.from(view)"
+        "Array.from(view)",
       ]).asArray().map { try $0.asInt() }
 
       #expect(buffer.byteLength == 5)
@@ -242,13 +243,13 @@ struct NativeArrayBufferTests {
         "originalBuffer = new ArrayBuffer(4)",
         "originalView = new Uint8Array(originalBuffer)",
         "originalView.fill(42)",
-        "originalBuffer"
+        "originalBuffer",
       ]).asArrayBuffer()
 
       // Process through native function that takes NativeArrayBuffer (creates copy)
       let processedBuffer = try runtime.eval([
         "processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(originalBuffer, 99)",
-        "processedBuffer"
+        "processedBuffer",
       ]).asArrayBuffer()
 
       // Check that original buffer is unchanged
@@ -264,7 +265,76 @@ struct NativeArrayBufferTests {
       #expect(originalBuffer.byteLength == 4)
       #expect(processedBuffer.byteLength == 4)
       #expect(originalValues.allSatisfy { $0 == 42 } == true)  // Original unchanged
-      #expect(processedValues.allSatisfy { $0 == 99 } == true) // Processed has new pattern
+      #expect(processedValues.allSatisfy { $0 == 99 } == true)  // Processed has new pattern
+    }
+
+    @Test
+    func `shares native-backed buffer when using NativeArrayBuffer argument`() throws {
+      let processedBuffer = try runtime.eval([
+        "nativeBackedBuffer = expo.modules.ArrayBufferTests.createNative(4)",
+        "new Uint8Array(nativeBackedBuffer).fill(42)",
+        "processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(nativeBackedBuffer, 99)",
+        "processedBuffer",
+      ]).asArrayBuffer()
+
+      let originalValues = try runtime.eval([
+        "Array.from(new Uint8Array(nativeBackedBuffer))"
+      ]).asArray().map { try $0.asInt() }
+
+      let processedValues = try runtime.eval([
+        "Array.from(new Uint8Array(processedBuffer))"
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(processedBuffer.byteLength == 4)
+      #expect(originalValues.allSatisfy { $0 == 99 } == true)
+      #expect(processedValues.allSatisfy { $0 == 99 } == true)
+    }
+
+    @Test
+    func `shares native-backed typed array view when using NativeArrayBuffer argument`() throws {
+      let processedBuffer = try runtime.eval([
+        "nativeBackedBuffer = expo.modules.ArrayBufferTests.createNative(5)",
+        "fullView = new Uint8Array(nativeBackedBuffer)",
+        "fullView.set([1, 2, 3, 4, 5])",
+        "partialView = new Uint8Array(nativeBackedBuffer, 1, 2)",
+        "processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(partialView, 99)",
+        "processedBuffer",
+      ]).asArrayBuffer()
+
+      let originalValues = try runtime.eval([
+        "Array.from(new Uint8Array(nativeBackedBuffer))"
+      ]).asArray().map { try $0.asInt() }
+
+      let processedValues = try runtime.eval([
+        "Array.from(new Uint8Array(processedBuffer))"
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(processedBuffer.byteLength == 2)
+      #expect(originalValues == [1, 99, 99, 4, 5])
+      #expect(processedValues == [99, 99])
+    }
+
+    @Test
+    func `copies JS-backed typed array view when using NativeArrayBuffer argument`() throws {
+      let processedBuffer = try runtime.eval([
+        "jsBackedBuffer = new Uint8Array([1, 2, 3, 4, 5]).buffer",
+        "fullView = new Uint8Array(jsBackedBuffer)",
+        "partialView = new Uint8Array(jsBackedBuffer, 1, 2)",
+        "processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(partialView, 99)",
+        "processedBuffer",
+      ]).asArrayBuffer()
+
+      let originalValues = try runtime.eval([
+        "Array.from(fullView)"
+      ]).asArray().map { try $0.asInt() }
+
+      let processedValues = try runtime.eval([
+        "Array.from(new Uint8Array(processedBuffer))"
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(processedBuffer.byteLength == 2)
+      #expect(originalValues == [1, 2, 3, 4, 5])
+      #expect(processedValues == [99, 99])
     }
   }
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 💡 Others
 
+- `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
+
 ## 56.0.7 — 2026-05-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/JSIUtils.cpp
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/JSIUtils.cpp
@@ -1,5 +1,7 @@
 #include "JSIUtils.h"
 
+#include <hermes/hermes.h>
+
 namespace expo {
 
 jsi::Runtime* createHermesRuntime() {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -3,7 +3,6 @@
 #pragma once
 #ifdef __cplusplus
 
-#include <hermes/hermes.h>
 #include <TargetConditionals.h>
 
 #include "HostFunctionClosure.h"
@@ -198,6 +197,35 @@ inline jsi::ArrayBuffer createArrayBuffer(
     cleanupFunction(cleanupContext);
   });
   return jsi::ArrayBuffer(runtime, std::move(buffer));
+}
+
+// MARK: - Zero-copy ArrayBuffer borrowing
+
+struct BorrowedBuffer {
+  uint8_t *_Nullable data;
+  size_t size;
+  void *_Nullable retainer;
+};
+
+/**
+ * Borrows a native-backed ArrayBuffer. The returned data pointer and size are
+ * captured at borrow time, so resizable or detached buffers are not supported.
+ */
+inline BorrowedBuffer tryBorrowMutableBuffer(
+  jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer
+) {
+  auto mutableBuf = arrayBuffer.tryGetMutableBuffer(runtime);
+  if (!mutableBuf) {
+    return {nullptr, 0, nullptr};
+  }
+  uint8_t *data = mutableBuf->data();
+  size_t size = mutableBuf->size();
+  auto *retained = new std::shared_ptr<jsi::MutableBuffer>(std::move(mutableBuf));
+  return {data, size, retained};
+}
+
+inline void releaseBorrowedBuffer(void *_Nonnull retainer) {
+  delete static_cast<std::shared_ptr<jsi::MutableBuffer> *>(retainer);
 }
 
 // MARK: - Native state

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -214,18 +214,30 @@ struct BorrowedBuffer {
 inline BorrowedBuffer tryBorrowMutableBuffer(
   jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer
 ) {
-  auto mutableBuf = arrayBuffer.tryGetMutableBuffer(runtime);
-  if (!mutableBuf) {
+#if defined(REACT_NATIVE_VERSION_MAJOR) && defined(REACT_NATIVE_VERSION_MINOR) && \
+    (REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 86)
+  auto mutableBuffer = arrayBuffer.tryGetMutableBuffer(runtime);
+  if (!mutableBuffer) {
     return {nullptr, 0, nullptr};
   }
-  uint8_t *data = mutableBuf->data();
-  size_t size = mutableBuf->size();
-  auto *retained = new std::shared_ptr<jsi::MutableBuffer>(std::move(mutableBuf));
+  uint8_t *data = mutableBuffer->data();
+  size_t size = mutableBuffer->size();
+  auto *retained = new std::shared_ptr<jsi::MutableBuffer>(std::move(mutableBuffer));
   return {data, size, retained};
+#else
+  (void)runtime;
+  (void)arrayBuffer;
+  return {nullptr, 0, nullptr};
+#endif
 }
 
 inline void releaseBorrowedBuffer(void *_Nonnull retainer) {
+#if defined(REACT_NATIVE_VERSION_MAJOR) && defined(REACT_NATIVE_VERSION_MINOR) && \
+    (REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 86)
   delete static_cast<std::shared_ptr<jsi::MutableBuffer> *>(retainer);
+#else
+  (void)retainer;
+#endif
 }
 
 // MARK: - Native state

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -210,6 +210,8 @@ struct BorrowedBuffer {
 /**
  * Borrows a native-backed ArrayBuffer. The returned data pointer and size are
  * captured at borrow time, so resizable or detached buffers are not supported.
+ * A non-null retainer must be passed to releaseBorrowedBuffer exactly once.
+ * The {nullptr, 0, nullptr} failure result must not be released.
  */
 inline BorrowedBuffer tryBorrowMutableBuffer(
   jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
@@ -45,6 +45,22 @@ public struct JavaScriptArrayBuffer: ~Copyable {
     return newBuffer
   }
 
+  // MARK: - Zero-copy borrowing
+
+  /// Attempts to obtain the underlying native MutableBuffer without copying.
+  /// Returns `nil` if the buffer is JS-heap-allocated (no MutableBuffer available).
+  /// The returned buffer keeps the underlying memory alive until it is deallocated.
+  public func tryBorrowMutableBuffer() -> JavaScriptMutableBuffer? {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let borrowed = expo.tryBorrowMutableBuffer(runtime.pointee, pointee)
+    guard let data = borrowed.data, let retainer = borrowed.retainer else {
+      return nil
+    }
+    return JavaScriptMutableBuffer(data: data, size: Int(borrowed.size), retainer: retainer)
+  }
+
   // MARK: - Conversions
 
   /// Returns this array buffer as a `JavaScriptValue`.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptMutableBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptMutableBuffer.swift
@@ -6,7 +6,7 @@ internal import ExpoModulesJSI_Cxx
 ///
 /// The data pointer and size are captured at borrow time. Resizable or detached
 /// ArrayBuffers are not supported by this borrowed representation.
-public struct JavaScriptMutableBuffer: ~Copyable, @unchecked Sendable {
+public struct JavaScriptMutableBuffer: ~Copyable {
   public let data: UnsafeMutablePointer<UInt8>
   public let size: Int
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptMutableBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptMutableBuffer.swift
@@ -1,0 +1,24 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+internal import ExpoModulesJSI_Cxx
+
+/// A borrowed native `MutableBuffer` backing a JavaScript `ArrayBuffer`.
+///
+/// The data pointer and size are captured at borrow time. Resizable or detached
+/// ArrayBuffers are not supported by this borrowed representation.
+public struct JavaScriptMutableBuffer: ~Copyable, @unchecked Sendable {
+  public let data: UnsafeMutablePointer<UInt8>
+  public let size: Int
+
+  private let retainer: UnsafeMutableRawPointer
+
+  internal init(data: UnsafeMutablePointer<UInt8>, size: Int, retainer: UnsafeMutableRawPointer) {
+    self.data = data
+    self.size = size
+    self.retainer = retainer
+  }
+
+  deinit {
+    expo.releaseBorrowedBuffer(retainer)
+  }
+}


### PR DESCRIPTION
# Why

Native-backed `ArrayBuffer`s were copied when passed back to native functions expecting `NativeArrayBuffer`. React Native 0.86 now added an API to expose the original mutable backing buffer (see https://github.com/facebook/react-native/pull/56156). This avoids unnecessary copies while preserving the existing copy behavior for JS-allocated buffers.

# How

- Use `tryGetMutableBuffer()`/`tryBorrowMutableBuffer()` to borrow native-backed `ArrayBuffer` memory and retain the underlying `MutableBuffer` for the lifetime of the native wrapper.
- Keep the copy fallback for JS-allocated buffers, add typed-array view support with `byteOffset`
- Moved hermes.h import to .cpp file to avoid unnecessarily including it in Swift interop

# Test Plan

Added tests to verify native-backed sharing and copy fallback behavior:
- iOS Unit tests
- Android instrumented tests

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
