### PR TITLE
fix(expo-worklets) throw a clear error when worklets are used without react-native-worklets

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
+- [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
-- [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure.
+- [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure. ([#46571](https://github.com/expo/expo/pull/46571) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -119,7 +119,7 @@ Pod::Spec.new do |s|
     s.static_framework = true
     s.header_dir     = 'ExpoModulesCore'
     s.source_files = 'ios/**/*.{h,m,mm,swift,cpp}', 'common/cpp/**/*.{h,cpp}'
-    s.exclude_files = ['ios/Tests', 'ios/Worklets', 'ios/WorkletsAdapter']
+    s.exclude_files = ['ios/Tests', 'ios/Worklets', 'ios/WorkletsTests', 'ios/WorkletsAdapter']
     s.compiler_flags = compiler_flags
     s.private_header_files = ['ios/**/*+Private.h', 'ios/**/Swift.h']
   end

--- a/packages/expo-modules-core/ExpoModulesWorklets.podspec
+++ b/packages/expo-modules-core/ExpoModulesWorklets.podspec
@@ -31,4 +31,11 @@ Pod::Spec.new do |s|
 
   s.source_files = 'ios/Worklets/**/*.{h,m,mm,swift,cpp}'
   s.private_header_files = 'ios/Worklets/**/*+Private.h'
+
+  s.test_spec 'Tests' do |test_spec|
+    # ExpoModulesCore requires React-hermes or React-jsc in tests, add ExpoModulesTestCore for the underlying dependencies
+    test_spec.dependency 'ExpoModulesTestCore'
+
+    test_spec.source_files = 'ios/WorkletsTests/**/*.{m,swift}'
+  end
 end

--- a/packages/expo-modules-core/ios/Worklets/Core/DynamicSerializableType.swift
+++ b/packages/expo-modules-core/ios/Worklets/Core/DynamicSerializableType.swift
@@ -28,6 +28,10 @@ internal struct DynamicSerializableType: AnyDynamicType {
       }
     }
     guard let jsSerializable else {
+      // Adapter not linked → the extractor returns nil for every value; give an actionable error.
+      if WorkletsProviderRegistry.shared == nil {
+        throw WorkletsNotInstalledException()
+      }
       throw NotSerializableException(innerType)
     }
     return Serializable(jsSerializable)

--- a/packages/expo-modules-core/ios/Worklets/Core/Worklet.swift
+++ b/packages/expo-modules-core/ios/Worklets/Core/Worklet.swift
@@ -46,3 +46,13 @@ internal final class NotWorkletException: GenericException<SerializableValueType
     "Expected Serializable of type Worklet but got \(param)"
   }
 }
+
+/// Thrown when a worklet operation is attempted but the `react-native-worklets` native
+/// adapter isn't linked (its provider is `nil`). Replaces misleading lower-level errors.
+internal final class WorkletsNotInstalledException: Exception, @unchecked Sendable {
+  override var reason: String {
+    "This feature requires `react-native-worklets`, but its native adapter isn't linked — usually " +
+    "because the package isn't installed (it's an optional peer dependency of libraries like Expo UI " +
+    "and Reanimated). Install it with `npx expo install react-native-worklets`, then rebuild the app."
+  }
+}

--- a/packages/expo-modules-core/ios/WorkletsTests/WorkletRuntimeIntegrationTests.swift
+++ b/packages/expo-modules-core/ios/WorkletsTests/WorkletRuntimeIntegrationTests.swift
@@ -1,0 +1,27 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+
+import ExpoModulesCore
+import ExpoModulesWorklets
+
+/**
+ Runtime-level checks for the worklets integration wiring.
+
+ Note: these run under `use_expo_modules_tests!`, which does not link companion pods, so the
+ worklets adapter — and therefore `WorkletsProviderRegistry.shared` — is intentionally absent
+ here (the same state as an app without `react-native-worklets`). Whether the adapter is
+ correctly autolinked is guarded by the JS test `WorkletsAdapterAutolinking-test.ts`; the
+ consumer-side behaviour when it's missing is covered by `WorkletsNotInstalledTests`.
+ */
+@Suite("WorkletRuntimeIntegration", .serialized)
+struct WorkletRuntimeIntegrationTests {
+  @Test
+  func `UI worklet runtime factory registers on the app context`() {
+    // `WorkletIntegration.register()` installs the core-side hook (normally invoked via +load)
+    // that turns a worklet runtime pointer into a usable runtime. Guards the factory wiring onto
+    // AppContext; it does not require the adapter to be linked.
+    WorkletIntegration.register()
+    #expect(AppContext.uiRuntimeFactory != nil)
+  }
+}

--- a/packages/expo-modules-core/ios/WorkletsTests/WorkletsNotInstalledTests.swift
+++ b/packages/expo-modules-core/ios/WorkletsTests/WorkletsNotInstalledTests.swift
@@ -1,0 +1,33 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+@testable import ExpoModulesWorklets
+
+/**
+ The `use_expo_modules_tests!` harness does not link companion pods, so the worklets adapter
+ never registers `WorkletsProviderRegistry.shared`. That nil-provider state is exactly an app
+ where `react-native-worklets` isn't installed — so this is the right place to assert that a
+ worklet operation fails with the actionable `WorkletsNotInstalledException` rather than a
+ misleading lower-level error (e.g. "not an instance of Worklet").
+ */
+@Suite("WorkletsNotInstalled", .serialized)
+@JavaScriptActor
+struct WorkletsNotInstalledTests {
+  @Test
+  func `converting a worklet argument reports that worklets are not installed`() throws {
+    // Only meaningful while the adapter is unlinked (the default in this test harness).
+    try #require(WorkletsProviderRegistry.shared == nil)
+
+    let appContext = AppContext.create()
+    let runtime = try appContext.runtime
+    // Any JS value works — with the adapter unlinked, extraction returns nil for everything.
+    let jsValue = try runtime.eval("42")
+    let dynamicType = DynamicSerializableType(innerType: Worklet.self)
+
+    #expect(throws: WorkletsNotInstalledException.self) {
+      _ = try dynamicType.cast(jsValue: jsValue, appContext: appContext)
+    }
+  }
+}

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -46,6 +46,7 @@
           "headerPattern": "**/*.h",
           "exclude": [
             "Tests/**",
+            "WorkletsTests/**",
             "Worklets/**",
             "WorkletsAdapter/**"
           ],
@@ -87,6 +88,7 @@
           "exclude": [
             "JSI/**",
             "Tests/**",
+            "WorkletsTests/**",
             "BridgeModule/**",
             "Views/**",
             "Worklets/**",

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -189,6 +189,27 @@ export class Package {
     return podspecPath || null;
   }
 
+  /**
+   * All podspec paths declared by the package (a package may ship several, e.g.
+   * expo-modules-core ships ExpoModulesCore + ExpoModulesWorklets). Unlike `podspecPath`,
+   * which returns only the first, this returns every entry so callers (e.g. native unit
+   * test discovery) can scan test specs across all of them.
+   */
+  get podspecPaths(): string[] {
+    const iosPodspecPath = this.expoModuleConfig?.ios?.podspecPath;
+    if (iosPodspecPath) {
+      return [iosPodspecPath];
+    }
+
+    const applePodspecPath = this.expoModuleConfig?.apple?.podspecPath;
+    if (applePodspecPath) {
+      return Array.isArray(applePodspecPath) ? applePodspecPath : [applePodspecPath];
+    }
+
+    const fallback = this.podspecPath;
+    return fallback ? [fallback] : [];
+  }
+
   get podspecName(): string | null {
     const iosConfig = {
       subdirectory: 'ios',

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -12,15 +12,25 @@ async function runTests(testTargets: string[]) {
   });
 }
 
-function getTestSpecNames(pkg: Packages.Package): string[] {
-  const podspec = fs.readFileSync(path.join(pkg.path, pkg.podspecPath!), 'utf8');
-  const regex = new RegExp("test_spec\\s'([^']*)'", 'g');
-  const testSpecNames: string[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(podspec)) !== null) {
-    testSpecNames.push(match[1]);
+// Computes the Xcode unit-test target names for a package by scanning every podspec it
+// declares — a package like expo-modules-core ships several (ExpoModulesCore,
+// ExpoModulesWorklets, …), each potentially with its own test specs. Each test spec becomes
+// `<PodName>-Unit-<TestSpecName>`, named after the podspec that owns it (not the package's
+// primary podspec), which is how CocoaPods generates the targets.
+function getUnitTestTargets(pkg: Packages.Package): string[] {
+  const targets: string[] = [];
+  for (const podspecRelPath of pkg.podspecPaths) {
+    const podspecAbsPath = path.join(pkg.path, podspecRelPath);
+    if (!fs.existsSync(podspecAbsPath)) {
+      continue;
+    }
+    const podName = path.basename(podspecRelPath, '.podspec');
+    const contents = fs.readFileSync(podspecAbsPath, 'utf8');
+    for (const match of contents.matchAll(/test_spec\s'([^']*)'/g)) {
+      targets.push(`${podName}-Unit-${match[1]}`);
+    }
   }
-  return testSpecNames;
+  return targets;
 }
 
 export async function iosNativeUnitTests({ packages }: { packages?: string }) {
@@ -41,16 +51,14 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
       continue;
     }
 
-    const testSpecNames = getTestSpecNames(pkg);
-    if (!testSpecNames.length) {
+    const pkgTargets = getUnitTestTargets(pkg);
+    if (!pkgTargets.length) {
       throw new Error(
-        `Failed to test package ${pkg.packageName}: no test specs were found in podspec file.`
+        `Failed to test package ${pkg.packageName}: no test specs were found in its podspec file(s).`
       );
     }
 
-    for (const testSpecName of testSpecNames) {
-      targetsToTest.push(`${pkg.podspecName}-Unit-${testSpecName}`);
-    }
+    targetsToTest.push(...pkgTargets);
     packagesToTest.push(pkg.packageName);
   }
 


### PR DESCRIPTION
# Why

Using a worklet (e.g. through Expo UI's `withAnimation`) without `react-native-worklets` installed failed with a confusing "not an instance of Worklet" error. The real cause — the native worklets adapter isn't linked — was hidden.

# How

When converting a worklet fails because the adapter isn't linked (`WorkletsProviderRegistry.shared == nil`), throw a `WorkletsNotInstalledException` that says how to fix it, instead of the misleading error.

Also adds native tests for it, and teaches the iOS unit-test runner to find test specs in a package's secondary podspecs (so the new `ExpoModulesWorklets` tests are discovered).

# Test plan

✅ Native `ExpoModulesWorklets-Unit-Tests` passes: converting a worklet while the adapter is unlinked
✅ Tested precompiling
✅ BareExpo iOS

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
