### PR TITLE
Fix flaky player-output e2e test by not auto-playing

### DIFF
--- a/apps/bare-expo/e2e/expo-video/player-output-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/player-output-test.yaml
@@ -6,7 +6,7 @@ jsEngine: graaljs
 - tapOn: 'Prepare for e2e'
 - extendedWaitUntil:
     visible: 'Players ready'
-    timeout: 10000
+    timeout: 30000
 - tapOn: 'Move player 1 to the next video view'
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml

--- a/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
@@ -12,7 +12,10 @@ import TitledSwitch from '../../components/TitledSwitch';
 const playerFactory = (player: VideoPlayer) => {
   player.loop = true;
   player.muted = true;
-  player.play();
+
+  // Don't auto-play: on iOS the Maestro driver waits for the app to be idle before each interaction,
+  // and continuously playing video never lets the screen settle, so the e2e taps hang for minutes.
+  // The players still load and the flow seeks them to a fixed frame via "Prepare for e2e".
 };
 
 export default function VideoChangePlayerOutputScreen() {


### PR DESCRIPTION
# Why

The `ios-test-e2e` job was flaky and frequently timed out after 40 minutes on `expo-video/player-output-test.yaml` ([example run](https://github.com/expo/expo/actions/runs/27127745656/job/80087943937)).

`VideoChangePlayerOutputScreen` auto-plays two looping videos on mount. On iOS the Maestro driver waits for the app to be idle before each interaction, and continuously playing video never lets the screen settle, so the tap hangs.

# How

- Stopped auto-playing in the screen's `playerFactory`. The players still load to `readyToPlay`, and the flow already pauses + seeks them to a fixed frame via "Prepare for e2e", so playback isn't needed for the test or screenshots.
- Bumped the `Players ready` wait from 10s to 30s, since the players now buffer fresh instead of pre-warmed.

# Test Plan

Ran the flow locally on the CI device (iPhone 17 Pro)

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

# Screenshot

<img width="896" height="1096" src="https://github.com/user-attachments/assets/4ebf5676-0e47-4e4e-8e67-76a87701d9f7" />
