### PR TITLE
[docs][ui] Improve textfield docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -197,37 +197,12 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: value => console.log('Searched:', value),
+          onSearch: (value) => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>
         </TextField.Label>
       </TextField>
-    </Host>
-  );
-}
-```
-
-### Error state
-
-Set `isError` to display the text field in an error state. Combine with `SupportingText` to show an error message.
-
-```tsx ErrorStateExample.tsx
-import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
-
-export default function ErrorStateExample() {
-  const email = useNativeState('invalid-email');
-
-  return (
-    <Host matchContents>
-      <OutlinedTextField value={email} isError singleLine>
-        <OutlinedTextField.Label>
-          <Text>Email</Text>
-        </OutlinedTextField.Label>
-        <OutlinedTextField.SupportingText>
-          <Text>Please enter a valid email</Text>
-        </OutlinedTextField.SupportingText>
-      </OutlinedTextField>
     </Host>
   );
 }

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -35,7 +35,7 @@ Expo UI provides two text field components that match the official Jetpack Compo
 
 ### Uncontrolled text field
 
-Bind a [`useNativeState`](usenativestate) observable to `value`; the field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
+Bind a [`useNativeState`](usenativestate) observable to `value`. The field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
 ```tsx BasicTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -197,7 +197,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: (value) => console.log('Searched:', value),
+          onSearch: value => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -33,22 +33,54 @@ Expo UI provides two text field components that match the official Jetpack Compo
 
 ## Usage
 
-### Basic text field
+### Uncontrolled text field
 
-A filled text field is the default Material3 text input style.
+Bind a [`useNativeState`](usenativestate) observable to `value`; the field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
 ```tsx BasicTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function BasicTextFieldExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField onValueChange={setValue}>
+      <TextField value={text}>
         <TextField.Label>
           <Text>Username</Text>
