### PR TITLE
[docs] Add embedded bundle as a patch base for bundle diffing

### DIFF
--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -78,8 +78,7 @@ Delete an embedded bundle:
 
 <Terminal cmd={['$ eas update:embedded:delete [id]']} />
 
-Deleting an unknown ID succeeds, so the command is safe to retry.
-
+The command is safe to retry.
 ## Verify bundle diffs are being served
 
 ### Expo website

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -32,7 +32,9 @@ Bundle diffing is enabled by default in SDK 56 and later. To opt out, set `updat
 
 ## Use the embedded bundle as a patch base
 
-On a fresh install, devices boot from the embedded JavaScript bundle. These devices aren't eligible for patches by default. To make the embedded bundle a patch base for future updates, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment variable on a build profile in **eas.json**. This is an experimental opt-in.
+> **info** This is an experimental opt-in. The behavior may change.
+
+On a fresh install, devices boot from the embedded JavaScript bundle. These devices aren't eligible for patches by default. To make the embedded bundle a patch base for future updates, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment variable in the `env` object of a build profile in **eas.json**:
 
 ```json eas.json
 {
@@ -46,13 +48,13 @@ On a fresh install, devices boot from the embedded JavaScript bundle. These devi
 }
 ```
 
-When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. If the upload fails, the build still succeeds &mdash; only the patch base is missing.
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. If the upload fails, the build still succeeds. Future updates on this channel won't be able to use this build's embedded bundle as a patch base.
 
-Patch application on the device also requires `enableBsdiffPatchSupport`, which is on by default in SDK 56 and later.
+Devices apply patches only when `enableBsdiffPatchSupport` is enabled in your [app config](/workflow/configuration/). It's on by default in SDK 56 and later.
 
-### Manage uploaded embedded bundles
+### Upload a bundle manually
 
-If you build outside of EAS Build, upload an embedded bundle manually:
+If you don't use EAS Build, you can upload an embedded bundle yourself. Build the bundle locally with `npx expo export`, then run:
 
 <Terminal
   cmd={[
@@ -60,6 +62,8 @@ If you build outside of EAS Build, upload an embedded bundle manually:
   ]}
   cmdCopy="eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]"
 />
+
+### Inspect or delete uploaded bundles
 
 List the embedded bundles registered for your project:
 
@@ -73,7 +77,7 @@ Delete an embedded bundle:
 
 <Terminal cmd={['$ eas update:embedded:delete [id]']} cmdCopy="eas update:embedded:delete [id]" />
 
-Delete is idempotent. Deleting an unknown ID succeeds, so the command is safe to retry from scripts.
+Deleting an unknown ID succeeds, so the command is safe to retry.
 
 ## Verify bundle diffs are being served
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -54,7 +54,7 @@ To enable, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment 
 }
 ```
 
-When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploads are best-effort; if EAS Build can't upload, or you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` at the JavaScript bundle and `--manifest` at the **app.manifest** produced by the native build:
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` at the JavaScript bundle and `--manifest` at the **app.manifest** produced by the native build:
 
 <Terminal
   cmd={[

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -74,7 +74,7 @@ View a single embedded bundle:
 
 Delete an embedded bundle:
 
-<Terminal cmd={['$ eas update:embedded:delete [id]']} cmdCopy="eas update:embedded:delete [id]" />
+<Terminal cmd={['$ eas update:embedded:delete [id]']} />
 
 Deleting an unknown ID succeeds, so the command is safe to retry.
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -18,7 +18,11 @@ With bundle diffing, EAS Update delivers a **bundle patch** when possible. When 
 
 ## Enable bundle diffing
 
-Bundle diffing is enabled by default in SDK 56 and later. To opt out, set `updates.enableBsdiffPatchSupport` to `false` in your project's [app config](/workflow/configuration/). On SDK 55, set it to `true` to opt in.
+Bundle diffing has two modes. Update-to-update patches deliver a diff between two published updates, so devices already running a published update receive a patch when they check for a newer one. Embedded-bundle-to-update patches (experimental) deliver a diff between a build's embedded JavaScript bundle and a published update, so devices on a fresh install receive a patch on their first update check instead of the full bundle.
+
+### Enable update-to-update patches
+
+Update-to-update patches are enabled by default in SDK 56 and later. To opt out, set `updates.enableBsdiffPatchSupport` to `false` in your project's [app config](/workflow/configuration/). On SDK 55, set it to `true` to opt in.
 
 ```json app.json
 {
@@ -30,11 +34,11 @@ Bundle diffing is enabled by default in SDK 56 and later. To opt out, set `updat
 }
 ```
 
-## Use the embedded bundle as a patch base
+### Enable embedded-bundle-to-update patches
 
-> **info** This is an experimental opt-in. The behavior may change.
+> **info** This mode is experimental and opt-in. The flag and behavior may change.
 
-On a fresh install, devices boot from the embedded JavaScript bundle. These devices aren't eligible for patches by default. To make the embedded bundle a patch base for future updates, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment variable in the `env` object of a build profile in **eas.json**:
+To enable, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment variable under `env` in a build profile in **eas.json**:
 
 ```json eas.json
 {
@@ -48,20 +52,21 @@ On a fresh install, devices boot from the embedded JavaScript bundle. These devi
 }
 ```
 
-When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploading is best effort, so if the upload fails, the build still succeeds.
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploading is best-effort. If the upload fails, the build still succeeds.
 
-
-### Upload a bundle manually
-
-If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **android/app/src/main/assets/index.android.bundle** on Android or **ios/build/App.app/main.jsbundle** on iOS):
+If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **android/app/src/main/assets/index.android.bundle** on Android and **ios/build/App.app/main.jsbundle** on iOS):
 
 <Terminal
   cmd={[
     '$ eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]',
+    '',
+    '# Example',
+    '$ eas update:embedded:upload --platform android --bundle android/app/src/main/assets/index.android.bundle --manifest android/app/src/main/assets/app.manifest --channel production',
   ]}
