### PR TITLE
[docs] Add info on building app variants locally with `expo run`

### DIFF
--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -154,7 +154,7 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 > **Note**: If you use EAS Update to publish JavaScript updates of your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `eas update` command. See the EAS Build [Environment variables and secrets](/build/updates) for more information.
 
-### Build and multiple app variants locally
+### Build and run multiple app variants locally
 
 If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build, run:
 
@@ -167,9 +167,9 @@ If you [build your app locally](/guides/local-app-overview/) with [`expo run:and
   }}
 />
 
-`APP_VARIANT` changes only the app's name and package name on Android and bundle identifier on iOS. It does not affect how the binary is compiled. When you switch variants, the existing **android** and **ios** directories still reflect the previous variant. If a native directory is already present, `expo run` will skip regenerating it and compile it as-is.
+`APP_VARIANT` changes only the app's name and package name on Android and bundle identifier on iOS. It does not affect how the binary is compiled. When you switch variants, the existing **android** and **ios** directories still reflect the previous variant. If a native directory is already present, `expo run` skips regenerating it and compiles it as-is.
 
-To switch variants, you need to regenerate the native directories again with `prebuild --clean` before compiling the app. In the example below, the `development` variant (existing debug build) is switched to `test`, which is a another debug build. To regenerate the **Android** and **ios** directories and then compile the `test` variant, set `APP_VARIANT` on both commands so that the clean prebuild and the compilation use the same variant:
+To switch variants, you need to regenerate the native directories again with `prebuild --clean` before compiling the app. In the example below, the `development` variant (existing debug build) is switched to `test`, which is another debug build. To regenerate the **android** and **ios** directories and then compile the `test` variant, set `APP_VARIANT` on both commands so that the clean prebuild and the compilation use the same variant:
 
 <Terminal
   cmd={{

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -155,7 +155,7 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 > **Note**: If you use EAS Update to publish JavaScript updates of your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `eas update` command. See the EAS Build [Environment variables and secrets](/build/updates) for more information.
 
 
-### Build and use a variant locally
+### Build and multiple app variants locally
 
 If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build, run:
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -7,6 +7,7 @@ description: Learn how to install multiple variants of an app on the same device
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { Terminal } from '~/ui/components/Snippet';
 
 When creating [development, preview, and production builds](/build/eas-json/#common-use-cases), installing these build variants simultaneously on the same device is common. This allows working in development, previewing the next version of the app, and running the production version on a device without needing to uninstall and reinstall the app.
 
@@ -153,7 +154,34 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 > **Note**: If you use EAS Update to publish JavaScript updates of your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `eas update` command. See the EAS Build [Environment variables and secrets](/build/updates) for more information.
 
-### In an existing (bare) React Native project
+
+### Build and use a variant locally
+
+If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/prebuild/), set the `APP_VARIANT` environment variable to when you run the `expo run` command. For example, to compile the `development` variant for iOS, run:
+
+<Terminal
+  cmd={{
+    npm: ['$ APP_VARIANT=development npx expo run:ios'],
+    yarn: ['$ APP_VARIANT=development yarn expo run:ios'],
+    pnpm: ['$ APP_VARIANT=development pnpm expo run:ios'],
+    bun: ['$ APP_VARIANT=development bun expo run:ios'],
+  }}
+/>
+
+When you switch variants, the existing native directory (**android** or **ios**) still reflects the previous variant. To ensure that you switch to the correct variant, regenerate the native directories with a clean prebuild before compiling your app locally. For example, to switch to the `preview` variant, generate the native directories with the command below:
+
+<Terminal
+  cmd={{
+    npm: ['$ APP_VARIANT=preview npx expo prebuild --clean'],
+    yarn: ['$ APP_VARIANT=preview yarn expo prebuild --clean'],
+    pnpm: ['$ APP_VARIANT=preview pnpm expo prebuild --clean'],
+    bun: ['$ APP_VARIANT=preview bun expo prebuild --clean'],
+  }}
+/>
+
+The **android** and **ios** directories are managed by [Continuous Native Generation](/workflow/continuous-native-generation/), so regenerating them is safe when they are listed in your **.gitignore**.
+
+### In an existing React Native project
 
 > **info** If you want to use your [app config file](/workflow/configuration/) as the source of truth for your app configuration (including bundle identifiers and package names for variants), you need to migrate to [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) and add **android** and **ios** directories to your **.gitignore** file. This is especially important if you started with a React Native CLI project and added custom native code. This ensures that the native project configuration doesn't take precedence over your app config, especially when using bundle ID lookup behavior. Without this, you may experience issues where the wrong app variant runs or development builds aren't detected properly. Alternatively, you can explicitly opt for the Android flavors and iOS schemes as described below.
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -154,7 +154,6 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 > **Note**: If you use EAS Update to publish JavaScript updates of your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `eas update` command. See the EAS Build [Environment variables and secrets](/build/updates) for more information.
 
-
 ### Build and multiple app variants locally
 
 If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build, run:

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -157,7 +157,7 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 ### Build and use a variant locally
 
-If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable to when you run the `expo run` command. For example, to compile the `development` variant for iOS, run:
+If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build (the default), run:
 
 <Terminal
   cmd={{
@@ -168,14 +168,32 @@ If you [build your app locally](/guides/local-app-overview/) with [`expo run:and
   }}
 />
 
