### PR TITLE
[widgets] Add initial layout registry

### DIFF
--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -107,6 +107,11 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
         '* `accessoryInline` - Inline text widget for Lock Screen',
       ].join('\n'),
     },
+    {
+      name: 'widgets[].ios.initialLayout',
+      description:
+        'A path to the file that registers this widget with `createWidget`. The path is relative to the project root. Set this so the widget appears in the widget gallery before the app is open for the first time.',
+    },
   ]}
 />
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
-- Add a initial layout registry for widgets.
+- Add a initial layout registry for widgets. ([#46501](https://github.com/expo/expo/pull/46501) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
+- Add a initial layout registry for widgets.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/bundle/async-require-stub.ts
+++ b/packages/expo-widgets/bundle/async-require-stub.ts
@@ -1,0 +1,28 @@
+{
+  type AsyncRequireStub = {
+    (): Promise<never>;
+    prefetch: () => void;
+    unstable_importMaybeSync: () => never;
+    unstable_resolve: () => never;
+    unstable_createWorker: () => never;
+  };
+
+  const asyncRequireStub = function () {
+    return Promise.reject(
+      new Error('Async imports are not supported while extracting widget layouts.')
+    );
+  } as AsyncRequireStub;
+
+  asyncRequireStub.prefetch = function prefetch() {};
+  asyncRequireStub.unstable_importMaybeSync = function unstableImportMaybeSync() {
+    throw new Error('Async imports are not supported while extracting widget layouts.');
+  };
+  asyncRequireStub.unstable_resolve = function unstableResolve() {
+    throw new Error('Async imports are not supported while extracting widget layouts.');
+  };
+  asyncRequireStub.unstable_createWorker = function unstableCreateWorker() {
+    throw new Error('Workers are not supported while extracting widget layouts.');
+  };
+
+  module.exports = asyncRequireStub;
+}

--- a/packages/expo-widgets/bundle/layout-registry-entry.js
+++ b/packages/expo-widgets/bundle/layout-registry-entry.js
@@ -1,0 +1,5 @@
+import { __expoWidgetsGetLayoutRegistry } from 'expo-widgets';
+
+import './build/ExpoWidgetsLayoutRegistry.imports';
+
+globalThis.__expoWidgetsLayoutRegistry = __expoWidgetsGetLayoutRegistry();

--- a/packages/expo-widgets/bundle/layout-registry-stub.ts
+++ b/packages/expo-widgets/bundle/layout-registry-stub.ts
@@ -1,0 +1,42 @@
+const widgetLayouts: Record<string, string> = {};
+const noopWidget = {
+  reload() {},
+  updateTimeline() {},
+  updateSnapshot() {},
+  getTimeline() {
+    return Promise.resolve([]);
+  },
+};
+const noopLiveActivityFactory = {
+  start() {
+    return {};
+  },
+  getInstances() {
+    return [];
+  },
+};
+
+export function createWidget(name: string, layout: string) {
+  widgetLayouts[name] = layout;
+  return noopWidget;
+}
+
+export function createLiveActivity() {
+  return noopLiveActivityFactory;
+}
+
+export function addUserInteractionListener() {
+  return { remove() {} };
+}
+
+export function addPushToStartTokenListener() {
+  return { remove() {} };
+}
+
+export function after(date: Date) {
+  return { after: date };
+}
+
+export function __expoWidgetsGetLayoutRegistry() {
+  return { ...widgetLayouts };
+}

--- a/packages/expo-widgets/ios/ExpoWidgets.podspec
+++ b/packages/expo-widgets/ios/ExpoWidgets.podspec
@@ -35,19 +35,29 @@ Pod::Spec.new do |s|
     :execution_position => :before_compile,
     # NOTE(@krystofwoldrich): Ideally we would specify `__dir__/**/*`, but Xcode doesn't support patterns
     :input_files  => ["#{__dir__}/../package.json"],
-    :output_files  => ["#{__dir__}/../bundle/build/ExpoWidgets.bundle"],
+    :output_files  => [
+      "#{__dir__}/../bundle/build/ExpoWidgets.bundle",
+      "#{__dir__}/../bundle/build/ExpoWidgetsLayoutRegistry.json",
+    ],
   }
   copy_bundle_script = {
     :name => 'Prepare ExpoWidgets Resources',
     :script => %Q{
       echo "Preparing ExpoWidgets.bundle..."
       source="#{__dir__}/../bundle/build/ExpoWidgets.bundle"
+      registry_source="#{__dir__}/../bundle/build/ExpoWidgetsLayoutRegistry.json"
       dest="${BUILT_PRODUCTS_DIR}/ExpoWidgets.bundle"
+      mkdir -p "${dest}"
       echo "Copying ${source} to ${dest}"
       cp "${source}" "${dest}"
+      echo "Copying ${registry_source} to ${dest}/ExpoWidgetsLayoutRegistry.json"
+      cp "${registry_source}" "${dest}/ExpoWidgetsLayoutRegistry.json"
     },
     :execution_position => :before_compile,
-    :input_files  => ["#{__dir__}/../bundle/build/ExpoWidgets.bundle"]
+    :input_files  => [
+      "#{__dir__}/../bundle/build/ExpoWidgets.bundle",
+      "#{__dir__}/../bundle/build/ExpoWidgetsLayoutRegistry.json",
+    ]
   }
   # :always_out_of_date is only available in CocoaPods 1.13.0 and later
   if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')

--- a/packages/expo-widgets/ios/Widgets/AppIntent.swift
+++ b/packages/expo-widgets/ios/Widgets/AppIntent.swift
@@ -53,7 +53,9 @@ struct WidgetUserInteraction: AppIntent {
       return .result()
     }
 
-    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(source)_layout") ?? ""
+    guard let layout = WidgetsLayoutRegistry.layout(for: source) else {
+      return .result()
+    }
     let timeline = WidgetsStorage.getArray(forKey: "__expo_widgets_\(source)_timeline")
 
     guard let timeline,

--- a/packages/expo-widgets/ios/Widgets/EntryView.swift
+++ b/packages/expo-widgets/ios/Widgets/EntryView.swift
@@ -25,8 +25,7 @@ public struct WidgetsEntryView: View {
   }
 
   public var body: some View {
-    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(entry.name)_layout"),
-       !layout.isEmpty {
+    if let layout = WidgetsLayoutRegistry.layout(for: entry.name) {
       let node = evaluateLayout(layout: layout, props: entry.props, environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {

--- a/packages/expo-widgets/ios/Widgets/WidgetsLayoutRegistry.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetsLayoutRegistry.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+private struct EmbeddedWidgetsLayoutRegistry: Decodable {
+  let widgets: [String: String]
+}
+
+public enum WidgetsLayoutRegistry {
+  public static func layout(for name: String) -> String? {
+    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(name)_layout"),
+       !layout.isEmpty {
+      return layout
+    }
+    if let layout = embeddedLayouts[name],
+       !layout.isEmpty {
+      return layout
+    }
+    return nil
+  }
+
+  private static let embeddedLayouts: [String: String] = {
+    guard let bundleURL = Bundle.main.url(forResource: "ExpoWidgets", withExtension: "bundle"),
+          let bundle = Bundle(url: bundleURL),
+          let registryURL = bundle.url(
+            forResource: "ExpoWidgetsLayoutRegistry",
+            withExtension: "json"
+          ),
+          let data = try? Data(contentsOf: registryURL),
+          let registry = try? JSONDecoder().decode(EmbeddedWidgetsLayoutRegistry.self, from: data) else {
+      return [:]
+    }
+
+    return registry.widgets
+  }()
+}

--- a/packages/expo-widgets/layout-registry.metro.config.js
+++ b/packages/expo-widgets/layout-registry.metro.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+const config = require('./metro.config.js');
+const baseResolveRequest = config.resolver.resolveRequest;
+const expoWidgetsStubPath = path.join(__dirname, 'bundle/layout-registry-stub.ts');
+const asyncRequireStubPath = path.join(__dirname, 'bundle/async-require-stub.ts');
+const emptyModuleStubPath = path.join(__dirname, 'bundle/empty-module-stub.js');
+const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
+
+config.resolver = {
+  ...config.resolver,
+  resolveRequest(context, moduleName, platform) {
+    if (fileSpecifierRe.test(moduleName)) {
+      return baseResolveRequest(context, moduleName, platform);
+    }
+    if (moduleName === 'expo-widgets') {
+      return { type: 'sourceFile', filePath: expoWidgetsStubPath };
+    }
+    if (
+      moduleName === 'metro-runtime/src/modules/asyncRequire' ||
+      moduleName === 'expo/internal/async-require-module'
+    ) {
+      return { type: 'sourceFile', filePath: asyncRequireStubPath };
+    }
+    return { type: 'empty' };
+  },
+};
+
+module.exports = config;

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -69,6 +69,7 @@ const buildConfig = {
   },
   serializer: {
     ...config.serializer,
+    getModulesRunBeforeMainModule: () => [],
     getPolyfills: () => [],
   },
 };

--- a/packages/expo-widgets/plugin/build/ios/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/ios/withWidgetSourceFiles.js
@@ -58,6 +58,10 @@ function validateWidget(widget) {
     for (const family of supportedFamilies) {
         assertWidgetFamily(family);
     }
+    const initialLayout = widget.ios?.initialLayout;
+    if (initialLayout != null && path.isAbsolute(initialLayout)) {
+        throw new Error(`Invalid initialLayout for ${JSON.stringify(widget.name)}: must be relative to the project root.`);
+    }
     const configuration = widget.ios?.configuration ?? widget.configuration;
     if (configuration) {
         for (const [paramName, param] of Object.entries(configuration.parameters)) {
@@ -100,9 +104,16 @@ const withWidgetSourceFiles = (config, { widgets, targetName, onFilesGenerated, 
             };
             fs.writeFileSync(entitlementsPath, plist_1.default.build(entitlementsContent));
             const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory, config.ios?.version ?? config.version ?? '1.0', config.ios?.buildNumber ?? '1', existingInfoPlist);
+            const layoutRegistryConfigPath = createLayoutRegistryConfig(widgets, targetDirectory);
             const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
             const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
-            onFilesGenerated([entitlementsPath, infoPlistPath, indexSwiftPath, ...widgetSwiftPaths]);
+            onFilesGenerated([
+                entitlementsPath,
+                infoPlistPath,
+                layoutRegistryConfigPath,
+                indexSwiftPath,
+                ...widgetSwiftPaths,
+            ]);
             return config;
         },
     ]);
@@ -134,6 +145,19 @@ const createWidgetSwift = (widget, targetPath) => {
     const widgetFilePath = path.join(targetPath, `${widget.name}.swift`);
     fs.writeFileSync(widgetFilePath, widgetSwift(widget));
     return widgetFilePath;
+};
+const createLayoutRegistryConfig = (widgets, targetPath) => {
+    const configPath = path.join(targetPath, 'ExpoWidgetsLayoutRegistry.config.json');
+    const config = {
+        widgets: widgets
+            .filter((widget) => widget.ios?.initialLayout != null)
+            .map((widget) => ({
+            name: widget.name,
+            initialLayout: widget.ios?.initialLayout,
+        })),
+    };
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+    return configPath;
 };
 const createInfoPlist = (groupIdentifier, targetPath, marketingVersion, bundleVersion, existingInfoPlist) => {
     const infoPlistPath = `${targetPath}/Info.plist`;
@@ -325,8 +349,7 @@ ${Object.entries(configuration?.parameters ?? {})
   }
 
   public var body: some View {
-    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout"),
-       !layout.isEmpty {
+    if let layout = WidgetsLayoutRegistry.layout(for: entry.name) {
       let node = evaluateLayout(layout: layout, props: entry.props, environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {

--- a/packages/expo-widgets/plugin/build/types/WidgetConfig.type.d.ts
+++ b/packages/expo-widgets/plugin/build/types/WidgetConfig.type.d.ts
@@ -13,6 +13,7 @@ export type WidgetConfig = {
     ios?: {
         supportedFamilies: WidgetFamily[];
         contentMarginsDisabled?: boolean;
+        initialLayout?: string;
         configuration?: {
             title: string;
             description?: string;

--- a/packages/expo-widgets/plugin/src/ios/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/ios/withWidgetSourceFiles.ts
@@ -35,6 +35,12 @@ function validateWidget(widget: WidgetConfig): void {
   for (const family of supportedFamilies) {
     assertWidgetFamily(family);
   }
+  const initialLayout = widget.ios?.initialLayout;
+  if (initialLayout != null && path.isAbsolute(initialLayout)) {
+    throw new Error(
+      `Invalid initialLayout for ${JSON.stringify(widget.name)}: must be relative to the project root.`
+    );
+  }
   const configuration = widget.ios?.configuration ?? widget.configuration;
   if (configuration) {
     for (const [paramName, param] of Object.entries(configuration.parameters)) {
@@ -86,10 +92,17 @@ const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
         config.ios?.buildNumber ?? '1',
         existingInfoPlist
       );
+      const layoutRegistryConfigPath = createLayoutRegistryConfig(widgets, targetDirectory);
       const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
       const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
 
-      onFilesGenerated([entitlementsPath, infoPlistPath, indexSwiftPath, ...widgetSwiftPaths]);
+      onFilesGenerated([
+        entitlementsPath,
+        infoPlistPath,
+        layoutRegistryConfigPath,
+        indexSwiftPath,
+        ...widgetSwiftPaths,
+      ]);
 
       return config;
     },
@@ -125,6 +138,21 @@ const createWidgetSwift = (widget: WidgetConfig, targetPath: string): string => 
   const widgetFilePath = path.join(targetPath, `${widget.name}.swift`);
   fs.writeFileSync(widgetFilePath, widgetSwift(widget));
   return widgetFilePath;
+};
+
+const createLayoutRegistryConfig = (widgets: WidgetConfig[], targetPath: string): string => {
+  const configPath = path.join(targetPath, 'ExpoWidgetsLayoutRegistry.config.json');
+  const config = {
+    widgets: widgets
+      .filter((widget) => widget.ios?.initialLayout != null)
+      .map((widget) => ({
+        name: widget.name,
+        initialLayout: widget.ios?.initialLayout,
+      })),
+  };
+
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return configPath;
 };
 
 const createInfoPlist = (
@@ -333,8 +361,7 @@ ${Object.entries(configuration?.parameters ?? {})
   }
 
   public var body: some View {
-    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout"),
-       !layout.isEmpty {
+    if let layout = WidgetsLayoutRegistry.layout(for: entry.name) {
       let node = evaluateLayout(layout: layout, props: entry.props, environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {

--- a/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
+++ b/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
@@ -17,6 +17,7 @@ export type WidgetConfig = {
   ios?: {
     supportedFamilies: WidgetFamily[];
     contentMarginsDisabled?: boolean;
+    initialLayout?: string;
     configuration?: {
       title: string;
       description?: string;

--- a/packages/expo-widgets/scripts/build-layout-registry.mjs
+++ b/packages/expo-widgets/scripts/build-layout-registry.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import spawn from '@expo/spawn-async';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process, { argv } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const [, , possibleProjectRoot = process.cwd(), platform = 'ios', registryOutput, configPath] =
+  argv;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(__dirname);
+
+const defaultOutputPath = path.join(__dirname, '../bundle/build/ExpoWidgetsLayoutRegistry.json');
+const registryEntryPath = path.join(__dirname, '../bundle/layout-registry-entry.js');
+const registryMetroConfigPath = path.join(__dirname, '../layout-registry.metro.config.js');
+
+async function main() {
+  const projectRoot = path.resolve(possibleProjectRoot);
+  const outputPath = path.resolve(projectRoot, registryOutput ?? defaultOutputPath);
+  const resolvedConfigPath = path.resolve(
+    projectRoot,
+    configPath ??
+      path.join(projectRoot, 'ios', 'ExpoWidgetsTarget', 'ExpoWidgetsLayoutRegistry.config.json')
+  );
+
+  await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
+
+  const expectedWidgets = await readExpectedWidgets(projectRoot, resolvedConfigPath);
+  if (expectedWidgets.length === 0) {
+    await writeRegistry(outputPath, { widgets: {} });
+    return;
+  }
+
+  const buildDir = path.join(__dirname, '../bundle/build');
+  await fs.promises.mkdir(buildDir, { recursive: true });
+
+  const importsPath = path.join(buildDir, 'ExpoWidgetsLayoutRegistry.imports.js');
+  const bundlePath = path.join(buildDir, 'ExpoWidgetsLayoutRegistry.bundle');
+
+  await fs.promises.writeFile(importsPath, createImportsSource(expectedWidgets));
+  await fs.promises.rm(bundlePath, { force: true });
+
+  await bundleRegistryEntry({ projectRoot, platform, entryPath: registryEntryPath, bundlePath });
+
+  const capturedLayouts = await evaluateRegistryBundle(bundlePath);
+  const registry = createLayoutRegistry(expectedWidgets, capturedLayouts);
+  await writeRegistry(outputPath, registry);
+}
+
+async function readExpectedWidgets(projectRoot, configPath) {
+  if (!fs.existsSync(configPath)) {
+    return [];
+  }
+
+  const contents = await fs.promises.readFile(configPath, 'utf8');
+  const config = JSON.parse(contents);
+  return (config.widgets ?? [])
+    .filter((widget) => widget?.initialLayout != null)
+    .map((widget) => ({
+      name: widget.name,
+      initialLayout: widget.initialLayout,
+      initialLayoutFile: path.resolve(projectRoot, widget.initialLayout),
+    }));
+}
+
+function createImportsSource(expectedWidgets) {
+  return `${expectedWidgets
+    .map((widget) => `import ${JSON.stringify(widget.initialLayoutFile)};`)
+    .join('\n')}\n`;
+}
+
+async function bundleRegistryEntry({ projectRoot, platform, entryPath, bundlePath }) {
+  const nodePath = process.env.NODE_BINARY || 'node';
+  const result = await spawn(
+    nodePath,
+    [
+      require.resolve('expo/bin/cli'),
+      'export:embed',
+      '--platform',
+      platform,
+      '--bundle-output',
+      bundlePath,
+      '--entry-file',
+      entryPath,
+      '--dev',
+      'false',
+      '--skip-server',
+    ],
+    {
+      stdio: 'inherit',
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        EXPO_OVERRIDE_METRO_CONFIG: registryMetroConfigPath,
+      },
+    }
+  );
+
+  if (result.error) {
+    process.exit(1);
+  }
+}
+
+async function evaluateRegistryBundle(bundlePath) {
+  const code = await fs.promises.readFile(bundlePath, 'utf8');
+  delete globalThis.__expoWidgetsLayoutRegistry;
+  vm.runInThisContext(code, { filename: bundlePath });
+  return globalThis.__expoWidgetsLayoutRegistry;
+}
+
+async function writeRegistry(outputPath, registry) {
+  await fs.promises.writeFile(outputPath, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function createLayoutRegistry(expectedWidgets, capturedLayouts) {
+  const registry = { widgets: {} };
+  const captured = capturedLayouts ?? {};
+  const capturedNames = new Set(Object.keys(captured));
+
+  for (const widget of expectedWidgets) {
+    const layout = captured[widget.name];
+    if (typeof layout !== 'string' || layout.length === 0) {
+      throw new Error(
+        `Expected ${JSON.stringify(widget.initialLayout)} to register ${JSON.stringify(
+          widget.name
+        )} with createWidget.`
+      );
+    }
+    registry.widgets[widget.name] = layout;
+    capturedNames.delete(widget.name);
+  }
+
+  if (capturedNames.size > 0) {
+    throw new Error(
+      `Unexpected Expo widget layout registration for ${JSON.stringify([...capturedNames][0])}.`
+    );
+  }
+
+  return registry;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  await main();
+}

--- a/packages/expo-widgets/scripts/xcode-build-bundle.sh
+++ b/packages/expo-widgets/scripts/xcode-build-bundle.sh
@@ -21,3 +21,4 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_WIDGETS_PACKAGE_DIR/../.."}
 cd "$PROJECT_ROOT" || exit
 
 "${EXPO_WIDGETS_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_WIDGETS_PACKAGE_DIR}/scripts/build-bundle.mjs" "$PROJECT_ROOT"
+"${EXPO_WIDGETS_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_WIDGETS_PACKAGE_DIR}/scripts/build-layout-registry.mjs" "$PROJECT_ROOT" "ios"


### PR DESCRIPTION
# Why

Widgets can render before the app has launched for the first time. In that state, layouts registered at runtime with `createWidget` are not available yet, so iOS will show a blank widget.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Add `ios.initialLayout`with a relative path for widget to `app.json`.
- Config plugin will create a layout registry with a paths to widgets.
- Evaluate the files on the build time with minimal metro runtime (ignore all imports, we need only the createWidget and string function).

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Create new widget with initialLayout and do not open the app.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)