### PR TITLE
[docs] Add expo-tools, testing, and PR guidance to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,62 @@
+## expo-tools (`et`)
+
+This repo ships its own CLI, `expo-tools`, available directly as `et <command> <...args>`.
+Call it as `et`, not via `npx`, `bunx`, or `pnpm run` — it's already on the PATH. Many of our
+processes (pod install, native unit tests, prebuild, and more) run through it.
+
+Commands you'll reach for during normal development:
+
+- `et pod-install` — install pods in the directories that are out of sync. Run after changing
+  dependencies or a podspec.
+- `et native-unit-tests` — run native unit tests for all packages that provide them. Scope to
+  one package with `--packages <name>` (e.g. `et native-unit-tests -p ios --packages @expo/ui`).
+- `et check-packages` — verify that packages build and their tests pass.
+
+Run `et --help` to discover the rest (publishing, changelogs, on-call dashboards, and more).
+
+## Rules
+
+- **Red/green:** write the test first and watch it fail, then implement the feature or fix until
+  it passes. Don't write the implementation before the failing test exists.
+
+## Writing tests
+
+### Unit tests
+
+JS/TS unit tests use Jest and live next to the code in `__tests__/` (or `*.test.ts`). They run
+as part of `et check-packages` (see Committing below).
+
+### Native tests
+
+Swift/Kotlin unit tests live in `packages/<pkg>/ios/Tests/` and `android/`, and run through
+`et native-unit-tests` (scope with `--packages <name>`). Adding or changing an iOS `test_spec`
+requires `et pod-install` first.
+
+## Committing
+
+Before committing, run `et check-packages`. It runs the unit tests **and** builds the package's
+JS files. The build output is committed alongside your source changes, so a commit that skips
+this step will be missing its built files. Stage both your source edits and the regenerated
+build output.
+
+## Creating PRs
+
+Follow the contribution guide: https://github.com/expo/expo/blob/main/CONTRIBUTING.md
+
+**Commit message:** format as `[platform][api] Title`, e.g. `[ios][video] Fix black screen on older devices`.
+
+**PR description** follows the repo template — fill in each section:
+
+- **Why:** the motivation for the change; link relevant issues, forum posts, or feature requests.
+- **How:** how you built the feature or fixed the bug, and why you took that approach.
+- **Test Plan:** how you tested the change and how a reviewer can reproduce it — include terminal
+  output or screenshots when there are no automated tests.
+- **Checklist:** added a `CHANGELOG.md` entry and rebuilt the package sources; confirmed the change
+  works with `npx expo prebuild` & EAS Build if relevant; follows the documentation style guide.
+
+**Before submitting:** run `et check-packages` (builds, lints, and tests), commit the `build/`
+output, and remove stray `console.log`s or commented-out code.
+
 ## Error messages
 
 When writing error messages, consider explaining what, why, and how:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,15 +1,13 @@
 ## expotools (`et`)
 
 This repo ships its own CLI, `expotools`, available directly as `et <command> <...args>`.
-Call it as `et`, not via `npx`, `bunx`, or `pnpm run` — it's already on the PATH. Many of our
-processes (pod install, native unit tests, prebuild, and more) run through it.
+Call it as `et`, not via `npx`, `bunx`, or `pnpm run`. It's put on the PATH by `direnv`, so run
+`direnv allow` once in the repo root if `et` isn't found; otherwise invoke it directly with
+`node ./tools/bin/expotools.js <command>`. Many of our processes (native unit tests, prebuild,
+and more) run through it.
 
 Commands you'll reach for during normal development:
 
-- `et pod-install` — install pods in the directories that are out of sync. Run after changing
-  dependencies or a podspec.
-- `et native-unit-tests` — run native unit tests for all packages that provide them. Scope to
-  one package with `--packages <name>` (e.g. `et native-unit-tests -p ios --packages @expo/ui`).
 - `et check-packages` — verify that packages build and their tests pass.
 
 Run `et --help` to discover the rest (publishing, changelogs, on-call dashboards, and more).
@@ -29,23 +27,31 @@ as part of `et check-packages` (see Committing below).
 ### Native tests
 
 Swift/Kotlin unit tests live in `packages/<pkg>/ios/Tests/` and `android/`, and run through
