### PR TITLE
[core][android] Fix `canAskAgain` from `getPermissionsAsync` reliability

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -27,6 +27,13 @@ const Stack = createNativeStackNavigator();
 export const ScreensList: ScreenConfig[] = [
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/CameraPermissions/CameraPermissionsScreen'));
+    },
+    name: 'CameraPermissions',
+    options: { title: 'Camera Permissions' },
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/ModulesCore/ModulesCoreScreen'));
     },
     name: 'ModulesCore',

--- a/apps/native-component-list/src/screens/CameraPermissions/CameraPermissionsScreen.tsx
+++ b/apps/native-component-list/src/screens/CameraPermissions/CameraPermissionsScreen.tsx
@@ -1,0 +1,102 @@
+import { Camera, type PermissionResponse } from 'expo-camera';
+import * as React from 'react';
+import { AppState, Button, Linking, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Manual harness for the Android `canAskAgain` fix (expo/expo#36883, #23805, #44180).
+ *
+ * Reach the "Ask every time" state and watch `canAskAgain`:
+ *   1. Tap "Request" and choose "Only this time", then revoke from the notification or wait for the OS to revoke it.
+ *   2. Or revoke from a terminal: `adb shell pm revoke dev.expo.payments android.permission.CAMERA`.
+ *   3. Return to the app — the readout refreshes on resume.
+ *
+ * Before the fix `canAskAgain` reads `false` in that state; after the fix it reads `true`.
+ */
+export default function CameraPermissionsScreen() {
+  const [response, setResponse] = React.useState<PermissionResponse | null>(null);
+
+  const check = React.useCallback(async () => {
+    setResponse(await Camera.getCameraPermissionsAsync());
+  }, []);
+
+  const request = React.useCallback(async () => {
+    setResponse(await Camera.requestCameraPermissionsAsync());
+  }, []);
+
+  React.useEffect(() => {
+    check();
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        check();
+      }
+    });
+    return () => subscription.remove();
+  }, [check]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.label}>getCameraPermissionsAsync()</Text>
+      <View style={styles.readout}>
+        <Text style={styles.json}>{JSON.stringify(response, null, 2)}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.field}>status</Text>
+        <Text style={styles.value}>{response?.status ?? '—'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.field}>granted</Text>
+        <Text style={styles.value}>{String(response?.granted ?? '—')}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.field}>canAskAgain</Text>
+        <Text style={styles.value}>{String(response?.canAskAgain ?? '—')}</Text>
+      </View>
+      <View style={styles.buttons}>
+        <Button title="Get (check)" onPress={check} />
+        <Button title="Request (ask)" onPress={request} />
+        <Button title="Open Settings" onPress={() => Linking.openSettings()} />
+      </View>
+    </ScrollView>
+  );
+}
+
+CameraPermissionsScreen.navigationOptions = {
+  title: 'Camera Permissions',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  readout: {
+    backgroundColor: '#11181c',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  json: {
+    color: '#7ee787',
+    fontFamily: 'Courier',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+  },
+  field: {
+    fontWeight: '600',
+  },
+  value: {
+    fontFamily: 'Courier',
+  },
+  buttons: {
+    marginTop: 24,
+    gap: 12,
+  },
+});

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure. ([#46571](https://github.com/expo/expo/pull/46571) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Fix `canAskAgain` returning `false` for re-requestable permissions in the "Ask every time" state.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure. ([#46571](https://github.com/expo/expo/pull/46571) by [@chrfalch](https://github.com/chrfalch))
-- [Android] Fix `canAskAgain` returning `false` for re-requestable permissions in the "Ask every time" state.
+- [Android] Fix `canAskAgain` returning `false` for re-requestable permissions in the "Ask every time" state. ([#46683](https://github.com/expo/expo/pull/46683) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -27,6 +27,7 @@ import java.util.Queue
 
 private const val PERMISSIONS_REQUEST: Int = 13
 private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
+private const val BLOCKED_PERMISSION_KEY_PREFIX = "blocked:"
 
 open class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
   private var mActivityProvider: ActivityProvider? = null
@@ -48,6 +49,42 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
       permissions.forEach { putBoolean(it, true) }
     }
   }
+
+  /**
+   * Android can't tell a permanently denied permission apart from a re-askable one ("Ask every time", or a revoked
+   * one-time grant) at query time, so we record it ourselves.
+   */
+  private fun isBlocked(permission: String): Boolean =
+    mAskedPermissionsCache.getBoolean(blockedPermissionKey(permission), false)
+
+  private fun setBlocked(permission: String, blocked: Boolean) {
+    mAskedPermissionsCache.edit(commit = true) {
+      putBoolean(blockedPermissionKey(permission), blocked)
+    }
+  }
+
+  private fun blockedPermissionKey(permission: String): String = "$BLOCKED_PERMISSION_KEY_PREFIX$permission"
+
+  /**
+   * Record whether each permission became permanently denied. A denied result with no rationale to show means the user blocked it.
+   * Anything else clears the flag. This is the only time the denied states are distinguishable,
+   * so we persist the result for later ``getPermissions` calls.
+   */
+  private fun withBlockedTracking(listener: PermissionsResponseListener): PermissionsResponseListener =
+    PermissionsResponseListener { result ->
+      listener.onResult(
+        result.mapValues { (permission, response) ->
+          if (response.status == PermissionsStatus.DENIED) {
+            val blocked = !shouldShowRequestPermissionRationale(permission)
+            setBlocked(permission, blocked)
+            PermissionsResponse(response.status, !blocked)
+          } else {
+            setBlocked(permission, false)
+            response
+          }
+        }
+      )
+    }
 
   override fun getExportedInterfaces(): List<Class<out Any>> = listOf(Permissions::class.java)
 
@@ -155,10 +192,10 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
           newListener.onResult(mutableMapOf())
           return
         }
-        askForManifestPermissions(permissionsToAsk, newListener)
+        askForManifestPermissions(permissionsToAsk, withBlockedTracking(newListener))
       }
     } else {
-      askForManifestPermissions(permissions, responseListener)
+      askForManifestPermissions(permissions, withBlockedTracking(responseListener))
     }
   }
 