+  cmdCopy="eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]"
 />
 
-### Inspect or delete uploaded bundles
+## Manage uploaded embedded bundles
 
 List the embedded bundles registered for your project:
 
@@ -69,11 +74,27 @@ List the embedded bundles registered for your project:
 
 View a single embedded bundle:
 
-<Terminal cmd={['$ eas update:embedded:view [id]']} />
+<Terminal
+  cmd={[
+    '$ eas update:embedded:view [id]',
+    '',
+    '# Example',
+    '$ eas update:embedded:view a1b2c3d4-1234-4000-8000-000000000000',
+  ]}
+  cmdCopy="eas update:embedded:view [id]"
+/>
 
 Delete an embedded bundle:
 
-<Terminal cmd={['$ eas update:embedded:delete [id]']} />
+<Terminal
+  cmd={[
+    '$ eas update:embedded:delete [id]',
+    '',
+    '# Example',
+    '$ eas update:embedded:delete a1b2c3d4-1234-4000-8000-000000000000',
+  ]}
+  cmdCopy="eas update:embedded:delete [id]"
+/>
 
 Deleting an unknown ID succeeds, so the command is safe to retry.
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -60,7 +60,6 @@ If you don't use EAS Build, you can upload an embedded bundle yourself. Point `-
   cmd={[
     '$ eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]',
   ]}
-  cmdCopy="eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]"
 />
 
 ### Inspect or delete uploaded bundles

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -22,13 +22,13 @@ Bundle diffing has two modes. Update-to-update patches deliver a diff between tw
 
 ### Enable update-to-update patches
 
-Update-to-update patches are enabled by default in SDK 56 and later. To opt out, set `updates.enableBsdiffPatchSupport` to `false` in your project's [app config](/workflow/configuration/). On SDK 55, set it to `true` to opt in.
+Update-to-update patches are enabled by default in SDK 56 and later. On SDK 55, set `updates.enableBsdiffPatchSupport` to `true` in your project's [app config](/workflow/configuration/) to opt in.
 
 ```json app.json
 {
   "expo": {
     "updates": {
-      "enableBsdiffPatchSupport": false
+      "enableBsdiffPatchSupport": true
     }
   }
 }
@@ -59,11 +59,7 @@ If you don't use EAS Build, you can upload an embedded bundle yourself. Point `-
 <Terminal
   cmd={[
     '$ eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]',
-    '',
-    '# Example',
-    '$ eas update:embedded:upload --platform android --bundle android/app/src/main/assets/index.android.bundle --manifest android/app/src/main/assets/app.manifest --channel production',
   ]}
-  cmdCopy="eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]"
 />
 
 ## Manage uploaded embedded bundles
@@ -74,27 +70,11 @@ List the embedded bundles registered for your project:
 
 View a single embedded bundle:
 
-<Terminal
-  cmd={[
-    '$ eas update:embedded:view [id]',
-    '',
-    '# Example',
-    '$ eas update:embedded:view a1b2c3d4-1234-4000-8000-000000000000',
-  ]}
-  cmdCopy="eas update:embedded:view [id]"
-/>
+<Terminal cmd={['$ eas update:embedded:view [id]']} />
 
 Delete an embedded bundle:
 
