### PR TITLE
[uri-scheme] Fix double-escaping of URI search parameters in `open`

### DIFF
--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `open` double-escaping special characters in URI search parameters (e.g. `@` becoming `%2540` instead of `%40`). ([#46685](https://github.com/expo/expo/issues/46685) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 2.1.0 — 2026-05-20

--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `open` double-escaping special characters in URI search parameters (e.g. `@` becoming `%2540` instead of `%40`). ([#46685](https://github.com/expo/expo/issues/46685) by [@zoontek](https://github.com/zoontek))
+- Fixed `open` double-escaping special characters in URI search parameters (e.g. `@` becoming `%2540` instead of `%40`). ([#46685](https://github.com/expo/expo/pull/46685) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -12,6 +12,7 @@ import path from 'path';
 
 import type { Options } from './Options';
 import { CommandError } from './Options';
+import { escapeUriParams } from './URIScheme';
 
 const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Intent';
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
@@ -193,7 +194,7 @@ async function writeConfigAsync(path: string, result: any) {
  *
  * @example
  *   - `myapp://(tabs)/explore` -> `myapp://\(tabs\)/explore`
- *   - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://\(tabs\)/explore?test=a%257Cb%257Cc`
+ *   - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://\(tabs\)/explore?test=a%7Cb%7Cc`
  */
 export function escapeUri(uri: string) {
   const [protocol, uriWithoutProtocol] = uri.split('://', 2);
@@ -204,12 +205,7 @@ export function escapeUri(uri: string) {
   const escapedUriPath = uriPath.replace(/(^|[^\\])([$\-_.+!*'(),])/g, '$1\\$2');
 
   if (uriParams?.length) {
-    const escapedUriParams = new URLSearchParams(uriParams);
-    for (const [key, value] of escapedUriParams.entries()) {
-      escapedUriParams.set(key, encodeURIComponent(decodeURIComponent(value)));
-    }
-
-    return `${protocol}://${escapedUriPath}?${escapedUriParams.toString()}`;
+    return `${protocol}://${escapedUriPath}?${escapeUriParams(uriParams)}`;
   }
 
   return `${protocol}://${escapedUriPath}`;

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 
 import type { Options } from './Options';
 import { CommandError } from './Options';
+import { escapeUriParams } from './URIScheme';
 
 const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
@@ -145,16 +146,12 @@ function writeConfig(path: string, plistObject: any) {
  *
  * @example
  * - `myapp://(tabs)/explore` -> `myapp://(tabs)/explore`
- * - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://(tabs)/explore?test=a%257Cb%257Cc`
+ * - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://(tabs)/explore?test=a%7Cb%7Cc`
  */
 export function escapeUri(uri: string) {
   if (!uri.includes('?')) return uri;
 
-  const [uriWithoutParams, uriParams] = uri.split('?', 2);
-  const escapedUriParams = new URLSearchParams(uriParams);
-  for (const [key, value] of escapedUriParams.entries()) {
-    escapedUriParams.set(key, encodeURIComponent(decodeURIComponent(value)));
-  }
+  const [uriWithoutParams, uriParams = ''] = uri.split('?', 2);
 
-  return `${uriWithoutParams}?${escapedUriParams.toString()}`;
+  return `${uriWithoutParams}?${escapeUriParams(uriParams)}`;
 }

--- a/packages/uri-scheme/src/URIScheme.ts
+++ b/packages/uri-scheme/src/URIScheme.ts
@@ -9,6 +9,23 @@ import * as Ios from './Ios';
 import type { Options } from './Options';
 import { CommandError } from './Options';
 
+/**
+ * Escape special characters in URI search parameters exactly once.
+ *
+ * `URLSearchParams` already decodes percent-encoded values when iterating over
+ * them, so we re-encode each value a single time and join the params manually.
+ * Relying on `URLSearchParams.toString()` would encode the values a second time
+ * (e.g. `@` -> `%40` -> `%2540`).
+ *
+ * Decoding first makes this idempotent: passing already-escaped input back in
+ * produces the same output.
+ */
+export function escapeUriParams(uriParams: string): string {
+  return Array.from(new URLSearchParams(uriParams).entries())
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
 function fileExists(filePath: string): boolean {
   try {
     return statSync(filePath).isFile();

--- a/packages/uri-scheme/src/__tests__/Android.test.ts
+++ b/packages/uri-scheme/src/__tests__/Android.test.ts
@@ -11,20 +11,21 @@ describe(escapeUri, () => {
 
   it('escapes special charactes in URI search parameter values', () => {
     expect(escapeUri('myapp://home?test=normal')).toBe('myapp://home?test=normal');
-    expect(escapeUri('myapp://home?test=a|b|c')).toBe('myapp://home?test=a%257Cb%257Cc');
-    expect(escapeUri('myapp://home?test=@1')).toBe('myapp://home?test=%25401');
+    expect(escapeUri('myapp://home?test=a|b|c')).toBe('myapp://home?test=a%7Cb%7Cc');
+    expect(escapeUri('myapp://home?test=@1')).toBe('myapp://home?test=%401');
+    expect(escapeUri('myapp://auto?email=jack@test.de')).toBe('myapp://auto?email=jack%40test.de');
   });
 
   it('escapes special characters in both URI path and search parameter values', () => {
     expect(escapeUri('myapp://(spec)/(cial)/characters?pipes=a|b|c&at=@1')).toBe(
-      'myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401'
+      'myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%7Cb%7Cc&at=%401'
     );
   });
 
   it('does not escape already escaped input', () => {
     expect('my-custom-app://\\(escaped\\)/already').toBe('my-custom-app://\\(escaped\\)/already');
-    expect(
-      escapeUri('myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401')
-    ).toBe('myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401');
+    expect(escapeUri('myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%7Cb%7Cc&at=%401')).toBe(
+      'myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%7Cb%7Cc&at=%401'
+    );
   });
 });

--- a/packages/uri-scheme/src/__tests__/Ios.test.ts
+++ b/packages/uri-scheme/src/__tests__/Ios.test.ts
@@ -3,18 +3,17 @@ import { escapeUri } from '../Ios';
 describe(escapeUri, () => {
   it('escapes special charactes in URI search parameter values', () => {
     expect(escapeUri('myapp://home?test=normal')).toBe('myapp://home?test=normal');
-    expect(escapeUri('myapp://(app)/home?test=@1')).toBe('myapp://(app)/home?test=%25401');
-    expect(escapeUri('myapp://(app)/home?test=a|b|c')).toBe(
-      'myapp://(app)/home?test=a%257Cb%257Cc'
-    );
+    expect(escapeUri('myapp://(app)/home?test=@1')).toBe('myapp://(app)/home?test=%401');
+    expect(escapeUri('myapp://(app)/home?test=a|b|c')).toBe('myapp://(app)/home?test=a%7Cb%7Cc');
+    expect(escapeUri('myapp://auto?email=jack@test.de')).toBe('myapp://auto?email=jack%40test.de');
   });
 
   it('does not escape already escaped input', () => {
-    expect(escapeUri('my-custom-app://(app)/home?test=%25401')).toBe(
-      'my-custom-app://(app)/home?test=%25401'
+    expect(escapeUri('my-custom-app://(app)/home?test=%401')).toBe(
+      'my-custom-app://(app)/home?test=%401'
     );
-    expect(escapeUri('myapp://(app)/home?test=a%257Cb%257Cc')).toBe(
-      'myapp://(app)/home?test=a%257Cb%257Cc'
+    expect(escapeUri('myapp://(app)/home?test=a%7Cb%7Cc')).toBe(
+      'myapp://(app)/home?test=a%7Cb%7Cc'
     );
   });
 });


### PR DESCRIPTION
# Why

Fixes #46388

`uri-scheme open` escapes special characters in search parameters twice, so `@` becomes `%2540` instead of `%40` and `|` becomes `%257C` instead of `%7C`.

# How

`escapeUri` built a `URLSearchParams`, called `encodeURIComponent` on each value, then `set` it back. `URLSearchParams.toString()` then encoded everything a second time (the `%` from the first pass became `%25`).

Now the params are escaped a single time: read the already-decoded entries from `URLSearchParams`, encode each key / value once, and join them manually instead of relying on `toString()`. Also dropped the `decodeURIComponent` call, which threw on a literal `%` in a value.

The shared logic now lives in a single `escapeUriParams` helper in `URIScheme.ts`, used by both the iOS and Android paths.

# Test Plan

Updated the existing Android and iOS unit tests (which asserted the buggy double-escaped output) and added a case for the reported `email=jack@test.de`. Escaping stays idempotent: already-escaped input is unchanged.

```
pnpm test --watch false
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
