### PR TITLE
[create-expo] Add optional Expo Skills prompt

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add optional Expo Skills installation for new projects, with interactive skill and agent selection.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/src/__tests__/installAgentSkills.test.ts
+++ b/packages/create-expo/src/__tests__/installAgentSkills.test.ts
@@ -1,0 +1,115 @@
+import type { SpawnResult } from '@expo/spawn-async';
+import spawnAsync from '@expo/spawn-async';
+import prompts from 'prompts';
+
+import {
+  installAgentSkillsAsync,
+  maybeInstallAgentSkillsAsync,
+  shouldInstallAgentSkillsAsync,
+} from '../installAgentSkills';
+import type { PackageManagerName } from '../resolvePackageManager';
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+const originalConsoleError = console.error;
+const originalEnv = process.env;
+
+jest.mock('@expo/spawn-async');
+jest.mock('prompts');
+
+beforeAll(() => {
+  console.error = jest.fn();
+});
+
+afterAll(() => {
+  console.error = originalConsoleError;
+  process.env = originalEnv;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...originalEnv };
+});
+
+describe(shouldInstallAgentSkillsAsync, () => {
+  it('uses the explicit agent skills option when provided', async () => {
+    await expect(shouldInstallAgentSkillsAsync({ agentSkills: true, yes: true })).resolves.toBe(
+      true
+    );
+    await expect(shouldInstallAgentSkillsAsync({ agentSkills: false, yes: false })).resolves.toBe(
+      false
+    );
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or install in yes mode by default', async () => {
+    await expect(shouldInstallAgentSkillsAsync({ yes: true })).resolves.toBe(false);
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or install in CI by default', async () => {
+    process.env.CI = '1';
+
+    await expect(shouldInstallAgentSkillsAsync({ yes: false })).resolves.toBe(false);
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('prompts in interactive mode', async () => {
+    asMock(prompts).mockResolvedValueOnce({ answer: true });
+
+    await expect(shouldInstallAgentSkillsAsync({ yes: false })).resolves.toBe(true);
+    expect(prompts).toHaveBeenCalledWith({
+      type: 'confirm',
+      name: 'answer',
+      message: 'Add Expo agent skills to this project?',
+      initial: false,
+    });
+  });
+});
+
+describe(installAgentSkillsAsync, () => {
+  it.each<[PackageManagerName, string, string[]]>([
+    ['npm', 'npx', ['--yes', 'skills', 'add', 'expo/skills', '--copy']],
+    ['yarn', 'yarn', ['dlx', 'skills', 'add', 'expo/skills', '--copy']],
+    ['pnpm', 'pnpm', ['dlx', 'skills', 'add', 'expo/skills', '--copy']],
+    ['bun', 'bunx', ['skills', 'add', 'expo/skills', '--copy']],
+  ])('runs the skills CLI with %s', async (packageManager, command, args) => {
+    asMock(spawnAsync).mockResolvedValueOnce({} as SpawnResult);
+
+    await expect(installAgentSkillsAsync('/tmp/my-app', packageManager)).resolves.toBe(true);
+    expect(spawnAsync).toHaveBeenCalledWith(command, args, {
+      cwd: '/tmp/my-app',
+      stdio: 'inherit',
+    });
+  });
+
+  it('returns false when skills installation fails', async () => {
+    asMock(spawnAsync).mockRejectedValueOnce(new Error('failed'));
+
+    await expect(installAgentSkillsAsync('/tmp/my-app', 'npm')).resolves.toBe(false);
+  });
+});
+
+describe(maybeInstallAgentSkillsAsync, () => {
+  it('skips installation when agent skills are not selected', async () => {
+    await maybeInstallAgentSkillsAsync('/tmp/my-app', { agentSkills: false, yes: false }, 'npm');
+
+    expect(spawnAsync).not.toHaveBeenCalled();
+  });
+
+  it('installs when agent skills are selected', async () => {
+    asMock(spawnAsync).mockResolvedValueOnce({} as SpawnResult);
+
+    await maybeInstallAgentSkillsAsync('/tmp/my-app', { agentSkills: true, yes: true }, 'npm');
+
+    expect(spawnAsync).toHaveBeenCalledWith(
+      'npx',
+      ['--yes', 'skills', 'add', 'expo/skills', '--copy'],
+      {
+        cwd: '/tmp/my-app',
+        stdio: 'inherit',
+      }
+    );
+  });
+});

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -17,6 +17,8 @@ async function run() {
     '--yes': Boolean,
     '--no-install': Boolean,
     '--no-agents-md': Boolean,
+    '--agent-skills': Boolean,
+    '--no-agent-skills': Boolean,
     '--help': Boolean,
     '--version': Boolean,
     // Aliases
@@ -42,6 +44,8 @@ async function run() {
         `-y, --yes             Use the default options for creating a project`,
         `    --no-install      Skip installing npm packages or CocoaPods`,
         `    --no-agents-md    Skip generating AGENTS.md, CLAUDE.md, and .claude/settings.json`,
+        `    --agent-skills    Install Expo agent skills for this project`,
+        `    --no-agent-skills Do not prompt to install Expo agent skills`,
         chalk`-t, --template {gray [pkg]}  NPM template to use: default, blank, blank-typescript, tabs, bare-minimum. Default: default`,
         chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
         `-v, --version         Version number`,
@@ -88,6 +92,7 @@ async function run() {
       example: parsed.args['--example'],
       install: !args['--no-install'],
       agentsMd: !args['--no-agents-md'],
+      agentSkills: args['--no-agent-skills'] ? false : args['--agent-skills'],
     });
 
     // Track successful event.

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -12,6 +12,7 @@ import {
 } from './Examples';
 import * as Template from './Template';
 import { generateAgentFiles } from './generateAgentFiles';
+import { maybeInstallAgentSkillsAsync } from './installAgentSkills';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
 import { applySdkVersionToTemplateAsync } from './promptSdkVersion';
@@ -38,6 +39,7 @@ export type Options = {
   example?: string | true;
   yes: boolean;
   agentsMd: boolean;
+  agentSkills?: boolean;
 };
 
 const debug = require('debug')('expo:init:create') as typeof console.log;
@@ -57,7 +59,10 @@ async function resolveProjectRootArgAsync(
   }
 }
 
-async function setupDependenciesAsync(projectRoot: string, props: Pick<Options, 'install'>) {
+async function setupDependenciesAsync(
+  projectRoot: string,
+  props: Pick<Options, 'install'>
+): Promise<PackageManagerName> {
   const shouldInstall = props.install;
   const packageManager = resolvePackageManager();
 
@@ -79,6 +84,7 @@ async function setupDependenciesAsync(projectRoot: string, props: Pick<Options, 
   if (!shouldInstall) {
     logNodeInstallWarning(cdPath, packageManager, needsPodsInstalled && !podsInstalled);
   }
+  return packageManager;
 }
 
 export async function createAsync(inputPath: string, options: Options): Promise<void> {
@@ -135,7 +141,7 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     }
   );
 
-  await setupDependenciesAsync(projectRoot, props);
+  const packageManager = await setupDependenciesAsync(projectRoot, props);
 
   if (props.agentsMd) {
     generateAgentFiles(projectRoot);
@@ -153,6 +159,8 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     debug(`Error initializing git: %O`, error);
     // todo: check if git is installed, bail out
   }
+
+  await maybeInstallAgentSkillsAsync(projectRoot, props, packageManager);
 }
 
 async function createExampleAsync(inputPath: string, props: Options): Promise<void> {
@@ -224,7 +232,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
       `Something went wrong in downloading and extracting the example files: ${error.message}`,
   });
 
-  await setupDependenciesAsync(projectRoot, props);
+  const packageManager = await setupDependenciesAsync(projectRoot, props);
 
   if (props.agentsMd) {
     generateAgentFiles(projectRoot);
@@ -242,6 +250,8 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
     debug(`Error initializing git: %O`, error);
     // todo: check if git is installed, bail out
   }
+
+  await maybeInstallAgentSkillsAsync(projectRoot, props, packageManager);
 }
 
 function getChangeDirectoryPath(projectRoot: string): string {

--- a/packages/create-expo/src/installAgentSkills.ts
+++ b/packages/create-expo/src/installAgentSkills.ts
@@ -1,0 +1,115 @@
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import prompts from 'prompts';
+
+import { Log } from './log';
+import type { PackageManagerName } from './resolvePackageManager';
+import { env } from './utils/env';
+import { withSectionLog } from './utils/log';
+
+const debug = require('debug')('expo:init:agent-skills') as typeof console.log;
+
+export type AgentSkillsOptions = {
+  agentSkills?: boolean;
+  yes: boolean;
+};
+
+type InstallAgentSkillsCommand = {
+  command: string;
+  args: string[];
+  display: string;
+};
+
+function resolveInstallAgentSkillsCommand(
+  packageManager: PackageManagerName
+): InstallAgentSkillsCommand {
+  switch (packageManager) {
+    case 'yarn':
+      return {
+        command: 'yarn',
+        args: ['dlx', 'skills', 'add', 'expo/skills', '--copy'],
+        display: 'yarn dlx skills add expo/skills --copy',
+      };
+    case 'pnpm':
+      return {
+        command: 'pnpm',
+        args: ['dlx', 'skills', 'add', 'expo/skills', '--copy'],
+        display: 'pnpm dlx skills add expo/skills --copy',
+      };
+    case 'bun':
+      return {
+        command: 'bunx',
+        args: ['skills', 'add', 'expo/skills', '--copy'],
+        display: 'bunx skills add expo/skills --copy',
+      };
+    case 'npm':
+    default:
+      return {
+        command: 'npx',
+        args: ['--yes', 'skills', 'add', 'expo/skills', '--copy'],
+        display: 'npx --yes skills add expo/skills --copy',
+      };
+  }
+}
+
+export async function shouldInstallAgentSkillsAsync(props: AgentSkillsOptions): Promise<boolean> {
+  if (props.agentSkills != null) {
+    return props.agentSkills;
+  }
+
+  if (props.yes || env.CI) {
+    return false;
+  }
+
+  const { answer } = await prompts({
+    type: 'confirm',
+    name: 'answer',
+    message: 'Add Expo agent skills to this project?',
+    initial: false,
+  });
+
+  return answer === true;
+}
+
+export async function installAgentSkillsAsync(
+  projectRoot: string,
+  packageManager: PackageManagerName
+): Promise<boolean> {
+  const installCommand = resolveInstallAgentSkillsCommand(packageManager);
+
+  try {
+    await withSectionLog(
+      (spinner) => {
+        spinner.stop();
+        return spawnAsync(installCommand.command, installCommand.args, {
+          cwd: projectRoot,
+          stdio: 'inherit',
+        });
+      },
+      {
+        pending: chalk.bold('Installing Expo agent skills.'),
+        success: 'Installed Expo agent skills.',
+        error: (error) => `Unable to install Expo agent skills: ${error.message}`,
+      }
+    );
+    return true;
+  } catch (error: any) {
+    debug(`Error installing Expo agent skills: %O`, error);
+    Log.error(
+      `Expo app created, but Expo agent skills installation failed. Run this inside your project: ${installCommand.display}`
+    );
+    return false;
+  }
+}
+
+export async function maybeInstallAgentSkillsAsync(
+  projectRoot: string,
+  props: AgentSkillsOptions,
+  packageManager: PackageManagerName
+): Promise<void> {
+  if (!(await shouldInstallAgentSkillsAsync(props))) {
+    return;
+  }
+
+  await installAgentSkillsAsync(projectRoot, packageManager);
+}


### PR DESCRIPTION
## Summary

- adds `--agent-skills` / `--no-agent-skills` to `create-expo`
- prompts interactive users before installing Expo Skills
- delegates skill and agent selection to the `skills` CLI
- keeps `--yes` and CI flows non-interactive by default

Related to #46472.

## Decisions needed

- Should the default prompt answer be yes or no?
- Which Expo-maintained skills should be selected by default, if any?
- Should this only promote Expo-maintained skills, or can it include vetted community skills too?

## Test plan

- `pnpm --filter create-expo build`
- `pnpm --filter create-expo test`
- `pnpm --filter create-expo typecheck`
- `pnpm --filter create-expo lint`
