### PR TITLE
[expo-app-metrics][ENG-21739] fix race condition between db inserts

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### 🐛 Bug fixes
 
+- fix race condition between db inserts ([#46702](https://github.com/expo/expo/pull/46702) by [@Ubax](https://github.com/Ubax))
+
 ### 💡 Others

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -13,6 +13,7 @@ import expo.modules.appmetrics.storage.JsMetric
 import expo.modules.appmetrics.storage.JsSession
 import expo.modules.appmetrics.storage.LogRecord
 import expo.modules.appmetrics.storage.Metric
+import expo.modules.appmetrics.storage.SessionCoordinator
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.updates.UpdatesMonitoring
 import expo.modules.appmetrics.updates.UpdatesStateEvent
@@ -45,18 +46,14 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   lateinit var memoryMetricsManager: MemoryMetricsManager
   lateinit var updatesMonitoring: UpdatesMonitoring
   private var subscription: UpdatesStateChangeSubscription? = null
-  lateinit var appSessionId: String
 
   private val moduleCreationTimestamp = TimeUtils.getCurrentTimestampInISOFormat()
 
   lateinit var sessionManager: SessionManager
 
-  // Tracks the in-flight session-row INSERT kicked off in `OnCreate`. `OnDestroy`
-  // joins it before stamping `endTimestamp` so the UPDATE doesn't race with the
-  // INSERT and silently no-op.
-  private var sessionStartJob: Job? = null
-
-  private var didSaveStartupMetrics: Boolean = false
+  // Owns the main session lifecycle and gates every write on the session row
+  // being persisted first.
+  lateinit var sessionCoordinator: SessionCoordinator
 
   // Lazy-initialized metadata - created once when first needed
   private val metadata: AppMetadata? by lazy {
@@ -92,11 +89,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
           // ordering startup-metric writes ahead of caller-driven log events.
           saveStartupMetricsIfNotSaved()
           // Globals merge happens inside `sessionManager.addLogs` so every
-          // persistence path picks them up.
-          sessionManager.addLogs(
+          // persistence path picks them up. The coordinator waits for the
+          // session row before inserting.
+          sessionCoordinator.addLogs(
             listOf(
               LogRecord(
-                sessionId = appSessionId,
+                sessionId = sessionCoordinator.sessionId,
                 timestamp = TimeUtils.getCurrentTimestampInISOFormat(),
                 name = validatedName,
                 body = validatedBody,
@@ -104,8 +102,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
                 attributes = sanitized.attributes?.let { JsonAny.encodeMapToJsonString(it) },
                 droppedAttributesCount = sanitized.droppedCount
               )
-            ),
-            sessionId = appSessionId
+            )
           )
         }
       }
@@ -117,27 +114,24 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       OnCreate {
         sessionManager = SessionManager(context)
 
-        appSessionId = sessionManager.createSessionId()
+        sessionCoordinator = SessionCoordinator(
+          sessionManager = sessionManager,
+          scope = scope,
+          deactivateBefore = moduleCreationTimestamp,
+          startTimestamp = TimeUtils.getProcessStartTimestamp(),
+          metadata = metadata
+        )
 
         // Persist the session row eagerly so it's visible to readers
-        // (`getMainSession`, `addCustomMetricToSession`, …) before any startup
-        // metrics arrive. Older app runs are deactivated in the same coroutine
-        // to keep the order well-defined. The `Job` is captured so `OnDestroy`
-        // can wait for the INSERT before stamping `endTimestamp`.
-        sessionStartJob = scope.launch {
-          sessionManager.deactivateAllSessionsBefore(moduleCreationTimestamp)
-          sessionManager.startSessionWithIdAt(
-            sessionId = appSessionId,
-            timestamp = TimeUtils.getProcessStartTimestamp(),
-            metadata = metadata
-          )
-        }
+        // (`getMainSession`, …) as soon as possible. Idempotent:
+        // a racing write triggers (and joins) the same single start job.
+        scope.launch { sessionCoordinator.awaitSessionReady() }
 
         memoryMetricsManager = MemoryMetricsManager(
           context = context,
           sessionManager = sessionManager
         )
-        updatesMonitoring = UpdatesMonitoring(sessionId = appSessionId)
+        updatesMonitoring = UpdatesMonitoring(sessionId = sessionCoordinator.sessionId)
         updatesMonitoring.patchAppInfoIfNeeded(metadata)
         UpdatesControllerRegistry.controller?.get()?.let { controller ->
           subscription = controller.subscribeToUpdatesStateChanges(this@AppMetricsModule)
@@ -157,12 +151,11 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       OnDestroy {
         // `modulesQueue` is cancelled immediately after this hook returns, so
         // run the UPDATE on the calling thread to make sure the end timestamp
-        // is persisted before teardown. Joining `sessionStartJob` first
-        // guarantees the INSERT lands before the UPDATE so the stamp doesn't
+        // is persisted before teardown. `stopSession` awaits the session-start
+        // job first, so the INSERT lands before the UPDATE and the stamp doesn't
         // silently no-op on a missing row.
         runBlocking {
-          sessionStartJob?.join()
-          sessionManager.stopSession(appSessionId)
+          sessionCoordinator.stopSession()
         }
       }
 
@@ -183,7 +176,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       }
 
       AsyncFunction("getMainSession") Coroutine { ->
-        sessionManager.getSessionById(appSessionId)?.let { JsSession.fromSessionWithMetrics(it) }
+        sessionManager.getSessionById(sessionCoordinator.sessionId)?.let { JsSession.fromSessionWithMetrics(it) }
       }
 
       Class(NetworkRequestObserver::class) {
@@ -205,22 +198,25 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       updatesMonitoring.downloadTimeMetric(subscription)?.let { metric ->
         scope.launch {
           // Attach any pending startup metrics first so the download-time
-          // metric lands alongside them. The session row itself is already
-          // persisted eagerly in `OnCreate`.
+          // metric lands alongside them. The coordinator waits for the session
+          // row before inserting.
           saveStartupMetricsIfNotSaved()
-          sessionManager.addMetrics(listOf(metric), sessionId = appSessionId)
+          sessionCoordinator.addMetrics(listOf(metric))
         }
       }
     }
   }
 
-  // TODO(@lukmccall): Potential race condition - multiple coroutines could enter the block simultaneously, causing duplicates.
-  internal suspend fun saveStartupMetricsIfNotSaved() {
-    if (!didSaveStartupMetrics) {
-      // The session row is written eagerly in `OnCreate`, so we only need to
-      // attach the startup metrics here once they've been collected.
-      sessionManager.addMetrics(AppStartupManager.metrics, sessionId = appSessionId)
-      didSaveStartupMetrics = true
+  // Persists the collected startup metrics once, then suspends until that write
+  // completes. The coordinator waits for the session row before inserting.
+  internal suspend fun saveStartupMetricsIfNotSaved() = saveStartupMetricsJob.join()
+  
+  // Startup metrics are persisted on first access and exactly once: `by lazy`
+  // runs the initializer a single time even across threads, so concurrent callers
+  // don't each insert them.
+  private val saveStartupMetricsJob: Job by lazy {
+    scope.launch {
+      sessionCoordinator.addMetrics(AppStartupManager.metrics)
     }
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionCoordinator.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionCoordinator.kt
@@ -1,0 +1,65 @@
+package expo.modules.appmetrics.storage
+
+import expo.modules.appmetrics.AppMetadata
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the main's session lifecycle and gates every write on the session row
+ * being persisted first.
+ *
+ * `metrics.sessionId` / `logs.sessionId` have a foreign key to `sessions.id`, so
+ * a metric or log written before its session row exists fails with
+ * `SQLiteConstraintException: FOREIGN KEY constraint failed` (ENG-21739).
+ *
+ * To guarantee ordering, the session row is created lazily by [sessionStartJob]
+ * (exactly once), and every write joins that job via [awaitSessionReady] before
+ * touching the database.
+ */
+class SessionCoordinator(
+  private val sessionManager: SessionManager,
+  private val scope: CoroutineScope,
+  // Sessions left active by a previous process (force-quit, OOM, crash) are
+  // deactivated up to this timestamp before the new session is created.
+  private val deactivateBefore: String,
+  private val startTimestamp: String,
+  private val metadata: AppMetadata?
+) {
+  // Generated synchronously so it's available immediately to readers and to
+  // collaborators (e.g. `UpdatesMonitoring`) that capture it before the session
+  // row has been persisted.
+  val sessionId: String = sessionManager.createSessionId()
+
+  // The session row is persisted on first access and exactly once: `by lazy`
+  // runs the initializer a single time even across threads, so no
+  // explicit lock or volatile flag is needed.
+  private val sessionStartJob: Job by lazy {
+    scope.launch {
+      // Deactivate must run before the INSERT: the new session's
+      // `startTimestamp` is the process-start time, which is older than
+      // `deactivateBefore`, so inserting first would let the sweep mark the
+      // brand-new active session inactive.
+      sessionManager.deactivateAllSessionsBefore(deactivateBefore)
+      sessionManager.startSessionWithIdAt(sessionId, startTimestamp, metadata)
+    }
+  }
+
+  /** Suspends until the session row has been persisted (kicked off lazily on first call). */
+  suspend fun awaitSessionReady() = sessionStartJob.join()
+
+  suspend fun addMetrics(metrics: List<Metric>) {
+    awaitSessionReady()
+    sessionManager.addMetrics(metrics, sessionId)
+  }
+
+  suspend fun addLogs(logs: List<LogRecord>) {
+    awaitSessionReady()
+    sessionManager.addLogs(logs, sessionId)
+  }
+
+  suspend fun stopSession() {
+    awaitSessionReady()
+    sessionManager.stopSession(sessionId)
+  }
+}


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-21739/android-crash-when-observe-is-enabled-on-sdk-56

In rare cases there can be a race condition between `startSessionWithIdAt` and `addMetrics(AppStartupManager.metrics`. The `addMetrics` is called before session is created in the database, and a `SQLiteConstraintException: FOREIGN KEY constraint failed` exception is thrown.

# How

1. Extract the session and metric logic to `SessionCoordinator`
2. Use `by lazy` to ensure that sessionStart is called only once
3. Use `job.join` to wait for session creation before any other insert operation can happen

# Test Plan

1. CI
2. Observe tester

It's hard to reproduce this issue, so just check for any regressions

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
