### PR TITLE
Bump hermes-parser / babel-plugin-syntax-hermes-parser

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump `hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 - Add misc. OOT platforms as base `react-native` paths for module configs like `getPolyfills` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -72,7 +72,7 @@
     "debug": "^4.3.2",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
-    "hermes-parser": "^0.33.3",
+    "hermes-parser": "^0.36.0",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "^1.30.1",
     "msgpackr": "^2.0.1",

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump `babel-plugin-syntax-hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-26

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -95,7 +95,7 @@
     "@react-native/babel-plugin-codegen": "0.86.0-rc.3",
     "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-react-native-web": "~0.21.0",
-    "babel-plugin-syntax-hermes-parser": "^0.33.3",
+    "babel-plugin-syntax-hermes-parser": "^0.36.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "debug": "^4.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2602,8 +2602,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.6
       hermes-parser:
-        specifier: ^0.33.3
-        version: 0.33.3
+        specifier: ^0.36.0
+        version: 0.36.0
       jsc-safe-url:
         specifier: ^0.2.4
         version: 0.2.4
@@ -3129,8 +3129,8 @@ importers:
         specifier: ~0.21.0
         version: 0.21.2
       babel-plugin-syntax-hermes-parser:
-        specifier: ^0.33.3
-        version: 0.33.3
+        specifier: ^0.36.0
+        version: 0.36.0
       babel-plugin-transform-flow-enums:
         specifier: ^0.0.2
         version: 0.0.2(@babel/core@7.29.0)
@@ -10151,9 +10151,6 @@ packages:
   babel-plugin-react-native-web@0.21.2:
     resolution: {integrity: sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==}
 
-  babel-plugin-syntax-hermes-parser@0.33.3:
-    resolution: {integrity: sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==}
-
   babel-plugin-syntax-hermes-parser@0.36.0:
     resolution: {integrity: sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==}
 
@@ -11990,9 +11987,6 @@ packages:
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
-  hermes-estree@0.33.3:
-    resolution: {integrity: sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==}
-
   hermes-estree@0.35.0:
     resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
 
@@ -12001,9 +11995,6 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
-  hermes-parser@0.33.3:
-    resolution: {integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==}
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
@@ -20401,10 +20392,6 @@ snapshots:
 
   babel-plugin-react-native-web@0.21.2: {}
 
-  babel-plugin-syntax-hermes-parser@0.33.3:
-    dependencies:
-      hermes-parser: 0.33.3
-
   babel-plugin-syntax-hermes-parser@0.36.0:
     dependencies:
       hermes-parser: 0.36.0
@@ -22646,8 +22633,6 @@ snapshots:
 
   hermes-estree@0.25.1: {}
 
-  hermes-estree@0.33.3: {}
-
   hermes-estree@0.35.0: {}
 
   hermes-estree@0.36.0: {}
@@ -22655,10 +22640,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  hermes-parser@0.33.3:
-    dependencies:
-      hermes-estree: 0.33.3
 
   hermes-parser@0.35.0:
     dependencies:


### PR DESCRIPTION
# Why

The nightly "Test React Native nightly build for Expo Modules" workflow fails on Android while bundling JS.

RN nightly's `EventEmitter.js` now uses newer Flow syntax (`readonly` property modifiers, `extends` generic bounds), and the `hermes-parser@0.33.3` pinned by `@expo/metro-config` can't parse it:

```
SyntaxError in react-native/Libraries/vendor/emitter/EventEmitter.js:
  ':' or '?' expected in property type annotation (44:11)
  readonly context: unknown;
```

# How

Bumped the parser deps to `^0.36.0` to match RN's own babel toolchain (`@react-native/babel-preset@0.86` already uses `0.36.0`):

- `hermes-parser` in `@expo/metro-config`
- `babel-plugin-syntax-hermes-parser` in `babel-preset-expo`

No source changes needed. The parse API is identical across these versions, so only the dependency versions and the lockfile change.

# Test Plan

Parsed the exact RN nightly `EventEmitter.js` through the parser `@expo/metro-config` resolves:

- `hermes-parser@0.33.3` fails with the CI error
- `0.36.0` parses it fine

Both packages still pass their suites:

- `@expo/metro-config`: 47 suites / 851 tests
- `babel-preset-expo`: 28 suites / 596 tests, 339 snapshots

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
