### PR TITLE
[docs] Fix wrong link on docs site for Splash screen and app icon

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -189,7 +189,7 @@ Further customization of the Android icon is possible using the [`android.adapti
 
 The Android Adaptive Icon is formed from two separate layers — a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects. For Android 13 and later, the OS supports a themed app icon that uses a wallpaper and theme to determine the color set by the device's theme.
 
-The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive) for launcher icons. You should also:
+The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/develop/ui/compose/system/icon_design_adaptive) for launcher icons. You should also:
 
 - Use **.png** files.
 - Use the `android.adaptiveIcon.foregroundImage` property to specify the path to your foreground image.


### PR DESCRIPTION
# Why
fix issue #46548

# How
changed link on docs file since it was wrong as explained in the issue

# Test Plan
only changed the link on the website

# Checklist
only docs style applies

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
