### PR TITLE
fix(task-manager)[android]: guard against null headless app loader in executeTask

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix `NullPointerException` in `TaskService.executeTask` when a background job runs while the app context has been released (e.g. headless location tasks restored after the process was killed). ([#46449](https://github.com/expo/expo/pull/46449) by [@rarf](https://github.com/rarf))
+
 ### 💡 Others
 
 ## 56.0.15 — 2026-05-26

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -423,7 +423,19 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
     }
     mTasksAndEventsRepository.putEventForAppScopeKey(appScopeKey, body);
 
-    getAppLoader().loadApp(mContextRef.get(),
+    HeadlessAppLoader appLoader = getAppLoader();
+    if (appLoader == null) {
+      // The headless app loader is unavailable because the context has been released
+      // (e.g. the process was killed and the JobService is restoring jobs in the
+      // background before the app context is set up again). Calling loadApp() on a
+      // null loader crashes the OS-level JobService callback with a NullPointerException,
+      // so drop the queued event and let the job finish cleanly instead.
+      Log.e(TAG, "Cannot execute background task '" + task.getName() + "': headless app loader is unavailable (context released). Dropping queued event.");
+      mTasksAndEventsRepository.removeEvents(appScopeKey);
+      return;
+    }
+
+    appLoader.loadApp(mContextRef.get(),
       new HeadlessAppLoader.Params(appScopeKey, task.getAppUrl()),
       () -> {
       },
@@ -443,8 +455,12 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   //region helpers
 
   private HeadlessAppLoader getAppLoader() {
-    if (mContextRef.get() != null) {
-      return AppLoaderProvider.getLoader("react-native-headless", mContextRef.get());
+    // Guard against `mContextRef` itself being null (not just its referent): `executeTask`
+    // runs on the JobScheduler worker thread, which can observe a not-yet-initialized
+    // field, and the WeakReference may also have been cleared once the process is killed.
+    Context context = mContextRef != null ? mContextRef.get() : null;
+    if (context != null) {
+      return AppLoaderProvider.getLoader("react-native-headless", context);
     } else {
       return null;
     }


### PR DESCRIPTION
# Why

`TaskService.executeTask` crashes with a `NullPointerException` on Android when a background location job fires while the app context is unavailable. This is reported in [#41663](https://github.com/expo/expo/issues/41663) and reproduces in production for apps that run `Location.startLocationUpdatesAsync` with a registered TaskManager task. The crash happens in native code **before any JS runs**, so apps cannot guard against it:

```
Caused by java.lang.NullPointerException:
  at expo.modules.taskManager.TaskService.executeTask (TaskService.java:412)
  at expo.modules.taskManager.Task.execute (Task.java:58)
  at expo.modules.location.taskConsumers.LocationTaskConsumer.executeTaskWithLocationBundles
  at expo.modules.location.taskConsumers.LocationTaskConsumer.didExecuteJob
  at expo.modules.taskManager.TaskService.handleJob
  at expo.modules.taskManager.TaskJobService.onStartJob
```

Root cause: when the OS restores/starts a job in the background (e.g. after the process was killed), the `Context` held by `mContextRef` can be released. `getAppLoader()` then returns `null`, and `executeTask` immediately calls `.loadApp(...)` on it without a null check, crashing the OS-level `JobService` callback. The crash is more frequent on Android 16 (SDK 36) due to stricter background-job / GC behavior, and on devices with aggressive process management.

# How

- `executeTask`: capture `getAppLoader()` into a local and bail out cleanly (drop the queued event, log, and return) when it is `null`, instead of dereferencing `null`. This lets the `JobService` finish without crashing.
- `getAppLoader()`: also guard against `mContextRef` *itself* being `null` (not just its referent). `executeTask` runs on the JobScheduler worker thread, which can observe the field before it is fully published, and the field is also dereferenced unconditionally elsewhere.

No behavior change in the normal path — only the previously-crashing path now degrades gracefully.

# Test Plan

- Built locally; the only path affected is the `appLoader == null` branch, which previously threw an unconditional NPE.
- The original NPE is non-deterministic and tied to OS-driven background job restoration, so it is not feasible to reproduce in a unit test; the fix is a defensive null guard on the exact dereference in the reported stack trace.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20JS%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
