### PR TITLE
[router][android] Support Stack.Toolbar.Badge in header placements

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/header-items.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/header-items.tsx
@@ -135,6 +135,7 @@ export default function HeaderItemsScreen() {
             hidden={!showLeftButton2}
             separateBackground={leftButton2SeparateBackground}
             selected={leftButton2Selected}
+            icon={process.env.EXPO_OS === 'ios' ? 'star' : searchIcon}
             onPress={handleLeftButton2Press}
             style={{
               fontWeight: 500,
@@ -142,7 +143,6 @@ export default function HeaderItemsScreen() {
               color: '#f0f',
             }}>
             <Stack.Toolbar.Label>Button 2</Stack.Toolbar.Label>
-            <Stack.Toolbar.Icon sf="star" />
             <Stack.Toolbar.Badge>33</Stack.Toolbar.Badge>
           </Stack.Toolbar.Button>
 

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -522,12 +522,13 @@ Use [`Stack.Toolbar.Spacer`](/versions/latest/sdk/router/stack/#stacktoolbarspac
 - **Android**: `Stack.Toolbar.Spacer` always requires an explicit `width`. There is no flexible-fill spacer at the moment.
 - **iOS**: a `Stack.Toolbar.Spacer` without a `width` creates flexible space between items, pushing them to opposite sides. This is useful for layouts like buttons on both ends of the toolbar. Pass a `width` for fixed-size spacing.
 
-## Adding badges to buttons (iOS only)
+## Adding badges to buttons
 
 In header toolbars, you can add badges to indicate counts or status. Use [`Stack.Toolbar.Icon`](/versions/latest/sdk/router/stack/#stacktoolbaricon), [`Stack.Toolbar.Label`](/versions/latest/sdk/router/stack/#stacktoolbarlabel), and [`Stack.Toolbar.Badge`](/versions/latest/sdk/router/stack/#stacktoolbarbadge) to compose the button content:
 
 ```tsx src/app/inbox.tsx
 import { Stack } from 'expo-router';
+import bellIcon from '@/assets/bell.png';
 
 export default function InboxScreen() {
   const unreadCount = 5;
@@ -535,8 +536,9 @@ export default function InboxScreen() {
   return (
     <>
       <Stack.Toolbar placement="right">
-        <Stack.Toolbar.Button onPress={() => {}}>
-          <Stack.Toolbar.Icon sf="bell" />
+        <Stack.Toolbar.Button
+          icon={process.env.EXPO_OS === 'ios' ? 'bell' : bellIcon}
+          onPress={() => {}}>
           <Stack.Toolbar.Label>Notifications</Stack.Toolbar.Label>
           {unreadCount > 0 && <Stack.Toolbar.Badge>{String(unreadCount)}</Stack.Toolbar.Badge>}
         </Stack.Toolbar.Button>
@@ -547,7 +549,7 @@ export default function InboxScreen() {
 }
 ```
 
-> **info** Badges only work in iOS header placements (`left` or `right`), not in the bottom toolbar nor on Android.
+> **info** Badges only work in header placements (`left` or `right`), not in the bottom toolbar. On Android, the `icon` prop or `Stack.Toolbar.Icon` with a `src` source is required for the badge to render.
 
 ## Embedding custom views
 
@@ -784,9 +786,9 @@ You cannot nest `Stack.Toolbar` components inside each other.
 
 </Collapsible>
 
-<Collapsible summary="Badge and Label primitives are not supported on Android">
+<Collapsible summary="Label primitive is not supported on Android">
 
-On Android, `Stack.Toolbar.Button` renders only its icon — the `Stack.Toolbar.Badge` and `Stack.Toolbar.Label` children are dropped. If you need badge-like UI on Android, embed a custom component using [`Stack.Toolbar.View`](/versions/latest/sdk/router/stack/#stacktoolbarview).
+On Android, `Stack.Toolbar.Button` renders only its icon and badge — the `Stack.Toolbar.Label` children are dropped. If you need label-like UI on Android, embed a custom component using [`Stack.Toolbar.View`](/versions/latest/sdk/router/stack/#stacktoolbarview).
 
 </Collapsible>
 

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -549,7 +549,7 @@ export default function InboxScreen() {
 }
 ```
 
-> **info** Badges only work in header placements (`left` or `right`), not in the bottom toolbar. On Android, the `icon` prop or `Stack.Toolbar.Icon` with a `src` source is required for the badge to render.
+> **info** Badges only work in header placements (`left` or `right`), not in the bottom toolbar.
 
 ## Embedding custom views
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [android] Support `Stack.Toolbar.Badge` in header left/right placements ([#46537](https://github.com/expo/expo/pull/46537) by [@benjaminkomen](https://github.com/benjaminkomen))
 - Add `standard-navigation` integration ([#46456](https://github.com/expo/expo/pull/46456) by [@Ubax](https://github.com/Ubax))
 - Re-export drawer content components and types (`DrawerContentScrollView`, `DrawerItem`, `DrawerItemList`, `DrawerContentComponentProps`, `DrawerNavigationProp`, and more) from `expo-router/drawer` ([#46635](https://github.com/expo/expo/pull/46635) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Emit a `tabPress` event with `isPrevented: true` when a `disabled` tab is tapped, without selecting it. ([#46445](https://github.com/expo/expo/pull/46445) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
@@ -59,6 +59,8 @@ jest.mock('@expo/ui/jetpack-compose', () => {
     Divider: jest.fn(() => <View testID="Divider" />),
     Icon: jest.fn((props) => <View testID="Icon" {...props} />),
     IconButton: jest.fn((props) => <View testID="IconButton" {...props} />),
+    Badge: jest.fn((props) => <View testID="Badge" {...props} />),
+    Box: jest.fn((props) => <View testID="Box" {...props} />),
     Text: jest.fn((props) => <View testID="ComposeText" {...props} />),
     RNHostView: jest.fn((props) => <View testID="RNHostView" {...props} />),
   };
@@ -323,4 +325,51 @@ describe('Stack.Toolbar Android integration tests', () => {
       }
     }
   );
+
+  describe('badge support in left/right placement', () => {
+    it.each(['left', 'right'] as const)(
+      'renders Box with Badge when button has a Badge child in %s placement',
+      (placement) => {
+        renderRouter({
+          _layout: () => (
+            <Stack>
+              <Stack.Screen name="index">
+                <Stack.Toolbar placement={placement}>
+                  <Stack.Toolbar.Button icon={{ uri: 'icon' }}>
+                    <Stack.Toolbar.Icon src={{ uri: 'icon' }} />
+                    <Stack.Toolbar.Badge>3</Stack.Toolbar.Badge>
+                  </Stack.Toolbar.Button>
+                </Stack.Toolbar>
+              </Stack.Screen>
+            </Stack>
+          ),
+          index: () => <View testID="index" />,
+        });
+
+        expect(screen.getByTestId('index')).toBeVisible();
+        expect(screen.getByTestId('Box')).toBeDefined();
+        expect(screen.getByTestId('Badge')).toBeDefined();
+      }
+    );
+
+    it('does not render Box when button has no Badge child', () => {
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index">
+              <Stack.Toolbar placement="right">
+                <Stack.Toolbar.Button icon={{ uri: 'icon' }}>
+                  <Stack.Toolbar.Icon src={{ uri: 'icon' }} />
+                </Stack.Toolbar.Button>
+              </Stack.Toolbar>
+            </Stack.Screen>
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+      expect(screen.queryByTestId('Box')).toBeNull();
+    });
+  });
 });

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
@@ -348,9 +348,34 @@ describe('Stack.Toolbar Android integration tests', () => {
 
         expect(screen.getByTestId('index')).toBeVisible();
         expect(screen.getByTestId('Box')).toBeDefined();
-        expect(screen.getByTestId('Badge')).toBeDefined();
+        const badge = screen.getByTestId('Badge');
+        expect(badge).toBeDefined();
+        expect(within(badge).getByTestId('ComposeText')).toBeDefined();
+        expect(within(badge).getByTestId('ComposeText').props.children).toBe('3');
       }
     );
+
+    it('renders dot badge when Badge has no children', () => {
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index">
+              <Stack.Toolbar placement="right">
+                <Stack.Toolbar.Button icon={{ uri: 'icon' }}>
+                  <Stack.Toolbar.Icon src={{ uri: 'icon' }} />
+                  <Stack.Toolbar.Badge />
+                </Stack.Toolbar.Button>
+              </Stack.Toolbar>
+            </Stack.Screen>
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+      expect(screen.getByTestId('Badge')).toBeDefined();
+      expect(screen.queryByTestId('ComposeText')).toBeNull();
+    });
 
     it('does not render Box when button has no Badge child', () => {
       renderRouter({

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
@@ -340,7 +340,9 @@ describe('NativeToolbarButton', () => {
     });
 
     it('does not render badge text when value is null', () => {
-      render(<NativeToolbarButton {...defaultProps} badge={{ value: null }} />);
+      render(
+        <NativeToolbarButton {...defaultProps} badge={{ value: null as unknown as string }} />
+      );
 
       expect(MockedBox).toHaveBeenCalled();
       expect(MockedBadge).toHaveBeenCalled();
@@ -411,18 +413,18 @@ describe('NativeToolbarButton', () => {
       consoleSpy.mockRestore();
     });
 
-    it('applies alpha modifier to Box when disabled with badge', () => {
+    it('applies alpha modifier to Badge when disabled with badge', () => {
       render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} disabled />);
 
-      expect(MockedBox.mock.calls[0]![0]).toMatchObject({
+      expect(MockedBadge.mock.calls[0]![0]).toMatchObject({
         modifiers: [{ type: 'alpha', alpha: 0.38 }],
       });
     });
 
-    it('does not apply alpha modifier to Box when enabled with badge', () => {
+    it('does not apply alpha modifier to Badge when enabled with badge', () => {
       render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} />);
 
-      expect(MockedBox.mock.calls[0]![0].modifiers).toBeUndefined();
+      expect(MockedBadge.mock.calls[0]![0].modifiers).toBeUndefined();
     });
   });
 

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
@@ -9,6 +9,9 @@ jest.mock('@expo/ui/jetpack-compose', () => {
   return {
     IconButton: jest.fn((props) => <View testID="IconButton" {...props} />),
     Icon: jest.fn((props) => <View testID="Icon" {...props} />),
+    Badge: jest.fn((props) => <View testID="Badge" {...props} />),
+    Box: jest.fn((props) => <View testID="Box" {...props} />),
+    Text: jest.fn((props) => <View testID="ComposeText" {...props} />),
   };
 });
 
@@ -29,11 +32,18 @@ jest.mock('../../../toolbar/AnimatedItemContainer', () => {
   };
 });
 
-const { IconButton, Icon } = jest.requireMock(
-  '@expo/ui/jetpack-compose'
-) as typeof import('@expo/ui/jetpack-compose');
+const {
+  IconButton,
+  Icon,
+  Badge,
+  Box,
+  Text: ComposeText,
+} = jest.requireMock('@expo/ui/jetpack-compose') as typeof import('@expo/ui/jetpack-compose');
 const MockedIconButton = IconButton as jest.MockedFunction<typeof IconButton>;
 const MockedIcon = Icon as jest.MockedFunction<typeof Icon>;
+const MockedBadge = Badge as jest.MockedFunction<typeof Badge>;
+const MockedBox = Box as jest.MockedFunction<typeof Box>;
+const MockedComposeText = ComposeText as jest.MockedFunction<typeof ComposeText>;
 
 const { AnimatedItemContainer } = jest.requireMock(
   '../../../toolbar/AnimatedItemContainer'
@@ -253,6 +263,75 @@ describe('NativeToolbarButton', () => {
 
       expect(MockedIcon.mock.calls[0]![0]).toMatchObject({
         contentDescription: undefined,
+      });
+    });
+  });
+
+  describe('badge rendering', () => {
+    it('renders Box with Badge and text when badge has a value', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} />);
+
+      expect(MockedBox).toHaveBeenCalled();
+      expect(MockedBox.mock.calls[0]![0]).toMatchObject({
+        contentAlignment: 'topEnd',
+      });
+      expect(MockedBadge).toHaveBeenCalled();
+      expect(MockedComposeText).toHaveBeenCalled();
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        children: '3',
+      });
+    });
+
+    it('renders Badge without children when badge value is empty string (dot indicator)', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '' }} />);
+
+      expect(MockedBox).toHaveBeenCalled();
+      expect(MockedBadge).toHaveBeenCalled();
+      expect(MockedComposeText).not.toHaveBeenCalled();
+    });
+
+    it('passes containerColor from badge.style.backgroundColor', () => {
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          badge={{ value: '5', style: { backgroundColor: 'red' } }}
+        />
+      );
+
+      expect(MockedBadge.mock.calls[0]![0]).toMatchObject({
+        containerColor: 'red',
+      });
+    });
+
+    it('passes contentColor from badge.style.color', () => {
+      render(
+        <NativeToolbarButton {...defaultProps} badge={{ value: '5', style: { color: 'white' } }} />
+      );
+
+      expect(MockedBadge.mock.calls[0]![0]).toMatchObject({
+        contentColor: 'white',
+      });
+    });
+
+    it('does not render Box when badge prop is undefined', () => {
+      render(<NativeToolbarButton {...defaultProps} />);
+
+      expect(MockedBox).not.toHaveBeenCalled();
+    });
+
+    it('converts numeric badge value to string', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: 42 }} />);
+
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        children: '42',
+      });
+    });
+
+    it('AnimatedItemContainer visible works with badge present', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '1' }} hidden />);
+
+      expect(MockedAnimatedItemContainer.mock.calls[0]![0]).toMatchObject({
+        visible: false,
       });
     });
   });

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.android.tsx
@@ -15,6 +15,10 @@ jest.mock('@expo/ui/jetpack-compose', () => {
   };
 });
 
+jest.mock('@expo/ui/jetpack-compose/modifiers', () => ({
+  alpha: jest.fn((value: number) => ({ type: 'alpha', alpha: value })),
+}));
+
 jest.mock('../../../color', () => ({
   Color: {
     android: {
@@ -333,6 +337,128 @@ describe('NativeToolbarButton', () => {
       expect(MockedAnimatedItemContainer.mock.calls[0]![0]).toMatchObject({
         visible: false,
       });
+    });
+
+    it('does not render badge text when value is null', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: null }} />);
+
+      expect(MockedBox).toHaveBeenCalled();
+      expect(MockedBadge).toHaveBeenCalled();
+      expect(MockedComposeText).not.toHaveBeenCalled();
+    });
+
+    it('renders badge text "0" when value is 0', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: 0 }} />);
+
+      expect(MockedComposeText).toHaveBeenCalled();
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        children: '0',
+      });
+    });
+
+    it('passes fontSize from badge.style to ComposeText', () => {
+      render(
+        <NativeToolbarButton {...defaultProps} badge={{ value: '1', style: { fontSize: 10 } }} />
+      );
+
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        style: expect.objectContaining({ fontSize: 10 }),
+      });
+    });
+
+    it('passes fontFamily from badge.style to ComposeText', () => {
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          badge={{ value: '1', style: { fontFamily: 'monospace' } }}
+        />
+      );
+
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        style: expect.objectContaining({ fontFamily: 'monospace' }),
+      });
+    });
+
+    it('passes supported fontWeight from badge.style to ComposeText', () => {
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          badge={{ value: '1', style: { fontWeight: '700' } }}
+        />
+      );
+
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        style: expect.objectContaining({ fontWeight: '700' }),
+      });
+    });
+
+    it('warns and omits unsupported fontWeight values', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          badge={{ value: '1', style: { fontWeight: 'semibold' } }}
+        />
+      );
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unsupported fontWeight "semibold"')
+      );
+      expect(MockedComposeText.mock.calls[0]![0]).toMatchObject({
+        style: expect.objectContaining({ fontWeight: undefined }),
+      });
+      consoleSpy.mockRestore();
+    });
+
+    it('applies alpha modifier to Box when disabled with badge', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} disabled />);
+
+      expect(MockedBox.mock.calls[0]![0]).toMatchObject({
+        modifiers: [{ type: 'alpha', alpha: 0.38 }],
+      });
+    });
+
+    it('does not apply alpha modifier to Box when enabled with badge', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} />);
+
+      expect(MockedBox.mock.calls[0]![0].modifiers).toBeUndefined();
+    });
+  });
+
+  describe('accessibility with badge', () => {
+    it('appends badge value to contentDescription', () => {
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          accessibilityLabel="Notifications"
+          badge={{ value: '3' }}
+        />
+      );
+
+      expect(MockedIcon.mock.calls[0]![0]).toMatchObject({
+        contentDescription: 'Notifications, 3',
+      });
+    });
+
+    it('does not append badge value when badge has no value', () => {
+      render(
+        <NativeToolbarButton
+          {...defaultProps}
+          accessibilityLabel="Notifications"
+          badge={{ value: '' }}
+        />
+      );
+
+      expect(MockedIcon.mock.calls[0]![0]).toMatchObject({
+        contentDescription: 'Notifications',
+      });
+    });
+
+    it('does not set contentDescription when no accessibilityLabel', () => {
+      render(<NativeToolbarButton {...defaultProps} badge={{ value: '3' }} />);
+
+      expect(MockedIcon.mock.calls[0]![0].contentDescription).toBeUndefined();
     });
   });
 });

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -3,6 +3,7 @@ import { Badge, Box, Icon, IconButton, Text as ComposeText } from '@expo/ui/jetp
 
 import type { NativeToolbarButtonProps } from './types';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
+import { convertFontWeightToComposeFontWeight } from '../../../../utils/font';
 import { useToolbarColors } from '../context';
 import { DEFAULT_TOOLBAR_TINT_COLOR } from '../defaults';
 
@@ -45,6 +46,8 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
     </IconButton>
   );
 
+  const hasBadge = props.badge?.value != null;
+
   return (
     <AnimatedItemContainer visible={!props.hidden}>
       {props.badge ? (
@@ -53,8 +56,14 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
           <Badge
             containerColor={props.badge.style?.backgroundColor}
             contentColor={props.badge.style?.color}>
-            {props.badge.value ? (
-              <ComposeText style={{ typography: 'labelSmall' }}>
+            {hasBadge ? (
+              <ComposeText
+                style={{
+                  typography: 'labelSmall',
+                  fontWeight: convertFontWeightToComposeFontWeight(props.badge.style?.fontWeight),
+                  fontSize: props.badge.style?.fontSize,
+                  fontFamily: props.badge.style?.fontFamily,
+                }}>
                 {String(props.badge.value)}
               </ComposeText>
             ) : null}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { IconButton, Icon } from '@expo/ui/jetpack-compose';
+import { Badge, Box, Icon, IconButton, Text as ComposeText } from '@expo/ui/jetpack-compose';
 
 import type { NativeToolbarButtonProps } from './types';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
@@ -30,16 +30,39 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
       ? null
       : (props.tintColor ?? toolbarColors.tintColor ?? DEFAULT_TOOLBAR_TINT_COLOR());
 
+  const iconElement = (
+    <Icon
+      source={props.source}
+      tint={tintColor}
+      size={24}
+      contentDescription={props.accessibilityLabel}
+    />
+  );
+
+  const button = (
+    <IconButton onClick={props.onPress} enabled={!props.disabled}>
+      {iconElement}
+    </IconButton>
+  );
+
   return (
     <AnimatedItemContainer visible={!props.hidden}>
-      <IconButton onClick={props.onPress} enabled={!props.disabled}>
-        <Icon
-          source={props.source}
-          tint={tintColor}
-          size={24}
-          contentDescription={props.accessibilityLabel}
-        />
-      </IconButton>
+      {props.badge ? (
+        <Box contentAlignment="topEnd">
+          {button}
+          <Badge
+            containerColor={props.badge.style?.backgroundColor}
+            contentColor={props.badge.style?.color}>
+            {props.badge.value ? (
+              <ComposeText style={{ typography: 'labelSmall' }}>
+                {String(props.badge.value)}
+              </ComposeText>
+            ) : null}
+          </Badge>
+        </Box>
+      ) : (
+        button
+      )}
     </AnimatedItemContainer>
   );
 };

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -58,13 +58,12 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
   return (
     <AnimatedItemContainer visible={!props.hidden}>
       {props.badge ? (
-        <Box
-          contentAlignment="topEnd"
-          modifiers={props.disabled ? [alphaModifier(0.38)] : undefined}>
+        <Box contentAlignment="topEnd">
           {button}
           <Badge
             containerColor={props.badge.style?.backgroundColor}
-            contentColor={props.badge.style?.color}>
+            contentColor={props.badge.style?.color}
+            modifiers={props.disabled ? [alphaModifier(0.38)] : undefined}>
             {hasBadge ? (
               <ComposeText
                 style={{

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Badge, Box, Icon, IconButton, Text as ComposeText } from '@expo/ui/jetpack-compose';
+import { alpha as alphaModifier } from '@expo/ui/jetpack-compose/modifiers';
 
 import type { NativeToolbarButtonProps } from './types';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
@@ -31,12 +32,20 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
       ? null
       : (props.tintColor ?? toolbarColors.tintColor ?? DEFAULT_TOOLBAR_TINT_COLOR());
 
+  const hasBadge = props.badge?.value != null && props.badge?.value !== '';
+
+  const contentDescription = props.accessibilityLabel
+    ? hasBadge
+      ? `${props.accessibilityLabel}, ${props.badge!.value}`
+      : props.accessibilityLabel
+    : undefined;
+
   const iconElement = (
     <Icon
       source={props.source}
       tint={tintColor}
       size={24}
-      contentDescription={props.accessibilityLabel}
+      contentDescription={contentDescription}
     />
   );
 
@@ -46,12 +55,12 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
     </IconButton>
   );
 
-  const hasBadge = props.badge?.value != null;
-
   return (
     <AnimatedItemContainer visible={!props.hidden}>
       {props.badge ? (
-        <Box contentAlignment="topEnd">
+        <Box
+          contentAlignment="topEnd"
+          modifiers={props.disabled ? [alphaModifier(0.38)] : undefined}>
           {button}
           <Badge
             containerColor={props.badge.style?.backgroundColor}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/types.ts
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/types.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { ColorValue, ImageSourcePropType, StyleProp, TextStyle } from 'react-native';
 import type { SFSymbol } from 'sf-symbols-typescript';
 
+import type { NativeStackHeaderItemButton } from '../../../../react-navigation/native-stack';
 import type { BasicTextStyle } from '../../../../utils/font';
 import type { StackHeaderItemSharedProps } from '../shared';
 
@@ -186,14 +187,5 @@ export interface NativeToolbarButtonProps {
   source?: ImageSourcePropType;
   /** Badge overlay on the icon. Only rendered in left/right placements.
    * @platform android */
-  badge?: {
-    value: number | string;
-    style?: {
-      color?: ColorValue;
-      backgroundColor?: ColorValue;
-      fontFamily?: string;
-      fontSize?: number;
-      fontWeight?: string;
-    };
-  };
+  badge?: NativeStackHeaderItemButton['badge'];
 }

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/types.ts
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/types.ts
@@ -184,4 +184,16 @@ export interface NativeToolbarButtonProps {
   label?: string;
   /* @platform android */
   source?: ImageSourcePropType;
+  /** Badge overlay on the icon. Only rendered in left/right placements.
+   * @platform android */
+  badge?: {
+    value: number | string;
+    style?: {
+      color?: ColorValue;
+      backgroundColor?: ColorValue;
+      fontFamily?: string;
+      fontSize?: number;
+      fontWeight?: string;
+    };
+  };
 }

--- a/packages/expo-router/src/utils/font.ts
+++ b/packages/expo-router/src/utils/font.ts
@@ -29,38 +29,21 @@ export function convertTextStyleToRNTextStyle<BaseStyleType extends Pick<TextSty
 
 export type BasicTextStyle = Pick<TextStyle, 'fontSize' | 'fontWeight' | 'fontFamily' | 'color'>;
 
-/**
- * Font weights supported by Jetpack Compose text. Structurally identical to
- * `TextFontWeight` from `@expo/ui/jetpack-compose`.
- */
 export type ComposeFontWeight = 'normal' | 'bold' | `${NumericFontWeight}`;
 
-// Named weights follow React Native core's iOS equivalences (RCTFont):
-// ultralight=100, thin=200, light=300, regular=400, medium=500, semibold=600,
-// bold=700, heavy=800, black=900.
-const COMPOSE_FONT_WEIGHTS: Record<string, ComposeFontWeight | undefined> = {
-  normal: 'normal',
-  bold: 'bold',
-  '100': '100',
-  '200': '200',
-  '300': '300',
-  '400': '400',
-  '500': '500',
-  '600': '600',
-  '700': '700',
-  '800': '800',
-  '900': '900',
-  ultralight: '100',
-  thin: '200',
-  light: '300',
-  regular: '400',
-  medium: '500',
-  semibold: '600',
-  condensed: '400',
-  condensedBold: '700',
-  heavy: '800',
-  black: '900',
-};
+const SUPPORTED_FONT_WEIGHTS = new Set([
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  'normal',
+  'bold',
+]);
 
 export function convertFontWeightToComposeFontWeight(
   fontWeight: string | number | undefined
@@ -68,5 +51,14 @@ export function convertFontWeightToComposeFontWeight(
   if (fontWeight == null) {
     return undefined;
   }
-  return COMPOSE_FONT_WEIGHTS[String(fontWeight)];
+  const value = String(fontWeight);
+  if (!SUPPORTED_FONT_WEIGHTS.has(value)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `Unsupported fontWeight "${value}". Supported values are 100–900, "normal", and "bold".`
+      );
+    }
+    return undefined;
+  }
+  return value as ComposeFontWeight;
 }

--- a/packages/expo-router/src/utils/font.ts
+++ b/packages/expo-router/src/utils/font.ts
@@ -28,3 +28,45 @@ export function convertTextStyleToRNTextStyle<BaseStyleType extends Pick<TextSty
 }
 
 export type BasicTextStyle = Pick<TextStyle, 'fontSize' | 'fontWeight' | 'fontFamily' | 'color'>;
+
+/**
+ * Font weights supported by Jetpack Compose text. Structurally identical to
+ * `TextFontWeight` from `@expo/ui/jetpack-compose`.
+ */
+export type ComposeFontWeight = 'normal' | 'bold' | `${NumericFontWeight}`;
+
+// Named weights follow React Native core's iOS equivalences (RCTFont):
+// ultralight=100, thin=200, light=300, regular=400, medium=500, semibold=600,
+// bold=700, heavy=800, black=900.
+const COMPOSE_FONT_WEIGHTS: Record<string, ComposeFontWeight | undefined> = {
+  normal: 'normal',
+  bold: 'bold',
+  '100': '100',
+  '200': '200',
+  '300': '300',
+  '400': '400',
+  '500': '500',
+  '600': '600',
+  '700': '700',
+  '800': '800',
+  '900': '900',
+  ultralight: '100',
+  thin: '200',
+  light: '300',
+  regular: '400',
+  medium: '500',
+  semibold: '600',
+  condensed: '400',
+  condensedBold: '700',
+  heavy: '800',
+  black: '900',
+};
+
+export function convertFontWeightToComposeFontWeight(
+  fontWeight: string | number | undefined
+): ComposeFontWeight | undefined {
+  if (fontWeight == null) {
+    return undefined;
+  }
+  return COMPOSE_FONT_WEIGHTS[String(fontWeight)];
+}


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/46498

`Stack.Toolbar.Badge` was silently dropped on Android. The badge data is already extracted from children in `shared.ts` and forwarded via `{...sharedProps}`, but the Android renderer (`native.android.tsx`) had no `badge` prop defined and therefore never rendered it.

# How

- Add `badge` prop to `NativeToolbarButtonProps` in `types.ts`
- Render badge using `Box contentAlignment="topEnd"` wrapping the `IconButton` and a `Badge` from `@expo/ui/jetpack-compose`
- Use `Box` instead of `BadgedBox` because `BadgedBox` renders badges outside measured bounds which gets clipped by the constrained header slot
- Empty badge value renders as a dot indicator (Badge with no children)
- Badge style props map to `containerColor` (backgroundColor) and `contentColor` (color)

<img width="368" height="789" alt="Screenshot 2026-06-03 at 7 23 42 AM" src="https://github.com/user-attachments/assets/1063e434-a599-4b36-b6dc-5b26a1e7beb7" />

# Test Plan

- [x] Unit tests: `StackToolbarButton.test.android.tsx` — 30 tests pass
- [x] Integration tests: `StackToolbar.integration.test.android.tsx` — 13 tests pass
- [x] Full test suite: 250 suites, 3971 tests pass
- [x] Lint passes with no warnings
- [x] Build succeeds
- [x] Manually tested on Android emulator — badge renders without clipping for single/multi digit values
- [x] Attach screenshot proof

# Checklist

- [x] Documentation updated (removed "iOS only" limitation, updated badge section in `stack-toolbar.mdx`)
- [x] Changelog entry added
- [x] Tests cover badge rendering, styling, dot indicator, and interaction with visibility prop