### PR TITLE
Send an empty body instead of a null byte for body-less POST/PUT/PATCH

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
@@ -6,15 +6,30 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
 import okhttp3.Call
 import okhttp3.CookieJar
+import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 
 private data class RequestHolder(var request: Request?)
 
 internal val METHODS_REQUIRING_BODY = arrayOf("POST", "PUT", "PATCH")
+
+internal fun buildRequestBody(method: String, requestBody: ByteArray?, mediaType: MediaType?): RequestBody? {
+  return requestBody?.toRequestBody(mediaType) ?: run {
+    // OkHttp requires a non-null body for POST/PATCH/PUT, unlike WinterTC fetch. Provide an empty
+    // (zero-length) body to match it, not `byteArrayOf(0)`, which sends a single 0x00 byte.
+    // Ref: https://github.com/expo/expo/issues/46668
+    if (method in METHODS_REQUIRING_BODY) {
+      ByteArray(0).toRequestBody(mediaType)
+    } else {
+      null
+    }
+  }
+}
 
 internal class NativeRequest(appContext: AppContext, internal val response: NativeResponse) :
   SharedObject(appContext) {
@@ -36,17 +51,7 @@ internal class NativeRequest(appContext: AppContext, internal val response: Nati
 
     val headers = requestInit.headers.toHeaders()
     val mediaType = headers["Content-Type"]?.toMediaTypeOrNull()
-    val reqBody = requestBody?.toRequestBody(mediaType) ?: run {
-      // OkHttp requires a non-null body for POST, PATCH, and PUT requests.
-      // WinterTC fetch, however, does not have this limitation.
-      // Provide an empty body to make OkHttp behave like WinterTC fetch.
-      // Ref: https://github.com/expo/expo/issues/35950#issuecomment-3245173248
-      if (requestInit.method in METHODS_REQUIRING_BODY) {
-        byteArrayOf(0).toRequestBody(mediaType)
-      } else {
-        null
-      }
-    }
+    val reqBody = buildRequestBody(requestInit.method, requestBody, mediaType)
     val request = Request.Builder()
       .headers(headers)
       .method(requestInit.method, reqBody)

--- a/packages/expo/android/src/test/java/expo/modules/fetch/NativeRequestTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/fetch/NativeRequestTest.kt
@@ -1,0 +1,33 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.fetch
+
+import com.google.common.truth.Truth.assertThat
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import org.junit.Test
+
+class NativeRequestTest {
+  private val jsonMediaType = "application/json".toMediaTypeOrNull()
+
+  @Test
+  fun `null body on a method requiring a body produces an empty body, not a null byte`() {
+    val body = buildRequestBody("POST", null, jsonMediaType)
+    assertThat(body).isNotNull()
+    // Regression test for https://github.com/expo/expo/issues/46668:
+    // OkHttp requires a non-null body for POST/PUT/PATCH, but the body must be
+    // empty (Content-Length: 0) rather than a single 0x00 byte (Content-Length: 1).
+    assertThat(body!!.contentLength()).isEqualTo(0L)
+  }
+
+  @Test
+  fun `null body on a method not requiring a body produces no body`() {
+    assertThat(buildRequestBody("GET", null, jsonMediaType)).isNull()
+  }
+
+  @Test
+  fun `a provided body is preserved`() {
+    val body = buildRequestBody("POST", "hello".toByteArray(), jsonMediaType)
+    assertThat(body).isNotNull()
+    assertThat(body!!.contentLength()).isEqualTo(5L)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #46668.

On Android, a body-less `POST`/`PUT`/`PATCH` via `expo/fetch` sent a single `0x00` byte (`Content-Length: 1`) instead of an empty body. Backends that parse the body as JSON (Express `body-parser`, NestJS, etc.) reject it with a 400, so every body-less request broke. iOS and Web are unaffected.

# How

OkHttp requires a non-null body for those methods, so #39363 added a placeholder, but it used `byteArrayOf(0)` (one null byte) instead of an empty array. Switched it to `ByteArray(0)` so the request sends a real empty body (`Content-Length: 0`).

Pulled the body building into a `buildRequestBody` helper so it can be unit tested.

# Test Plan

Added `NativeRequestTest` covering the empty body, no-body, and provided-body cases:

```
cd apps/bare-expo/android
CI=true ./gradlew :expo:testDebugUnitTest --tests "expo.modules.fetch.NativeRequestTest"
```

```
tests="3" skipped="0" failures="0" errors="0"
```

Also confirmed against the repro: a body-less `POST https://httpbin.org/post` now reports `Content-Length: "0"` and empty `data`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
