### PR TITLE
[expo-observe] Add unit tests for direct react-navigation and expo-router imports

### DIFF
--- a/packages/expo-observe/src/__tests__/optionalImport.test.ts
+++ b/packages/expo-observe/src/__tests__/optionalImport.test.ts
@@ -1,0 +1,58 @@
+jest.mock('expo-router', () => {
+  throw new Error('simulated: expo-router is not installed');
+});
+jest.mock('@react-navigation/native', () => {
+  throw new Error('simulated: @react-navigation/native is not installed');
+});
+
+jest.mock('../integrations/expo-router/router', () => ({
+  __esModule: true,
+  isRouterInstalled: true,
+  optionalRouter: {
+    useRoute: jest.fn(),
+    useNavigation: jest.fn(),
+    useCurrentRouteInfo: jest.fn(),
+    unstable_navigationEvents: {
+      enable: jest.fn(),
+      addListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  },
+}));
+jest.mock('../integrations/react-navigation/reactNavigation', () => ({
+  __esModule: true,
+  isReactNavigationInstalled: true,
+  optionalReactNavigation: {
+    NavigationContainer: () => null,
+    useNavigationContainerRef: jest.fn(),
+    useRoute: jest.fn(),
+    useNavigation: jest.fn(),
+    useStateForPath: jest.fn(),
+  },
+}));
+
+// The native module and app-metrics are unrelated to this guard; stub them so requiring
+// the root entry doesn't reach native code at load time. `NativeModule`/`registerWebModule`
+// are needed for the web build (`module.web.ts`), which extends `NativeModule`.
+jest.mock('expo', () => ({
+  requireNativeModule: jest.fn(() => ({
+    configure: jest.fn(),
+    setBundleDefaults: jest.fn(),
+    dispatchEvents: jest.fn(() => Promise.resolve()),
+  })),
+  NativeModule: class {},
+  registerWebModule: jest.fn((ModuleClass) => new ModuleClass()),
+}));
+jest.mock('expo-app-metrics', () => ({
+  __esModule: true,
+  default: {
+    markInteractive: jest.fn(),
+    getMainSession: jest.fn(async () => ({ id: 'session-1' })),
+    addCustomMetricToSession: jest.fn(),
+  },
+}));
+
+describe('expo-observe root entry optional imports', () => {
+  it('loads with neither expo-router nor @react-navigation/native installed', () => {
+    expect(() => require('../index')).not.toThrow();
+  });
+});

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/optionalImport.test.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/optionalImport.test.ts
@@ -1,0 +1,26 @@
+// `expo-router` is an optional peer dependency. The integration must reach it ONLY
+// through the `router` wrapper (a try/catch require), never via a direct
+// `import { x } from 'expo-router'`
+jest.mock('expo-router', () => {
+  throw new Error('simulated: expo-router is not installed');
+});
+
+jest.mock('../router', () => ({
+  __esModule: true,
+  isRouterInstalled: true,
+  optionalRouter: {
+    useRoute: jest.fn(),
+    useNavigation: jest.fn(),
+    useCurrentRouteInfo: jest.fn(),
+    unstable_navigationEvents: {
+      enable: jest.fn(),
+      addListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  },
+}));
+
+describe('expo-router integration optional imports', () => {
+  it('loads its entry point without expo-router installed', () => {
+    expect(() => require('../index')).not.toThrow();
+  });
+});

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/optionalImport.test.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/optionalImport.test.ts
@@ -1,0 +1,24 @@
+// `@react-navigation/native` is an optional peer dependency. The integration must
+// reach it ONLY through the `reactNavigation` wrapper (a try/catch require), never
+// via a direct `import { x } from '@react-navigation/native'`
+jest.mock('@react-navigation/native', () => {
+  throw new Error('simulated: @react-navigation/native is not installed');
+});
+
+jest.mock('../reactNavigation', () => ({
+  __esModule: true,
+  isReactNavigationInstalled: true,
+  optionalReactNavigation: {
+    NavigationContainer: () => null,
+    useNavigationContainerRef: jest.fn(),
+    useRoute: jest.fn(),
+    useNavigation: jest.fn(),
+    useStateForPath: jest.fn(),
+  },
+}));
+
+describe('react-navigation integration optional imports', () => {
+  it('loads its entry point without @react-navigation/native installed', () => {
+    expect(() => require('../index')).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Why

In order to avoid regressions like - https://github.com/expo/expo/pull/46293

# How

Add tests ensuring that `@react-navigation/native` and `expo-router` are not imported directly

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
