### PR TITLE
fix(cli): render call stacks in dev server console

### DIFF
--- a/apps/router-e2e/__e2e__/06-errors/app/index.tsx
+++ b/apps/router-e2e/__e2e__/06-errors/app/index.tsx
@@ -32,6 +32,39 @@ export default function App() {
           console.log(undefinedVariable);
         }}
       />
+      <BigButton
+        title="Log unsymbolicated stack trace"
+        onPress={() => {
+          console.log(new Error('').stack);
+        }}
+      />
+      <BigButton
+        title="Runtime error: throw new Error"
+        onPress={() => {
+          throw new Error('E2E_UNHANDLED_THROW');
+        }}
+      />
+      <BigButton
+        title="Runtime error: async throw new Error"
+        onPress={() => {
+          async function throwAsyncError() {
+            throw new Error('E2E_UNHANDLED_ASYNC_THROW');
+          }
+          void throwAsyncError();
+        }}
+      />
+      <BigButton
+        title="Runtime error: throw string"
+        onPress={() => {
+          throw 'E2E_UNHANDLED_THROW_STRING';
+        }}
+      />
+      <BigButton
+        title="Runtime error: reject string"
+        onPress={() => {
+          void Promise.reject('E2E_UNHANDLED_REJECTION_STRING');
+        }}
+      />
       <Headline>From fixtures:</Headline>
       <BigButton
         title="Build error: syntax error"
@@ -62,6 +95,24 @@ export default function App() {
         title="console.error: Error"
         onPress={() => {
           console.error(new Error('Hello'));
+        }}
+      />
+      <BigButton
+        title="console.error: E2E Error"
+        onPress={() => {
+          console.error(new Error('E2E_CONSOLE_ERROR_OBJECT'));
+        }}
+      />
+      <BigButton
+        title="console.error: E2E string"
+        onPress={() => {
+          console.error('E2E_CONSOLE_ERROR_STRING');
+        }}
+      />
+      <BigButton
+        title="console.warn: E2E string"
+        onPress={() => {
+          console.warn('E2E_CONSOLE_WARN_STRING');
         }}
       />
       <DomButtonWithConsoleError

--- a/apps/router-e2e/__e2e__/06-errors/app/index.tsx
+++ b/apps/router-e2e/__e2e__/06-errors/app/index.tsx
@@ -39,30 +39,30 @@ export default function App() {
         }}
       />
       <BigButton
-        title="Runtime error: throw new Error"
+        title="throw new Error()"
         onPress={() => {
-          throw new Error('E2E_UNHANDLED_THROW');
+          throw new Error('unhandled-throw');
         }}
       />
       <BigButton
-        title="Runtime error: async throw new Error"
+        title="async throw new Error()"
         onPress={() => {
           async function throwAsyncError() {
-            throw new Error('E2E_UNHANDLED_ASYNC_THROW');
+            throw new Error('unhandled-async-throw');
           }
           void throwAsyncError();
         }}
       />
       <BigButton
-        title="Runtime error: throw string"
+        title="throw string"
         onPress={() => {
-          throw 'E2E_UNHANDLED_THROW_STRING';
+          throw 'unhandled-throw-string';
         }}
       />
       <BigButton
-        title="Runtime error: reject string"
+        title="Promise.reject(string)"
         onPress={() => {
-          void Promise.reject('E2E_UNHANDLED_REJECTION_STRING');
+          void Promise.reject('unhandled-rejection-string');
         }}
       />
       <Headline>From fixtures:</Headline>
@@ -86,33 +86,21 @@ export default function App() {
       />
       <Headline>From console:</Headline>
       <BigButton
-        title="console.error: string"
+        title="console.error(new Error())"
         onPress={() => {
-          console.error('Hello');
+          console.error(new Error('console-error-object'));
         }}
       />
       <BigButton
-        title="console.error: Error"
+        title="console.error(string)"
         onPress={() => {
-          console.error(new Error('Hello'));
+          console.error('console-error-string');
         }}
       />
       <BigButton
-        title="console.error: E2E Error"
+        title="console.warn(string)"
         onPress={() => {
-          console.error(new Error('E2E_CONSOLE_ERROR_OBJECT'));
-        }}
-      />
-      <BigButton
-        title="console.error: E2E string"
-        onPress={() => {
-          console.error('E2E_CONSOLE_ERROR_STRING');
-        }}
-      />
-      <BigButton
-        title="console.warn: E2E string"
-        onPress={() => {
-          console.warn('E2E_CONSOLE_WARN_STRING');
+          console.warn('console-warn-string');
         }}
       />
       <DomButtonWithConsoleError

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))
 

