### PR TITLE
[expo-navigation-bar] Apply `setStyle` and `setHidden` to React Native `<Modal>` windows via `ExtraWindowEventListener` on Android

### DIFF
--- a/apps/bare-expo/scripts/start-emulator.sh
+++ b/apps/bare-expo/scripts/start-emulator.sh
@@ -1,42 +1,50 @@
 #!/usr/bin/env bash
 
-port=${2:-8081}
-
 CURRENT_ENV=${NODE_ENV:-"development"}
 ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-$ANDROID_HOME}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+has_device=false
+
+for arg in "$@"; do
+    if [[ "$arg" == "--device" || "$arg" == "-d" ]]; then
+        has_device=true
+        break
+    fi
+done
+
 echo " ☛  Bootstrapping Expo in ${CURRENT_ENV} mode"
 
 "$DIR/setup-android-project.sh"
 
-if ! $ANDROID_SDK_ROOT/tools/android list avd | grep -q bare-expo; then
-    echo " ⚠️  No emulator for bare Expo found, creating one..."
-    $DIR/create-emulator.sh 34
-fi
+if ! $has_device; then
+    if ! $ANDROID_SDK_ROOT/tools/android list avd | grep -q bare-expo; then
+        echo " ⚠️  No emulator for bare Expo found, creating one..."
+        $DIR/create-emulator.sh 34
+    fi
 
-if $ANDROID_SDK_ROOT/platform-tools/adb devices -l | grep -q emulator; then
-    echo " ✅ Emulator is already running"
-else
-    echo " ⚠️  Starting emulator..."
-    echo "no" | $ANDROID_SDK_ROOT/emulator/emulator "-avd" "bare-expo" "-no-audio" "-no-boot-anim" "-port" "5554" "-no-snapshot" "-partition-size" "1024" &
+    if $ANDROID_SDK_ROOT/platform-tools/adb devices -l | grep -q emulator; then
+        echo " ✅ Emulator is already running"
+    else
+        echo " ⚠️  Starting emulator..."
+        echo "no" | $ANDROID_SDK_ROOT/emulator/emulator "-avd" "bare-expo" "-no-audio" "-no-boot-anim" "-port" "5554" "-no-snapshot" "-partition-size" "1024" &
 
-    $DIR/wait-for-emulator.sh
-    sleep 30
+        $DIR/wait-for-emulator.sh
+        sleep 30
 
-    $ANDROID_SDK_ROOT/platform-tools/adb wait-for-device
-    $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global window_animation_scale 0
-    $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global transition_animation_scale 0
-    $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global animator_duration_scale 0
-    $ANDROID_SDK_ROOT/platform-tools/adb shell am broadcast -a android.intent.action.BOOT_COMPLETED &
+        $ANDROID_SDK_ROOT/platform-tools/adb wait-for-device
+        $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global window_animation_scale 0
+        $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global transition_animation_scale 0
+        $ANDROID_SDK_ROOT/platform-tools/adb shell settings put global animator_duration_scale 0
+        $ANDROID_SDK_ROOT/platform-tools/adb shell am broadcast -a android.intent.action.BOOT_COMPLETED &
 
-    sleep 5
-    echo " ✅ Emulator is running"
+        sleep 5
+        echo " ✅ Emulator is running"
+    fi
 fi
 
 if [ "${CURRENT_ENV}" = "test" ]; then
-
     if [ -f "android/app/build/outputs/apk/release/app-release.apk" ]; then
         echo " ✅ Project is built for Android"
     else
@@ -49,5 +57,5 @@ if [ "${CURRENT_ENV}" = "test" ]; then
     "${DIR}/start-android-e2e-test.ts --test"
 else
     echo " ☛  Running the Android project..."
-    npx expo run:android --port "${port}"
+    npx expo run:android --port 8081 "$@"
 fi

--- a/apps/native-component-list/src/screens/NavigationBarScreen.tsx
+++ b/apps/native-component-list/src/screens/NavigationBarScreen.tsx
@@ -1,10 +1,24 @@
 import { NavigationBar, NavigationBarStyle } from 'expo-navigation-bar';
 import * as React from 'react';
