### PR TITLE
[docs] Add multi-pm (package managers)Terminal blocks in Reference

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -1,22 +1,27 @@
 import { PropsWithChildren } from 'react';
 
 import { usePageMetadata } from '~/providers/page-metadata';
-import { Terminal } from '~/ui/components/Snippet';
+import { Terminal, type PackageManagerCommandSet } from '~/ui/components/Snippet';
 import { A, P, CODE } from '~/ui/components/Text';
 
 type InstallSectionProps = PropsWithChildren<{
   packageName: string;
   hideBareInstructions?: boolean;
-  cmd?: string[];
+  cmd?: string[] | PackageManagerCommandSet;
   href?: string;
 }>;
 
-const getInstallCmd = (packageName: string) => `$ npx expo install ${packageName}`;
+const getInstallCmd = (packageName: string): PackageManagerCommandSet => ({
+  npm: [`$ npx expo install ${packageName}`],
+  yarn: [`$ yarn expo install ${packageName}`],
+  pnpm: [`$ pnpm expo install ${packageName}`],
+  bun: [`$ bun expo install ${packageName}`],
+});
 
 export default function InstallSection({
   packageName,
   hideBareInstructions = false,
-  cmd = [getInstallCmd(packageName)],
+  cmd = getInstallCmd(packageName),
   href,
 }: InstallSectionProps) {
   if (href) {

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -25,7 +25,14 @@ The Expo SDK is a collection of packages that provide access to device and syste
 
 You can install any Expo SDK package using the [`npx expo install`](/more/expo-cli/#install) command. For example, three different packages are installed using the following command:
 
-<Terminal cmd={['$ npx expo install expo-camera expo-contacts expo-sensors']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-camera expo-contacts expo-sensors'],
+    yarn: ['$ yarn expo install expo-camera expo-contacts expo-sensors'],
+    pnpm: ['$ pnpm expo install expo-camera expo-contacts expo-sensors'],
+    bun: ['$ bun expo install expo-camera expo-contacts expo-sensors'],
+  }}
+/>
 
 After installing one or more packages, you can import them into your JavaScript code:
 
@@ -42,8 +49,21 @@ This allows you to write [`Contact.getAll()`](./sdk/contacts#contactgetalloption
 Expo apps are React Native apps, so all Expo SDK packages work in any React Native app with the `expo` package installed and configured. The easiest way to create a React Native app with support for Expo SDK packages is to use `create-expo-app`. However, you can also add Expo SDK support to an existing React Native app with the `npx install-expo-modules` command.
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={{
+    npm: [
+      '# Create a project named my-app',
+      '$ npx create-expo-app my-app --template bare-minimum',
+    ],
+    yarn: [
+      '# Create a project named my-app',
+      '$ yarn create expo-app my-app --template bare-minimum',
+    ],
+    pnpm: [
+      '# Create a project named my-app',
+      '$ pnpm create expo-app my-app --template bare-minimum',
+    ],
+    bun: ['# Create a project named my-app', '$ bun create expo my-app --template bare-minimum'],
+  }}
 />
 
 <BoxLink
@@ -74,11 +94,24 @@ New Expo SDK versions are released three times each year. Between these releases
 Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `56.0.0-canary-20260506-03817f5`. To install the latest canary release:
 
 <Terminal
-  cmd={[
-    '# Install the alpha version of expo and its related packages',
-    '$ npm install expo@canary && npx expo install --fix',
-  ]}
-  cmdCopy="npm install expo@canary && npx expo install --fix"
+  cmd={{
+    npm: [
+      '# Install the alpha version of expo and its related packages',
+      '$ npm install expo@canary && npx expo install --fix',
+    ],
+    yarn: [
+      '# Install the alpha version of expo and its related packages',
+      '$ yarn add expo@canary && yarn expo install --fix',
+    ],
+    pnpm: [
+      '# Install the alpha version of expo and its related packages',
+      '$ pnpm add expo@canary && pnpm expo install --fix',
+    ],
+    bun: [
+      '# Install the alpha version of expo and its related packages',
+      '$ bun add expo@canary && bun expo install --fix',
+    ],
+  }}
 />
 
 You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in canary-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the canary package and once you have verified that it works well for your use cases.

--- a/docs/pages/versions/unversioned/sdk/dev-menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-menu.mdx
@@ -66,7 +66,14 @@ If you are using [development builds](/develop/development-builds/introduction/)
 - Improved debugging tools
 - Support for loading updates from [EAS Update](/eas-update/introduction/)
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 For more information, check the [`expo-dev-client` reference](/versions/latest/sdk/dev-client/).
 

--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -21,11 +21,25 @@ import { CODE } from '~/ui/components/Text';
 
 If you wish to use `@expo/fingerprint` as a standalone package, you can install it by running the command:
 
-<Terminal cmd={['$ npx expo install @expo/fingerprint']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/fingerprint'],
+    yarn: ['$ yarn expo install @expo/fingerprint'],
+    pnpm: ['$ pnpm expo install @expo/fingerprint'],
+    bun: ['$ bun expo install @expo/fingerprint'],
+  }}
+/>
 
 ## CLI Usage
 
-<Terminal cmd={['$ npx @expo/fingerprint --help']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx @expo/fingerprint --help'],
+    yarn: ['$ yarn dlx @expo/fingerprint --help'],
+    pnpm: ['$ pnpm dlx @expo/fingerprint --help'],
+    bun: ['$ bunx @expo/fingerprint --help'],
+  }}
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -159,7 +159,14 @@ This guide demonstrates how to create a blurhash of an uploaded image on the bac
 
 Start by installing a few dependencies: [`multer`](https://github.com/expressjs/multer) for handling multipart requests, [`sharp`](https://github.com/lovell/sharp) for converting files to a data buffer, and the official [`blurhash` JavaScript package](https://github.com/woltapp/blurhash/tree/master/TypeScript).
 
-<Terminal cmd={['$ npm install multer sharp blurhash']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install multer sharp blurhash'],
+    yarn: ['$ yarn add multer sharp blurhash'],
+    pnpm: ['$ pnpm add multer sharp blurhash'],
+    bun: ['$ bun add multer sharp blurhash'],
+  }}
+/>
 
 Next, import all required functions from installed packages and initialize `multer`:
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -18,7 +18,14 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 ## Installation
 
-<Terminal cmd={['$ npx expo install react-native-reanimated react-native-worklets']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-native-reanimated react-native-worklets'],
+    yarn: ['$ yarn expo install react-native-reanimated react-native-worklets'],
+    pnpm: ['$ pnpm expo install react-native-reanimated react-native-worklets'],
+    bun: ['$ bun expo install react-native-reanimated react-native-worklets'],
+  }}
+/>
 
 <br />
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -29,7 +29,14 @@ An icon component for rendering Material Symbol XML vector drawables in Jetpack 
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/material-symbols'],
+    yarn: ['$ yarn expo install @expo/material-symbols'],
+    pnpm: ['$ pnpm expo install @expo/material-symbols'],
+    bun: ['$ bun expo install @expo/material-symbols'],
+  }}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
@@ -20,7 +20,14 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles on the Jetpack Compose Icon page](/versions/latest/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/material-symbols'],
+    yarn: ['$ yarn expo install @expo/material-symbols'],
+    pnpm: ['$ pnpm expo install @expo/material-symbols'],
+    bun: ['$ bun expo install @expo/material-symbols'],
+  }}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/v56.0.0/index.mdx
+++ b/docs/pages/versions/v56.0.0/index.mdx
@@ -25,7 +25,14 @@ The Expo SDK is a collection of packages that provide access to device and syste
 
 You can install any Expo SDK package using the [`npx expo install`](/more/expo-cli/#install) command. For example, three different packages are installed using the following command:
 
-<Terminal cmd={['$ npx expo install expo-camera expo-contacts expo-sensors']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-camera expo-contacts expo-sensors'],
+    yarn: ['$ yarn expo install expo-camera expo-contacts expo-sensors'],
+    pnpm: ['$ pnpm expo install expo-camera expo-contacts expo-sensors'],
+    bun: ['$ bun expo install expo-camera expo-contacts expo-sensors'],
+  }}
+/>
 
 After installing one or more packages, you can import them into your JavaScript code:
 