--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -1,0 +1,242 @@
+import { test, expect } from '@playwright/test';
+import { stripVTControlCharacters } from 'node:util';
+
+import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
+import { getRouterE2ERoot } from '../../__tests__/utils';
+import { createExpoStart } from '../../utils/expo';
+import { openPageAndEagerlyLoadJS } from '../../utils/hmr';
+import { processCollectOutput } from '../../utils/process';
+
+test.beforeAll(() => clearEnv());
+test.afterAll(() => restoreEnv());
+
+const projectRoot = getRouterE2ERoot();
+
+test.describe('dev console errors', () => {
+  const expoStart = createExpoStart({
+    cwd: projectRoot,
+    env: {
+      NODE_ENV: 'development',
+      EXPO_USE_STATIC: 'single',
+      E2E_ROUTER_JS_ENGINE: 'hermes',
+      E2E_ROUTER_SRC: '06-errors',
+      E2E_ROUTER_ASYNC: 'development',
+
+      // Ensure CI is disabled otherwise the file watcher won't run.
+      CI: '0',
+    },
+  });
+
+  test.beforeEach(async () => {
+    console.time('expo start');
+    await expoStart.startAsync();
+    console.timeEnd('expo start');
+
+    console.time('Eagerly bundled JS');
+    await expoStart.fetchBundleAsync('/').then((response) => response.text());
+    console.timeEnd('Eagerly bundled JS');
+  });
+
+  test.afterEach(async () => {
+    await expoStart.stopAsync();
+  });
+
+  test('prints call stack and component stack of unhandled errors', async ({ page }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('Runtime error: throw new Error').click();
+
+    const expectedConsoleOutput = `
+Web  ERROR  [Error: E2E_UNHANDLED_THROW] 
+
+Code: index.tsx
+  42 |         title="Runtime error: throw new Error"
+  43 |         onPress={() => {
+> 44 |           throw new Error('E2E_UNHANDLED_THROW');
+     |                 ^
+  45 |         }}
+  46 |       />
+  47 |       <BigButton
+Call Stack
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:44:17)
+
+Code: index.tsx
+  152 |   return (
+  153 |     <Text
+> 154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+      |              ^
+  155 |       onPress={onPress}>
+  156 |       {title}
+  157 |     </Text>
+Call Stack
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:154:14)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:41:7)
+    `.trim();
+
+    await expectOutput(output, expectedConsoleOutput);
+  });
+
+  test('prints call stack of unhandled rejections', async ({
+    page,
+  }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('Runtime error: async throw new Error').click();
+
+    const expectedConsoleOutput = `
+Web  ERROR  [Error: E2E_UNHANDLED_ASYNC_THROW] 
+
+Code: index.tsx
+  49 |         onPress={() => {
+  50 |           async function throwAsyncError() {
+> 51 |             throw new Error('E2E_UNHANDLED_ASYNC_THROW');
+     |                   ^
+  52 |           }
+  53 |           void throwAsyncError();
+  54 |         }}
+Call Stack
+  throwAsyncError (apps/router-e2e/__e2e__/06-errors/app/index.tsx:51:19)
+    `.trim();
+
+    await expectOutput(output, expectedConsoleOutput);
+  });
+
+  test('prints component stack of unhandled thrown non-Error values (strings)', async ({ page }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('Runtime error: throw string').click();
+
+    const expectedConsoleOutput = [
+      'Web  ERROR  E2E_UNHANDLED_THROW_STRING ',
+      '',
+      'Code: index.tsx',
+      '  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {',
+      '  152 |   return (',
+      '> 153 |     <Text',
+      '      |     ^',
+      "  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}",
+      '  155 |       onPress={onPress}>',
+      '  156 |       {title}',
+      'Call Stack',
+      '  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)',
+      '  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:56:7)',
+    ].join('\n');
+
+    await expectOutput(output, expectedConsoleOutput);
+  });
+
+  test('prints no stack for unhandled rejected non-Error values (strings)', async ({ page }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('Runtime error: reject string').click();
+
+    await expectOutput(output, 'Web  ERROR  E2E_UNHANDLED_REJECTION_STRING');
+    expectNoStackTrace(output);
+  });
+
+  test('prints call stack and component stack for console.error Error', async ({
+    page,
+  }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('console.error: E2E Error').click();
+
+    // TODO: This is not right, it prints only the component stack (twice)
+    const expectedConsoleOutput = `
+Web  ERROR  [Error: E2E_CONSOLE_ERROR_OBJECT] 
+
+Code: index.tsx
+  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  152 |   return (
+> 153 |     <Text
+      |     ^
+  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  155 |       onPress={onPress}>
+  156 |       {title}
+Call Stack
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:100:7)
+
+Code: index.tsx
+  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  152 |   return (
+> 153 |     <Text
+      |     ^
+  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  155 |       onPress={onPress}>
+  156 |       {title}
+Call Stack
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:100:7)
+    `.trim();
+
+    await expectOutput(output, expectedConsoleOutput);
+  });
+
+  test('prints call stack and component stack of console.error non-Error values (strings)', async ({
+    page,
+  }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('console.error: E2E string').click();
+
+    const expectedConsoleOutput = `
+Web  ERROR  E2E_CONSOLE_ERROR_STRING
+
+Code: index.tsx
+  107 |         title="console.error: E2E string"
+  108 |         onPress={() => {
+> 109 |           console.error('E2E_CONSOLE_ERROR_STRING');
+      |                   ^
+  110 |         }}
+  111 |       />
+  112 |       <BigButton
+Call Stack
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:109:19)
+
+Code: index.tsx
+  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  152 |   return (
+> 153 |     <Text
+      |     ^
+  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  155 |       onPress={onPress}>
+  156 |       {title}
+Call Stack
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:106:7)
+    `.trim();
+
+    await expectOutput(output, expectedConsoleOutput);
+  });
+
+  test('prints console.warn strings without stack traces', async ({ page }) => {
+    const output = processCollectOutput(expoStart.process);
+
+    await openPageAndEagerlyLoadJS(expoStart, page);
+    await page.getByText('console.warn: E2E string').click();
+
+    await expectOutput(output, 'Web  WARN  E2E_CONSOLE_WARN_STRING');
+    expectNoStackTrace(output);
+  });
+});
+
+async function expectOutput(output: { all: string }, expectedConsoleOutput: string) {
+  await expect
+    .poll(() => stripVTControlCharacters(output.all), { timeout: 30_000 })
+    .toContain(expectedConsoleOutput);
+}
+
+function expectNoStackTrace(output: { all: string }) {
+  const terminalOutput = stripVTControlCharacters(output.all);
+  // `http://localhost:8081/apps/router-e2e` would mean an unsymbolicated stack trace leaked.
+  expect(terminalOutput).not.toContain('http://localhost:8081/apps/router-e2e');
+  // `apps/router-e2e/__e2e__/06-errors/app/index.tsx` would mean a symbolicated stack trace leaked.
+  expect(terminalOutput).not.toContain('apps/router-e2e/__e2e__/06-errors/app/index.tsx');
+}

