### PR TITLE
Update dessant/lock-threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-inactive-days: '180'
           add-issue-labels: 'outdated'


### PR DESCRIPTION
# Why

The scheduled **Lock Threads** workflow has been failing ([run](https://github.com/expo/expo/actions/runs/27143529203/job/80114907738)) with:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

`dessant/lock-threads` v5 validates its `github-token` input with `Joi.string().max(100)`. GitHub now issues `GITHUB_TOKEN`s longer than 100 characters, so the action rejects the token before it can do anything. This is the same token whether it comes from `secrets.GITHUB_TOKEN` or the `${{ github.token }}` default, so the length check fails either way.

v6 raised this limit to `max(1000)`, which fixes the failure.

# How

- Bumped `dessant/lock-threads` from v5 to v6.0.2 (pinned to commit `89ae32b`), which raises the `github-token` length limit.

> **Note:** v6 is a major bump — the action now runs on the `node24` runtime (v5 used `node20`). This is a non-issue here: the job runs on the GitHub-hosted `ubuntu-24.04` runner, whose Actions runtime supports `node24`.

# Test Plan

This only runs on a schedule (`cron: '0 0 * * MON'`) and via `workflow_dispatch`. After merging, it can be verified by manually dispatching the workflow and confirming the job succeeds.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
