### PR TITLE
[autolinking][ios] Apply macro plugin flag to test targets

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))
+- Fixed the macro plugin flag not being applied to test targets, so macros couldn't be used in unit tests. ([#46595](https://github.com/expo/expo/pull/46595) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -150,17 +150,36 @@ module Expo
           is_core = pod_target.name == 'ExpoModulesCore'
           has_core_dependency = pod_target.dependencies.find { |dependency| dependency == 'ExpoModulesCore' }
           next unless is_core || has_core_dependency
+
           pod_target.build_settings.each do |build_configuration_name, build_settings|
-            xcconfig = build_settings.xcconfig
-            swift_flags = xcconfig.attributes[SWIFT_FLAGS] || '$(inherited)'
-            unless swift_flags.include?(macro_flags)
-              xcconfig_path = pod_target.xcconfig_path(build_configuration_name)
-              xcconfig.attributes[SWIFT_FLAGS] = "#{swift_flags} #{macro_flags}"
-              xcconfig.save_as(xcconfig_path)
+            xcconfig_path = pod_target.xcconfig_path(build_configuration_name)
+            append_macro_flags(build_settings, xcconfig_path, macro_flags)
+          end
+
+          # Test specs are compiled into their own native targets with their own xcconfigs, so the flag
+          # set on the library target above doesn't reach them. Apply it to each test spec's build
+          # settings as well, so macros can be used from unit tests.
+          pod_target.test_specs.each do |test_spec|
+            test_type = test_spec.consumer(pod_target.platform).test_type
+            pod_target.test_spec_build_settings_by_config[test_spec.name].each do |build_configuration_name, build_settings|
+              xcconfig_variant = "#{test_type.capitalize}-#{pod_target.subspec_label(test_spec)}.#{build_configuration_name}"
+              xcconfig_path = pod_target.xcconfig_path(xcconfig_variant)
+              append_macro_flags(build_settings, xcconfig_path, macro_flags)
             end
           end
         end
       end
+    end
+
+    # Appends the macro plugin flags to the target's `OTHER_SWIFT_FLAGS` and saves the xcconfig,
+    # skipping it when the flags are already present.
+    def self.append_macro_flags(build_settings, xcconfig_path, macro_flags)
+      xcconfig = build_settings.xcconfig
+      swift_flags = xcconfig.attributes[SWIFT_FLAGS] || '$(inherited)'
+      return if swift_flags.include?(macro_flags)
+
+      xcconfig.attributes[SWIFT_FLAGS] = "#{swift_flags} #{macro_flags}"
+      xcconfig.save_as(xcconfig_path)
     end
 
     def self.resolve_macros_plugin_dir(core_src_root)


### PR DESCRIPTION
## Why

The autolinking integrator injects the `-load-plugin-executable` flag that loads `@expo/expo-modules-macros-plugin` into `ExpoModulesCore` and every target that depends on it. But CocoaPods compiles a podspec `test_spec` into its **own** native target with a separate xcconfig, and that xcconfig never received the flag.

As a result, any macro used from a unit test fails to build:

```
external macro implementation type 'ExpoModulesMacros.RecordMacro' could not be found
for macro 'Record()'; plugin for module 'ExpoModulesMacros' not found
```

This wasn't hit before because the existing macros (`@ExpoModule`, `@SharedObject`) aren't exercised from the core test target.

## How

`integrate_core_macro_plugins` now also iterates each pod target's `test_specs` and applies the flag to their build settings, using the same xcconfig-variant naming CocoaPods uses internally (`"#{test_type.capitalize}-#{subspec_label}.#{config}"`). The flag-application logic is extracted into an idempotent `append_macro_flags` helper shared by the library and test paths.

## Test plan

- `pod install` in `apps/bare-expo`, then confirmed the flag now lands in `ExpoModulesCore.unit-tests.{debug,release}.xcconfig` (previously only in the library xcconfig).
