### PR TITLE
[ios][jsi] Add closure-taking `JavaScriptObject.setProperty` convenience

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add closure-taking `JavaScriptObject.setProperty(_:function:)` overloads that create a sync or async host function from the given closure. ([#46622](https://github.com/expo/expo/pull/46622) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -256,6 +256,30 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     expo.setProperty(runtime.pointee, pointee, name, facebook.jsi.Value(runtime.pointee, object.pointee))
   }
 
+  /// Sets a property to a synchronous host function created from the given closure. The function
+  /// is named after the property and runs the closure when called from JavaScript, returning its
+  /// result synchronously. Equivalent to `setProperty(name, runtime.createFunction(name) { … })`.
+  @JavaScriptActor
+  public func setProperty(_ name: String, function: sending @escaping JavaScriptRuntime.SyncFunctionClosure) {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    setProperty(name, value: runtime.createFunction(name, function))
+  }
+
+  /// Sets a property to an asynchronous host function created from the given closure. The function
+  /// is named after the property and runs the closure when called from JavaScript, returning a
+  /// promise that resolves with its result. Equivalent to
+  /// `setProperty(name, runtime.createAsyncFunction(name) { … })`. The `async` closure body
+  /// selects this overload over the synchronous `setProperty(_:_:)`.
+  @JavaScriptActor
+  public func setProperty(_ name: String, function: sending @escaping JavaScriptRuntime.AsyncFunctionClosure) {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    setProperty(name, value: runtime.createAsyncFunction(name, function))
+  }
+
   /// Deletes a property with the given name. After calling this function,
   /// `hasProperty` will return `false`, and `getProperty` will return `undefined` value.
   #if !os(macOS)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -224,6 +224,29 @@ struct JavaScriptObjectTests {
     }
 
     @Test
+    @JavaScriptActor
+    func `set property with sync function closure`() throws {
+      let object = JavaScriptObject(runtime)
+      object.setProperty("double") { this, arguments in
+        return JavaScriptValue(self.runtime, arguments[0].getInt() * 2)
+      }
+      let fn = try object.getPropertyAsFunction("double")
+      #expect(try fn.call(arguments: 21).getInt() == 42)
+    }
+
+    @Test
+    @JavaScriptActor
+    func `set property with async function closure`() async throws {
+      let object = JavaScriptObject(runtime)
+      object.setProperty("addAsync") { this, arguments async throws in
+        return JavaScriptValue(self.runtime, arguments[0].getInt() + arguments[1].getInt())
+      }
+      let fn = try object.getPropertyAsFunction("addAsync")
+      let result = try await fn.call(arguments: 20, 22).getPromise().await()
+      #expect(result.getInt() == 42)
+    }
+
+    @Test
     func `delete property`() {
       let object = JavaScriptObject(runtime)
       object.setProperty("temp", value: true)


### PR DESCRIPTION
# Why

Installing a host function on a JS object currently means creating the function, converting it to an object, and passing that to `setProperty`:

```swift
object.setProperty("name", runtime.createFunction("name") { this, arguments in … }.asObject())
```

That's verbose at every call site and does an unnecessary `JavaScriptFunction` → `JavaScriptObject` round-trip.

# How

Adds two `setProperty(_:function:)` overloads on `JavaScriptObject` that take a `SyncFunctionClosure` / `AsyncFunctionClosure` and create the host function under the hood, so callers can write:

```swift
object.setProperty("name") { this, arguments in … }
```

The `async` closure body selects the async overload (creating the function via `createAsyncFunction`), so JavaScript receives a promise. The created function is set straight through its JSI value via the internal `setProperty(_:value:)` path, with no intermediate `JavaScriptObject`.

# Test Plan

- Added unit tests for both overloads in `JavaScriptObjectTests` (a sync closure callable directly, an async closure whose returned promise resolves with the result); the `JavaScriptObjectTests` suite passes via `pnpm test`.
- `pnpm swift:lint` and `pnpm swift:format` pass in `expo-modules-jsi`.
- `swift build` of the package succeeds.