@@ -42,8 +49,21 @@ This allows you to write [`Contact.getAll()`](./sdk/contacts#contactgetalloption
 Expo apps are React Native apps, so all Expo SDK packages work in any React Native app with the `expo` package installed and configured. The easiest way to create a React Native app with support for Expo SDK packages is to use `create-expo-app`. However, you can also add Expo SDK support to an existing React Native app with the `npx install-expo-modules` command.
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={{
+    npm: [
+      '# Create a project named my-app',
+      '$ npx create-expo-app my-app --template bare-minimum',
+    ],
+    yarn: [
+      '# Create a project named my-app',
+      '$ yarn create expo-app my-app --template bare-minimum',
+    ],
+    pnpm: [
+      '# Create a project named my-app',
+      '$ pnpm create expo-app my-app --template bare-minimum',
+    ],
+    bun: ['# Create a project named my-app', '$ bun create expo my-app --template bare-minimum'],
+  }}
 />
 
 <BoxLink
@@ -74,11 +94,24 @@ New Expo SDK versions are released three times each year. Between these releases
 Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `56.0.0-canary-20260506-03817f5`. To install the latest canary release:
 
 <Terminal
-  cmd={[
-    '# Install the alpha version of expo and its related packages',
-    '$ npm install expo@canary && npx expo install --fix',
-  ]}
-  cmdCopy="npm install expo@canary && npx expo install --fix"
+  cmd={{
+    npm: [
+      '# Install the alpha version of expo and its related packages',
+      '$ npm install expo@canary && npx expo install --fix',
+    ],
+    yarn: [
+      '# Install the alpha version of expo and its related packages',
+      '$ yarn add expo@canary && yarn expo install --fix',
+    ],
+    pnpm: [
+      '# Install the alpha version of expo and its related packages',
+      '$ pnpm add expo@canary && pnpm expo install --fix',
+    ],
+    bun: [
+      '# Install the alpha version of expo and its related packages',
+      '$ bun add expo@canary && bun expo install --fix',
+    ],
+  }}
 />
 
 You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in canary-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the canary package and once you have verified that it works well for your use cases.

--- a/docs/pages/versions/v56.0.0/sdk/dev-menu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/dev-menu.mdx
@@ -66,7 +66,14 @@ If you are using [development builds](/develop/development-builds/introduction/)
 - Improved debugging tools
 - Support for loading updates from [EAS Update](/eas-update/introduction/)
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 For more information, check the [`expo-dev-client` reference](/versions/latest/sdk/dev-client/).
 

--- a/docs/pages/versions/v56.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/fingerprint.mdx
@@ -21,11 +21,25 @@ import { CODE } from '~/ui/components/Text';
 
 If you wish to use `@expo/fingerprint` as a standalone package, you can install it by running the command:
 
-<Terminal cmd={['$ npx expo install @expo/fingerprint']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/fingerprint'],
+    yarn: ['$ yarn expo install @expo/fingerprint'],
+    pnpm: ['$ pnpm expo install @expo/fingerprint'],
+    bun: ['$ bun expo install @expo/fingerprint'],
+  }}
+/>
 
 ## CLI Usage
 
