### PR TITLE
[ios][ui] Resolve font on the Text concatenation path

### DIFF
--- a/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
@@ -301,6 +301,12 @@ export default function ModifiersScreen() {
               <Text modifiers={[font({ textStyle: 'caption' })]}>caption scales</Text>
             </VStack>
 
+            {/* font on concatenated Text runs scales + keeps weight */}
+            <Text>
+              <Text modifiers={[font({ textStyle: 'largeTitle', weight: 'bold' })]}>Big </Text>
+              <Text modifiers={[font({ textStyle: 'caption' })]}>and small, both scale</Text>
+            </Text>
+
             <HStack spacing={20}>
               <Text modifiers={[font({ size: 14 }), textCase('lowercase')]}>lowercase</Text>
               <Text modifiers={[font({ size: 14 }), textCase('uppercase')]}>uppercase</Text>

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix `TextField` and `SecureField` worklet `onTextChange` firing more than once per keystroke (when a change triggers reformatting) and on programmatic text updates. ([#46483](https://github.com/expo/expo/pull/46483) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix the `font` modifier dropping Dynamic Type scaling (`relativeTo`) and `weight` on concatenated `Text` runs. The Text-concatenation path now resolves the same `Font` as the view path. ([#46509](https://github.com/expo/expo/pull/46509) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [android] Fix universal `TextInput` ignoring `style` `backgroundColor` / `borderWidth` and not applying `textAlign` to the placeholder. ([#46441](https://github.com/expo/expo/pull/46441) by [@duyanhv](https://github.com/duyanhv))
 
 ### 💡 Others

--- a/packages/expo-ui/ios/Modifiers/FontModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/FontModifier.swift
@@ -86,7 +86,10 @@ internal struct FontModifier: ViewModifier, Record {
     content.font(resolveFont())
   }
 
-  private func resolveFont() -> Font {
+  // Shared so the Text-concatenation path (`applyTextModifier`) resolves the
+  // same `Font` as the view path, instead of a fixed-size `Font.custom` that
+  // drops `relativeTo` (Dynamic Type) and `weight`.
+  func resolveFont() -> Font {
     if let family = family {
       let baseSize = size ?? 17
       var font: Font = if let textStyle = textStyle {

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -1228,14 +1228,7 @@ public class ViewModifierRegistry {
       return text.monospacedDigit()
     case "font":
       guard let modifier = try? FontModifier(from: params, appContext: appContext) else { return text }
-      if let family = modifier.family {
-        return text.font(Font.custom(family, size: modifier.size ?? 17))
-      }
-      return text.font(.system(
-        size: modifier.size ?? 17,
-        weight: modifier.weight?.toSwiftUI() ?? .regular,
-        design: modifier.design?.toSwiftUI() ?? .default
-      ))
+      return text.font(modifier.resolveFont())
     case "foregroundColor":
       guard let modifier = try? ForegroundColorModifier(from: params, appContext: appContext),
             let color = modifier.color else { return text }


### PR DESCRIPTION
Completes #46007, which added `textStyle` Dynamic Type scaling to the `@expo/ui/swift-ui` `font` modifier on the view path but left the Text-concatenation path behind. When a `<Text>` is nested inside another `<Text>`, `applyTextModifier` built a fixed-size `Font.custom(family, size:)` that dropped both `relativeTo` (Dynamic Type) and `weight`. So `font({ textStyle, weight })` scaled and kept its weight standalone but lost both once concatenated.

`FontModifier.resolveFont()` already resolves the correct `Font`. It was just `private`, so the concatenation path reimplemented a lossy subset. Make it non-private and call it from both paths. Concatenated runs now resolve the identical `Font` and participate in Dynamic Type, the SwiftUI-native path for [Apple's Larger Text Accessibility Nutrition Label](https://developer.apple.com/help/app-store-connect/manage-app-accessibility/larger-text-evaluation-criteria).

```tsx
import { Host, Text } from '@expo/ui/swift-ui';
import { font } from '@expo/ui/swift-ui/modifiers';

<Host matchContents>
  <Text>
    <Text modifiers={[font({ textStyle: 'largeTitle', weight: 'bold' })]}>Big </Text>
    <Text modifiers={[font({ textStyle: 'caption' })]}>and small, both scale</Text>
  </Text>
</Host>
```

`Text.font(_:)` returns `Text`, so each run keeps its own resolved `Font` through concatenation. No JS, type, or API change.

# Test Plan

Smoke-tested on iPhone 17 Pro simulator (iOS 26.5, Xcode 26.5) via `apps/native-component-list`:

- `pnpm build`, `pnpm lint --max-warnings 0`, and `pnpm test` (9 suites, 50 tests) all green in `packages/expo-ui`.
- `et generate-docs-api-data -p expo-ui` produces no diffs caused by this PR. The TypeScript surface is unchanged so there's nothing to regenerate. The only diff it surfaced was unrelated drift from another PR, which I discarded.
- Modifiers screen renders a concatenated `<Text>` with a bold `largeTitle` run and a `caption` run. At default size the first run is large and bold and the second is caption-sized. Setting iOS Larger Text to AX5 via `xcrun simctl ui booted content_size accessibility-extra-extra-extra-large` grows both runs while the adjacent fixed-size demos hold. The old concatenation factory ignored `textStyle` and dropped `weight`, so before this change both runs held their default size and weight.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: no module plugin touched.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
