### PR TITLE
[router] Add redirects type to config plugin

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Add the missing `redirects` type to the Expo Router config plugin options. ([#46574](https://github.com/expo/expo/issues/46574) by [@cyphercodes](https://github.com/cyphercodes))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others

--- a/packages/expo-router/plugin/build/withRouter.d.ts
+++ b/packages/expo-router/plugin/build/withRouter.d.ts
@@ -1,4 +1,15 @@
 import { ConfigPlugin } from 'expo/config-plugins';
+type RedirectMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD';
+type RedirectConfig = {
+    /** The previous file path that this route should redirect from */
+    source: string;
+    /** The target file path that this route should redirect to */
+    destination: string;
+    /** Whether the redirect is temporary or permanent. Defaults to `false`. */
+    permanent?: boolean;
+    /** HTTP methods that should be redirected. Omit to redirect all methods. */
+    methods?: RedirectMethod[];
+};
 export type Props = {
     /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
     origin?: string;
@@ -17,6 +28,8 @@ export type Props = {
     sitemap?: boolean;
     /** Generate partial typed routes */
     partialTypedGroups?: boolean;
+    /** An array of static redirect rules. */
+    redirects?: RedirectConfig[];
     /** A list of headers that are set on every route response from the server */
     headers?: Record<string, string | string[]>;
     /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */

--- a/packages/expo-router/plugin/src/withRouter.ts
+++ b/packages/expo-router/plugin/src/withRouter.ts
@@ -3,6 +3,19 @@ import { ConfigPlugin, withInfoPlist, withPodfile } from 'expo/config-plugins';
 
 const schema = require('../options.json');
 
+type RedirectMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD';
+
+type RedirectConfig = {
+  /** The previous file path that this route should redirect from */
+  source: string;
+  /** The target file path that this route should redirect to */
+  destination: string;
+  /** Whether the redirect is temporary or permanent. Defaults to `false`. */
+  permanent?: boolean;
+  /** HTTP methods that should be redirected. Omit to redirect all methods. */
+  methods?: RedirectMethod[];
+};
+
 const withExpoHeadIos: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
     // TODO: Add a way to enable this...
@@ -45,6 +58,8 @@ export type Props = {
   sitemap?: boolean;
   /** Generate partial typed routes */
   partialTypedGroups?: boolean;
+  /** An array of static redirect rules. */
+  redirects?: RedirectConfig[];
   /** A list of headers that are set on every route response from the server */
   headers?: Record<string, string | string[]>;
   /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */


### PR DESCRIPTION
## Why

Fixes #46574.

The `expo-router` config plugin schema already accepts `redirects`, and the option is forwarded into `extra.router`, but the typed config plugin `Props` type did not include it. This caused TypeScript errors for typed app configs that use static redirects.

## How

- Added a config-plugin redirect option type that matches the documented schema (`source`, `destination`, optional `permanent`, optional HTTP `methods`).
- Added `redirects?: RedirectConfig[]` to the plugin `Props` type.
- Rebuilt the checked-in plugin declaration output.
- Added a changelog entry.

## Test Plan

- `corepack pnpm@10.33.0 install --frozen-lockfile --ignore-scripts`
- `corepack pnpm@10.33.0 --filter expo-router exec expo-module build -p plugin/tsconfig.json`
- `corepack pnpm@10.33.0 --filter expo-router build`
- `corepack pnpm@10.33.0 --filter expo-router test:types`
- `corepack pnpm@10.33.0 --filter expo-router lint`
- `./node_modules/.bin/tsc --ignoreConfig --noEmit --strict --skipLibCheck --module ESNext --moduleResolution bundler --target ES2020 --types node --resolveJsonModule /tmp/oss-pr-pipeline/expo-46574-plugin-redirects-typecheck.ts`
- `git diff --check`
