### PR TITLE
fix(cli): Disable sextant QR rendering for Windows Terminal app

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.1.12 — 2026-05-26

--- a/packages/@expo/cli/src/utils/qr.ts
+++ b/packages/@expo/cli/src/utils/qr.ts
@@ -28,14 +28,13 @@ function supportsSextants() {
   } else if (process.env.COLOR === '0' || process.env.COLOR === 'false') {
     return false;
   }
-  const isWindowsTerminal = process.platform === 'win32' && !!process.env.WT_SESSION?.length;
   const isGhostty = process.env.TERM_PROGRAM === 'ghostty';
   const isWezterm = process.env.TERM_PROGRAM === 'WezTerm';
   // NOTE(@kitten): Zed regressed on rendering sextants
   const isZed = process.env.TERM_PROGRAM === 'zed';
   const isKitty = !!process.env.KITTY_WINDOW_ID?.length;
   const isAlacritty = !!process.env.ALACRITTY_WINDOW_ID?.length && !isZed;
-  return isWindowsTerminal || isGhostty || isWezterm || isKitty || isAlacritty;
+  return isGhostty || isWezterm || isKitty || isAlacritty;
 }
 
 /** ANSI QR code output by using half-blocks (1x2-sized unicode blocks) */


### PR DESCRIPTION
## Summary

Resolves #46454
Related #46148

I may have failed to check this correctly in the past (or Microsoft Terminal has regressed). The sextant character support in Windows is font-dependent, so not reliable enough to keep enabled for it.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
