### PR TITLE
[create-expo] generate Claude files only when installed

### DIFF
--- a/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
+++ b/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
@@ -108,13 +108,4 @@ describe(generateAgentFiles, () => {
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
-
-  it('generates Claude files when project .claude directory exists', () => {
-    fs.mkdirSync(path.join(tmpDir, '.claude'));
-
-    generateAgentFiles(tmpDir);
-
-    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
-  });
 });

--- a/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
+++ b/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
@@ -6,9 +6,12 @@ import { generateAgentFiles } from '../generateAgentFiles';
 
 describe(generateAgentFiles, () => {
   let tmpDir: string;
+  let homeDir: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-test-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-home-'));
+    jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
     // Write a minimal package.json so the SDK version can be resolved
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
@@ -18,14 +21,21 @@ describe(generateAgentFiles, () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
   });
 
-  it('generates all three files when none exist', () => {
+  it('always generates AGENTS.md', () => {
     generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('does not generate Claude files when Claude Code is not installed', () => {
+    generateAgentFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(false);
   });
 
   it('writes correct content to AGENTS.md with versioned docs URL', () => {
@@ -47,6 +57,8 @@ describe(generateAgentFiles, () => {
   });
 
   it('writes correct content to CLAUDE.md', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     generateAgentFiles(tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
@@ -54,6 +66,8 @@ describe(generateAgentFiles, () => {
   });
 
   it('writes correct content to .claude/settings.json', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     generateAgentFiles(tmpDir);
 
     const content = JSON.parse(
@@ -63,6 +77,7 @@ describe(generateAgentFiles, () => {
   });
 
   it('skips files that already exist', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
     fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), 'custom content');
     fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), 'custom claude');
 
@@ -74,12 +89,32 @@ describe(generateAgentFiles, () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
 
-  it('creates .claude/ directory when it does not exist', () => {
+  it('creates .claude/ directory for settings when global .claude.json exists', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
 
     generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
     expect(fs.statSync(path.join(tmpDir, '.claude')).isDirectory()).toBe(true);
+  });
+
+  it('generates Claude files when global .claude directory exists', () => {
+    fs.mkdirSync(path.join(homeDir, '.claude'));
+
+    generateAgentFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('generates Claude files when project .claude directory exists', () => {
+    fs.mkdirSync(path.join(tmpDir, '.claude'));
+
+    generateAgentFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
 });

--- a/packages/create-expo/src/generateAgentFiles.ts
+++ b/packages/create-expo/src/generateAgentFiles.ts
@@ -34,12 +34,11 @@ const CLAUDE_SETTINGS_CONTENT = `{
 }
 `;
 
-function isClaudeCodeInstalled(root: string): boolean {
+function isClaudeCodeInstalled(): boolean {
   const home = os.homedir();
   return (
-    fs.existsSync(path.join(root, '.claude')) ||
-    (!!home &&
-      (fs.existsSync(path.join(home, '.claude.json')) || fs.existsSync(path.join(home, '.claude'))))
+    !!home &&
+    (fs.existsSync(path.join(home, '.claude.json')) || fs.existsSync(path.join(home, '.claude')))
   );
 }
 
@@ -50,7 +49,7 @@ export function generateAgentFiles(root: string): void {
     { filePath: path.join(root, 'AGENTS.md'), content: getAgentsMdContent(sdkVersion) },
   ];
 
-  if (isClaudeCodeInstalled(root)) {
+  if (isClaudeCodeInstalled()) {
     files.push(
       { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
       { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT }

--- a/packages/create-expo/src/generateAgentFiles.ts
+++ b/packages/create-expo/src/generateAgentFiles.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 function getExpoSdkVersion(root: string): string | null {
@@ -33,14 +34,28 @@ const CLAUDE_SETTINGS_CONTENT = `{
 }
 `;
 
+function isClaudeCodeInstalled(root: string): boolean {
+  const home = os.homedir();
+  return (
+    fs.existsSync(path.join(root, '.claude')) ||
+    (!!home &&
+      (fs.existsSync(path.join(home, '.claude.json')) || fs.existsSync(path.join(home, '.claude'))))
+  );
+}
+
 export function generateAgentFiles(root: string): void {
   const sdkVersion = getExpoSdkVersion(root);
 
   const files: { filePath: string; content: string }[] = [
     { filePath: path.join(root, 'AGENTS.md'), content: getAgentsMdContent(sdkVersion) },
-    { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
-    { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT },
   ];
+
+  if (isClaudeCodeInstalled(root)) {
+    files.push(
+      { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
+      { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT }
+    );
+  }
 
   for (const { filePath, content } of files) {
     if (fs.existsSync(filePath)) {


### PR DESCRIPTION
## Summary
- always generate `AGENTS.md` for create-expo projects
- generate `CLAUDE.md` and `.claude/settings.json` only when Claude Code is detected
- cover global and project Claude Code detection signals in tests

## Test plan
- run `create-expo-app` without global Claude Code configuration -> verify the `CLAUDE.md` and `.claude/settings.json` is not included in the newly created app