--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -59,18 +59,18 @@ Code: index.tsx
   46 |       />
   47 |       <BigButton
 Call Stack
-  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:44:17)
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:44:17) 
 
 Code: index.tsx
+  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
   152 |   return (
-  153 |     <Text
-> 154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-      |              ^
+> 153 |     <Text
+      |     ^
+  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
   155 |       onPress={onPress}>
   156 |       {title}
-  157 |     </Text>
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:154:14)
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
   App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:41:7)
     `.trim();
 
@@ -109,21 +109,21 @@ Call Stack
     await openPageAndEagerlyLoadJS(expoStart, page);
     await page.getByText('Runtime error: throw string').click();
 
-    const expectedConsoleOutput = [
-      'Web  ERROR  E2E_UNHANDLED_THROW_STRING ',
-      '',
-      'Code: index.tsx',
-      '  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {',
-      '  152 |   return (',
-      '> 153 |     <Text',
-      '      |     ^',
-      "  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}",
-      '  155 |       onPress={onPress}>',
-      '  156 |       {title}',
-      'Call Stack',
-      '  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)',
-      '  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:56:7)',
-    ].join('\n');
+    const expectedConsoleOutput = `
+Web  ERROR  E2E_UNHANDLED_THROW_STRING 
+
+Code: index.tsx
+  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  152 |   return (
+> 153 |     <Text
+      |     ^
+  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  155 |       onPress={onPress}>
+  156 |       {title}
+Call Stack
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:56:7)
+    `.trim();
 
     await expectOutput(output, expectedConsoleOutput);
   });
@@ -146,21 +146,19 @@ Call Stack
     await openPageAndEagerlyLoadJS(expoStart, page);
     await page.getByText('console.error: E2E Error').click();
 
-    // TODO: This is not right, it prints only the component stack (twice)
     const expectedConsoleOutput = `
 Web  ERROR  [Error: E2E_CONSOLE_ERROR_OBJECT] 
 
 Code: index.tsx
