### PR TITLE
Derive template SDK from CLI version for standalone modules

### DIFF
--- a/packages/create-expo-module/src/__tests__/templateUtils-test.ts
+++ b/packages/create-expo-module/src/__tests__/templateUtils-test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getGeneratedWebStubSentinel, updateWebStub } from '../templateUtils';
+import { getGeneratedWebStubSentinel, getTemplateDistTag, updateWebStub } from '../templateUtils';
 import type { SubstitutionData } from '../types';
 
 const mockData: SubstitutionData = {
@@ -32,6 +32,25 @@ async function writeMinimalWebTemplate(templateDir: string) {
     'export default class <%- project.moduleName %> {}\n'
   );
 }
+
+describe('getTemplateDistTag', () => {
+  it('maps an SDK-aligned version to its `sdk-<major>` tag', () => {
+    expect(getTemplateDistTag('56.0.3')).toBe('sdk-56');
+    expect(getTemplateDistTag('54.0.45')).toBe('sdk-54');
+    expect(getTemplateDistTag('50.0.0')).toBe('sdk-50');
+  });
+
+  it('falls back to `latest` for versions from the old, non-SDK-aligned scheme', () => {
+    expect(getTemplateDistTag('1.0.15')).toBe('latest');
+    expect(getTemplateDistTag('0.5.0')).toBe('latest');
+  });
+
+  it('falls back to `latest` for missing or unparsable versions', () => {
+    expect(getTemplateDistTag(undefined)).toBe('latest');
+    expect(getTemplateDistTag('')).toBe('latest');
+    expect(getTemplateDistTag('not-a-version')).toBe('latest');
+  });
+});
 
 describe('updateWebStub', () => {
   let tmpDir: string;

--- a/packages/create-expo-module/src/__tests__/templateUtils-test.ts
+++ b/packages/create-expo-module/src/__tests__/templateUtils-test.ts
@@ -36,11 +36,12 @@ async function writeMinimalWebTemplate(templateDir: string) {
 describe('getTemplateDistTag', () => {
   it('maps an SDK-aligned version to its `sdk-<major>` tag', () => {
     expect(getTemplateDistTag('56.0.3')).toBe('sdk-56');
-    expect(getTemplateDistTag('54.0.45')).toBe('sdk-54');
-    expect(getTemplateDistTag('50.0.0')).toBe('sdk-50');
+    expect(getTemplateDistTag('57.0.0')).toBe('sdk-57');
+    expect(getTemplateDistTag('60.1.2')).toBe('sdk-60');
   });
 
   it('falls back to `latest` for versions from the old, non-SDK-aligned scheme', () => {
+    expect(getTemplateDistTag('2.1.7')).toBe('latest');
     expect(getTemplateDistTag('1.0.15')).toBe('latest');
     expect(getTemplateDistTag('0.5.0')).toBe('latest');
   });

--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -41,35 +41,16 @@ export async function createExampleApp(
     // Pin the example template to the same SDK as the module template (derived from the CLI's own
     // version), so `create-expo-module@sdk-XX` scaffolds an SDK XX example rather than always using
     // `latest`. Fall back to `latest` when the SDK can't be determined or its template isn't published.
-    const templateVersion = env.EXPO_BETA
-      ? 'next'
-      : getTemplateDistTag(require('../package.json').version);
-
-    const initExampleApp = async (templateVersion: string): Promise<void> => {
-      const template = `expo-template-blank-typescript@${templateVersion}`;
-      debug(`Using example template: ${template}`);
-      const command = createCommand(packageManager, exampleProjectSlug, template);
-
-      try {
-        await spawnAsync(packageManager, command, {
-          cwd: targetDir,
-        });
-      } catch (error: any) {
-        throw new Error(
-          `${command.join(' ')} failed with exit code: ${error?.status}.\n\nError stack:\n${error?.stderr}`
-        );
-      }
-    };
+    const distTag = env.EXPO_BETA ? 'next' : getTemplateDistTag(require('../package.json').version);
 
     try {
-      await initExampleApp(templateVersion);
+      await initExampleApp(packageManager, exampleProjectSlug, targetDir, distTag);
     } catch (error: any) {
-      if (templateVersion !== 'latest' && templateVersion !== 'next') {
-        debug(`Failed to use the "${templateVersion}" example template, falling back to "latest".`);
-        await initExampleApp('latest');
-      } else {
+      if (env.EXPO_BETA || distTag === 'latest') {
         throw error;
       }
+      debug(`Failed to use the "${distTag}" example template, falling back to "latest".`);
+      await initExampleApp(packageManager, exampleProjectSlug, targetDir, 'latest');
     }
 
     step.succeed('Initialized the example app');
@@ -122,6 +103,30 @@ async function installExpoUI(exampleAppPath: string): Promise<void> {
     cwd: exampleAppPath,
     stdio: ['ignore', 'ignore', 'pipe'],
   });
+}
+
+/**
+ * Initializes the example app from `expo-template-blank-typescript` at the given dist-tag.
+ */
+async function initExampleApp(
+  packageManager: PackageManagerName,
+  exampleProjectSlug: string,
+  targetDir: string,
+  distTag: string
+): Promise<void> {
+  const template = `expo-template-blank-typescript@${distTag}`;
+  debug(`Using example template: ${template}`);
+  const command = createCommand(packageManager, exampleProjectSlug, template);
+
+  try {
+    await spawnAsync(packageManager, command, {
+      cwd: targetDir,
+    });
+  } catch (error: any) {
+    throw new Error(
+      `${command.join(' ')} failed with exit code: ${error?.status}.\n\nError stack:\n${error?.stderr}`
+    );
+  }
 }
 
 function createCommand(

--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -1,4 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -49,7 +50,11 @@ export async function createExampleApp(
       if (env.EXPO_BETA || distTag === 'latest') {
         throw error;
       }
-      debug(`Failed to use the "${distTag}" example template, falling back to "latest".`);
+
+      console.warn(
+        chalk.yellow(`Failed to use the "${distTag}" example template, falling back to "latest".`)
+      );
+
       await initExampleApp(packageManager, exampleProjectSlug, targetDir, 'latest');
     }
 

--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { usesExpoUI } from './features';
 import { installDependencies, type PackageManagerName } from './packageManager';
+import { getTemplateDistTag } from './templateUtils';
 import type { SubstitutionData } from './types';
 import { env } from './utils/env';
 import { newStep } from './utils/ora';
@@ -37,18 +38,38 @@ export async function createExampleApp(
   }
 
   await newStep('Initializing the example app', async (step) => {
-    const templateVersion = env.EXPO_BETA ? 'next' : 'latest';
-    const template = `expo-template-blank-typescript@${templateVersion}`;
-    debug(`Using example template: ${template}`);
-    const command = createCommand(packageManager, exampleProjectSlug, template);
+    // Pin the example template to the same SDK as the module template (derived from the CLI's own
+    // version), so `create-expo-module@sdk-XX` scaffolds an SDK XX example rather than always using
+    // `latest`. Fall back to `latest` when the SDK can't be determined or its template isn't published.
+    const templateVersion = env.EXPO_BETA
+      ? 'next'
+      : getTemplateDistTag(require('../package.json').version);
+
+    const initExampleApp = async (templateVersion: string): Promise<void> => {
+      const template = `expo-template-blank-typescript@${templateVersion}`;
+      debug(`Using example template: ${template}`);
+      const command = createCommand(packageManager, exampleProjectSlug, template);
+
+      try {
+        await spawnAsync(packageManager, command, {
+          cwd: targetDir,
+        });
+      } catch (error: any) {
+        throw new Error(
+          `${command.join(' ')} failed with exit code: ${error?.status}.\n\nError stack:\n${error?.stderr}`
+        );
+      }
+    };
+
     try {
-      await spawnAsync(packageManager, command, {
-        cwd: targetDir,
-      });
+      await initExampleApp(templateVersion);
     } catch (error: any) {
-      throw new Error(
-        `${command.join(' ')} failed with exit code: ${error?.status}.\n\nError stack:\n${error?.stderr}`
-      );
+      if (templateVersion !== 'latest' && templateVersion !== 'next') {
+        debug(`Failed to use the "${templateVersion}" example template, falling back to "latest".`);
+        await initExampleApp('latest');
+      } else {
+        throw error;
+      }
     }
 
     step.succeed('Initialized the example app');

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -158,10 +158,10 @@ async function getLocalSdkMajorVersion(): Promise<string | null> {
   return version?.split('.')[0] ?? null;
 }
 
-// The first SDK that `create-expo-module` is versioned in lockstep with. Earlier releases used
-// an independent `0.x`/`1.x` scheme whose major doesn't map to an SDK, so we treat anything below
-// this as "not SDK-aligned" and fall back to `latest`.
-const FIRST_SDK_ALIGNED_MAJOR = 50;
+// The first SDK the CLI is versioned in lockstep with (CLI major == SDK major). Earlier releases
+// used an independent scheme (e.g. `1.x` for sdk-54, `2.x` for sdk-55) whose major doesn't map to
+// an SDK, so anything below this falls back to `latest`.
+const FIRST_SDK_ALIGNED_MAJOR = 56;
 
 /**
  * Resolves the template dist-tag targeted by a `create-expo-module` release from its own package

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -158,15 +158,37 @@ async function getLocalSdkMajorVersion(): Promise<string | null> {
   return version?.split('.')[0] ?? null;
 }
 
+// The first SDK that `create-expo-module` is versioned in lockstep with. Earlier releases used
+// an independent `0.x`/`1.x` scheme whose major doesn't map to an SDK, so we treat anything below
+// this as "not SDK-aligned" and fall back to `latest`.
+const FIRST_SDK_ALIGNED_MAJOR = 50;
+
 /**
- * Selects correct version of the template based on the SDK version for local modules and EXPO_BETA flag.
+ * Resolves the template dist-tag targeted by a `create-expo-module` release from its own package
+ * version. The CLI is published in lockstep with the SDK (e.g. `56.x.y` ships alongside SDK 56), so
+ * its major version is the SDK major and maps to `sdk-<major>`. Falls back to `latest` for the
+ * older, non-SDK-aligned versions.
+ */
+export function getTemplateDistTag(version: string | undefined): string {
+  const major = Number(version?.split('.')[0]);
+  return Number.isInteger(major) && major >= FIRST_SDK_ALIGNED_MAJOR ? `sdk-${major}` : 'latest';
+}
+
+/**
+ * Selects correct version of the template based on the SDK version and EXPO_BETA flag.
+ *
+ * - For local modules, the SDK is derived from the host project's `expo` dependency.
+ * - For standalone modules, the SDK is derived from the CLI's own version, so that
+ *   `create-expo-module@sdk-XX` scaffolds an SDK XX module rather than always using `latest`.
+ *
+ * In both cases we fall back to `latest` when the SDK can't be determined.
  */
 async function getTemplateVersion(isLocal: boolean) {
   if (env.EXPO_BETA) {
     return 'next';
   }
   if (!isLocal) {
-    return 'latest';
+    return getTemplateDistTag(require('../package.json').version);
   }
   try {
     const sdkVersionMajor = await getLocalSdkMajorVersion();


### PR DESCRIPTION
# Why

Fixes future issues similar to #46632.

For standalone modules, `create-expo-module` always downloaded `expo-module-template@latest` and `expo-template-blank-typescript@latest`, ignoring the SDK the CLI was meant to target.

# How

`create-expo-module` is published in lockstep with the SDK (56.x ships with SDK 56), so the CLI's own major version is the SDK major. Added `getTemplateDistTag()`, which turns the CLI version into a `sdk-<major>` dist-tag (falling back to `latest` for the pre-56 versions that used the old 1.x/2.x scheme), and used it for both the module template and the example app template. The example app keeps a fallback to `latest` if the versioned template isn't published yet.

# Test Plan

Added unit tests for `getTemplateDistTag` covering SDK-aligned versions, the old scheme, and unparsable input. `et check-packages create-expo-module` passes (typecheck, lint, test).

Note: this fixes the SDK 56 line and forward. It can't repair the already published `create-expo-module@sdk-54` (1.0.15) and `@sdk-55` (2.1.7), since those predate the SDK-aligned versioning and have no way to know their SDK.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
