### PR TITLE
[ui][android] - TextField + material3 expression theme combination causes layout shift

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [jetpack-compose] Fix `TextField` jiggling the surrounding content while its label animates on focus (a Material 3 expressive motion spring overshoot). ([#46568](https://github.com/expo/expo/pull/46568) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `BottomSheet` animating open from the bottom-left corner in `fitToContents` mode. ([#46546](https://github.com/expo/expo/pull/46546) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `TextField` and `SecureField` worklet `onTextChange` firing more than once per keystroke (when a change triggers reformatting) and on programmatic text updates. ([#46483](https://github.com/expo/expo/pull/46483) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `font` modifier dropping Dynamic Type scaling (`relativeTo`) and `weight` on concatenated `Text` runs. The Text-concatenation path now resolves the same `Font` as the view path. ([#46509](https://github.com/expo/expo/pull/46509) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -119,7 +120,11 @@ internal class HostView(context: Context, appContext: AppContext) :
     val layoutDirection = props.layoutDirection.value.toLayoutDirection()
 
     CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-      MaterialExpressiveTheme(colorScheme = colorScheme) {
+      // Workaround (pending upstream fix, https://issuetracker.google.com/issues/519816993)
+      // the expressive motion scheme's spring overshoots >1f, and TextField's calculateHeight
+      // extrapolates that overshoot, transiently growing the field and jiggling surrounding
+      // content. Forcing the standard (non-overshooting) spatial spring removes the jiggle.
+      MaterialExpressiveTheme(colorScheme = colorScheme, motionScheme = MotionScheme.standard()) {
         MaybeMatchContentsLayout {
           Children(this@Content)
         }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
-import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -120,11 +119,7 @@ internal class HostView(context: Context, appContext: AppContext) :
     val layoutDirection = props.layoutDirection.value.toLayoutDirection()
 
     CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-      // Workaround (pending upstream fix, https://issuetracker.google.com/issues/519816993)
-      // the expressive motion scheme's spring overshoots >1f, and TextField's calculateHeight
-      // extrapolates that overshoot, transiently growing the field and jiggling surrounding
-      // content. Forcing the standard (non-overshooting) spatial spring removes the jiggle.
-      MaterialExpressiveTheme(colorScheme = colorScheme, motionScheme = MotionScheme.standard()) {
+      MaterialExpressiveTheme(colorScheme = colorScheme) {
         MaybeMatchContentsLayout {
           Children(this@Content)
         }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
@@ -4,6 +4,9 @@ import android.graphics.Color
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextField
@@ -277,6 +280,7 @@ private fun ObservableState.extractSelection(textLength: Int): TextRange {
 
 // region View
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FunctionalComposableScope.TextFieldContent(
   props: TextFieldProps,
@@ -466,30 +470,36 @@ fun FunctionalComposableScope.TextFieldContent(
     else -> VisualTransformation.None
   }
 
-  if (isOutlined) {
-    OutlinedTextField(
-      value = value, onValueChange = onValueChange, modifier = modifier,
-      enabled = props.enabled, readOnly = props.readOnly, textStyle = textStyle,
-      label = label, placeholder = placeholder,
-      leadingIcon = leadingIcon, trailingIcon = trailingIcon,
-      prefix = prefix, suffix = suffix, supportingText = supportingText,
-      isError = props.isError, visualTransformation = visualTransformation,
-      keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
-      singleLine = singleLine, maxLines = maxLines, minLines = minLines,
-      shape = shape, colors = colors
-    )
-  } else {
-    TextField(
-      value = value, onValueChange = onValueChange, modifier = modifier,
-      enabled = props.enabled, readOnly = props.readOnly, textStyle = textStyle,
-      label = label, placeholder = placeholder,
-      leadingIcon = leadingIcon, trailingIcon = trailingIcon,
-      prefix = prefix, suffix = suffix, supportingText = supportingText,
-      isError = props.isError, visualTransformation = visualTransformation,
-      keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
-      singleLine = singleLine, maxLines = maxLines, minLines = minLines,
-      shape = shape, colors = colors
-    )
+  // Workaround (pending upstream fix, https://issuetracker.google.com/issues/519816993)
+  // the expressive motion scheme's spring overshoots >1f, and TextField's calculateHeight
+  // extrapolates that overshoot, transiently growing the field and jiggling surrounding
+  // content. Forcing the standard (non-overshooting) spatial spring removes the jiggle.
+  MaterialExpressiveTheme(motionScheme = MotionScheme.standard()) {
+    if (isOutlined) {
+      OutlinedTextField(
+        value = value, onValueChange = onValueChange, modifier = modifier,
+        enabled = props.enabled, readOnly = props.readOnly, textStyle = textStyle,
+        label = label, placeholder = placeholder,
+        leadingIcon = leadingIcon, trailingIcon = trailingIcon,
+        prefix = prefix, suffix = suffix, supportingText = supportingText,
+        isError = props.isError, visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
+        singleLine = singleLine, maxLines = maxLines, minLines = minLines,
+        shape = shape, colors = colors
+      )
+    } else {
+      TextField(
+        value = value, onValueChange = onValueChange, modifier = modifier,
+        enabled = props.enabled, readOnly = props.readOnly, textStyle = textStyle,
+        label = label, placeholder = placeholder,
+        leadingIcon = leadingIcon, trailingIcon = trailingIcon,
+        prefix = prefix, suffix = suffix, supportingText = supportingText,
+        isError = props.isError, visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
+        singleLine = singleLine, maxLines = maxLines, minLines = minLines,
+        shape = shape, colors = colors
+      )
+    }
   }
 }
 


### PR DESCRIPTION
# Why

https://github.com/user-attachments/assets/d734535f-240c-41ef-88ba-d64908b59ac5

Originally reported by @keith-kurak [here](https://exponent-internal.slack.com/archives/C09J34STRE2/p1780547094338069?thread_ts=1780494210.193459&cid=C09J34STRE2)

The same issue happens in a plain android jetpack compose project. I reported here - https://issuetracker.google.com/issues/519816993. Will make an upstream PR to fix it. (just needs to add overshoot clamping to animation)


Repro in Jetpack compose - https://github.com/intergalacticspacehighway/jetpack-compose-layoutshift-with-textfield/


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Issue is material3's spring animation overshoots the `TextField` label when it animates and it causes layout shift. To workaround the issue, we pass `standard` motion which overrides the default spring motion. It needs an upstream fix.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the repro, the layoutshift is gone.

https://github.com/user-attachments/assets/fc8f9cb2-610c-4d4a-9eec-dbd31b12f215



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
