### PR TITLE
[expo-router] Add missing config plugin options to Props type

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others

--- a/packages/expo-router/plugin/build/withRouter.d.ts
+++ b/packages/expo-router/plugin/build/withRouter.d.ts
@@ -1,31 +1,59 @@
 import { ConfigPlugin } from 'expo/config-plugins';
+type AsyncRouteOption = 'development' | 'production' | boolean;
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD';
+type RedirectConfig = {
+    /** The previous file path that this route should redirect from */
+    source: string;
+    /** The target file path that this route should redirect to */
+    destination: string;
+    /** Whether the redirect is temporary or permanent. Defaults to `false`. */
+    permanent?: boolean;
+    /** HTTP methods that should be redirected. Omit to redirect all methods. */
+    methods?: HttpMethod[];
+};
+type RewriteConfig = {
+    /** The previous file path that should be rewritten */
+    source: string;
+    /** The target file path that this route should rewrite */
+    destination: string;
+    /** HTTP methods that should be rewritten. Omit to rewrite all methods. */
+    methods?: HttpMethod[];
+};
 export type Props = {
     /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
-    origin?: string;
+    origin?: string | boolean;
     /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
     headOrigin?: string;
-    /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
+    /** Changes the routes directory from `app` to another value. Defaults to `app`. Avoid using this property. */
     root?: string;
-    /** Should Async Routes be enabled, currently only `development` is supported. */
-    asyncRoutes?: string | {
-        android?: string;
-        ios?: string;
-        web?: string;
-        default?: string;
-    };
-    /** Should the sitemap be generated. Defaults to `true` */
+    /** Enable or disable platform-specific routes. Defaults to `true`. */
+    platformRoutes?: boolean;
+    /** Enable or disable automatically generated routes. Defaults to `true`. */
     sitemap?: boolean;
-    /** Generate partial typed routes */
-    partialTypedGroups?: boolean;
+    /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
+    asyncRoutes?: AsyncRouteOption | {
+        android?: AsyncRouteOption;
+        ios?: AsyncRouteOption;
+        web?: AsyncRouteOption;
+        default?: AsyncRouteOption;
+    };
+    /** Enable or disable partial route type generation. Defaults to `true`. */
+    partialRouteTypes?: boolean;
+    /** Enable static redirects. Defaults to `true`. */
+    redirects?: RedirectConfig[];
+    /** Enable static rewrites */
+    rewrites?: RewriteConfig[];
     /** A list of headers that are set on every route response from the server */
     headers?: Record<string, string | string[]>;
     /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */
     unstable_useServerMiddleware?: boolean;
-    /** Enable experimental data loader support. Requires `web.output: 'static'` to be set in app config. */
+    /** Enable experimental data loader support. This is only supported for `web.output: 'static'` outputs at the moment. */
     unstable_useServerDataLoaders?: boolean;
     /** Enable experimental server-side rendering. When enabled with `web.output: 'server'`, HTML is rendered at request time instead of being pre-rendered at build time. */
     unstable_useServerRendering?: boolean;
-    /** Enable automatic app rerender on color scheme changes. Defaults to `true`. */
+    /** Disable synchronous layout updates for native screens. */
+    disableSynchronousScreensUpdates?: boolean;
+    /** Rerender the app on color scheme changes. When enabled, the app tree will rerender when the system theme changes (light/dark mode). Defaults to `true`. */
     adaptiveColors?: boolean;
 };
 declare const withRouter: ConfigPlugin<Props | void>;

--- a/packages/expo-router/plugin/build/withRouter.d.ts
+++ b/packages/expo-router/plugin/build/withRouter.d.ts
@@ -47,7 +47,7 @@ export type Props = {
     headers?: Record<string, string | string[]>;
     /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */
     unstable_useServerMiddleware?: boolean;
-    /** Enable experimental data loader support. This is only supported for `web.output: 'static'` outputs at the moment. */
+    /** Enable experimental data loader support. Requires `web.output: 'static' | 'server'` to be set in app config. */
     unstable_useServerDataLoaders?: boolean;
     /** Enable experimental server-side rendering. When enabled with `web.output: 'server'`, HTML is rendered at request time instead of being pre-rendered at build time. */
     unstable_useServerRendering?: boolean;

--- a/packages/expo-router/plugin/options.json
+++ b/packages/expo-router/plugin/options.json
@@ -159,7 +159,7 @@
           "default": false
         },
         "unstable_useServerDataLoaders": {
-          "description": "Enable experimental data loader support. This is only supported for `web.output: 'static'` outputs at the moment.",
+          "description": "Enable experimental data loader support. Requires `web.output: 'static' | 'server'` to be set in app config.",
           "type": "boolean",
           "default": false
         },

