### PR TITLE
[docs] Update Google authentication guide for Credential Manager and Nitro Google Sign-In

### DIFF
--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -19,9 +19,8 @@ This guide provides information on how to configure the library for your project
 
 <Prerequisites>
   <Requirement title="A development build">
-    These libraries can't be used in Expo Go because they
-    require custom native code. Learn more about [adding custom native code to your
-    app](/workflow/customizing/).
+    These libraries can't be used in Expo Go because they require custom native code. Learn more
+    about [adding custom native code to your app](/workflow/customizing/).
   </Requirement>
 </Prerequisites>
 
@@ -59,6 +58,7 @@ We recommend uploading the app to the Google Play Store if your app intends to r
 ### Configure your Firebase or Google Cloud Console project
 
 > Refer to the library documentation for a more in-depth configuration guide:
+>
 > - [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io)
 > - [`@react-native-google-signin/google-signin`](https://react-native-google-signin.github.io/docs/setting-up/get-config-file)
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -8,12 +8,19 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 You can integrate Google authentication in your Expo app using either of the following libraries:
 
-- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io): Uses modern native APIs — including **Android Credential Manager**.
-- [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin): A widely used alternative implementation. Note that **Android Credential Manager APIs are available as part of their paid offering**.
+- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io): A library that uses modern native APIs.
+- [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin): A widely used library.
 
 Both libraries provide native sign-in buttons and support authenticating the user (and obtaining authorization to use Google APIs). Because they require custom native code, you'll need to use a [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/) and build a development build.
 
