### PR TITLE
[ui][iOS] Fix pager view safe area insets with ScrollView

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `PagerView` offsetting `ScrollView` by safe area insets. ([#46637](https://github.com/expo/expo/pull/46637) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `SegmentedControl` being overlapped by sibling components inside a `ScrollView`, by disabling the `Host` safe area insets. ([#46575](https://github.com/expo/expo/pull/46575) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Fix `TextField` jiggling the surrounding content while its label animates on focus (a Material 3 expressive motion spring overshoot). ([#46568](https://github.com/expo/expo/pull/46568) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `BottomSheet` animating open from the bottom-left corner in `fitToContents` mode. ([#46546](https://github.com/expo/expo/pull/46546) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/src/community/pager-view/PagerView.ios.tsx
+++ b/packages/expo-ui/src/community/pager-view/PagerView.ios.tsx
@@ -213,7 +213,7 @@ export function PagerView(props: PagerViewProps) {
   ];
 
   return (
-    <Host style={style ?? { flex: 1 }} {...passthrough}>
+    <Host style={style ?? { flex: 1 }} ignoreSafeArea="all" {...passthrough}>
       <ScrollView axes="horizontal" showsIndicators={false} modifiers={modifiers}>
         <LazyHStack spacing={0} modifiers={[scrollTargetLayout()]}>
           {pages}


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/46562

Host adds safe area insets to Pager view content.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Pass `ignoreSafeArea="all"` to `Host`. Will make a follow up PR to set this as default in `Host`. It will be a breaking change (but probably in a good way 😅).

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the repro shared in issue.

### Before
<img width="200"  alt="simulator_screenshot_8538DBF4-0E0D-4AE7-BAB6-5201F6905BE0" src="https://github.com/user-attachments/assets/b47b9f4d-5cb9-457e-b566-048d01cd6624" />

### After
<img width="200"  alt="simulator_screenshot_F46599C8-57A8-4CF5-886E-8AB36788CC60" src="https://github.com/user-attachments/assets/fe429176-5afc-49c0-8046-c99e79122b93" />

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
