### PR TITLE
fix(router): expose native stack entry

### DIFF
--- a/packages/expo-router/native-stack.d.ts
+++ b/packages/expo-router/native-stack.d.ts
@@ -1,0 +1,2 @@
+export * from './build/fork/native-stack/createNativeStackNavigator';
+export * from './build/fork/native-stack/NativeStackView';

--- a/packages/expo-router/native-stack.js
+++ b/packages/expo-router/native-stack.js
@@ -1,0 +1,7 @@
+const createNativeStackNavigator = require('./build/fork/native-stack/createNativeStackNavigator');
+const NativeStackView = require('./build/fork/native-stack/NativeStackView');
+
+module.exports = {
+  ...createNativeStackNavigator,
+  ...NativeStackView,
+};

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -54,6 +54,8 @@
     "js-tabs.d.ts",
     "js-stack.js",
     "js-stack.d.ts",
+    "native-stack.js",
+    "native-stack.d.ts",
     "js-top-tabs.js",
     "js-top-tabs.d.ts",
     "tabs.js",


### PR DESCRIPTION
## Summary

Adds a public `expo-router/native-stack` entry point that exports Expo Router's bundled native stack factory and view:

- `createNativeStackNavigator`
- `NativeStackView`

This lets apps import the bundled native stack through a stable package subpath instead of reaching into `expo-router/build/...` internals.

Closes #46480.

## Test Plan

- `node node_modules/typescript/bin/tsc -p packages/expo-router/tsconfig.test.json --noEmit`
- `node node_modules/typescript/bin/tsc /tmp/native-stack-entry.ts --noEmit --ignoreConfig --jsx react-jsx --moduleResolution node16 --module node16 --target es2022 --skipLibCheck --typeRoots packages/expo-router/node_modules/@types --ignoreDeprecations 6.0`
- `node -e "const pkg = require('./packages/expo-router/package.json'); for (const file of ['native-stack.js','native-stack.d.ts']) { if (!pkg.files.includes(file)) throw new Error(file + ' missing from package files'); }"`

Notes:
- `pnpm --filter expo-router test:types` could not start locally because Corepack failed before invoking pnpm with `Cannot find matching keyid`.
- `npm pack --workspace expo-router --dry-run --json` failed in this monorepo with `Cannot set properties of null (setting 'peer')` before producing a tarball.
