### PR TITLE
[expo] Add `Wenszel` to `expo-calendar`

### DIFF
--- a/.github/codemention.yml
+++ b/.github/codemention.yml
@@ -83,7 +83,7 @@ rules:
   - patterns: ['packages/expo-build-properties/**']
     mentions: ['Kudo', 'gabrieldonadel']
   - patterns: ['packages/expo-calendar/**']
-    mentions: ['jakex7', 'alanjhughes']
+    mentions: ['Wenszel', 'alanjhughes']
   - patterns: ['packages/expo-camera/**']
     mentions: ['lukmccall', 'alanjhughes']
   - patterns: ['packages/expo-cellular/**']


### PR DESCRIPTION
# Why

Adds `Wenszel` to `expo-calendar` and removes me.