### PR TITLE
[image] Add writeToCacheAsync and readFromCacheAsync

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageCacheKeyScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageCacheKeyScreen.tsx
@@ -1,23 +1,43 @@
 import { Image } from 'expo-image';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import Button from '../../components/Button';
 import MonoText from '../../components/MonoText';
 import { Colors } from '../../constants';
 
-export default function ImagePlaceholderScreen() {
+const CACHE_KEY = 'CUSTOM_CONSTANT_CACHE_KEY';
+
+export default function ImageCacheKeyScreen() {
   const [uri, setUri] = useState<string>(getRandomImageUri());
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  // Set while seeding so the top view's `onLoad` reports where it loaded the seeded image from.
+  const reportSeedResult = useRef<boolean>(false);
 
   const loadRandomImage = useCallback(() => {
     setIsLoading(true);
     setUri(getRandomImageUri());
   }, [uri]);
 
+  const seedCache = useCallback(async () => {
+    setIsLoading(true);
+    // Start from an empty cache so the reload below has to go through the disk cache.
+    await Image.clearDiskCache();
+    await Image.clearMemoryCache();
+
+    // Load a random image into memory and write it to the disk cache under the constant key.
+    const randomUri = getRandomImageUri();
+    const image = await Image.loadAsync({ uri: randomUri });
+    await Image.writeToCacheAsync(image, CACHE_KEY);
+
+    // Render the seeded image at the top via the cache key source and report how it loaded.
+    reportSeedResult.current = true;
+    setUri(randomUri);
+  }, []);
+
   const source = {
     uri,
-    cacheKey: 'CUSTOM_CONSTANT_CACHE_KEY',
+    cacheKey: CACHE_KEY,
   };
 
   return (
@@ -27,7 +47,14 @@ export default function ImagePlaceholderScreen() {
         source={source}
         cachePolicy="disk"
         onLoad={({ cacheType }) => {
-          if (cacheType === 'disk') {
+          if (reportSeedResult.current) {
+            reportSeedResult.current = false;
+            alert(
+              cacheType === 'disk' || cacheType === 'memory'
+                ? `Seeded image was served from the ${cacheType} cache`
+                : `Seeded image was not served from the cache (cacheType: ${cacheType})`
+            );
+          } else if (cacheType === 'disk') {
             alert('Image was loaded from the disk cache');
           }
           setIsLoading(false);
@@ -61,6 +88,21 @@ export default function ImagePlaceholderScreen() {
           style={styles.actionButton}
           title="Set random source uri"
           onPress={loadRandomImage}
+        />
+
+        <Text style={styles.text}>
+          You can also seed the cache yourself.{'\n'}
+          This clears the cache, writes a random image{'\n'}
+          to it under the constant key, renders it above,{'\n'}
+          and reports where it was loaded from{'\n'}
+          👇
+        </Text>
+
+        <Button
+          disabled={isLoading}
+          style={styles.actionButton}
+          title="Seed cache"
+          onPress={seedCache}
         />
       </ScrollView>
     </View>

--- a/apps/test-suite/tests/Image.js
+++ b/apps/test-suite/tests/Image.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { Asset } from 'expo-asset';
 import { Image } from 'expo-image';
 import React from 'react';
 import { Platform } from 'react-native';
@@ -277,6 +278,59 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
         }
       });
     });
+
+    if (Platform.OS === 'android' || Platform.OS === 'ios') {
+      t.describe('writeToCacheAsync / readFromCacheAsync', () => {
+        const CACHE_KEY = 'test-suite-seeded-image';
+
+        t.it('seeds the cache from an ImageRef and reads it back', async () => {
+          await Image.clearDiskCache();
+          await Image.clearMemoryCache();
+          const image = await Image.loadAsync(REMOTE_SOURCE);
+
+          await Image.writeToCacheAsync(image, CACHE_KEY);
+
+          const path = await Image.getCachePathAsync(CACHE_KEY);
+          t.expect(typeof path).toBe('string');
+
+          const cached = await Image.readFromCacheAsync(CACHE_KEY);
+          t.expect(cached).toBeDefined();
+          t.expect(cached instanceof Image.Image).toBe(true);
+          t.expect(cached.width).toBeGreaterThan(0);
+          t.expect(cached.height).toBeGreaterThan(0);
+        });
+
+        t.it('seeds the cache from a local file URI', async () => {
+          await Image.clearDiskCache();
+          await Image.clearMemoryCache();
+
+          // A bundled asset gives us a guaranteed local file URI on device.
+          const asset = await Asset.fromModule(require('../assets/icons/app.png')).downloadAsync();
+          t.expect(typeof asset.localUri).toBe('string');
+
+          await Image.writeToCacheAsync(asset.localUri, CACHE_KEY);
+
+          const path = await Image.getCachePathAsync(CACHE_KEY);
+          t.expect(typeof path).toBe('string');
+
+          const cached = await Image.readFromCacheAsync(CACHE_KEY);
+          t.expect(cached).toBeDefined();
+          t.expect(cached instanceof Image.Image).toBe(true);
+        });
+
+        t.it('resolves to null when reading a key that was never seeded', async () => {
+          await Image.clearDiskCache();
+          await Image.clearMemoryCache();
+
+          const cached = await Image.readFromCacheAsync('test-suite-never-seeded-key');
+          t.expect(cached).toBe(null);
+        });
+
+        t.it('rejects when given a remote URL', async () => {
+          await throws(() => Image.writeToCacheAsync(REMOTE_SOURCE.uri, CACHE_KEY));
+        });
+      });
+    }
 
     if (Platform.OS === 'ios') {
       t.describe('generateBlurhashAsync', () => {

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Added `Image.writeToCacheAsync` and `Image.readFromCacheAsync` to seed and read the image cache by cache key. ([#46620](https://github.com/expo/expo/pull/46620) by [@tsapeta](https://github.com/tsapeta))
 - [web] Improved `static` image source selection on web to be based on the rendered layout size by leading the generated `sizes` with `auto`, and default `static` images to `loading="lazy"` (opt out with `loading="eager"`). ([#46425](https://github.com/expo/expo/pull/46425) by [@sebholl](https://github.com/sebholl))
 
 ### 🐛 Bug fixes

--- a/packages/expo-image/android/src/main/java/expo/modules/image/Exceptions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/Exceptions.kt
@@ -4,3 +4,18 @@ import expo.modules.kotlin.exception.CodedException
 
 class ImageLoadFailed(exception: Exception) :
   CodedException(message = "Failed to load the image: ${exception.message}")
+
+class WriteToCacheRemoteSourceException(uri: String) :
+  CodedException(
+    message = "Cannot write a remote image to the cache from the URL: '$uri'. " +
+      "Pass a local file URI (for example one returned by 'expo-image-picker' or 'expo-file-system'), " +
+      "or use 'prefetch' to cache a remote image"
+  )
+
+class WriteToCacheReadException(path: String) :
+  CodedException(
+    message = "Unable to read the image file at: '$path'. Make sure the file exists and is readable"
+  )
+
+class WriteToCacheEncodeException :
+  CodedException(message = "Unable to encode the image reference for the cache")

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.Base64
+import android.util.Log
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toBitmapOrNull
 import androidx.core.view.doOnDetach
@@ -281,8 +282,11 @@ class ExpoImageModule : Module() {
             .submit()
             .get()
           return@withContext Image(drawable)
-        } catch (_: Exception) {
-          // `onlyRetrieveFromCache` makes Glide fail the request when the image isn't cached.
+        } catch (exception: Exception) {
+          // `onlyRetrieveFromCache` makes Glide fail the request when the image isn't cached, which
+          // is the expected miss path. A decode failure of a corrupt or partial cached entry surfaces
+          // here too, so log it to keep that case diagnosable rather than indistinguishable from a miss.
+          Log.d("ExpoImage", "readFromCacheAsync failed for key \"$cacheKey\"", exception)
           return@withContext null
         }
       }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -16,6 +16,7 @@ import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.load.model.LazyHeaders
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.signature.EmptySignature
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import com.github.penfeizhou.animation.gif.GifDrawable
 import com.github.penfeizhou.animation.webp.WebPDrawable
@@ -28,6 +29,7 @@ import expo.modules.image.records.DecodeFormat
 import expo.modules.image.records.DecodedSource
 import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.ImageTransition
+import expo.modules.image.okhttp.GlideUrlWithCustomCacheKey
 import expo.modules.image.records.SourceMap
 import expo.modules.image.thumbhash.ThumbhashEncoder
 import expo.modules.kotlin.Promise
@@ -42,6 +44,8 @@ import expo.modules.kotlin.types.EitherOfThree
 import expo.modules.kotlin.types.toKClass
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
 import java.net.URL
 
 class ExpoImageModule : Module() {
@@ -110,6 +114,64 @@ class ExpoImageModule : Module() {
             }
           })
           .submit()
+      }
+    }
+
+    AsyncFunction("writeToCacheAsync") Coroutine { source: Either<URL, Image>, cacheKey: String ->
+      val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+
+      val isImageRef = source.`is`(Image::class)
+
+      val localFilePath = withContext(Dispatchers.IO) {
+        if (isImageRef) {
+          // The ref carries no original encoded data, so re-encode the drawable into a temporary file.
+          val bitmap = source.get(Image::class).ref.toBitmap()
+          val tempFile = File.createTempFile("expo-image-cache-seed", null, context.cacheDir)
+          try {
+            FileOutputStream(tempFile).use { output ->
+              bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+            }
+          } catch (e: Exception) {
+            tempFile.delete()
+            throw WriteToCacheEncodeException()
+          }
+          return@withContext tempFile
+        }
+
+        val url = source.get(URL::class)
+        if (url.protocol != "file") {
+          throw WriteToCacheRemoteSourceException(url.toString())
+        }
+        val file = File(url.toURI())
+        if (!file.exists()) {
+          throw WriteToCacheReadException(file.absolutePath)
+        }
+        return@withContext file
+      }
+
+      try {
+        // A non-empty URI is required by `GlideUrl`, but only the cache key affects the disk cache key.
+        val model = GlideUrlWithCustomCacheKey(
+          uri = localFilePath.toURI().toString(),
+          headers = Headers.DEFAULT,
+          cacheKey = cacheKey,
+          localFilePath = localFilePath.absolutePath
+        )
+
+        withContext(Dispatchers.IO) {
+          Glide
+            .with(context)
+            .asFile()
+            .load(model)
+            .diskCacheStrategy(DiskCacheStrategy.DATA)
+            .signature(EmptySignature.obtain())
+            .submit()
+            .get()
+        }
+      } finally {
+        if (isImageRef) {
+          localFilePath.delete()
+        }
       }
     }
 
@@ -204,6 +266,25 @@ class ExpoImageModule : Module() {
         file.absolutePath
       } catch (_: Exception) {
         null
+      }
+    }
+
+    AsyncFunction("readFromCacheAsync") Coroutine { cacheKey: String ->
+      val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+
+      withContext(Dispatchers.IO) {
+        try {
+          val drawable = Glide
+            .with(context)
+            .load(GlideUrl(cacheKey))
+            .onlyRetrieveFromCache(true)
+            .submit()
+            .get()
+          return@withContext Image(drawable)
+        } catch (_: Exception) {
+          // `onlyRetrieveFromCache` makes Glide fail the request when the image isn't cached.
+          return@withContext null
+        }
       }
     }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -22,7 +22,13 @@ import java.io.InputStream
 class GlideUrlWithCustomCacheKey(
   uri: String?,
   headers: Headers?,
-  private val cacheKey: String
+  private val cacheKey: String,
+  /**
+   * When set, this model is being used to seed the disk cache from a local file rather than
+   * to display a remote image. [LocalFileGlideModelLoader] reads the file at this path and lets
+   * Glide store its bytes under [cacheKey], so a later load using the same cache key hits the cache.
+   */
+  val localFilePath: String? = null
 ) : GlideUrl(uri, headers) {
   /**
    * Cached hash code value
@@ -76,5 +82,8 @@ class ExpoImageOkHttpClientGlideModule : LibraryGlideModule() {
     // to make sure that the app will use only one client.
     registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
     registry.prepend(GlideUrlWrapper::class.java, InputStream::class.java, GlideUrlWrapperLoader.Factory(client))
+    // Prepend so seeding models (those with a local file path) take precedence over the inherited
+    // `GlideUrl` OkHttp loader. Regular `GlideUrlWithCustomCacheKey` loads have no path and fall through.
+    registry.prepend(GlideUrlWithCustomCacheKey::class.java, InputStream::class.java, LocalFileGlideModelLoader.Factory())
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/LocalFileGlideModelLoader.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/LocalFileGlideModelLoader.kt
@@ -1,0 +1,76 @@
+package expo.modules.image.okhttp
+
+import com.bumptech.glide.Priority
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.data.DataFetcher
+import com.bumptech.glide.load.model.ModelLoader
+import com.bumptech.glide.load.model.ModelLoaderFactory
+import com.bumptech.glide.load.model.MultiModelLoaderFactory
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+
+/**
+ * Reads the bytes of a local file referenced by [GlideUrlWithCustomCacheKey.localFilePath] while
+ * keeping the model as the source key, so Glide stores those bytes in its disk cache under the
+ * model's custom cache key. This is what lets `Image.writeToCacheAsync` seed the cache: a later
+ * load that uses the same cache key resolves to the same disk entry.
+ *
+ * It only handles seeding models (those with a non-null `localFilePath`). Regular remote loads keep
+ * using the OkHttp-based `GlideUrl` loader, so display behavior is unaffected.
+ */
+class LocalFileGlideModelLoader : ModelLoader<GlideUrlWithCustomCacheKey, InputStream> {
+  override fun handles(model: GlideUrlWithCustomCacheKey): Boolean = model.localFilePath != null
+
+  override fun buildLoadData(
+    model: GlideUrlWithCustomCacheKey,
+    width: Int,
+    height: Int,
+    options: Options
+  ): ModelLoader.LoadData<InputStream>? {
+    val localFilePath = model.localFilePath ?: return null
+    // Passing `model` as the source key makes Glide derive the disk cache key from its custom cache key.
+    return ModelLoader.LoadData(model, LocalFileFetcher(File(localFilePath)))
+  }
+
+  class Factory : ModelLoaderFactory<GlideUrlWithCustomCacheKey, InputStream> {
+    override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<GlideUrlWithCustomCacheKey, InputStream> {
+      return LocalFileGlideModelLoader()
+    }
+
+    override fun teardown() = Unit
+  }
+
+  private class LocalFileFetcher(
+    private val file: File
+  ) : DataFetcher<InputStream> {
+    private var stream: InputStream? = null
+
+    override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
+      try {
+        val opened = FileInputStream(file)
+        stream = opened
+        callback.onDataReady(opened)
+      } catch (e: Exception) {
+        callback.onLoadFailed(e)
+      }
+    }
+
+    override fun cleanup() {
+      try {
+        stream?.close()
+      } catch (_: Exception) {
+        // Ignore failures while closing the stream.
+      }
+      stream = null
+    }
+
+    override fun cancel() = Unit
+
+    override fun getDataClass(): Class<InputStream> = InputStream::class.java
+
+    // Must not be `DATA_DISK_CACHE` or `MEMORY_CACHE`, otherwise `DiskCacheStrategy.DATA` won't store the data.
+    override fun getDataSource(): DataSource = DataSource.LOCAL
+  }
+}

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -245,6 +245,49 @@ public final class ImageModule: Module {
       }
     }
 
+    AsyncFunction("writeToCacheAsync") { (source: Either<Image, URL>, cacheKey: String) async throws in
+      // UIImage isn't Sendable, but SDWebImage's store is internally thread-safe, so it's safe to hand off.
+      nonisolated(unsafe) let image: UIImage?
+      let imageData: Data?
+
+      if let imageRef: Image = source.get() {
+        // The ref carries no original encoded data, so let SDWebImage encode the image when storing.
+        image = imageRef.ref
+        imageData = nil
+      } else if let url: URL = source.get() {
+        guard url.isFileURL else {
+          throw WriteToCacheRemoteSourceException(url.absoluteString)
+        }
+        do {
+          imageData = try Data(contentsOf: url)
+        } catch {
+          throw WriteToCacheReadException(url.absoluteString).causedBy(error)
+        }
+        image = nil
+      } else {
+        throw WriteToCacheSourceException()
+      }
+
+      await withCheckedContinuation { continuation in
+        SDImageCache.shared.store(image, imageData: imageData, forKey: cacheKey, toDisk: true) {
+          continuation.resume()
+        }
+      }
+    }
+
+    AsyncFunction("readFromCacheAsync") { (cacheKey: String) async -> Image? in
+      let cachedImage: UIImage? = await withCheckedContinuation { continuation in
+        // Queries the memory cache first and falls back to disk, decoding the image if needed.
+        SDImageCache.shared.queryCacheOperation(forKey: cacheKey) { image, _, _ in
+          continuation.resume(returning: image)
+        }
+      }
+      guard let cachedImage else {
+        return nil
+      }
+      return Image(cachedImage)
+    }
+
     AsyncFunction("loadAsync") { (source: ImageSource, options: ImageLoadOptions?) -> Image? in
       let image = try await ImageLoadTask(source, options: options ?? ImageLoadOptions()).load()
       return Image(image)

--- a/packages/expo-image/ios/Tests/ImageCacheSeedingTests.swift
+++ b/packages/expo-image/ios/Tests/ImageCacheSeedingTests.swift
@@ -97,7 +97,11 @@ struct ImageCacheSeedingTests {
     }
 
     #expect(exists)
-    #expect(SDImageCache.shared.cachePath(forKey: cacheKey) != nil)
+    // `cachePath(forKey:)` derives a path string from the key deterministically, so assert the file
+    // it points at actually exists on disk to make this specific to the seeded entry.
+    let cachePath = SDImageCache.shared.cachePath(forKey: cacheKey)
+    #expect(cachePath != nil)
+    #expect(FileManager.default.fileExists(atPath: cachePath ?? ""))
     removeImage(forKey: cacheKey)
   }
 }

--- a/packages/expo-image/ios/Tests/ImageCacheSeedingTests.swift
+++ b/packages/expo-image/ios/Tests/ImageCacheSeedingTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+internal import SDWebImage
+
+@testable import ExpoImage
+
+// A 1x1 red PNG, the smallest valid image we can seed the cache with.
+private let imageData = Data(
+  base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)!
+
+private func makeCacheKey() -> String {
+  return "expo-image-test-\(UUID().uuidString)"
+}
+
+private func store(image: UIImage?, imageData: Data?, forKey key: String) async {
+  await withCheckedContinuation { continuation in
+    SDImageCache.shared.store(image, imageData: imageData, forKey: key, toDisk: true) {
+      continuation.resume()
+    }
+  }
+}
+
+private func storeDataToDisk(_ data: Data, forKey key: String) async {
+  await withCheckedContinuation { continuation in
+    SDImageCache.shared.storeImageData(data, forKey: key) {
+      continuation.resume()
+    }
+  }
+}
+
+private func queryCache(forKey key: String) async -> (image: UIImage?, cacheType: SDImageCacheType) {
+  return await withCheckedContinuation { continuation in
+    SDImageCache.shared.queryCacheOperation(forKey: key) { image, _, cacheType in
+      continuation.resume(returning: (image, cacheType))
+    }
+  }
+}
+
+private func removeImage(forKey key: String) {
+  SDImageCache.shared.removeImage(forKey: key, fromDisk: true, withCompletion: nil)
+}
+
+// Exercises the cache-key contract that `writeToCacheAsync`/`readFromCacheAsync` rely on:
+// image data stored under a key must be queryable back under the same key, and an unseeded key
+// must miss. Each test uses a unique key and cleans up after itself so the shared `SDImageCache`
+// doesn't leak state between cases.
+@Suite("ImageCacheSeeding")
+struct ImageCacheSeedingTests {
+  @Test
+  func `reads back an image stored under a custom key`() async {
+    let cacheKey = makeCacheKey()
+    let image = SDImageCodersManager.shared.decodedImage(with: imageData, options: nil)
+
+    // Mirrors `writeToCacheAsync`: store image + original data to disk under the custom key.
+    await store(image: image, imageData: imageData, forKey: cacheKey)
+    // Mirrors `readFromCacheAsync`: query the cache back by the same key.
+    let result = await queryCache(forKey: cacheKey)
+
+    #expect(result.image != nil)
+    removeImage(forKey: cacheKey)
+  }
+
+  @Test
+  func `reads back an image seeded straight to disk after the memory cache is cleared`() async {
+    let cacheKey = makeCacheKey()
+
+    await storeDataToDisk(imageData, forKey: cacheKey)
+    // Drop the in-memory copy so the query has to hit disk, like a fresh app launch would.
+    SDImageCache.shared.clearMemory()
+    let result = await queryCache(forKey: cacheKey)
+
+    #expect(result.image != nil)
+    #expect(result.cacheType == .disk)
+    removeImage(forKey: cacheKey)
+  }
+
+  @Test
+  func `returns nil for a key that was never seeded`() async {
+    let cacheKey = makeCacheKey()
+
+    let result = await queryCache(forKey: cacheKey)
+
+    #expect(result.image == nil)
+  }
+
+  @Test
+  func `exposes a disk path for a seeded key`() async {
+    let cacheKey = makeCacheKey()
+
+    await storeDataToDisk(imageData, forKey: cacheKey)
+    let exists = await withCheckedContinuation { continuation in
+      SDImageCache.shared.diskImageExists(withKey: cacheKey) { exists in
+        continuation.resume(returning: exists)
+      }
+    }
+
+    #expect(exists)
+    #expect(SDImageCache.shared.cachePath(forKey: cacheKey) != nil)
+    removeImage(forKey: cacheKey)
+  }
+}

--- a/packages/expo-image/ios/Utils/ImageUtils.swift
+++ b/packages/expo-image/ios/Utils/ImageUtils.swift
@@ -12,6 +12,33 @@ public final class BlurhashGenerationException: Exception {
   }
 }
 
+/**
+ An exception thrown when `writeToCacheAsync` is given a source that is neither a local file URI nor an image reference.
+ */
+internal final class WriteToCacheSourceException: Exception, @unchecked Sendable {
+  override var reason: String {
+    "The image source must be a local file URI or an image reference"
+  }
+}
+
+/**
+ An exception thrown when `writeToCacheAsync` is given a remote URL instead of a local file.
+ */
+internal final class WriteToCacheRemoteSourceException: GenericException<String>, @unchecked Sendable {
+  override var reason: String {
+    "Cannot write a remote image to the cache from the URL: '\(param)'. Pass a local file URI (for example one returned by 'expo-image-picker' or 'expo-file-system'), or use 'prefetch' to cache a remote image"
+  }
+}
+
+/**
+ An exception thrown when `writeToCacheAsync` fails to read the data of a local file.
+ */
+internal final class WriteToCacheReadException: GenericException<String>, @unchecked Sendable {
+  override var reason: String {
+    "Unable to read the image file at: '\(param)'. Make sure the file exists and is readable"
+  }
+}
+
 func cacheTypeToString(_ cacheType: SDImageCacheType) -> String {
   switch cacheType {
   case .none:

--- a/packages/expo-image/src/Image.tsx
+++ b/packages/expo-image/src/Image.tsx
@@ -154,6 +154,37 @@ export class Image extends React.PureComponent<ImageProps> {
   }
 
   /**
+   * Asynchronously writes a local image to the disk cache under the given cache key,
+   * without fetching it over the network. Use this to seed the cache from an image you
+   * already have on the device, for example one returned by `expo-image-picker` or
+   * downloaded with `expo-file-system`. A later image load that uses the same `cacheKey`
+   * in its [`source`](#imagesource) will then be served straight from the cache.
+   * @param source - The image to cache, either a local file URI (`string`) or an [`ImageRef`](#imageref).
+   * @param cacheKey - The cache key to store the image under. Pass the same value in the
+   * `cacheKey` of the [`source`](#imagesource) when you later render the image.
+   * @platform android
+   * @platform ios
+   * @return A promise that resolves once the image has been written to the disk cache.
+   */
+  static async writeToCacheAsync(source: string | ImageRef, cacheKey: string): Promise<void> {
+    return await ImageModule.writeToCacheAsync(source, cacheKey);
+  }
+
+  /**
+   * Asynchronously reads an image stored in the cache under the given cache key and resolves to
+   * an [`ImageRef`](#imageref) that can be passed straight to the [`source`](#imagesource) of an
+   * image view. Resolves to `null` when no image is cached for the key.
+   * @param cacheKey - The cache key to read the image from. Unless you have set a custom cache key,
+   * this is the source URL of the image.
+   * @platform android
+   * @platform ios
+   * @return A promise resolving to the cached image reference, or `null` if it isn't cached.
+   */
+  static async readFromCacheAsync(cacheKey: string): Promise<ImageRef | null> {
+    return await ImageModule.readFromCacheAsync(cacheKey);
+  }
+
+  /**
    * Configures the image cache. This allows you to manage the cache eviction policy.
    * @param config - The cache configuration.
    * @platform ios

--- a/packages/expo-image/src/Image.tsx
+++ b/packages/expo-image/src/Image.tsx
@@ -160,6 +160,9 @@ export class Image extends React.PureComponent<ImageProps> {
    * downloaded with `expo-file-system`. A later image load that uses the same `cacheKey`
    * in its [`source`](#imagesource) will then be served straight from the cache.
    * @param source - The image to cache, either a local file URI (`string`) or an [`ImageRef`](#imageref).
+   * > **Note:** Caching an animated image (GIF, APNG, animated WebP) from an `ImageRef` flattens
+   * > it to a single frame, because the reference holds the decoded image rather than the original
+   * > encoded bytes. To seed an animated image losslessly, pass its local file URI instead.
    * @param cacheKey - The cache key to store the image under. Pass the same value in the
    * `cacheKey` of the [`source`](#imagesource) when you later render the image.
    * @platform android

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -811,6 +811,8 @@ export declare class ImageNativeModule extends NativeModule {
 
   configureCache(config: ImageCacheConfig): void;
   getCachePathAsync(cacheKey: string): Promise<string | null>;
+  writeToCacheAsync(source: string | ImageRef, cacheKey: string): Promise<void>;
+  readFromCacheAsync(cacheKey: string): Promise<ImageRef | null>;
 
   generateBlurhashAsync(
     source: string | ImageRef,

--- a/packages/expo-image/src/ImageModule.web.ts
+++ b/packages/expo-image/src/ImageModule.web.ts
@@ -65,6 +65,14 @@ class ImageModule extends NativeModule implements ImageNativeModule {
     return Promise.resolve(null);
   }
 
+  writeToCacheAsync(_: string | ImageRef, __: string): Promise<void> {
+    throw new Error('Writing to the cache is not supported on Web.');
+  }
+
+  readFromCacheAsync(_: string): Promise<ImageRef | null> {
+    return Promise.resolve(null);
+  }
+
   generateBlurhashAsync(
     _: string | ImageRef,
     __: [number, number] | { width: number; height: number }


### PR DESCRIPTION
# Why

`expo-image` could clear the cache and read a cached file path, but there was no way to put an image into the cache yourself or read a cached image back as a usable source. Apps that already have an image on the device (from `expo-image-picker`, `expo-file-system`, a share extension, etc.) had no way to seed the cache so a later render is served from disk instead of refetching.

Closes the feature request: https://expo.canny.io/feature-requests/p/featexpo-image-add-ability-to-manually-write-seed-image-to-cache-with-a-specific

# How

Adds two static methods on `Image`:

- `Image.writeToCacheAsync(source, cacheKey)` — writes a local file URI or an in-memory `ImageRef` into the disk cache under the given cache key. A later `<Image source={{ uri, cacheKey }}>` (or `getCachePathAsync(cacheKey)`) then hits the cache.
- `Image.readFromCacheAsync(cacheKey)` — reads a cached image back as an `ImageRef`, or resolves to `null` when nothing is cached for the key.

Platform implementations:

- **iOS** stores via `SDImageCache` (file data is read directly; an `ImageRef` is re-encoded) and reads via `queryCacheOperation`. The SDWebImage completion blocks are bridged with `withCheckedContinuation`.
- **Android** seeds Glide's disk cache by loading the local file through a custom `ModelLoader` that keeps the model's custom cache key as the disk cache key, so the entry matches the key the display path and `getCachePathAsync` look up. An `ImageRef` is re-encoded to a temporary file first. Reads use `onlyRetrieveFromCache`.
- **Web** is stubbed (`writeToCacheAsync` throws as unsupported; `readFromCacheAsync` resolves `null`).

The write API always targets the disk cache; there is intentionally no cache-policy argument, since seeding is about persistence.

# Test Plan

Added a `test-suite` block (`apps/test-suite/tests/Image.js`) that runs on **both iOS and Android** on device: seed the cache from an `ImageRef` and from a local file URI, read it back as an `ImageRef`, get `null` for an unseeded key, and reject a remote URL.

Added an iOS native spec (`ImageCacheSeedingSpec`) for the cache-key round-trip contract (store under a key → read back, including a disk-only read after clearing memory; unseeded key misses; disk path is exposed). Ran the iOS native unit tests:

```
ImageCacheSeedingSpec — 4 tests, 0 failures
ImageResizingSpec — 19 tests, 0 failures
Executed 23 tests, with 0 failures. Test Succeeded.
```

`et check-packages expo-image` builds and lints clean; the regenerated `build/` output is committed.