-  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  152 |   return (
-> 153 |     <Text
-      |     ^
-  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  155 |       onPress={onPress}>
-  156 |       {title}
+  101 |         title="console.error: E2E Error"
+  102 |         onPress={() => {
+> 103 |           console.error(new Error('E2E_CONSOLE_ERROR_OBJECT'));
+      |                         ^
+  104 |         }}
+  105 |       />
+  106 |       <BigButton
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
-  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:100:7)
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:103:25) 
 
 Code: index.tsx
   151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
@@ -187,7 +185,7 @@ Call Stack
     await page.getByText('console.error: E2E string').click();
 
     const expectedConsoleOutput = `
-Web  ERROR  E2E_CONSOLE_ERROR_STRING
+Web  ERROR  E2E_CONSOLE_ERROR_STRING 
 
 Code: index.tsx
   107 |         title="console.error: E2E string"
@@ -198,7 +196,7 @@ Code: index.tsx
   111 |       />
   112 |       <BigButton
 Call Stack
-  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:109:19)
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:109:19) 
 
 Code: index.tsx
   151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {

--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -45,15 +45,15 @@ test.describe('dev console errors', () => {
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('Runtime error: throw new Error').click();
+    await page.getByText('throw new Error()', { exact: true }).click();
 
     const expectedConsoleOutput = `
-Web  ERROR  [Error: E2E_UNHANDLED_THROW] 
+Web  ERROR  [Error: unhandled-throw] 
 
 Code: index.tsx
-  42 |         title="Runtime error: throw new Error"
+  42 |         title="throw new Error()"
   43 |         onPress={() => {
-> 44 |           throw new Error('E2E_UNHANDLED_THROW');
+> 44 |           throw new Error('unhandled-throw');
      |                 ^
   45 |         }}
   46 |       />
@@ -62,36 +62,34 @@ Call Stack
   BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:44:17) 
 
 Code: index.tsx
-  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  152 |   return (
-> 153 |     <Text
+  139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  140 |   return (
+> 141 |     <Text
       |     ^
-  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  155 |       onPress={onPress}>
-  156 |       {title}
+  142 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  143 |       onPress={onPress}>
+  144 |       {title}
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:141:5)
   App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:41:7)
     `.trim();
 
     await expectOutput(output, expectedConsoleOutput);
   });
 
-  test('prints call stack of unhandled rejections', async ({
-    page,
-  }) => {
+  test('prints call stack of unhandled rejections', async ({ page }) => {
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('Runtime error: async throw new Error').click();
+    await page.getByText('async throw new Error()').click();
 
     const expectedConsoleOutput = `