-When you switch variants, the existing native directory (**android** or **ios**) still reflects the previous variant. To ensure that you switch to the correct variant, regenerate the native directories with a clean prebuild before compiling your app locally. For example, to switch to the `preview` variant, generate the native directories with the command below:
+`APP_VARIANT` changes only the app's name and package name on Android and bundle identifier on iOS. It does not affect how the binary is compiled. When you switch variants, the existing **android** and **ios** directories still reflect the previous variant. If a native directory is already present, `expo run` will skip regenerating it and compile it as-is.
+
+To switch variants, you need to regenerate the native directories again with `prebuild --clean` before compiling the app. In the example below, the `development` variant (existing debug build) is switched to `test`, which is a another debug build. To regenerate the **Android** and **ios** directories and then compile the `test` variant, set `APP_VARIANT` on both commands so that the clean prebuild and the compilation use the same variant:
 
 <Terminal
   cmd={{
-    npm: ['$ APP_VARIANT=preview npx expo prebuild --clean'],
-    yarn: ['$ APP_VARIANT=preview yarn expo prebuild --clean'],
-    pnpm: ['$ APP_VARIANT=preview pnpm expo prebuild --clean'],
-    bun: ['$ APP_VARIANT=preview bun expo prebuild --clean'],
+    npm: [
+      '$ APP_VARIANT=test npx expo prebuild --clean',
+      '',
+      '$ APP_VARIANT=test npx expo run:ios',
+    ],
+    yarn: [
+      '$ APP_VARIANT=test yarn expo prebuild --clean',
+      '',
+      '$ APP_VARIANT=test yarn expo run:ios',
+    ],
+    pnpm: [
+      '$ APP_VARIANT=test pnpm expo prebuild --clean',
+      '',
+      '$ APP_VARIANT=test pnpm expo run:ios',
+    ],
+    bun: [
+      '$ APP_VARIANT=test bun expo prebuild --clean',
+      '',
+      '$ APP_VARIANT=test bun expo run:ios',
+    ],
   }}
 />
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -157,7 +157,7 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 ### Build and use a variant locally
 
-If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/prebuild/), set the `APP_VARIANT` environment variable to when you run the `expo run` command. For example, to compile the `development` variant for iOS, run:
+If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable to when you run the `expo run` command. For example, to compile the `development` variant for iOS, run:
 
 <Terminal
   cmd={{

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -157,7 +157,7 @@ When you run `eas build --profile production` the `APP_VARIANT` variable environ
 
 ### Build and use a variant locally
 
-If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build (the default), run:
+If you [build your app locally](/guides/local-app-overview/) with [`expo run:android|ios`](/workflow/continuous-native-generation/#usage), set the `APP_VARIANT` environment variable when you run the `expo run` command. For example, to compile the `development` variant for iOS as a debug build, run:
 
 <Terminal
   cmd={{


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21580

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a `Build and multiple app variants locally` section to `variants.mdx` that shows setting `APP_VARIANT` with `expo run:android|ios` and explains that switching variants requires regenerating the native directories with `expo prebuild --clean`, with an example.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2324" height="1314" alt="CleanShot 2026-06-03 at 22 05 55@2x" src="https://github.com/user-attachments/assets/2cd42b6f-3b48-4bea-bf76-a6ce10b872eb" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
