### PR TITLE
[docs] Sync EAS CLI `20.1.0` changes

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 20.0.0
+cliVersion: 20.1.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,10 +1,10 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-29T10:54:00.512Z",
-    "cliVersion": "20.0.0"
+    "fetchedAt": "2026-06-08T07:41:21.204Z",
+    "cliVersion": "20.1.0"
   },
-  "totalCommands": 120,
+  "totalCommands": 123,
   "commands": [
     {
       "command": "eas account:login",
@@ -477,9 +477,24 @@
       "usage": "USAGE\n  $ eas update:edit [GROUPID] [--rollout-percentage <value>] [--branch <value>] [--json] [--non-interactive]\n\nARGUMENTS\n  [GROUPID]  The ID of an update group to edit.\n\nFLAGS\n  --branch=<value>              Branch for which to list updates to select from\n  --json                        Enable JSON output, non-JSON messages will be printed to stderr. Implies\n                                --non-interactive.\n  --non-interactive             Run the command in non-interactive mode.\n  --rollout-percentage=<value>  Rollout percentage to set for a rollout update. The specified number must be an integer\n                                between 1 and 100.\n\nDESCRIPTION\n  edit all the updates in an update group"
     },
     {
+      "command": "eas update:embedded:delete ID",
+      "description": "delete an embedded update registered with EAS Update",
+      "usage": "USAGE\n  $ eas update:embedded:delete ID [--json] [--non-interactive]\n\nARGUMENTS\n  ID  The ID of the embedded update (manifest UUID from app.manifest).\n\nFLAGS\n  --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.\n  --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  delete an embedded update registered with EAS Update"
+    },
+    {
+      "command": "eas update:embedded:list",
+      "description": "list embedded updates registered with EAS Update for this project",
+      "usage": "USAGE\n  $ eas update:embedded:list [-p ios|android] [--runtime-version <value>] [--channel <value>] [--limit <value>]\n    [--after-cursor <value>] [--json] [--non-interactive]\n\nFLAGS\n  -p, --platform=<option>        Filter by platform\n                                 <options: ios|android>\n      --after-cursor=<value>     Return items after this cursor (for pagination)\n      --channel=<value>          Filter by channel name (pass \"all\" to skip the channel prompt)\n      --json                     Enable JSON output, non-JSON messages will be printed to stderr. Implies\n                                 --non-interactive.\n      --limit=<value>            The number of items to fetch each query. Defaults to 25 and is capped at 50.\n      --non-interactive          Run the command in non-interactive mode.\n      --runtime-version=<value>  Filter by runtime version\n\nDESCRIPTION\n  list embedded updates registered with EAS Update for this project"
+    },
+    {
       "command": "eas update:embedded:upload",
       "description": "upload the JS bundle embedded in a native build so EAS Update can generate bsdiff patches against it",
       "usage": "USAGE\n  $ eas update:embedded:upload -p ios|android --bundle <value> --manifest <value> --channel <value> [--build-id <value>]\n    [--json] [--non-interactive]\n\nFLAGS\n  -p, --platform=<option>  (required) Platform of the embedded bundle\n                           <options: ios|android>\n      --build-id=<value>   EAS Build ID that produced this binary (required when invoked from EAS Build)\n      --bundle=<value>     (required) Path to the embedded JS bundle file\n      --channel=<value>    (required) Channel name the embedded update should be associated with\n      --json               Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.\n      --manifest=<value>   (required) Path to the app.manifest file embedded in the build\n      --non-interactive    Run the command in non-interactive mode.\n\nDESCRIPTION\n  upload the JS bundle embedded in a native build so EAS Update can generate bsdiff patches against it\n\nEXAMPLES\n  $ eas update:embedded:upload --platform ios --bundle ios/build/App.app/main.jsbundle --manifest ios/build/App.app/app.manifest --channel production\n\n  $ eas update:embedded:upload --platform android --bundle android/app/src/main/assets/index.android.bundle --manifest android/app/src/main/assets/app.manifest --channel production --build-id <BUILD-ID>"
+    },
+    {
+      "command": "eas update:embedded:view ID",
+      "description": "view details of an embedded update registered with EAS Update",
+      "usage": "USAGE\n  $ eas update:embedded:view ID [--json]\n\nARGUMENTS\n  ID  The ID of the embedded update (manifest UUID from app.manifest).\n\nFLAGS\n  --json  Enable JSON output, non-JSON messages will be printed to stderr.\n\nDESCRIPTION\n  view details of an embedded update registered with EAS Update"
     },
     {
       "command": "eas update:insights GROUPID",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://github.com/expo/eas-cli/releases/tag/v20.1.0

# How

<!--
How did you build this feature or fix this bug and why?
-->

Sync EAS CLI `20.1.0` changes using `pnpm eas-cli-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
