### PR TITLE
[docs] Clarify `faceIDPermission` false option in  LocalAuthentication reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -58,7 +58,7 @@ You can configure `expo-local-authentication` using its built-in [config plugin]
       name: 'faceIDPermission',
       platform: 'ios',
       description:
-        'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message.',
+        'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message. Set it to `false` to omit `NSFaceIDUsageDescription` from your **Info.plist** if your app does not use Face ID.',
       default: '"Allow $(PRODUCT_NAME) to use Face ID"',
     },
   ]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21534

- The `expo-local-authentication` config plugin types `faceIDPermission` as [`string | false`](https://github.com/expo/expo/blob/cd51b6634f5cc5c6dcd3899154d9761a5c65982f/packages/expo-local-authentication/plugin/src/withLocalAuthentication.ts#L12), and passing `false` [deletes `NSFaceIDUsageDescription` from the Info.plist](https://github.com/expo/expo/blob/119b336f677fc6ce44658ea34f79ba823028923d/packages/@expo/config-plugins/src/ios/Permissions.ts#L19-L21), but the docs only documented the string form.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated the `faceIDPermission` description in the `ConfigPluginProperties` table on `local-authentication.mdx` to note that setting it to `false` omits `NSFaceIDUsageDescription` from the **Info.plist**.
- Changes applied to `unversioned` reference.

# Test Plan

Proofread.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).