### PR TITLE
[expo-sensors] Fix prebuilt framework returning denied for motion permission

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the prebuilt `ExpoSensors.xcframework` always returning `denied` for the motion permission on iOS. The prebuild config unconditionally defined `EXPO_DISABLE_MOTION_PERMISSION`, which is only meant to be set when opting out via the `motionPermission: false` config plugin option. ([#46686](https://github.com/expo/expo/issues/46686) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-21

--- a/packages/expo-sensors/spm.config.json
+++ b/packages/expo-sensors/spm.config.json
@@ -32,9 +32,6 @@
           ],
           "includeDirectories": [
             "."
-          ],
-          "compilerFlags": [
-            "-DEXPO_DISABLE_MOTION_PERMISSION=1"
           ]
         },
         {


### PR DESCRIPTION
# Why

Fixes [#46354](https://github.com/expo/expo/issues/46354). On a fresh iOS install, the prebuilt `ExpoSensors.xcframework` returns `denied` for the motion permission and never shows the native Motion & Fitness prompt. Building `expo-sensors` from source works fine.

# How

The prebuild config `packages/expo-sensors/spm.config.json` unconditionally defined `-DEXPO_DISABLE_MOTION_PERMISSION=1` on the Objective-C target. That macro is only meant to be set when a developer opts out via the `motionPermission: false` config plugin option (handled conditionally by the podspec through the `MOTION_PERMISSION` Podfile property). Because it was baked into the published binary, `EXMotionPermissionRequester` always took the disabled branch.

Removing that hardcoded flag restores the default (enabled) behavior and makes the prebuilt framework match the source build. The Swift target never defined the macro, so this also makes the two targets consistent.

# Test Plan

Using the [reporter's repro](https://github.com/erickreutz/expo-sensors-motion-permission-repro) with the patched prebuilt framework on a fresh simulator:

- `DeviceMotion.getPermissionsAsync()` returns `undetermined` instead of `denied`.
- `DeviceMotion.requestPermissionsAsync()` shows the native Motion & Fitness prompt and returns `granted` after allowing.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
