### PR TITLE
[widgets] Fix changelog merging issue

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 ### 🎉 New features
 
+- [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
+- Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
+
 ### 🐛 Bug fixes
+
+- [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 
@@ -20,14 +25,11 @@
 
 - [Android] Create base android package. ([#46090](https://github.com/expo/expo/pull/46090) by [@jakex7](https://github.com/jakex7))
 - [plugin] Create config plugin for android. ([#46091](https://github.com/expo/expo/pull/46091) by [@jakex7](https://github.com/jakex7))
-- [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
-- Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 
 - Allow string widget family values in the typed config plugin. ([#46133](https://github.com/expo/expo/issues/46133) by [@eliotgevers](https://github.com/eliotgevers))
 - [plugin] Inherit `ios.deploymentTarget` from app config for generated widget extension targets. ([#46193](https://github.com/expo/expo/pull/46193) by [@eliotgevers](https://github.com/eliotgevers))
-- [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.14 — 2026-05-23
 


### PR DESCRIPTION
# Why

For some reason merge broke the changelog without a conflicts. 
This PR adds a change to UNPUBLISHED section: https://github.com/expo/expo/pull/46286/changes#diff-e92c934d636c85205cc69bbabdb3291767d3ab5fda9c6ec9199f8f02057a0298R11
But merge commit adds it to PUBLISHED version: https://github.com/expo/expo/commit/f7c7b692453c697384278c41a39d91c15fe072f9#diff-e92c934d636c85205cc69bbabdb3291767d3ab5fda9c6ec9199f8f02057a0298R19

# How

Fixes the changelog after merge that caused sections to become incorrectly ordered.