-Web  ERROR  [Error: E2E_UNHANDLED_ASYNC_THROW] 
+Web  ERROR  [Error: unhandled-async-throw] 
 
 Code: index.tsx
   49 |         onPress={() => {
   50 |           async function throwAsyncError() {
-> 51 |             throw new Error('E2E_UNHANDLED_ASYNC_THROW');
+> 51 |             throw new Error('unhandled-async-throw');
      |                   ^
   52 |           }
   53 |           void throwAsyncError();
@@ -107,21 +105,21 @@ Call Stack
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('Runtime error: throw string').click();
+    await page.getByText('throw string').click();
 
     const expectedConsoleOutput = `
-Web  ERROR  E2E_UNHANDLED_THROW_STRING 
+Web  ERROR  unhandled-throw-string 
 
 Code: index.tsx
-  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  152 |   return (
-> 153 |     <Text
+  139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  140 |   return (
+> 141 |     <Text
       |     ^
-  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  155 |       onPress={onPress}>
-  156 |       {title}
+  142 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  143 |       onPress={onPress}>
+  144 |       {title}
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:141:5)
   App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:56:7)
     `.trim();
 
@@ -132,83 +130,79 @@ Call Stack
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('Runtime error: reject string').click();
+    await page.getByText('Promise.reject(string)').click();
 
-    await expectOutput(output, 'Web  ERROR  E2E_UNHANDLED_REJECTION_STRING');
+    await expectOutput(output, 'Web  ERROR  unhandled-rejection-string');
     expectNoStackTrace(output);
   });
 