-<Terminal cmd={['$ npx @expo/fingerprint --help']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx @expo/fingerprint --help'],
+    yarn: ['$ yarn dlx @expo/fingerprint --help'],
+    pnpm: ['$ pnpm dlx @expo/fingerprint --help'],
+    bun: ['$ bunx @expo/fingerprint --help'],
+  }}
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/v56.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/image.mdx
@@ -159,7 +159,14 @@ This guide demonstrates how to create a blurhash of an uploaded image on the bac
 
 Start by installing a few dependencies: [`multer`](https://github.com/expressjs/multer) for handling multipart requests, [`sharp`](https://github.com/lovell/sharp) for converting files to a data buffer, and the official [`blurhash` JavaScript package](https://github.com/woltapp/blurhash/tree/master/TypeScript).
 
-<Terminal cmd={['$ npm install multer sharp blurhash']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install multer sharp blurhash'],
+    yarn: ['$ yarn add multer sharp blurhash'],
+    pnpm: ['$ pnpm add multer sharp blurhash'],
+    bun: ['$ bun add multer sharp blurhash'],
+  }}
+/>
 
 Next, import all required functions from installed packages and initialize `multer`:
 

--- a/docs/pages/versions/v56.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/reanimated.mdx
@@ -18,7 +18,14 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 ## Installation
 
-<Terminal cmd={['$ npx expo install react-native-reanimated react-native-worklets']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-native-reanimated react-native-worklets'],
+    yarn: ['$ yarn expo install react-native-reanimated react-native-worklets'],
+    pnpm: ['$ pnpm expo install react-native-reanimated react-native-worklets'],
+    bun: ['$ bun expo install react-native-reanimated react-native-worklets'],
+  }}
+/>
 
 <br />
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
@@ -29,7 +29,14 @@ An icon component for rendering Material Symbol XML vector drawables in Jetpack 
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/material-symbols'],
+    yarn: ['$ yarn expo install @expo/material-symbols'],
+    pnpm: ['$ pnpm expo install @expo/material-symbols'],
+    bun: ['$ bun expo install @expo/material-symbols'],
+  }}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
@@ -20,7 +20,14 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles on the Jetpack Compose Icon page](/versions/v56.0.0/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/material-symbols'],
+    yarn: ['$ yarn expo install @expo/material-symbols'],
+    pnpm: ['$ pnpm expo install @expo/material-symbols'],
+    bun: ['$ bun expo install @expo/material-symbols'],
+  }}
+/>
 
 ## Usage
 

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -22,7 +22,7 @@ import {
 } from './packageManagerStore';
 import type { PackageManagerKey } from './packageManagerStore';
 
-type PackageManagerCommandSet = Partial<Record<PackageManagerKey, string[]>>;
+export type PackageManagerCommandSet = Partial<Record<PackageManagerKey, string[]>>;
 
 type TerminalProps = {
   cmd: string[] | PackageManagerCommandSet;

--- a/docs/ui/components/Snippet/index.ts
+++ b/docs/ui/components/Snippet/index.ts
@@ -1,3 +1,4 @@
 export { DiffBlock } from './blocks/DiffBlock';
 export { SnackInline } from './blocks/SnackInline';
 export { Terminal } from './blocks/Terminal';
+export type { PackageManagerCommandSet } from './blocks/Terminal';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Follow-up https://github.com/expo/expo/pull/46338

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update Reference section Terminal references to include npm, yarn, pnpm, and bun variants where Expo docs conventions call for multi-package-manager commands.
- Update InstallSection component to support all 4 package managers.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
