### PR TITLE
[bare-expo] Enable outOfTreePlatforms experiment

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -28,20 +28,20 @@ on:
       - packages/expo-updates/**
       - packages/expo-updates-interface/**
       - packages/expo-web-browser/**
-      - '!packages/**/android/**'
+      - "!packages/**/android/**"
       # Common ignores from detect-platform-change action
-      - '!**/*.md'
-      - '!**/LICENSE*'
-      - '!**/.gitignore'
-      - '!**/CHANGELOG*'
-      - '!**/.npmignore'
-      - '!**/.eslintrc*'
-      - '!**/.prettierrc*'
-      - '!**/.gitattributes'
-      - '!**/.watchmanconfig'
-      - '!**/.fingerprintignore'
-      - '!**/__tests__/**'
-      - '!**/__mocks__/**'
+      - "!**/*.md"
+      - "!**/LICENSE*"
+      - "!**/.gitignore"
+      - "!**/CHANGELOG*"
+      - "!**/.npmignore"
+      - "!**/.eslintrc*"
+      - "!**/.prettierrc*"
+      - "!**/.gitattributes"
+      - "!**/.watchmanconfig"
+      - "!**/.fingerprintignore"
+      - "!**/__tests__/**"
+      - "!**/__mocks__/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -55,8 +55,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.4.1
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
+      - name: 🔨 Switch to Xcode 26.2
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -75,12 +75,12 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          bare-expo-macos-pods: 'true'
+          bare-expo-macos-pods: "true"
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
@@ -100,12 +100,18 @@ jobs:
       - name: 🏗️ Build macOS project
         run: |
           set -o pipefail
-          xcodebuild -workspace macos/BareExpo-macOS.xcworkspace -scheme ExpoMacOS-macOS -sdk macosx -derivedDataPath "macos/build" | xcpretty
+          xcodebuild -workspace macos/BareExpo-macOS.xcworkspace -scheme ExpoMacOS-macOS -sdk macosx -derivedDataPath "macos/build" | tee xcodebuild.log | xcpretty
         working-directory: apps/bare-expo
         timeout-minutes: 55
         env:
           EXPO_DEBUG: 1
           NODE_ENV: production
+      - name: 📄 Upload xcodebuild log
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bare-expo-macos-xcodebuild-log
+          path: apps/bare-expo/xcodebuild.log
       - name: 📸 Upload builds
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -116,5 +122,5 @@ jobs:
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
-          channel: '#expo-ios'
+          channel: "#expo-ios"
           author_name: Test Suite (macOS)

--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -9,7 +9,7 @@
     "facebookDisplayName": "Expo APIs",
     "privacy": "unlisted",
     "version": "1.0.0",
-    "platforms": ["ios", "android", "web"],
+    "platforms": ["ios", "android", "web", "macos"],
     "userInterfaceStyle": "automatic",
     "android": {
       "scheme": ["com.googleusercontent.apps.29635966244-knmlpr1upnv6rs4bumqea7hpit4o7kg2"],
@@ -41,7 +41,7 @@
     },
     "extra": {
       "eas": {
-        "projectId": "2c28de10-a2cd-11e6-b8ce-59d1587e6774",
+        "projectId": "2c28de10-a2cd-11e6-b8ce-59d1587e6774"
       }
     },
     "runtimeVersion": "1.0.0",