--- a/packages/expo-router/plugin/src/withRouter.ts
+++ b/packages/expo-router/plugin/src/withRouter.ts
@@ -32,28 +32,67 @@ const withGammaScreens: ConfigPlugin = (config) => {
   });
 };
 
+type AsyncRouteOption = 'development' | 'production' | boolean;
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD';
+
+type RedirectConfig = {
+  /** The previous file path that this route should redirect from */
+  source: string;
+  /** The target file path that this route should redirect to */
+  destination: string;
+  /** Whether the redirect is temporary or permanent. Defaults to `false`. */
+  permanent?: boolean;
+  /** HTTP methods that should be redirected. Omit to redirect all methods. */
+  methods?: HttpMethod[];
+};
+
+type RewriteConfig = {
+  /** The previous file path that should be rewritten */
+  source: string;
+  /** The target file path that this route should rewrite */
+  destination: string;
+  /** HTTP methods that should be rewritten. Omit to rewrite all methods. */
+  methods?: HttpMethod[];
+};
+
 export type Props = {
   /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
-  origin?: string;
+  origin?: string | boolean;
   /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
   headOrigin?: string;
-  /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
+  /** Changes the routes directory from `app` to another value. Defaults to `app`. Avoid using this property. */
   root?: string;
-  /** Should Async Routes be enabled, currently only `development` is supported. */
-  asyncRoutes?: string | { android?: string; ios?: string; web?: string; default?: string };
-  /** Should the sitemap be generated. Defaults to `true` */
+  /** Enable or disable platform-specific routes. Defaults to `true`. */
+  platformRoutes?: boolean;
+  /** Enable or disable automatically generated routes. Defaults to `true`. */
   sitemap?: boolean;
-  /** Generate partial typed routes */
-  partialTypedGroups?: boolean;
+  /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
+  asyncRoutes?:
+    | AsyncRouteOption
+    | {
+        android?: AsyncRouteOption;
+        ios?: AsyncRouteOption;
+        web?: AsyncRouteOption;
+        default?: AsyncRouteOption;
+      };
+  /** Enable or disable partial route type generation. Defaults to `true`. */
+  partialRouteTypes?: boolean;
+  /** Enable static redirects. Defaults to `true`. */
+  redirects?: RedirectConfig[];
+  /** Enable static rewrites */
+  rewrites?: RewriteConfig[];
   /** A list of headers that are set on every route response from the server */
   headers?: Record<string, string | string[]>;
   /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */
   unstable_useServerMiddleware?: boolean;
-  /** Enable experimental data loader support. Requires `web.output: 'static'` to be set in app config. */
+  /** Enable experimental data loader support. This is only supported for `web.output: 'static'` outputs at the moment. */
   unstable_useServerDataLoaders?: boolean;
   /** Enable experimental server-side rendering. When enabled with `web.output: 'server'`, HTML is rendered at request time instead of being pre-rendered at build time. */
   unstable_useServerRendering?: boolean;
-  /** Enable automatic app rerender on color scheme changes. Defaults to `true`. */
+  /** Disable synchronous layout updates for native screens. */
+  disableSynchronousScreensUpdates?: boolean;
+  /** Rerender the app on color scheme changes. When enabled, the app tree will rerender when the system theme changes (light/dark mode). Defaults to `true`. */
   adaptiveColors?: boolean;
 };
 

--- a/packages/expo-router/plugin/src/withRouter.ts
+++ b/packages/expo-router/plugin/src/withRouter.ts
@@ -86,7 +86,7 @@ export type Props = {
   headers?: Record<string, string | string[]>;
   /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */
   unstable_useServerMiddleware?: boolean;
-  /** Enable experimental data loader support. This is only supported for `web.output: 'static'` outputs at the moment. */
+  /** Enable experimental data loader support. Requires `web.output: 'static' | 'server'` to be set in app config. */
   unstable_useServerDataLoaders?: boolean;
   /** Enable experimental server-side rendering. When enabled with `web.output: 'server'`, HTML is rendered at request time instead of being pre-rendered at build time. */
   unstable_useServerRendering?: boolean;


### PR DESCRIPTION
# Why

Fixes #46574. Supersedes #46576.

The config plugin `Props` type had drifted from `plugin/options.json`, the schema that `validate` actually enforces at runtime.

# How

Synced the `Props` type with the options schema:

- Added the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options.
- Renamed `partialTypedGroups` to `partialRouteTypes` to match the schema (the old name was never accepted by `validate`).
- Fixed `origin` to accept `string | boolean` and tightened `asyncRoutes` to the documented values.

# Test Plan

Type-checked the plugin against the schema:

```
tsc --noEmit -p ./tsconfig.json
```

A config that previously errored now type-checks:

```ts
withRouter(config, {
  redirects: [{ source: '/old', destination: '/new', permanent: true }],
});
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
