### PR TITLE
[widgets][Android] Add Hermes runtime

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
 - Add a initial layout registry for widgets. ([#46501](https://github.com/expo/expo/pull/46501) by [@jakex7](https://github.com/jakex7))
 - Add `initialProps` to widgets layout registry. ([#46527](https://github.com/expo/expo/pull/46527) by [@jakex7](https://github.com/jakex7))
+- [Android] Add Hermes runtime. ([#46684](https://github.com/expo/expo/pull/46684) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/android/CMakeLists.txt
+++ b/packages/expo-widgets/android/CMakeLists.txt
@@ -5,22 +5,11 @@ project(expo-widgets)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(
-  folly_FLAGS
-  -DFOLLY_NO_CONFIG=1
-  -DFOLLY_HAVE_CLOCK_GETTIME=1
-  -DFOLLY_USE_LIBCPP=1
-  -DFOLLY_CFG_NO_COROUTINES=1
-  -DFOLLY_MOBILE=1
-  -DFOLLY_HAVE_RECVMMSG=1
-  -DFOLLY_HAVE_PTHREAD=1
-  -DFOLLY_HAVE_XSI_STRERROR_R=1
-)
+include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 find_package(hermes-engine REQUIRED CONFIG)
-find_library(LOG_LIB log)
 
 add_library(
   expo-widgets
@@ -34,6 +23,10 @@ target_compile_options(
   ${folly_FLAGS}
   -frtti
   -fexceptions
+  --std=c++20
+  -O2
+  -Wall
+  -fstack-protector-all
 )
 
 target_link_libraries(
@@ -42,5 +35,4 @@ target_link_libraries(
   ReactAndroid::reactnative
   fbjni::fbjni
   hermes-engine::hermesvm
-  ${LOG_LIB}
 )

--- a/packages/expo-widgets/android/CMakeLists.txt
+++ b/packages/expo-widgets/android/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(expo-widgets)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(
+  folly_FLAGS
+  -DFOLLY_NO_CONFIG=1
+  -DFOLLY_HAVE_CLOCK_GETTIME=1
+  -DFOLLY_USE_LIBCPP=1
+  -DFOLLY_CFG_NO_COROUTINES=1
+  -DFOLLY_MOBILE=1
+  -DFOLLY_HAVE_RECVMMSG=1
+  -DFOLLY_HAVE_PTHREAD=1
+  -DFOLLY_HAVE_XSI_STRERROR_R=1
+)
+
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
+find_package(hermes-engine REQUIRED CONFIG)
+find_library(LOG_LIB log)
+
+add_library(
+  expo-widgets
+  SHARED
+  src/main/cpp/WidgetsHermesRuntime.cpp
+)
+
+target_compile_options(
+  expo-widgets
+  PRIVATE
+  ${folly_FLAGS}
+  -frtti
+  -fexceptions
+)
+
+target_link_libraries(
+  expo-widgets
+  ReactAndroid::jsi
+  ReactAndroid::reactnative
+  fbjni::fbjni
+  hermes-engine::hermesvm
+  ${LOG_LIB}
+)

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -34,16 +34,41 @@ expoModule {
   canBePublished false
 }
 
+def reactNativeArchitectures() {
+  def value = project.getProperties().get("reactNativeArchitectures")
+  return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 android {
   namespace "expo.modules.widgets"
   defaultConfig {
     versionCode 1
     versionName '56.0.15'
+
+    externalNativeBuild {
+      cmake {
+        abiFilters(*reactNativeArchitectures())
+        arguments "-DANDROID_STL=c++_shared"
+      }
+    }
+  }
+
+  externalNativeBuild {
+    cmake {
+      path "CMakeLists.txt"
+    }
   }
 
   buildFeatures {
     prefab true
     compose true
+  }
+
+  packagingOptions {
+    excludes += [
+      "**/libc++_shared.so",
+      "**/libhermesvm.so",
+    ]
   }
 }
 
@@ -81,6 +106,8 @@ androidComponents {
 }
 
 dependencies {
+  implementation 'com.facebook.react:react-android'
+  implementation 'com.facebook.react:hermes-android'
   api 'androidx.glance:glance:1.2.0-rc01'
   api 'androidx.glance:glance-appwidget:1.2.0-rc01'
 }

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -1,18 +1,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
-  }
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+  id 'org.jetbrains.kotlin.plugin.compose' version "$kotlinVersion"
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'expo-module-gradle-plugin'
-apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 group = 'expo.modules.widgets'
 version = '56.0.15'
@@ -47,8 +39,13 @@ android {
 
     externalNativeBuild {
       cmake {
+        def cppArguments = [
+          "-DANDROID_STL=c++_shared",
+          "-DREACT_NATIVE_DIR=${expoModule.reactNativeDir}",
+        ]
+
         abiFilters(*reactNativeArchitectures())
-        arguments "-DANDROID_STL=c++_shared"
+        arguments(*cppArguments)
       }
     }
   }

--- a/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
+++ b/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 
@@ -25,19 +24,6 @@ namespace expo::widgets {
 
   void throwRuntimeException(const std::string &message) {
     jni::throwNewJavaException("java/lang/RuntimeException", message.c_str());
-  }
-
-  jsi::Value parseJson(jsi::Runtime &rt, const std::string &json) {
-    auto jsonObject = rt.global().getPropertyAsObject(rt, "JSON");
-    auto parse = jsonObject.getPropertyAsFunction(rt, "parse");
-    return parse.call(rt, jsi::String::createFromUtf8(rt, json));
-  }
-
-  jsi::Value parseJsonOrUndefined(jsi::Runtime &rt, const std::optional<std::string> &json) {
-    if (!json.has_value()) {
-      return jsi::Value::undefined();
-    }
-    return parseJson(rt, *json);
   }
 
   jsi::Value readableMapToValue(
@@ -66,8 +52,8 @@ namespace expo::widgets {
       runtime = facebook::hermes::makeHermesRuntime(config);
     }
 
-    static jobject initHybrid(JNIEnv *, jclass) {
-      return makeCxxInstance().release();
+    static jni::local_ref<WidgetsHermesRuntime::jhybriddata> initHybrid(jni::alias_ref<jhybridobject> clazz) {
+      return makeCxxInstance();
     }
 
     static void registerNatives() {
@@ -94,14 +80,14 @@ namespace expo::widgets {
 
     jni::local_ref<react::ReadableNativeMap::jhybridobject> nativeRender(
       const jni::alias_ref<jstring> &layout,
-      const jni::alias_ref<jstring> &propsJson,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &props,
       const jni::alias_ref<react::ReadableNativeMap::javaobject> &environment
     ) {
       try {
         std::scoped_lock lock(mutex);
         return renderWithFunction(
           layout->toStdString(),
-          jstringToOptionalString(propsJson),
+          props,
           environment
         );
       } catch (const jsi::JSError &error) {
@@ -132,7 +118,7 @@ namespace expo::widgets {
 
     jni::local_ref<react::ReadableNativeMap::jhybridobject> renderWithFunction(
       const std::string &layout,
-      const std::optional<std::string> &propsJson,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &propsMap,
       const jni::alias_ref<react::ReadableNativeMap::javaobject> &environmentMap
     ) {
       auto &rt = *runtime;
@@ -140,7 +126,7 @@ namespace expo::widgets {
 
       rt.global().setProperty(rt, "__expoWidgetLayout", jsi::Value(rt, *layoutCache.at(layout)));
 
-      auto props = parseJsonOrUndefined(rt, propsJson);
+      auto props = readableMapToValue(rt, propsMap);
       auto environment = readableMapToValue(rt, environmentMap);
       jsi::Value args[] = {std::move(props), std::move(environment)};
       const jsi::Value *argsPtr = args;

--- a/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
+++ b/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
@@ -1,0 +1,163 @@
+#include <fbjni/fbjni.h>
+#include <hermes/hermes.h>
+#include <jsi/JSIDynamic.h>
+#include <jsi/jsi.h>
+#include <react/jni/ReadableNativeMap.h>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+namespace jsi = facebook::jsi;
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo::widgets {
+  std::optional<std::string> jstringToOptionalString(const jni::alias_ref<jstring> &value) {
+    if (!value) {
+      return std::nullopt;
+    }
+    return value->toStdString();
+  }
+
+  void throwRuntimeException(const std::string &message) {
+    jni::throwNewJavaException("java/lang/RuntimeException", message.c_str());
+  }
+
+  jsi::Value parseJson(jsi::Runtime &rt, const std::string &json) {
+    auto jsonObject = rt.global().getPropertyAsObject(rt, "JSON");
+    auto parse = jsonObject.getPropertyAsFunction(rt, "parse");
+    return parse.call(rt, jsi::String::createFromUtf8(rt, json));
+  }
+
+  jsi::Value parseJsonOrUndefined(jsi::Runtime &rt, const std::optional<std::string> &json) {
+    if (!json.has_value()) {
+      return jsi::Value::undefined();
+    }
+    return parseJson(rt, *json);
+  }
+
+  jsi::Value readableMapToValue(
+    jsi::Runtime &rt,
+    const jni::alias_ref<react::ReadableNativeMap::javaobject> &map
+  ) {
+    if (!map) {
+      return jsi::Value::undefined();
+    }
+
+    return jsi::valueFromDynamic(rt, map->cthis()->consume());
+  }
+
+  jsi::Value evaluateScript(jsi::Runtime &rt, const std::string &script, const std::string &sourceUrl) {
+    return rt.evaluateJavaScript(std::make_shared<jsi::StringBuffer>(script), sourceUrl);
+  }
+
+  class WidgetsHermesRuntime : public jni::HybridClass<WidgetsHermesRuntime> {
+  public:
+    static constexpr auto kJavaDescriptor = "Lexpo/modules/widgets/jni/WidgetsHermesRuntime;";
+
+    WidgetsHermesRuntime() {
+      auto config = ::hermes::vm::RuntimeConfig::Builder()
+        .withEnableSampleProfiling(false)
+        .build();
+      runtime = facebook::hermes::makeHermesRuntime(config);
+    }
+
+    static jobject initHybrid(JNIEnv *, jclass) {
+      return makeCxxInstance().release();
+    }
+
+    static void registerNatives() {
+      registerHybrid({
+        makeNativeMethod("initHybrid", WidgetsHermesRuntime::initHybrid),
+        makeNativeMethod("nativeEvaluateBundle", WidgetsHermesRuntime::nativeEvaluateBundle),
+        makeNativeMethod("nativeRender", WidgetsHermesRuntime::nativeRender),
+      });
+    }
+
+    void nativeEvaluateBundle(
+      const jni::alias_ref<jstring> &script,
+      const jni::alias_ref<jstring> &sourceUrl
+    ) {
+      try {
+        std::scoped_lock lock(mutex);
+        evaluateScript(*runtime, script->toStdString(), sourceUrl->toStdString());
+      } catch (const jsi::JSError &error) {
+        throwRuntimeException(error.getMessage());
+      } catch (const std::exception &error) {
+        throwRuntimeException(error.what());
+      }
+    }
+
+    jni::local_ref<react::ReadableNativeMap::jhybridobject> nativeRender(
+      const jni::alias_ref<jstring> &layout,
+      const jni::alias_ref<jstring> &propsJson,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &environment
+    ) {
+      try {
+        std::scoped_lock lock(mutex);
+        return renderWithFunction(
+          layout->toStdString(),
+          jstringToOptionalString(propsJson),
+          environment
+        );
+      } catch (const jsi::JSError &error) {
+        throwRuntimeException(error.getMessage());
+      } catch (const std::exception &error) {
+        throwRuntimeException(error.what());
+      }
+      return nullptr;
+    }
+
+  private:
+    std::unique_ptr<jsi::Runtime> runtime;
+    std::mutex mutex;
+    std::unordered_map<std::string, std::unique_ptr<jsi::Value>> layoutCache;
+
+    void ensureLayoutFunction(const std::string &layout) {
+      if (layoutCache.contains(layout)) {
+        return;
+      }
+
+      auto layoutValue = evaluateScript(*runtime, "(" + layout + ")", "expo-widget-layout.js");
+      if (!layoutValue.isObject() || !layoutValue.asObject(*runtime).isFunction(*runtime)) {
+        throw std::runtime_error("Widget layout string did not evaluate to a function");
+      }
+
+      layoutCache.emplace(layout, std::make_unique<jsi::Value>(*runtime, layoutValue));
+    }
+
+    jni::local_ref<react::ReadableNativeMap::jhybridobject> renderWithFunction(
+      const std::string &layout,
+      const std::optional<std::string> &propsJson,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &environmentMap
+    ) {
+      auto &rt = *runtime;
+      ensureLayoutFunction(layout);
+
+      rt.global().setProperty(rt, "__expoWidgetLayout", jsi::Value(rt, *layoutCache.at(layout)));
+
+      auto props = parseJsonOrUndefined(rt, propsJson);
+      auto environment = readableMapToValue(rt, environmentMap);
+      jsi::Value args[] = {std::move(props), std::move(environment)};
+      const jsi::Value *argsPtr = args;
+      auto render = rt.global().getPropertyAsFunction(rt, "__expoWidgetRender");
+      auto result = render.call(rt, argsPtr, static_cast<size_t>(2));
+      if (!result.isObject()) {
+        throw std::runtime_error("Widget render function must return an object");
+      }
+
+      auto dynamic = jsi::dynamicFromValue(rt, result);
+      return react::ReadableNativeMap::createWithContents(std::move(dynamic));
+    }
+  };
+} // namespace expo::widgets
+
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+  return jni::initialize(vm, [] {
+    expo::widgets::WidgetsHermesRuntime::registerNatives();
+  });
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
@@ -9,8 +9,17 @@ internal object WidgetsJSRuntime {
   private var runtime: WidgetsHermesRuntime? = null
 
   @Synchronized
-  fun render(context: Context, layout: String): ReadableMap {
-    return getRuntime(context).render(layout, null, Arguments.makeNativeMap(emptyMap()))
+  fun render(
+    context: Context,
+    layout: String,
+    props: Map<String, Any?>?,
+    environment: Map<String, Any?>
+  ): ReadableMap {
+    return getRuntime(context).render(
+      layout,
+      Arguments.makeNativeMap(props),
+      Arguments.makeNativeMap(environment)
+    )
   }
 
   private fun getRuntime(context: Context): WidgetsHermesRuntime {

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
@@ -1,0 +1,29 @@
+package expo.modules.widgets
+
+import android.content.Context
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.widgets.jni.WidgetsHermesRuntime
+
+internal object WidgetsJSRuntime {
+  private var runtime: WidgetsHermesRuntime? = null
+
+  @Synchronized
+  fun render(context: Context, layout: String): ReadableMap {
+    return getRuntime(context).render(layout, null, Arguments.makeNativeMap(emptyMap()))
+  }
+
+  private fun getRuntime(context: Context): WidgetsHermesRuntime {
+    return runtime ?: WidgetsHermesRuntime().also {
+      it.evaluateBundle(readBundle(context))
+      runtime = it
+    }
+  }
+
+  private fun readBundle(context: Context): String {
+    return context.applicationContext.resources
+      .openRawResource(R.raw.expo_widgets_bundle)
+      .bufferedReader()
+      .use { it.readText() }
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
@@ -14,18 +14,16 @@ internal class WidgetsHermesRuntime : Closeable {
     nativeEvaluateBundle(script, "ExpoWidgets.bundle")
   }
 
-  fun render(layout: String, propsJson: String?, environment: ReadableNativeMap): ReadableNativeMap {
-    return nativeRender(layout, propsJson, environment)
+  fun render(layout: String, props: ReadableNativeMap?, environment: ReadableNativeMap): ReadableNativeMap {
+    return nativeRender(layout, props, environment)
   }
 
   override fun close() {
-    if (mHybridData.isValid) {
-      mHybridData.resetNative()
-    }
+    mHybridData.resetNative()
   }
 
   private external fun nativeEvaluateBundle(script: String, sourceUrl: String)
-  private external fun nativeRender(layout: String, propsJson: String?, environment: ReadableNativeMap): ReadableNativeMap
+  private external fun nativeRender(layout: String, props: ReadableNativeMap?, environment: ReadableNativeMap): ReadableNativeMap
 
   companion object {
     init {

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
@@ -1,0 +1,38 @@
+package expo.modules.widgets.jni
+
+import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.bridge.ReadableNativeMap
+import java.io.Closeable
+
+@DoNotStripAny
+internal class WidgetsHermesRuntime : Closeable {
+  @Suppress("NoHungarianNotation")
+  private val mHybridData: HybridData = initHybrid()
+
+  fun evaluateBundle(script: String) {
+    nativeEvaluateBundle(script, "ExpoWidgets.bundle")
+  }
+
+  fun render(layout: String, propsJson: String?, environment: ReadableNativeMap): ReadableNativeMap {
+    return nativeRender(layout, propsJson, environment)
+  }
+
+  override fun close() {
+    if (mHybridData.isValid) {
+      mHybridData.resetNative()
+    }
+  }
+
+  private external fun nativeEvaluateBundle(script: String, sourceUrl: String)
+  private external fun nativeRender(layout: String, propsJson: String?, environment: ReadableNativeMap): ReadableNativeMap
+
+  companion object {
+    init {
+      System.loadLibrary("expo-widgets")
+    }
+
+    @JvmStatic
+    private external fun initHybrid(): HybridData
+  }
+}


### PR DESCRIPTION
# Why

Android needs own JavaScript runtime (Hermes) equivalent to the existing iOS JSC runtime so widgets can render registered layouts with props and environment values.

# How

- Added a native `WidgetsHermesRuntime` backed by Hermes

# Test Plan

- Verified on the stack.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)