### PR TITLE
[ios][autolinking] Link companion pods whose package is installed via an optional peer

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))
+- [iOS] Link companion pods like `ExpoModulesWorkletsAdapter` when their backing package (e.g. `react-native-worklets`) is installed but reached only through an optional peer dependency.
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))
-- [iOS] Link companion pods like `ExpoModulesWorkletsAdapter` when their backing package (e.g. `react-native-worklets`) is installed but reached only through an optional peer dependency.
+- [iOS] Link companion pods like `ExpoModulesWorkletsAdapter` when their backing package (e.g. `react-native-worklets`) is installed but missing from the autolinking enumeration (e.g. reached transitively under shallow linking, or only through an optional peer dependency). ([#46533](https://github.com/expo/expo/pull/46533) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))
-- [iOS] Link companion pods like `ExpoModulesWorkletsAdapter` when their backing package (e.g. `react-native-worklets`) is installed but reached only through an optional peer dependency.
+- [iOS] Link companion pods like `ExpoModulesWorkletsAdapter` when their backing package (e.g. `react-native-worklets`) is installed but reached only through an optional peer dependency. ([#46533](https://github.com/expo/expo/pull/46533) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -487,7 +487,7 @@ module Expo
       #     "disabledValue": "false"
       #   }
       #   "autolinkWhen": {
-      #     "podName": "RNWorklets"
+      #     "npmPackage": "react-native-worklets"
       #   }
       def register_companion_pods(podfile, target_definition, project_directory, tests_only: false)
         return if tests_only
@@ -498,7 +498,7 @@ module Expo
           condition = info[:autolink_when]
           next unless condition
           next if target_definition.dependencies.any? { |dep| dep.name == pod_name }
-          next unless companion_autolink_condition_met?(condition, properties)
+          next unless companion_autolink_condition_met?(condition, properties, project_directory)
 
           podspec_file = File.join(info[:podspec_dir], "#{pod_name}.podspec")
           unless File.exist?(podspec_file)
@@ -563,12 +563,13 @@ module Expo
         JSON.parse(File.read(props_path)) rescue {}
       end
 
-      def companion_autolink_condition_met?(condition, properties)
+      def companion_autolink_condition_met?(condition, properties, project_directory)
         pod_name = condition['podName']
         return pod_lookup_map.key?(pod_name) if pod_name
 
+        # Linked when the npm package is installed (Node-resolvable from the project)
         npm_package = condition['npmPackage']
-        return react_native_config.dig('dependencies', npm_package) != nil if npm_package
+        return node_module_resolvable?(npm_package, project_directory) if npm_package
 
         property = condition['podfileProperty']
         return false unless property
@@ -579,6 +580,17 @@ module Expo
 
       def companion_autolink_condition_label(condition)
         condition['podName'] || condition['npmPackage'] || condition['podfileProperty']
+      end
+
+      # True if `package_name` is resolvable from `project_directory` via Node (pnpm/yarn/hoist-safe).
+      def node_module_resolvable?(package_name, project_directory)
+        return false if package_name.nil? || package_name.empty?
+
+        script = "require.resolve('#{package_name}/package.json', { paths: ['#{project_directory}'] })"
+        output, _stderr, status = Open3.capture3('node', '--print', script)
+        status.success? && !output.strip.empty?
+      rescue StandardError
+        false
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -567,9 +567,19 @@ module Expo
         pod_name = condition['podName']
         return pod_lookup_map.key?(pod_name) if pod_name
 
-        # Linked when the npm package is installed (Node-resolvable from the project)
+        # Linked when the npm package is present. Two complementary signals, since the
+        # package can be linked via a path the other misses:
+        #   - Node resolution from the project root catches packages that the autolinking
+        #     enumeration drops (optional peers, or transitive deps under shallow linking)
+        #     as long as they're hoisted to a node_modules the project can reach.
+        #   - The autolinking dependency list catches strict (non-hoisted) layouts where a
+        #     transitive-only package isn't Node-resolvable from the project root but is
+        #     still surfaced by real-resolution autolinking (e.g. via a non-optional peer).
         npm_package = condition['npmPackage']
-        return node_module_resolvable?(npm_package, project_directory) if npm_package
+        if npm_package
+          return true if node_module_resolvable?(npm_package, project_directory)
+          return react_native_config.dig('dependencies', npm_package) != nil
+        end
 
         property = condition['podfileProperty']
         return false unless property

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -176,7 +176,7 @@
         "iOS(.v16)"
       ],
       "autolinkWhen": {
-        "podName": "RNWorklets"
+        "npmPackage": "react-native-worklets"
       },
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-modules-core/src/__tests__/WorkletsAdapterAutolinking-test.ts
+++ b/packages/expo-modules-core/src/__tests__/WorkletsAdapterAutolinking-test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+
+// Regression guard for iOS worklets-adapter autolinking.
+//
+// `ExpoModulesWorkletsAdapter` is a source-only pod that hard-depends on `RNWorklets`
+// (react-native-worklets) and whose podspec raises if it can't resolve that package.
+// It must therefore be linked ONLY when react-native-worklets is installed. That
+// conditional gate lives in `spm.config.json` as `autolinkWhen: { npmPackage: 'react-native-worklets' }`.
+//
+// Entries in `apple.podspecPath` (expo-module.config.json) are linked UNCONDITIONALLY
+// into every app — `ExpoModuleConfig.applePodspecPaths()` returns them as-is, with no
+// filtering. Listing the adapter there forces `RNWorklets` onto apps that don't use
+// worklets, breaking their `pod install` with:
+//   "Unable to find a specification for `RNWorklets` depended upon by
+//    `ExpoModulesWorkletsAdapter`"
+// (this is what broke the updates-e2e build). So the adapter must stay OUT of
+// podspecPath and remain companion-gated. This test fails if either invariant regresses.
+
+const packageRoot = path.resolve(__dirname, '../..');
+
+function readJson(name: string): any {
+  return JSON.parse(fs.readFileSync(path.join(packageRoot, name), 'utf8'));
+}
+
+describe('iOS worklets-adapter autolinking', () => {
+  it('keeps ExpoModulesWorkletsAdapter out of apple.podspecPath', () => {
+    const podspecPaths: string[] = readJson('expo-module.config.json').apple?.podspecPath ?? [];
+
+    // Unconditional podspecPath entries break apps without react-native-worklets.
+    const adapterEntries = podspecPaths.filter((p) => /WorkletsAdapter/i.test(p));
+    expect(adapterEntries).toEqual([]);
+  });
+
+  it('gates ExpoModulesWorkletsAdapter on react-native-worklets in spm.config.json', () => {
+    const products: any[] = readJson('spm.config.json').products ?? [];
+    const adapter = products.find((p) => p?.name === 'ExpoModulesWorkletsAdapter');
+
+    expect(adapter).toBeDefined();
+    // The companion-pod gate: linked only when react-native-worklets is installed.
+    expect(adapter.autolinkWhen).toEqual({ npmPackage: 'react-native-worklets' });
+  });
+});

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -190,6 +190,29 @@
                 "sourceOnly": {
                     "type": "boolean",
                     "description": "When true, the product is never prebuilt as an xcframework. The prebuild flow skips it entirely — it does not generate sources, build, or resolve its externalDependencies. The product entry remains so autolinking (`autolinkWhen`) can still register the matching CocoaPods source pod. Use this for companion adapters that must always compile from source because they bridge to a peer pod that may not be present."
+                },
+                "autolinkWhen": {
+                    "type": "object",
+                    "description": "Condition gating whether this product's CocoaPods pod is autolinked into a consumer app (used for companion/adapter pods). One key is used, checked in order: `podName` (a resolved pod with this name is present), `npmPackage` (the npm package is installed / Node-resolvable from the project, even when React Native autolinking skips it — e.g. an optional peer dependency), or `podfileProperty` (a Podfile.properties.json value, autolinked unless it equals `disabledValue`).",
+                    "properties": {
+                        "podName": {
+                            "type": "string",
+                            "description": "Autolink when a resolved product pod with this name is present."
+                        },
+                        "npmPackage": {
+                            "type": "string",
+                            "description": "Autolink when this npm package is installed (Node-resolvable from the project)."
+                        },
+                        "podfileProperty": {
+                            "type": "string",
+                            "description": "Autolink based on a Podfile.properties.json property (see `disabledValue`)."
+                        },
+                        "disabledValue": {
+                            "type": "string",
+                            "description": "Used with `podfileProperty`: skip autolinking only when the property equals this value."
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "required": [ "name", "podName", "targets" ],


### PR DESCRIPTION
# Why

Expo UI can crash at runtime ("worklet can't be cast to Serializable") because `ExpoModulesWorkletsAdapter` — the source-only bridge that registers `WorkletsProviderRegistry.shared` in `+load` — isnt linked.

The adapter is a companion pod gated (via `spm.config.json` `autolinkWhen`) on `react-native-worklets` being installed, but that gate consults React Native autolinking's dependency list, which deliberately skips *optional* peer dependencies.

`@expo/ui` declares `react-native-worklets` as an optional peer, so the package can be present (the worklet runtime is pulled in transitively, e.g. by react-native-reanimated) yet never surface to the gate — leaving the adapter unlinked even though worklets are clearly in use.

This was mentioned in a PR that tried fixed the same issue: #46440 - but the fix and repro was wrong :)

# How

The `npmPackage` autolink condition now checks whether the package is installed via Node resolution, instead of reading the autolinking dependency list. The adapter's condition changes from `podName: RNWorklets` to `npmPackage: react-native-worklets`, so it links whenever the package is installed.

Also adds the `autolinkWhen` property to the spm.config schema — it was already used but never defined there.

# Test plan

- Gate unit check: package resolvable -> linked; not resolvable -> skipped; the `podName` branch is unchanged.
- Standalone app with worklets unsurfaced (shallow linking): the adapter was unlinked; with the fix it links, and `pod install` succeeds (RNWorklets comes in via reanimated).
- No regression: apps with worklets as a direct dependency still link the adapter; worklets-free apps still skip it.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