-<Terminal
-  cmd={[
-    '$ eas update:embedded:delete [id]',
-    '',
-    '# Example',
-    '$ eas update:embedded:delete a1b2c3d4-1234-4000-8000-000000000000',
-  ]}
-  cmdCopy="eas update:embedded:delete [id]"
-/>
+<Terminal cmd={['$ eas update:embedded:delete [id]']} />
 
 Deleting an unknown ID succeeds, so the command is safe to retry.
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -18,11 +18,11 @@ With bundle diffing, EAS Update delivers a **bundle patch** when possible. When 
 
 ## Enable bundle diffing
 
-Bundle diffing has two modes. Update-to-update patches deliver a diff between two published updates, so devices already running a published update receive a patch when they check for a newer one. Embedded-bundle-to-update patches (experimental) deliver a diff between a build's embedded JavaScript bundle and a published update, so devices on a fresh install receive a patch on their first update check instead of the full bundle.
+Bundle diffing works in two situations. By default, devices already running a published update get a patch when a newer one is available. Opt in (experimental) and devices on a fresh install can also get a patch on their very first update check, instead of downloading the full new bundle.
 
-### Enable update-to-update patches
+### Patches between updates
 
-Update-to-update patches are enabled by default in SDK 56 and later. On SDK 55, set `updates.enableBsdiffPatchSupport` to `true` in your project's [app config](/workflow/configuration/) to opt in.
+Enabled by default in SDK 56 and later. On SDK 55, set `updates.enableBsdiffPatchSupport` to `true` in your project's [app config](/workflow/configuration/) to opt in.
 
 ```json app.json
 {
@@ -34,7 +34,9 @@ Update-to-update patches are enabled by default in SDK 56 and later. On SDK 55, 
 }
 ```
 
-### Enable embedded-bundle-to-update patches
+To disable on SDK 56 and later, set `enableBsdiffPatchSupport` to `false`.
+
+### Patches from the embedded bundle
 
 > **info** This mode is experimental and opt-in. The flag and behavior may change.
 