-`et native-unit-tests` (scope with `--packages <name>`). Adding or changing an iOS `test_spec`
-requires `et pod-install` first.
+`et native-unit-tests` (scope with `--packages <name>`).
+
+On iOS/macOS (Android needs no pod step), install pods before running native tests or building,
+and again after adding or changing an iOS `test_spec`. Run `pod install` directly in the relevant
+`apps/*/ios` or `apps/*/macos` directory rather than `et pod-install` — running it directly is
+faster and avoids installing for apps you aren't working on, like Expo Go.
+
+Running native tests:
+`et native-unit-tests` — run native unit tests for all packages that provide them. Scope to
+one package with `--packages <name>` (e.g. `et native-unit-tests -p ios --packages @expo/ui`).
 
 ## Committing
 
-Before committing, run `et check-packages <...packages>` with the package names that has changed. It runs the unit tests **and** builds the package's
+Before committing, run `et check-packages <...packages>` with the names of the packages that changed. It runs the unit tests **and** builds the package's
 JS files. The build output is committed alongside your source changes, so a commit that skips
 this step will be missing its built files. Stage both your source edits and the regenerated
 build output.
 
 ## Creating PRs
 
-Follow the contribution guide: https://github.com/expo/expo/blob/main/CONTRIBUTING.md
+Follow the contribution guide: https://github.com/expo/expo/blob/main/CONTRIBUTING.md and the PR template:
 
 **Commit message:** format as `[platform][api] Title`, e.g. `[ios][video] Fix black screen on older devices`.
 
-**PR description** follows the repo template — fill in each section:
+**PR description** follows the [repo PR template](https://github.com/expo/expo/blob/main/.github/PULL_REQUEST_TEMPLATE) — fill in each section:
 
 - **Why:** the motivation for the change; link relevant issues, forum posts, or feature requests.
 - **How:** how you built the feature or fixed the bug, and why you took that approach.
@@ -56,6 +62,11 @@ Follow the contribution guide: https://github.com/expo/expo/blob/main/CONTRIBUTI
 
 **Before submitting:** run `et check-packages` (builds, lints, and tests), commit the `build/`
 output, and remove stray `console.log`s or commented-out code.
+
+**See also:**
+
+- [Updating Changelogs](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md)
+- [Expo Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
 
 ## Error messages
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-## expo-tools (`et`)
+## expotools (`et`)
 
 This repo ships its own CLI, `expo-tools`, available directly as `et <command> <...args>`.
 Call it as `et`, not via `npx`, `bunx`, or `pnpm run` — it's already on the PATH. Many of our

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 ## expotools (`et`)
 
-This repo ships its own CLI, `expo-tools`, available directly as `et <command> <...args>`.
+This repo ships its own CLI, `expotools`, available directly as `et <command> <...args>`.
 Call it as `et`, not via `npx`, `bunx`, or `pnpm run` — it's already on the PATH. Many of our
 processes (pod install, native unit tests, prebuild, and more) run through it.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,7 +34,7 @@ requires `et pod-install` first.
 
 ## Committing
 
-Before committing, run `et check-packages`. It runs the unit tests **and** builds the package's
+Before committing, run `et check-packages <...packages>` with the package names that has changed. It runs the unit tests **and** builds the package's
 JS files. The build output is committed alongside your source changes, so a commit that skips
 this step will be missing its built files. Stage both your source edits and the regenerated
 build output.


### PR DESCRIPTION
#  Why

We decided to add some rules and info to the root `Claude.md` file in our team sync today. This is the first iteration with rules and information we wanted to start with. Please update the file with new rules and information as needed.

Each package that needs specific rules or info should have its own `Claude.md` file.

The repo had no agent-facing guidance file documenting our core development conventions. New contributors (and AI agents) had to discover the et CLI, our red/green testing rule, the check-packages commit step, and PR conventions on their own. This consolidates that into .claude/CLAUDE.md so the expectations are stated up front.

#  How

Added several sections to .claude/CLAUDE.md:

  - expo-tools (et): documents that the CLI is on the PATH and lists the commands used in normal development (pod-install, native-unit-tests, check-packages).
  - Rules: the red/green testing discipline (failing test first, then implement).
  - Writing tests: where JS/TS (Jest, __tests__/) and native (Swift/Kotlin) tests live and how they run.
  - Committing: run et check-packages and commit the regenerated build output alongside source.
  - Creating PRs: the [platform][api] commit format and the Why/How/Test Plan/Checklist PR template.

#  Test Plan

Documentation-only change to a Markdown file — no code paths affected. Verified the file renders correctly and links are valid.

#  Checklist

  - [x] Documentation-only change; no CHANGELOG.md entry or package rebuild required
  - [x] N/A — no native code, no npx expo prebuild / EAS Build impact
  - [x] Follows the documentation style guide