### PR TITLE
[video][ios] Add a workaround for leaks in `expo-video`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
 - [iOS] Fixed a thread-safety crash caused by mutating the internal player registries while they were being iterated on another thread (e.g. during audio session and now playing updates). ([#46930](https://github.com/expo/expo/pull/46930) by [@jiunshinn](https://github.com/jiunshinn))
+- Fix VideoView holding a strong reference to VideoPlayer even after the player has been detached.
 
 ### 💡 Others
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
 - [iOS] Fixed a thread-safety crash caused by mutating the internal player registries while they were being iterated on another thread (e.g. during audio session and now playing updates). ([#46930](https://github.com/expo/expo/pull/46930) by [@jiunshinn](https://github.com/jiunshinn))
-- Fix VideoView holding a strong reference to VideoPlayer even after the player has been detached.
+- Fix VideoView holding a strong reference to VideoPlayer even after the player has been detached. ([#46453](https://github.com/expo/expo/pull/46453) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
+++ b/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
@@ -1,0 +1,152 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import AVKit
+
+// AVPlayerViewController can keep stale internal references to AVPlayers after the
+// owning VideoPlayer is deallocated. Recreating the controller is expensive, so this
+// wrapper keeps the fast path as a plain player replacement and rebuilds the controller
+// only after a previously attached VideoPlayer has emitted its deinit signal.
+internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserverDelegate {
+  private final class WeakVideoPlayer {
+    weak var value: VideoPlayer?
+
+    init(_ value: VideoPlayer) {
+      self.value = value
+    }
+  }
+
+  private weak var delegate: AVPlayerViewControllerDelegate?
+  private var registeredPlayers: [WeakVideoPlayer] = []
+  private var hasStalePlayerReference = false
+
+  #if !os(tvOS)
+  private var fullscreenOptions: FullscreenOptions?
+  private var hasSetFullscreenOptions = false
+  #endif
+
+  let view = UIView()
+  private(set) var controller: OrientationAVPlayerViewController
+
+  init(delegate: AVPlayerViewControllerDelegate?) {
+    self.delegate = delegate
+    self.controller = OrientationAVPlayerViewController(delegate: delegate)
+    view.clipsToBounds = true
+    view.backgroundColor = .clear
+    configure(controller)
+    view.addSubview(controller.view)
+  }
+
+  @discardableResult
+  func setPlayer(_ player: VideoPlayer?) -> Bool {
+    if let player {
+      register(player)
+    }
+
+    guard hasStalePlayerReference else {
+      controller.player = player?.ref
+      return false
+    }
+
+    let oldController = controller
+    controller = makeController(copying: oldController)
+    controller.player = player?.ref
+
+    #if !os(tvOS)
+    if view.window != nil {
+      oldController.beginAppearanceTransition(false, animated: false)
+      oldController.endAppearanceTransition()
+    }
+    #endif
+
+    oldController.view.removeFromSuperview()
+    view.addSubview(controller.view)
+
+    #if !os(tvOS)
+    if view.window != nil {
+      controller.beginAppearanceTransition(true, animated: false)
+      controller.endAppearanceTransition()
+    }
+    #endif
+
+    hasStalePlayerReference = false
+    return true
+  }
+
+  func layoutControllerView() {
+    controller.view.frame = view.bounds
+  }
+
+  // This is the only way that I (@behenate) found to force re-calculation of the safe-area insets for native controls
+  func refreshSafeAreaInsets() {
+    controller.view.removeFromSuperview()
+    view.addSubview(controller.view)
+  }
+
+  #if !os(tvOS)
+  func setFullscreenOptions(_ options: FullscreenOptions?) {
+    fullscreenOptions = options
+    hasSetFullscreenOptions = true
+    applyFullscreenOptions(to: controller)
+  }
+  #endif
+
+  private func register(_ player: VideoPlayer) {
+    guard !registeredPlayers.contains(where: { $0.value === player }) else {
+      return
+    }
+    registeredPlayers.append(WeakVideoPlayer(player))
+    player.observer?.registerDelegate(delegate: self)
+  }
+
+  func onPlayerDeinit(player: VideoPlayer) {
+    hasStalePlayerReference = true
+  }
+
+  private func makeController(copying oldController: OrientationAVPlayerViewController) -> OrientationAVPlayerViewController {
+    let newController = OrientationAVPlayerViewController(delegate: delegate)
+    configure(newController)
+
+    newController.showsPlaybackControls = oldController.showsPlaybackControls
+    newController.videoGravity = oldController.videoGravity
+    newController.allowsPictureInPicturePlayback = oldController.allowsPictureInPicturePlayback
+    newController.requiresLinearPlayback = oldController.requiresLinearPlayback
+    newController.view.frame = oldController.view.frame
+
+    #if os(tvOS)
+    newController.isSkipForwardEnabled = oldController.isSkipForwardEnabled
+    newController.isSkipBackwardEnabled = oldController.isSkipBackwardEnabled
+    #else
+    newController.canStartPictureInPictureAutomaticallyFromInline = oldController.canStartPictureInPictureAutomaticallyFromInline
+    if #available(iOS 16.0, macCatalyst 18.0, *) {
+      newController.allowsVideoFrameAnalysis = oldController.allowsVideoFrameAnalysis
+    }
+    newController.showsTimecodes = oldController.showsTimecodes
+    applyFullscreenOptions(to: newController)
+    #endif
+
+    return newController
+  }
+
+  private func configure(_ controller: OrientationAVPlayerViewController) {
+    controller.view.frame = view.bounds
+    controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    controller.view.backgroundColor = .clear
+    #if !os(tvOS)
+    controller.updatesNowPlayingInfoCenter = false
+    applyFullscreenOptions(to: controller)
+    #endif
+  }
+
+  #if !os(tvOS)
+  private func applyFullscreenOptions(to controller: OrientationAVPlayerViewController) {
+    guard hasSetFullscreenOptions else {
+      return
+    }
+
+    controller.fullscreenOrientation = fullscreenOptions?.orientation.toUIInterfaceOrientationMask() ?? .all
+    controller.autoExitOnRotate = fullscreenOptions?.autoExitOnRotate ?? false
+    controller.keepFullscreenOnPiPStop = fullscreenOptions?.keepFullscreenOnPiPStop ?? .never
+    controller.setValue(fullscreenOptions?.enable ?? true, forKey: "allowsEnteringFullScreen")
+  }
+  #endif
+}

--- a/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
+++ b/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
@@ -42,7 +42,15 @@ internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserv
       register(player)
     }
 
-    guard hasStalePlayerReference else {
+    // Don't rebuild the controller while it's presenting fullscreen or Picture in Picture,
+    // doing so would tear down the active session. Keep the flag set so the rebuild happens
+    // on the next inline `setPlayer`.
+    var isPresenting = controller.isInPictureInPicture
+    #if !os(tvOS)
+    isPresenting = isPresenting || controller.isFullscreen
+    #endif
+
+    guard hasStalePlayerReference, !isPresenting else {
       controller.player = player?.ref
       return false
     }
@@ -91,6 +99,7 @@ internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserv
   #endif
 
   private func register(_ player: VideoPlayer) {
+    registeredPlayers.removeAll { $0.value == nil }
     guard !registeredPlayers.contains(where: { $0.value === player }) else {
       return
     }
@@ -99,7 +108,9 @@ internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserv
   }
 
   func onPlayerDeinit(player: VideoPlayer) {
-    hasStalePlayerReference = true
+    DispatchQueue.main.async { [weak self] in
+      self?.hasStalePlayerReference = true
+    }
   }
 
   private func makeController(copying oldController: OrientationAVPlayerViewController) -> OrientationAVPlayerViewController {

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -65,10 +65,7 @@ public final class VideoModule: Module {
 
       Prop("fullscreenOptions") {(view, options: FullscreenOptions?) in
         #if !os(tvOS)
-        view.playerViewController.fullscreenOrientation = options?.orientation.toUIInterfaceOrientationMask() ?? .all
-        view.playerViewController.autoExitOnRotate = options?.autoExitOnRotate ?? false
-        view.playerViewController.setValue(options?.enable ?? true, forKey: "allowsEnteringFullScreen")
-        view.playerViewController.keepFullscreenOnPiPStop = options?.keepFullscreenOnPiPStop ?? .never
+        view.setFullscreenOptions(options)
         #endif
       }
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -181,6 +181,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   deinit {
+    observer?.notifyPlayerDeinit(player: self)
     observer?.cleanup()
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -59,6 +59,7 @@ protocol VideoPlayerObserverDelegate: AnyObject {
   func onLoadedPlayerItem(player: AVPlayer, playerItem: AVPlayerItem?)
   func onVideoTrackChanged(player: AVPlayer, oldVideoTrack: VideoTrack?, newVideoTrack: VideoTrack?)
   func onIsExternalPlaybackActiveChanged(player: AVPlayer, oldIsExternalPlaybackActive: Bool?, newIsExternalPlaybackActive: Bool)
+func onPlayerDeinit(player: VideoPlayer)
 }
 
 // Default implementations for the delegate
@@ -78,6 +79,7 @@ extension VideoPlayerObserverDelegate {
   func onLoadedPlayerItem(player: AVPlayer, playerItem: AVPlayerItem?) {}
   func onVideoTrackChanged(player: AVPlayer, oldVideoTrack: VideoTrack?, newVideoTrack: VideoTrack?) {}
   func onIsExternalPlaybackActiveChanged(player: AVPlayer, oldIsExternalPlaybackActive: Bool?, newIsExternalPlaybackActive: Bool) {}
+  func onPlayerDeinit(player: VideoPlayer) {}
 }
 
 // Wrapper used to store WeakReferences to the observer delegate
@@ -208,6 +210,12 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
   func unregisterDelegate(delegate: VideoPlayerObserverDelegate) {
     delegates.remove(WeakPlayerObserverDelegate(value: delegate))
+  }
+
+  func notifyPlayerDeinit(player: VideoPlayer) {
+    delegates.forEach { delegate in
+      delegate.value?.onPlayerDeinit(player: player)
+    }
   }
 
   func cleanup() {

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -59,7 +59,7 @@ protocol VideoPlayerObserverDelegate: AnyObject {
   func onLoadedPlayerItem(player: AVPlayer, playerItem: AVPlayerItem?)
   func onVideoTrackChanged(player: AVPlayer, oldVideoTrack: VideoTrack?, newVideoTrack: VideoTrack?)
   func onIsExternalPlaybackActiveChanged(player: AVPlayer, oldIsExternalPlaybackActive: Bool?, newIsExternalPlaybackActive: Bool)
-func onPlayerDeinit(player: VideoPlayer)
+  func onPlayerDeinit(player: VideoPlayer)
 }
 
 // Default implementations for the delegate

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -4,11 +4,17 @@ import AVKit
 import ExpoModulesCore
 
 public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
-  lazy var playerViewController = OrientationAVPlayerViewController(delegate: self)
+  private lazy var playerViewControllerWrapper = OrientationAVPlayerViewControllerWrapper(delegate: self)
+  var playerViewController: OrientationAVPlayerViewController {
+    playerViewControllerWrapper.controller
+  }
 
   weak var player: VideoPlayer? {
     didSet {
-      playerViewController.player = player?.ref
+      if playerViewControllerWrapper.setPlayer(player) {
+        removeFirstFrameObserver()
+        addFirstFrameObserver()
+      }
     }
   }
 
@@ -42,7 +48,8 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   public override var bounds: CGRect {
     didSet {
-      playerViewController.view.frame = self.bounds
+      playerViewControllerWrapper.view.frame = bounds
+      playerViewControllerWrapper.layoutControllerView()
     }
   }
 
@@ -52,15 +59,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     VideoManager.shared.register(videoView: self)
 
     clipsToBounds = true
-    playerViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    playerViewController.view.backgroundColor = .clear
-    // Now playing is managed by the `NowPlayingManager`
-    #if !os(tvOS)
-    playerViewController.updatesNowPlayingInfoCenter = false
-    #endif
 
     addFirstFrameObserver()
-    addSubview(playerViewController.view)
+    addSubview(playerViewControllerWrapper.view)
   }
 
   deinit {
@@ -113,8 +114,8 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     self.onFullscreenExit()
     self.isFullscreen = false
     // Reset the bounds of the view controller and add it back to our view
-    self.playerViewController.view.frame = self.bounds
-    addSubview(self.playerViewController.view)
+    self.playerViewControllerWrapper.layoutControllerView()
+    self.playerViewControllerWrapper.view.addSubview(self.playerViewController.view)
     // End the appearance transition
     self.playerViewController.endAppearanceTransition()
     // Ensure playing state is preserved
@@ -174,10 +175,14 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   public override func safeAreaInsetsDidChange() {
     super.safeAreaInsetsDidChange()
-    // This is the only way that I (@behenate) found to force re-calculation of the safe-area insets for native controls
-    playerViewController.view.removeFromSuperview()
-    addSubview(playerViewController.view)
+    playerViewControllerWrapper.refreshSafeAreaInsets()
   }
+
+  #if !os(tvOS)
+  func setFullscreenOptions(_ options: FullscreenOptions?) {
+    playerViewControllerWrapper.setFullscreenOptions(options)
+  }
+  #endif
 
   private func addFirstFrameObserver() {
     firstFrameObserver = playerViewController.observe(\.isReadyForDisplay, changeHandler: { [weak self] playerViewController, _ in


### PR DESCRIPTION
# Why

We have a bit of a weird issue in `expo-video`. We have to manually call `beginAppearanceTransition` once the View has appeared in the window. It fixes the built-in controls not appearing. This is likely because the `AVPlayerViewController` is orphaned and doesn't receive appropriate events, and React Native has a non-typical view hierarchy.

It seems like this change breaks the memory management inside the `AVPlayerViewController` - the controller stores a strong reference to every `AVPlayer` that has ever been played inside of it until the controller is destroyed.

This does not happen when we don't call `beginAppearanceTransition`, but then the native controls are broken. 

I have tried to find anything that would allow us to have the controls and fix the leak, but it was not possible.

# How

In the end I have opted for a workaround solution - I added a wrapper for our view controller that keeps track of all players that have ever been mounted inside of it. If a `VideoPlayer` receives a `deinit` call (`VideoPlayer` gets destroyed correctly, it's just the underlying `AVPlayer` that is being referenced) an it has been mounted in an AVPlayerViewController which is still alive, the AVPlayerViewController is destroyed and replaced with a new one. This happens when the player of the `AVPlayerViewController` is replacing it's current player to hide playback disruptions. 

I don't like this solution because it is about 2-5x slower than just replacing the player in the ViewController. On the bright side this leak is pretty hard to come across in a real app - in the vast majority of use cases the player lives just as long or longer than the view controller. There should also be no performance penalty when the leak didn't occur.

We can further reduce the chances of this happening by changing how the `useVideoPlayer` hook works - we should call `replaceAsync` on the player instead of recreating it from scratch (I'll do this in a separate PR). 

# Test Plan

Tested in BareExpo on iOS.