### PR TITLE
refactor(cli): Upgrade internal ws-tunnel package to `@expo/ws-tunnel@^2.0.0`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Add experimental `tvos` and `macos` autolinking gated by `expriments.outOfTreePlatforms` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 - [Internal] Unify favicon injection between SPA, SSG and SSR pipelines ([#46586](https://github.com/expo/expo/pull/46586) by [@hassankhan](https://github.com/hassankhan))
+- Bump to `@expo/ws-tunnel@^2.0.0` ([#46696](https://github.com/expo/expo/pull/46696) by [@kitten](https://github.com/kitten))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -69,7 +69,7 @@
     "@expo/router-server": "workspace:^56.0.12",
     "@expo/schema-utils": "workspace:^56.0.0",
     "@expo/spawn-async": "^1.8.0",
-    "@expo/ws-tunnel": "^1.0.1",
+    "@expo/ws-tunnel": "^2.0.0",
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0-rc.3",
     "accepts": "^1.3.8",

--- a/packages/@expo/cli/src/api/graphql/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/graphql/__tests__/client-test.ts
@@ -1,0 +1,67 @@
+import { fetch } from '../../../utils/fetch';
+import { graphql, query, mutate } from '../client';
+
+jest.mock('../../../utils/fetch', () => ({
+  ...jest.requireActual('../../../utils/fetch'),
+  fetch: jest.fn(),
+}));
+jest.mock('../../user/UserSettings', () => ({
+  getAccessToken: jest.fn(() => 'token'),
+  getSession: jest.fn(() => null),
+}));
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+type Data = { value: number };
+
+const Document = graphql<Data>(`
+  mutation Example {
+    value
+  }
+`);
+
+function mockJsonResponseOnce(data: unknown) {
+  asMock(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ data }),
+  } as any);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('mutate', () => {
+  it('hits the network on every call and never serves a cached result', async () => {
+    mockJsonResponseOnce({ value: 1 });
+    mockJsonResponseOnce({ value: 2 });
+
+    // Even with identical documents and variables, a mutation must re-run rather than return the
+    // previous result from the in-memory cache.
+    expect(await mutate(Document, {})).toEqual({ value: 1 });
+    expect(await mutate(Document, {})).toEqual({ value: 2 });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('issues a POST to the GraphQL endpoint', async () => {
+    mockJsonResponseOnce({ value: 1 });
+    await mutate(Document, {});
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/graphql'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});
+
+describe('query', () => {
+  it('serves repeated identical queries from the in-memory cache', async () => {
+    mockJsonResponseOnce({ value: 7 });
+    // Queued but should never be requested, since the second call is a cache hit.
+    mockJsonResponseOnce({ value: 999 });
+    expect(await query(Document, {})).toEqual({ value: 7 });
+    expect(await query(Document, {})).toEqual({ value: 7 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -94,6 +94,7 @@ export const query = (() => {
     const headersKey = stringifySorted(headers);
     if (!cacheKey || cacheKey !== headersKey) {
       resetCache();
+      cacheKey = headersKey;
     }
 
     // Retrieve a cached result, if we have any via a `query => variables => Result` cache key

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -30,7 +30,7 @@ export interface QueryOptions {
   headers?: Record<string, string>;
 }
 
-export const query = (() => {
+export const { query, mutate } = (() => {
   const url = getExpoApiBaseUrl() + '/graphql';
 
   let _fetch: FetchLike | undefined;
@@ -79,10 +79,12 @@ export const query = (() => {
     cache = {};
   }
 
-  return async function query<Result extends JSONObject, Variables extends JSONObject>(
+  async function request<Result extends JSONObject, Variables extends JSONObject>(
     query: StaticDocumentNode<Result, Variables>,
     variables: Variables,
-    options?: QueryOptions
+    options: QueryOptions | undefined,
+    // Mutations must never be served from (or written to) the in-memory cache.
+    useCache: boolean
   ): Promise<Result> {
     let isTransient = false;
     let response: Response | undefined;
@@ -100,7 +102,7 @@ export const query = (() => {
     // Retrieve a cached result, if we have any via a `query => variables => Result` cache key
     const variablesKey = stringifySorted(variables);
     const queryCache = cache[query] || (cache[query] = new Map());
-    if (queryCache.has(variablesKey)) {
+    if (useCache && queryCache.has(variablesKey)) {
       data = queryCache.get(variablesKey) as Result;
     }
 
@@ -151,7 +153,9 @@ export const query = (() => {
 
     // Store the data in the cache, and only return a result if we have any values
     if (data) {
-      queryCache.set(variablesKey, data);
+      if (useCache) {
+        queryCache.set(variablesKey, data);
+      }
       const keys = Object.keys(data);
       if (keys.length > 0 && keys.some((key) => data[key as keyof typeof data] != null)) {
         return data;
@@ -171,5 +175,24 @@ export const query = (() => {
     } else {
       throw new UnexpectedServerData('Unexpected server error: No returned query result');
     }
+  }
+
+  return {
+    /** Run a GraphQL query, served from the in-memory cache when possible. */
+    query<Result extends JSONObject, Variables extends JSONObject>(
+      document: StaticDocumentNode<Result, Variables>,
+      variables: Variables,
+      options?: QueryOptions
+    ): Promise<Result> {
+      return request(document, variables, options, /* useCache */ true);
+    },
+    /** Run a GraphQL mutation, always hitting the network and never touching the cache. */
+    mutate<Result extends JSONObject, Variables extends JSONObject>(
+      document: StaticDocumentNode<Result, Variables>,
+      variables: Variables,
+      options?: QueryOptions
+    ): Promise<Result> {
+      return request(document, variables, options, /* useCache */ false);
+    },
   };
 })();

--- a/packages/@expo/cli/src/api/graphql/mutations/TunnelMutation.ts
+++ b/packages/@expo/cli/src/api/graphql/mutations/TunnelMutation.ts
@@ -1,0 +1,39 @@
+import { graphql, mutate } from '../client';
+
+export type SignedTunnelUrl = {
+  /** The unique tunnel label, used as the hostname segment of the tunnel URL. */
+  label: string;
+  /** The signed tunnel URL `@expo/ws-tunnel` connects to. */
+  url: string;
+};
+
+type CreateSignedTunnelUrlData = {
+  tunnels: {
+    createSignedTunnelUrl: SignedTunnelUrl;
+  };
+};
+
+type CreateSignedTunnelUrlVariables = {
+  accountId: string;
+};
+
+const CreateSignedTunnelUrlDocument = graphql<
+  CreateSignedTunnelUrlData,
+  CreateSignedTunnelUrlVariables
+>(`
+  mutation CreateSignedTunnelUrl($accountId: ID!) {
+    tunnels {
+      createSignedTunnelUrl(accountId: $accountId) {
+        label
+        url
+      }
+    }
+  }
+`);
+
+export const TunnelMutation = {
+  async createSignedTunnelUrlAsync(accountId: string): Promise<SignedTunnelUrl> {
+    const data = await mutate(CreateSignedTunnelUrlDocument, { accountId });
+    return data.tunnels.createSignedTunnelUrl;
+  },
+};

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -1,35 +1,40 @@
+import { getConfig } from '@expo/config';
 import * as tunnel from '@expo/ws-tunnel';
 import chalk from 'chalk';
 import * as fs from 'node:fs';
 import { tmpdir, hostname } from 'node:os';
 import * as path from 'node:path';
 
+import { TunnelMutation } from '../../api/graphql/mutations/TunnelMutation';
+import { AppQuery } from '../../api/graphql/queries/AppQuery';
+import { hasCredentials } from '../../api/user/UserSettings';
+import { getUserAsync } from '../../api/user/user';
 import * as Log from '../../log';
 import { env, envIsWebcontainer } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
 
 const debug = require('debug')('expo:start:server:ws-tunnel') as typeof console.log;
 
-export class AsyncWsTunnel {
-  /** Info about the currently running instance of tunnel. */
-  private serverUrl: string | null = null;
+export interface AsyncWsTunnelOptions {
+  useExpoAccount?: boolean;
+}
 
-  constructor(_projectRoot: string, port: number) {
-    if (port !== 8081) {
-      throw new CommandError(
-        'WS_TUNNEL_PORT',
-        `WS-tunnel only supports tunneling over port 8081, attempted to use port ${port}`
-      );
-    }
-  }
+export class AsyncWsTunnel {
+  private serverUrl: URL | null = null;
+
+  constructor(
+    private projectRoot: string,
+    private port: number,
+    private options: AsyncWsTunnelOptions = {}
+  ) {}
 
   public getActiveUrl(): string | null {
-    return this.serverUrl;
+    return this.serverUrl?.href ?? null;
   }
 
   async startAsync(): Promise<void> {
     this.serverUrl = await tunnel.startAsync({
-      ...getTunnelOptions(),
+      ...(await this.getTunnelOptionsAsync()),
       onStatusChange(status) {
         if (status === 'disconnected') {
           Log.error(
@@ -41,7 +46,30 @@ export class AsyncWsTunnel {
       },
     });
 
-    debug('Tunnel URL:', this.serverUrl);
+    debug('Tunnel URL:', this.serverUrl.href);
+  }
+
+  private async getTunnelOptionsAsync(): Promise<tunnel.WsTunnelOptions> {
+    if (this.options.useExpoAccount) {
+      return this.getExpoAccountTunnelOptionsAsync();
+    } else {
+      return getLegacyTunnelOptions(this.port);
+    }
+  }
+
+  private async getExpoAccountTunnelOptionsAsync(): Promise<tunnel.WsTunnelOptions> {
+    const apiUrl = await getExpoAccountTunnelUrlAsync(this.projectRoot);
+    if (!apiUrl) {
+      const cause = hasCredentials()
+        ? `Your Expo account may not have access to it, or the tunnel service is unavailable.`
+        : `You're not logged in to your Expo account — run 'npx expo login'.`;
+      throw new CommandError(
+        'WS_TUNNEL_SIGNED_URL',
+        `Couldn't create a signed tunnel URL for this project. ${cause} ` +
+          `Unset EXPO_UNSTABLE_TUNNEL_V2 to use an ngrok tunnel instead.`
+      );
+    }
+    return { apiUrl, targetUrl: `http://localhost:${this.port}` };
   }
 
   async stopAsync(): Promise<void> {
@@ -51,33 +79,83 @@ export class AsyncWsTunnel {
   }
 }
 
-// Generate a base-36 string of 5 characters (from 32 bits of randomness)
-function randomStr() {
-  return (Math.random().toString(36) + '00000').slice(2, 7);
-}
-
-function getTunnelSession(): string {
-  let session = randomStr() + randomStr() + randomStr();
-  if (envIsWebcontainer()) {
-    const leaseId = Buffer.from(hostname()).toString('base64url');
-    const leaseFile = path.join(tmpdir(), `_ws_tunnel_lease_${leaseId}`);
-    try {
-      session = fs.readFileSync(leaseFile, 'utf8').trim() || session;
-    } catch {}
-    try {
-      fs.writeFileSync(leaseFile, session, 'utf8');
-    } catch {}
+function getLegacyTunnelOptions(port: number): tunnel.WsTunnelOptions {
+  if (port !== 8081) {
+    throw new CommandError(
+      'WS_TUNNEL_PORT',
+      `WS-tunnel only supports tunneling over port 8081, attempted to use port ${port}`
+    );
   }
-  return session;
-}
 
-function getTunnelOptions() {
+  function randomSessionId(): string {
+    const randomPart = () => (Math.random().toString(36) + '00000').slice(2, 7);
+    return randomPart() + randomPart() + randomPart();
+  }
+
+  function getWebcontainerSession(): string {
+    let session = randomSessionId();
+    if (envIsWebcontainer()) {
+      const leaseId = Buffer.from(hostname()).toString('base64url');
+      const leaseFile = path.join(tmpdir(), `_ws_tunnel_lease_${leaseId}`);
+      try {
+        session = fs.readFileSync(leaseFile, 'utf8').trim() || session;
+      } catch {}
+      try {
+        fs.writeFileSync(leaseFile, session, 'utf8');
+      } catch {}
+    }
+    return session;
+  }
+
   const userDefinedSubdomain = env.EXPO_TUNNEL_SUBDOMAIN;
   if (userDefinedSubdomain && typeof userDefinedSubdomain === 'string') {
     debug('Session:', userDefinedSubdomain);
     return { session: userDefinedSubdomain };
-  } else {
-    const session = getTunnelSession();
-    return { session };
+  }
+  return { session: getWebcontainerSession() };
+}
+
+export async function getExpoAccountTunnelUrlAsync(projectRoot: string): Promise<string | null> {
+  async function resolveExpoAccountIdAsync(projectRoot: string): Promise<string | null> {
+    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+    const easProjectId = exp.extra?.eas?.projectId as string | undefined | null;
+    if (easProjectId) {
+      try {
+        const app = await AppQuery.byIdAsync(easProjectId);
+        const appOwnerAccountId = app?.ownerAccount?.id;
+        if (appOwnerAccountId) {
+          return appOwnerAccountId;
+        }
+      } catch (error) {
+        debug('Failed to resolve owning account from EAS project ID:', error);
+      }
+    }
+
+    const actor = await getUserAsync();
+    if (!actor) {
+      return null;
+    } else if (actor.__typename === 'User' || actor.__typename === 'SSOUser') {
+      const actorPrimaryAccountId = actor.primaryAccount?.id;
+      if (actorPrimaryAccountId) {
+        return actorPrimaryAccountId;
+      }
+    }
+
+    // Robots have no primary account; fall back to their first available account.
+    return actor.accounts[0]?.id ?? null;
+  }
+
+  try {
+    const accountId = await resolveExpoAccountIdAsync(projectRoot);
+    if (!accountId) {
+      debug('No Expo account available to create a signed tunnel URL; user is likely logged out.');
+      return null;
+    }
+    const { url } = await TunnelMutation.createSignedTunnelUrlAsync(accountId);
+    debug('Created signed tunnel URL for account:', accountId);
+    return url;
+  } catch (error) {
+    debug('Failed to create a signed tunnel URL:', error);
+    return null;
   }
 }

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -256,16 +256,25 @@ export abstract class BundlerDevServer {
     this.notifier.startObserving();
   }
 
-  /** Create ngrok instance and start the tunnel server. Exposed for testing. */
+  /** Create the tunnel instance and start the tunnel server. Exposed for testing. */
   public async _startTunnelAsync(): Promise<AsyncNgrok | AsyncWsTunnel | null> {
     const port = this.getInstance()?.location.port;
     if (!port) return null;
     debug('[tunnel] connect to port: ' + port);
-    this.tunnel = envIsWebcontainer()
-      ? new AsyncWsTunnel(this.projectRoot, port)
-      : new AsyncNgrok(this.projectRoot, port);
+    this.tunnel = this._createTunnel(port);
     await this.tunnel.startAsync();
     return this.tunnel;
+  }
+
+  /** Resolve which tunnel implementation to use, without starting it. */
+  private _createTunnel(port: number): AsyncNgrok | AsyncWsTunnel {
+    const useV2Tunnel = env.EXPO_UNSTABLE_TUNNEL_V2 || envIsWebcontainer();
+    if (useV2Tunnel) {
+      const useExpoAccount = !!env.EXPO_UNSTABLE_TUNNEL_V2;
+      return new AsyncWsTunnel(this.projectRoot, port, { useExpoAccount });
+    }
+
+    return new AsyncNgrok(this.projectRoot, port);
   }
 
   protected async startDevSessionAsync() {

--- a/packages/@expo/cli/src/start/server/__mocks__/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/__mocks__/AsyncWsTunnel.ts
@@ -1,6 +1,12 @@
 export class AsyncWsTunnel {
   private serverUrl: string | null = null;
 
+  constructor(
+    public projectRoot: string,
+    public port: number,
+    public options: { useExpoAccount?: boolean } = {}
+  ) {}
+
   getActiveUrl = jest.fn(() => this.serverUrl);
 
   startAsync = jest.fn(async () => {

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncWsTunnel-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncWsTunnel-test.ts
@@ -1,0 +1,165 @@
+import { getConfig } from '@expo/config';
+import * as tunnel from '@expo/ws-tunnel';
+
+import { TunnelMutation } from '../../../api/graphql/mutations/TunnelMutation';
+import { AppQuery } from '../../../api/graphql/queries/AppQuery';
+import { hasCredentials } from '../../../api/user/UserSettings';
+import { getUserAsync } from '../../../api/user/user';
+import { AsyncWsTunnel, getExpoAccountTunnelUrlAsync } from '../AsyncWsTunnel';
+
+jest.mock('@expo/config');
+jest.mock('@expo/ws-tunnel');
+jest.mock('../../../api/graphql/queries/AppQuery');
+jest.mock('../../../api/graphql/mutations/TunnelMutation');
+jest.mock('../../../api/user/user');
+jest.mock('../../../api/user/UserSettings', () => ({
+  ...jest.requireActual('../../../api/user/UserSettings'),
+  hasCredentials: jest.fn(() => false),
+}));
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+function mockConfig(extra?: Record<string, any>) {
+  asMock(getConfig).mockReturnValue({ exp: { extra } } as any);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  asMock(hasCredentials).mockReturnValue(false);
+  asMock(TunnelMutation.createSignedTunnelUrlAsync).mockResolvedValue({
+    label: 'c-acme-abc123-xyz',
+    url: 'https://c-acme-abc123-xyz.on.expo.app/_tunnel/connect?token=jwt',
+  });
+});
+
+describe('getExpoAccountTunnelUrlAsync', () => {
+  it('mints a signed URL for the EAS project owning account', async () => {
+    mockConfig({ eas: { projectId: 'project-id' } });
+    asMock(AppQuery.byIdAsync).mockResolvedValue({
+      id: 'project-id',
+      scopeKey: 'scope',
+      ownerAccount: { id: 'owner-account-id', name: 'acme' },
+    });
+
+    const url = await getExpoAccountTunnelUrlAsync('/');
+
+    expect(AppQuery.byIdAsync).toHaveBeenCalledWith('project-id');
+    expect(TunnelMutation.createSignedTunnelUrlAsync).toHaveBeenCalledWith('owner-account-id');
+    expect(url).toBe('https://c-acme-abc123-xyz.on.expo.app/_tunnel/connect?token=jwt');
+  });
+
+  it('falls back to the actor primary account when there is no EAS project ID', async () => {
+    mockConfig(undefined);
+    asMock(getUserAsync).mockResolvedValue({
+      __typename: 'User',
+      id: 'user-id',
+      username: 'acme',
+      primaryAccount: { id: 'primary-account-id' },
+      accounts: [],
+    });
+
+    const url = await getExpoAccountTunnelUrlAsync('/');
+
+    expect(AppQuery.byIdAsync).not.toHaveBeenCalled();
+    expect(TunnelMutation.createSignedTunnelUrlAsync).toHaveBeenCalledWith('primary-account-id');
+    expect(url).toBe('https://c-acme-abc123-xyz.on.expo.app/_tunnel/connect?token=jwt');
+  });
+
+  it('returns null when logged out', async () => {
+    mockConfig(undefined);
+    asMock(getUserAsync).mockResolvedValue(undefined);
+
+    expect(await getExpoAccountTunnelUrlAsync('/')).toBeNull();
+    expect(TunnelMutation.createSignedTunnelUrlAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the mutation fails', async () => {
+    mockConfig({ eas: { projectId: 'project-id' } });
+    asMock(AppQuery.byIdAsync).mockResolvedValue({
+      id: 'project-id',
+      scopeKey: 'scope',
+      ownerAccount: { id: 'owner-account-id', name: 'acme' },
+    });
+    asMock(TunnelMutation.createSignedTunnelUrlAsync).mockRejectedValue(new Error('rate limited'));
+
+    expect(await getExpoAccountTunnelUrlAsync('/')).toBeNull();
+  });
+});
+
+describe('startAsync (signed)', () => {
+  it('throws a CommandError prompting login when logged out', async () => {
+    asMock(hasCredentials).mockReturnValue(false);
+    mockConfig(undefined);
+    asMock(getUserAsync).mockResolvedValue(undefined);
+
+    const wsTunnel = new AsyncWsTunnel('/', 8081, { useExpoAccount: true });
+    const error = await wsTunnel.startAsync().then(
+      () => null,
+      (e) => e
+    );
+    expect(error.message).toMatch(/Couldn't create a signed tunnel URL for this project/);
+    expect(error.message).toMatch(/npx expo login/);
+  });
+
+  it('omits the login hint when the user is already logged in', async () => {
+    asMock(hasCredentials).mockReturnValue(true);
+    mockConfig(undefined);
+    asMock(getUserAsync).mockResolvedValue({
+      __typename: 'User',
+      id: 'user-id',
+      username: 'acme',
+      primaryAccount: { id: 'primary-account-id' },
+      accounts: [],
+    });
+    asMock(TunnelMutation.createSignedTunnelUrlAsync).mockRejectedValue(new Error('no access'));
+
+    const wsTunnel = new AsyncWsTunnel('/', 8081, { useExpoAccount: true });
+    const error = await wsTunnel.startAsync().then(
+      () => null,
+      (e) => e
+    );
+    expect(error.message).toMatch(/may not have access/);
+    expect(error.message).not.toMatch(/expo login/);
+  });
+
+  it('tunnels the signed URL to the dev server on any port', async () => {
+    mockConfig({ eas: { projectId: 'project-id' } });
+    asMock(AppQuery.byIdAsync).mockResolvedValue({
+      id: 'project-id',
+      scopeKey: 'scope',
+      ownerAccount: { id: 'owner-account-id', name: 'acme' },
+    });
+    asMock(tunnel.startAsync).mockResolvedValue(new URL('https://c-acme.on.expo.app/'));
+
+    const wsTunnel = new AsyncWsTunnel('/', 3000, { useExpoAccount: true });
+    await wsTunnel.startAsync();
+
+    expect(tunnel.startAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiUrl: 'https://c-acme-abc123-xyz.on.expo.app/_tunnel/connect?token=jwt',
+        targetUrl: 'http://localhost:3000',
+      })
+    );
+    expect(wsTunnel.getActiveUrl()).toBe('https://c-acme.on.expo.app/');
+  });
+});
+
+describe('startAsync (legacy)', () => {
+  it('only supports tunneling a dev server on port 8081', async () => {
+    const wsTunnel = new AsyncWsTunnel('/', 3000);
+    await expect(wsTunnel.startAsync()).rejects.toThrow(/only supports tunneling over port 8081/);
+    expect(tunnel.startAsync).not.toHaveBeenCalled();
+  });
+
+  it('connects to the default service with a session on port 8081', async () => {
+    asMock(tunnel.startAsync).mockResolvedValue(new URL('https://exp.ws-tunnel.dev/'));
+
+    const wsTunnel = new AsyncWsTunnel('/', 8081);
+    await wsTunnel.startAsync();
+
+    expect(tunnel.startAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ session: expect.any(String) })
+    );
+  });
+});

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -2,6 +2,8 @@ import { vol } from 'memfs';
 
 import { envIsWebcontainer } from '../../../utils/env';
 import { openBrowserAsync } from '../../../utils/open';
+import { AsyncNgrok } from '../AsyncNgrok';
+import { AsyncWsTunnel } from '../AsyncWsTunnel';
 import type { BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import { BundlerDevServer } from '../BundlerDevServer';
 import { UrlCreator } from '../UrlCreator';
@@ -49,6 +51,7 @@ beforeEach(() => {
   vol.reset();
   jest.mocked(envIsWebcontainer).mockReset();
   delete process.env.EXPO_NO_REDIRECT_PAGE;
+  delete process.env.EXPO_UNSTABLE_TUNNEL_V2;
 });
 
 afterAll(() => {
@@ -415,6 +418,31 @@ describe('_startTunnelAsync', () => {
   );
   it(`returns null when the server isn't running`, async () => {
     expect(await server._startTunnelAsync()).toEqual(null);
+  });
+
+  it('uses an ngrok tunnel by default', async () => {
+    const devServer = await getRunningServer();
+    const tunnel = await devServer._startTunnelAsync();
+    expect(tunnel).toBeInstanceOf(AsyncNgrok);
+  });
+
+  it('uses a webcontainer ws tunnel without a signed URL', async () => {
+    jest.mocked(envIsWebcontainer).mockReturnValue(true);
+
+    const devServer = await getRunningServer();
+    const tunnel = (await devServer._startTunnelAsync()) as AsyncWsTunnel;
+    expect(tunnel).toBeInstanceOf(AsyncWsTunnel);
+    // Bolt/Stackblitz use the default service, not the signed Expo-account URL.
+    expect((tunnel as any).options).toEqual({ useExpoAccount: false });
+  });
+
+  it('routes --tunnel through a signed ws tunnel when opted in', async () => {
+    process.env.EXPO_UNSTABLE_TUNNEL_V2 = '1';
+
+    const devServer = await getRunningServer();
+    const tunnel = (await devServer._startTunnelAsync()) as AsyncWsTunnel;
+    expect(tunnel).toBeInstanceOf(AsyncWsTunnel);
+    expect((tunnel as any).options).toEqual({ useExpoAccount: true });
   });
 });
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -120,6 +120,10 @@ class Env {
     return getOriginalEnvValue('EXPO_PACKAGER_PROXY_URL') || '';
   }
 
+  get EXPO_UNSTABLE_TUNNEL_V2(): boolean {
+    return boolish('EXPO_UNSTABLE_TUNNEL_V2', false);
+  }
+
   /**
    * **Experimental** - Disable using `exp.direct` as the hostname for
    * `--tunnel` connections. This enables **https://** forwarding which

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1876,8 +1876,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       '@expo/ws-tunnel':
-        specifier: ^1.0.1
-        version: 1.0.6
+        specifier: ^2.0.0
+        version: 2.0.0(ws@8.19.0)
       '@expo/xcpretty':
         specifier: ^4.4.4
         version: 4.4.4
@@ -7683,8 +7683,10 @@ packages:
       react: '*'
       react-native: 0.86.0-rc.3
 
-  '@expo/ws-tunnel@1.0.6':
-    resolution: {integrity: sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q==}
+  '@expo/ws-tunnel@2.0.0':
+    resolution: {integrity: sha512-j+JfTRdCk820J9dU0sA2SqshQIKFOMo7ED84w9MJFcebfbNQgsLztEY/SABDkGnjatrW4xGqnUhVRxSBVyCkXw==}
+    peerDependencies:
+      ws: ^8.0.0
 
   '@expo/xcpretty@4.4.4':
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
@@ -17557,7 +17559,9 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0-rc.3(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0-rc.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0-rc.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
 
-  '@expo/ws-tunnel@1.0.6': {}
+  '@expo/ws-tunnel@2.0.0(ws@8.19.0)':
+    dependencies:
+      ws: 8.19.0
 
   '@expo/xcpretty@4.4.4':
     dependencies:


### PR DESCRIPTION
## Summary

Adds new authentication flow and experimental flag for new flow and code path in `@expo/ws-tunnel`.

## Set of changes

- Add `EXPO_UNSTABLE_TUNNEL_V2` flag
- Fix `cacheKey` not being set preventing in-memory query caching
- Add `mutate` helper for GraphQL client
- Add new `TunnelMutations`
- Upgrade to `@expo/ws-tunnel@^2.0.0` and update `AsyncWsTunnel`
- Conditionally activate new flow with `EXPO_UNSTABLE_TUNNEL_V2`

## Test Plan

- Unit tests
- **Note:** Needs a manual test once `www` change lands

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
