### PR TITLE
Fix build against React Native 0.87+ with legacy architecture removed

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix iOS build against React Native 0.87+ where the legacy architecture (bridge) APIs were removed, by guarding the bridge-based `RCTRootViewFactoryConfiguration` setup behind `RCT_REMOVE_LEGACY_ARCH`. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
+- Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup, whose APIs were removed in RN 0.87+ and were already unused since the old architecture was dropped in SDK 55. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup, whose APIs were removed in RN 0.87+ and were already unused since the old architecture was dropped in SDK 55. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
+- Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS build against React Native 0.87+ where the legacy architecture (bridge) APIs were removed, by guarding the bridge-based `RCTRootViewFactoryConfiguration` setup behind `RCT_REMOVE_LEGACY_ARCH`. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -89,17 +89,8 @@ Pod::Spec.new do |s|
       # [end] transitive dependencies of React-RCTAppDelegate that are not defined modules
     ])
   end
-
-  # React Native 0.87+ removed the legacy architecture APIs. RN guards them with `RCT_REMOVE_LEGACY_ARCH`
-  # but only defines it for ObjC/C++, so we mirror the macro for Swift to stop referencing removed APIs.
-  swift_compilation_conditions = ['$(inherited)']
-  if reactNativeTargetVersion >= 87
-    swift_compilation_conditions << 'RCT_REMOVE_LEGACY_ARCH'
-  end
-
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
-    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => swift_compilation_conditions.join(' '),
   }
   s.user_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => [

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -89,8 +89,17 @@ Pod::Spec.new do |s|
       # [end] transitive dependencies of React-RCTAppDelegate that are not defined modules
     ])
   end
+
+  # React Native 0.87+ removed the legacy architecture APIs. RN guards them with `RCT_REMOVE_LEGACY_ARCH`
+  # but only defines it for ObjC/C++, so we mirror the macro for Swift to stop referencing removed APIs.
+  swift_compilation_conditions = ['$(inherited)']
+  if reactNativeTargetVersion >= 87
+    swift_compilation_conditions << 'RCT_REMOVE_LEGACY_ARCH'
+  end
+
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => swift_compilation_conditions.join(' '),
   }
   s.user_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => [

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -39,52 +39,10 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       return weakDelegate?.bundleURL()
     }
 
-#if RCT_REMOVE_LEGACY_ARCH
-    // React Native 0.87+ removed the legacy architecture, so the New Architecture is always enabled
-    // and the bridge-based configuration below no longer exists on the delegate.
     let configuration = RCTRootViewFactoryConfiguration(
       bundleURLBlock: bundleUrlBlock,
       newArchEnabled: true
     )
-#else
-    let configuration = RCTRootViewFactoryConfiguration(
-      bundleURLBlock: bundleUrlBlock,
-      newArchEnabled: weakDelegate.newArchEnabled()
-    )
-
-    configuration.createRootViewWithBridge = { bridge, moduleName, initProps in
-      return weakDelegate.createRootView(with: bridge, moduleName: moduleName, initProps: initProps)
-    }
-
-    configuration.createBridgeWithDelegate = { delegate, launchOptions in
-      weakDelegate.createBridge(with: delegate, launchOptions: launchOptions)
-    }
-
-    // NOTE(kudo): `sourceURLForBridge` is not referenced intentionally because it does not support New Architecture.
-    configuration.sourceURLForBridge = nil
-
-    configuration.loadSourceForBridgeWithProgress = { bridge, onProgress, onComplete in
-      weakDelegate.loadSource(for: bridge, onProgress: onProgress, onComplete: onComplete)
-    }
-
-    if weakDelegate.responds(to: #selector(RCTReactNativeFactoryDelegate.extraModules(for:))) {
-      configuration.extraModulesForBridge = { bridge in
-        weakDelegate.extraModules(for: bridge)
-      }
-    }
-
-    if weakDelegate.responds(to: #selector(RCTReactNativeFactoryDelegate.extraLazyModuleClasses(for:))) {
-      configuration.extraLazyModuleClassesForBridge = { bridge in
-        weakDelegate.extraLazyModuleClasses(for: bridge)
-      }
-    }
-
-    if weakDelegate.responds(to: #selector(RCTReactNativeFactoryDelegate.bridge(_:didNotFindModule:))) {
-      configuration.bridgeDidNotFindModule = { bridge, moduleName in
-        weakDelegate.bridge(bridge, didNotFindModule: moduleName)
-      }
-    }
-#endif
 
     configuration.jsRuntimeConfiguratorDelegate = delegate
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -39,6 +39,14 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       return weakDelegate?.bundleURL()
     }
 
