### PR TITLE
[widgets][Android] Fix widget strings file location

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Allow string widget family values in the typed config plugin. ([#46133](https://github.com/expo/expo/issues/46133) by [@eliotgevers](https://github.com/eliotgevers))
 - [plugin] Inherit `ios.deploymentTarget` from app config for generated widget extension targets. ([#46193](https://github.com/expo/expo/pull/46193) by [@eliotgevers](https://github.com/eliotgevers))
+- [Android] Fix widget strings file location.
 
 ## 56.0.14 — 2026-05-23
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 - Allow string widget family values in the typed config plugin. ([#46133](https://github.com/expo/expo/issues/46133) by [@eliotgevers](https://github.com/eliotgevers))
 - [plugin] Inherit `ios.deploymentTarget` from app config for generated widget extension targets. ([#46193](https://github.com/expo/expo/pull/46193) by [@eliotgevers](https://github.com/eliotgevers))
-- [Android] Fix widget strings file location.
+- [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.14 — 2026-05-23
 

--- a/packages/expo-widgets/plugin/build/android/withAndroidWidgetFiles.js
+++ b/packages/expo-widgets/plugin/build/android/withAndroidWidgetFiles.js
@@ -50,7 +50,7 @@ const withAndroidWidgetFiles = (config, widgets) => {
             const packageDirectory = path.join(projectRoot, 'app/src/main/java', ...androidPackage.split('.'));
             const xmlDirectory = path.join(projectRoot, 'app/src/main/res/xml');
             const valuesDirectory = path.join(projectRoot, 'app/src/main/res/values');
-            const widgetsXmlPath = path.join(xmlDirectory, 'expo_widgets.xml');
+            const widgetsXmlPath = path.join(valuesDirectory, 'expo_widgets.xml');
             fs.mkdirSync(packageDirectory, { recursive: true });
             fs.mkdirSync(xmlDirectory, { recursive: true });
             fs.mkdirSync(valuesDirectory, { recursive: true });

--- a/packages/expo-widgets/plugin/src/android/withAndroidWidgetFiles.ts
+++ b/packages/expo-widgets/plugin/src/android/withAndroidWidgetFiles.ts
@@ -32,7 +32,7 @@ const withAndroidWidgetFiles: ConfigPlugin<WidgetConfig[]> = (config, widgets) =
       );
       const xmlDirectory = path.join(projectRoot, 'app/src/main/res/xml');
       const valuesDirectory = path.join(projectRoot, 'app/src/main/res/values');
-      const widgetsXmlPath = path.join(xmlDirectory, 'expo_widgets.xml');
+      const widgetsXmlPath = path.join(valuesDirectory, 'expo_widgets.xml');
 
       fs.mkdirSync(packageDirectory, { recursive: true });
       fs.mkdirSync(xmlDirectory, { recursive: true });


### PR DESCRIPTION
# Why

Widgets config plugin creates strings resource in wrong file.

# How

Save `expo_widgets.xml` in `/res/values` instead of `/res/xml`

# Test Plan

Prebuild with `androidEnabled: true`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).