### PR TITLE
[core] Add `@Record` macro for synthesized records

### DIFF
--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -9,6 +9,12 @@ struct Point: Record {
   var y: Double = 0
 }
 
+@Record
+struct SynthesizedPoint {
+  var x: Double = 0
+  var y: Double = 0
+}
+
 final class SharedPoint: SharedObject {
   var x: Double = 0
   var y: Double = 0
@@ -58,6 +64,10 @@ public final class BenchmarkingExpoModule: Module {
     }
 
     Function("passthroughRecord") { (point: Point) in
+      return point
+    }
+
+    Function("passthroughSynthesizedRecord") { (point: SynthesizedPoint) in
       return point
     }
 

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -17,6 +17,7 @@ declare class BenchmarkingExpoModule extends NativeModule {
   foldArray(array: number[]): number;
   passthroughDict(point: { x: number; y: number }): { x: number; y: number };
   passthroughRecord(point: { x: number; y: number }): { x: number; y: number };
+  passthroughSynthesizedRecord(point: { x: number; y: number }): { x: number; y: number };
   passthroughSharedObject(point: SharedPoint): SharedPoint;
   SharedPoint: typeof SharedPoint;
   addNumbersAsync(a: number, b: number): Promise<number>;

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -334,11 +334,11 @@ export const GROUPS: Group[] = [
     id: 'passthrough',
     title: 'passthrough({ x, y })',
     description:
-      'Synchronous round-trip of a 2D point represented in three different ways. Compares `[String: Any]` dictionary, `Record`, and `SharedObject` decoding/encoding within Expo Modules. TurboModule and BridgeModule provide a dictionary baseline.',
+      'Synchronous round-trip of a 2D point represented in four different ways. Compares `[String: Any]` dictionary, `Record`, `@Record`-synthesized record, and `SharedObject` decoding/encoding within Expo Modules. TurboModule and BridgeModule provide a dictionary baseline.',
     benchmarks: [
       {
         id: 'expo-dict',
-        label: 'ExpoModule (dictionary)',
+        label: 'Dictionary',
         available: ExpoModule?.passthroughDict != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
@@ -350,7 +350,7 @@ export const GROUPS: Group[] = [
       },
       {
         id: 'expo-record',
-        label: 'ExpoModule (record)',
+        label: 'Record + @Field',
         available: ExpoModule?.passthroughRecord != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
@@ -361,8 +361,20 @@ export const GROUPS: Group[] = [
         },
       },
       {
+        id: 'expo-synthesized-record',
+        label: '@Record',
+        available: ExpoModule?.passthroughSynthesizedRecord != null,
+        async run(iterations) {
+          const point = { x: 1.5, y: 2.5 };
+          ExpoModule.passthroughSynthesizedRecord(point);
+          return timeSync(iterations, () => {
+            ExpoModule.passthroughSynthesizedRecord(point);
+          });
+        },
+      },
+      {
         id: 'expo-shared',
-        label: 'ExpoModule (shared object)',
+        label: 'SharedObject',
         available: ExpoModule?.passthroughSharedObject != null && ExpoModule?.SharedPoint != null,
         async run(iterations) {
           const point = new ExpoModule.SharedPoint(1.5, 2.5);
@@ -374,7 +386,7 @@ export const GROUPS: Group[] = [
       },
       {
         id: 'turbo-dict',
-        label: 'TurboModule (dictionary)',
+        label: 'Dictionary (TurboModule)',
         available: TurboModule?.passthroughDict != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
@@ -386,7 +398,7 @@ export const GROUPS: Group[] = [
       },
       {
         id: 'bridge-dict',
-        label: 'BridgeModule (dictionary)',
+        label: 'Dictionary (BridgeModule)',
         available: BridgeModule?.passthroughDict != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Added the `@Record` macro that synthesizes a record from a type's stored properties, with no `@Field` wrappers needed. ([#46547](https://github.com/expo/expo/pull/46547) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -21,10 +21,10 @@ internal struct DynamicConvertibleType: AnyDynamicType {
 
   @JavaScriptActor
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    // `from(object:)` dispatches dynamically: reflection-based hydration for `@Field` records,
+    // a direct statically-typed factory for `@Record`-synthesized ones.
     if let recordType = innerType as? any Record.Type {
-      let record = recordType.init()
-      try record.update(withObject: try jsValue.asObject(), appContext: appContext)
-      return record
+      return try recordType.from(object: jsValue.asObject(), appContext: appContext)
     }
     return try innerType.convert(from: jsValue.getAny(), appContext: appContext)
   }
@@ -53,6 +53,19 @@ internal struct DynamicConvertibleType: AnyDynamicType {
     return try convertOriginalValueToJS(value, appContext: appContext)
   }
 
+  // The protocol default for the `in: runtime` variant pre-converts the value via
+  // `convertFunctionResult` (which calls `convertResult` → `Record.toDictionary` for records) before
+  // reaching `castToJS`, defeating the direct object path. Override it to try the direct path first —
+  // the same short-circuit as the no-runtime `convertToJS` above — so records (including
+  // `@Record`-synthesized ones) convert straight through `toObject` on the return side too.
+  func convertToJS<ValueType>(_ value: ValueType, appContext: AppContext, in runtime: JavaScriptRuntime) throws -> JavaScriptValue {
+    if let directJSValue = try directJSValueIfPossible(value, appContext: appContext) {
+      return directJSValue
+    }
+    let result = Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: self)
+    return try castToJS(result, appContext: appContext, in: runtime)
+  }
+
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     return try innerType.convertResult(result, appContext: appContext)
   }
@@ -62,15 +75,17 @@ internal struct DynamicConvertibleType: AnyDynamicType {
   }
 
   private func directJSValueIfPossible<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue? {
+    // `toObject` is a `Record` requirement, so the synthesized override dispatches dynamically;
+    // `@Field` records fall through to the reflection-based default.
     if let value = value as? any Record {
       return try JavaScriptActor.assumeIsolated {
-        try value.toJSValue(appContext: appContext)
+        try value.toObject(appContext: appContext).asValue()
       }
     }
     // `FormattedRecord` isn't a `Record`, so it needs this separate branch to preserve the direct path.
-    if let value = value as? any RecordJavaScriptValueConvertible {
+    if let value = value as? any RecordObjectConvertible {
       return try JavaScriptActor.assumeIsolated {
-        try value.toJSValue(appContext: appContext)
+        try value.toObject(appContext: appContext).asValue()
       }
     }
     return nil

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -84,3 +84,29 @@ public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
 @attached(member, names: named(_exposedClassDefinition))
 public macro SharedObject(_ name: String? = nil) =
   #externalMacro(module: "ExpoModulesMacros", type: "SharedObjectMacro")
+
+/// Member + extension macro applied to a record `struct` or `class`. Every non-`static`,
+/// non-`private`/`fileprivate`, non-`lazy`, non-computed stored property is part of the record — no
+/// `@Field` wrapper needed — and the macro synthesizes the whole conversion surface from each
+/// property's static type: a memberwise `init`, the `from(object:appContext:)` /
+/// `from(dictionary:appContext:)` factories, and the `toDictionary(appContext:)` /
+/// `toObject(appContext:)` write side. The type is auto-conformed to `Record`; the synthesized
+/// methods override `Record`'s reflection-based defaults, so it stays usable anywhere a `Record`
+/// argument is expected.
+///
+/// Requiredness is inferred from each property: a default value makes it optional, an optional type
+/// makes it nullable and optional, and a non-optional property without a default is required (the
+/// factories throw `RecordPropertyRequiredException` when the source omits it).
+///
+/// Usage:
+///
+///     @Record
+///     struct Options {
+///       var name: String          // required
+///       var count: Int = 0        // optional (has default)
+///       var note: String?         // nullable + optional
+///     }
+@attached(member, names: named(init), named(from), named(toDictionary), named(toObject))
+@attached(extension, conformances: Record)
+public macro Record() =
+  #externalMacro(module: "ExpoModulesMacros", type: "RecordMacro")

--- a/packages/expo-modules-core/ios/Core/Records/FormattedRecord.swift
+++ b/packages/expo-modules-core/ios/Core/Records/FormattedRecord.swift
@@ -2,7 +2,7 @@
  Class that binds a formatter with a record.
  It can be converted to JS, but it can't be converted from a JS value.
  */
-public struct FormattedRecord<RecordType: Record>: Convertible, RecordJavaScriptValueConvertible {
+public struct FormattedRecord<RecordType: Record>: Convertible, RecordObjectConvertible {
   internal final class FormattedRecordCannotBeUsedAsParameterException: Exception, @unchecked Sendable {
     override var reason: String {
       "FormattedRecord cannot be used as a parameter"
@@ -39,7 +39,7 @@ public struct FormattedRecord<RecordType: Record>: Convertible, RecordJavaScript
   }
 
   @JavaScriptActor
-  func toJSValue(appContext: AppContext) throws -> JavaScriptValue {
+  func toObject(appContext: AppContext) throws -> JavaScriptObject {
     let object = try appContext.runtime.createObject()
 
     for field in fieldsOf(record) {
@@ -58,6 +58,6 @@ public struct FormattedRecord<RecordType: Record>: Convertible, RecordJavaScript
       let jsValue = try recordFieldValueToJSValue(value, appContext: appContext)
       object.setProperty(key, value: jsValue)
     }
-    return object.asValue()
+    return object
   }
 }

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -21,14 +21,52 @@ public protocol Record: Convertible {
   init(from: Dict, appContext: AppContext) throws
 
   /**
+   Reads the record's members off a `JavaScriptObject`. The `@Field`-based default goes through
+   reflection (`init()` + `update(withObject:)`); the `@Record` macro overrides it with a direct,
+   factory that reads each stored property by its declared type.
+   */
+  @JavaScriptActor
+  static func from(object: borrowing JavaScriptObject, appContext: AppContext) throws -> Self
+
+  /**
+   Reads the record's members from a `[String: Any]` dictionary. The `@Field`-based default goes
+   through reflection (`init()` + `update(withDict:)`); the `@Record` macro overrides it with a
+   direct, statically-typed factory.
+   */
+  static func from(dictionary: Dict, appContext: AppContext) throws -> Self
+
+  /**
    Converts the record back to the dictionary. Only members wrapped by `@Field` will be set in the dictionary.
    */
   func toDictionary(appContext: AppContext?) -> Dict
+
+  /**
+   Converts the record to a `JavaScriptObject`. The `@Field`-based default builds the object via
+   reflection; the `@Record` macro overrides it with a direct, statically-typed conversion.
+   */
+  @JavaScriptActor
+  func toObject(appContext: AppContext) throws -> JavaScriptObject
 }
 
-internal protocol RecordJavaScriptValueConvertible {
+/**
+ Adopted by record-like types that produce a `JavaScriptObject` directly but aren't themselves a
+ `Record` — currently just `FormattedRecord`. Lets `DynamicConvertibleType` take the direct
+ object-building path for them, same as for records.
+ */
+internal protocol RecordObjectConvertible {
   @JavaScriptActor
-  func toJSValue(appContext: AppContext) throws -> JavaScriptValue
+  func toObject(appContext: AppContext) throws -> JavaScriptObject
+}
+
+/**
+ Thrown by a synthesized record's factories when a required property is missing from the source.
+ Public because the `@Record`-generated code lives in user modules and references it directly.
+ The `@Field`-based path has its own internal `FieldRequiredException`.
+ */
+public final class RecordPropertyRequiredException: GenericException<String>, @unchecked Sendable {
+  override public var reason: String {
+    return "Value for property '\(param)' is required, got nil"
+  }
 }
 
 /**
@@ -37,7 +75,9 @@ internal protocol RecordJavaScriptValueConvertible {
 public extension Record {
   static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     if let value = value as? Dict {
-      return try Self(from: value, appContext: appContext)
+      // `from(dictionary:)` dispatches dynamically — reflection for `@Field` records, the
+      // synthesized factory for `@Record` ones — so both read correctly off a dictionary.
+      return try Self.from(dictionary: value, appContext: appContext)
     }
     // It's possible that the current implementation tries to convert a value that is already of the desired type.
     // Handle that gracefully instead of throwing an exception.
@@ -50,6 +90,22 @@ public extension Record {
   init(from dict: Dict, appContext: AppContext) throws {
     self.init()
     try update(withDict: dict, appContext: appContext)
+  }
+
+  @JavaScriptActor
+  static func from(object: borrowing JavaScriptObject, appContext: AppContext) throws -> Self {
+    // Reflection-based default for `@Field` records. The `@Record` macro synthesizes a direct,
+    // statically-typed override that takes precedence over this.
+    let record = Self()
+    try record.update(withObject: object, appContext: appContext)
+    return record
+  }
+
+  static func from(dictionary: Dict, appContext: AppContext) throws -> Self {
+    // Reflection-based default for `@Field` records. The `@Record` macro synthesizes a direct,
+    // statically-typed override that takes precedence over this. Delegates to `init(from:appContext:)`
+    // so any custom dictionary initializer a record provides still runs.
+    return try Self(from: dictionary, appContext: appContext)
   }
 
   func update(withDict dict: Dict, appContext: AppContext) throws {
@@ -107,7 +163,7 @@ public extension Record {
   }
 
   @JavaScriptActor
-  func toJSValue(appContext: AppContext) throws -> JavaScriptValue {
+  func toObject(appContext: AppContext) throws -> JavaScriptObject {
     let object = try appContext.runtime.createObject()
 
     for field in fieldsOf(self) {
@@ -117,7 +173,7 @@ public extension Record {
       let value = try recordFieldValueToJSValue(field.get(), dynamicType: field.fieldType, appContext: appContext)
       object.setProperty(key, value: value)
     }
-    return object.asValue()
+    return object
   }
 }
 

--- a/packages/expo-modules-core/ios/Tests/RecordTests.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordTests.swift
@@ -1,0 +1,177 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+
+// Records synthesized by the `@Record` macro — every stored property is part of the record, with no
+// `@Field` wrapper. Declared at file scope so the macro's `extension … : Record {}` is emitted in a
+// top-level context.
+
+@Record
+struct SynthesizedPointRecord {
+  var x: Double = 0
+  var y: Double = 0
+}
+
+@Record
+struct SynthesizedMixedRecord {
+  // Required: non-optional, no default — the source must provide it.
+  var name: String
+  // Optional via default — the default applies when the source omits it.
+  var count: Int = 7
+  // Nullable + optional — becomes `nil` when the source omits it or sends null.
+  var note: String?
+}
+
+enum SynthesizedStatus: String, Enumerable {
+  case active
+  case inactive
+}
+
+@Record
+struct SynthesizedEnumRecord {
+  var status: SynthesizedStatus = .inactive
+}
+
+@Suite("Record")
+struct RecordTests {
+
+  @Suite("SynthesizedRecord")
+  struct SynthesizedRecordTests {
+    let appContext = AppContext.create()
+
+    @Test
+    func `every stored property is part of the record without @Field`() throws {
+      let record = try SynthesizedMixedRecord.from(
+        dictionary: ["name": "alpha", "count": 3, "note": "hi"],
+        appContext: appContext
+      )
+
+      #expect(record.name == "alpha")
+      #expect(record.count == 3)
+      #expect(record.note == "hi")
+    }
+
+    @Test
+    func `defaulted property falls back to its declared default when omitted`() throws {
+      let record = try SynthesizedMixedRecord.from(
+        dictionary: ["name": "alpha"],
+        appContext: appContext
+      )
+
+      #expect(record.name == "alpha")
+      #expect(record.count == 7)
+      #expect(record.note == nil)
+    }
+
+    @Test
+    func `missing required property throws RecordPropertyRequiredException`() {
+      #expect(throws: RecordPropertyRequiredException.self) {
+        try SynthesizedMixedRecord.from(dictionary: [:], appContext: appContext)
+      }
+    }
+
+    @Test
+    func `toDictionary round-trips every property`() throws {
+      let record = try SynthesizedMixedRecord.from(
+        dictionary: ["name": "alpha", "count": 3, "note": "hi"],
+        appContext: appContext
+      )
+      let dictionary = record.toDictionary(appContext: appContext)
+
+      #expect(dictionary["name"] as? String == "alpha")
+      #expect(dictionary["count"] as? Int == 3)
+      #expect(dictionary["note"] as? String == "hi")
+    }
+
+    @Test
+    func `all-defaulted struct constructs from an empty dictionary`() throws {
+      let record = try SynthesizedPointRecord.from(dictionary: [:], appContext: appContext)
+
+      #expect(record.x == 0)
+      #expect(record.y == 0)
+    }
+
+    @Test
+    func `is usable wherever a Record is expected`() throws {
+      // The macro auto-conforms to `Record`, so the type satisfies a `Record`-constrained generic and
+      // its synthesized `from(dictionary:)` overrides the reflection-based default.
+      func acceptsRecord<T: Record>(_ type: T.Type, from dictionary: [String: Any]) throws -> T {
+        return try type.from(dictionary: dictionary, appContext: appContext)
+      }
+
+      let record = try acceptsRecord(SynthesizedPointRecord.self, from: ["x": 1.5, "y": 2.5])
+      #expect(record.x == 1.5)
+      #expect(record.y == 2.5)
+    }
+
+    @Test
+    func `optional property reads explicit null as nil`() throws {
+      let omitted = try SynthesizedMixedRecord.from(dictionary: ["name": "a"], appContext: appContext)
+      let explicitNull = try SynthesizedMixedRecord.from(
+        dictionary: ["name": "a", "note": NSNull()],
+        appContext: appContext
+      )
+
+      #expect(omitted.note == nil)
+      #expect(explicitNull.note == nil)
+    }
+
+    @Test
+    func `converts from a dictionary value via the Convertible entry point`() throws {
+      // A record nested inside a `[String: Any]` is hydrated through `Convertible.convert(from:)`,
+      // which routes to the synthesized `from(dictionary:)` rather than the reflection default.
+      let dynamicType = SynthesizedPointRecord.getDynamicType()
+      let value = try dynamicType.cast(["x": 1.5, "y": 2.5], appContext: appContext)
+      let record = try #require(value as? SynthesizedPointRecord)
+
+      #expect(record.x == 1.5)
+      #expect(record.y == 2.5)
+    }
+
+    @Test
+    func `reads an enum property through its dynamic type`() throws {
+      // Exercises `getDynamicType().cast` for a non-primitive property type — the enum's raw value is
+      // coerced back to the case rather than passed through verbatim.
+      let active = try SynthesizedEnumRecord.from(dictionary: ["status": "active"], appContext: appContext)
+      let defaulted = try SynthesizedEnumRecord.from(dictionary: [:], appContext: appContext)
+
+      #expect(active.status == .active)
+      #expect(defaulted.status == .inactive)
+    }
+
+    @Suite("JavaScript")
+    @JavaScriptActor
+    struct JavaScriptTests {
+      let appContext: AppContext
+      var runtime: ExpoRuntime {
+        get throws {
+          try appContext.runtime
+        }
+      }
+
+      init() {
+        appContext = AppContext.create()
+
+        appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
+          Name("RecordTestModule")
+
+          Function("passthrough") { (point: SynthesizedPointRecord) in
+            return point
+          }
+        })
+      }
+
+      // Round-trips a synthesized record through JS: the argument exercises `from(object:)` and the
+      // return value exercises the direct `toObject` path.
+      @Test
+      func `passes through JavaScript via a function`() throws {
+        try runtime.eval("result = expo.modules.RecordTestModule.passthrough({ x: 1.5, y: 2.5 })")
+
+        #expect(try runtime.eval("result.x").asDouble() == 1.5)
+        #expect(try runtime.eval("result.y").asDouble() == 2.5)
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -55,7 +55,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "~0.0.9",
+    "@expo/expo-modules-macros-plugin": "0.1.0",
     "expo-modules-jsi": "workspace:~56.0.7",
     "invariant": "^2.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4909,8 +4909,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: ~0.0.9
-        version: 0.0.9
+        specifier: 0.1.0
+        version: 0.1.0
       expo-modules-jsi:
         specifier: workspace:~56.0.7
         version: link:../expo-modules-jsi
@@ -7559,8 +7559,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.0.9':
-    resolution: {integrity: sha512-odai6D7ng/gA7At8ukFcWcauNEeDdyVqzVPbQxDkyU2NTJ4kgphA4I5iigS5C4LXFicSIzEt2nzdlLM8sjsTdA==}
+  '@expo/expo-modules-macros-plugin@0.1.0':
+    resolution: {integrity: sha512-ARl5U3PcwMdyPAb+r2Y9NXZBsGyfZx+oYNf4SHEuvTCp1gbluOPHTp4YIb0OeDcU/TimEeCXzcssov934SvueA==}
 
   '@expo/material-symbols@0.1.1':
     resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
@@ -17409,7 +17409,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/expo-modules-macros-plugin@0.0.9': {}
+  '@expo/expo-modules-macros-plugin@0.1.0': {}
 
   '@expo/material-symbols@0.1.1': {}
 


### PR DESCRIPTION
## Why

Records currently require wrapping every member in `@Field`, and conversion to/from JS goes through reflection (`Mirror`, per-field dynamic dispatch). This adds a fully-synthesized alternative: a `@Record` macro where records are plain Swift structs/classes and the conversion surface is generated at compile time from each property's static type — no `@Field`, no reflection.

```swift
@Record
struct Options {
  var name: String      // required (non-optional, no default)
  var count: Int = 0    // optional (default applies when omitted)
  var note: String?     // nullable + optional
}
```

The macro itself ships in `@expo/expo-modules-macros-plugin`, published as `0.1.0` (expo/expo-modules-macros-plugin#9). This PR is the **core side** that pairs with it; `expo-modules-core` now depends on the exact version `0.1.0`.

## What changed in core

- **`Record` protocol** now declares `from(object:)`, `from(dictionary:)`, `toObject` and `toDictionary` as requirements, each with a reflection-based default implementation. The `@Field` path is unchanged (it uses the defaults); `@Record` records override them with direct, statically-typed implementations.
- **`toObject(appContext:) -> JavaScriptObject`** is the write-side primitive (replacing `toJSValue`). `DynamicConvertibleType` and `FormattedRecord` build the object directly through it. `Record.toJSValue(appContext:)` is removed (it was an incidental, undocumented method; callers can use `toObject(appContext:).asValue()`).
- **`DynamicConvertibleType`** reads synthesized records via `from(object:)` and writes via `toObject`. It also overrides the `convertToJS(_:appContext:in:)` runtime variant so a record return value takes the direct object path instead of being flattened to a dictionary and re-serialized — the previous default pre-converted via `convertResult` → `toDictionary`, defeating the fast path.
- **`RecordObjectConvertible`** (internal, renamed from `RecordJavaScriptValueConvertible`) lets `FormattedRecord` — which isn't a `Record` — share the direct `toObject` path.
- **public `RecordPropertyRequiredException`** — thrown by the synthesized factories when a required property is missing from the source (distinct from the `@Field` path's internal `FieldRequiredException`).

## Naming

Members of a synthesized record are called **properties**, not "fields", to keep them distinct from the `@Field`-wrapper path. JS-object access follows the JSI convention — `from(object:)` / `toObject`, no `JS` abbreviation.

## Performance

Synthesized records skip the reflection machinery (`Mirror`, `fieldsOf`, per-field `AnyFieldInternal` dispatch). A `passthrough({ x, y })` benchmark comparing dictionary / `@Field` record / synthesized record / shared object was added to the benchmarking module + `native-component-list`.

`passthrough({ x, y })`, 100,000 iterations, mean of 3 runs, iPhone 16 Pro, Release build:

| variant | time | vs Record (no macro) |
| --- | --- | --- |
| Record (no macro) | 941.08 ms | 1.00× |
| dictionary | 444.18 ms | 2.12× faster |
| dictionary (TurboModule) | 214.78 ms | 4.38× faster |
| **Record (macro)** | **185.05 ms** | **5.09× faster** |
| `SharedObject` | 141.88 ms | 6.63× faster |

The macro-synthesized record is **~5.1× faster than the reflection-based (`@Field`) record** and ~2.4× faster than a plain dictionary. It even edges out a TurboModule dictionary passthrough (~1.16×) and lands within ~1.3× of a raw `SharedObject`.

## Testing

- `RecordTests.swift` (Swift Testing) under a `Record` › `SynthesizedRecord` suite: property inference without `@Field`, requiredness/default inference, missing-required throws `RecordPropertyRequiredException`, dictionary round-trip, all-defaulted construction, generic `Record` usage, optional `null`→`nil`, the `convert(from: dictionary)` entry point, enum-property coercion, and a JS round-trip exercising `from(object:)` + `toObject`.
- Macro-expansion tests live in the plugin repo.

## Depends on

- expo/expo-modules-macros-plugin#9 — the `@Record` macro implementation, published as `0.1.0`. `expo-modules-core` pins this exact version so the macro and core stay in lockstep; bumping it is a deliberate edit.