@@ -52,9 +54,7 @@ To enable, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment 
 }
 ```
 
-When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploading is best-effort. If the upload fails, the build still succeeds.
-
-If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **android/app/src/main/assets/index.android.bundle** on Android and **ios/build/App.app/main.jsbundle** on iOS):
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploads are best-effort; if EAS Build can't upload, or you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` at the JavaScript bundle and `--manifest` at the **app.manifest** produced by the native build:
 
 <Terminal
   cmd={[
@@ -63,6 +63,8 @@ If you don't use EAS Build, you can upload an embedded bundle yourself. Point `-
 />
 
 ## Manage uploaded embedded bundles
+
+Find ids with `eas update:embedded:list`, then pass them to view or delete.
 
 List the embedded bundles registered for your project:
 
@@ -104,5 +106,6 @@ A patch is served only when:
 
 ## Current limitations
 
+- **Fresh installs receive the full bundle on their first update unless you opt in to [patches from the embedded bundle](#patches-from-the-embedded-bundle).**
 - **Patches aren't guaranteed for every possible update pair immediately.** When an update is published, EAS Update precomputes a patch only against the second-newest update on the channel. If a device requests the new update while running a different published update, it will initially receive the full bundle. A patch for that specific base update is then generated on demand and served to future similar requests.
 - **Patches are generated shortly after publishing.** It can take a few minutes between publishing an update and the patch being ready. During that window, devices may receive the full bundle.

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -50,7 +50,6 @@ On a fresh install, devices boot from the embedded JavaScript bundle. These devi
 
 When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploading is best effort, so if the upload fails, the build still succeeds.
 
-Devices apply patches only when `enableBsdiffPatchSupport` is enabled in your [app config](/workflow/configuration/). It's on by default in SDK 56 and later.
 
 ### Upload a bundle manually
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -48,7 +48,7 @@ On a fresh install, devices boot from the embedded JavaScript bundle. These devi
 }
 ```
 
-When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. If the upload fails, the build still succeeds. Future updates on this channel won't be able to use this build's embedded bundle as a patch base.
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. Uploading is best effort, so if the upload fails, the build still succeeds.
 
 Devices apply patches only when `enableBsdiffPatchSupport` is enabled in your [app config](/workflow/configuration/). It's on by default in SDK 56 and later.
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -70,7 +70,7 @@ List the embedded bundles registered for your project:
 
 View a single embedded bundle:
 
-<Terminal cmd={['$ eas update:embedded:view [id]']} cmdCopy="eas update:embedded:view [id]" />
+<Terminal cmd={['$ eas update:embedded:view [id]']} />
 
 Delete an embedded bundle:
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -6,6 +6,7 @@ description: Enable your project to accept bundle diffs when available.
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **important** Bundle diffing is in [**beta**](/more/release-statuses/#beta) and may have limitations. See [Current limitations](#current-limitations) for details.
 
@@ -28,6 +29,51 @@ Bundle diffing is enabled by default in SDK 56 and later. To opt out, set `updat
   }
 }
 ```
+
+## Use the embedded bundle as a patch base
+
+On a fresh install, devices boot from the embedded JavaScript bundle. These devices aren't eligible for patches by default. To make the embedded bundle a patch base for future updates, set the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` environment variable on a build profile in **eas.json**. This is an experimental opt-in.
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "env": {
+        "EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE": "1"
+      }
+    }
+  }
+}
+```
+
+When the build completes, EAS uploads the embedded bundle. Updates published later to the same channel can then be served as patches against it. If the upload fails, the build still succeeds &mdash; only the patch base is missing.
+
+Patch application on the device also requires `enableBsdiffPatchSupport`, which is on by default in SDK 56 and later.
+
+### Manage uploaded embedded bundles
+
+If you build outside of EAS Build, upload an embedded bundle manually:
+
+<Terminal
+  cmd={[
+    '$ eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]',
+  ]}
+  cmdCopy="eas update:embedded:upload --platform [platform] --bundle [path] --manifest [path] --channel [name]"
+/>
+
+List the embedded bundles registered for your project:
+
+<Terminal cmd={['$ eas update:embedded:list']} />
+
+View a single embedded bundle:
+
+<Terminal cmd={['$ eas update:embedded:view [id]']} cmdCopy="eas update:embedded:view [id]" />
+
+Delete an embedded bundle:
+
+<Terminal cmd={['$ eas update:embedded:delete [id]']} cmdCopy="eas update:embedded:delete [id]" />
+
+Delete is idempotent. Deleting an unknown ID succeeds, so the command is safe to retry from scripts.
 
 ## Verify bundle diffs are being served
 
@@ -55,6 +101,5 @@ A patch is served only when:
 
 ## Current limitations
 
-- **Embedded bundles aren't eligible.** The embedded bundle is never used as a base for patching. Devices must already be running a published update to receive a patch.
 - **Patches aren't guaranteed for every possible update pair immediately.** When an update is published, EAS Update precomputes a patch only against the second-newest update on the channel. If a device requests the new update while running a different published update, it will initially receive the full bundle. A patch for that specific base update is then generated on demand and served to future similar requests.
 - **Patches are generated shortly after publishing.** It can take a few minutes between publishing an update and the patch being ready. During that window, devices may receive the full bundle.

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -54,7 +54,7 @@ Devices apply patches only when `enableBsdiffPatchSupport` is enabled in your [a
 
 ### Upload a bundle manually
 
-If you don't use EAS Build, you can upload an embedded bundle yourself. Build the bundle locally with `npx expo export`, then run:
+If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **ios/build/App.app/main.jsbundle** on iOS or **android/app/src/main/assets/index.android.bundle** on Android):
 
 <Terminal
   cmd={[

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -79,6 +79,7 @@ Delete an embedded bundle:
 <Terminal cmd={['$ eas update:embedded:delete [id]']} />
 
 The command is safe to retry.
+
 ## Verify bundle diffs are being served
 
 ### Expo website

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -54,7 +54,7 @@ Devices apply patches only when `enableBsdiffPatchSupport` is enabled in your [a
 
 ### Upload a bundle manually
 
-If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **ios/build/App.app/main.jsbundle** on iOS or **android/app/src/main/assets/index.android.bundle** on Android):
+If you don't use EAS Build, you can upload an embedded bundle yourself. Point `--bundle` and `--manifest` at the JavaScript bundle and **app.manifest** produced by the native build (for example, **android/app/src/main/assets/index.android.bundle** on Android or **ios/build/App.app/main.jsbundle** on iOS):
 
 <Terminal
   cmd={[


### PR DESCRIPTION
## Why

Document the opt-in to use a build's embedded JavaScript bundle as a patch base, so devices on a fresh install can receive bsdiff patches on their first update. Previously called out as a limitation on the page (now removed).

## How

Edit **pages/eas-update/bundle-diffing.mdx**:

- New section `## Use the embedded bundle as a patch base` after the existing "Enable bundle diffing": the `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` env var, an **eas.json** snippet, behavior on success or failure, and the dependency on `enableBsdiffPatchSupport`.
- Subsection `### Manage uploaded embedded bundles`: `eas update:embedded:upload`, `:list`, `:view`, `:delete` via the `Terminal` component.
- Remove the "Embedded bundles aren't eligible" bullet from "Current limitations" (no longer accurate).

Marked as experimental in prose.

## Test Plan

- `pnpm lint-prose` — 0 errors, 0 warnings, 0 suggestions
- `pnpm lint` — `tsc` and `eslint` clean on touched files