### PR TITLE
[docs] Clarify env variable visibility in Sentry guide

### DIFF
--- a/docs/pages/eas/environment-variables/index.mdx
+++ b/docs/pages/eas/environment-variables/index.mdx
@@ -124,7 +124,7 @@ There are three different visibility settings available for each environment var
 
 > **warning** Note that **anything that is included in your client-side code should be considered public and readable to any individual that can run your app**.
 
-> **warning** **Secret type environment variables** are intended to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs. For example, setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
+> **warning** **Secret type environment variables** are intended to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs. For example, setting an `NPM_TOKEN` to install private packages from npm. Secrets do not provide any additional security for values that you end up embedding in your application itself.
 
 ## Where to go next
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -95,7 +95,7 @@ import { Button } from 'react-native';
 
 ## Usage with EAS Build
 
-Ensure that `SENTRY_AUTH_TOKEN` is set in your build environment, and Sentry will automatically upload source maps for you. If you use environment variables rather than properties in your app config, ensure that those are set as well.
+Ensure that `SENTRY_AUTH_TOKEN` is set in your build environment with [sensitive visibility](/eas/environment-variables/#visibility-settings-for-environment-variables). Sentry will automatically upload source maps for you. If you use environment variables rather than properties in your app config, ensure that those are set as well.
 
 Using the above instructions, no additional work is needed to integrate Sentry into your project when using EAS Build.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21511

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add clarification to set `SENTRY_AUTH_TOKEN` with `sensitive` visibility in `guides/using-sentry.mdx`, linking to the visibility settings reference. 
- Remove the misleading Sentry example from the secret-variables warning in `eas/environment-variables/index.mdx`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2400" height="376" alt="CleanShot 2026-06-01 at 18 52 55@2x" src="https://github.com/user-attachments/assets/2484b5ed-e947-44dc-80c9-4f2df2c66c28" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
