### PR TITLE
[launcher][Android] Discover packagers across all connected networks on Android 33+

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Discover packagers across all connected networks on Android 33+.
+- [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Discover packagers across all connected networks on Android 33+.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
   <application>
     <meta-data

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
@@ -2,8 +2,10 @@ package expo.modules.devlauncher.nsd
 
 import android.app.Application
 import android.content.Context
+import android.net.NetworkRequest
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.os.Build
 import android.util.Log
 import expo.modules.devlauncher.helpers.await
 import expo.modules.devlauncher.services.PackagerInfo
@@ -81,13 +83,33 @@ internal abstract class NsdDiscoveryBase(
       return
     }
 
-    val listener = createDiscoveryListener()
-    discoveryListener = listener
-    manager.discoverServices(
-      SERVICE_TYPE,
-      NsdManager.PROTOCOL_DNS_SD,
-      listener
-    )
+    val listener = createDiscoveryListener().also {
+      discoveryListener = it
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      // Matches every network (clearing the default capabilities also drops NET_CAPABILITY_NOT_VPN,
+      // so VPN/proxy networks are included).
+      val discoveryNetworkRequest = NetworkRequest
+        .Builder()
+        .clearCapabilities()
+        .build()
+
+      manager.discoverServices(
+        SERVICE_TYPE,
+        NsdManager.PROTOCOL_DNS_SD,
+        discoveryNetworkRequest,
+        Runnable::run,
+        listener
+      )
+    } else {
+      manager.discoverServices(
+        SERVICE_TYPE,
+        NsdManager.PROTOCOL_DNS_SD,
+        listener
+      )
+    }
+
     isDiscovering = true
   }
 


### PR DESCRIPTION
# Why

Discovers packagers across all connected networks on Android 33+.

# How

On **API 33+**, switch to the `discoverServices` overload with a permissive `NetworkRequest` built via `clearCapabilities()`. The platform then registers a per-network discovery for every connected network, so packagers on secondary interfaces are discovered alongside the default-network ones. Clearing capabilities also drops `NET_CAPABILITY_NOT_VPN`, so VPN/proxy-backed networks match as well. However, it doesn't mean that the server behind the VPN will be discovered correctly. As far as I know, all Android VPNs are TUN-based. So they're point-to-point links, so the NSD multicast won't be carried through. 

# Test Plan

- bare-expo ✅ 