### PR TITLE
Add ExpoObserve screen to native-components-list

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -63,6 +63,7 @@
     "expo": "workspace:*",
     "expo-2d-context": "^0.0.4",
     "expo-age-range": "workspace:*",
+    "expo-app-metrics": "workspace:*",
     "expo-apple-authentication": "workspace:*",
     "expo-application": "workspace:*",
     "expo-asset": "workspace:*",

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -109,6 +109,13 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/AppMetricsScreen'));
+    },
+    name: 'AppMetrics',
+    options: { title: 'App Metrics' },
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/AsyncStorageScreen'));
     },
     name: 'AsyncStorage',

--- a/apps/native-component-list/src/screens/AppMetricsScreen.tsx
+++ b/apps/native-component-list/src/screens/AppMetricsScreen.tsx
@@ -1,0 +1,84 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { useTheme } from 'ThemeProvider';
+import AppMetrics, { type MainSession, type Metric } from 'expo-app-metrics';
+import * as React from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function AppMetricsScreen() {
+  const { theme } = useTheme();
+  const [session, setSession] = React.useState<MainSession | null>(null);
+  const [refreshing, setRefreshing] = React.useState(false);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      let cancelled = false;
+      AppMetrics.getMainSession().then((s) => {
+        if (!cancelled) setSession(s);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, [])
+  );
+
+  const onRefresh = React.useCallback(async () => {
+    setRefreshing(true);
+    try {
+      setSession(await AppMetrics.getMainSession());
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const navMetrics: Metric[] = (session?.metrics ?? []).filter((m) => m.category === 'navigation');
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
+      <Text style={[styles.header, { color: theme.text.default }]}>Navigation metrics</Text>
+      {navMetrics.length === 0 ? (
+        <Text style={{ color: theme.text.secondary }}>
+          No navigation metrics yet. Navigate around the app, then pull to refresh.
+        </Text>
+      ) : (
+        navMetrics.map((m, i) => (
+          <View key={`${m.timestamp}-${i}`} style={styles.row}>
+            <View style={styles.rowTop}>
+              <Text style={[styles.name, { color: theme.text.default }]}>
+                expo.navigation.{m.name}
+              </Text>
+              <Text style={[styles.value, { color: theme.text.default }]}>
+                {m.value.toFixed(3)}s
+              </Text>
+            </View>
+            {m.routeName ? (
+              <Text style={{ color: theme.text.secondary }}>Route: {m.routeName}</Text>
+            ) : null}
+            {m.params ? (
+              <Text style={{ color: theme.text.secondary }}>
+                Params: {JSON.stringify(m.params)}
+              </Text>
+            ) : null}
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+AppMetricsScreen.navigationOptions = { title: 'App Metrics' };
+
+const styles = StyleSheet.create({
+  content: { padding: 12, gap: 8 },
+  header: { fontSize: 18, fontWeight: '600', marginBottom: 4 },
+  row: {
+    paddingVertical: 8,
+    borderBottomColor: 'rgba(0,0,0,0.1)',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowTop: { flexDirection: 'row', justifyContent: 'space-between' },
+  name: { fontFamily: 'Courier', fontSize: 14 },
+  value: { fontFamily: 'Courier', fontSize: 14 },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,6 +866,9 @@ importers:
       expo-age-range:
         specifier: workspace:*
         version: link:../../packages/expo-age-range
+      expo-app-metrics:
+        specifier: workspace:*
+        version: link:../../packages/expo-app-metrics
       expo-apple-authentication:
         specifier: workspace:*
         version: link:../../packages/expo-apple-authentication


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/46041 was merged to incorrect base branch

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<img height="512" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 12 57 43" src="https://github.com/user-attachments/assets/2749473f-0b15-492c-a65f-06438152db63" />
<img height="512" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 12 57 39" src="https://github.com/user-attachments/assets/74afda47-1f0c-47a3-ba36-1bd6a3461359" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
