### PR TITLE
[expo-video] Recover failed players to fix broken playback placeholder

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -66,8 +66,7 @@ class VideoManager {
 
   func onAppForegrounded() {
     // While the app is backgrounded iOS can release the decode pipeline, leaving items in a
-    // `.failed` state once we come back. Reload only the failed players so the broken-playback
-    // placeholder is replaced with the recovered video, without disrupting healthy players.
+    // `.failed` state once we come back.
     reloadPlayers { $0.reloadIfFailed() }
   }
 

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -11,11 +11,31 @@ class VideoManager {
   static var shared = VideoManager()
 
   private static var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
+  private var mediaServicesResetObserver: NSObjectProtocol?
   private var videoViews = NSHashTable<VideoView>.weakObjects()
   private var videoPlayers = NSHashTable<VideoPlayer>.weakObjects()
 
   var hasRegisteredPlayers: Bool {
     return !videoPlayers.allObjects.isEmpty
+  }
+
+  private init() {
+    // When the system resets media services all audio/video objects become invalid. We have to
+    // re-establish the audio session and rebuild every player's item, otherwise they stay in a
+    // failed state and `AVPlayerViewController` keeps showing its broken-playback placeholder.
+    mediaServicesResetObserver = NotificationCenter.default.addObserver(
+      forName: AVAudioSession.mediaServicesWereResetNotification,
+      object: nil,
+      queue: nil
+    ) { [weak self] _ in
+      self?.onMediaServicesWereReset()
+    }
+  }
+
+  deinit {
+    if let mediaServicesResetObserver {
+      NotificationCenter.default.removeObserver(mediaServicesResetObserver)
+    }
   }
 
   func register(videoPlayer: VideoPlayer) {
@@ -44,7 +64,33 @@ class VideoManager {
     videoViews.remove(videoView)
   }
 
-  func onAppForegrounded() {}
+  func onAppForegrounded() {
+    // While the app is backgrounded iOS can release the decode pipeline, leaving items in a
+    // `.failed` state once we come back. Reload only the failed players so the broken-playback
+    // placeholder is replaced with the recovered video, without disrupting healthy players.
+    reloadPlayers { $0.reloadIfFailed() }
+  }
+
+  private func onMediaServicesWereReset() {
+    setAppropriateAudioSessionOrWarn()
+    reloadPlayers { $0.reloadCurrentSource() }
+  }
+
+  private func reloadPlayers(_ reload: @escaping (VideoPlayer) -> Void) {
+    Self.managerQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+
+      let players = self.videoPlayers.allObjects
+
+      DispatchQueue.main.async {
+        for player in players {
+          reload(player)
+        }
+      }
+    }
+  }
 
   func onAppBackgrounded() {
     for videoView in videoViews.allObjects {

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -286,7 +286,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         return
       }
 
-      if resumeTime.isFinite && resumeTime > 0 {
+      if resumeTime > 0 {
         self.dangerousPropertiesStore.currentTime = resumeTime
       }
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -270,6 +270,56 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     }
   }
 
+  /**
+   * Reloads the current source on the existing `AVPlayer`, preserving the playhead and play state.
+   * iOS can tear down the decode pipeline while the app is backgrounded or when the system resets
+   * media services, leaving the `AVPlayerItem` in a `.failed` state. A failed item makes
+   * `AVPlayerViewController` render its broken-playback placeholder, so we rebuild the item to recover.
+   */
+  func reloadCurrentSource() {
+    guard let videoSource = (ref.currentItem as? VideoPlayerItem)?.videoSource else {
+      return
+    }
+
+    let resumeTime = ref.currentTime().seconds
+    let wasPlaying = isPlaying
+
+    Task { [weak self] in
+      guard let self else {
+        return
+      }
+
+      // `replaceCurrentItem` re-applies the stored `currentTime` once the new item finishes loading.
+      if resumeTime.isFinite && resumeTime > 0 {
+        self.dangerousPropertiesStore.currentTime = resumeTime
+      }
+
+      do {
+        try await self.replaceCurrentItem(with: videoSource)
+      } catch {
+        log.warn("[expo-video] Failed to reload the video source while recovering a failed player: \(error.localizedDescription)")
+        return
+      }
+
+      if wasPlaying {
+        await MainActor.run {
+          self.ref.play()
+        }
+      }
+    }
+  }
+
+  /**
+   * Reloads the current source only when the player or its current item have entered the `.failed`
+   * state. Used on app foreground to clear the broken-playback placeholder without disrupting
+   * players that are still healthy.
+   */
+  func reloadIfFailed() {
+    if ref.status == .failed || ref.currentItem?.status == .failed {
+      reloadCurrentSource()
+    }
+  }
+
   private func clearCurrentItem() {
     videoSourceLoader.cancelCurrentTask()
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -278,7 +278,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       return
     }
 
-    let resumeTime = ref.currentTime().seconds
+    let resumeTime = currentTime
     let wasPlaying = isPlaying
 
     Task { [weak self] in

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -272,9 +272,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   /**
    * Reloads the current source on the existing `AVPlayer`, preserving the playhead and play state.
-   * iOS can tear down the decode pipeline while the app is backgrounded or when the system resets
-   * media services, leaving the `AVPlayerItem` in a `.failed` state. A failed item makes
-   * `AVPlayerViewController` render its broken-playback placeholder, so we rebuild the item to recover.
    */
   func reloadCurrentSource() {
     guard let videoSource = (ref.currentItem as? VideoPlayerItem)?.videoSource else {

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -305,11 +305,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     }
   }
 
-  /**
-   * Reloads the current source only when the player or its current item have entered the `.failed`
-   * state. Used on app foreground to clear the broken-playback placeholder without disrupting
-   * players that are still healthy.
-   */
   func reloadIfFailed() {
     if ref.status == .failed || ref.currentItem?.status == .failed {
       reloadCurrentSource()

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -286,7 +286,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         return
       }
 
-      // `replaceCurrentItem` re-applies the stored `currentTime` once the new item finishes loading.
       if resumeTime.isFinite && resumeTime > 0 {
         self.dangerousPropertiesStore.currentTime = resumeTime
       }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/46553

On iOS, players could get stuck in a `.failed` state after the app was backgrounded or the system reset media services. `AVPlayerViewController` then shows its broken-playback placeholder over a video that should still work.

# How

`VideoManager` now listens for `mediaServicesWereResetNotification` and reloads every player's source after re-establishing the audio session. On app foreground it reloads only the players whose `AVPlayer` or current item is `.failed`, so healthy players are left untouched.

`VideoPlayer.reloadCurrentSource()` rebuilds the current item on the existing `AVPlayer`, keeping the playhead and play state. `reloadIfFailed()` does it only when the player has actually failed.

# Test Plan

Tested on a physical device: play a video, lock the device or trigger a media services reset, then return to the app. Before the fix the broken-playback placeholder stayed up; after it the video recovers and resumes where it left off.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