-> The legacy Google Sign-In SDK for Android (part of `com.google.android.gms:play-services-auth`) is deprecated and Google recommends migrating to **Android Credential Manager**. See [About the migration from legacy Google Sign-In](https://developer.android.com/identity/sign-in/legacy-gsi-migration).
+## Choosing a library
+
+When choosing between the two libraries, consider the following differences:
+
+- `react-native-nitro-google-signin` includes support for **Android Credential Manager**.
+- `@react-native-google-signin/google-signin` provides **Android Credential Manager APIs as part of their paid offering**.
+
+> **warning** The legacy Google Sign-In SDK for Android (part of `com.google.android.gms:play-services-auth`) is deprecated and Google recommends migrating to **Android Credential Manager**. See [About the migration from legacy Google Sign-In](https://developer.android.com/identity/sign-in/legacy-gsi-migration).
 
 This guide provides information on how to configure the library for your project.
 
@@ -57,10 +64,10 @@ We recommend uploading the app to the Google Play Store if your app intends to r
 
 ### Configure your Firebase or Google Cloud Console project
 
-> Refer to the library documentation for a more in-depth configuration guide:
->
-> - [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io)
-> - [`@react-native-google-signin/google-signin`](https://react-native-google-signin.github.io/docs/setting-up/get-config-file)
+Refer to the library documentation for a more in-depth configuration guide:
+
+- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io/docs/setup/google-cloud)
+- [`@react-native-google-signin/google-signin`](https://react-native-google-signin.github.io/docs/setting-up/get-config-file)
 
 For Android, once you have uploaded your app, you need to provide the SHA-1 certificate fingerprint values when asked while configuring the project in Firebase or Google Cloud Console. There are two types of values that you can provide:
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,26 +1,38 @@
 ---
 title: Using Google authentication
-description: A guide on using @react-native-google-signin/google-signin library to integrate Google authentication in your Expo project.
+description: A guide on using react-native-nitro-google-signin (Android Credential Manager) or @react-native-google-signin/google-signin to integrate Google authentication in your Expo project.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
-The [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin) library provides a way to integrate Google authentication in your Expo app. It also provides native sign-in buttons and supports authenticating the user as well as obtaining their authorization to use Google APIs. You can use the library in your project by adding the [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/).
+You can integrate Google authentication in your Expo app using either of the following libraries:
+
+- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io): Uses modern native APIs — including **Android Credential Manager**.
+- [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin): A widely used alternative implementation. Note that **Android Credential Manager APIs are available as part of their paid offering**.
+
+Both libraries provide native sign-in buttons and support authenticating the user (and obtaining authorization to use Google APIs). Because they require custom native code, you'll need to use a [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/) and build a development build.
+
+> The legacy Google Sign-In SDK for Android (part of `com.google.android.gms:play-services-auth`) is deprecated and Google recommends migrating to **Android Credential Manager**. See [About the migration from legacy Google Sign-In](https://developer.android.com/identity/sign-in/legacy-gsi-migration).
 
 This guide provides information on how to configure the library for your project.
 
 <Prerequisites>
   <Requirement title="A development build">
-    The `@react-native-google-signin/google-signin` library can't be used in Expo Go because it
-    requires custom native code. Learn more about [adding custom native code to your
+    These libraries can't be used in Expo Go because they
+    require custom native code. Learn more about [adding custom native code to your
     app](/workflow/customizing/).
   </Requirement>
 </Prerequisites>
 
 ## Installation
 
-See `@react-native-google-signin/google-signin` documentation for instructions on how to install and configure the library:
+Choose an installation guide based on the library you want to use:
+
+<BoxLink
+  title="React Native Nitro Google Sign-In"
+  href="https://react-native-nitro-google-signin.github.io"
+/>
 
 <BoxLink
   title="React Native Google Sign In: Expo installation instructions"
@@ -46,7 +58,9 @@ We recommend uploading the app to the Google Play Store if your app intends to r
 
 ### Configure your Firebase or Google Cloud Console project
 
-> Refer to the [library's documentation](https://react-native-google-signin.github.io/docs/setting-up/get-config-file) for a more in-depth configuration guide.
+> Refer to the library documentation for a more in-depth configuration guide:
+> - [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io)
+> - [`@react-native-google-signin/google-signin`](https://react-native-google-signin.github.io/docs/setting-up/get-config-file)
 
 For Android, once you have uploaded your app, you need to provide the SHA-1 certificate fingerprint values when asked while configuring the project in Firebase or Google Cloud Console. There are two types of values that you can provide:
 
@@ -58,7 +72,12 @@ For Android, once you have uploaded your app, you need to provide the SHA-1 cert
 For more instructions on how to configure your project for Android and iOS with Firebase:
 
 <BoxLink
-  title="Firebase"
+  title="Firebase (Nitro Google Sign-In)"
+  href="https://react-native-nitro-google-signin.github.io/docs/setup/expo#with-firebase--google-services-files-recommended"
+/>
+
+<BoxLink
+  title="Firebase (@react-native-google-signin/google-signin)"
   href="https://react-native-google-signin.github.io/docs/setting-up/expo#expo-and-firebase-authentication"
 />
 
@@ -78,6 +97,11 @@ This is an alternate method to configure a Google project when you are not using
 For more instructions on how to configure your Google project Android and iOS with Google Cloud Console:
 
 <BoxLink
-  title="Expo without Firebase"
+  title="Expo without Firebase (Nitro Google Sign-In)"
+  href="https://react-native-nitro-google-signin.github.io/docs/setup/expo#without-firebase-manual-ios-url-scheme"
+/>
+
+<BoxLink
+  title="Expo without Firebase (@react-native-google-signin/google-signin)"
   href="https://react-native-google-signin.github.io/docs/setting-up/expo#expo-without-firebase"
 />

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -8,7 +8,7 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 You can integrate Google authentication in your Expo app using either of the following libraries:
 
-- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io): A library that uses modern native APIs.
+- [`react-native-nitro-google-signin`](https://react-native-nitro-google-sign-in.github.io): A library that uses modern native APIs.
 - [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin): A widely used library.
 
 Both libraries provide native sign-in buttons and support authenticating the user (and obtaining authorization to use Google APIs). Because they require custom native code, you'll need to use a [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/) and build a development build.
@@ -37,7 +37,7 @@ Choose an installation guide based on the library you want to use:
 
 <BoxLink
   title="React Native Nitro Google Sign-In"
-  href="https://react-native-nitro-google-signin.github.io"
+  href="https://react-native-nitro-google-sign-in.github.io"
 />
 
 <BoxLink
@@ -66,7 +66,7 @@ We recommend uploading the app to the Google Play Store if your app intends to r
 
 Refer to the library documentation for a more in-depth configuration guide:
 
-- [`react-native-nitro-google-signin`](https://react-native-nitro-google-signin.github.io/docs/setup/google-cloud)
+- [`react-native-nitro-google-signin`](https://react-native-nitro-google-sign-in.github.io/docs/setup/google-cloud)
 - [`@react-native-google-signin/google-signin`](https://react-native-google-signin.github.io/docs/setting-up/get-config-file)
 
 For Android, once you have uploaded your app, you need to provide the SHA-1 certificate fingerprint values when asked while configuring the project in Firebase or Google Cloud Console. There are two types of values that you can provide:
@@ -80,7 +80,7 @@ For more instructions on how to configure your project for Android and iOS with 
 
 <BoxLink
   title="Firebase (Nitro Google Sign-In)"
-  href="https://react-native-nitro-google-signin.github.io/docs/setup/expo#with-firebase--google-services-files-recommended"
+  href="https://react-native-nitro-google-sign-in.github.io/docs/setup/expo#with-firebase--google-services-files-recommended"
 />
 
 <BoxLink
@@ -105,7 +105,7 @@ For more instructions on how to configure your Google project Android and iOS wi
 
 <BoxLink
   title="Expo without Firebase (Nitro Google Sign-In)"
-  href="https://react-native-nitro-google-signin.github.io/docs/setup/expo#without-firebase-manual-ios-url-scheme"
+  href="https://react-native-nitro-google-sign-in.github.io/docs/setup/expo#without-firebase-manual-ios-url-scheme"
 />
 
 <BoxLink

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Google authentication
-description: A guide on using react-native-nitro-google-signin (Android Credential Manager) or @react-native-google-signin/google-signin to integrate Google authentication in your Expo project.
+description: A guide on using react-native-nitro-google-signin or @react-native-google-signin/google-signin to integrate Google authentication in your Expo project.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';


### PR DESCRIPTION
# Why

Update Expo docs to reflect Google's recommendation to migrate from legacy Google Sign-In on Android to Credential Manager.

# How

- Document `react-native-nitro-google-signin` as the Credential Manager-based option.
- Keep `@react-native-google-signin/google-signin` as an alternative, noting Credential Manager support is part of its paid offering.
- Link to official Android guidance on migrating from legacy Google Sign-In to Credential Manager.

Proof: https://developer.android.com/identity/sign-in/legacy-gsi-migration

# Test Plan

- Verified the guide renders as valid MDX.
- Opened the external links to ensure they resolve.