### PR TITLE
[ui][ios] Fix TextField worklet onTextChange firing multiple times

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `TextField` and `SecureField` worklet `onTextChange` firing more than once per keystroke (when a change triggers reformatting) and on programmatic text updates. ([#46483](https://github.com/expo/expo/pull/46483) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Fix universal `TextInput` ignoring `style` `backgroundColor` / `borderWidth` and not applying `textAlign` to the placeholder. ([#46441](https://github.com/expo/expo/pull/46441) by [@duyanhv](https://github.com/duyanhv))
 
 ### 💡 Others

--- a/packages/expo-ui/ios/SecureFieldView.swift
+++ b/packages/expo-ui/ios/SecureFieldView.swift
@@ -70,8 +70,22 @@ private struct StatefulSecureField: View {
   @FocusState.Binding var isFocused: Bool
   let promptText: Text?
 
+  // See `StatefulTextField.userEditing` in TextFieldView.swift.
+  @State private var userEditing = false
+
+  private var textBinding: Binding<String> {
+    Binding(
+      get: { (state.value as? String) ?? "" },
+      set: { newValue in
+        let current = (state.value as? String) ?? ""
+        guard newValue != current else { return }
+        userEditing = true
+        state.value = newValue
+      }
+    )
+  }
+
   var body: some View {
-    let textBinding = state.binding("")
     SecureField(
       promptText == nil ? props.placeholder : "",
       text: textBinding,
@@ -84,10 +98,12 @@ private struct StatefulSecureField: View {
         }
       }
       .onChange(of: state.value as? String) { newValue in
+        guard userEditing else { return }
         if let max = props.maxLength, let str = newValue, str.count > max {
           state.value = String(str.prefix(max))
           return
         }
+        userEditing = false
         props.onTextChange(["value": newValue])
         props.onTextChangeSync?.invoke(arguments: [newValue])
       }

--- a/packages/expo-ui/ios/SecureFieldView.swift
+++ b/packages/expo-ui/ios/SecureFieldView.swift
@@ -70,8 +70,8 @@ private struct StatefulSecureField: View {
   @FocusState.Binding var isFocused: Bool
   let promptText: Text?
 
-  // See `StatefulTextField.userEditing` in TextFieldView.swift.
-  @State private var userEditing = false
+  // See `StatefulTextField.userMutatingState` in TextFieldView.swift.
+  @State private var userMutatingState = false
 
   private var textBinding: Binding<String> {
     Binding(
@@ -79,7 +79,7 @@ private struct StatefulSecureField: View {
       set: { newValue in
         let current = (state.value as? String) ?? ""
         guard newValue != current else { return }
-        userEditing = true
+        userMutatingState = true
         state.value = newValue
       }
     )
@@ -98,12 +98,12 @@ private struct StatefulSecureField: View {
         }
       }
       .onChange(of: state.value as? String) { newValue in
-        guard userEditing else { return }
+        guard userMutatingState else { return }
         if let max = props.maxLength, let str = newValue, str.count > max {
           state.value = String(str.prefix(max))
           return
         }
-        userEditing = false
+        userMutatingState = false
         props.onTextChange(["value": newValue])
         props.onTextChangeSync?.invoke(arguments: [newValue])
       }

--- a/packages/expo-ui/ios/TextFieldView.swift
+++ b/packages/expo-ui/ios/TextFieldView.swift
@@ -123,13 +123,27 @@ private struct StatefulTextField: View {
   @FocusState.Binding var isFocused: Bool
   let promptText: Text?
 
+  // True only while the current `state.value` change came from the user typing.
+  @State private var userMutatingState = false
+
   private var swiftUIAxis: Axis {
     props.axis == .vertical ? .vertical : .horizontal
   }
 
+  private var textBinding: Binding<String> {
+    Binding(
+      get: { (state.value as? String) ?? "" },
+      set: { newValue in
+        let current = (state.value as? String) ?? ""
+        guard newValue != current else { return }
+        userMutatingState = true
+        state.value = newValue
+      }
+    )
+  }
+
   @ViewBuilder
   var textField: some View {
-    let textBinding = state.binding("")
     if #available(iOS 16.0, tvOS 16.0, *) {
       TextField(
         promptText == nil ? props.placeholder : "",
@@ -156,10 +170,12 @@ private struct StatefulTextField: View {
         }
       }
       .onChange(of: state.value as? String) { newValue in
+        guard userMutatingState else { return }
         if let max = props.maxLength, let str = newValue, str.count > max {
           state.value = String(str.prefix(max))
           return
         }
+        userMutatingState = false
         props.onTextChange(["value": newValue])
         props.onTextChangeSync?.invoke(arguments: [newValue])
       }
@@ -184,13 +200,26 @@ private struct StatefulSelectableTextField: View {
   let promptText: Text?
 
   @State private var localSelection: SwiftUI.TextSelection?
+  // See `StatefulTextField.userMutatingState`.
+  @State private var userMutatingState = false
 
   private var swiftUIAxis: Axis {
     props.axis == .vertical ? .vertical : .horizontal
   }
 
+  private var textBinding: Binding<String> {
+    Binding(
+      get: { (state.value as? String) ?? "" },
+      set: { newValue in
+        let current = (state.value as? String) ?? ""
+        guard newValue != current else { return }
+        userMutatingState = true
+        state.value = newValue
+      }
+    )
+  }
+
   var body: some View {
-    let textBinding = state.binding("")
     TextField(
       promptText == nil ? props.placeholder : "",
       text: textBinding,
@@ -221,10 +250,12 @@ private struct StatefulSelectableTextField: View {
       props.onSelectionChange(["start": start, "end": end])
     }
     .onChange(of: state.value as? String) { newValue in
+      guard userMutatingState else { return }
       if let max = props.maxLength, let str = newValue, str.count > max {
         state.value = String(str.prefix(max))
         return
       }
+      userMutatingState = false
       props.onTextChange(["value": newValue])
       props.onTextChangeSync?.invoke(arguments: [newValue])
     }


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/46444

On iOS, the `TextField` / `SecureField` (and universal `TextInput`) worklet `onTextChange` fired more than once per keystroke when a change triggered a reformat, and also fired on programmatic text writes. Android already fires exactly once per user edit.

# How
Trigger callback only when value is updated by input change itself, and not when user manually sets the state. Matching with android.

# Test Plan

Repro from the issue: a `TextField` with `text={useNativeState('')}` and a masking `onTextChange` worklet that reformats the text and counts invocations via `runOnJS`.

- Before: typing `5551234` counts ~9 (digits that trigger a reformat fire twice); programmatic `setText` also fires `onTextChange`.
- After: counts 7 (one per keystroke); programmatic writes no longer fire `onTextChange`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
