### PR TITLE
fix(cli): ensure router E2E assertions wait for UI state

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
@@ -10,6 +10,11 @@ test.afterAll(() => restoreEnv());
 
 const projectRoot = getRouterE2ERoot();
 const inputDir = 'headless';
+
+const visibleTestId = (page: Page, testId: string) =>
+  page.getByTestId(testId).filter({ visible: true });
+const movieDetailsFor = (page: Page, name: string) =>
+  visibleTestId(page, 'tab-movie-details').filter({ hasText: name });
 
 test.describe(inputDir, () => {
   const expoStart = createExpoStart({
@@ -45,19 +50,19 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-home-index')).toBeVisible();
 
     await page.getByText('Go to Tab functions').click();
 
-    expect(page.getByTestId('tab-home-functions')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-home-functions')).toBeVisible();
 
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-movies-index')).toBeVisible();
 
     await page.getByTestId('tab-home').click();
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-home-index')).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -70,29 +75,30 @@ test.describe(inputDir, () => {
 
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-movies-index')).toBeVisible();
 
     await page.getByRole('link', { name: 'Toy Story' }).click();
 
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    expect(page.getByText('Toy Story')).toBeDefined();
-    expect(page.getByText('Lorem ipsum dolor sit amet')).toBeDefined();
+    const movieDetails = movieDetailsFor(page, 'Toy Story');
+    await expect(movieDetails).toBeVisible();
+    await expect(movieDetails).toContainText('Toy Story');
+    await expect(movieDetails).toContainText('Lorem ipsum dolor sit amet');
 
     await page.getByTestId('tab-home').click();
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-home-index')).toBeVisible();
 
     await page.getByTestId('tab-movies').click();
 
     // Still on the movie details page
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    expect(page.getByText('Toy Story')).toBeDefined();
-    expect(page.getByText('Lorem ipsum dolor sit amet')).toBeDefined();
+    await expect(movieDetails).toBeVisible();
+    await expect(movieDetails).toContainText('Toy Story');
+    await expect(movieDetails).toContainText('Lorem ipsum dolor sit amet');
 
     // Second click on focused tab resets it
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-movies-index')).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -105,32 +111,31 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(visibleTestId(page, 'tab-home-index')).toBeVisible();
 
     await page.getByText('Toy Story').click();
 
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Toy Story' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
+    const toyStoryDetails = movieDetailsFor(page, 'Toy Story');
+    await expect(toyStoryDetails).toBeVisible();
+    await expect(toyStoryDetails).toContainText('Toy Story');
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     await page.getByRole('link', { name: 'Monsters Inc.' }).click();
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Monsters Inc.' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Monsters%20Inc$/);
+    const monstersDetails = movieDetailsFor(page, 'Monsters Inc.');
+    await expect(monstersDetails).toBeVisible();
+    await expect(monstersDetails).toContainText('Monsters Inc.');
+    await expect(page).toHaveURL(/\/movies\/Monsters%20Inc$/);
 
     // Go back to Toy Story
     await page.goBack();
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Toy Story' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
+    await expect(toyStoryDetails).toBeVisible();
+    await expect(toyStoryDetails).toContainText('Toy Story');
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     // Go back to movies index
     await page.goBack();
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
-    expect(page).toHaveURL(/\/$/);
+    await expect(visibleTestId(page, 'tab-home-index')).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
@@ -10,6 +10,9 @@ test.afterAll(() => restoreEnv());
 
 const projectRoot = getRouterE2ERoot();
 const inputDir = 'native-tabs';
+
+const visibleTestId = (page: Page, testId: string) =>
+  page.getByTestId(testId).filter({ visible: true });
 
 test.describe(inputDir, () => {
   const expoStart = createExpoStart({
@@ -45,19 +48,19 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested/inner', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-inner')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-index')).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -68,35 +71,35 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     // 1 is the badge value on the "nested" tab
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-index')).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested/inner', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-inner')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-inner')).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-index')).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-nested-index')).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -107,14 +110,14 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(visibleTestId(page, 'native-tabs-index')).toBeVisible();
 
-    expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).toBeDefined();
+    await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).toBeVisible();
     await page.getByRole('tab', { name: 'Dynamic 9', exact: true }).click();
-    expect(page.getByTestId('native-tabs-dynamic')).toBeDefined();
-    expect(page.getByTestId('label-input')).toBeDefined();
+    await expect(visibleTestId(page, 'label-input')).toBeVisible();
+    await expect(visibleTestId(page, 'badge-input')).toBeVisible();
 
-    expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).not.toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).not.toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });


### PR DESCRIPTION
# Why

Some router Playwright E2E tests under `@expo/cli` were using `expect(locator).toBeDefined()`.

For Playwright Locators, this only verifies that a Locator object was constructed. It does not verify that the target UI exists, rendered, or became visible. This can let assertions pass even when a selector is stale or the expected screen did not appear.

This follows Playwright's recommended use of [web-first assertions](https://playwright.dev/docs/test-assertions), such as [`toBeVisible()`](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-visible), for Locator-backed UI checks.

I noticed this while reviewing the tests with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills/tree/main#skill-2-e2e-reviewer--quality-review), which flags always-passing Locator assertions and missing awaits on Playwright web-first assertions.

# How

Replaced Locator object existence checks with awaited Playwright web-first assertions so the tests wait for rendered UI state:

- `expect(locator).toBeDefined()` -> `await expect(locator).toBeVisible()`
- `expect(page).toHaveURL(...)` -> `await expect(page).toHaveURL(...)`

While making these assertions meaningful, a few previously hidden selector/runtime issues became visible:

- `tab-movies-details` -> `tab-movie-details`, matching the existing fixture test ID
- replaced nonexistent `native-tabs-dynamic` with the existing visible controls `label-input` and `badge-input`
- scoped screen assertions to the visible matching instance, because router navigation can leave inactive cached screens in the DOM and Playwright strict locators should target the active screen
- scoped movie detail assertions by visible details container text instead of relying on duplicate page-level text matches

# Test Plan

Local verification run after rebasing this branch onto `origin/main`:

- `git diff --check`
- `npx --yes prettier@3.8.3 --check packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts packages/@expo/cli/e2e/playwright/dev/headless.test.ts`
- `E2E_SMELL_NO_ESLINT_DOWNLOAD=1 E2E_SMELL_NO_AST_GREP_DOWNLOAD=1 bash <local-e2e-skills-install>/skills/e2e-reviewer/scripts/scan.sh packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts packages/@expo/cli/e2e/playwright/dev/headless.test.ts`
  - Result: `Summary: 0 total hit(s), 0 P0, 0 P1/P2 heuristic.`
- `pnpm --filter @expo/cli exec eslint e2e/playwright/dev/native-tabs.test.ts e2e/playwright/dev/headless.test.ts`
- `pnpm --filter @expo/cli typecheck`
- `pnpm --filter @expo/cli exec playwright test --config e2e/playwright.config.ts --workers=1 --reporter=list dev/native-tabs.test.ts dev/headless.test.ts`
  - Result: `6 passed`

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)