### PR TITLE
fix(expo-router): defer initial linking bookkeeping until mount

### DIFF
--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -88,6 +88,35 @@ function NavigationContainerInner(
   useImperativeApiEmitter(refContainer);
 
   const [lastUnhandledLink, setLastUnhandledLink] = React.useState<string | undefined>();
+  const pendingUnhandledLinkRef = React.useRef<string | undefined>(undefined);
+  const hasPendingUnhandledLinkRef = React.useRef(false);
+  const hasMountedRef = React.useRef(false);
+
+  // Initial linking can resolve while NavigationContainer is rendering.
+  // Queue that bookkeeping update until after mount to avoid a render-time state update.
+  const onUnhandledLinking = useLatestCallback((link: string | undefined) => {
+    if (hasMountedRef.current) {
+      setLastUnhandledLink(link);
+      return;
+    }
+
+    pendingUnhandledLinkRef.current = link;
+    hasPendingUnhandledLinkRef.current = true;
+  });
+
+  React.useEffect(() => {
+    hasMountedRef.current = true;
+
+    if (hasPendingUnhandledLinkRef.current) {
+      hasPendingUnhandledLinkRef.current = false;
+      setLastUnhandledLink(pendingUnhandledLinkRef.current);
+      pendingUnhandledLinkRef.current = undefined;
+    }
+
+    return () => {
+      hasMountedRef.current = false;
+    };
+  }, []);
 
   const { getInitialState } = useLinking(
     refContainer,
@@ -96,7 +125,7 @@ function NavigationContainerInner(
       prefixes: [],
       ...linking,
     },
-    setLastUnhandledLink
+    onUnhandledLinking
   );
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);

--- a/packages/expo-router/src/react-navigation/native/NavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/native/NavigationContainer.tsx
@@ -94,6 +94,35 @@ function NavigationContainerInner(
   useDocumentTitle(refContainer, documentTitle);
 
   const [lastUnhandledLink, setLastUnhandledLink] = React.useState<string | undefined>();
+  const pendingUnhandledLinkRef = React.useRef<string | undefined>(undefined);
+  const hasPendingUnhandledLinkRef = React.useRef(false);
+  const hasMountedRef = React.useRef(false);
+
+  // Initial linking can resolve while NavigationContainer is rendering.
+  // Queue that bookkeeping update until after mount to avoid a render-time state update.
+  const onUnhandledLinking = useLatestCallback((link: string | undefined) => {
+    if (hasMountedRef.current) {
+      setLastUnhandledLink(link);
+      return;
+    }
+
+    pendingUnhandledLinkRef.current = link;
+    hasPendingUnhandledLinkRef.current = true;
+  });
+
+  React.useEffect(() => {
+    hasMountedRef.current = true;
+
+    if (hasPendingUnhandledLinkRef.current) {
+      hasPendingUnhandledLinkRef.current = false;
+      setLastUnhandledLink(pendingUnhandledLinkRef.current);
+      pendingUnhandledLinkRef.current = undefined;
+    }
+
+    return () => {
+      hasMountedRef.current = false;
+    };
+  }, []);
 
   const { getInitialState } = useLinking(
     refContainer,
@@ -102,7 +131,7 @@ function NavigationContainerInner(
       prefixes: [],
       ...linking,
     },
-    setLastUnhandledLink
+    onUnhandledLinking
   );
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);

--- a/packages/expo-router/src/react-navigation/native/__tests__/NavigationContainerInitialLinking.test.android.tsx
+++ b/packages/expo-router/src/react-navigation/native/__tests__/NavigationContainerInitialLinking.test.android.tsx
@@ -1,0 +1,40 @@
+import { afterEach, expect, jest, test } from '@jest/globals';
+import { act, render } from '@testing-library/react-native';
+import * as React from 'react';
+import { Text } from 'react-native';
+
+import { NavigationContainer } from '../../../fork/NavigationContainer';
+import { createStackNavigator } from '../__stubs__/createStackNavigator';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('does not update unhandled linking state during initial render', async () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const Stack = createStackNavigator<{ Home: undefined }>();
+
+  const linking = {
+    prefixes: ['example://'],
+    config: {
+      screens: {
+        Home: 'home',
+      },
+    },
+    getInitialURL: () => Promise.resolve('example://home'),
+  };
+
+  await act(async () => {
+    render(
+      <NavigationContainer linking={linking}>
+        <Stack.Navigator>
+          <Stack.Screen name="Home">{() => <Text>Home</Text>}</Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  });
+
+  expect(consoleError.mock.calls.flat().join("\n")).not.toContain(
+    "state update on a component that hasn't mounted"
+  );
+});

--- a/packages/expo-router/src/react-navigation/native/__tests__/NavigationContainerInitialLinking.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native/__tests__/NavigationContainerInitialLinking.test.ios.tsx
@@ -1,0 +1,40 @@
+import { afterEach, expect, jest, test } from '@jest/globals';
+import { act, render } from '@testing-library/react-native';
+import * as React from 'react';
+import { Text } from 'react-native';
+
+import { NavigationContainer } from '../../../fork/NavigationContainer';
+import { createStackNavigator } from '../__stubs__/createStackNavigator';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('does not update unhandled linking state during initial render', async () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const Stack = createStackNavigator<{ Home: undefined }>();
+
+  const linking = {
+    prefixes: ['example://'],
+    config: {
+      screens: {
+        Home: 'home',
+      },
+    },
+    getInitialURL: () => Promise.resolve('example://home'),
+  };
+
+  await act(async () => {
+    render(
+      <NavigationContainer linking={linking}>
+        <Stack.Navigator>
+          <Stack.Screen name="Home">{() => <Text>Home</Text>}</Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  });
+
+  expect(consoleError.mock.calls.flat().join("\n")).not.toContain(
+    "state update on a component that hasn't mounted"
+  );
+});


### PR DESCRIPTION
# Why

Native initial linking can resolve while `NavigationContainer` is still rendering initial navigation state.

`useLinking` reports handled/unhandled link bookkeeping through `onUnhandledLinking`. `NavigationContainer` previously passed `setLastUnhandledLink` directly as that callback, so initial URL resolution could trigger a React state update before `NavigationContainer` had mounted.

React warns in this case:

> Can't perform a React state update on a component that hasn't mounted yet.


# How

Instead of passing `setLastUnhandledLink` directly to `useLinking`, `NavigationContainer` now wraps the callback:

- before mount, store the unhandled link value in refs
- after mount, flush any pending value in an effect
- after mount, update `lastUnhandledLink` immediately as before

This preserves the existing linking bookkeeping behavior while avoiding a render-time state update.



# Test Plan
Added native platform regression coverage for both:

- `NavigationContainerInitialLinking.test.ios.tsx`
- `NavigationContainerInitialLinking.test.android.tsx`

These tests verify that resolving an initial link does not log the React warning about updating state on a component that has not mounted.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
