### PR TITLE
[docs] Mention interactive example list for create-expo --example

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -65,6 +65,7 @@ Use this option to initialize a project using an example from [expo/examples](ht
 
 For example:
 
+- Running `npx create-expo-app --example` shows an interactive list of available examples to choose from
 - Running `npx create-expo-app --example with-router` sets up a project with the Expo Router library
 - Running `npx create-expo-app --example with-react-navigation` sets up a project similar to the default template, but configured with plain React Navigation library
 


### PR DESCRIPTION
## Why

Running `npx create-expo-app --example` without a value shows an interactive list of examples to choose from. This wasn't documented in our docs, but could be useful.

## How

Added a bullet to the `--example` section on the create-expo page.

<img width="1122" height="270" alt="image" src="https://github.com/user-attachments/assets/3cb8f5f1-6835-4e88-83dd-5edd988f6695" />

## Test Plan

Spin up locally or preview and visit `/more/create-expo/#--example`.

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)