### PR TITLE
[ui][ios] Fix SegmentedControl safe area view behavior

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `SegmentedControl` being overlapped by sibling components inside a `ScrollView`, by disabling the `Host` safe area insets. ([#46575](https://github.com/expo/expo/pull/46575) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Fix `TextField` jiggling the surrounding content while its label animates on focus (a Material 3 expressive motion spring overshoot). ([#46568](https://github.com/expo/expo/pull/46568) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `BottomSheet` animating open from the bottom-left corner in `fitToContents` mode. ([#46546](https://github.com/expo/expo/pull/46546) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `TextField` and `SecureField` worklet `onTextChange` firing more than once per keystroke (when a change triggers reformatting) and on programmatic text updates. ([#46483](https://github.com/expo/expo/pull/46483) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/src/community/segmented-control/SegmentedControl.ios.tsx
+++ b/packages/expo-ui/src/community/segmented-control/SegmentedControl.ios.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl(props: SegmentedControlProps) {
   };
 
   return (
-    <Host matchContents={{ vertical: true }} style={style}>
+    <Host matchContents={{ vertical: true }} style={style} ignoreSafeArea="all">
       <Picker
         selection={selectedIndex}
         onSelectionChange={handleSelectionChange}


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/46573

One more case where it makes sense to set ignoreSafeArea="all" as a default value in `Host` on iOS. We have seen similar issues in the past. The safe area insets added by `Host` creates issues when we put SwiftUI views in an RN view that goes beyond safe area view.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

ignore safe area view in universal SegmentedControl. Other components are worth visiting, and maybe making `ignoreSafeArea="all"` as a default in Host also makes sense.

# Test Plan

Tested the repro shared by user

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
