### PR TITLE
[expo-router] refactor native tabs to use standard-navigation

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### 💡 Others
 
+- Rewrite native tabs using standard-navigation ([#46457](https://github.com/expo/expo/pull/46457) by [@Ubax](https://github.com/Ubax))
+
 ## 56.2.7 — 2026-05-26
 
 ### 🐛 Bug fixes

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -1,15 +1,14 @@
 'use client';
 
 import React, { use, useCallback, useMemo, useRef } from 'react';
+import type { NavigatorArgs } from 'standard-navigation';
 
-import { withLayoutContext } from '../layouts/withLayoutContext';
-import { getPathFromState } from '../link/linking';
 import type {
   ParamListBase,
   TabNavigationState,
   TabRouterOptions,
 } from '../react-navigation/native';
-import { createNavigatorFactory, useNavigationBuilder } from '../react-navigation/native';
+import { unstable_createStandardRouterNavigator } from '../standard-navigation';
 import { getAllChildrenNotOfType, getAllChildrenOfType } from '../utils/children';
 import { NativeBottomTabsRouter } from './NativeBottomTabsRouter';
 import { NativeTabTrigger } from './NativeTabTrigger';
@@ -19,6 +18,7 @@ import type {
   NativeTabNavigationEventMap,
   NativeTabOptions,
   NativeTabsProps,
+  NativeTabsViewProps,
   NativeTabsViewTabItem,
   OnTabChangeEventPayload,
 } from './types';
@@ -28,69 +28,32 @@ import { convertIconColorPropToObject, convertLabelStylePropToObject } from './u
 const defaultBackBehavior = 'initialRoute';
 export const NativeTabsContext = React.createContext<boolean>(false);
 
-export function NativeTabsNavigator({
-  children,
-  backBehavior = defaultBackBehavior,
+function NativeTabsContent({
+  state,
+  descriptors,
+  actions,
+  emitter,
+  // These per-tab style props are folded into `screenOptions` by `NativeTabsNavigatorWrapper` and
+  // read back per-tab from `descriptors`. Pull them out of `rest` so they aren't forwarded to
+  // `NativeTabsView` as top-level props.
   labelStyle,
   iconColor,
-  blurEffect,
   backgroundColor,
   badgeBackgroundColor,
+  blurEffect,
   indicatorColor,
   badgeTextColor,
-  shadowColor,
   rippleColor,
   disableIndicator,
   labelVisibilityMode,
-  screenListeners,
   ...rest
-}: InternalNativeTabsProps) {
+}: NavigatorArgs<NativeTabOptions, NativeTabNavigationEventMap> &
+  Omit<InternalNativeTabsProps, 'screenListeners'>) {
   if (use(NativeTabsContext)) {
     throw new Error(
       'Nesting Native Tabs inside each other is not supported natively. Use JS tabs for nesting instead.'
     );
   }
-
-  const processedLabelStyle = convertLabelStylePropToObject(labelStyle);
-  const processedIconColor = convertIconColorPropToObject(iconColor);
-
-  const selectedLabelStyle = processedLabelStyle.selected
-    ? {
-        ...processedLabelStyle.selected,
-        color: processedLabelStyle.selected.color ?? rest.tintColor,
-      }
-    : rest.tintColor
-      ? { color: rest.tintColor }
-      : undefined;
-
-  const { state, descriptors, navigation, NavigationContent } = useNavigationBuilder<
-    TabNavigationState<ParamListBase>,
-    TabRouterOptions,
-    Record<string, (...args: unknown[]) => void>,
-    NativeTabOptions,
-    NativeTabNavigationEventMap
-  >(NativeBottomTabsRouter, {
-    children,
-    backBehavior,
-    screenListeners,
-    screenOptions: {
-      disableTransparentOnScrollEdge: rest.disableTransparentOnScrollEdge,
-      labelStyle: processedLabelStyle.default,
-      selectedLabelStyle,
-      iconColor: processedIconColor.default,
-      selectedIconColor: processedIconColor.selected ?? rest.tintColor,
-      blurEffect,
-      backgroundColor,
-      badgeBackgroundColor,
-      indicatorColor,
-      badgeTextColor,
-      shadowColor,
-      rippleColor,
-      disableIndicator,
-      labelVisibilityMode,
-      tintColor: rest.tintColor,
-    },
-  });
 
   const { routes } = state;
 
@@ -121,8 +84,9 @@ export function NativeTabsNavigator({
 
   if (visibleFocusedTabIndex < 0) {
     if (process.env.NODE_ENV !== 'production') {
+      const focusedRoute = routes[state.index];
       throw new Error(
-        `The focused tab in NativeTabsView cannot be displayed. Make sure path is correct and the route is not hidden. Path: "${getPathFromState(state)}"`
+        `The focused tab in NativeTabsView cannot be displayed. Make sure path is correct and the route is not hidden. Route: "${focusedRoute?.href ?? focusedRoute?.name}"`
       );
     }
   }
@@ -135,7 +99,7 @@ export function NativeTabsNavigator({
         // The native side blocked selecting a disabled tab. Notify listeners, but
         // don't advance navigation or acknowledge a (non-existent) state transition,
         // so the provenance counter is left untouched.
-        navigation.emit({
+        emitter.emit({
           type: 'tabPress',
           target: selectedKey,
           data: {
@@ -150,8 +114,17 @@ export function NativeTabsNavigator({
       provenanceRef.current = provenance;
 
       if (isNativeAction) {
-        const { route } = descriptors[selectedKey]!;
-        navigation.emit({
+        const selectedRoute = routes.find((route) => route.key === selectedKey);
+        if (!selectedRoute) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              `NativeTabs received a native tab change for an unknown tab (key: "${selectedKey}"), so the change was ignored. ` +
+                `This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.`
+            );
+          }
+          return;
+        }
+        emitter.emit({
           type: 'tabPress',
           target: selectedKey,
           data: {
@@ -159,45 +132,45 @@ export function NativeTabsNavigator({
             isPrevented: false,
           },
         });
-        navigation.dispatch({
-          type: 'JUMP_TO',
-          target: state.key,
-          payload: {
-            name: route.name,
-          },
-        });
+        actions.navigate(selectedRoute.name);
       }
     },
-    [descriptors, navigation, state.key]
+    [routes, actions, emitter]
   );
 
+  // Compile-time guard: everything spread onto `<NativeTabsView>` must be a prop it declares. The
+  // `Record<…, never>` turns any prop the view doesn't accept into a type error here instead of
+  // letting it leak silently through the spread.
+  const nativeTabsViewProps: Omit<
+    NativeTabsViewProps,
+    'focusedIndex' | 'provenance' | 'tabs' | 'onTabChange'
+  > &
+    Record<Exclude<keyof typeof rest, keyof NativeTabsViewProps>, never> = rest;
+
   return (
-    <NavigationContent>
-      <NativeTabsContext value>
-        <NativeTabsView
-          {...rest}
-          key={visibleTabsKeys}
-          focusedIndex={focusedIndex}
-          // Provenance should only be sent with updates, and updates
-          // on JS side are only triggered by rerender, so passing ref
-          // here is ok.
-          provenance={provenanceRef.current}
-          tabs={visibleTabs}
-          onTabChange={onTabChange}
-        />
-      </NativeTabsContext>
-    </NavigationContent>
+    <NativeTabsContext value>
+      <NativeTabsView
+        {...nativeTabsViewProps}
+        key={visibleTabsKeys}
+        focusedIndex={focusedIndex}
+        // Provenance should only be sent with updates, and updates
+        // on JS side are only triggered by rerender, so passing ref
+        // here is ok.
+        provenance={provenanceRef.current}
+        tabs={visibleTabs}
+        onTabChange={onTabChange}
+      />
+    </NativeTabsContext>
   );
 }
 
-const createNativeTabNavigator = createNavigatorFactory(NativeTabsNavigator);
-
-const NativeTabsNavigatorWithContext = withLayoutContext<
+const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
   NativeTabOptions,
-  typeof NativeTabsNavigator,
   TabNavigationState<ParamListBase>,
-  NativeTabNavigationEventMap
->(createNativeTabNavigator().Navigator, undefined, true);
+  NativeTabNavigationEventMap,
+  Omit<InternalNativeTabsProps, 'screenListeners'>,
+  TabRouterOptions
+>(NativeTabsContent, NativeBottomTabsRouter, { useOnlyUserDefinedScreens: true });
 
 export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
   const triggerChildren = useMemo(
@@ -209,11 +182,77 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
     [props.children]
   );
 
+  const {
+    backBehavior = defaultBackBehavior,
+    labelStyle,
+    iconColor,
+    blurEffect,
+    backgroundColor,
+    badgeBackgroundColor,
+    indicatorColor,
+    badgeTextColor,
+    shadowColor,
+    rippleColor,
+    disableIndicator,
+    labelVisibilityMode,
+    tintColor,
+    disableTransparentOnScrollEdge,
+  } = props;
+
+  const screenOptions = useMemo(() => {
+    const processedLabelStyle = convertLabelStylePropToObject(labelStyle);
+    const processedIconColor = convertIconColorPropToObject(iconColor);
+
+    const selectedLabelStyle = processedLabelStyle.selected
+      ? {
+          ...processedLabelStyle.selected,
+          color: processedLabelStyle.selected.color ?? tintColor,
+        }
+      : tintColor
+        ? { color: tintColor }
+        : undefined;
+
+    return {
+      disableTransparentOnScrollEdge,
+      labelStyle: processedLabelStyle.default,
+      selectedLabelStyle,
+      iconColor: processedIconColor.default,
+      selectedIconColor: processedIconColor.selected ?? tintColor,
+      blurEffect,
+      backgroundColor,
+      badgeBackgroundColor,
+      indicatorColor,
+      badgeTextColor,
+      shadowColor,
+      rippleColor,
+      disableIndicator,
+      labelVisibilityMode,
+      tintColor,
+    };
+  }, [
+    labelStyle,
+    iconColor,
+    blurEffect,
+    backgroundColor,
+    badgeBackgroundColor,
+    indicatorColor,
+    badgeTextColor,
+    shadowColor,
+    rippleColor,
+    disableIndicator,
+    labelVisibilityMode,
+    tintColor,
+    disableTransparentOnScrollEdge,
+  ]);
+
   return (
     <NativeTabsNavigatorWithContext
       {...props}
       children={triggerChildren}
       nonTriggerChildren={nonTriggerChildren}
+      screenOptions={screenOptions}
+      // Passed to TabRouter
+      backBehavior={backBehavior}
     />
   );
 }

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -12,10 +12,9 @@ import type { SFSymbol } from 'sf-symbols-typescript';
 import type {
   DefaultRouterOptions,
   ParamListBase,
-  RouteProp,
-  ScreenListeners,
   TabNavigationState,
 } from '../react-navigation/native';
+import type { StandardUseNavigationBuilderOptions } from '../standard-navigation';
 import type { ScreenProps } from '../useScreens';
 
 /**
@@ -451,11 +450,12 @@ export interface NativeTabsProps extends PropsWithChildren {
    * </NativeTabs>
    * ```
    */
-  screenListeners?:
-    | ScreenListeners<TabNavigationState<ParamListBase>, NativeTabNavigationEventMap>
-    | ((prop: {
-        route: RouteProp<ParamListBase, string>;
-      }) => ScreenListeners<TabNavigationState<ParamListBase>, NativeTabNavigationEventMap>);
+  screenListeners?: StandardUseNavigationBuilderOptions<
+    TabNavigationState<ParamListBase>,
+    object,
+    NativeTabNavigationEventMap
+  >['screenListeners'];
+
   /**
    * Props passed to the underlying native tab host implementation in `react-native-screens`.
    * Use this to configure props that are not directly exposed by Expo Router.


### PR DESCRIPTION
# Why

Part of the `standard-navigation` migration. Moves native tabs off react-navigation's `useNavigationBuilder` / `withLayoutContext` and onto a `standard-navigation` navigator.

# How

- Replace `createNavigatorFactory` + `useNavigationBuilder` + `withLayoutContext` with `unstable_createStandardRouterNavigator`
- Split the component in two:
  - `NativeTabsContent` now consumes `NavigatorArgs` (`state`, `descriptors`, `actions`, `emitter`) instead of building them itself.
  - `NativeTabsNavigatorWrapper` computes the memoized `screenOptions` from the style props and forwards `backBehavior` to the router.
- Drive navigation through discrete actions: `actions.navigate(name)` instead of dispatching `JUMP_TO`, and `emitter.emit` instead of `navigation.emit`.
- Derive the `screenListeners` prop type from `StandardUseNavigationBuilderOptions` instead of react-navigation's `ScreenListeners`.
- Drop `getPathFromState` from the focused-tab error message (use the route `href` / `name`), and guard native tab changes for an unknown key with a dev warning instead of crashing on a missing descriptor.
- Add a compile-time guard so only props `NativeTabsView` declares can be spread onto it.

# Test Plan

1. CI
2. Router e2e — native tabs on iOS & Android (tab switching, disabled tabs, hidden routes)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
