### PR TITLE
[video] When `source` of `useVideoPlayer` changes use `replaceAsync`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - [Android] Removed outdated ExoPlayer changelog references and aligned Android media dependencies with AndroidX Media3 (`1.9.1`). ([#45368](https://github.com/expo/expo/pull/45368) by [@saisreelasyaappali](https://github.com/saisreelasyaappali))
 - Replace `TimeoutID` typing on `_timeUpdateLoop` ([#46730](https://github.com/expo/expo/pull/46730) by [@kitten](https://github.com/kitten))
+- When `source` of `useVideoPlayer` changes use `replaceAsync` instead of re-creating the player.
 
 ## 56.1.2 — 2026-05-21
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - [Android] Removed outdated ExoPlayer changelog references and aligned Android media dependencies with AndroidX Media3 (`1.9.1`). ([#45368](https://github.com/expo/expo/pull/45368) by [@saisreelasyaappali](https://github.com/saisreelasyaappali))
 - Replace `TimeoutID` typing on `_timeUpdateLoop` ([#46730](https://github.com/expo/expo/pull/46730) by [@kitten](https://github.com/kitten))
-- When `source` of `useVideoPlayer` changes use `replaceAsync` instead of re-creating the player.
+- When `source` of `useVideoPlayer` changes use `replaceAsync` instead of re-creating the player. ([#46495](https://github.com/expo/expo/pull/46495) by [@behenate](https://github.com/behenate))
 
 ## 56.1.2 — 2026-05-21
 

--- a/packages/expo-video/src/VideoPlayer.tsx
+++ b/packages/expo-video/src/VideoPlayer.tsx
@@ -1,4 +1,5 @@
 import { useReleasingSharedObjectWithLifecycle } from 'expo-modules-core';
+import { useState } from 'react';
 
 import NativeVideoModule from './NativeVideoModule';
 import type { VideoSource, VideoPlayer, PlayerBuilderOptions } from './VideoPlayer.types';
@@ -52,6 +53,7 @@ export function useVideoPlayer(
   const parsedSource = parseSource(source);
   const parsedSourceKey = JSON.stringify(parsedSource);
   const playerBuilderOptionsKey = JSON.stringify(playerBuilderOptions);
+  const [forceRecreateCount, setForceRecreateCount] = useState(0);
 
   return useReleasingSharedObjectWithLifecycle(
     {
@@ -61,19 +63,21 @@ export function useVideoPlayer(
         return player;
       },
       shouldRecreate: (_player, { previousDependencies, dependencies }) => {
-        // Factory options differ
-        return previousDependencies[1] !== dependencies[1];
+        // Recreate if builder options ([1]) changed or if replaceAsync failed ([2]).
+        return (
+          previousDependencies[1] !== dependencies[1] || previousDependencies[2] !== dependencies[2]
+        );
       },
       update: (player, { previousDependencies, dependencies }) => {
-        // Sources differ
+        // Source ([0]) changed — use replaceAsync; fall back to recreate on failure.
         if (previousDependencies[0] !== dependencies[0]) {
-          player.replaceAsync(parsedSource).catch((error) => {
-            console.error('expo-video: Failed to replace video source:', error);
+          player.replaceAsync(parsedSource).catch(() => {
+            setForceRecreateCount((c) => c + 1);
           });
         }
       },
     },
-    [parsedSourceKey, playerBuilderOptionsKey]
+    [parsedSourceKey, playerBuilderOptionsKey, forceRecreateCount] // [0] source, [1] options, [2] recreate counter
   );
 }
 

--- a/packages/expo-video/src/VideoPlayer.tsx
+++ b/packages/expo-video/src/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { useReleasingSharedObject } from 'expo';
+import { useReleasingSharedObjectWithLifecycle } from 'expo-modules-core';
 
 import NativeVideoModule from './NativeVideoModule';
 import type { VideoSource, VideoPlayer, PlayerBuilderOptions } from './VideoPlayer.types';
@@ -50,12 +50,31 @@ export function useVideoPlayer(
   playerBuilderOptions?: PlayerBuilderOptions
 ): VideoPlayer {
   const parsedSource = parseSource(source);
+  const parsedSourceKey = JSON.stringify(parsedSource);
+  const playerBuilderOptionsKey = JSON.stringify(playerBuilderOptions);
 
-  return useReleasingSharedObject(() => {
-    const player = new NativeVideoModule.VideoPlayer(parsedSource, false, playerBuilderOptions);
-    setup?.(player);
-    return player;
-  }, [JSON.stringify(parsedSource), JSON.stringify(playerBuilderOptions)]);
+  return useReleasingSharedObjectWithLifecycle(
+    {
+      factory: () => {
+        const player = new NativeVideoModule.VideoPlayer(parsedSource, false, playerBuilderOptions);
+        setup?.(player);
+        return player;
+      },
+      shouldRecreate: (_player, { previousDependencies, dependencies }) => {
+        // Factory options differ
+        return previousDependencies[1] !== dependencies[1];
+      },
+      update: (player, { previousDependencies, dependencies }) => {
+        // Sources differ
+        if (previousDependencies[0] !== dependencies[0]) {
+          player.replaceAsync(parsedSource).catch((error) => {
+            console.error('expo-video: Failed to replace video source:', error);
+          });
+        }
+      },
+    },
+    [parsedSourceKey, playerBuilderOptionsKey]
+  );
 }
 
 function parseSource(source: VideoSource): VideoSource {

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -1,8 +1,10 @@
 import { useReleasingSharedObjectWithLifecycle } from 'expo-modules-core';
+import { useState } from 'react';
 
 import type {
   BufferOptions,
   PlayerError,
+  PlayerBuilderOptions,
   VideoPlayerStatus,
   VideoSource,
   VideoPlayer,
@@ -20,9 +22,10 @@ import resolveAssetSource from './resolveAssetSource';
 export function useVideoPlayer(
   source: VideoSource,
   setup?: (player: VideoPlayer) => void,
-  _playerBuilderOptions?: unknown
+  _playerBuilderOptions?: PlayerBuilderOptions
 ): VideoPlayer {
   const parsedSource = typeof source === 'string' ? { uri: source } : source;
+  const [forceRecreateCount, setForceRecreateCount] = useState(0);
 
   return useReleasingSharedObjectWithLifecycle(
     {
@@ -31,14 +34,18 @@ export function useVideoPlayer(
         setup?.(player);
         return player;
       },
-      shouldRecreate: () => false,
+      shouldRecreate: (_player, { previousDependencies, dependencies }) => {
+        // Recreate if replaceAsync failed ([1]).
+        return previousDependencies[1] !== dependencies[1];
+      },
       update: (player) => {
-        player.replaceAsync(parsedSource).catch((error) => {
-          console.error('expo-video: Failed to replace video source:', error);
+        // Source ([0]) changed — use replaceAsync; fall back to recreate on failure.
+        player.replaceAsync(parsedSource).catch(() => {
+          setForceRecreateCount((c) => c + 1);
         });
       },
     },
-    [JSON.stringify(source)]
+    [JSON.stringify(source), forceRecreateCount] // [0] source, [1] recreate counter
   );
 }
 

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useReleasingSharedObjectWithLifecycle } from 'expo-modules-core';
 
 import type {
   BufferOptions,
@@ -19,15 +19,27 @@ import resolveAssetSource from './resolveAssetSource';
 
 export function useVideoPlayer(
   source: VideoSource,
-  setup?: (player: VideoPlayer) => void
+  setup?: (player: VideoPlayer) => void,
+  _playerBuilderOptions?: unknown
 ): VideoPlayer {
   const parsedSource = typeof source === 'string' ? { uri: source } : source;
 
-  return useMemo(() => {
-    const player = new VideoPlayerWeb(parsedSource);
-    setup?.(player);
-    return player;
-  }, [JSON.stringify(source)]);
+  return useReleasingSharedObjectWithLifecycle(
+    {
+      factory: () => {
+        const player = new VideoPlayerWeb(parsedSource);
+        setup?.(player);
+        return player;
+      },
+      shouldRecreate: () => false,
+      update: (player) => {
+        player.replaceAsync(parsedSource).catch((error) => {
+          console.error('expo-video: Failed to replace video source:', error);
+        });
+      },
+    },
+    [JSON.stringify(source)]
+  );
 }
 
 export function getSourceUri(source?: VideoSource): string | null {


### PR DESCRIPTION
# Why

When the `source` parameter of the `useVideoPlayer` changes we recreate the entire object. This is much slower than calling `replaceAsync` I also find it unintuitive.

# How

Use the new `useReleasingSharedObjectWithLifecycle` hook instead of the standard `useReleasingSharedObject`

# Test Plan

Tested in BareExpo on iOS
