### PR TITLE
Refactor Babel runtime version handling

### DIFF
--- a/packages/babel-preset-expo/src/configs/module-transforms.ts
+++ b/packages/babel-preset-expo/src/configs/module-transforms.ts
@@ -16,12 +16,15 @@ module.exports = function (_api: ConfigAPI, options: ModuleTransformOptions) {
   // Runtime transform (no regenerator for hermes-v0)
   if (options.enableBabelRuntime !== false) {
     const isVersion = typeof options.enableBabelRuntime === 'string';
+    const fallbackVersion = require('@babel/runtime/package.json').version;
+    const version = isVersion ? options.enableBabelRuntime : fallbackVersion;
+
     plugins.push([
       require('@babel/plugin-transform-runtime'),
       {
         helpers: true,
         regenerator: true,
-        ...(isVersion && { version: options.enableBabelRuntime }),
+        version,
       },
     ]);
   }


### PR DESCRIPTION

# Why

If expo babel preset won't specify `version` as `@babel/plugin-transform-runtime` option, Babel will continue to inline some helpers like `_interopRequireWildcard` in each file again and again 

see: 
- https://github.com/babel/babel/issues/18050
- https://github.com/facebook/react-native/issues/57123
- https://github.com/facebook/react-native/pull/57126 
- https://x.com/tell_me_mur/status/2064328541861183526?s=20



# Test Plan

build expo app and check final JS bundle, all `_interopRequireWildcard` fn. have to be imported not inlined 