### PR TITLE
[updates] Fix flaky lastAccessed timing assertion in iOS tests

### DIFF
--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
@@ -111,7 +111,9 @@ class AppLauncherWithDatabaseTests {
     db.databaseQueue.sync {
       let sameUpdate = try! db.update(withId: testUpdate.updateId, config: config)
       #expect(yesterday != sameUpdate?.lastAccessed)
-      #expect(abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) < 3)
+      // `lastAccessed` should have been bumped to roughly "now". Use a generous tolerance
+      // so the assertion doesn't flake on slow CI runners where `launchUpdate` takes longer.
+      #expect(abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) < 60)
     }
   }
 }


### PR DESCRIPTION
# Why

The `main` iOS Unit Tests job [failed](https://github.com/expo/expo/actions/runs/26744190880/job/78815391438) on a flaky timing assertion in `AppLauncherWithDatabaseTests`:

```
Recorded an issue (Expectation failed:
  (abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) → 3.045332908630371) < (3 → 3.0))
Suite "AppLauncherWithDatabase" failed after 3.344 seconds with 1 issue(s)
```

The test launches an update through the full async `launchUpdate` flow and then asserts that the update's `lastAccessed` timestamp was bumped to "now" — within a **3-second** window. On the CI runner the async launch took 3.045s, just over the bound, failing the assertion and the whole job.

This assertion has existed since the February Swift Testing migration, so it's a long-standing flake that a slow runner finally tripped — not a regression.

# How

Widen the tolerance from `< 3` to `< 60`. The assertion only needs to confirm `lastAccessed` moved away from `yesterday` (already checked on the line above) to roughly now; a generous bound preserves that intent without being sensitive to runner speed.

# Test Plan

- Existing `AppLauncherWithDatabase` suite continues to pass; the assertion no longer flakes on slow runners.
