### PR TITLE
chore(precompiled,ios) remove epxo-sensors from list of precompiled packages

### DIFF
--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -111,7 +111,6 @@ const IOS_PREBUILD_PACKAGES = [
   'expo-media-library',
   'expo-modules-core',
   'expo-print',
-  'expo-sensors',
   'expo-ui',
   'expo-video',
 ];


### PR DESCRIPTION
## Why

Expo-sensors has a conditional define that doesn't work well with precompiled xcframeworks - and instead of refactoring this we have decided that the module isn't big enough to be precompiled - building from source is probl. faster as well.

## How

Removed it from the bundleIOSPrebuilds.ts `IOS_PREBUILD_PACKAGES` list.

Supersedes #46686

