### PR TITLE
[network][macOS] Add macOS platform support

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -8,6 +8,7 @@ on:
       - apps/bare-expo/macos/**
       - packages/expo/**
       - packages/expo-asset/**
+      - packages/expo-clipboard/**
       - packages/expo-constants/**
       - packages/expo-crypto/**
       - packages/expo-dev-client/**
@@ -23,10 +24,12 @@ on:
       - packages/expo-mesh-gradient/**
       - packages/expo-modules-autolinking/**
       - packages/expo-modules-core/**
+      - packages/expo-network/**
       - packages/expo-sqlite/**
       - packages/expo-structured-headers/**
-      - packages/expo-updates/**
+      - packages/expo-symbols/**
       - packages/expo-updates-interface/**
+      - packages/expo-updates/**
       - packages/expo-web-browser/**
       - "!packages/**/android/**"
       # Common ignores from detect-platform-change action

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [macOS] Add support for the macOS platform. ([#46535](https://github.com/expo/expo/pull/46535) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-network/ios/ExpoNetwork.podspec
+++ b/packages/expo-network/ios/ExpoNetwork.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '16.4',
-    :tvos => '16.4'
+    :tvos => '16.4',
+    :osx => '13.4'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true


### PR DESCRIPTION
# Why

`expo-network`'s iOS implementation is already fully macOS-compatible — it uses only the `Network` framework (`NWPathMonitor`, `NWPath`, `NWInterface`), BSD socket APIs (`getifaddrs`/`getnameinfo`/`freeifaddrs`), and GCD, with no UIKit or other iOS-only dependencies. The only thing preventing it from building on macOS was the missing platform declaration in the podspec.

# How

- Add `:osx => '13.4'` to the podspec `s.platforms` block.
- No Swift changes were necessary — the existing code compiles and runs on macOS as-is. The `"en"` interface-name heuristic in `getIPAddress()` matches macOS Ethernet/Wi-Fi interfaces (`en0`, `en1`, …) the same way it does on iOS.
- `expo-module.config.json` already declares the unified `"apple"` platform, so no JS-side change.

# Test Plan

- Builds for macOS once the platform is declared.
- `getIpAddressAsync`, `getNetworkStateAsync`, and the `onNetworkStateChanged` event behave the same as on iOS since they share the underlying `Network` framework APIs.
