### PR TITLE
Pick Host component colorScheme docs update in SDK 56

### DIFF
--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/host.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/host.mdx
@@ -127,7 +127,7 @@ export default function IgnoreSafeAreaExample() {
 
 ### Forcing a color scheme
 
-Use `colorScheme` to override the appearance of descendant native views. Pass `'light'` or `'dark'` to force one, or omit it to follow the device setting. Android and iOS only — ignored on web.
+Use `colorScheme` to override the appearance of the subtree. Pass `'light'` or `'dark'` to force one, or omit it to follow the device setting. On Android and iOS, this is forwarded to the platform-native `Host` (see [Jetpack Compose](../jetpack-compose/host)/[SwiftUI](../swift-ui/host) for the exact platform semantics). On web, it sets `data-theme` on the underlying `View` so the design-token CSS variables resolve to the forced scheme regardless of `prefers-color-scheme`.
 
 ```tsx HostColorSchemeExample.tsx
 import { Host, Button } from '@expo/ui';


### PR DESCRIPTION
Pick documentation change to SDK 56 docs before cherry-picks.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
