### PR TITLE
[ci] Fix Lock Threads workflow by using the default workflow token

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: '180'
           add-issue-labels: 'outdated'
           exclude-any-issue-labels: 'help wanted'


### PR DESCRIPTION
# Why

The scheduled **Lock Threads** workflow has been failing ([run](https://github.com/expo/expo/actions/runs/27109957683/job/80005785875)).

The workflow passed `github-token: ${{ secrets.GITHUB_TOKEN }}` explicitly, which was redundant: the workflow already grants `issues: write` via its `permissions:` block, and `dessant/lock-threads` defaults its `github-token` input to `${{ github.token }}` — the token issued for the workflow run with those exact permissions.

# How

Dropped the explicit `github-token` input so the action falls back to the default `${{ github.token }}`, as recommended in the [action's own examples](https://github.com/dessant/lock-threads#examples).

# Test Plan

This only runs on a schedule (`cron: '0 0 * * MON'`) and via `workflow_dispatch`. After merging, it can be verified by manually dispatching the workflow and confirming the job succeeds.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