-import { Platform, ScrollView } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { BodyText } from '../components/BodyText';
 import Button from '../components/Button';
 import { Page, Section } from '../components/Page';
+
+const styles = StyleSheet.create({
+  section: {
+    gap: 8,
+  },
+  currentValue: {
+    fontWeight: '700',
+  },
+  buttonsRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+  },
+});
 
 export default function NavigationBarScreen() {
   return (
@@ -34,7 +48,6 @@ const STYLES: NavigationBarStyle[] = ['auto', 'inverted', 'light', 'dark'];
 
 function StyleExample() {
   const [style, setStyle] = React.useState<NavigationBarStyle>('auto');
-  const nextStyle = STYLES[STYLES.findIndex((item) => item === style) + 1] ?? 'auto';
 
   React.useEffect(() => {
     NavigationBar.setStyle('auto');
@@ -42,19 +55,31 @@ function StyleExample() {
   }, []);
 
   return (
-    <Button
-      title={`Toggle style: ${nextStyle}`}
-      onPress={() => {
-        NavigationBar.setStyle(nextStyle);
-        setStyle(nextStyle);
-      }}
-    />
+    <View style={styles.section}>
+      <Text>
+        Current: <Text style={styles.currentValue}>{style}</Text>
+      </Text>
+
+      <View style={styles.buttonsRow}>
+        <Text>Toggle:</Text>
+
+        {STYLES.map((nextStyle) => (
+          <Button
+            key={`set-style-btn-${nextStyle}`}
+            title={nextStyle}
+            onPress={() => {
+              NavigationBar.setStyle(nextStyle);
+              setStyle(nextStyle);
+            }}
+          />
+        ))}
+      </View>
+    </View>
   );
 }
 
 function HiddenExample() {
   const [hidden, setHidden] = React.useState(false);
-  const nextHidden = !hidden;
 
   React.useEffect(() => {
     NavigationBar.setHidden(false);
@@ -62,12 +87,25 @@ function HiddenExample() {
   }, []);
 
   return (
-    <Button
-      title={`Toggle hidden: ${nextHidden}`}
-      onPress={() => {
-        NavigationBar.setHidden(nextHidden);
-        setHidden(nextHidden);
-      }}
-    />
+    <View style={styles.section}>
+      <Text>
+        Current: <Text style={styles.currentValue}>{String(hidden)}</Text>
+      </Text>
+
+      <View style={styles.buttonsRow}>
+        <Text>Toggle:</Text>
+
+        {[true, false].map((nextHidden) => (
+          <Button
+            key={`set-hidden-btn-${nextHidden}`}
+            title={String(nextHidden)}
+            onPress={() => {
+              NavigationBar.setHidden(nextHidden);
+              setHidden(nextHidden);
+            }}
+          />
+        ))}
+      </View>
+    </View>
   );
 }

--- a/apps/native-component-list/src/screens/NavigationBarScreen.tsx
+++ b/apps/native-component-list/src/screens/NavigationBarScreen.tsx
@@ -40,7 +40,7 @@ export default function NavigationBarScreen() {
         <Section title="Visibility">
           <HiddenExample />
         </Section>
-        <Section title="Into Modal" row={true}>
+        <Section title="Into Modal" row>
           <ModalExample />
         </Section>
       </Page>

--- a/apps/native-component-list/src/screens/NavigationBarScreen.tsx
+++ b/apps/native-component-list/src/screens/NavigationBarScreen.tsx
@@ -1,6 +1,6 @@
 import { NavigationBar, NavigationBarStyle } from 'expo-navigation-bar';
 import * as React from 'react';
-import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Modal, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { BodyText } from '../components/BodyText';
 import Button from '../components/Button';
@@ -18,6 +18,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 4,
   },
+  modal: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
 });
 
 export default function NavigationBarScreen() {
@@ -34,6 +39,9 @@ export default function NavigationBarScreen() {
         </Section>
         <Section title="Visibility">
           <HiddenExample />
+        </Section>
+        <Section title="Into Modal" row={true}>
+          <ModalExample />
         </Section>
       </Page>
     </ScrollView>
@@ -106,6 +114,31 @@ function HiddenExample() {
           />
         ))}
       </View>
+    </View>
+  );
+}
+
+function ModalExample() {
+  const [modalVisible, setModalVisible] = React.useState(false);
+
+  return (
+    <View style={styles.section}>
+      <Button
+        title="Open example Modal"
+        onPress={() => {
+          setModalVisible(true);
+        }}
+      />
+
+      <Modal
+        visible={modalVisible}
+        onRequestClose={() => {
+          setModalVisible(false);
+        }}>
+        <View style={styles.modal}>
+          <Text>style and hidden are preserved</Text>
+        </View>
+      </Modal>
     </View>
   );
 }

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Apply `setStyle` and `setHidden` to React Native `<Modal>` windows via `ExtraWindowEventListener` on Android. ([#46491](https://github.com/expo/expo/pull/46491) by [@zoontek](https://github.com/zoontek))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-navigation-bar/android/build.gradle
+++ b/packages/expo-navigation-bar/android/build.gradle
@@ -17,4 +17,5 @@ android {
 dependencies {
   implementation 'androidx.core:core:1.17.0'
   implementation 'androidx.appcompat:appcompat:1.7.1'
+  implementation 'com.facebook.react:react-android'
 }

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -31,7 +31,7 @@ internal val DarkNavigationBarColor = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
 @Suppress("DEPRECATION")
 internal fun Window.setNavigationBarStyle(
   hasLightBackground: Boolean,
-  isContrastEnforced: Boolean,
+  isContrastEnforced: Boolean
 ) {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
     return // isAppearanceLightNavigationBars is not available below Android O.

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -68,17 +68,17 @@ class NavigationBarModule : Module(), ExtraWindowEventListener {
 
   private val isContrastEnforced: Boolean by lazy {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      return@lazy true
-    }
-
-    val theme = currentActivity.theme
-    val resId = android.R.attr.enforceNavigationBarContrast
-    val value = TypedValue()
-
-    return@lazy if (theme.resolveAttribute(resId, value, true)) {
-      value.data != 0
-    } else {
       true
+    } else {
+      val theme = currentActivity.theme
+      val resId = android.R.attr.enforceNavigationBarContrast
+      val value = TypedValue()
+
+      if (theme.resolveAttribute(resId, value, true)) {
+        value.data != 0
+      } else {
+        true
+      }
     }
   }
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -3,13 +3,21 @@ package expo.modules.navigationbar
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.View
+import android.view.Window
 import android.view.WindowInsets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.interfaces.ExtraWindowEventListener
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import java.util.Collections
+import java.util.WeakHashMap
 
 // The light scrim color used in the platform API 29+
 // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/com/android/internal/policy/DecorView.java;drc=6ef0f022c333385dba2c294e35b8de544455bf19;l=142
@@ -20,13 +28,72 @@ internal val LightNavigationBarColor = Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
 // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/res/remote_color_resources_res/values/colors.xml;l=67
 internal val DarkNavigationBarColor = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
 
-class NavigationBarModule : Module() {
+@Suppress("DEPRECATION")
+internal fun Window.setNavigationBarStyle(
+  hasLightBackground: Boolean,
+  isContrastEnforced: Boolean,
+) {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+    return // isAppearanceLightNavigationBars is not available below Android O.
+  }
+
+  // android:enforceNavigationBarContrast is not available below Android Q.
+  // This means the button style is not automatically adjusted for contrast,
+  // so we set an explicit navigation bar color to avoid invisible buttons.
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+    navigationBarColor = if (hasLightBackground) LightNavigationBarColor else DarkNavigationBarColor
+  } else {
+    isNavigationBarContrastEnforced = isContrastEnforced
+  }
+
+  WindowInsetsControllerCompat(this, decorView).run {
+    isAppearanceLightNavigationBars = hasLightBackground
+  }
+}
+
+internal fun Window.setNavigationBarHidden(hidden: Boolean) {
+  WindowInsetsControllerCompat(this, decorView).apply {
+    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+
+    when (hidden) {
+      true -> hide(WindowInsetsCompat.Type.navigationBars())
+      else -> show(WindowInsetsCompat.Type.navigationBars())
+    }
+  }
+}
+
+class NavigationBarModule : Module(), ExtraWindowEventListener {
   private val currentActivity get() = appContext.throwingActivity
+  private val reactContext get() = appContext.reactContext as? ReactApplicationContext
+
+  private fun isNavigationBarContrastEnforced(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return true
+    }
+
+    val theme = currentActivity.theme
+    val resId = android.R.attr.enforceNavigationBarContrast
+    val value = TypedValue()
+
+    return if (theme.resolveAttribute(resId, value, true)) {
+      value.data != 0
+    } else {
+      true
+    }
+  }
 
   override fun definition() = ModuleDefinition {
     Name("ExpoNavigationBar")
 
     Events(VISIBILITY_EVENT_NAME)
+
+    OnCreate {
+      reactContext?.addExtraWindowEventListener(this@NavigationBarModule)
+    }
+
+    OnDestroy {
+      reactContext?.removeExtraWindowEventListener(this@NavigationBarModule)
+    }
 
     OnStartObserving {
       val decorView = currentActivity.window.decorView
@@ -56,39 +123,18 @@ class NavigationBarModule : Module() {
 
     @Suppress("DEPRECATION")
     AsyncFunction("setStyle") { style: String ->
-      // isAppearanceLightNavigationBars is not available below Android O.
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-        return@AsyncFunction
-      }
-
-      val window = currentActivity.window
       val hasLightBackground = style == "dark" // dark content -> light background
+      val isContrastEnforced = isNavigationBarContrastEnforced()
 
-      // android:enforceNavigationBarContrast is not available below Android Q.
-      // This means the button style is not automatically adjusted for contrast,
-      // so we set an explicit navigation bar color to avoid invisible buttons.
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-        window.navigationBarColor = if (hasLightBackground) LightNavigationBarColor else DarkNavigationBarColor
-      }
-
-      WindowInsetsControllerCompat(window, window.decorView).run {
-        isAppearanceLightNavigationBars = hasLightBackground
-      }
+      currentActivity.window.setNavigationBarStyle(hasLightBackground, isContrastEnforced)
+      extraWindows.forEach { it.setNavigationBarStyle(hasLightBackground, isContrastEnforced) }
 
       return@AsyncFunction
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("setHidden") { hidden: Boolean ->
-      val window = currentActivity.window
-
-      WindowInsetsControllerCompat(window, window.decorView).run {
-        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-
-        when (hidden) {
-          true -> hide(WindowInsetsCompat.Type.navigationBars())
-          false -> show(WindowInsetsCompat.Type.navigationBars())
-        }
-      }
+      currentActivity.window.setNavigationBarHidden(hidden)
+      extraWindows.forEach { it.setNavigationBarHidden(hidden) }
 
       return@AsyncFunction
     }.runOnQueue(Queues.MAIN)
@@ -104,7 +150,28 @@ class NavigationBarModule : Module() {
     }.runOnQueue(Queues.MAIN)
   }
 
+  override fun onExtraWindowCreate(window: Window) {
+    extraWindows.add(window)
+
+    val isContrastEnforced = isNavigationBarContrastEnforced()
+
+    currentActivity.window.let { activityWindow ->
+      val controller = WindowCompat.getInsetsController(activityWindow, activityWindow.decorView)
+      val insets = ViewCompat.getRootWindowInsets(activityWindow.decorView)
+      val hasLightBackground = controller.isAppearanceLightNavigationBars
+      val visible = insets?.isVisible(WindowInsetsCompat.Type.navigationBars()) ?: true
+
+      window.setNavigationBarStyle(hasLightBackground, isContrastEnforced)
+      window.setNavigationBarHidden(!visible)
+    }
+  }
+
+  override fun onExtraWindowDestroy(window: Window) {
+    extraWindows.remove(window)
+  }
+
   companion object {
     private const val VISIBILITY_EVENT_NAME = "ExpoNavigationBar.didChange"
+    private val extraWindows = Collections.newSetFromMap<Window>(WeakHashMap())
   }
 }

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -66,16 +66,16 @@ class NavigationBarModule : Module(), ExtraWindowEventListener {
   private val currentActivity get() = appContext.throwingActivity
   private val reactContext get() = appContext.reactContext as? ReactApplicationContext
 
-  private fun isNavigationBarContrastEnforced(): Boolean {
+  private val isContrastEnforced: Boolean by lazy {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      return true
+      return@lazy true
     }
 
     val theme = currentActivity.theme
     val resId = android.R.attr.enforceNavigationBarContrast
     val value = TypedValue()
 
-    return if (theme.resolveAttribute(resId, value, true)) {
+    return@lazy if (theme.resolveAttribute(resId, value, true)) {
       value.data != 0
     } else {
       true
@@ -121,10 +121,8 @@ class NavigationBarModule : Module(), ExtraWindowEventListener {
       }
     }
 
-    @Suppress("DEPRECATION")
     AsyncFunction("setStyle") { style: String ->
       val hasLightBackground = style == "dark" // dark content -> light background
-      val isContrastEnforced = isNavigationBarContrastEnforced()
 
       currentActivity.window.setNavigationBarStyle(hasLightBackground, isContrastEnforced)
       extraWindows.forEach { it.setNavigationBarStyle(hasLightBackground, isContrastEnforced) }
@@ -152,8 +150,6 @@ class NavigationBarModule : Module(), ExtraWindowEventListener {
 
   override fun onExtraWindowCreate(window: Window) {
     extraWindows.add(window)
-
-    val isContrastEnforced = isNavigationBarContrastEnforced()
 
     currentActivity.window.let { activityWindow ->
       val controller = WindowCompat.getInsetsController(activityWindow, activityWindow.decorView)


### PR DESCRIPTION
# Why

Closes #39749

On Android, React Native's `<Modal>` renders into its own `Window`. Calls to `NavigationBar.setStyle` and `NavigationBar.setHidden` only applied to the activity window, so when a modal was opened the navigation bar lost its configured style and visibility, often resulting in invisible buttons or an unexpectedly visible bar.

# How

`NavigationBarModule` now implements `ExtraWindowEventListener` and tracks every extra window created by React Native (currently `<Modal>`). The `setStyle` / `setHidden` logic was extracted into `Window.setNavigationBarStyle` and `Window.setNavigationBarHidden` extension functions, which are applied to both the activity window and all tracked extra windows. When a new extra window is created, the current style and visibility are read from the activity window and forwarded to it.

A few related cleanups:

- `isNavigationBarContrastEnforced` is now resolved lazily from the activity theme (`android:enforceNavigationBarContrast`) instead of being hardcoded, so user themes are respected.
- Added `com.facebook.react:react-android` as a dependency to access `ExtraWindowEventListener`.
- Demo screen in `native-component-list` was expanded with per-value buttons, a current-value readout, and a new "Into Modal" section to verify the fix.
- `bare-expo`'s `start-emulator.sh` now supports starting a device, matching how it's used in `native-component-list`.

# Test Plan

1. Run `native-component-list` on an Android device or emulator.
2. Open the "NavigationBar" screen.
3. Toggle style (auto / inverted / light / dark) and toggle hidden.
4. Tap "Open example Modal" and confirm the navigation bar keeps the selected style and visibility inside the modal.
5. Close the modal and confirm the bar still matches the selected values.
6. Repeat on API 28 (pre-Q) to verify the explicit `navigationBarColor` fallback works in the modal too.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<img width="540" height="1212" alt="Screenshot_20260602-130903" src="https://github.com/user-attachments/assets/a1a78e64-a26d-4a12-a6a1-a2f6bc53a6d5" />