### PR TITLE
[docs] Clarify SecureStore is for small values in Store data overview

### DIFF
--- a/docs/pages/develop/user-interface/store-data.mdx
+++ b/docs/pages/develop/user-interface/store-data.mdx
@@ -11,7 +11,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
 
 ## Expo SecureStore
 
-`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. It's intended for small values such as tokens, keys, and other secrets.
 
 <BoxLink
   title="Expo SecureStore API reference"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Resolves ENG-21526

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adds one sentence to the Expo SecureStore section in `store-data.mdx` noting it's intended for small values such as tokens, keys, and other secrets.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
