### PR TITLE
test(@expo/cli): switch `experiments.asyncRoutes` to true for all router E2E tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export-embed-eager.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-eager.test.ts
@@ -56,7 +56,7 @@ it('runs `npx expo export:embed --platform ios --eager`', async () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     }
   );

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -112,7 +112,7 @@ it('runs `npx expo export:embed`', async () => {
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_JS_ENGINE: 'hermes',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     }
   );
@@ -187,7 +187,7 @@ it('runs `npx expo export:embed --platform ios` with source maps', async () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     }
   );
@@ -257,7 +257,7 @@ it('runs `npx expo export:embed --platform ios` with a robot user', async () => 
       env: {
         NODE_ENV: 'production',
         E2E_ROUTER_SRC: 'react-native-canary',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
 
         // Most important part:
         // NOTE(EvanBacon): This is a robot user token for an expo-managed account that can authenticate with view-only permission.
@@ -336,7 +336,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     }
   );
@@ -426,7 +426,7 @@ it('runs `npx expo export:embed --bytecode`', async () => {
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_JS_ENGINE: 'hermes',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     }
   );

--- a/packages/@expo/cli/e2e/__tests__/export/base-path.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/base-path.test.ts
@@ -22,7 +22,7 @@ describe('static-rendering with a custom base path', () => {
         EXPO_E2E_BASE_PATH: baseUrl,
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/export-embed-rsc.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-embed-rsc.test.ts
@@ -52,7 +52,7 @@ jest.unmock('resolve-from');
           NODE_ENV: 'production',
 
           E2E_ROUTER_SRC: '01-rsc',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
 
           EXPO_USE_STATIC: 'single',
           E2E_ROUTER_JS_ENGINE: 'hermes',

--- a/packages/@expo/cli/e2e/__tests__/export/export-no-ssg.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-no-ssg.test.ts
@@ -22,7 +22,7 @@ describe('export-no-ssg', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'server',
           E2E_ROUTER_SRC: 'server',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/modal-splitting.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/modal-splitting.test.ts
@@ -23,7 +23,7 @@ describe('exports static splitting with modal', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'modal-splitting',
-        E2E_ROUTER_ASYNC: 'production',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/no-bytecode.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/no-bytecode.test.ts
@@ -25,7 +25,7 @@ describe('exports for hermes with no bytecode', () => {
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_JS_ENGINE: 'hermes',
           E2E_ROUTER_SRC: 'url-polyfill',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );
@@ -82,7 +82,7 @@ describe('exports for hermes with no bytecode and no minification', () => {
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_JS_ENGINE: 'hermes',
           E2E_ROUTER_SRC: 'url-polyfill',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/no-sitemap.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/no-sitemap.test.ts
@@ -18,7 +18,7 @@ describe('static-rendering with no sitemap', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
         E2E_ROUTER_SITEMAP: 'false',
       },
     });

--- a/packages/@expo/cli/e2e/__tests__/export/serializer-plugins.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/serializer-plugins.test.ts
@@ -16,7 +16,7 @@ describe('exports with serializer plugins', () => {
   const outputDir = path.join(projectRoot, outputName);
 
   beforeAll(async () => {
-    // E2E_USE_MOCK_SERIALIZER_PLUGIN=1 NODE_ENV=production EXPO_USE_STATIC=static E2E_ROUTER_SRC=static-rendering E2E_ROUTER_ASYNC=production npx expo export -p web --source-maps --output-dir dist-static-splitting-plugins
+    // E2E_USE_MOCK_SERIALIZER_PLUGIN=1 NODE_ENV=production EXPO_USE_STATIC=static E2E_ROUTER_SRC=static-rendering E2E_ROUTER_ASYNC=true npx expo export -p web --source-maps --output-dir dist-static-splitting-plugins
     await executeExpoAsync(
       projectRoot,
       ['export', '-p', 'web', '--source-maps', '--output-dir', outputName],
@@ -26,7 +26,7 @@ describe('exports with serializer plugins', () => {
           E2E_USE_MOCK_SERIALIZER_PLUGINS: '1',
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_SRC: 'modal-splitting',
-          E2E_ROUTER_ASYNC: 'production',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
@@ -20,7 +20,7 @@ const projectRoot = getRouterE2ERoot();
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'server',
           E2E_ROUTER_SRC: 'server',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
           NODE_OPTIONS: '--no-experimental-fetch',
         },
       })

--- a/packages/@expo/cli/e2e/__tests__/export/server-rendering.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-rendering.test.ts
@@ -20,7 +20,7 @@ describe('exports server', () => {
       fixtureName: 'static-rendering',
       export: {
         env: {
-          E2E_ROUTER_ASYNC: '',
+          E2E_ROUTER_ASYNC: 'true',
           E2E_ROUTER_SERVER_RENDERING: 'true',
         },
         cliFlags: ['--source-maps'],

--- a/packages/@expo/cli/e2e/__tests__/export/server-root-group.test.tsx
+++ b/packages/@expo/cli/e2e/__tests__/export/server-root-group.test.tsx
@@ -25,7 +25,7 @@ describe('server-root-group', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'server',
           E2E_ROUTER_SRC: 'server-root-group',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -21,7 +21,7 @@ describe('server-output', () => {
       fixtureName: 'server',
       export: {
         env: {
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
         },
       },
       serve: {

--- a/packages/@expo/cli/e2e/__tests__/export/single-page-app.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/single-page-app.test.ts
@@ -19,7 +19,7 @@ describe('exports with single-page', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'single',
         E2E_ROUTER_SRC: 'static-rendering',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/static-redirects-api.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-redirects-api.test.ts
@@ -23,7 +23,7 @@ describe('server api redirects', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'server',
           E2E_ROUTER_SRC: 'static-redirects',
-          E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_ASYNC: 'true',
           E2E_ROUTER_REDIRECTS: JSON.stringify([
             { source: '/redirect/permanent/methods', destination: '/methods', permanent: true },
             { source: '/redirect/methods', destination: '/methods' },

--- a/packages/@expo/cli/e2e/__tests__/export/static-redirects-screens.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-redirects-screens.test.ts
@@ -23,7 +23,7 @@ describe('exports static', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_SRC: 'static-rendering',
-          E2E_ROUTER_ASYNC: '',
+          E2E_ROUTER_ASYNC: 'true',
           E2E_ROUTER_REDIRECTS: JSON.stringify([
             { source: '/styled-redirect', destination: '/styled' },
           ] as RedirectConfig[]),

--- a/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
@@ -22,7 +22,7 @@ describe('exports static', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_SRC: 'static-rendering',
-          E2E_ROUTER_ASYNC: '',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
@@ -20,7 +20,7 @@ describe('exports static with bundle splitting', () => {
   const outputDir = path.join(projectRoot, outputName);
 
   beforeAll(async () => {
-    // NODE_ENV=production EXPO_USE_STATIC=static E2E_ROUTER_SRC=static-rendering E2E_ROUTER_ASYNC=production npx expo export -p web --source-maps --output-dir dist-static-splitting
+    // NODE_ENV=production EXPO_USE_STATIC=static E2E_ROUTER_SRC=static-rendering E2E_ROUTER_ASYNC=true npx expo export -p web --source-maps --output-dir dist-static-splitting
     await executeExpoAsync(
       projectRoot,
       ['export', '-p', 'web', '--source-maps', '--output-dir', outputName],
@@ -29,7 +29,7 @@ describe('exports static with bundle splitting', () => {
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_SRC: 'static-rendering',
-          E2E_ROUTER_ASYNC: 'production',
+          E2E_ROUTER_ASYNC: 'true',
         },
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/export/tailwind-postcss.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/tailwind-postcss.test.ts
@@ -19,7 +19,7 @@ describe('exports with tailwind and postcss', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'tailwind-postcss',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/url-polyfill.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/url-polyfill.test.ts
@@ -19,7 +19,7 @@ describe('exports with url-polyfill', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'url-polyfill',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/web-modal.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/web-modal.test.ts
@@ -26,7 +26,7 @@ describe.each(['0', '1'])(
           NODE_ENV: 'production',
           EXPO_USE_STATIC: 'static',
           E2E_ROUTER_SRC: 'web-modal',
-          E2E_ROUTER_ASYNC: 'production',
+          E2E_ROUTER_ASYNC: 'true',
           EXPO_UNSTABLE_WEB_MODAL,
         },
       });

--- a/packages/@expo/cli/e2e/__tests__/export/with-atlas.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/with-atlas.test.ts
@@ -19,7 +19,7 @@ describe('exports all platforms with static export', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'url-polyfill',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
         EXPO_ATLAS: 'true',
       },
     });

--- a/packages/@expo/cli/e2e/__tests__/export/without-sourcemaps.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/without-sourcemaps.test.ts
@@ -19,7 +19,7 @@ describe('exports static without sourcemaps', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'static',
         E2E_ROUTER_SRC: 'url-polyfill',
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
       },
     });
   });

--- a/packages/@expo/cli/e2e/playwright/dev/01-rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/01-rsc.test.ts
@@ -25,7 +25,7 @@ for (const outputMode of outputModes) {
         EXPO_USE_STATIC: outputMode,
         E2E_ROUTER_JS_ENGINE: 'hermes',
         E2E_ROUTER_SRC: inputDir,
-        E2E_ROUTER_ASYNC: 'development',
+        E2E_ROUTER_ASYNC: 'true',
         E2E_RSC_ENABLED: '1',
         TEST_SECRET_VALUE: 'test-secret',
 

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -24,7 +24,7 @@ test.describe(inputDir, () => {
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: testName,
       E2E_SERVER_FUNCTIONS: '1',
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
       E2E_RSC_ENABLED: '1',
       TEST_SECRET_VALUE: 'test-secret',
 

--- a/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
@@ -23,7 +23,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: testName,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
       E2E_SERVER_FUNCTIONS: '1',
       TEST_SECRET_VALUE: 'test-secret',
 

--- a/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
@@ -26,7 +26,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
 
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',

--- a/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
@@ -19,7 +19,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
 
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',

--- a/packages/@expo/cli/e2e/playwright/dev/metro-resolver.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/metro-resolver.test.ts
@@ -15,7 +15,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',
     },

--- a/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
@@ -19,7 +19,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
 
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',

--- a/packages/@expo/cli/e2e/playwright/dev/navigator-browser-history.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/navigator-browser-history.test.ts
@@ -20,7 +20,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
 
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',

--- a/packages/@expo/cli/e2e/playwright/dev/router-misc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/router-misc.test.ts
@@ -19,7 +19,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
 
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',

--- a/packages/@expo/cli/e2e/playwright/dev/web-workers.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/web-workers.test.ts
@@ -26,7 +26,7 @@ test.describe(inputDir, () => {
       EXPO_USE_STATIC: 'single',
       E2E_ROUTER_JS_ENGINE: 'hermes',
       E2E_ROUTER_SRC: testName,
-      E2E_ROUTER_ASYNC: 'development',
+      E2E_ROUTER_ASYNC: 'true',
       // Ensure CI is disabled otherwise the file watcher won't run.
       CI: '0',
     },


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
