### PR TITLE
fix(doctor): Fix Metro config check for SDK <=55 with missing `metro.config.js` files

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))
+- Remove `@expo/metro-config` install from `expo customize metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/customize/templates.ts
+++ b/packages/@expo/cli/src/customize/templates.ts
@@ -66,7 +66,7 @@ export const TEMPLATES: {
   },
   {
     id: 'metro.config.js',
-    dependencies: ['@expo/metro-config'],
+    dependencies: [],
     destination: () => 'metro.config.js',
     file: (projectRoot) => importFromVendor(projectRoot, 'metro.config.js'),
   },

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix SDK 55 Metro config check for missing `metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 1.19.8 — 2026-05-23

--- a/packages/expo-doctor/src/utils/metroConfigLoader.ts
+++ b/packages/expo-doctor/src/utils/metroConfigLoader.ts
@@ -65,7 +65,19 @@ export async function loadMetroUserConfigAsync(
   } else {
     try {
       const MetroConfig = importMetroConfigFromProject(projectRoot);
-      return await MetroConfig.loadConfig({ cwd: projectRoot }, {});
+      // `loadConfig` adds the metro defaults when no config exists, so we need to manually check
+      // if a user config exists first and bail out if it doesn't
+      const { filepath, isEmpty } = await MetroConfig.resolveConfig(undefined, projectRoot);
+      if (isEmpty) {
+        return null;
+      }
+      return await MetroConfig.loadConfig(
+        {
+          cwd: projectRoot,
+          config: filepath,
+        },
+        {}
+      );
     } catch {
       // If we can't load the config, we assume it doesn't exist
       return null;


### PR DESCRIPTION
## Summary

Fix regression in #46155
Resolves #46572

The old code path for SDK <=55 that uses `metro-config` directly, that's now been replaced for SDK 56, still needs to assert that the `metro.config.js` (or other) config file exists. Without it, the check is a no-op. If we don't assert this, then we're validating against Metro's default config.

We also seem to still install `@expo/metro-config` on `expo customize metro.config.js` which we can fix in SDK 56. No need to backport this just yet

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
