### PR TITLE
[expo-crypto] - Remove Swift macro dependency from randomUUID

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed iOS builds by removing the Swift macro dependency from `randomUUID()`.
+- Fixed iOS builds by removing the Swift macro dependency from `randomUUID()`. ([#46477](https://github.com/expo/expo/pull/46477) by [@AbbanMustafa](https://github.com/AbbanMustafa))
 
 ### 💡 Others
 

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed iOS builds by removing the Swift macro dependency from `randomUUID()`.
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-26

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -15,12 +15,9 @@ public class CryptoModule: Module {
 
     Function("digest", digest)
 
-    Function("randomUUID", randomUUID())
-  }
-
-  @OptimizedFunction
-  private func randomUUID() -> String {
-    return UUID().uuidString.lowercased()
+    Function("randomUUID") {
+      return UUID().uuidString.lowercased()
+    }
   }
 }
 


### PR DESCRIPTION
# Why

```
❌  (../../node_modules/.pnpm/expo-crypto@56.0.4_expo@56.0.5/node_modules/expo-crypto/ios/CryptoModule.swift:22:16)

  20 | 
  21 |   @OptimizedFunction
> 22 |   private func randomUUID() -> String {
     |                ^ external macro implementation type 'ExpoModulesMacros.OptimizedFunctionAttachedMacro' could not be found for macro 'OptimizedFunction'; No such file or directory
  23 |     return UUID().uuidString.lowercased()
  24 |   }
  25 | }


❌  (../../node_modules/.pnpm/expo-crypto@56.0.4_expo@56.0.5/node_modules/expo-crypto/ios/CryptoModule.swift:18:28)

  16 |     Function("digest", digest)
  17 | 
> 18 |     Function("randomUUID", randomUUID())
     |                            ^ cannot convert value of type 'String' to expected argument type 'OptimizedFunctionDescriptor'
  19 |   }
  20 | 
  21 |   @OptimizedFunction
```
# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