@@ -106,6 +106,7 @@
       "./plugins/withBenchmarkModules"
     ],
     "experiments": {
+      "outOfTreePlatforms": true,
       "inlineModules": {
         "watchedDirectories": [
           "../native-component-list/src/screens/inlineModules/inlineModulesExamples"

--- a/apps/bare-expo/macos/Podfile
+++ b/apps/bare-expo/macos/Podfile
@@ -16,7 +16,7 @@ target 'BareExpo-macOS' do
     'react-native-config',
     '--json',
     '--platform',
-    'ios',
+    'macos',
     '--source-dir',
     File.expand_path('.', __dir__)
   ]

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -1,16 +1,17 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (55.0.2):
+  - EASClient (56.0.1):
     - ExpoModulesCore
-  - EXConstants (55.0.7):
+  - EXConstants (56.0.16):
     - ExpoModulesCore
-  - EXManifests (55.0.9):
+  - EXManifests (56.0.4):
     - ExpoModulesCore
-  - Expo (55.0.2):
+  - Expo (56.0.5):
     - boost
     - DoubleConversion
     - ExpoModulesCore
+    - ExpoModulesJSI
     - fast_float
     - fmt
     - glog
@@ -38,17 +39,17 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-client (55.0.9):
+  - expo-dev-client (56.0.16):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (55.0.10):
+  - expo-dev-launcher (56.0.16):
     - boost
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 55.0.10)
+    - expo-dev-launcher/Main (= 56.0.16)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -81,7 +82,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Main (55.0.10):
+  - expo-dev-launcher/Main (56.0.16):
     - boost
     - DoubleConversion
     - EXManifests
@@ -118,7 +119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Unsafe (55.0.10):
+  - expo-dev-launcher/Unsafe (56.0.16):
     - boost
     - DoubleConversion
     - EXManifests
@@ -154,10 +155,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (55.0.9):
+  - expo-dev-menu (56.0.15):
     - boost
     - DoubleConversion
-    - expo-dev-menu/Main (= 55.0.9)
+    - expo-dev-menu/Main (= 56.0.15)
     - fast_float
     - fmt
     - glog
@@ -183,8 +184,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu-interface (55.0.1)
-  - expo-dev-menu/Main (55.0.9):
+  - expo-dev-menu-interface (56.0.1)
+  - expo-dev-menu/Main (56.0.15):
     - boost
     - DoubleConversion
     - EXManifests
@@ -216,25 +217,29 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoAsset (55.0.7):
+  - ExpoAsset (56.0.15):
     - ExpoModulesCore
-  - ExpoCrypto (55.0.8):
+  - ExpoClipboard (56.0.3):
     - ExpoModulesCore
-  - ExpoFileSystem (55.0.9):
+  - ExpoCrypto (56.0.4):
     - ExpoModulesCore
-  - ExpoFont (55.0.4):
+  - ExpoFileSystem (56.0.7):
     - ExpoModulesCore
-  - ExpoKeepAwake (55.0.4):
+  - ExpoFont (56.0.5):
     - ExpoModulesCore
-  - ExpoLinking (55.0.7):
+  - ExpoKeepAwake (56.0.3):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (55.0.8):
+  - ExpoLinearGradient (56.0.4):
     - ExpoModulesCore
-  - ExpoLogBox (55.0.7):
+  - ExpoLinking (56.0.12):
+    - ExpoModulesCore
+  - ExpoLocalAuthentication (56.0.4):
+    - ExpoModulesCore
+  - ExpoLogBox (56.0.12):
     - React-Core
-  - ExpoMeshGradient (55.0.8):
+  - ExpoMeshGradient (56.0.3):
     - ExpoModulesCore
-  - ExpoModulesCore (55.0.12):
+  - ExpoModulesCore (56.0.13):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -264,21 +269,25 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (55.0.12):
-    - hermes-engine
+  - ExpoModulesJSI (56.0.7):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesWorklets (55.0.12):
+  - ExpoModulesWorklets (56.0.13):
     - ExpoModulesCore
     - ExpoModulesJSI
+  - ExpoModulesWorkletsAdapter (56.0.13):
+    - ExpoModulesCore
+    - ExpoModulesJSI
+    - ExpoModulesWorklets
     - RNWorklets
-  - ExpoSQLite (55.0.10):
+  - ExpoSQLite (56.0.4):
     - ExpoModulesCore
-  - ExpoWebBrowser (55.0.9):
+  - ExpoSymbols (56.0.5):
     - ExpoModulesCore
-  - EXStructuredHeaders (55.0.0)
-  - EXUpdates (55.0.11):
+  - ExpoWebBrowser (56.0.5):
+    - ExpoModulesCore
+  - EXStructuredHeaders (56.0.0)
+  - EXUpdates (56.0.17):
     - boost
     - DoubleConversion
     - EASClient
@@ -312,7 +321,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdatesInterface (55.1.3):
+  - EXUpdatesInterface (56.0.2):
     - ExpoModulesCore
   - fast_float (8.0.0)
   - FBLazyVector (0.81.7)
@@ -321,36 +330,6 @@ PODS:
   - hermes-engine (0.81.6):
     - hermes-engine/Pre-built (= 0.81.6)
   - hermes-engine/Pre-built (0.81.6)
-  - lottie-ios (4.6.0)
-  - lottie-react-native (7.3.6):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - lottie-ios (= 4.6.0)
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2121,94 +2100,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - react-native-safe-area-context/common (= 5.6.2)
-    - react-native-safe-area-context/fabric (= 5.6.2)
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - react-native-safe-area-context/common (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - react-native-safe-area-context/fabric (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - react-native-safe-area-context/common
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - react-native-webview (13.16.0):
+  - react-native-webview (13.16.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2769,7 +2661,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNGestureHandler (2.30.0):
+  - RNGestureHandler (2.31.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2797,40 +2689,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.3.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNReanimated/apple (= 4.3.0)
-    - RNReanimated/common (= 4.3.0)
-    - RNWorklets
-    - SocketRocket
-    - Yoga
-  - RNReanimated/apple (4.3.0):
+  - RNReanimated (4.3.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2858,10 +2717,12 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - RNReanimated/apple (= 4.3.1)
+    - RNReanimated/common (= 4.3.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/common (4.3.0):
+  - RNReanimated/apple (4.3.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2892,7 +2753,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets (0.8.1):
+  - RNReanimated/common (4.3.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2920,11 +2781,42 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/apple (= 0.8.1)
-    - RNWorklets/common (= 0.8.1)
+    - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets/apple (0.8.1):
+  - RNWorklets (0.8.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
+    - SocketRocket
+    - Yoga
+  - RNWorklets/apple (0.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2954,7 +2846,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets/common (0.8.1):
+  - RNWorklets/common (0.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2999,18 +2891,22 @@ DEPENDENCIES:
   - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
+  - ExpoClipboard (from `../../../packages/expo-clipboard/ios`)
   - ExpoCrypto (from `../../../packages/expo-crypto/ios`)
   - ExpoFileSystem (from `../../../packages/expo-file-system/ios`)
   - ExpoFont (from `../../../packages/expo-font/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
+  - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
   - ExpoLinking (from `../../../packages/expo-linking/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - "ExpoLogBox (from `../../../packages/@expo/log-box`)"
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
-  - ExpoModulesJSI (from `../../../packages/expo-modules-core`)
+  - ExpoModulesJSI (from `../../../packages/expo-modules-jsi/apple`)
   - ExpoModulesWorklets (from `../../../packages/expo-modules-core`)
+  - ExpoModulesWorkletsAdapter (from `../../../packages/expo-modules-core`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
+  - ExpoSymbols (from `../../../packages/expo-symbols/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
   - EXUpdates (from `../../../packages/expo-updates/ios`)
@@ -3020,7 +2916,6 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native-macos/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native-macos/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native-macos/sdks/hermes-engine/hermes-engine.podspec`)
-  - "lottie-react-native (from `../../../node_modules/.pnpm/lottie-react-native@7.3.6_patch_hash=37746ba73ff63ad55f0b85b8f86a7d5cb4a571f6a70dfb1882_c2ad4381419d24d88ade1559425adfc7/node_modules/lottie-react-native`)"
   - RCT-Folly (from `../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native-macos/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native-macos/Libraries/Required`)
@@ -3055,9 +2950,8 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native-macos/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native-macos/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/microtasks`)
-  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_8c00f34e506f253739502776a6b151b3/node_modules/@react-native-community/netinfo`)"
-  - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.2_react-native@0.85.2_patch_hash=26e2b529e765bf444b7_4c4e874d7e413c452c675c18547f03af/node_modules/react-native-safe-area-context`)"
-  - "react-native-webview (from `../../../node_modules/.pnpm/react-native-webview@13.16.0_react-native@0.85.2_patch_hash=26e2b529e765bf444b707b628f5_ed94a4777d932f77580fcbe7088d9627/node_modules/react-native-webview`)"
+  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_09a60ed3c23ce9283ba9c11e8da8057f/node_modules/@react-native-community/netinfo`)"
+  - "react-native-webview (from `../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0-rc.2_patch_hash=26e2b529e765bf444b707b_51b811a0fe43658e98cf8315e72b690b/node_modules/react-native-webview`)"
   - React-NativeModulesApple (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native-macos/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native-macos/ReactCommon/reactperflogger`)
@@ -3088,16 +2982,15 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
-  - "RNCAsyncStorage (from `../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.85.2_patch_hash=26e2b529_b044ebd20cc5ecbcdb2bd0989d915941/node_modules/@react-native-async-storage/async-storage`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.2_patch_hash=26e2b529e765bf444b70_6358249b5529bf8bf711045dadefcef4/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_0fedd36eff10fd1be5140aec862daae6/node_modules/react-native-reanimated`)"
-  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.8.1_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_bc3f67456b46d4b595389bc345cda557/node_modules/react-native-worklets`)"
+  - "RNCAsyncStorage (from `../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0-rc.2_patch_hash=26e_f8d702413189dadcf7af4b26165e40b2/node_modules/@react-native-async-storage/async-storage`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.31.2_patch_hash=e8fb2a67f1fa221dc758c27292b3ee21ed737178_4323434482c172dafecca4b8ccd10d02/node_modules/react-native-gesture-handler`)"
+  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_a00ece94bf0ad826d3ee1b71023fb58b/node_modules/react-native-reanimated`)"
+  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_f398d734a48395c596eb4d2ccf3cf0b0/node_modules/react-native-worklets`)"
   - SocketRocket (~> 0.7.1)
   - Yoga (from `../node_modules/react-native-macos/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
-    - lottie-ios
     - ReachabilitySwift
     - SocketRocket
 
@@ -3116,6 +3009,7 @@ EXTERNAL SOURCES:
     inhibit_warnings: false
     :path: "../../../packages/expo-manifests/ios"
   Expo:
+    inhibit_warnings: false
     :path: "../../../packages/expo"
   expo-dev-client:
     inhibit_warnings: false
@@ -3132,6 +3026,9 @@ EXTERNAL SOURCES:
   ExpoAsset:
     inhibit_warnings: false
     :path: "../../../packages/expo-asset/ios"
+  ExpoClipboard:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-clipboard/ios"
   ExpoCrypto:
     inhibit_warnings: false
     :path: "../../../packages/expo-crypto/ios"
@@ -3144,6 +3041,9 @@ EXTERNAL SOURCES:
   ExpoKeepAwake:
     inhibit_warnings: false
     :path: "../../../packages/expo-keep-awake/ios"
+  ExpoLinearGradient:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-linear-gradient/ios"
   ExpoLinking:
     inhibit_warnings: false
     :path: "../../../packages/expo-linking/ios"
@@ -3161,13 +3061,18 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-modules-core"
   ExpoModulesJSI:
     inhibit_warnings: false
-    :path: "../../../packages/expo-modules-core"
+    :path: "../../../packages/expo-modules-jsi/apple"
   ExpoModulesWorklets:
     inhibit_warnings: false
+    :path: "../../../packages/expo-modules-core"
+  ExpoModulesWorkletsAdapter:
     :path: "../../../packages/expo-modules-core"
   ExpoSQLite:
     inhibit_warnings: false
     :path: "../../../packages/expo-sqlite/ios"
+  ExpoSymbols:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-symbols/ios"
   ExpoWebBrowser:
     inhibit_warnings: false
     :path: "../../../packages/expo-web-browser/ios"
@@ -3191,8 +3096,6 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native-macos/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
-  lottie-react-native:
-    :path: "../../../node_modules/.pnpm/lottie-react-native@7.3.6_patch_hash=37746ba73ff63ad55f0b85b8f86a7d5cb4a571f6a70dfb1882_c2ad4381419d24d88ade1559425adfc7/node_modules/lottie-react-native"
   RCT-Folly:
     :podspec: "../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -3260,11 +3163,9 @@ EXTERNAL SOURCES:
   React-microtasksnativemodule:
     :path: "../node_modules/react-native-macos/ReactCommon/react/nativemodule/microtasks"
   react-native-netinfo:
-    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_8c00f34e506f253739502776a6b151b3/node_modules/@react-native-community/netinfo"
-  react-native-safe-area-context:
-    :path: "../../../node_modules/.pnpm/react-native-safe-area-context@5.6.2_react-native@0.85.2_patch_hash=26e2b529e765bf444b7_4c4e874d7e413c452c675c18547f03af/node_modules/react-native-safe-area-context"
+    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_09a60ed3c23ce9283ba9c11e8da8057f/node_modules/@react-native-community/netinfo"
   react-native-webview:
-    :path: "../../../node_modules/.pnpm/react-native-webview@13.16.0_react-native@0.85.2_patch_hash=26e2b529e765bf444b707b628f5_ed94a4777d932f77580fcbe7088d9627/node_modules/react-native-webview"
+    :path: "../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0-rc.2_patch_hash=26e2b529e765bf444b707b_51b811a0fe43658e98cf8315e72b690b/node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native-macos/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -3326,51 +3227,53 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native-macos/ReactCommon"
   RNCAsyncStorage:
-    :path: "../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.85.2_patch_hash=26e2b529_b044ebd20cc5ecbcdb2bd0989d915941/node_modules/@react-native-async-storage/async-storage"
+    :path: "../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0-rc.2_patch_hash=26e_f8d702413189dadcf7af4b26165e40b2/node_modules/@react-native-async-storage/async-storage"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.2_patch_hash=26e2b529e765bf444b70_6358249b5529bf8bf711045dadefcef4/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.31.2_patch_hash=e8fb2a67f1fa221dc758c27292b3ee21ed737178_4323434482c172dafecca4b8ccd10d02/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_0fedd36eff10fd1be5140aec862daae6/node_modules/react-native-reanimated"
+    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_a00ece94bf0ad826d3ee1b71023fb58b/node_modules/react-native-reanimated"
   RNWorklets:
-    :path: "../../../node_modules/.pnpm/react-native-worklets@0.8.1_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_bc3f67456b46d4b595389bc345cda557/node_modules/react-native-worklets"
+    :path: "../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_f398d734a48395c596eb4d2ccf3cf0b0/node_modules/react-native-worklets"
   Yoga:
     :path: "../node_modules/react-native-macos/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
   boost: cea1d4f90a3a59537f3deb03ff5656489d7133dd
   DoubleConversion: d31b1eb37f6d6f456530c4fd9124b857d6889cab
-  EASClient: cb7854d65c09c520cc7d165f266c1d3bb901ceb7
-  EXConstants: ed3e09607493bb717a7932f0e6786846169692a2
-  EXManifests: ad24b3a497444eee9e07cc8590b09974ba369050
-  Expo: afa1e57c45ee9b2b4d2b048df78f1de8849eb507
-  expo-dev-client: 929c5e873b07c54035ab42aa165f095f74478d6c
-  expo-dev-launcher: c7d71dc39d9279d532347d640121c90afb09e9d3
-  expo-dev-menu: 8e225e6d1b0bd560f63cd8c96dd405a638d665d3
-  expo-dev-menu-interface: 58beb5e831034c20466d8c26ba679b0aa385abd2
-  ExpoAsset: 595cc0587b67afaaedddca79d4c1cf506400cb27
-  ExpoCrypto: 51dabf8af02467094127eb920e140c318d300080
-  ExpoFileSystem: ad5826003c4064d55ab867193a8a79d19e85bce3
-  ExpoFont: 387d22422f85258b053db3bdac0883974c304a96
-  ExpoKeepAwake: 72475c0e8644ad4dae17742bde04d5a0fe4ad4f9
-  ExpoLinking: 8505f5b8fa023e82b9d3ac7be1f1241f35b415dd
-  ExpoLocalAuthentication: efe64e98f2686d8bd0bd04300ba5ed360b3d0100
-  ExpoLogBox: 4a892fbcf6e343ffc1a6b714dcdc04a754d7e42f
-  ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 6ac10871b4b9b56a13ecccb798cb7de19ae63b63
-  ExpoModulesJSI: 793687b04cbaa73ee8548bfdbcfba85954d1b2b5
-  ExpoModulesWorklets: c333b8e54a0a3785c48720f497de4fd6212142d3
-  ExpoSQLite: bb89f888d972448c0594042c6654c41957b006a8
-  ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
-  EXStructuredHeaders: e25ac67c966d3795153dfdb40bfd3b999df18929
-  EXUpdates: 9128a615d41f62abc13371b6c5cb2ef7a8b41ab3
-  EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
+  EASClient: 2321f8d99fa86c710a6f68e017f3b54366baed9f
+  EXConstants: 1c400bb9969f4c9e5ab324553138b74ae47b9efe
+  EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
+  Expo: 2f84590402ecef7c27722177775b38bdb8b7439d
+  expo-dev-client: 47bd82ac19bbfce73d04f9140f4a607b8468dde7
+  expo-dev-launcher: 3c614462e1c11cf13e688ce50b606c6426f10c53
+  expo-dev-menu: d21ab72323c504ed0a5e1c4604a64afe77e74f7b
+  expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
+  ExpoAsset: c2e7b5ba1fe75be683282d6264e38fd7cd8defbb
+  ExpoClipboard: 40221903a1caa68259e022517af49d12962821fe
+  ExpoCrypto: b54a97c4357d46d7f8de079e69fa89029572244b
+  ExpoFileSystem: d730a1cb33f2c91dec01561f0d710054fda32ae9
+  ExpoFont: 6fe496f2be617ed4367f159f215dcc4ba27d37d6
+  ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
+  ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
+  ExpoLinking: 82458b046854a5802092a37a5228a8a228f928a4
+  ExpoLocalAuthentication: 93f29833d2a8b957f996eddc05a632eb2bdeaa7d
+  ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
+  ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
+  ExpoModulesCore: 54fe1c082ac0fbc1bd3f4efb9ab1b79797dd352b
+  ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
+  ExpoModulesWorklets: c755176116ae553ede2268ca6837c31eb4081f8a
+  ExpoModulesWorkletsAdapter: 33314a6f5235a51ddf8d9bec2313e2e5d0499979
+  ExpoSQLite: 38a35f67bbb3370d9bb859aa65d106909c4e3b19
+  ExpoSymbols: b3c964ddc1f1c8d8ddb0eeb830e3a8e42b77ed2d
+  ExpoWebBrowser: 6e3d90e3fe1952d21a8494872b1e1a485cd50e2f
+  EXStructuredHeaders: 9e89bcdd636ae2ecb59995cfba3230f5d7547c08
+  EXUpdates: f729bd14cd6088ca8e65013515ff15dfa2328082
+  EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   fast_float: 20817c22759af6ac8d4d67e6e059b8b499953656
   FBLazyVector: e8ec216d79635ba4c9fb0e9becc30391ca4bff1b
   fmt: 24e7591456deb60b4a77518f83d9a916ac84223f
   glog: 0b31c25149b9d350b2666c7d459229861a00ec07
   hermes-engine: 7219f6e751ad6ec7f3d7ec121830ee34dae40749
-  lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
-  lottie-react-native: 983fd0489530e8d40f173de7f04e2f88b9317a15
   RCT-Folly: c803cf33238782d5fd21a5e02d44f64068e0e130
   RCTDeprecation: 32fb5034012098ad1f67eba8a62d73bdd7d082e7
   RCTRequired: 9f51919b547926d0c148032cf2a7271a37655af4
@@ -3406,8 +3309,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 59df6730a578de280cd8675cdf5440b91c243bdf
   React-microtasksnativemodule: 255f0b29a74d001ecd202e4d5f7f170a009b3987
   react-native-netinfo: 57447b5a45c98808f8eae292cf641f3d91d13830
-  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-webview: 654f794a7686b47491cf43aa67f7f428bea00eed
+  react-native-webview: 8407aaaf6b539b1e38b72fabb55d6885de03beaf
   React-NativeModulesApple: c1e8f5e34efed354e5a066ef47c45a4ca5dddbb4
   React-oscompat: b359d251f6ea20fa91e5e0f99fd7b563f50a8af3
   React-perflogger: e5156a6e931998e62a95a5e1a4428e3a17a0e5cf
@@ -3436,15 +3338,15 @@ SPEC CHECKSUMS:
   React-timing: f91e37f2154ef9b25e1ded28326f9998669145f1
   React-utils: 35e85af00d70760e6fda280c78d184da64d89e3d
   ReactAppDependencyProvider: 17d150a60ad301142905427154168f58641e38c4
-  ReactCodegen: e4bbe2efd9da85d7876829eb9f58cd8770c0e311
+  ReactCodegen: df525e57209169eecbcf15c319d505bace9ed668
   ReactCommon: b2b6ff304cf01e1b67d8e9646e34d58320be0964
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNGestureHandler: 9573b15d45c38e5771aac3330c89ab4683834bb6
-  RNReanimated: 3973ec11f4fc93bae13beecedd5f530257bf9ee8
-  RNWorklets: ef7fddf9c4c1fcd4cb44256c33c04940b5b5e7f8
+  RNGestureHandler: 7d628c670dfcc1b9fa5840de5648b87ac0635362
+  RNReanimated: 3f5f1c52d537ff4bc947de9e8029ad4ca6a8c1b5
+  RNWorklets: 1cc0d72b9329453d8dbabd552f2e9aef7e9c6056
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 8a0df683a71bee13fe0b9d8b653d1a062ff65b2e
 
-PODFILE CHECKSUM: 1382777d200f8b5ba1656ebc4e3714ad26a4bdb0
+PODFILE CHECKSUM: 2080184fe7378b7b21bd66f763b107271b042a9b
 
 COCOAPODS: 1.16.2

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -10,6 +10,17 @@ config.resolver.assetExts.push(
   'wasm' // For expo-sqlite on web
 );
 
+// TODO(gabrieldonadel): Remove this when bumping react-native-macos to 0.83.0
+const upstream = config.server?.rewriteRequestUrl;
+config.server.rewriteRequestUrl = function rewriteRequestUrl(url) {
+  let next = upstream ? upstream(url) : url;
+  if (!next.includes('platform=macos')) return next;
+
+  // Hermes V1 is not supported on macOS yet and setting engine=hermes causes
+  // the transformer to fail with "SyntaxError: 36642:5:private properties are not supported"
+  return next.replace('&transform.engine=hermes', '');
+};
+
 // writing a screenshot otherwise shows a metro refresh banner at the top of the screen which can interfere with another screenshot
 config.resolver.blockList.push(/^e2e/);
 

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -10,31 +10,8 @@ config.resolver.assetExts.push(
   'wasm' // For expo-sqlite on web
 );
 
-// When testing on MacOS we need to swap out `react-native` for `react-native-macos`
-config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (
-    platform === 'macos' &&
-    (moduleName === 'react-native' || moduleName.startsWith('react-native/'))
-  ) {
-    const newModuleName = moduleName.replace('react-native', 'react-native-macos');
-    return context.resolveRequest(context, newModuleName, platform);
-  }
-  return context.resolveRequest(context, moduleName, platform);
-};
 // writing a screenshot otherwise shows a metro refresh banner at the top of the screen which can interfere with another screenshot
 config.resolver.blockList.push(/^e2e/);
-
-// When testing on MacOS we need to include the `react-native-macos/Libraries/Core/InitializeCore` as prepended global module
-const originalGetModulesRunBeforeMainModule = config.serializer.getModulesRunBeforeMainModule;
-config.serializer.getModulesRunBeforeMainModule = () => {
-  try {
-    return [
-      require.resolve('react-native/Libraries/Core/InitializeCore'),
-      require.resolve('react-native-macos/Libraries/Core/InitializeCore'),
-    ];
-  } catch {}
-  return originalGetModulesRunBeforeMainModule();
-};
 
 // `expo-sqlite` uses `SharedArrayBuffer` on web, which requires explicit COOP and COEP headers
 // See: https://github.com/expo/expo/pull/35208

--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos@0.81.7.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos@0.81.7.patch
@@ -1,0 +1,59 @@
+diff --git a/react-native.config.js b/react-native.config.js
+index a34cefa6cf076b7ddca4a6dd9e0f6be8f4b9891a..b38a2837e35555d3834fb35578c45886d455329c 100644
+--- a/react-native.config.js
++++ b/react-native.config.js
+@@ -83,7 +83,19 @@ try {
+ }
+ 
+ // $FlowFixMe[untyped-import]
+-const macosCommands = require('./local-cli/runMacOS/runMacOS');
++let macosCommands;
++try {
++  // runMacOS resolves @react-native-community/cli at module-load time, so
++  // requiring it here would throw in projects that don't depend on the CLI
++  // (e.g. Expo apps). Guard it like the platform lookups above.
++  macosCommands = require('./local-cli/runMacOS/runMacOS');
++} catch {
++  if (verbose) {
++    console.warn(
++      'local-cli/runMacOS could not be loaded - @react-native-community/cli is likely not installed.',
++    );
++  }
++}
+ const {
+   bundleCommand,
+   startCommand,
+@@ -156,7 +168,9 @@ if (android != null) {
+ }
+ 
+ // [macOS
+-config.commands.push(...macosCommands);
++if (macosCommands) {
++  config.commands.push(...macosCommands);
++}
+ if (apple) {
+   config.platforms.macos = {
+     linkConfig: () => {
+diff --git a/scripts/cocoapods/autolinking.rb b/scripts/cocoapods/autolinking.rb
+index d8e9c7cec2f57c124cc2b2fc52b69de8940d3eb5..3eede671066cb814ca43567815e166acbf409cc6 100644
+--- a/scripts/cocoapods/autolinking.rb
++++ b/scripts/cocoapods/autolinking.rb
+@@ -38,7 +38,8 @@ def list_native_modules!(config_command)
+   config = JSON.parse(json)
+ 
+   packages = config["dependencies"]
+-  ios_project_root = Pathname.new(config["project"]["ios"]["sourceDir"])
++  project_config = config["project"]["macos"] || config["project"]["ios"]
++  ios_project_root = Pathname.new(project_config["sourceDir"])
+   react_native_path = Pathname.new(config["reactNativePath"])
+   codegen_output_path = ios_project_root.join("build/generated/autolinking/autolinking.json")
+ 
+@@ -49,7 +50,7 @@ def list_native_modules!(config_command)
+   found_pods = []
+ 
+   packages.each do |package_name, package|
+-    next unless package_config = package["platforms"]["ios"]
++    next unless package_config = package["platforms"]["macos"] || package["platforms"]["ios"]
+ 
+     name = package["name"]
+     podspec_path = package_config["podspecPath"]


### PR DESCRIPTION
# Why

With #46344, consumers no longer need to manually wire up `react-native-macos` resolution in Metro or repoint autolinking. `bare-expo` was still carrying the legacy manual setup 

# How

- Add `experiments.outOfTreePlatforms` and `macos` to `platforms` to bare-expo's app.json
- remove `resolveRequest` + `getModulesRunBeforeMainModule` overrides from metro.config.js
- Update macOS `Podfile` to call `react-native-config` with `--platform macos` so autolinking sees the macOS dependency graph.

Two other issues surfaced while turning it on:

1. `react-native.config.js` in `react-native-macos` unconditionally `require`s `local-cli/runMacOS`, which itself resolves `@react-native-community/cli` at module load, causing autolinking to error out before it could even read the config. The autolinking ruby script also only ever looked at `config.project.ios`, ignoring the `macos` project entry that the new `--platform macos` invocation produces. To fix that, I created a temporary patch for react-native-macos and will be sending a PR upstream soon

2. The bundler now sets `transform.engine=hermes` for the macOS platform, which causes the Hermes v1 transformer to throw `SyntaxError: private properties are not supported` because Hermes v1 isn't available on macOS yet, and disabling it through build-properies does not add the necessary polyfills. Add a temporary metro `rewriteRequestUrl` shim that strips `&transform.engine=hermes` for `platform=macos` requests for now
 
# Test Plan

- `cd apps/bare-expo/&& ./scripts/setup-macos-project.sh` 
- `pnpm start` and launch bareexpo macOS build