-  test('prints call stack and component stack for console.error Error', async ({
-    page,
-  }) => {
+  test('prints call stack and component stack for console.error Error', async ({ page }) => {
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('console.error: E2E Error').click();
+    await page.getByText('console.error(new Error())').click();
 
     const expectedConsoleOutput = `
-Web  ERROR  [Error: E2E_CONSOLE_ERROR_OBJECT] 
+Web  ERROR  [Error: console-error-object] 
 
 Code: index.tsx
-  101 |         title="console.error: E2E Error"
-  102 |         onPress={() => {
-> 103 |           console.error(new Error('E2E_CONSOLE_ERROR_OBJECT'));
-      |                         ^
-  104 |         }}
-  105 |       />
-  106 |       <BigButton
+  89 |         title="console.error(new Error())"
+  90 |         onPress={() => {
+> 91 |           console.error(new Error('console-error-object'));
+     |                         ^
+  92 |         }}
+  93 |       />
+  94 |       <BigButton
 Call Stack
-  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:103:25) 
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:91:25) 
 
 Code: index.tsx
-  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  152 |   return (
-> 153 |     <Text
+  139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  140 |   return (
+> 141 |     <Text
       |     ^
-  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  155 |       onPress={onPress}>
-  156 |       {title}
+  142 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  143 |       onPress={onPress}>
+  144 |       {title}
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
-  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:100:7)
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:141:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:88:7)
     `.trim();
 
     await expectOutput(output, expectedConsoleOutput);
   });
 
-  test('prints call stack and component stack of console.error non-Error values (strings)', async ({
-    page,
-  }) => {
+  test('prints call stack and component stack of console.error non-Error values (strings)', async ({ page }) => {
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('console.error: E2E string').click();
+    await page.getByText('console.error(string)').click();
 
     const expectedConsoleOutput = `
-Web  ERROR  E2E_CONSOLE_ERROR_STRING 
+Web  ERROR  console-error-string 
 
 Code: index.tsx
-  107 |         title="console.error: E2E string"
-  108 |         onPress={() => {
-> 109 |           console.error('E2E_CONSOLE_ERROR_STRING');
+   95 |         title="console.error(string)"
+   96 |         onPress={() => {
+>  97 |           console.error('console-error-string');
       |                   ^
-  110 |         }}
-  111 |       />
-  112 |       <BigButton
+   98 |         }}
+   99 |       />
+  100 |       <BigButton
 Call Stack
-  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:109:19) 
+  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:97:19) 
 
 Code: index.tsx
-  151 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  152 |   return (
-> 153 |     <Text
+  139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
+  140 |   return (
+> 141 |     <Text
       |     ^
-  154 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  155 |       onPress={onPress}>
-  156 |       {title}
+  142 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
+  143 |       onPress={onPress}>
+  144 |       {title}
 Call Stack
-  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:153:5)
-  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:106:7)
+  BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:141:5)
+  App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:94:7)
     `.trim();
 
     await expectOutput(output, expectedConsoleOutput);
@@ -218,9 +212,9 @@ Call Stack
     const output = processCollectOutput(expoStart.process);
 
     await openPageAndEagerlyLoadJS(expoStart, page);
-    await page.getByText('console.warn: E2E string').click();
+    await page.getByText('console.warn(string)').click();
 
-    await expectOutput(output, 'Web  WARN  E2E_CONSOLE_WARN_STRING');
+    await expectOutput(output, 'Web  WARN  console-warn-string');
     expectNoStackTrace(output);
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -350,7 +350,11 @@ export class MetroTerminalReporter extends TerminalReporter {
       let hasStack = false;
       const parsed = data.map((msg) => {
         // Quick check to see if an unsymbolicated stack is being logged.
-        if (typeof msg === 'string' && msg.includes('.bundle//&platform=')) {
+        if (
+          typeof msg === 'string' &&
+          // Native stack frames use `.bundle//&platform=...`; web stack frames use `.bundle?platform=...`.
+          (msg.includes('.bundle//&platform=') || msg.includes('.bundle?platform='))
+        ) {
           const stack = parseErrorStringToObject(msg);
           if (stack) {
             hasStack = true;

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -166,6 +166,50 @@ describe('symbolicate React stacks', () => {
 `);
   });
 
+  it('should symbolicate a web error stack', async () => {
+    let parsedError: any;
+    jest
+      .mocked(maybeSymbolicateAndFormatJSErrorStackLogAsync)
+      .mockImplementationOnce((_projectRoot, _level, error) => {
+        parsedError = error;
+        return Promise.resolve({
+          isFallback: false,
+          stack: '\n\n  at app/index.tsx:1:1',
+        });
+      });
+
+    reporter._log({
+      type: 'client_log',
+      level: 'error',
+      data: [
+        '[Error: Hello]',
+        'Error: Hello\n    at Page (http://localhost:8081/packages/expo-router/entry.bundle?platform=web&dev=true&hot=false:123:45)',
+      ],
+      mode: 'web',
+    } as any);
+
+    expect(parseErrorStringToObject).toHaveBeenCalledWith(
+      expect.stringContaining('/packages/expo-router/entry.bundle?platform=web')
+    );
+    expect(maybeSymbolicateAndFormatJSErrorStackLogAsync).toHaveBeenCalledTimes(1);
+    expect(parsedError.stack[0]).toEqual({
+      arguments: [],
+      column: 44,
+      file: 'http://localhost:8081/packages/expo-router/entry.bundle?platform=web&dev=true&hot=false',
+      lineNumber: 123,
+      methodName: 'Page',
+    });
+
+    await jest.runAllTimersAsync();
+
+    expect(terminal.log).toHaveBeenCalledTimes(1);
+    expect(stripVTControlCharacters(terminal.log.mock.calls[0].join(''))).toMatchInlineSnapshot(`
+"Web  ERROR [Error: Hello]
+
+  at app/index.tsx:1:1"
+`);
+  });
+
   it(`should symbolicate multiple errors stacks - SDK 54 style`, async () => {
     jest
       .mocked(maybeSymbolicateAndFormatJSErrorStackLogAsync)

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Preserve Error call stacks when capturing component stacks. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+
 ### 💡 Others
 
 ## 56.0.12 — 2026-05-20

--- a/packages/@expo/log-box/src/Data/parseLogBoxLog.ts
+++ b/packages/@expo/log-box/src/Data/parseLogBoxLog.ts
@@ -331,17 +331,13 @@ export function parseLogBoxLog(args: any[]): {
     error = new Error(message);
   }
 
-  // Use the official stack from componentDidCatch
-  if ('componentStack' in error) {
-    // @ts-expect-error
-    error.stack = error.componentStack;
-  } else {
-    // Try to capture owner stack now if missing.
-    error.stack = React.captureOwnerStack() || undefined;
-  }
+  const componentStack =
+    'componentStack' in error && typeof error.componentStack === 'string'
+      ? error.componentStack
+      : React.captureOwnerStack() || undefined;
 
   return {
-    componentStack: parseErrorStack(error.stack ?? ''),
+    componentStack: parseErrorStack(componentStack ?? ''),
     category: error.message,
     message: {
       content: message,

--- a/packages/@expo/metro-runtime/build/metroServerLogs.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/metroServerLogs.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"metroServerLogs.native.d.ts","sourceRoot":"","sources":["../src/metroServerLogs.native.ts"],"names":[],"mappings":"AASA,wBAAgB,yBAAyB,SAoDxC"}
+{"version":3,"file":"metroServerLogs.native.d.ts","sourceRoot":"","sources":["../src/metroServerLogs.native.ts"],"names":[],"mappings":"AASA,wBAAgB,yBAAyB,SAsDxC"}

--- a/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
+++ b/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
@@ -28,7 +28,7 @@ export function captureStackForServerLogs() {
     }
 
     const hasErrorLikeStack = data.some((item) => {
-      return hasStringKey(item, 'stack')
+      return hasStringKey(item, 'stack');
     });
     const hasComponentStack = data.some(
       (item) =>

--- a/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
+++ b/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
@@ -27,7 +27,9 @@ export function captureStackForServerLogs() {
       return;
     }
 
-    const hasErrorLikeStack = data.some((item) => hasStringKey(item, 'stack'));
+    const hasErrorLikeStack = data.some((item) => {
+      return hasStringKey(item, 'stack')
+    });
     const hasComponentStack = data.some(
       (item) =>
         (typeof item === 'string' && isComponentStack(withoutANSIColorStyles(item))) ||
@@ -104,5 +106,6 @@ class NamelessError extends Error {
   name = '';
 }
 function captureCurrentStack() {
+  // If you're reading this, look deeper into the call stack to find the actual error source.
   return new NamelessError().stack;
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### 🐛 Bug fixes
 
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
-- Forward unhandled errors and rejections to the dev server console. ([#46578](https://github.com/expo/expo/pull/46578) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))
 - Prevent fatal `The stream is not in a state that permits close` in `expo/fetch` when native delivers `didComplete`/`didFailWithError` after the consumer has already canceled the body stream. ([#44909](https://github.com/expo/expo/pull/44909) by [@safaiyeh](https://github.com/safaiyeh))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Forward unhandled errors and rejections to the dev server console. ([#46578](https://github.com/expo/expo/pull/46578) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/src/async-require/setupHMR.ts
+++ b/packages/expo/src/async-require/setupHMR.ts
@@ -1,3 +1,5 @@
+import type * as React from 'react';
+
 import HMRClient from './hmr';
 
 if (typeof window !== 'undefined') {
@@ -17,19 +19,60 @@ if (typeof window !== 'undefined') {
   LEVELS.forEach((level) => {
     const originalFunction = console[level];
     console[level] = function (...args: any[]) {
-      HMRClient.log(level, args);
+      HMRClient.log(level, level === 'error' ? addErrorStacks(args) : args);
       originalFunction.apply(console, args);
     };
   });
 
   window.addEventListener('error', (event) => {
-    HMRClient.log('error', [event.error]);
+    HMRClient.log('error', addErrorStacks([event.error]));
   });
 
   window.addEventListener('unhandledrejection', (event) => {
-    HMRClient.log('error', [event.reason]);
+    HMRClient.log('error', addErrorStacks([event.reason]));
   });
 }
 
 // This is called native on native platforms
 HMRClient.setup({ isEnabled: true });
+
+function addErrorStacks(data: unknown[]) {
+  const dataWithStacks = [...data];
+  let hasStack = false;
+  data.forEach((item) => {
+    if (hasStringKey(item, 'stack')) {
+      hasStack = true;
+      dataWithStacks.push(item.stack);
+    }
+  });
+
+  const stack = captureCurrentStack();
+  if (!hasStack && typeof stack === 'string') {
+    dataWithStacks.push(stack);
+  }
+
+  const react = require('react') as typeof React;
+  const componentStack = react.captureOwnerStack?.();
+  if (componentStack) {
+    dataWithStacks.push(componentStack);
+  }
+
+  return dataWithStacks;
+}
+
+function hasStringKey(obj: unknown, key: string): obj is { [key: string]: string } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    key in obj &&
+    typeof (obj as Record<string, unknown>)[key] === 'string'
+  );
+}
+
+class NamelessError extends Error {
+  name = '';
+}
+
+function captureCurrentStack() {
+  return new NamelessError().stack;
+}

--- a/packages/expo/src/async-require/setupHMR.ts
+++ b/packages/expo/src/async-require/setupHMR.ts
@@ -58,6 +58,7 @@ function addErrorStacks(data: unknown[], shouldCaptureCurrentStack = false) {
     // for console.* to point to the call site
     const stack = captureCurrentStack();
     if (typeof stack === 'string') {
+      hasStack = true;
       dataWithStacks.push(stack);
     }
   }

--- a/packages/expo/src/async-require/setupHMR.ts
+++ b/packages/expo/src/async-require/setupHMR.ts
@@ -19,16 +19,20 @@ if (typeof window !== 'undefined') {
   LEVELS.forEach((level) => {
     const originalFunction = console[level];
     console[level] = function (...args: any[]) {
-      HMRClient.log(level, level === 'error' ? addErrorStacks(args) : args);
+      HMRClient.log(level, level === 'error' ? addErrorStacks(args, true) : args);
       originalFunction.apply(console, args);
     };
   });
 
   window.addEventListener('error', (event) => {
+    // Not capturing current stack as it would only point to this function,
+    // the stack chain is preserved by the browser.
     HMRClient.log('error', addErrorStacks([event.error]));
   });
 
   window.addEventListener('unhandledrejection', (event) => {
+    // Not capturing current stack as it would only point to this function,
+    // the stack chain is preserved by the browser.
     HMRClient.log('error', addErrorStacks([event.reason]));
   });
 }
@@ -36,19 +40,26 @@ if (typeof window !== 'undefined') {
 // This is called native on native platforms
 HMRClient.setup({ isEnabled: true });
 
-function addErrorStacks(data: unknown[]) {
+function addErrorStacks(data: unknown[], shouldCaptureCurrentStack = false) {
   const dataWithStacks = [...data];
   let hasStack = false;
   data.forEach((item) => {
-    if (hasStringKey(item, 'stack')) {
+    // on native handled in packages/@expo/metro-runtime/src/metroServerLogs.native.ts
+    // https://github.com/expo/expo/blob/118528654c982b6df2f4b3e73bbf2ae0b78d84a2/packages/%40expo/metro-runtime/src/metroServerLogs.native.ts#L30
+    // this differs from native implementation where error from native modules
+    // would not pass instanceof Error check
+    if (item instanceof Error && item.stack) {
       hasStack = true;
       dataWithStacks.push(item.stack);
     }
   });
 
-  const stack = captureCurrentStack();
-  if (!hasStack && typeof stack === 'string') {
-    dataWithStacks.push(stack);
+  if (!hasStack && shouldCaptureCurrentStack) {
+    // for console.* to point to the call site
+    const stack = captureCurrentStack();
+    if (typeof stack === 'string') {
+      dataWithStacks.push(stack);
+    }
   }
 
   const react = require('react') as typeof React;
@@ -60,19 +71,11 @@ function addErrorStacks(data: unknown[]) {
   return dataWithStacks;
 }
 
-function hasStringKey(obj: unknown, key: string): obj is { [key: string]: string } {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    key in obj &&
-    typeof (obj as Record<string, unknown>)[key] === 'string'
-  );
-}
-
 class NamelessError extends Error {
   name = '';
 }
 
 function captureCurrentStack() {
+  // If you're reading this, look deeper into the call stack to find the actual error source.
   return new NamelessError().stack;
 }


### PR DESCRIPTION
## Summary
- follow up to https://github.com/expo/expo/pull/45516
- and to https://github.com/expo/expo/pull/46578
- add passing calls stack thru hmr on the web
- fix rendering of web stacks (needed update of stack string check) 

## Test plan
- updated terminal reporter tests to include web stack example
- call console.error, throw unhandled error or rejection and observe pretty rendered stack in the dev server console

## Before this PR
<img width="391" height="48" alt="Screenshot 2026-06-05 at 00 12 58" src="https://github.com/user-attachments/assets/c67aa67d-81b6-47af-b6bf-e3d20919e612" />

## After this PR
<img width="1422" height="1304" alt="Screenshot 2026-06-04 at 23 40 30" src="https://github.com/user-attachments/assets/bd3ce18b-f7c1-4a89-9762-3e601491399d" />
