### PR TITLE
Skip dev console errors e2e on Windows

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { platform } from 'node:process';
 import { stripVTControlCharacters } from 'node:util';
 
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
@@ -13,6 +14,13 @@ test.afterAll(() => restoreEnv());
 const projectRoot = getRouterE2ERoot();
 
 test.describe('dev console errors', () => {
+  if (platform === 'win32') {
+    test.skip('skipping on windows', () => {
+      // On Windows, the code snippets are currently not rendering and project frames filtering is not working.
+    });
+    return;
+  }
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {


### PR DESCRIPTION
## Why

- introduced in https://github.com/expo/expo/pull/46584

Skip the dev console errors Playwright suite on Windows because code snippets are currently not rendering and project frames filtering is not working.

## Test plan

Not run; this is a platform skip for an e2e suite.