+        </TextField.Label>
+      </TextField>
+    </Host>
+  );
+}
+```
+
+### Controlled text field
+
+Pass a [`useNativeState`](usenativestate) observable as `value` and an `onValueChange` worklet to transform or validate input before writing it back. The example below uppercases the text as it is typed.
+
+> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+
+```tsx ControlledTextFieldExample.tsx
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
+import { useCallback } from 'react';
+
+export default function ControlledTextFieldExample() {
+  const text = useNativeState('');
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value.toUpperCase();
+    },
+    [text]
+  );
+
+  return (
+    <Host matchContents>
+      <TextField value={text} onValueChange={handleValueChange}>
+        <TextField.Label>
+          <Text>Name</Text>
         </TextField.Label>
       </TextField>
     </Host>
@@ -61,15 +93,14 @@ export default function BasicTextFieldExample() {
 Use `OutlinedTextField` for a text field with a border outline instead of a filled background.
 
 ```tsx OutlinedTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, OutlinedTextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function OutlinedTextFieldExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <OutlinedTextField onValueChange={setValue}>
+      <OutlinedTextField value={text}>
         <OutlinedTextField.Label>
           <Text>Email</Text>
         </OutlinedTextField.Label>
@@ -87,15 +118,14 @@ export default function OutlinedTextFieldExample() {
 Both `TextField` and `OutlinedTextField` support 7 composable slots that match the Compose API: `Label`, `Placeholder`, `LeadingIcon`, `TrailingIcon`, `Prefix`, `Suffix`, and `SupportingText`.
 
 ```tsx TextFieldSlotsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function TextFieldSlotsExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField onValueChange={setValue}>
+      <TextField value={text}>
         <TextField.Label>
           <Text>Price</Text>
         </TextField.Label>
@@ -125,16 +155,15 @@ export default function TextFieldSlotsExample() {
 Use the `keyboardOptions` prop to configure the keyboard type, capitalization, auto-correct, and IME action.
 
 ```tsx KeyboardOptionsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function KeyboardOptionsExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
-        onValueChange={setValue}
+        value={text}
         singleLine
         keyboardOptions={{
           keyboardType: 'email',
@@ -156,21 +185,19 @@ export default function KeyboardOptionsExample() {
 Use the `keyboardActions` prop to handle IME action button presses. The triggered callback depends on the `imeAction` set in `keyboardOptions`. Each callback receives the current text value.
 
 ```tsx KeyboardActionsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function KeyboardActionsExample() {
-  const [value, setValue] = useState('');
-  const [submitted, setSubmitted] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
-        onValueChange={setValue}
+        value={text}
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: text => setSubmitted(text),
+          onSearch: value => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>
@@ -186,21 +213,19 @@ export default function KeyboardActionsExample() {
 Set `isError` to display the text field in an error state. Combine with `SupportingText` to show an error message.
 
 ```tsx ErrorStateExample.tsx
-import { useState } from 'react';
-import { Host, OutlinedTextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function ErrorStateExample() {
-  const [value, setValue] = useState('');
-  const hasError = value.length > 0 && !value.includes('@');
+  const email = useNativeState('invalid-email');
 
   return (
     <Host matchContents>
-      <OutlinedTextField onValueChange={setValue} isError={hasError} singleLine>
+      <OutlinedTextField value={email} isError singleLine>
         <OutlinedTextField.Label>
           <Text>Email</Text>
         </OutlinedTextField.Label>
         <OutlinedTextField.SupportingText>
-          <Text>{hasError ? 'Please enter a valid email' : 'Required'}</Text>
+          <Text>Please enter a valid email</Text>
         </OutlinedTextField.SupportingText>
       </OutlinedTextField>
     </Host>
@@ -213,18 +238,27 @@ export default function ErrorStateExample() {
 Use a ref to imperatively set text, clear the field, change the selection, or move focus.
 
 ```tsx ImperativeRefExample.tsx
-import { useRef, useState } from 'react';
-import { Host, TextField, TextFieldRef, Button, Row, Text, Column } from '@expo/ui/jetpack-compose';
+import { useRef } from 'react';
+import {
+  Host,
+  TextField,
+  TextFieldRef,
+  Button,
+  Row,
+  Text,
+  Column,
+  useNativeState,
+} from '@expo/ui/jetpack-compose';
 import { padding } from '@expo/ui/jetpack-compose/modifiers';
 
 export default function ImperativeRefExample() {
   const ref = useRef<TextFieldRef>(null);
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <Column>
-        <TextField ref={ref} onValueChange={setValue} singleLine>
+        <TextField ref={ref} value={text} singleLine>
           <TextField.Label>
             <Text>Name</Text>
           </TextField.Label>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -30,7 +30,7 @@ Expo UI TextField matches the official SwiftUI [TextField API](https://developer
 
 ### Uncontrolled text field
 
-Bind a [`useNativeState`](usenativestate) observable to `text`; the field tracks the user's input on its own, and you read the current value from `textState.value`.
+Bind a [`useNativeState`](usenativestate) observable to `text`. The field tracks the user's input on its own, and you read the current value from `textState.value`.
 
 ```tsx BasicTextFieldExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
@@ -80,7 +80,7 @@ export default function ControlledTextFieldExample() {
 Set `axis="vertical"` to allow the text field to expand vertically. Use the [`lineLimit`](modifiers/#linelimit) modifier to control the visible line count. When using `Host matchContents`, add `fixedSize({ horizontal: false, vertical: true })` so the text field accepts the parent's width while using its ideal height.
 
 ```tsx MultilineTextFieldExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { lineLimit, fixedSize } from '@expo/ui/swift-ui/modifiers';
 
 export default function MultilineTextFieldExample() {
@@ -104,7 +104,7 @@ export default function MultilineTextFieldExample() {
 Use the [`keyboardType`](modifiers/#keyboardtypekeyboardtype) modifier to display a specific keyboard layout.
 
 ```tsx KeyboardTypeExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType, autocorrectionDisabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function KeyboardTypeExample() {
@@ -127,7 +127,7 @@ export default function KeyboardTypeExample() {
 Use the [`submitLabel`](modifiers/#submitlabelsubmitlabel) modifier to customize the return key and [`onSubmit`](modifiers/#onsubmithandler) to handle the submit action.
 
 ```tsx SubmitHandlingExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { submitLabel, onSubmit } from '@expo/ui/swift-ui/modifiers';
 
 export default function SubmitHandlingExample() {

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -28,18 +28,48 @@ Expo UI TextField matches the official SwiftUI [TextField API](https://developer
 
 ## Usage
 
-### Basic text field
+### Uncontrolled text field
+
+Bind a [`useNativeState`](usenativestate) observable to `text`; the field tracks the user's input on its own, and you read the current value from `textState.value`.
 
 ```tsx BasicTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 
 export default function BasicTextFieldExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField placeholder="Username" onTextChange={setValue} />
+      <TextField placeholder="Username" text={textState} />
+    </Host>
+  );
+}
+```
+
+### Controlled text field
+
+Pass an `onTextChange` worklet to transform or validate input and write the result back to the [`useNativeState`](usenativestate) observable state. The example below uppercases the text as it is typed.
+
+> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+
+```tsx ControlledTextFieldExample.tsx
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
+import { useCallback } from 'react';
+
+export default function ControlledTextFieldExample() {
+  const text = useNativeState('');
+
+  const handleTextChange = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value.toUpperCase();
+    },
+    [text]
+  );
+
+  return (
+    <Host matchContents>
+      <TextField placeholder="Name" text={text} onTextChange={handleTextChange} />
     </Host>
   );
 }
@@ -50,19 +80,18 @@ export default function BasicTextFieldExample() {
 Set `axis="vertical"` to allow the text field to expand vertically. Use the [`lineLimit`](modifiers/#linelimit) modifier to control the visible line count. When using `Host matchContents`, add `fixedSize({ horizontal: false, vertical: true })` so the text field accepts the parent's width while using its ideal height.
 
 ```tsx MultilineTextFieldExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { lineLimit, fixedSize } from '@expo/ui/swift-ui/modifiers';
 
 export default function MultilineTextFieldExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         axis="vertical"
+        text={textState}
         placeholder="Tell us about yourself..."
-        onTextChange={setValue}
         modifiers={[lineLimit(5), fixedSize({ horizontal: false, vertical: true })]}
       />
     </Host>
@@ -75,18 +104,17 @@ export default function MultilineTextFieldExample() {
 Use the [`keyboardType`](modifiers/#keyboardtypekeyboardtype) modifier to display a specific keyboard layout.
 
 ```tsx KeyboardTypeExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { keyboardType, autocorrectionDisabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function KeyboardTypeExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         placeholder="Email"
-        onTextChange={setValue}
+        text={textState}
         modifiers={[keyboardType('email-address'), autocorrectionDisabled()]}
       />
     </Host>
@@ -99,19 +127,21 @@ export default function KeyboardTypeExample() {
 Use the [`submitLabel`](modifiers/#submitlabelsubmitlabel) modifier to customize the return key and [`onSubmit`](modifiers/#onsubmithandler) to handle the submit action.
 
 ```tsx SubmitHandlingExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { submitLabel, onSubmit } from '@expo/ui/swift-ui/modifiers';
 
 export default function SubmitHandlingExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         placeholder="Search..."
-        onTextChange={setValue}
-        modifiers={[submitLabel('search'), onSubmit(() => console.log('Submitted:', value))]}
+        text={textState}
+        modifiers={[
+          submitLabel('search'),
+          onSubmit(() => console.log('Submitted:', textState.value)),
+        ]}
       />
     </Host>
   );
@@ -139,12 +169,12 @@ import { buttonStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function ImperativeRefExample() {
   const ref = useRef<TextFieldRef>(null);
-  const text = useNativeState('Select me!');
+  const textState = useNativeState('Select me!');
 
   return (
     <Host matchContents>
       <VStack>
-        <TextField ref={ref} text={text} placeholder="Imperative field" />
+        <TextField ref={ref} text={textState} placeholder="Imperative field" />
         <HStack spacing={12}>
           <Button
             modifiers={[buttonStyle('bordered')]}

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -197,37 +197,12 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: value => console.log('Searched:', value),
+          onSearch: (value) => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>
         </TextField.Label>
       </TextField>
-    </Host>
-  );
-}
-```
-
-### Error state
-
-Set `isError` to display the text field in an error state. Combine with `SupportingText` to show an error message.
-
-```tsx ErrorStateExample.tsx
-import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
-
-export default function ErrorStateExample() {
-  const email = useNativeState('invalid-email');
-
-  return (
-    <Host matchContents>
-      <OutlinedTextField value={email} isError singleLine>
-        <OutlinedTextField.Label>
-          <Text>Email</Text>
-        </OutlinedTextField.Label>
-        <OutlinedTextField.SupportingText>
-          <Text>Please enter a valid email</Text>
-        </OutlinedTextField.SupportingText>
-      </OutlinedTextField>
     </Host>
   );
 }

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -35,7 +35,7 @@ Expo UI provides two text field components that match the official Jetpack Compo
 
 ### Uncontrolled text field
 
-Bind a [`useNativeState`](usenativestate) observable to `value`; the field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
+Bind a [`useNativeState`](usenativestate) observable to `value`. The field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
 ```tsx BasicTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -197,7 +197,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: (value) => console.log('Searched:', value),
+          onSearch: value => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -33,22 +33,54 @@ Expo UI provides two text field components that match the official Jetpack Compo
 
 ## Usage
 
-### Basic text field
+### Uncontrolled text field
 
-A filled text field is the default Material3 text input style.
+Bind a [`useNativeState`](usenativestate) observable to `value`; the field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
 ```tsx BasicTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function BasicTextFieldExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField onValueChange={setValue}>
+      <TextField value={text}>
         <TextField.Label>
           <Text>Username</Text>
+        </TextField.Label>
+      </TextField>
+    </Host>
+  );
+}
+```
+
+### Controlled text field
+
+Pass a [`useNativeState`](usenativestate) observable as `value` and an `onValueChange` worklet to transform or validate input before writing it back. The example below uppercases the text as it is typed.
+
+> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+
+```tsx ControlledTextFieldExample.tsx
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
+import { useCallback } from 'react';
+
+export default function ControlledTextFieldExample() {
+  const text = useNativeState('');
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value.toUpperCase();
+    },
+    [text]
+  );
+
+  return (
+    <Host matchContents>
+      <TextField value={text} onValueChange={handleValueChange}>
+        <TextField.Label>
+          <Text>Name</Text>
         </TextField.Label>
       </TextField>
     </Host>
@@ -61,15 +93,14 @@ export default function BasicTextFieldExample() {
 Use `OutlinedTextField` for a text field with a border outline instead of a filled background.
 
 ```tsx OutlinedTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, OutlinedTextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function OutlinedTextFieldExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <OutlinedTextField onValueChange={setValue}>
+      <OutlinedTextField value={text}>
         <OutlinedTextField.Label>
           <Text>Email</Text>
         </OutlinedTextField.Label>
@@ -87,15 +118,14 @@ export default function OutlinedTextFieldExample() {
 Both `TextField` and `OutlinedTextField` support 7 composable slots that match the Compose API: `Label`, `Placeholder`, `LeadingIcon`, `TrailingIcon`, `Prefix`, `Suffix`, and `SupportingText`.
 
 ```tsx TextFieldSlotsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function TextFieldSlotsExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField onValueChange={setValue}>
+      <TextField value={text}>
         <TextField.Label>
           <Text>Price</Text>
         </TextField.Label>
@@ -125,16 +155,15 @@ export default function TextFieldSlotsExample() {
 Use the `keyboardOptions` prop to configure the keyboard type, capitalization, auto-correct, and IME action.
 
 ```tsx KeyboardOptionsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function KeyboardOptionsExample() {
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
-        onValueChange={setValue}
+        value={text}
         singleLine
         keyboardOptions={{
           keyboardType: 'email',
@@ -156,21 +185,19 @@ export default function KeyboardOptionsExample() {
 Use the `keyboardActions` prop to handle IME action button presses. The triggered callback depends on the `imeAction` set in `keyboardOptions`. Each callback receives the current text value.
 
 ```tsx KeyboardActionsExample.tsx
-import { useState } from 'react';
-import { Host, TextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function KeyboardActionsExample() {
-  const [value, setValue] = useState('');
-  const [submitted, setSubmitted] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
-        onValueChange={setValue}
+        value={text}
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: text => setSubmitted(text),
+          onSearch: value => console.log('Searched:', value),
         }}>
         <TextField.Label>
           <Text>Search</Text>
@@ -186,21 +213,19 @@ export default function KeyboardActionsExample() {
 Set `isError` to display the text field in an error state. Combine with `SupportingText` to show an error message.
 
 ```tsx ErrorStateExample.tsx
-import { useState } from 'react';
-import { Host, OutlinedTextField, Text } from '@expo/ui/jetpack-compose';
+import { Host, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
 export default function ErrorStateExample() {
-  const [value, setValue] = useState('');
-  const hasError = value.length > 0 && !value.includes('@');
+  const email = useNativeState('invalid-email');
 
   return (
     <Host matchContents>
-      <OutlinedTextField onValueChange={setValue} isError={hasError} singleLine>
+      <OutlinedTextField value={email} isError singleLine>
         <OutlinedTextField.Label>
           <Text>Email</Text>
         </OutlinedTextField.Label>
         <OutlinedTextField.SupportingText>
-          <Text>{hasError ? 'Please enter a valid email' : 'Required'}</Text>
+          <Text>Please enter a valid email</Text>
         </OutlinedTextField.SupportingText>
       </OutlinedTextField>
     </Host>
@@ -213,18 +238,27 @@ export default function ErrorStateExample() {
 Use a ref to imperatively set text, clear the field, change the selection, or move focus.
 
 ```tsx ImperativeRefExample.tsx
-import { useRef, useState } from 'react';
-import { Host, TextField, TextFieldRef, Button, Row, Text, Column } from '@expo/ui/jetpack-compose';
+import { useRef } from 'react';
+import {
+  Host,
+  TextField,
+  TextFieldRef,
+  Button,
+  Row,
+  Text,
+  Column,
+  useNativeState,
+} from '@expo/ui/jetpack-compose';
 import { padding } from '@expo/ui/jetpack-compose/modifiers';
 
 export default function ImperativeRefExample() {
   const ref = useRef<TextFieldRef>(null);
-  const [value, setValue] = useState('');
+  const text = useNativeState('');
 
   return (
     <Host matchContents>
       <Column>
-        <TextField ref={ref} onValueChange={setValue} singleLine>
+        <TextField ref={ref} value={text} singleLine>
           <TextField.Label>
             <Text>Name</Text>
           </TextField.Label>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -30,7 +30,7 @@ Expo UI TextField matches the official SwiftUI [TextField API](https://developer
 
 ### Uncontrolled text field
 
-Bind a [`useNativeState`](usenativestate) observable to `text`; the field tracks the user's input on its own, and you read the current value from `textState.value`.
+Bind a [`useNativeState`](usenativestate) observable to `text`. The field tracks the user's input on its own, and you read the current value from `textState.value`.
 
 ```tsx BasicTextFieldExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
@@ -80,7 +80,7 @@ export default function ControlledTextFieldExample() {
 Set `axis="vertical"` to allow the text field to expand vertically. Use the [`lineLimit`](modifiers/#linelimit) modifier to control the visible line count. When using `Host matchContents`, add `fixedSize({ horizontal: false, vertical: true })` so the text field accepts the parent's width while using its ideal height.
 
 ```tsx MultilineTextFieldExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { lineLimit, fixedSize } from '@expo/ui/swift-ui/modifiers';
 
 export default function MultilineTextFieldExample() {
@@ -104,7 +104,7 @@ export default function MultilineTextFieldExample() {
 Use the [`keyboardType`](modifiers/#keyboardtypekeyboardtype) modifier to display a specific keyboard layout.
 
 ```tsx KeyboardTypeExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType, autocorrectionDisabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function KeyboardTypeExample() {
@@ -127,7 +127,7 @@ export default function KeyboardTypeExample() {
 Use the [`submitLabel`](modifiers/#submitlabelsubmitlabel) modifier to customize the return key and [`onSubmit`](modifiers/#onsubmithandler) to handle the submit action.
 
 ```tsx SubmitHandlingExample.tsx
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { submitLabel, onSubmit } from '@expo/ui/swift-ui/modifiers';
 
 export default function SubmitHandlingExample() {

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -28,18 +28,48 @@ Expo UI TextField matches the official SwiftUI [TextField API](https://developer
 
 ## Usage
 
-### Basic text field
+### Uncontrolled text field
+
+Bind a [`useNativeState`](usenativestate) observable to `text`; the field tracks the user's input on its own, and you read the current value from `textState.value`.
 
 ```tsx BasicTextFieldExample.tsx
-import { useState } from 'react';
-import { Host, TextField } from '@expo/ui/swift-ui';
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 
 export default function BasicTextFieldExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
-      <TextField placeholder="Username" onTextChange={setValue} />
+      <TextField placeholder="Username" text={textState} />
+    </Host>
+  );
+}
+```
+
+### Controlled text field
+
+Pass an `onTextChange` worklet to transform or validate input and write the result back to the [`useNativeState`](usenativestate) observable state. The example below uppercases the text as it is typed.
+
+> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+
+```tsx ControlledTextFieldExample.tsx
+import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
+import { useCallback } from 'react';
+
+export default function ControlledTextFieldExample() {
+  const text = useNativeState('');
+
+  const handleTextChange = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value.toUpperCase();
+    },
+    [text]
+  );
+
+  return (
+    <Host matchContents>
+      <TextField placeholder="Name" text={text} onTextChange={handleTextChange} />
     </Host>
   );
 }
@@ -50,19 +80,18 @@ export default function BasicTextFieldExample() {
 Set `axis="vertical"` to allow the text field to expand vertically. Use the [`lineLimit`](modifiers/#linelimit) modifier to control the visible line count. When using `Host matchContents`, add `fixedSize({ horizontal: false, vertical: true })` so the text field accepts the parent's width while using its ideal height.
 
 ```tsx MultilineTextFieldExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { lineLimit, fixedSize } from '@expo/ui/swift-ui/modifiers';
 
 export default function MultilineTextFieldExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         axis="vertical"
+        text={textState}
         placeholder="Tell us about yourself..."
-        onTextChange={setValue}
         modifiers={[lineLimit(5), fixedSize({ horizontal: false, vertical: true })]}
       />
     </Host>
@@ -75,18 +104,17 @@ export default function MultilineTextFieldExample() {
 Use the [`keyboardType`](modifiers/#keyboardtypekeyboardtype) modifier to display a specific keyboard layout.
 
 ```tsx KeyboardTypeExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { keyboardType, autocorrectionDisabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function KeyboardTypeExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         placeholder="Email"
-        onTextChange={setValue}
+        text={textState}
         modifiers={[keyboardType('email-address'), autocorrectionDisabled()]}
       />
     </Host>
@@ -99,19 +127,21 @@ export default function KeyboardTypeExample() {
 Use the [`submitLabel`](modifiers/#submitlabelsubmitlabel) modifier to customize the return key and [`onSubmit`](modifiers/#onsubmithandler) to handle the submit action.
 
 ```tsx SubmitHandlingExample.tsx
-import { useState } from 'react';
 import { Host, TextField } from '@expo/ui/swift-ui';
 import { submitLabel, onSubmit } from '@expo/ui/swift-ui/modifiers';
 
 export default function SubmitHandlingExample() {
-  const [value, setValue] = useState('');
+  const textState = useNativeState('');
 
   return (
     <Host matchContents>
       <TextField
         placeholder="Search..."
-        onTextChange={setValue}
-        modifiers={[submitLabel('search'), onSubmit(() => console.log('Submitted:', value))]}
+        text={textState}
+        modifiers={[
+          submitLabel('search'),
+          onSubmit(() => console.log('Submitted:', textState.value)),
+        ]}
       />
     </Host>
   );
@@ -139,12 +169,12 @@ import { buttonStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function ImperativeRefExample() {
   const ref = useRef<TextFieldRef>(null);
-  const text = useNativeState('Select me!');
+  const textState = useNativeState('Select me!');
 
   return (
     <Host matchContents>
       <VStack>
-        <TextField ref={ref} text={text} placeholder="Imperative field" />
+        <TextField ref={ref} text={textState} placeholder="Imperative field" />
         <HStack spacing={12}>
           <Button
             modifiers={[buttonStyle('bordered')]}

--- a/packages/expo-ui/src/State/useNativeState.ts
+++ b/packages/expo-ui/src/State/useNativeState.ts
@@ -71,19 +71,11 @@ type NativeObservableState = {
  * Adds a `value` property that delegates to the native `getValue`/`setValue` functions.
  */
 function defineValueProperty(state: NativeObservableState): void {
-  let warnedOnJSWrite = false;
   Object.defineProperty(state, 'value', {
     get() {
       return state.getValue();
     },
     set(v: unknown) {
-      if (__DEV__ && !warnedOnJSWrite && worklets && !worklets.isUIRuntime()) {
-        warnedOnJSWrite = true;
-        console.warn(
-          'ObservableState.value was set from the JS thread, the result may be unexpected. ' +
-            'Use a worklet to update the state.'
-        );
-      }
       state.setValue({ value: v });
     },
   });


### PR DESCRIPTION
# Why

Current docs do not use controlled/uncontrolled textfield terminology and also uses `useState` instead of `useNativeState` which is confusing

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
- Change title to uncontrolled/controlled textfield
- Replace `useState` with `useNativeState`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested examples locally
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