@@ -213,7 +250,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     return ContextCompat.checkSelfPermission(context, permission)
   }
 
-  private fun canAskAgain(permission: String): Boolean {
+  protected open fun shouldShowRequestPermissionRationale(permission: String): Boolean {
     return mActivityProvider?.currentActivity?.let {
       ActivityCompat.shouldShowRequestPermissionRationale(it, permission)
     } == true
@@ -236,7 +273,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     return PermissionsResponse(
       status,
       if (status == PermissionsStatus.DENIED) {
-        canAskAgain(permission)
+        !isBlocked(permission)
       } else {
         true
       }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/adapters/react/permissions/PermissionsServiceTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/adapters/react/permissions/PermissionsServiceTest.kt
@@ -1,0 +1,143 @@
+package expo.modules.adapters.react.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import expo.modules.core.ModuleRegistry
+import expo.modules.core.interfaces.ActivityProvider
+import expo.modules.core.interfaces.services.UIManager
+import expo.modules.interfaces.permissions.PermissionsResponse
+import expo.modules.interfaces.permissions.PermissionsResponseListener
+import expo.modules.interfaces.permissions.PermissionsStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
+private const val BLOCKED_PERMISSION_KEY_PREFIX = "blocked:"
+private const val CAMERA = Manifest.permission.CAMERA
+
+private class FakePermissionsService(context: Context) : PermissionsService(context) {
+  var grantState: Int = PackageManager.PERMISSION_DENIED
+  var rationale: Boolean = false
+
+  var requestOutcome: Int = PackageManager.PERMISSION_DENIED
+
+  override fun getManifestPermissionFromContext(permission: String): Int = grantState
+
+  override fun shouldShowRequestPermissionRationale(permission: String): Boolean = rationale
+
+  override fun askForManifestPermissions(
+    permissions: Array<out String>,
+    listener: PermissionsResponseListener
+  ) {
+    grantState = requestOutcome
+    context.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
+      .edit().apply { permissions.forEach { putBoolean(it, true) } }.commit()
+    val granted = requestOutcome == PackageManager.PERMISSION_GRANTED
+    val result = permissions.associateWith {
+      PermissionsResponse(if (granted) PermissionsStatus.GRANTED else PermissionsStatus.DENIED)
+    }
+    listener.onResult(result)
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+internal class PermissionsServiceTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    prefs().edit().clear().commit()
+  }
+
+  private fun prefs() = context.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
+
+  private fun createService(): FakePermissionsService {
+    val service = FakePermissionsService(context)
+    val activityProvider = mockk<ActivityProvider> { every { currentActivity } returns null }
+    val uiManager = mockk<UIManager>(relaxed = true)
+    val registry = mockk<ModuleRegistry> {
+      every { getModule(ActivityProvider::class.java) } returns activityProvider
+      every { getModule(UIManager::class.java) } returns uiManager
+    }
+    service.onCreate(registry)
+    return service
+  }
+
+  private fun markAsked(permission: String) =
+    prefs().edit().putBoolean(permission, true).commit()
+
+  private fun markBlocked(permission: String) =
+    prefs().edit().putBoolean("$BLOCKED_PERMISSION_KEY_PREFIX$permission", true).commit()
+
+  private fun getPermission(service: PermissionsService, permission: String): PermissionsResponse {
+    var result: Map<String, PermissionsResponse>? = null
+    service.getPermissions({ result = it }, permission)
+    return result!!.getValue(permission)
+  }
+
+  private fun askPermission(service: PermissionsService, permission: String) {
+    service.askForPermissions({}, permission)
+  }
+
+  @Test
+  fun `denied permission that was asked but never blocked can be asked again`() {
+    markAsked(CAMERA)
+    val service = createService().apply { grantState = PackageManager.PERMISSION_DENIED }
+
+    val response = getPermission(service, CAMERA)
+
+    Truth.assertThat(response.status).isEqualTo(PermissionsStatus.DENIED)
+    Truth.assertThat(response.canAskAgain).isTrue()
+  }
+
+  @Test
+  fun `request denied with no rationale blocks further asks`() {
+    val service = createService().apply {
+      rationale = false
+      requestOutcome = PackageManager.PERMISSION_DENIED
+    }
+
+    askPermission(service, CAMERA)
+    val response = getPermission(service, CAMERA)
+
+    Truth.assertThat(response.status).isEqualTo(PermissionsStatus.DENIED)
+    Truth.assertThat(response.canAskAgain).isFalse()
+  }
+
+  @Test
+  fun `request denied with rationale keeps permission askable`() {
+    val service = createService().apply {
+      rationale = true
+      requestOutcome = PackageManager.PERMISSION_DENIED
+    }
+
+    askPermission(service, CAMERA)
+    val response = getPermission(service, CAMERA)
+
+    Truth.assertThat(response.canAskAgain).isTrue()
+  }
+
+  @Test
+  fun `granting a previously blocked permission makes it askable again`() {
+    markBlocked(CAMERA)
+    val service = createService().apply { requestOutcome = PackageManager.PERMISSION_GRANTED }
+
+    askPermission(service, CAMERA)
+
+    service.grantState = PackageManager.PERMISSION_DENIED
+    markAsked(CAMERA)
+    val response = getPermission(service, CAMERA)
+
+    Truth.assertThat(response.canAskAgain).isTrue()
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7947,85 +7947,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -8401,42 +8388,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -9051,28 +9032,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -9693,49 +9670,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -12910,28 +12879,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
# Why
Closes #44180
`getPermissionsAsync()` reports `canAskAgain: false` for permissions that are actually still requestable.

`canAskAgain` was inferred from `ActivityCompat.shouldShowRequestPermissionRationale`, which returns false for both a permanently-denied permission and a re-requestable "Ask every time" one. These are indistinguishable at query time, so the re-askable case was misreported.

# How

Record whether a permission is actually blocked when Android makes it observable when our own permission request resolves.
- A request that comes back denied with no rationale to show: the user blocked it, blocked = true.
- Any other outcome (granted, or denied-with-rationale): clear the flag.

# Test Plan
Bare expo
- Added PermissionsServiceTest
- Added a test screen to NCL using camera to verify

