### PR TITLE
[observe] Add CHANGELOG.md for expo-observe and expo-app-metrics

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unpublished
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unpublished
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others


### PR DESCRIPTION
# Why

The `expo-observe` and `expo-app-metrics` packages were missing a `CHANGELOG.md`, so changes to them couldn't be tracked through our standard changelog flow. Closes ENG-21537.

# How

Added a `CHANGELOG.md` to each package using the standard new-package template (`## Unpublished` with the Breaking changes / New features / Bug fixes / Others sections).

# Test Plan

N/A — adds two empty changelog templates, no source changes.
