### PR TITLE
[autolinking][Android] Disable `lintVitalAnalyze` task for 3rd party modules

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
@@ -18,6 +18,58 @@ class ExpoRootProjectPlugin : Plugin<Project> {
 
     with(rootProject) {
       defineDefaultProperties(libs)
+      disableLinkedModulesLintWhenRequested()
+    }
+  }
+}
+
+/**
+ * Determines whether autolinked native modules should be linted when building the release version
+ * of the app.
+ */
+internal fun Project.isLinkedModuleLintEnabled(): Boolean {
+  (findProperty("expo.android.enableLint") as? String)?.let { return it.toBoolean() }
+  System.getenv("EXPO_ANDROID_ENABLE_LINT")?.let { return it.toBoolean() }
+  return false
+}
+
+/**
+ * Centrally skips the expensive lint-vital *analysis* for autolinked native modules when
+ * module linting is disabled (see [isLinkedModuleLintEnabled]).
+ *
+ * A module's lint-vital analysis is skipped when either is true:
+ *  - Its sources live under `node_modules` (third-party React Native libraries).
+ *  - It is an Expo module
+ *
+ * The app itself is left untouched - its lint-vital still runs.
+ *
+ * Only `lintVitalAnalyze*` is disabled - that's the task that actually runs the lint
+ * detectors. The cheap `generate*LintVitalModel` task is left enabled on purpose: the
+ * app's `lintVitalReportRelease` requires every dependency's vital model and fails with
+ * "Lint model ... does not exist" if it's missing. Keeping the model while skipping the
+ * analysis lets the app build skip the work without breaking the report.
+ */
+internal fun Project.disableLinkedModulesLintWhenRequested() {
+  if (isLinkedModuleLintEnabled()) {
+    return
+  }
+
+  subprojects { subproject ->
+    // Third-party native modules autolinked from node_modules.
+    if (subproject.projectDir.invariantSeparatorsPath.contains("/node_modules/")) {
+      subproject.disableLintVitalAnalysis()
+    }
+    // Every Expo module, wherever its sources live.
+    subproject.plugins.withId("expo-module-gradle-plugin") {
+      subproject.disableLintVitalAnalysis()
+    }
+  }
+}
+
+private fun Project.disableLintVitalAnalysis() {
+  tasks.configureEach { task ->
+    if (task.name.startsWith("lintVitalAnalyze")) {
+      task.enabled = false
     }
   }
 }


### PR DESCRIPTION
# Why

On a release build, AGP runs lint-vital for every module in the build - including all autolinked native modules: expo modules and third-party React Native libraries from node_modules. That analysis is pure wasted time during an app build, and the app author can't act on it.

# How

Added a switch to the expo-root-project plugin, which is applied once to the consuming app's root project and can reach every subproject. When linting is disabled, it walks subprojects and disables `lintVitalAnalyze*` for a module when either is true:
- its sources live under `node_modules` (third-party RN libraries), or
- it is an Expo module

# Test Plan

1. Default behavior - `lintVitalAnalyze` is skipped for autolinked modules
`./gradlew :expo-blob:lintVitalAnalyzeRelease --console=plain`
`./gradlew :react-native-screens:lintVitalAnalyzeRelease --console=plain`
✅ Both report > Task :…:lintVitalAnalyzeRelease SKIPPED

2. Opt back in re-enables analysis
`./gradlew :expo-blob:lintVitalAnalyzeRelease -Pexpo.android.enableLint=true --console=plain`
`EXPO_ANDROID_ENABLE_LINT=true ./gradlew :expo-blob:lintVitalAnalyzeRelease --console=plain`
✅ The task executes in both cases

3. The app itself is still linted
`./gradlew :app:assembleRelease -PreactNativeArchitectures=arm64-v8a --console=plain`
✅ Expected in the output:
	```
	- :expo-* and :react-native-* -> lintVitalAnalyzeRelease SKIPPED
	- :app:lintVitalAnalyzeRelease -> runs 
	- :app:lintVitalReportRelease -> succeeds
	```

4. Build succeeds end-to-end
`./gradlew :app:assembleRelease -PreactNativeArchitectures=arm64-v8a`
✅ BUILD SUCCESSFUL