### PR TITLE
[core][ios] Add emit API to Module via shared EventEmitter protocol

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Added the `@Record` macro that synthesizes a record from a type's stored properties, with no `@Field` wrappers needed. ([#46547](https://github.com/expo/expo/pull/46547) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added `Module.emit` that sends an event directly to the module's own JavaScript object, mirroring `SharedObject.emit`. Both now share an `EventEmitter` protocol. ([#46555](https://github.com/expo/expo/pull/46555) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Events/EventEmitter.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventEmitter.swift
@@ -1,0 +1,119 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+/**
+ A protocol for native objects that have an associated JavaScript object capable of receiving events.
+ Conformers only need to provide the JavaScript object to send events to - the `emit` overloads that
+ schedule onto the runtime, convert payloads and dispatch to JS are provided by the extension below.
+ */
+public protocol EventEmitter: AnyObject {
+  /**
+   An app context for which the emitter was created.
+   */
+  var appContext: AppContext? { get }
+
+  /**
+   Lends the JavaScript object the events should be emitted to for the duration of `body`. Called on
+   the JS thread right before dispatching, so it reflects the object's current association with the JS
+   runtime. Returns `nil` without invoking `body` when the emitter is not associated with a JS object -
+   the object is non-copyable, so it can only be borrowed, never handed out.
+   */
+  @JavaScriptActor
+  func withEventTarget<R>(_ body: (borrowing JavaScriptObject) throws -> R) rethrows -> R?
+}
+
+public extension EventEmitter {
+  /**
+   Schedules an event with the given name to be emitted to the associated JavaScript object.
+   */
+  func emit(event: String) {
+    emit(event: event, payload: JavaScriptValue.undefined)
+  }
+
+  /**
+   Schedules an event with the given name and a pre-converted JavaScript payload to be emitted
+   to the associated JavaScript object. This is the lowest-level emit overload - use it when the
+   value is already a `JavaScriptValue` to skip the native-to-JS conversion step.
+   */
+  func emit(event: String, payload: JavaScriptValue) {
+    guard let appContext, let runtime = try? appContext.runtime else {
+      log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
+      return
+    }
+    // The emitter is not necessarily `Sendable` - some modules hold non-sendable state — so we can't let
+    // the compiler send `self` into the `@JavaScriptActor` region. Capturing it as `nonisolated(unsafe)` is
+    // safe here because the scheduled closure only calls `withEventTarget`, which touches `@JavaScriptActor`-
+    // isolated or `Sendable` state (the JS object, the registry, `appContext`) and the emitter's identity -
+    // never the module's own mutable state.
+    nonisolated(unsafe) weak let emitter = self
+
+    runtime.schedule {
+      guard let emitter else {
+        return
+      }
+      let dispatched = emitter.withEventTarget { target in
+        dispatchEvent(event: event, payload: payload, to: target, in: runtime)
+        return true
+      }
+      if dispatched == nil {
+        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
+      }
+    }
+  }
+
+  /**
+   Schedules an event with the given name and payload to be emitted to the associated JavaScript object.
+   */
+  func emit<P: AnyArgument>(event: String, payload: sending P) {
+    guard let appContext, let runtime = try? appContext.runtime else {
+      log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
+      return
+    }
+    // See the note in `emit(event:payload:)` above - the emitter is captured as `nonisolated(unsafe)`
+    // because it isn't necessarily `Sendable`, and the scheduled closure only reaches `@JavaScriptActor`-
+    // isolated or `Sendable` state through it.
+    nonisolated(unsafe) weak let emitter = self
+
+    runtime.schedule { [weak appContext] in
+      guard let emitter, let appContext else {
+        return
+      }
+      let jsPayload: JavaScriptValue
+      do {
+        jsPayload = try (~P.self).castToJS(payload, appContext: appContext, in: runtime)
+      } catch {
+        log.warn("Failed to convert payload for event '\(event)' on \(P.self); the event will not be emitted: \(error)")
+        return
+      }
+      let dispatched = emitter.withEventTarget { target in
+        dispatchEvent(event: event, payload: jsPayload, to: target, in: runtime)
+        return true
+      }
+      if dispatched == nil {
+        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
+      }
+    }
+  }
+}
+
+/**
+ Sends a pre-converted event payload to the given JavaScript object via the JSI emitter helper.
+ Must run on the JS thread; the public `emit` overloads schedule onto the runtime before calling in.
+ */
+@JavaScriptActor
+internal func dispatchEvent(event: String, payload: JavaScriptValue, to target: borrowing JavaScriptObject, in runtime: JavaScriptRuntime) {
+  runtime.withUnsafePointee { runtimePtr in
+    target.withUnsafePointee { objectPtr in
+      payload.withUnsafePointee { payloadPtr in
+        JSUtils.emitEvent(
+          event,
+          runtimePointer: runtimePtr,
+          objectPointer: objectPtr,
+          argumentsPointer: payloadPtr,
+          argumentCount: 1
+        )
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -78,6 +78,19 @@ public final class ModuleHolder {
   }
 
   @JavaScriptActor
+  func withEventTarget<R>(_ body: (borrowing JavaScriptObject) throws -> R) rethrows -> R? {
+    if javaScriptObject == nil {
+      javaScriptObject = createJavaScriptModuleObject()
+    }
+    // Creating the object can still fail (e.g. the app context has been destroyed), in which case
+    // there is nothing to emit to and we behave like `getJavaScriptValue()` by returning `nil`.
+    if javaScriptObject == nil {
+      return nil
+    }
+    return try body(javaScriptObject!)
+  }
+
+  @JavaScriptActor
   func getJavaScriptValue() -> JavaScriptValue? {
     if javaScriptObject == nil {
       javaScriptObject = createJavaScriptModuleObject()

--- a/packages/expo-modules-core/ios/Core/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/Module.swift
@@ -1,5 +1,7 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+import ExpoModulesJSI
+
 /**
  `BaseModule` is just a stub class that fulfils `AnyModule` protocol requirement of public default initializer,
  but doesn't implement that protocol explicitly, though — it would have to provide a definition which would require
@@ -20,6 +22,21 @@ open class BaseModule {
    */
   public func sendEvent(_ eventName: String, _ body: [String: Any?] = [:]) {
     appContext?.eventEmitter?.sendEvent(withName: eventName, body: body)
+  }
+}
+
+extension BaseModule: EventEmitter {
+  /**
+   Lends the module's JavaScript object, looked up from the module registry, for the duration of `body`.
+   */
+  @JavaScriptActor
+  public func withEventTarget<R>(_ body: (borrowing JavaScriptObject) throws -> R) rethrows -> R? {
+    guard let appContext else {
+      return nil
+    }
+    let holder = appContext.moduleRegistry.first { $0.module === self }
+
+    return try holder?.withEventTarget(body) ?? nil
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -68,61 +68,6 @@ open class SharedObject: AnySharedObject {
   }
 
   /**
-   Schedules an event with the given name and a pre-converted JavaScript payload to be emitted
-   to the associated JavaScript object. This is the lowest-level emit overload — use it when the
-   value is already a `JavaScriptValue` to skip the native-to-JS conversion step.
-   */
-  public func emit(event: String, payload: JavaScriptValue) {
-    guard let appContext, let runtime = try? appContext.runtime else {
-      log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
-      return
-    }
-    runtime.schedule { [weak appContext, sharedObjectId] in
-      guard let appContext else {
-        return
-      }
-      guard let jsValue = appContext.sharedObjectRegistry.toJavaScriptValue(sharedObjectId: sharedObjectId) else {
-        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
-        return
-      }
-      dispatch(event: event, payload: payload, to: jsValue, in: runtime)
-    }
-  }
-
-  /**
-   Schedules an event with the given name to be emitted to the associated JavaScript object.
-   */
-  public func emit(event: String) {
-    emit(event: event, payload: .undefined)
-  }
-
-  /**
-   Schedules an event with the given name and payload to be emitted to the associated JavaScript object.
-   */
-  public func emit<P: AnyArgument>(event: String, payload: sending P) {
-    guard let appContext, let runtime = try? appContext.runtime else {
-      log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
-      return
-    }
-    runtime.schedule { [weak appContext, sharedObjectId] in
-      guard let appContext else {
-        return
-      }
-      guard let jsValue = appContext.sharedObjectRegistry.toJavaScriptValue(sharedObjectId: sharedObjectId) else {
-        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
-        return
-      }
-      do {
-        let jsPayload = try (~P.self).castToJS(payload, appContext: appContext, in: runtime)
-        dispatch(event: event, payload: jsPayload, to: jsValue, in: runtime)
-      } catch {
-        log.warn("Failed to convert payload for event '\(event)' on \(P.self); the event will not be emitted: \(error)")
-        return
-      }
-    }
-  }
-
-  /**
    Backwards-compatible overload that forwards to `emit(event:payload:)`. Existing single-argument
    call sites keep working unchanged; the parameter has been renamed to `payload` to make the
    single-payload semantics explicit, so callers should migrate the label.
@@ -133,23 +78,12 @@ open class SharedObject: AnySharedObject {
   }
 }
 
-/**
- Sends a pre-converted event payload to the given JavaScript object via the JSI emitter helper.
- Must run on the JS thread; the public `emit` overloads schedule onto the runtime before calling in.
- */
-@JavaScriptActor
-private func dispatch(event: String, payload: JavaScriptValue, to value: JavaScriptValue, in runtime: JavaScriptRuntime) {
-  runtime.withUnsafePointee { runtimePtr in
-    value.withUnsafePointee { objectPtr in
-      payload.withUnsafePointee { payloadPtr in
-        JSUtils.emitEvent(
-          event,
-          runtimePointer: runtimePtr,
-          objectPointer: objectPtr,
-          argumentsPointer: payloadPtr,
-          argumentCount: 1
-        )
-      }
+extension SharedObject: EventEmitter {
+  @JavaScriptActor
+  public func withEventTarget<R>(_ body: (borrowing JavaScriptObject) throws -> R) rethrows -> R? {
+    guard let target = getJavaScriptObject() else {
+      return nil
     }
+    return try body(target)
   }
 }

--- a/packages/expo-modules-core/ios/JS/EXJSUtils.h
+++ b/packages/expo-modules-core/ios/JS/EXJSUtils.h
@@ -16,7 +16,8 @@ NS_SWIFT_NAME(JSUtils)
     withArguments:(nonnull NSArray<id> *)arguments;
 
 /**
- Same as above but takes a raw `facebook::jsi::Value` pointer and count.
+ Same as above, but the objectPointer is a raw pointer to `facebook::jsi::Object` (the target JS object)
+ and the arguments are passed as a raw `facebook::jsi::Value` pointer and count.
  */
 + (void)emitEvent:(nonnull NSString *)eventName
    runtimePointer:(nonnull void *)runtimePointer

--- a/packages/expo-modules-core/ios/JS/EXJSUtils.mm
+++ b/packages/expo-modules-core/ios/JS/EXJSUtils.mm
@@ -29,7 +29,7 @@
     argumentCount:(NSUInteger)argumentCount
 {
   auto &runtime = *static_cast<jsi::Runtime *>(runtimePointer);
-  auto object = static_cast<const jsi::Value *>(objectPointer)->asObject(runtime);
+  auto &object = *static_cast<const jsi::Object *>(objectPointer);
 
   if (argumentCount == 0 || argumentsPointer == nullptr) {
     expo::EventEmitter::emitEvent(runtime, object, [eventName UTF8String], nullptr, 0);

--- a/packages/expo-modules-core/ios/Tests/ModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleTests.swift
@@ -1,0 +1,163 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("Module")
+@JavaScriptActor
+struct ModuleTests {
+
+  @Suite("EventEmitter")
+  @JavaScriptActor
+  struct EventEmitterTests {
+    let appContext: AppContext
+    var runtime: ExpoRuntime {
+      get throws {
+        try appContext.runtime
+      }
+    }
+
+    init() {
+      appContext = AppContext.create()
+      appContext.moduleRegistry.register(moduleType: TestModule.self, name: nil)
+    }
+
+    private var module: TestModule? {
+      return appContext.moduleRegistry.get(moduleWithName: "TestModule") as? TestModule
+    }
+
+    @Test
+    func `emits events with a record payload`() throws {
+      try runtime.eval(
+        """
+        result = null;
+        expo.modules.TestModule.addListener('test event', (payload) => { result = payload });
+        """
+      )
+
+      struct EventPayload: Record {
+        @Field var number: Int = 123
+        @Field var string: String = "test"
+        @Field var boolean: Bool = true
+      }
+
+      module?.emit(event: "test event", payload: EventPayload())
+
+      let result = try runtime.eval("result").asObject()
+
+      #expect(try result.getProperty("number").asInt() == 123)
+      #expect(try result.getProperty("string").asString() == "test")
+      #expect(try result.getProperty("boolean").asBool() == true)
+    }
+
+    @Test
+    func `emits events with no payload`() throws {
+      try runtime.eval(
+        """
+        result = false;
+        expo.modules.TestModule.addListener('ping', () => { result = true });
+        """
+      )
+
+      module?.emit(event: "ping")
+
+      #expect(try runtime.eval("result").asBool() == true)
+    }
+
+    @Test
+    func `emits events with a pre-converted JavaScriptValue payload`() throws {
+      try runtime.eval(
+        """
+        result = null;
+        expo.modules.TestModule.addListener('test event', (payload) => { result = payload });
+        """
+      )
+
+      let prebuiltPayload = try runtime.eval("({ kind: 'prebuilt', count: 7 })")
+
+      module?.emit(event: "test event", payload: prebuiltPayload)
+
+      let result = try runtime.eval("result").asObject()
+
+      #expect(try result.getProperty("kind").asString() == "prebuilt")
+      #expect(try result.getProperty("count").asInt() == 7)
+    }
+
+    @Test
+    func `emits primitive payloads`() throws {
+      try runtime.eval(
+        """
+        result = null;
+        expo.modules.TestModule.addListener('number', (payload) => { result = payload });
+        """
+      )
+
+      module?.emit(event: "number", payload: 42)
+
+      #expect(try runtime.eval("result").asInt() == 42)
+    }
+
+    @Test
+    func `routes each event to its own listeners`() throws {
+      try runtime.eval(
+        """
+        pings = 0;
+        numbers = null;
+        expo.modules.TestModule.addListener('ping', () => { pings += 1 });
+        expo.modules.TestModule.addListener('number', (payload) => { numbers = payload });
+        """
+      )
+
+      module?.emit(event: "ping")
+
+      #expect(try runtime.eval("pings").asInt() == 1)
+      #expect(try runtime.eval("numbers").isNull() == true)
+    }
+
+    @Test
+    func `does not emit to a removed listener`() throws {
+      try runtime.eval(
+        """
+        count = 0;
+        listener = () => { count += 1 };
+        expo.modules.TestModule.addListener('ping', listener);
+        """
+      )
+
+      module?.emit(event: "ping")
+      try runtime.eval("expo.modules.TestModule.removeListener('ping', listener)")
+      module?.emit(event: "ping")
+
+      #expect(try runtime.eval("count").asInt() == 1)
+    }
+
+    @Test
+    func `does not crash when emitting with no listeners`() throws {
+      module?.emit(event: "ping")
+      module?.emit(event: "number", payload: 42)
+    }
+
+    @Test
+    func `does not crash when emitting from a module not associated with a JS object`() throws {
+      // A module that was never registered has no holder in the registry, so `withEventTarget`
+      // resolves to nil and the defensive branches in the public `emit` overloads should log and
+      // return cleanly rather than crash.
+      let detached = TestModule(appContext: appContext)
+
+      detached.emit(event: "ignored")
+      detached.emit(event: "ignored", payload: ["key": "value"])
+      detached.emit(event: "ignored", payload: .undefined)
+    }
+  }
+}
+
+// MARK: - Test Helpers
+
+private final class TestModule: Module {
+  func definition() -> ModuleDefinition {
+    Name("TestModule")
+    Events("test event", "ping", "number")
+  }
+}


### PR DESCRIPTION
## Why

Modules and `SharedObject`s emitted events to JS through two unrelated native paths. `SharedObject` had a modern JSI `emit`, while `Module` only had `sendEvent`, which routes through the deprecated `LegacyEventEmitterCompat` and *broadcasts* to every module declaring the event name (legacy device-event-emitter behavior).

## What

- Adds an `EventEmitter` Swift protocol (`ios/Core/Events/EventEmitter.swift`). Conformers provide `appContext` and a `withEventTarget` lend of their JS object; the protocol extension provides the `emit` overloads and the shared `dispatchEvent` JSI primitive.
- `SharedObject` and `Module` (`BaseModule`) both conform via dedicated extensions, so they now share one emit implementation.
- `Module` gains `emit(event:)`, `emit(event:payload:)` (typed and pre-converted `JavaScriptValue`), sending **directly to the module's own JS object** instead of broadcasting.
- Drops a per-emit allocation: the `argumentsPointer:` variant of `EXJSUtils.emitEvent` now takes a `jsi::Object*` directly instead of a `jsi::Value*` it has to `asObject`. The `withArguments:` variant (still used by the legacy path) is unchanged.

The JS object is `~Copyable`, so it's lent through a `withEventTarget { ... }` closure rather than returned by value. The emitter is captured `nonisolated(unsafe)` into the `@JavaScriptActor` schedule closure because `Module`/`SharedObject` can't be `Sendable` (some modules hold non-sendable state); it's sound because the closure only reaches `@JavaScriptActor`-isolated/`Sendable` state.

## Not in this PR (deliberate follow-ups)

- **Deprecating `sendEvent`** — held until its ~56 first-party call sites are migrated to `emit`, to avoid warning churn.
- **Benchmarks** — an `emitEvents(count:)` benchmark comparing the legacy broadcast path vs. the new direct `emit`, most useful during the migration.

## Test plan

- New `ModuleTests` suite (`Module › EventEmitter`) covering record/primitive/no/pre-converted payloads, per-event routing, removed listeners, no-listener, and detached-module cases.
- Verified at runtime in bare-expo (legacy `sendEvent` path still fires via screen-orientation rotation; new `emit` path covered by the unit tests).
