### PR TITLE
[docs] Update callout in Icons guide

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -9,7 +9,7 @@ You can use popular icon sets through icon fonts such as FontAwesome, Glyphicons
 
 ## `@expo/vector-icons`
 
-> **warning** `@expo/vector-icons` will be deprecated and is not recommended. [Learn more about migrating to `@react-native-vector-icons`](https://expo.fyi/migrating-from-expo-vector-icons).
+> **warning** `@expo/vector-icons` will be deprecated and is not recommended. [Learn more about migrating to `@react-native-vector-icons`](https://expo.dev/blog/moving-away-from-expo-vector-icons).
 
 The `@expo/vector-icons` library is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -9,7 +9,7 @@ You can use popular icon sets through icon fonts such as FontAwesome, Glyphicons
 
 ## `@expo/vector-icons`
 
-> **warning** `@expo/vector-icons` is deprecated. [Learn more](https://expo.fyi/migrating-from-expo-vector-icons) about migrating to `@react-native-vector-icons`.
+> **warning** `@expo/vector-icons` will be deprecated and is not recommended. [Learn more about migrating to `@react-native-vector-icons`](https://expo.fyi/migrating-from-expo-vector-icons).
 
 The `@expo/vector-icons` library is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/37960/

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Improve callout to avoid saying "deprecated" and instead mention that it will be deprecated in future.
- Fix link and update it to blog post.

Context: https://expo.dev/blog/moving-away-from-expo-vector-icons

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
