### PR TITLE
[expo] fix(web-hmr): Add unhanled errors and rejections to dev server

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Forward unhandled errors and rejections to the dev server console. ([#46578](https://github.com/expo/expo/pull/46578) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))
 - Prevent fatal `The stream is not in a state that permits close` in `expo/fetch` when native delivers `didComplete`/`didFailWithError` after the consumer has already canceled the body stream. ([#44909](https://github.com/expo/expo/pull/44909) by [@safaiyeh](https://github.com/safaiyeh))

--- a/packages/expo/src/async-require/setupHMR.ts
+++ b/packages/expo/src/async-require/setupHMR.ts
@@ -21,6 +21,14 @@ if (typeof window !== 'undefined') {
       originalFunction.apply(console, args);
     };
   });
+
+  window.addEventListener('error', (event) => {
+    HMRClient.log('error', [event.error]);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    HMRClient.log('error', [event.reason]);
+  });
 }
 
 // This is called native on native platforms


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- follow up to https://github.com/expo/expo/pull/45516
- the dev server console was missing the unhandled errors and rejections

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `error` and `unhandledrejection` listeners to forward the objects to HMRClient log function with error level when HMRClient is enabled for web.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Throw or reject and observe the logs in the dev server.

<img width="422" height="106" alt="Screenshot 2026-06-04 at 19 29 10" src="https://github.com/user-attachments/assets/b544f287-85c4-4dc6-a78f-02410d9f1856" />

# Future

- [ ] stacks are not passed, and when passed they are not parsed correctly (will look into that later)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
