### PR TITLE
[expo-router] refactor native-stack before standard-navigation integration

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### 💡 Others
 
+- Refactor native-stack for compliance with standard-navigation integration ([#46592](https://github.com/expo/expo/pull/46592) by [@Ubax](https://github.com/Ubax))
 - Remove the deprecated static-navigation API from `expo-router/react-navigation`. ([#48071](https://github.com/expo/expo/pull/48071) by [@Ubax](https://github.com/Ubax))
 - Remove `UNSTABLE_routeNamesChangeBehavior` and unhandled-state replay from `useNavigationBuilder`. ([#47985](https://github.com/expo/expo/pull/47985) by [@Ubax](https://github.com/Ubax))
 - Remove `useOnlyUserDefinedScreens` from `withLayoutContext` ([#47983](https://github.com/expo/expo/pull/47983) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/native-stack/__tests__/usePreviewTransition.test.ios.tsx
+++ b/packages/expo-router/src/fork/native-stack/__tests__/usePreviewTransition.test.ios.tsx
@@ -50,8 +50,8 @@ function makeDescriptors(keys: string[]): NativeStackDescriptorMap {
   return result;
 }
 
-function makeNavigation() {
-  return { emit: jest.fn((..._args: any[]) => ({ defaultPrevented: false })) };
+function makeEmit() {
+  return jest.fn((..._args: any[]) => ({ defaultPrevented: false }));
 }
 
 describe('usePreviewTransition', () => {
@@ -71,23 +71,21 @@ describe('usePreviewTransition', () => {
     jest.restoreAllMocks();
   });
 
-  it('passes through original state, descriptors, and navigation when no preview is active', () => {
+  it('passes through original state and emit when no preview is active', () => {
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     expect(result.current.computedState).toBe(state);
     expect(result.current.computedDescriptors).toBe(descriptors);
-    expect(result.current.navigationWrapper).toBe(navigation);
+    expect(result.current.emit).toBe(emit);
     expect(describe).not.toHaveBeenCalled();
   });
 
-  it('wraps navigation.emit when openPreviewKey is set', () => {
+  it('wraps emit when openPreviewKey is set', () => {
     mockUseLinkPreviewContext.mockReturnValue({
       isStackAnimationDisabled: true,
       openPreviewKey: 'preview-key',
@@ -95,17 +93,13 @@ describe('usePreviewTransition', () => {
     });
 
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
-    // Navigation wrapper should be a new object, not the original
-    expect(result.current.navigationWrapper).not.toBe(navigation);
-    expect(result.current.navigationWrapper.emit).not.toBe(navigation.emit);
+    expect(result.current.emit).not.toBe(emit);
   });
 
   it('intercepts transitionStart and starts tracking the preview screen', () => {
@@ -119,18 +113,16 @@ describe('usePreviewTransition', () => {
     const state = makeState({
       preloadedRoutes: [preloadedRoute],
     });
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const previewDescriptor = makeDescriptor('preview-key');
     const describe = jest.fn().mockReturnValue(previewDescriptor);
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     // Fire transitionStart for the preview key
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'preview-key',
         data: { closing: false },
@@ -148,7 +140,7 @@ describe('usePreviewTransition', () => {
     expect(result.current.computedDescriptors['preview-key']).toBe(previewDescriptor);
 
     // Original emit should still have been called
-    expect(navigation.emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 
   it('intercepts transitionEnd and calls setOpenPreviewKey(undefined)', () => {
@@ -159,16 +151,14 @@ describe('usePreviewTransition', () => {
     });
 
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionEnd',
         target: 'preview-key',
         data: { closing: false },
@@ -176,7 +166,7 @@ describe('usePreviewTransition', () => {
     });
 
     expect(mockSetOpenPreviewKey).toHaveBeenCalledWith(undefined);
-    expect(navigation.emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 
   it('does not intercept events with closing: true', () => {
@@ -187,16 +177,14 @@ describe('usePreviewTransition', () => {
     });
 
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'preview-key',
         data: { closing: true },
@@ -206,7 +194,7 @@ describe('usePreviewTransition', () => {
     // State should remain unchanged - closing events are not intercepted
     expect(result.current.computedState).toBe(state);
     expect(mockSetOpenPreviewKey).not.toHaveBeenCalled();
-    expect(navigation.emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 
   it('does not intercept events for a different target', () => {
@@ -217,16 +205,14 @@ describe('usePreviewTransition', () => {
     });
 
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'other-key',
         data: { closing: false },
@@ -235,7 +221,7 @@ describe('usePreviewTransition', () => {
 
     // State should remain unchanged - different target
     expect(result.current.computedState).toBe(state);
-    expect(navigation.emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 
   it('reuses existing descriptor when already present in descriptors map', () => {
@@ -250,7 +236,7 @@ describe('usePreviewTransition', () => {
     const state = makeState({
       preloadedRoutes: [preloadedRoute],
     });
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     // Descriptors already include preview-key
     const descriptors = {
       ...makeDescriptors(['index-key']),
@@ -258,13 +244,11 @@ describe('usePreviewTransition', () => {
     };
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     // Fire transitionStart to begin tracking
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'preview-key',
         data: { closing: false },
@@ -288,20 +272,20 @@ describe('usePreviewTransition', () => {
     const state = makeState({
       preloadedRoutes: [preloadedRoute],
     });
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const previewDescriptor = makeDescriptor('preview-key');
     const describe = jest.fn().mockReturnValue(previewDescriptor);
 
     const { result, rerender } = renderHook(
       ({ state, descriptors }: HookProps) =>
-        usePreviewTransition(state, navigation, descriptors, describe),
+        usePreviewTransition(state, emit, descriptors, describe),
       { initialProps: { state, descriptors } as HookProps } as RenderHookOptions<HookProps>
     );
 
     // Start tracking
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'preview-key',
         data: { closing: false },
@@ -337,48 +321,45 @@ describe('usePreviewTransition', () => {
     });
 
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     act(() => {
-      result.current.navigationWrapper.emit({
-        type: 'transitionStart',
+      result.current.emit({
+        type: 'gestureCancel',
         target: 'preview-key',
       });
     });
 
     // Without data property, the event should pass through without interception
     expect(result.current.computedState).toBe(state);
-    expect(navigation.emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 
-  it('preserves navigationWrapper reference across re-renders when no preview is active', () => {
+  it('preserves emit reference across re-renders when no preview is active', () => {
     const state = makeState();
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
     const { result, rerender } = renderHook(
       ({ state, descriptors }: HookProps) =>
-        usePreviewTransition(state, navigation, descriptors, describe),
+        usePreviewTransition(state, emit, descriptors, describe),
       { initialProps: { state, descriptors } as HookProps } as RenderHookOptions<HookProps>
     );
 
-    const firstWrapper = result.current.navigationWrapper;
-    expect(firstWrapper).toBe(navigation);
+    const firstEmit = result.current.emit;
+    expect(firstEmit).toBe(emit);
 
     // Rerender with new state/descriptors but no preview active
     const newState = makeState({ index: 0 });
     const newDescriptors = makeDescriptors(['index-key']);
     rerender({ state: newState, descriptors: newDescriptors });
 
-    // navigationWrapper should still be the same navigation reference
-    expect(result.current.navigationWrapper).toBe(navigation);
+    expect(result.current.emit).toBe(emit);
   });
 
   it('falls through to original state when no matching preloaded route exists', () => {
@@ -392,17 +373,15 @@ describe('usePreviewTransition', () => {
     const state = makeState({
       preloadedRoutes: [makeRoute('other-preloaded')],
     });
-    const navigation = makeNavigation();
+    const emit = makeEmit();
     const descriptors = makeDescriptors(['index-key']);
     const describe = jest.fn();
 
-    const { result } = renderHook(() =>
-      usePreviewTransition(state, navigation, descriptors, describe)
-    );
+    const { result } = renderHook(() => usePreviewTransition(state, emit, descriptors, describe));
 
     // Start tracking
     act(() => {
-      result.current.navigationWrapper.emit({
+      result.current.emit({
         type: 'transitionStart',
         target: 'preview-key',
         data: { closing: false },

--- a/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
@@ -25,6 +25,7 @@ import {
   type NativeStackNavigationProp,
   NativeStackView,
   type NativeStackNavigatorProps,
+  makePopAction,
 } from '../../react-navigation/native-stack';
 import { CompositionContext, mergeOptions, useCompositionRegistry } from './composition-options';
 import { DescriptorsContext } from './descriptors-context';
@@ -63,7 +64,12 @@ function NativeStackNavigator({
     UNSTABLE_router,
   });
 
-  useClearGuardedRoutes(state, navigation);
+  const removeRoutesFromState = React.useCallback(
+    (routeNames: string[]) =>
+      navigation.dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
+    [navigation]
+  );
+  useClearGuardedRoutes(removeRoutesFromState);
 
   React.useEffect(
     () =>
@@ -97,12 +103,14 @@ function NativeStackNavigator({
   );
 
   // START FORK
-  const { computedState, computedDescriptors, navigationWrapper } = usePreviewTransition(
+  const { computedState, computedDescriptors, emit } = usePreviewTransition(
     state,
-    navigation,
+    navigation.emit,
     descriptors,
     describe
   );
+
+  const pop = makePopAction(navigation.dispatch, state.key);
 
   // Map internal gesture option to React Navigation's gestureEnabled option
   // This allows Expo Router to override gesture behavior without affecting user settings
@@ -153,8 +161,9 @@ function NativeStackNavigator({
             {...rest}
             // START FORK
             state={computedState}
-            navigation={navigationWrapper}
             descriptors={mergedDescriptors}
+            emit={emit}
+            pop={pop}
             // state={state}
             // navigation={navigation}
             // descriptors={descriptors}

--- a/packages/expo-router/src/fork/native-stack/usePreviewTransition.ts
+++ b/packages/expo-router/src/fork/native-stack/usePreviewTransition.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { useLinkPreviewContext } from '../../link/preview/LinkPreviewContext';
 import type { ParamListBase, StackNavigationState } from '../../react-navigation/native';
+import type { NativeStackViewEmit } from '../../react-navigation/native-stack';
 import type { NativeStackDescriptor, NativeStackDescriptorMap } from './descriptors-context';
 
 /** Mirrors the `describe` function returned by `useNavigationBuilder` */
@@ -15,12 +16,12 @@ type DescribeFn = (
  *
  * Tracks when a preloaded screen is transitioning on the native side (after
  * the preview is committed) but before React Navigation state is updated.
- * During this window, the hook synthesizes state/descriptors to keep native
- * and JS state in sync.
+ * During this window, the hook synthesizes state to keep native and JS state
+ * in sync.
  */
-export function usePreviewTransition<TNavigation extends { emit: (...args: any[]) => any }>(
+export function usePreviewTransition(
   state: StackNavigationState<ParamListBase>,
-  navigation: TNavigation,
+  originalEmit: NativeStackViewEmit,
   descriptors: NativeStackDescriptorMap,
   describe: DescribeFn
 ) {
@@ -41,10 +42,10 @@ export function usePreviewTransition<TNavigation extends { emit: (...args: any[]
     }
   }, [state, previewTransitioningScreenId]);
 
-  const navigationWrapper = React.useMemo(() => {
+  const emit = React.useMemo(() => {
     if (openPreviewKey) {
-      const emit: (typeof navigation)['emit'] = (...args) => {
-        const { target, type, data } = args[0];
+      const emit: NativeStackViewEmit = (event) => {
+        const { target, type, data } = event;
         if (target === openPreviewKey && data && 'closing' in data && !data.closing) {
           // onWillAppear
           if (type === 'transitionStart') {
@@ -58,15 +59,12 @@ export function usePreviewTransition<TNavigation extends { emit: (...args: any[]
             setOpenPreviewKey(undefined);
           }
         }
-        return navigation.emit(...args);
+        return originalEmit(event);
       };
-      return {
-        ...navigation,
-        emit,
-      };
+      return emit;
     }
-    return navigation;
-  }, [navigation, openPreviewKey, setOpenPreviewKey]);
+    return originalEmit;
+  }, [openPreviewKey, originalEmit, setOpenPreviewKey]);
 
   const { computedState, computedDescriptors } = React.useMemo(() => {
     // The preview screen was pushed on the native side, but react-navigation state was not updated yet
@@ -108,5 +106,5 @@ export function usePreviewTransition<TNavigation extends { emit: (...args: any[]
     };
   }, [state, previewTransitioningScreenId, describe, descriptors]);
 
-  return { computedState, computedDescriptors, navigationWrapper };
+  return { computedState, computedDescriptors, emit };
 }

--- a/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
+++ b/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
@@ -1,51 +1,26 @@
 'use client';
 
-import { use, useEffect } from 'react';
+import { use, useEffect, useEffectEvent } from 'react';
 
-import { CommonActions } from '../react-navigation/native';
-import {
-  getRoutesForRouteNames,
-  type ParamListBase,
-  type StackNavigationState,
-} from '../react-navigation/routers';
-import { GuardContext, isRouteGuarded } from './GuardContext';
+import { GuardContext, normalizeRouteName } from './GuardContext';
 
 /**
  * Lets a stack navigator clear its own guarded routes from history, based on the guard context.
  */
-export function useClearGuardedRoutes(
-  state: StackNavigationState<ParamListBase>,
-  navigation: {
-    dispatch: (
-      action: Readonly<{ type: string; payload?: object; source?: string; target?: string }>
-    ) => void;
-  }
-) {
+export function useClearGuardedRoutes(removeRoutesFromState: (routeNames: string[]) => void) {
   const guards = use(GuardContext);
+  const removeRoutes = useEffectEvent(removeRoutesFromState);
 
   useEffect(() => {
-    if (!guards) {
+    if (!guards?.size) {
       return;
     }
 
-    const focusedName = state.routes[state.index]?.name;
-    // If focused route becomes guarded then we let the redirect fire
-    const hasGuardedRoute = state.routes.some(
-      (route) => route.name !== focusedName && isRouteGuarded(route.name, guards)
-    );
-    if (!hasGuardedRoute) {
-      return;
-    }
-
-    const allowedNames = state.routeNames.filter(
-      (name) => name === focusedName || !isRouteGuarded(name, guards)
-    );
-
-    const { routes, index } = getRoutesForRouteNames(state, allowedNames, { routeParamList: {} });
-
-    navigation.dispatch({
-      ...CommonActions.reset({ ...state, routes, index }),
-      target: state.key,
+    const routeNames = Array.from(guards.keys()).flatMap((name) => {
+      const normalizedName = normalizeRouteName(name);
+      return [normalizedName, `${normalizedName}/index`];
     });
-  }, [guards, state, navigation]);
+
+    removeRoutes(routeNames);
+  }, [guards]);
 }

--- a/packages/expo-router/src/modal/web/ModalStack.tsx
+++ b/packages/expo-router/src/modal/web/ModalStack.tsx
@@ -22,7 +22,7 @@ import type {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
 } from '../../react-navigation/native-stack';
-import { NativeStackView } from '../../react-navigation/native-stack';
+import { makePopAction, NativeStackView } from '../../react-navigation/native-stack';
 import { ModalStackRouteDrawer } from './ModalStackRouteDrawer';
 import { TransparentModalStackRouteDrawer } from './TransparentModalStackRouteDrawer';
 import type { ModalStackNavigatorProps, ModalStackViewProps } from './types';
@@ -100,6 +100,8 @@ const ModalStackView = ({ state, navigation, descriptors, describe }: ModalStack
     index: nonModalIndex,
   };
 
+  const pop = makePopAction(navigation.dispatch, state.key);
+
   const dismiss = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
@@ -114,9 +116,10 @@ const ModalStackView = ({ state, navigation, descriptors, describe }: ModalStack
     <div style={{ flex: 1, display: 'flex' }}>
       <NativeStackView
         state={newStackState}
-        navigation={navigation}
         descriptors={descriptors}
         describe={describe}
+        emit={navigation.emit}
+        pop={pop}
       />
       {isWeb &&
         overlayRoutes.map((route) => {

--- a/packages/expo-router/src/react-navigation/native-stack/index.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/index.tsx
@@ -12,11 +12,13 @@ export { NativeStackView } from './views/NativeStackView';
  * Hooks
  */
 export { useAnimatedHeaderHeight } from './utils/useAnimatedHeaderHeight';
+export { makePopAction } from './utils/makePopAction';
 
 /**
  * Types
  */
 export type {
+  NativeStackEmit,
   NativeStackHeaderBackProps,
   NativeStackHeaderItem,
   NativeStackHeaderItemButton,
@@ -32,10 +34,12 @@ export type {
   NativeStackHeaderNativeProps,
   NativeStackNativeProps,
   NativeStackNavigationEventMap,
+  NativeStackDescriptorMap,
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
   NativeStackNavigatorProps,
   NativeStackOptionsArgs,
   NativeStackScreenNativeProps,
   NativeStackScreenProps,
+  NativeStackViewEmit,
 } from './types';

--- a/packages/expo-router/src/react-navigation/native-stack/navigators/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/navigators/createNativeStackNavigator.tsx
@@ -22,6 +22,7 @@ import type {
   NativeStackNavigationProp,
   NativeStackNavigatorProps,
 } from '../types';
+import { makePopAction } from '../utils/makePopAction';
 import { NativeStackView } from '../views/NativeStackView';
 
 function NativeStackNavigator({
@@ -80,14 +81,17 @@ function NativeStackNavigator({
     });
   }, [meta, navigation, state.index, state.key]);
 
+  const pop = makePopAction(navigation.dispatch, state.key);
+
   return (
     <NavigationContent>
       <NativeStackView
         {...rest}
         state={state}
-        navigation={navigation}
         descriptors={descriptors}
         describe={describe}
+        emit={navigation.emit}
+        pop={pop}
       />
     </NavigationContent>
   );

--- a/packages/expo-router/src/react-navigation/native-stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/types.tsx
@@ -1215,6 +1215,23 @@ export type NativeStackHeaderItem =
   | NativeStackHeaderItemSpacing
   | NativeStackHeaderItemCustom;
 
+export type NativeStackEmit = NativeStackNavigationHelpers['emit'];
+
+export type NativeStackViewEmit = (
+  event:
+    | {
+        type: 'transitionStart' | 'transitionEnd';
+        target?: string;
+        data: { closing: boolean };
+      }
+    | { type: 'gestureCancel'; target?: string; data?: undefined }
+    | {
+        type: 'sheetDetentChange';
+        target?: string;
+        data: { index: number; stable: boolean };
+      }
+) => void;
+
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<
   ParamListBase,
   string | undefined,

--- a/packages/expo-router/src/react-navigation/native-stack/utils/__tests__/makePopAction.test.ios.ts
+++ b/packages/expo-router/src/react-navigation/native-stack/utils/__tests__/makePopAction.test.ios.ts
@@ -1,0 +1,19 @@
+import { makePopAction } from '../makePopAction';
+
+describe('makePopAction', () => {
+  it('dispatches a POP action with count, source, and target', () => {
+    const dispatch = jest.fn();
+
+    makePopAction(dispatch, 'stack-key')(2, 'route-key');
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'POP',
+        payload: { count: 2 },
+        source: 'route-key',
+        target: 'stack-key',
+      })
+    );
+  });
+});

--- a/packages/expo-router/src/react-navigation/native-stack/utils/makePopAction.ts
+++ b/packages/expo-router/src/react-navigation/native-stack/utils/makePopAction.ts
@@ -1,0 +1,12 @@
+import type { NavigationAction } from '../../native';
+import { StackActions } from '../../native';
+
+export function makePopAction(dispatch: (action: NavigationAction) => void, stateKey: string) {
+  return (count: number, sourceRouteKey: string) => {
+    dispatch({
+      ...StackActions.pop(count),
+      source: sourceRouteKey,
+      target: stateKey,
+    });
+  };
+}

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -23,7 +23,6 @@ import {
   NavigationProvider,
   type ParamListBase,
   type RouteProp,
-  StackActions,
   type StackNavigationState,
   usePreventRemoveContext,
   useTheme,
@@ -32,7 +31,7 @@ import type {
   NativeStackDescriptor,
   NativeStackDescriptorMap,
   NativeStackNavigationConfig,
-  NativeStackNavigationHelpers,
+  NativeStackViewEmit,
 } from '../types';
 import { ScreenPresentationContext } from '../utils/ScreenPresentationContext';
 import { debounce } from '../utils/debounce';
@@ -460,16 +459,18 @@ const SceneView = ({
 
 type Props = {
   state: StackNavigationState<ParamListBase>;
-  navigation: NativeStackNavigationHelpers;
   descriptors: NativeStackDescriptorMap;
   describe: (route: RouteProp<ParamListBase>, placeholder: boolean) => NativeStackDescriptor;
+  emit: NativeStackViewEmit;
+  pop: (count: number, sourceRouteKey: string) => void;
 } & NativeStackNavigationConfig;
 
 export function NativeStackView({
   state,
-  navigation,
   descriptors,
   describe,
+  emit,
+  pop,
   unstable_nativeProps,
 }: Props) {
   const { colors } = useTheme();
@@ -534,64 +535,52 @@ export function NativeStackView({
               isPresentationModal={isModal}
               isPreloaded={isPreloaded}
               onWillDisappear={() => {
-                navigation.emit({
+                emit({
                   type: 'transitionStart',
                   data: { closing: true },
                   target: route.key,
                 });
               }}
               onWillAppear={() => {
-                navigation.emit({
+                emit({
                   type: 'transitionStart',
                   data: { closing: false },
                   target: route.key,
                 });
               }}
               onAppear={() => {
-                navigation.emit({
+                emit({
                   type: 'transitionEnd',
                   data: { closing: false },
                   target: route.key,
                 });
               }}
               onDisappear={() => {
-                navigation.emit({
+                emit({
                   type: 'transitionEnd',
                   data: { closing: true },
                   target: route.key,
                 });
               }}
               onDismissed={(event) => {
-                navigation.dispatch({
-                  ...StackActions.pop(event.nativeEvent.dismissCount),
-                  source: route.key,
-                  target: state.key,
-                });
+                pop(event.nativeEvent.dismissCount, route.key);
 
                 setNextDismissedKey(route.key);
               }}
               onHeaderBackButtonClicked={() => {
-                navigation.dispatch({
-                  ...StackActions.pop(),
-                  source: route.key,
-                  target: state.key,
-                });
+                pop(1, route.key);
               }}
               onNativeDismissCancelled={(event) => {
-                navigation.dispatch({
-                  ...StackActions.pop(event.nativeEvent.dismissCount),
-                  source: route.key,
-                  target: state.key,
-                });
+                pop(event.nativeEvent.dismissCount, route.key);
               }}
               onGestureCancel={() => {
-                navigation.emit({
+                emit({
                   type: 'gestureCancel',
                   target: route.key,
                 });
               }}
               onSheetDetentChanged={(event) => {
-                navigation.emit({
+                emit({
                   type: 'sheetDetentChange',
                   target: route.key,
                   data: {

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
@@ -22,16 +22,17 @@ import type {
   NativeStackDescriptor,
   NativeStackDescriptorMap,
   NativeStackNavigationConfig,
-  NativeStackNavigationHelpers,
+  NativeStackViewEmit,
 } from '../types';
 import { AnimatedHeaderHeightContext } from '../utils/useAnimatedHeaderHeight';
 
 type Props = {
   state: StackNavigationState<ParamListBase>;
-  // This is used for the native implementation of the stack.
-  navigation: NativeStackNavigationHelpers;
   descriptors: NativeStackDescriptorMap;
   describe: (route: RouteProp<ParamListBase>, placeholder: boolean) => NativeStackDescriptor;
+  // These are used for the native implementation of the stack.
+  emit: NativeStackViewEmit;
+  pop: (count: number, sourceRouteKey: string) => void;
 } & NativeStackNavigationConfig;
 
 const TRANSPARENT_PRESENTATIONS = ['transparentModal', 'containedTransparentModal'];

--- a/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
@@ -46,6 +46,10 @@ export type StackActionType =
       };
       source?: string;
       target?: string;
+    }
+  | {
+      type: 'REMOVE_ROUTES';
+      payload: { routeNames: string[] };
     };
 
 export type StackRouterOptions = DefaultRouterOptions;
@@ -520,6 +524,24 @@ export function StackRouter(options: StackRouterOptions) {
               ...state.routes.slice(0, index),
               params !== route.params ? { ...route, params } : state.routes[index]!,
             ],
+          };
+        }
+
+        case 'REMOVE_ROUTES': {
+          const focusedRoute = state.routes[state.index]!;
+          const routes = state.routes.filter(
+            (route) =>
+              route.key === focusedRoute.key || !action.payload.routeNames.includes(route.name)
+          );
+
+          if (routes.length === state.routes.length) {
+            return state;
+          }
+
+          return {
+            ...state,
+            index: routes.findIndex((route) => route.key === focusedRoute.key),
+            routes,
           };
         }
 

--- a/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
@@ -3129,3 +3129,75 @@ test('does not use preloaded route with different ID when popTo replaces current
     ],
   });
 });
+
+test('removes routes by name while preserving the focused route instance', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['index', 'secret', 'other'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 3,
+        preloadedRoutes: [],
+        routeNames: ['index', 'secret', 'other'],
+        routes: [
+          { key: 'index', name: 'index' },
+          { key: 'secret-old', name: 'secret' },
+          { key: 'other', name: 'other' },
+          { key: 'secret-current', name: 'secret' },
+        ],
+      },
+      { type: 'REMOVE_ROUTES', payload: { routeNames: ['secret', 'other'] } },
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [],
+    routeNames: ['index', 'secret', 'other'],
+    routes: [
+      { key: 'index', name: 'index' },
+      { key: 'secret-current', name: 'secret' },
+    ],
+  });
+});
+
+test.each(['secret', 'nonExisting'])(
+  'handles route %p removal without changing state when no history entries match',
+  (name: string) => {
+    const router = StackRouter({});
+    const state = {
+      stale: false as const,
+      type: 'stack' as const,
+      key: 'root',
+      index: 1,
+      preloadedRoutes: [],
+      routeNames: ['index', 'secret'],
+      routes: [
+        { key: 'index', name: 'index' },
+        { key: 'secret', name: 'secret' },
+      ],
+    };
+
+    expect(
+      router.getStateForAction(
+        state,
+        { type: 'REMOVE_ROUTES', payload: { routeNames: [name] } },
+        {
+          routeNames: state.routeNames,
+          routeParamList: {},
+          routeGetIdList: {},
+        }
+      )
+    ).toBe(state);
+  }
+);

--- a/packages/expo-router/src/standard-navigation/__tests__/descriptorIdentity.integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/descriptorIdentity.integration.test.ios.tsx
@@ -1,0 +1,81 @@
+import { Fragment } from 'react';
+import { View } from 'react-native';
+import type { NavigatorArgs } from 'standard-navigation';
+
+import { router } from '../../imperative-api';
+import type { ParamListBase } from '../../react-navigation/core';
+import {
+  StackRouter,
+  type StackNavigationState,
+  type StackRouterOptions,
+} from '../../react-navigation/native';
+import { act, renderRouter } from '../../testing-library';
+import { unstable_createStandardRouterNavigator } from '../index';
+
+type EventMap = Record<string, { data: object | undefined; canPreventDefault: boolean }>;
+type Descriptor = { options: object; render: () => React.ReactNode };
+
+const mockProjection: {
+  raw?: Record<string, Descriptor>;
+  projected?: Record<string, Descriptor>;
+  described: Map<string, Descriptor>;
+} = { described: new Map() };
+
+jest.mock('../useProjectedDescriptors', () => {
+  const actual = jest.requireActual(
+    '../useProjectedDescriptors'
+  ) as typeof import('../useProjectedDescriptors');
+  return {
+    useProjectedDescriptors: (
+      state: StackNavigationState<ParamListBase>,
+      descriptors: Record<string, Descriptor>,
+      describe: (
+        route: StackNavigationState<ParamListBase>['routes'][number],
+        placeholder: boolean
+      ) => Descriptor
+    ) => {
+      mockProjection.raw = descriptors;
+      const projected = actual.useProjectedDescriptors(state, descriptors, (route, placeholder) => {
+        const descriptor = describe(route, placeholder);
+        mockProjection.described.set(route.key, descriptor);
+        return descriptor;
+      });
+      mockProjection.projected = projected;
+      return projected;
+    },
+  };
+});
+
+let contentArgs: NavigatorArgs<object, EventMap> | undefined;
+
+function Content(args: NavigatorArgs<object, EventMap>) {
+  contentArgs = args;
+  return args.state.routes.map((route) => (
+    <Fragment key={route.key}>{args.descriptors[route.key]!.render()}</Fragment>
+  ));
+}
+
+const Stack = unstable_createStandardRouterNavigator<
+  object,
+  StackNavigationState<ParamListBase>,
+  EventMap,
+  object,
+  StackRouterOptions
+>(Content, StackRouter);
+
+it('passes builder and described descriptor objects through unchanged', () => {
+  renderRouter({
+    _layout: () => <Stack />,
+    index: () => <View />,
+    second: () => <View />,
+  });
+
+  const activeKey = contentArgs!.state.routes[0]!.key;
+  expect(contentArgs!.descriptors[activeKey]).toBe(mockProjection.raw![activeKey]);
+
+  act(() => router.prefetch('/second'));
+
+  const preloadedKey = contentArgs!.state.routes.find((route) => route.name === 'second')!.key;
+  expect(contentArgs!.descriptors[preloadedKey]).toBe(mockProjection.described.get(preloadedKey));
+  expect(contentArgs!.descriptors).toBe(mockProjection.projected);
+});


### PR DESCRIPTION
# Why

Before migrating native-stack to standard-navigation interface we need to refactor the code

# How

1. Remove `navigation` usage from native-stack and replace it with specific functions - `pop` and `emit`
2. Extract `useClearGuardedRoutes` logic to `StackRouter` - removing routes  which were marked as protected from history

# Test Plan

1. CI
2. Router-e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
