### PR TITLE
[cli][ios] Support Xcode 27 (DeviceHub.app) for simulator launch

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `run:ios` and iOS simulator launch failing on Xcode 27, which replaced the standalone `Simulator.app` with `DeviceHub.app`. ([#46701](https://github.com/expo/expo/pull/46701) by [@GersonRocha9](https://github.com/GersonRocha9))
 - Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
@@ -8,44 +8,63 @@ import { Prerequisite, PrerequisiteCommandError } from '../Prerequisite';
 const debug = require('debug')('expo:doctor:apple:simulatorApp') as typeof console.log;
 
 /**
- * Get the bundle ID of the Simulator.app via AppleScript / LaunchServices.
- * May return null if the Simulator.app is not registered in LaunchServices
- * (e.g. when Xcode lives on an external or renamed volume).
+ * Bundle identifier of DeviceHub.app, which replaced the standalone Simulator.app in Xcode 27.
+ */
+const DEVICE_HUB_BUNDLE_IDENTIFIER = 'com.apple.dt.Devices';
+
+/**
+ * Get the bundle ID of the simulator host app via AppleScript / LaunchServices.
+ * Checks both Simulator.app and Xcode 27's DeviceHub.app. May return null if neither is
+ * registered in LaunchServices (e.g. when Xcode lives on an external or renamed volume).
  */
 async function getSimulatorAppIdViaAppleScriptAsync(): Promise<string | null> {
-  try {
-    return (await execAsync('id of app "Simulator"')).trim();
-  } catch {
-    // This error may occur in CI where the user intends to install just the simulators but no
-    // Xcode, or when Simulator.app is not registered in LaunchServices (e.g. Xcode on an
-    // external or renamed volume).
+  for (const appName of ['Simulator', 'DeviceHub']) {
+    try {
+      const id = (await execAsync(`id of app "${appName}"`)).trim();
+      if (id) {
+        return id;
+      }
+    } catch {
+      // This error may occur in CI where the user intends to install just the simulators but no
+      // Xcode, or when the app is not registered in LaunchServices (e.g. Xcode on an external or
+      // renamed volume).
+    }
   }
   return null;
 }
 
 /**
- * Fallback: locate Simulator.app via the active Xcode developer directory and read its
- * CFBundleIdentifier directly from the app bundle's Info.plist.
- * This works even when LaunchServices hasn't indexed Simulator.app.
+ * Fallback: locate the simulator host app via the active Xcode developer directory and read its
+ * CFBundleIdentifier directly from the app bundle's Info.plist. This works even when
+ * LaunchServices hasn't indexed the app. Xcode 27 moved the developer apps from
+ * Contents/Developer/Applications up to Contents/Applications and replaced Simulator.app with
+ * DeviceHub.app, so several candidate locations are checked.
  */
 async function getSimulatorAppIdFromBundleAsync(): Promise<string | null> {
   try {
     const { stdout: developerDir } = await spawnAsync('xcode-select', ['--print-path']);
-    const simulatorInfoPlist = path.join(
-      developerDir.trim(),
-      'Applications',
-      'Simulator.app',
-      'Contents',
-      'Info.plist'
-    );
-    const { stdout: bundleId } = await spawnAsync('defaults', [
-      'read',
-      simulatorInfoPlist,
-      'CFBundleIdentifier',
-    ]);
-    return bundleId.trim() || null;
+    const root = developerDir.trim();
+    const candidates = [
+      path.join(root, 'Applications', 'Simulator.app', 'Contents', 'Info.plist'),
+      path.join(root, '..', 'Applications', 'DeviceHub.app', 'Contents', 'Info.plist'),
+      path.join(root, 'Applications', 'DeviceHub.app', 'Contents', 'Info.plist'),
+    ];
+    for (const infoPlist of candidates) {
+      try {
+        const { stdout: bundleId } = await spawnAsync('defaults', [
+          'read',
+          infoPlist,
+          'CFBundleIdentifier',
+        ]);
+        if (bundleId.trim()) {
+          return bundleId.trim();
+        }
+      } catch {
+        // This candidate app isn't present at this path; try the next one.
+      }
+    }
   } catch {
-    // Simulator.app not found at the expected path or xcode-select is unavailable.
+    // Neither app found at the expected path or xcode-select is unavailable.
   }
   return null;
 }
@@ -70,7 +89,8 @@ export class SimulatorAppPrerequisite extends Prerequisite {
     }
     if (
       result !== 'com.apple.iphonesimulator' &&
-      result !== 'com.apple.CoreSimulator.SimulatorTrampoline'
+      result !== 'com.apple.CoreSimulator.SimulatorTrampoline' &&
+      result !== DEVICE_HUB_BUNDLE_IDENTIFIER
     ) {
       throw new PrerequisiteCommandError(
         'SIMULATOR_APP',

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
@@ -22,6 +22,46 @@ it(`detects that Simulator.app is installed`, async () => {
   expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });
 
+it(`detects DeviceHub.app on Xcode 27`, async () => {
+  // Xcode 27 dropped the standalone Simulator.app in favor of DeviceHub.app.
+  jest
+    .mocked(execAsync)
+    // id of app "Simulator" — no longer registered on Xcode 27
+    .mockRejectedValueOnce(new Error('not registered'))
+    // id of app "DeviceHub"
+    .mockResolvedValueOnce('com.apple.dt.Devices');
+  jest.mocked(spawnAsync).mockResolvedValueOnce({} as any);
+
+  await SimulatorAppPrerequisite.instance.assertImplementation();
+
+  expect(execAsync).toHaveBeenCalledWith('id of app "DeviceHub"');
+  expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
+});
+
+it(`falls back to reading DeviceHub.app Info.plist on Xcode 27`, async () => {
+  // Neither app is registered in LaunchServices and Simulator.app no longer exists.
+  jest.mocked(execAsync).mockRejectedValue(new Error('not registered'));
+  jest
+    .mocked(spawnAsync)
+    // xcode-select --print-path
+    .mockResolvedValueOnce({ stdout: '/Applications/Xcode.app/Contents/Developer\n' } as any)
+    // defaults read … Simulator.app (gone on Xcode 27)
+    .mockRejectedValueOnce(new Error('does not exist'))
+    // defaults read … DeviceHub.app
+    .mockResolvedValueOnce({ stdout: 'com.apple.dt.Devices\n' } as any)
+    // xcrun simctl help
+    .mockResolvedValueOnce({} as any);
+
+  await SimulatorAppPrerequisite.instance.assertImplementation();
+
+  expect(spawnAsync).toHaveBeenCalledWith('defaults', [
+    'read',
+    expect.stringContaining('DeviceHub.app'),
+    'CFBundleIdentifier',
+  ]);
+  expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
+});
+
 it(`falls back to reading Info.plist when LaunchServices lookup fails`, async () => {
   // Simulate LaunchServices not having Simulator.app registered (e.g. Xcode on external volume).
   jest.mocked(execAsync).mockRejectedValueOnce(new Error('not registered'));

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -26,6 +26,9 @@ const debug = require('debug')('expo:start:platforms:ios:AppleDeviceManager') as
 
 const EXPO_GO_BUNDLE_IDENTIFIER = 'host.exp.Exponent';
 
+/** Bundle identifier of DeviceHub.app, which replaced the standalone Simulator.app in Xcode 27. */
+const DEVICE_HUB_BUNDLE_IDENTIFIER = 'com.apple.dt.Devices';
+
 /**
  * Ensure a simulator is booted and the Simulator app is opened.
  * This is where any timeout related error handling should live.
@@ -216,7 +219,14 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     // In non-interactive mode, we should assume this is an agent and not attempt to focus the Simulator app since it doesn't need focus.
     if (isInteractive()) {
       // TODO: Focus the individual window
-      await osascript.execAsync(`tell application "Simulator" to activate`);
+      // Xcode 27 replaced Simulator.app with DeviceHub.app; activate it by bundle id and fall back.
+      try {
+        await osascript.execAsync(
+          `tell application id "${DEVICE_HUB_BUNDLE_IDENTIFIER}" to activate`
+        );
+      } catch {
+        await osascript.execAsync(`tell application "Simulator" to activate`);
+      }
     }
   }
 

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
@@ -1,4 +1,7 @@
+import { execAsync } from '@expo/osascript';
+
 import { CommandError } from '../../../../utils/errors';
+import { isInteractive } from '../../../../utils/interactive';
 import { AppleDeviceManager } from '../AppleDeviceManager';
 import type { Device } from '../simctl';
 import { getInfoPlistValueAsync, openAppIdAsync, openUrlAsync } from '../simctl';
@@ -8,6 +11,8 @@ jest.mock('../simctl', () => ({
   openUrlAsync: jest.fn(),
   getInfoPlistValueAsync: jest.fn(),
 }));
+jest.mock('../ensureSimulatorAppRunning');
+jest.mock('../../../../utils/interactive');
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 
@@ -106,5 +111,38 @@ describe('openUrlAsync', () => {
     device.launchApplicationIdAsync = jest.fn(async () => {});
     await device.openUrlAsync('@foobar');
     expect(device.launchApplicationIdAsync).toHaveBeenCalledWith('@foobar');
+  });
+});
+
+describe('activateWindowAsync', () => {
+  it('activates DeviceHub.app by bundle id in interactive mode', async () => {
+    jest.mocked(isInteractive).mockReturnValue(true);
+    const device = createDevice();
+
+    await device.activateWindowAsync();
+
+    expect(execAsync).toHaveBeenCalledWith(
+      'tell application id "com.apple.dt.Devices" to activate'
+    );
+  });
+
+  it('falls back to activating Simulator.app when DeviceHub.app is unavailable', async () => {
+    jest.mocked(isInteractive).mockReturnValue(true);
+    // DeviceHub.app isn't registered on Xcode < 27.
+    jest.mocked(execAsync).mockRejectedValueOnce(new Error('not running'));
+    const device = createDevice();
+
+    await device.activateWindowAsync();
+
+    expect(execAsync).toHaveBeenCalledWith('tell application "Simulator" to activate');
+  });
+
+  it('does not attempt to focus the window in non-interactive mode', async () => {
+    jest.mocked(isInteractive).mockReturnValue(false);
+    const device = createDevice();
+
+    await device.activateWindowAsync();
+
+    expect(execAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
@@ -15,12 +15,27 @@ it('should do nothing when the Simulator.app is running', async () => {
   expect(Log.log).not.toHaveBeenCalled();
 });
 
-it('should activate the window when Simulator.app is not running', async () => {
+it('should open DeviceHub.app when the simulator host is not running', async () => {
   jest.mocked(execAsync).mockResolvedValueOnce('0').mockResolvedValueOnce('1');
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 
   expect(Log.log).toHaveBeenCalledWith(expect.stringMatching(/Opening the iOS simulator/));
+  expect(spawnAsync).toHaveBeenCalledWith('open', ['-b', 'com.apple.dt.Devices']);
+});
+
+it('falls back to Simulator.app when DeviceHub.app is unavailable', async () => {
+  jest.mocked(execAsync).mockResolvedValueOnce('0').mockResolvedValueOnce('1');
+  jest
+    .mocked(spawnAsync)
+    // open -b com.apple.dt.Devices — DeviceHub not installed on Xcode < 27
+    .mockRejectedValueOnce(new Error('Unable to find application'))
+    // open -a Simulator
+    .mockResolvedValueOnce({} as any);
+
+  await ensureSimulatorAppRunningAsync({ udid: '123' });
+
+  expect(spawnAsync).toHaveBeenCalledWith('open', ['-b', 'com.apple.dt.Devices']);
   expect(spawnAsync).toHaveBeenCalledWith('open', [
     '-a',
     'Simulator',

--- a/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
@@ -6,7 +6,10 @@ import * as Log from '../../../log';
 import { waitForActionAsync } from '../../../utils/delay';
 import { CommandError } from '../../../utils/errors';
 
-/** Open the Simulator.app and return when the system registers it as 'open'. */
+/** Bundle identifier of DeviceHub.app, which replaced the standalone Simulator.app in Xcode 27. */
+const DEVICE_HUB_BUNDLE_IDENTIFIER = 'com.apple.dt.Devices';
+
+/** Open the simulator host app and return when the system registers it as 'open'. */
 export async function ensureSimulatorAppRunningAsync(
   device: Partial<Pick<Device, 'udid'>>,
   {
@@ -48,7 +51,7 @@ async function isSimulatorAppRunningAsync(): Promise<boolean> {
   try {
     const zeroMeansNo = (
       await osascript.execAsync(
-        'tell app "System Events" to count processes whose name is "Simulator"'
+        'tell app "System Events" to count (processes whose name is "Simulator" or name is "DeviceHub")'
       )
     ).trim();
     if (zeroMeansNo === '0') {
@@ -65,6 +68,15 @@ async function isSimulatorAppRunningAsync(): Promise<boolean> {
 }
 
 async function openSimulatorAppAsync(device: { udid?: string }) {
+  // Xcode 27 removed the standalone Simulator.app in favor of DeviceHub.app. Prefer opening
+  // DeviceHub by its bundle identifier and fall back to the legacy Simulator.app on older Xcode.
+  try {
+    await spawnAsync('open', ['-b', DEVICE_HUB_BUNDLE_IDENTIFIER]);
+    return;
+  } catch {
+    // DeviceHub.app is unavailable (Xcode < 27); fall back to Simulator.app below.
+  }
+
   const args = ['-a', 'Simulator'];
   if (device.udid) {
     // This has no effect if the app is already running.


### PR DESCRIPTION
# Why

Xcode 27 removed the standalone `Simulator.app` and replaced it with `DeviceHub.app` (bundle id `com.apple.dt.Devices`). It also moved the developer apps from `Xcode.app/Contents/Developer/Applications/` up to `Xcode.app/Contents/Applications/`. The runtimes and `simctl` still work, but `@expo/cli` hardcodes `"Simulator"` in three places, so `npx expo run:ios` and `npx expo start --ios` fail on Xcode 27 with:

```
Can't determine id of Simulator app; the Simulator is most likely not installed on this machine. Run `sudo xcode-select -s /Applications/Xcode.app`
```

Addresses #46662 and #46671 (both previously closed for lack of a minimal repro).

# How

Three spots in `@expo/cli` assumed `Simulator.app`:

1. **`SimulatorAppPrerequisite.ts`** — the prerequisite that throws the error above.
   - AppleScript lookup (`id of app …`) now checks both `Simulator` and `DeviceHub`.
   - The `Info.plist` fallback now also checks `DeviceHub.app`, including the new `Contents/Applications/` location.
   - Accepts the DeviceHub bundle id `com.apple.dt.Devices` as a valid simulator host.
2. **`ensureSimulatorAppRunning.ts`** — opening the simulator GUI.
   - Opens `DeviceHub.app` by bundle id, falling back to `Simulator.app` on older Xcode.
   - The "is it running?" check now counts the `DeviceHub` process as well as `Simulator`.
3. **`AppleDeviceManager.ts`** — focusing the window.
   - `activateWindowAsync` activates DeviceHub by bundle id, falling back to `Simulator`.

All changes are backward compatible — on Xcode ≤ 26 the `Simulator.app` paths are still used. Booting the device itself is unaffected; it already goes through `simctl boot` in `ensureSimulatorOpenAsync`.

# Test Plan

- Added unit tests covering DeviceHub detection / open / activate and the `Simulator.app` fallback.
- `@expo/cli` apple + ios suites: **64 passing**.

  ```
  Test Suites: 12 passed, 12 total
  Tests:       64 passed, 64 total
  ```
- `pnpm typecheck` and `pnpm lint` clean.

# Checklist

- [x] I added a `CHANGELOG.md` entry. (`@expo/cli`'s `build/` is gitignored, so there are no compiled sources to rebuild.)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A, this only affects the local simulator launch flow.
- [x] Conforms with the Documentation Writing Style Guide — N/A, no docs changes.
