### PR TITLE
[jsi] Include Swift toolchain version in xcframework cache key

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix build framework for Mac Catalyst ([#46289](https://github.com/expo/expo/pull/46289) by [@theeket](https://github.com/theeket))
 - [iOS] Throw instead of aborting when `getPropertyAsFunction` targets a missing or non-callable property. ([#46437](https://github.com/expo/expo/pull/46437) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Throw instead of aborting when `getPropertyAsObject` targets a non-object property. ([#46438](https://github.com/expo/expo/pull/46438) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Include the Swift toolchain version in the xcframework cache key so upgrading Xcode rebuilds slices instead of reusing ones built by an older compiler. ([#46523](https://github.com/expo/expo/pull/46523) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -100,6 +100,13 @@ compute_hash() {
     # sources invalidates the cache.
     echo "PODS_ROOT=${PODS_ROOT:-}"
     echo "RN_ROOT=${RN_ROOT:-}"
+    # Include the Swift toolchain version so upgrading Xcode invalidates the
+    # cache. A slice's .swiftmodule and Clang module cache are tied to the
+    # compiler that produced them; reusing a slice built by an older toolchain
+    # after an Xcode upgrade surfaces as spurious compile errors that look like
+    # source problems. swiftc --version reports the swiftlang/clang tags and the
+    # target triple, so any toolchain change forces a clean rebuild.
+    echo "TOOLCHAIN_VERSION=$(xcrun swiftc --version 2>/dev/null || true)"
     echo "$all_files" | LC_ALL=C sort | while IFS= read -r file; do
       echo "$file"
       cat "$file"


### PR DESCRIPTION
# Why

The `expo-modules-jsi` xcframework build caches per-platform slices keyed by a hash of the sources, `Package.swift`, the build scripts, the JSI headers, and `PODS_ROOT`/`RN_ROOT`. The Swift toolchain version was **not** part of that hash.

A slice's `.swiftmodule` and the Clang module cache are tied to the compiler that produced them. So after upgrading Xcode, the script would see an unchanged hash, reuse a slice built by the *older* compiler, and the new toolchain would choke on the incompatible artifacts — surfacing as spurious compile errors that look like source problems (e.g. the errors reported in #46242 after moving to a newer Xcode).

# How

Add the Swift toolchain version to `compute_hash`:

```sh
echo "TOOLCHAIN_VERSION=$(xcrun swiftc --version 2>/dev/null || true)"
```

`swiftc --version` reports the swiftlang/clang tags and the target triple, so any toolchain change invalidates the cache and forces a clean rebuild of the affected slices under the new compiler. Ordinary single-file edits are unaffected.

# Test Plan

- Build once on the current toolchain (slice cached).
- `xcrun swiftc --version` output differs after an Xcode upgrade → hash changes → slices rebuild from source instead of reusing the old ones.
- Script still parses (`bash -n`) and the hashed value is stable and non-empty within a toolchain.