+#if RCT_REMOVE_LEGACY_ARCH
+    // React Native 0.87+ removed the legacy architecture, so the New Architecture is always enabled
+    // and the bridge-based configuration below no longer exists on the delegate.
+    let configuration = RCTRootViewFactoryConfiguration(
+      bundleURLBlock: bundleUrlBlock,
+      newArchEnabled: true
+    )
+#else
     let configuration = RCTRootViewFactoryConfiguration(
       bundleURLBlock: bundleUrlBlock,
       newArchEnabled: weakDelegate.newArchEnabled()
@@ -48,14 +56,8 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       return weakDelegate.createRootView(with: bridge, moduleName: moduleName, initProps: initProps)
     }
 
-    configuration.jsRuntimeConfiguratorDelegate = delegate
-
     configuration.createBridgeWithDelegate = { delegate, launchOptions in
       weakDelegate.createBridge(with: delegate, launchOptions: launchOptions)
-    }
-
-    configuration.customizeRootView = { rootView in
-      weakDelegate.customize(rootView)
     }
 
     // NOTE(kudo): `sourceURLForBridge` is not referenced intentionally because it does not support New Architecture.
@@ -81,6 +83,13 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       configuration.bridgeDidNotFindModule = { bridge, moduleName in
         weakDelegate.bridge(bridge, didNotFindModule: moduleName)
       }
+    }
+#endif
+
+    configuration.jsRuntimeConfiguratorDelegate = delegate
+
+    configuration.customizeRootView = { rootView in
+      weakDelegate.customize(rootView)
     }
 
     return ExpoReactRootViewFactory(


### PR DESCRIPTION
# Why

The nightly "Test React Native nightly build for Expo Modules" workflow fails on iOS while compiling the `Expo` pod.

React Native 0.87 removes the legacy architecture, so the bridge-era APIs `ExpoReactNativeFactory.swift` relies on no longer exist on the delegate:

```
ExpoReactNativeFactory.swift: value of type 'ExpoReactNativeFactoryDelegate' has no member 'newArchEnabled'
ExpoReactNativeFactory.swift: value of type 'ExpoReactNativeFactoryDelegate' has no member 'createRootView'
ExpoReactNativeFactory.swift: value of type 'ExpoReactNativeFactoryDelegate' has no member 'createBridge'
ExpoReactNativeFactory.swift: value of type 'ExpoReactNativeFactoryDelegate' has no member 'loadSource'
ExpoReactNativeFactory.swift: type 'any RCTReactNativeFactoryDelegate' has no member 'extraModules(for:)'
ExpoReactNativeFactory.swift: type 'any RCTReactNativeFactoryDelegate' has no member 'extraLazyModuleClasses(for:)'
```

RN guards these with `#if !defined(RCT_REMOVE_LEGACY_ARCH)` (default on from 0.87), but only defines that macro for ObjC/C++ (`OTHER_CFLAGS`), not for Swift.

# How

Mirror RN's `RCT_REMOVE_LEGACY_ARCH` guard in Swift:

- `Expo.podspec` sets a `RCT_REMOVE_LEGACY_ARCH` Swift active compilation condition when the React Native minor version is `>= 87` (it already computes `reactNativeTargetVersion`).
- `ExpoReactNativeFactory.swift` wraps the bridge-based `RCTRootViewFactoryConfiguration` setup in `#if !RCT_REMOVE_LEGACY_ARCH`. On 0.87+ it just passes `newArchEnabled: true` and keeps the APIs that still exist (`bundleURLBlock`, `jsRuntimeConfiguratorDelegate`, `customizeRootView`).

This keeps 0.86 behaving exactly as before (legacy branch compiles) and unblocks 0.87+ (new-arch branch).

# Test Plan

Diffed the RN nightly iOS headers against 0.86 to confirm which APIs were removed and that the new-arch branch only references surviving symbols (`RCTRootViewFactoryConfiguration(bundleURLBlock:newArchEnabled:)`, `jsRuntimeConfiguratorDelegate`, `customizeRootView`, `customize`, `bundleURL`).

Verified the podspec version gate: `0.86.0-rc.3` -> no flag, `0.87.0-nightly-*` -> `RCT_REMOVE_LEGACY_ARCH`.

The full native build is covered by the nightly workflow.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
