### PR TITLE
[docs] Update latest image tag

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -89,7 +89,7 @@ You can replace the worker default by setting `GRADLE_OPTS` under a build profil
 
 ### Android server images
 
-#### <CopyTextButton>`ubuntu-26.04-jdk-17-ndk-r27b` (`sdk-56`)</CopyTextButton>
+#### <CopyTextButton>`ubuntu-26.04-jdk-17-ndk-r27b` (`latest`, `sdk-56`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -106,7 +106,7 @@ You can replace the worker default by setting `GRADLE_OPTS` under a build profil
 
 </Collapsible>
 
-#### <CopyTextButton>`ubuntu-24.04-jdk-17-ndk-r27b-sdk-55` (`latest`, `sdk-55`)</CopyTextButton>
+#### <CopyTextButton>`ubuntu-24.04-jdk-17-ndk-r27b-sdk-55` (`sdk-55`)</CopyTextButton>
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -359,7 +359,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### <CopyTextButton>`macos-tahoe-26.4-xcode-26.4` (`sdk-56`)</CopyTextButton>
+#### <CopyTextButton>`macos-tahoe-26.4-xcode-26.4` (`latest`, `sdk-56`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -378,7 +378,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### <CopyTextButton>`macos-sequoia-15.6-xcode-26.2` (`latest`, `sdk-55`)</CopyTextButton>
+#### <CopyTextButton>`macos-sequoia-15.6-xcode-26.2` (`sdk-55`)</CopyTextButton>
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

The `latest` iOS image is now the SDK 56 one.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Move the tag up to `56`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

👀 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
