### PR TITLE
[expo-sqlite] Fix JNI crash on startup with libSQL session bindings

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a fatal JNI crash on Android when using `useLibSQL: true`, caused by the libSQL session bindings still declaring `byte[]` signatures after [#42638](https://github.com/expo/expo/pull/42638) switched Kotlin and the default native bindings to `ByteBuffer`. ([#46651](https://github.com/expo/expo/pull/46651) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-21

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.cpp
@@ -56,13 +56,13 @@ void NativeSessionBinding::sqlite3session_delete() {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
 }
 
-jni::local_ref<jni::JArrayByte>
+jni::local_ref<jni::JByteBuffer>
 NativeSessionBinding::sqlite3session_changeset() {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
   return nullptr;
 }
 
-jni::local_ref<jni::JArrayByte>
+jni::local_ref<jni::JByteBuffer>
 NativeSessionBinding::sqlite3session_changeset_inverted() {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
   return nullptr;
@@ -70,13 +70,13 @@ NativeSessionBinding::sqlite3session_changeset_inverted() {
 
 int NativeSessionBinding::sqlite3changeset_apply(
     jni::alias_ref<NativeDatabaseBinding::javaobject> db,
-    jni::alias_ref<jni::JArrayByte> changeset) {
+    jni::alias_ref<jni::JByteBuffer> changeset) {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
   return -1;
 }
 
-jni::local_ref<jni::JArrayByte> NativeSessionBinding::sqlite3changeset_invert(
-    jni::alias_ref<jni::JArrayByte> changeset) {
+jni::local_ref<jni::JByteBuffer> NativeSessionBinding::sqlite3changeset_invert(
+    jni::alias_ref<jni::JByteBuffer> changeset) {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
   return nullptr;
 }

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
+#include <fbjni/ByteBuffer.h>
 #include <string>
 
 #include "NativeDatabaseBinding.h"
@@ -25,13 +26,13 @@ public:
   int sqlite3session_attach(jni::alias_ref<jni::JString> tableName);
   int sqlite3session_enable(bool enabled);
   void sqlite3session_delete();
-  jni::local_ref<jni::JArrayByte> sqlite3session_changeset();
-  jni::local_ref<jni::JArrayByte> sqlite3session_changeset_inverted();
+  jni::local_ref<jni::JByteBuffer> sqlite3session_changeset();
+  jni::local_ref<jni::JByteBuffer> sqlite3session_changeset_inverted();
   int sqlite3changeset_apply(
       jni::alias_ref<NativeDatabaseBinding::javaobject> db,
-      jni::alias_ref<jni::JArrayByte> changeset);
-  jni::local_ref<jni::JArrayByte>
-  sqlite3changeset_invert(jni::alias_ref<jni::JArrayByte> changeset);
+      jni::alias_ref<jni::JByteBuffer> changeset);
+  jni::local_ref<jni::JByteBuffer>
+  sqlite3changeset_invert(jni::alias_ref<jni::JByteBuffer> changeset);
 
 private:
   explicit NativeSessionBinding(


### PR DESCRIPTION
# Why

Fixes [#46627](https://github.com/expo/expo/issues/46627). On Android, an app using `expo-sqlite` with `useLibSQL: true` crashes on launch with a fatal JNI `NoSuchMethodError` (regression from SDK 55).

# How

[#42638](https://github.com/expo/expo/pull/42638) switched the session changeset bindings from `byte[]` to `ByteBuffer`, but only updated the Kotlin and default native code - the libSQL variant (`cpp/libsql/NativeSessionBinding.{h,cpp}`) still used `jni::JArrayByte`. So in a libSQL build, fbjni tries to register `()[B` against the Kotlin `()Ljava/nio/ByteBuffer;` method, fails, and crashes on startup.

Updated the libSQL stubs to `jni::JByteBuffer` to match.

# Test Plan

Built an Android app with `useLibSQL: true` (the [repro](https://github.com/ifyajah/expo-sqlite-libsql-bug)). Before: crashes on launch. After: launches and `SQLiteProvider` initializes the libSQL database.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
