### PR TITLE
[prebuild-config] Make testing-library matchers color-safe

### DIFF
--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `toMatchInfoPlist` and `toMatchAppleEntitlements` testing-library matchers when Jest color output is enabled. The custom matcher hint relied on `context.utils.matcherHint`, which interleaves ANSI escape codes inside `.not.`, breaking `toThrow(/\.not\.toMatchInfoPlist/)`-style assertions.
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-26

--- a/packages/@expo/prebuild-config/src/testing-library/__tests__/expect.ts
+++ b/packages/@expo/prebuild-config/src/testing-library/__tests__/expect.ts
@@ -28,10 +28,13 @@ function printMatcherDiff(
 }
 
 function getMatcherHint(context: jest.MatcherContext, matcherName: string): string {
-  return context.utils.matcherHint(matcherName, undefined, undefined, {
-    isNot: context.isNot,
-    promise: context.promise,
-  });
+  // Plain-text hint instead of `context.utils.matcherHint(...)` — that helper
+  // wraps the `expect(`, `)`, `.not.` and `(expected)` fragments in
+  // `chalk.dim`, which interleaves ANSI escape codes inside the hint when
+  // colors are enabled. Tests that use `.toThrow(/\.not\.toMatchInfoPlist/)`
+  // need a continuous substring to match, which the colored variant doesn't
+  // provide.
+  return `expect(received).${context.isNot ? 'not.' : ''}${matcherName}(expected)`;
 }
 
 expect.extend({


### PR DESCRIPTION
Closing this, will merge this change in a different PR