### PR TITLE
[widgets][plugin] Add `enableAndroid` option to temporary disable android config plugin

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Temporarily make the Android config plugin opt-in with `enableAndroid`.
+- Temporarily make the Android config plugin opt-in with `enableAndroid`. ([#46463](https://github.com/expo/expo/pull/46463) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.15 — 2026-05-26
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Temporarily make the Android config plugin opt-in with `enableAndroid`.
+
 ## 56.0.15 — 2026-05-26
 
 ### 🎉 New features

--- a/packages/expo-widgets/plugin/build/withWidgets.d.ts
+++ b/packages/expo-widgets/plugin/build/withWidgets.d.ts
@@ -5,6 +5,11 @@ export type ExpoWidgetsConfigPluginProps = {
     groupIdentifier?: string;
     enablePushNotifications?: boolean;
     frequentUpdates?: boolean;
+    /**
+     * Enable the Android config plugin. Defaults to false.
+     * This option will be removed and Android widget will be enabled by default in the future.
+     */
+    enableAndroid?: boolean;
     widgets?: WidgetConfig[];
 };
 declare const _default: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined>;

--- a/packages/expo-widgets/plugin/build/withWidgets.js
+++ b/packages/expo-widgets/plugin/build/withWidgets.js
@@ -8,10 +8,9 @@ const withAndroidWidgets_1 = __importDefault(require("./android/withAndroidWidge
 const withIosWidgets_1 = __importDefault(require("./ios/withIosWidgets"));
 const pkg = require('../../package.json');
 const withWidgets = (config, props) => {
+    const enableAndroid = props?.enableAndroid ?? false;
     const widgets = props?.widgets ?? [];
-    return (0, config_plugins_1.withPlugins)(config, [
-        [withAndroidWidgets_1.default, { widgets }],
-        [withIosWidgets_1.default, { ...(props ?? {}), widgets }],
-    ]);
+    const nextConfig = enableAndroid ? (0, withAndroidWidgets_1.default)(config, { widgets }) : config;
+    return (0, withIosWidgets_1.default)(nextConfig, { ...props, widgets });
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withWidgets, pkg.name, pkg.version);

--- a/packages/expo-widgets/plugin/src/withWidgets.ts
+++ b/packages/expo-widgets/plugin/src/withWidgets.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin, createRunOncePlugin, withPlugins } from 'expo/config-plugins';
+import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
 import withAndroidWidgets from './android/withAndroidWidgets';
 import withIosWidgets from './ios/withIosWidgets';
@@ -15,16 +15,20 @@ export type ExpoWidgetsConfigPluginProps = {
   enablePushNotifications?: boolean;
   // Enable frequent updates for widgets. Defaults to false.
   frequentUpdates?: boolean;
+  /**
+   * Enable the Android config plugin. Defaults to false.
+   * This option will be removed and Android widget will be enabled by default in the future.
+   */
+  enableAndroid?: boolean;
   widgets?: WidgetConfig[];
 };
 
 const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined> = (config, props) => {
+  const enableAndroid = props?.enableAndroid ?? false;
   const widgets = props?.widgets ?? [];
 
-  return withPlugins(config, [
-    [withAndroidWidgets, { widgets }],
-    [withIosWidgets, { ...(props ?? {}), widgets }],
-  ]);
+  const nextConfig = enableAndroid ? withAndroidWidgets(config, { widgets }) : config;
+  return withIosWidgets(nextConfig, { ...props, widgets });
 };
 
 export default createRunOncePlugin(withWidgets, pkg.name, pkg.version);


### PR DESCRIPTION
# Why

Android widgets are still in development, but part of that is already cherry-picked to SDK 56.

# How

Add a temporary `enableAndroid` flag to `expo-widgets` so Android config plugin wiring only runs when explicitly enabled.

# Test Plan

Create a project with expo-widgets and do not set `enableAndroid: true`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
