### PR TITLE
[gha] Upgrade docs workflows to use Node.js 24

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
       - name: ⬢ Setup Node
@@ -59,7 +59,7 @@ jobs:
         id: vale-version
         run: echo "version=$(node -p "require('./.vale-version.json').version")" >> "$GITHUB_OUTPUT"
       - name: 💬 Lint Docs website content
-        uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # 2.1.2
         with:
           version: ${{ steps.vale-version.outputs.version }}
           reporter: github-pr-check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 30000
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
       - name: ⬢ Setup Node
@@ -73,7 +73,7 @@ jobs:
         working-directory: docs
         run: echo "version=$(node -p "require('./.vale-version.json').version")" >> "$GITHUB_OUTPUT"
       - name: 💬 Lint Docs website content
-        uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # 2.1.2
         with:
           version: ${{ steps.vale-version.outputs.version }}
           reporter: github-pr-check


### PR DESCRIPTION
# Why

GitHub Actions warns that `pnpm/action-setup` (v4) and `vale-cli/vale-action` (v2.1.1) still run on the deprecated Node.js 20 runtime, which will be forced to Node 24 on June 16, 2026 and removed from runners on September 16, 2026.

# How

Bump the SHA-pinned `pnpm/action-setup` to v6 (`0e279bb`) and `vale-cli/vale-action` to 2.1.2 (`85f9f7f`) in both `docs-pr.yml` and `docs.yml`, both of which declare `runs.using: node24`. The `version` and Vale inputs are unchanged and still supported in the new releases.


## Pin provenance

SHAs resolved from upstream release tags and verified via `git ls-remote`.
Both target releases declare `runs.using: node24` in their `action.yml`.

| Action | Tag | Pinned commit |
| --- | --- | --- |
| `pnpm/action-setup` | [`v6.0.8`](https://github.com/pnpm/action-setup/releases/tag/v6.0.8) | [`0e279bb`](https://github.com/pnpm/action-setup/commit/0e279bb959325dab635dd2c09392533439d90093) |
| `vale-cli/vale-action` | [`2.1.2`](https://github.com/vale-cli/vale-action/releases/tag/2.1.2) | [`85f9f7f`](https://github.com/vale-cli/vale-action/commit/85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a) |

`runs.using: node24` confirmed in each `action.yml` at the pinned commit:
- pnpm: https://github.com/pnpm/action-setup/blob/0e279bb959325dab635dd2c09392533439d90093/action.yml
- vale: https://github.com/vale-cli/vale-action/blob/85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a/action.yml

Context: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

# Test Plan

Open a docs PR and confirm the `docs-pr` job passes with no Node 20 deprecation warning for these two actions. (The `actions/cache` warning persists separately, as it lives in the shared `expo-caches` composite.)



# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).we