### PR TITLE
[docs] Add @expo/ui component tables to SDK reference pages

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
     "copy-latest": "node ./scripts/copy-latest.js",
     "generate-llms": "node --experimental-strip-types ./scripts/generate-llms/index.js",
     "generate-markdown-pages": "node --experimental-strip-types ./scripts/generate-markdown-pages.ts",
+    "generate-ui-component-tables": "node --experimental-strip-types ./scripts/generate-ui-component-tables.ts",
     "check-markdown-pages": "node --experimental-strip-types ./scripts/check-markdown-pages.ts",
     "generate-static-resources": "node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",

--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/index.mdx
@@ -5,15 +5,18 @@ description: Components and APIs that serve as drop-in replacements for popular 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'web', 'expo-go']
+hideTOC: true
 ---
 
 The following components provide API-compatible replacements for popular React Native community libraries, powered by `@expo/ui` native components (Jetpack Compose on Android and SwiftUI on iOS).
 
-- **[BottomSheet](bottomsheet)**: Compatible with `@gorhom/bottom-sheet`
-- **[DateTimePicker](datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
-- **[MaskedView](maskedview)**: Compatible with `@react-native-masked-view/masked-view`
-- **[Menu](menu)**: Compatible with `@react-native-menu/menu`
-- **[PagerView](pagerview)**: Compatible with `react-native-pager-view`
-- **[Picker](picker)**: Compatible with `@react-native-picker/picker`
-- **[SegmentedControl](segmentedcontrol)**: Compatible with `@react-native-segmented-control/segmented-control`
-- **[Slider](slider)**: Compatible with `@react-native-community/slider`
+| Component                              | Compatible with                                     |
+| -------------------------------------- | --------------------------------------------------- |
+| [`BottomSheet`](bottomsheet)           | `@gorhom/bottom-sheet`                              |
+| [`DateTimePicker`](datetimepicker)     | `@react-native-community/datetimepicker`            |
+| [`MaskedView`](maskedview)             | `@react-native-masked-view/masked-view`             |
+| [`Menu`](menu)                         | `@react-native-menu/menu`                           |
+| [`PagerView`](pagerview)               | `react-native-pager-view`                           |
+| [`Picker`](picker)                     | `@react-native-picker/picker`                       |
+| [`SegmentedControl`](segmentedcontrol) | `@react-native-segmented-control/segmented-control` |
+| [`Slider`](slider)                     | `@react-native-community/slider`                    |

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -25,6 +25,42 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 
 {/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
 
+### Drop-in replacements
+
+| Component                                                   | Description                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
+| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
+| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
+| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
+| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
+| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
+| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
+| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
+
+### Universal
+
+| Component                              | Description                                                                                               |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
+| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
+| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
+| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
+| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
+| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
+| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
+| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
+| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
+| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
+| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
+| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
+| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
+| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
+| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
+| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
+| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
+| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
+
 ### Jetpack Compose
 
 | Component                                                                | Description                                                                                                      |
@@ -121,41 +157,5 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 | [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                     |
 | [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                              |
 | [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                           |
-
-### Universal
-
-| Component                              | Description                                                                                               |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
-| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
-| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
-| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
-| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
-| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
-| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
-| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
-| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
-| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
-| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
-| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
-| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
-| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
-| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
-| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
-| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
-| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
-
-### Drop-in replacements
-
-| Component                                                   | Description                                                                            |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
-| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
-| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
-| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
-| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
-| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
-| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
-| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
 
 {/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -5,7 +5,6 @@ description: A set of components that allow you to build UIs directly with Jetpa
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'tvos', 'expo-go']
-hideTOC: true
 ---
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with Jetpack Compose and SwiftUI. It aims to provide the commonly used features and components that a typical app will need.
@@ -21,3 +20,142 @@ Components are available for the following platforms:
 ## Drop-in replacements
 
 See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacements for popular React Native community libraries.
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+### Jetpack Compose
+
+| Component                                                                | Description                                                                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| [`AlertDialog`](jetpack-compose/alertdialog)                             | AlertDialog component for displaying native alert dialogs.                                                       |
+| [`Badge`](jetpack-compose/badge)                                         | Badge component for displaying status indicators and counts.                                                     |
+| [`BadgedBox`](jetpack-compose/badgedbox)                                 | BadgedBox component for overlaying badges on content.                                                            |
+| [`BasicAlertDialog`](jetpack-compose/basicalertdialog)                   | BasicAlertDialog component for displaying dialogs with custom content.                                           |
+| [`Box`](jetpack-compose/box)                                             | Box component for stacking child elements.                                                                       |
+| [`Button`](jetpack-compose/button)                                       | Button components for displaying native Material3 buttons.                                                       |
+| [`Card`](jetpack-compose/card)                                           | Card component for displaying content in a styled container.                                                     |
+| [`Carousel`](jetpack-compose/carousel)                                   | Carousel components for displaying scrollable collections of items.                                              |
+| [`Checkbox`](jetpack-compose/checkbox)                                   | Checkbox component for selection controls.                                                                       |
+| [`Chip`](jetpack-compose/chip)                                           | Chip components for displaying compact elements.                                                                 |
+| [`Column`](jetpack-compose/column)                                       | Column component for placing children vertically.                                                                |
+| [`DateTimePicker`](jetpack-compose/datetimepicker)                       | DateTimePicker component for selecting dates and times.                                                          |
+| [`Divider`](jetpack-compose/divider)                                     | Divider components for creating visual separators.                                                               |
+| [`DockedSearchBar`](jetpack-compose/dockedsearchbar)                     | DockedSearchBar component for displaying an inline search input.                                                 |
+| [`DropdownMenu`](jetpack-compose/dropdownmenu)                           | DropdownMenu component for displaying dropdown menus.                                                            |
+| [`ExposedDropdownMenuBox`](jetpack-compose/exposeddropdownmenubox)       | ExposedDropdownMenuBox component for displaying a dropdown menu with a customizable anchor.                      |
+| [`FloatingActionButton`](jetpack-compose/floatingactionbutton)           | FloatingActionButton components following Material Design 3.                                                     |
+| [`FlowRow`](jetpack-compose/flowrow)                                     | FlowRow component for wrapping children horizontally.                                                            |
+| [`HorizontalFloatingToolbar`](jetpack-compose/horizontalfloatingtoolbar) | HorizontalFloatingToolbar component for displaying a floating action bar.                                        |
+| [`HorizontalPager`](jetpack-compose/horizontalpager)                     | HorizontalPager component for swipeable pages.                                                                   |
+| [`Host`](jetpack-compose/host)                                           | Host component for bridging React Native and Jetpack Compose.                                                    |
+| [`Icon`](jetpack-compose/icon)                                           | Icon component for displaying icons.                                                                             |
+| [`IconButton`](jetpack-compose/iconbutton)                               | IconButton components for displaying native Material3 icon buttons.                                              |
+| [`LazyColumn`](jetpack-compose/lazycolumn)                               | LazyColumn component for displaying scrollable lists.                                                            |
+| [`LazyRow`](jetpack-compose/lazyrow)                                     | LazyRow component for displaying horizontally scrolling lists.                                                   |
+| [`ListItem`](jetpack-compose/listitem)                                   | ListItem component for displaying structured list entries.                                                       |
+| [`LoadingIndicator`](jetpack-compose/loadingindicator)                   | Loading indicator components for displaying loading state.                                                       |
+| [`ModalBottomSheet`](jetpack-compose/bottomsheet)                        | ModalBottomSheet component that presents content from the bottom of the screen.                                  |
+| [`NavigationBar`](jetpack-compose/navigationbar)                         | NavigationBar component for Material 3 bottom navigation.                                                        |
+| [`Progress Indicators`](jetpack-compose/progress)                        | Progress indicator components for displaying operation status.                                                   |
+| [`PullToRefreshBox`](jetpack-compose/pulltorefreshbox)                   | PullToRefreshBox component for pull-to-refresh interactions.                                                     |
+| [`RadioButton`](jetpack-compose/radiobutton)                             | RadioButton component for single-selection controls.                                                             |
+| [`RNHostView`](jetpack-compose/rnhostview)                               | A component that enables React Native views inside Jetpack Compose.                                              |
+| [`Row`](jetpack-compose/row)                                             | Row component for placing children horizontally.                                                                 |
+| [`SearchBar`](jetpack-compose/searchbar)                                 | SearchBar component for search input functionality.                                                              |
+| [`SegmentedButton`](jetpack-compose/segmentedbutton)                     | Segmented Button components for single or multi-choice selection.                                                |
+| [`Shape`](jetpack-compose/shape)                                         | Shape component for drawing geometric shapes.                                                                    |
+| [`Slider`](jetpack-compose/slider)                                       | Slider component for selecting values from a range.                                                              |
+| [`Snackbar`](jetpack-compose/snackbar)                                   | A brief notification that appears at the bottom of the screen to provide feedback without interrupting the user. |
+| [`Spacer`](jetpack-compose/spacer)                                       | Spacer component for adding flexible space between elements.                                                     |
+| [`Surface`](jetpack-compose/surface)                                     | Surface component for styled content containers.                                                                 |
+| [`Switch`](jetpack-compose/switch)                                       | Switch component for toggle controls.                                                                            |
+| [`Text`](jetpack-compose/text)                                           | Text component for displaying styled text.                                                                       |
+| [`TextField`](jetpack-compose/textfield)                                 | TextField components for native Material3 text input.                                                            |
+| [`ToggleButton`](jetpack-compose/togglebutton)                           | ToggleButton components for displaying native Material3 toggle buttons.                                          |
+| [`Tooltip`](jetpack-compose/tooltip)                                     | Tooltip components for displaying contextual information on long-press.                                          |
+
+### SwiftUI
+
+| Component                                                         | Description                                                                                         |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
+| [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
+| [`Button`](swift-ui/button)                                       | Button component for displaying native buttons.                                                     |
+| [`ColorPicker`](swift-ui/colorpicker)                             | ColorPicker component for selecting colors.                                                         |
+| [`ConfirmationDialog`](swift-ui/confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
+| [`ContextMenu`](swift-ui/contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
+| [`ControlGroup`](swift-ui/controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
+| [`DatePicker`](swift-ui/datepicker)                               | DatePicker component for selecting dates and times.                                                 |
+| [`DisclosureGroup`](swift-ui/disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
+| [`Divider`](swift-ui/divider)                                     | Divider component for creating visual separators.                                                   |
+| [`Form`](swift-ui/form)                                           | Form component for collecting user input in a structured layout.                                    |
+| [`Gauge`](swift-ui/gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
+| [`Group`](swift-ui/group)                                         | Group component for grouping views without affecting layout.                                        |
+| [`Host`](swift-ui/host)                                           | Host component that enables SwiftUI components in React Native.                                     |
+| [`HStack`](swift-ui/hstack)                                       | HStack component for horizontal layouts.                                                            |
+| [`Image`](swift-ui/image)                                         | Image component for displaying SF Symbols.                                                          |
+| [`Label`](swift-ui/label)                                         | Label component for displaying text with an icon.                                                   |
+| [`LazyHStack`](swift-ui/lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
+| [`LazyVStack`](swift-ui/lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
+| [`Link`](swift-ui/link)                                           | Link component for displaying clickable links.                                                      |
+| [`List`](swift-ui/list)                                           | List component for displaying scrollable lists of items.                                            |
+| [`Menu`](swift-ui/menu)                                           | Menu component for displaying dropdown menus.                                                       |
+| [`Namespace`](swift-ui/namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
+| [`Overlay`](swift-ui/overlay)                                     | Overlay component for layering content on top of another view.                                      |
+| [`Picker`](swift-ui/picker)                                       | Picker component for selecting options from a list.                                                 |
+| [`Popover`](swift-ui/popover)                                     | Popover component for displaying content in a floating overlay.                                     |
+| [`ProgressView`](swift-ui/progressview)                           | ProgressView component for displaying progress indicators.                                          |
+| [`RNHostView`](swift-ui/rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
+| [`ScrollView`](swift-ui/scrollview)                               | ScrollView component for scrollable content.                                                        |
+| [`Section`](swift-ui/section)                                     | Section component for grouping content within lists and forms.                                      |
+| [`SecureField`](swift-ui/securefield)                             | SecureField component for password input.                                                           |
+| [`Slider`](swift-ui/slider)                                       | Slider component for selecting values from a range.                                                 |
+| [`Spacer`](swift-ui/spacer)                                       | Spacer component for flexible spacing.                                                              |
+| [`SwipeActions`](swift-ui/swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
+| [`TabView`](swift-ui/tabview)                                     | TabView component for paged or tabbed content.                                                      |
+| [`Text`](swift-ui/text)                                           | Text component for displaying styled text with support for nested texts.                            |
+| [`TextField`](swift-ui/textfield)                                 | TextField component for text input.                                                                 |
+| [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                     |
+| [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                              |
+| [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                           |
+
+### Universal
+
+| Component                              | Description                                                                                               |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
+| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
+| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
+| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
+| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
+| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
+| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
+| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
+| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
+| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
+| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
+| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
+| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
+| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
+| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
+| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
+| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
+| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
+
+### Drop-in replacements
+
+| Component                                                   | Description                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
+| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
+| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
+| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
+| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
+| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
+| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
+| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -16,6 +16,8 @@ Components are available for the following platforms:
 - **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
 - **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 - **[Universal](universal)**: Cross-platform components that run on Android, iOS, and web from a single source
+- **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
+- **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 
 ## Drop-in replacements
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
@@ -5,7 +5,6 @@ description: Jetpack Compose components for building native Android interfaces w
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'expo-go']
-hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -31,3 +30,58 @@ export function SaveButton() {
   );
 }
 ```
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+| Component                                                | Description                                                                                                      |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`AlertDialog`](alertdialog)                             | AlertDialog component for displaying native alert dialogs.                                                       |
+| [`Badge`](badge)                                         | Badge component for displaying status indicators and counts.                                                     |
+| [`BadgedBox`](badgedbox)                                 | BadgedBox component for overlaying badges on content.                                                            |
+| [`BasicAlertDialog`](basicalertdialog)                   | BasicAlertDialog component for displaying dialogs with custom content.                                           |
+| [`Box`](box)                                             | Box component for stacking child elements.                                                                       |
+| [`Button`](button)                                       | Button components for displaying native Material3 buttons.                                                       |
+| [`Card`](card)                                           | Card component for displaying content in a styled container.                                                     |
+| [`Carousel`](carousel)                                   | Carousel components for displaying scrollable collections of items.                                              |
+| [`Checkbox`](checkbox)                                   | Checkbox component for selection controls.                                                                       |
+| [`Chip`](chip)                                           | Chip components for displaying compact elements.                                                                 |
+| [`Column`](column)                                       | Column component for placing children vertically.                                                                |
+| [`DateTimePicker`](datetimepicker)                       | DateTimePicker component for selecting dates and times.                                                          |
+| [`Divider`](divider)                                     | Divider components for creating visual separators.                                                               |
+| [`DockedSearchBar`](dockedsearchbar)                     | DockedSearchBar component for displaying an inline search input.                                                 |
+| [`DropdownMenu`](dropdownmenu)                           | DropdownMenu component for displaying dropdown menus.                                                            |
+| [`ExposedDropdownMenuBox`](exposeddropdownmenubox)       | ExposedDropdownMenuBox component for displaying a dropdown menu with a customizable anchor.                      |
+| [`FloatingActionButton`](floatingactionbutton)           | FloatingActionButton components following Material Design 3.                                                     |
+| [`FlowRow`](flowrow)                                     | FlowRow component for wrapping children horizontally.                                                            |
+| [`HorizontalFloatingToolbar`](horizontalfloatingtoolbar) | HorizontalFloatingToolbar component for displaying a floating action bar.                                        |
+| [`HorizontalPager`](horizontalpager)                     | HorizontalPager component for swipeable pages.                                                                   |
+| [`Host`](host)                                           | Host component for bridging React Native and Jetpack Compose.                                                    |
+| [`Icon`](icon)                                           | Icon component for displaying icons.                                                                             |
+| [`IconButton`](iconbutton)                               | IconButton components for displaying native Material3 icon buttons.                                              |
+| [`LazyColumn`](lazycolumn)                               | LazyColumn component for displaying scrollable lists.                                                            |
+| [`LazyRow`](lazyrow)                                     | LazyRow component for displaying horizontally scrolling lists.                                                   |
+| [`ListItem`](listitem)                                   | ListItem component for displaying structured list entries.                                                       |
+| [`LoadingIndicator`](loadingindicator)                   | Loading indicator components for displaying loading state.                                                       |
+| [`ModalBottomSheet`](bottomsheet)                        | ModalBottomSheet component that presents content from the bottom of the screen.                                  |
+| [`NavigationBar`](navigationbar)                         | NavigationBar component for Material 3 bottom navigation.                                                        |
+| [`Progress Indicators`](progress)                        | Progress indicator components for displaying operation status.                                                   |
+| [`PullToRefreshBox`](pulltorefreshbox)                   | PullToRefreshBox component for pull-to-refresh interactions.                                                     |
+| [`RadioButton`](radiobutton)                             | RadioButton component for single-selection controls.                                                             |
+| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside Jetpack Compose.                                              |
+| [`Row`](row)                                             | Row component for placing children horizontally.                                                                 |
+| [`SearchBar`](searchbar)                                 | SearchBar component for search input functionality.                                                              |
+| [`SegmentedButton`](segmentedbutton)                     | Segmented Button components for single or multi-choice selection.                                                |
+| [`Shape`](shape)                                         | Shape component for drawing geometric shapes.                                                                    |
+| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                                              |
+| [`Snackbar`](snackbar)                                   | A brief notification that appears at the bottom of the screen to provide feedback without interrupting the user. |
+| [`Spacer`](spacer)                                       | Spacer component for adding flexible space between elements.                                                     |
+| [`Surface`](surface)                                     | Surface component for styled content containers.                                                                 |
+| [`Switch`](switch)                                       | Switch component for toggle controls.                                                                            |
+| [`Text`](text)                                           | Text component for displaying styled text.                                                                       |
+| [`TextField`](textfield)                                 | TextField components for native Material3 text input.                                                            |
+| [`ToggleButton`](togglebutton)                           | ToggleButton components for displaying native Material3 toggle buttons.                                          |
+| [`Tooltip`](tooltip)                                     | Tooltip components for displaying contextual information on long-press.                                          |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -62,3 +62,53 @@ For more information, see the following resources:
   title="Expo UI iOS Liquid Glass Tutorial"
   description="Learn how to build real SwiftUI views in your React Native app with the new Expo UI."
 />
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+| Component                                                | Description                                                                                         |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
+| [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
+| [`Button`](button)                                       | Button component for displaying native buttons.                                                     |
+| [`ColorPicker`](colorpicker)                             | ColorPicker component for selecting colors.                                                         |
+| [`ConfirmationDialog`](confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
+| [`ContextMenu`](contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
+| [`ControlGroup`](controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
+| [`DatePicker`](datepicker)                               | DatePicker component for selecting dates and times.                                                 |
+| [`DisclosureGroup`](disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
+| [`Divider`](divider)                                     | Divider component for creating visual separators.                                                   |
+| [`Form`](form)                                           | Form component for collecting user input in a structured layout.                                    |
+| [`Gauge`](gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
+| [`Group`](group)                                         | Group component for grouping views without affecting layout.                                        |
+| [`Host`](host)                                           | Host component that enables SwiftUI components in React Native.                                     |
+| [`HStack`](hstack)                                       | HStack component for horizontal layouts.                                                            |
+| [`Image`](image)                                         | Image component for displaying SF Symbols.                                                          |
+| [`Label`](label)                                         | Label component for displaying text with an icon.                                                   |
+| [`LazyHStack`](lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
+| [`LazyVStack`](lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
+| [`Link`](link)                                           | Link component for displaying clickable links.                                                      |
+| [`List`](list)                                           | List component for displaying scrollable lists of items.                                            |
+| [`Menu`](menu)                                           | Menu component for displaying dropdown menus.                                                       |
+| [`Namespace`](namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
+| [`Overlay`](overlay)                                     | Overlay component for layering content on top of another view.                                      |
+| [`Picker`](picker)                                       | Picker component for selecting options from a list.                                                 |
+| [`Popover`](popover)                                     | Popover component for displaying content in a floating overlay.                                     |
+| [`ProgressView`](progressview)                           | ProgressView component for displaying progress indicators.                                          |
+| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
+| [`ScrollView`](scrollview)                               | ScrollView component for scrollable content.                                                        |
+| [`Section`](section)                                     | Section component for grouping content within lists and forms.                                      |
+| [`SecureField`](securefield)                             | SecureField component for password input.                                                           |
+| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                                 |
+| [`Spacer`](spacer)                                       | Spacer component for flexible spacing.                                                              |
+| [`SwipeActions`](swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
+| [`TabView`](tabview)                                     | TabView component for paged or tabbed content.                                                      |
+| [`Text`](text)                                           | Text component for displaying styled text with support for nested texts.                            |
+| [`TextField`](textfield)                                 | TextField component for text input.                                                                 |
+| [`Toggle`](toggle)                                       | Toggle component for displaying native toggles.                                                     |
+| [`VStack`](vstack)                                       | VStack component for vertical layouts.                                                              |
+| [`ZStack`](zstack)                                       | ZStack component for overlapping layouts.                                                           |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/universal/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/index.mdx
@@ -5,7 +5,6 @@ description: Cross-platform components for building shared UIs across Android, i
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'web', 'expo-go']
-hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -35,16 +34,18 @@ export default function Example() {
 }
 ```
 
-## Components
+## Available components
 
-- **Container:** [`Host`](host) — the required root for every universal subtree.
-- **Layout:** [`Column`](column), [`Row`](row), [`Spacer`](spacer), [`ScrollView`](scrollview).
-- **Display:** [`Text`](text), [`Icon`](icon).
-- **Controls:** [`Button`](button), [`Switch`](switch), [`Checkbox`](checkbox), [`Slider`](slider), [`TextInput`](textinput), [`Picker`](picker).
-- **Disclosure and presentation:** [`BottomSheet`](bottomsheet), [`Collapsible`](collapsible).
-- **Collections and forms:** [`List`](list) (with `ListItem`), [`FieldGroup`](fieldgroup).
+| Category                    | Components                                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Container                   | [`Host`](host), the required root for every universal subtree.                                                                   |
+| Layout                      | [`Column`](column), [`Row`](row), [`Spacer`](spacer), [`ScrollView`](scrollview)                                                 |
+| Display                     | [`Text`](text), [`Icon`](icon)                                                                                                   |
+| Controls                    | [`Button`](button), [`Switch`](switch), [`Checkbox`](checkbox), [`Slider`](slider), [`TextInput`](textinput), [`Picker`](picker) |
+| Disclosure and presentation | [`BottomSheet`](bottomsheet), [`Collapsible`](collapsible)                                                                       |
+| Collections and forms       | [`List`](list) (with `ListItem`), [`FieldGroup`](fieldgroup)                                                                     |
 
-## When to use this versus `swift-ui` / `jetpack-compose`
+## When to use this versus `jetpack-compose`/`swift-ui`
 
 - Reach for **universal** components when you want one component tree that runs unmodified on Android, iOS, and web. The platform-native look and feel is preserved on Android and iOS because the components delegate to Jetpack Compose/SwiftUI under the hood.
-- Reach for **[`@expo/ui/swift-ui`](../swift-ui)** or **[`@expo/ui/jetpack-compose`](../jetpack-compose)** directly when you need platform-specific controls, modifiers, or behavior that the universal API doesn't surface.
+- Reach for **[`@expo/ui/jetpack-compose`](../jetpack-compose)** or **[`@expo/ui/swift-ui`](../swift-ui)** directly when you need platform-specific controls, modifiers, or behavior that the universal API doesn't surface.

--- a/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/index.mdx
@@ -5,15 +5,18 @@ description: Components and APIs that serve as drop-in replacements for popular 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-56/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'web', 'expo-go']
+hideTOC: true
 ---
 
 The following components provide API-compatible replacements for popular React Native community libraries, powered by `@expo/ui` native components (Jetpack Compose on Android and SwiftUI on iOS).
 
-- **[BottomSheet](bottomsheet)**: Compatible with `@gorhom/bottom-sheet`
-- **[DateTimePicker](datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
-- **[MaskedView](maskedview)**: Compatible with `@react-native-masked-view/masked-view`
-- **[Menu](menu)**: Compatible with `@react-native-menu/menu`
-- **[PagerView](pagerview)**: Compatible with `react-native-pager-view`
-- **[Picker](picker)**: Compatible with `@react-native-picker/picker`
-- **[SegmentedControl](segmentedcontrol)**: Compatible with `@react-native-segmented-control/segmented-control`
-- **[Slider](slider)**: Compatible with `@react-native-community/slider`
+| Component                              | Compatible with                                     |
+| -------------------------------------- | --------------------------------------------------- |
+| [`BottomSheet`](bottomsheet)           | `@gorhom/bottom-sheet`                              |
+| [`DateTimePicker`](datetimepicker)     | `@react-native-community/datetimepicker`            |
+| [`MaskedView`](maskedview)             | `@react-native-masked-view/masked-view`             |
+| [`Menu`](menu)                         | `@react-native-menu/menu`                           |
+| [`PagerView`](pagerview)               | `react-native-pager-view`                           |
+| [`Picker`](picker)                     | `@react-native-picker/picker`                       |
+| [`SegmentedControl`](segmentedcontrol) | `@react-native-segmented-control/segmented-control` |
+| [`Slider`](slider)                     | `@react-native-community/slider`                    |

--- a/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
@@ -5,7 +5,6 @@ description: A set of components that allow you to build UIs directly with Jetpa
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-56/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'tvos', 'expo-go']
-hideTOC: true
 ---
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with Jetpack Compose and SwiftUI. It aims to provide the commonly used features and components that a typical app will need.
@@ -21,3 +20,141 @@ Components are available for the following platforms:
 ## Drop-in replacements
 
 See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacements for popular React Native community libraries.
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+### Jetpack Compose
+
+| Component                                                                | Description                                                                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| [`AlertDialog`](jetpack-compose/alertdialog)                             | AlertDialog component for displaying native alert dialogs.                                                       |
+| [`Badge`](jetpack-compose/badge)                                         | Badge component for displaying status indicators and counts.                                                     |
+| [`BadgedBox`](jetpack-compose/badgedbox)                                 | BadgedBox component for overlaying badges on content.                                                            |
+| [`BasicAlertDialog`](jetpack-compose/basicalertdialog)                   | BasicAlertDialog component for displaying dialogs with custom content.                                           |
+| [`Box`](jetpack-compose/box)                                             | Box component for stacking child elements.                                                                       |
+| [`Button`](jetpack-compose/button)                                       | Button components for displaying native Material3 buttons.                                                       |
+| [`Card`](jetpack-compose/card)                                           | Card component for displaying content in a styled container.                                                     |
+| [`Carousel`](jetpack-compose/carousel)                                   | Carousel components for displaying scrollable collections of items.                                              |
+| [`Checkbox`](jetpack-compose/checkbox)                                   | Checkbox component for selection controls.                                                                       |
+| [`Chip`](jetpack-compose/chip)                                           | Chip components for displaying compact elements.                                                                 |
+| [`Column`](jetpack-compose/column)                                       | Column component for placing children vertically.                                                                |
+| [`DateTimePicker`](jetpack-compose/datetimepicker)                       | DateTimePicker component for selecting dates and times.                                                          |
+| [`Divider`](jetpack-compose/divider)                                     | Divider components for creating visual separators.                                                               |
+| [`DockedSearchBar`](jetpack-compose/dockedsearchbar)                     | DockedSearchBar component for displaying an inline search input.                                                 |
+| [`DropdownMenu`](jetpack-compose/dropdownmenu)                           | DropdownMenu component for displaying dropdown menus.                                                            |
+| [`ExposedDropdownMenuBox`](jetpack-compose/exposeddropdownmenubox)       | ExposedDropdownMenuBox component for displaying a dropdown menu with a customizable anchor.                      |
+| [`FloatingActionButton`](jetpack-compose/floatingactionbutton)           | FloatingActionButton components following Material Design 3.                                                     |
+| [`FlowRow`](jetpack-compose/flowrow)                                     | FlowRow component for wrapping children horizontally.                                                            |
+| [`HorizontalFloatingToolbar`](jetpack-compose/horizontalfloatingtoolbar) | HorizontalFloatingToolbar component for displaying a floating action bar.                                        |
+| [`HorizontalPager`](jetpack-compose/horizontalpager)                     | HorizontalPager component for swipeable pages.                                                                   |
+| [`Host`](jetpack-compose/host)                                           | Host component for bridging React Native and Jetpack Compose.                                                    |
+| [`Icon`](jetpack-compose/icon)                                           | Icon component for displaying icons.                                                                             |
+| [`IconButton`](jetpack-compose/iconbutton)                               | IconButton components for displaying native Material3 icon buttons.                                              |
+| [`LazyColumn`](jetpack-compose/lazycolumn)                               | LazyColumn component for displaying scrollable lists.                                                            |
+| [`LazyRow`](jetpack-compose/lazyrow)                                     | LazyRow component for displaying horizontally scrolling lists.                                                   |
+| [`ListItem`](jetpack-compose/listitem)                                   | ListItem component for displaying structured list entries.                                                       |
+| [`ModalBottomSheet`](jetpack-compose/bottomsheet)                        | ModalBottomSheet component that presents content from the bottom of the screen.                                  |
+| [`NavigationBar`](jetpack-compose/navigationbar)                         | NavigationBar component for Material 3 bottom navigation.                                                        |
+| [`Progress Indicators`](jetpack-compose/progress)                        | Progress indicator components for displaying operation status.                                                   |
+| [`PullToRefreshBox`](jetpack-compose/pulltorefreshbox)                   | PullToRefreshBox component for pull-to-refresh interactions.                                                     |
+| [`RadioButton`](jetpack-compose/radiobutton)                             | RadioButton component for single-selection controls.                                                             |
+| [`RNHostView`](jetpack-compose/rnhostview)                               | A component that enables React Native views inside Jetpack Compose.                                              |
+| [`Row`](jetpack-compose/row)                                             | Row component for placing children horizontally.                                                                 |
+| [`SearchBar`](jetpack-compose/searchbar)                                 | SearchBar component for search input functionality.                                                              |
+| [`SegmentedButton`](jetpack-compose/segmentedbutton)                     | Segmented Button components for single or multi-choice selection.                                                |
+| [`Shape`](jetpack-compose/shape)                                         | Shape component for drawing geometric shapes.                                                                    |
+| [`Slider`](jetpack-compose/slider)                                       | Slider component for selecting values from a range.                                                              |
+| [`Snackbar`](jetpack-compose/snackbar)                                   | A brief notification that appears at the bottom of the screen to provide feedback without interrupting the user. |
+| [`Spacer`](jetpack-compose/spacer)                                       | Spacer component for adding flexible space between elements.                                                     |
+| [`Surface`](jetpack-compose/surface)                                     | Surface component for styled content containers.                                                                 |
+| [`Switch`](jetpack-compose/switch)                                       | Switch component for toggle controls.                                                                            |
+| [`Text`](jetpack-compose/text)                                           | Text component for displaying styled text.                                                                       |
+| [`TextField`](jetpack-compose/textfield)                                 | TextField components for native Material3 text input.                                                            |
+| [`ToggleButton`](jetpack-compose/togglebutton)                           | ToggleButton components for displaying native Material3 toggle buttons.                                          |
+| [`Tooltip`](jetpack-compose/tooltip)                                     | Tooltip components for displaying contextual information on long-press.                                          |
+
+### SwiftUI
+
+| Component                                                         | Description                                                                                         |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
+| [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
+| [`Button`](swift-ui/button)                                       | Button component for displaying native buttons.                                                     |
+| [`ColorPicker`](swift-ui/colorpicker)                             | ColorPicker component for selecting colors.                                                         |
+| [`ConfirmationDialog`](swift-ui/confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
+| [`ContextMenu`](swift-ui/contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
+| [`ControlGroup`](swift-ui/controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
+| [`DatePicker`](swift-ui/datepicker)                               | DatePicker component for selecting dates and times.                                                 |
+| [`DisclosureGroup`](swift-ui/disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
+| [`Divider`](swift-ui/divider)                                     | Divider component for creating visual separators.                                                   |
+| [`Form`](swift-ui/form)                                           | Form component for collecting user input in a structured layout.                                    |
+| [`Gauge`](swift-ui/gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
+| [`Group`](swift-ui/group)                                         | Group component for grouping views without affecting layout.                                        |
+| [`Host`](swift-ui/host)                                           | Host component that enables SwiftUI components in React Native.                                     |
+| [`HStack`](swift-ui/hstack)                                       | HStack component for horizontal layouts.                                                            |
+| [`Image`](swift-ui/image)                                         | Image component for displaying SF Symbols.                                                          |
+| [`Label`](swift-ui/label)                                         | Label component for displaying text with an icon.                                                   |
+| [`LazyHStack`](swift-ui/lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
+| [`LazyVStack`](swift-ui/lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
+| [`Link`](swift-ui/link)                                           | Link component for displaying clickable links.                                                      |
+| [`List`](swift-ui/list)                                           | List component for displaying scrollable lists of items.                                            |
+| [`Menu`](swift-ui/menu)                                           | Menu component for displaying dropdown menus.                                                       |
+| [`Namespace`](swift-ui/namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
+| [`Overlay`](swift-ui/overlay)                                     | Overlay component for layering content on top of another view.                                      |
+| [`Picker`](swift-ui/picker)                                       | Picker component for selecting options from a list.                                                 |
+| [`Popover`](swift-ui/popover)                                     | Popover component for displaying content in a floating overlay.                                     |
+| [`ProgressView`](swift-ui/progressview)                           | ProgressView component for displaying progress indicators.                                          |
+| [`RNHostView`](swift-ui/rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
+| [`ScrollView`](swift-ui/scrollview)                               | ScrollView component for scrollable content.                                                        |
+| [`Section`](swift-ui/section)                                     | Section component for grouping content within lists and forms.                                      |
+| [`SecureField`](swift-ui/securefield)                             | SecureField component for password input.                                                           |
+| [`Slider`](swift-ui/slider)                                       | Slider component for selecting values from a range.                                                 |
+| [`Spacer`](swift-ui/spacer)                                       | Spacer component for flexible spacing.                                                              |
+| [`SwipeActions`](swift-ui/swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
+| [`TabView`](swift-ui/tabview)                                     | TabView component for paged or tabbed content.                                                      |
+| [`Text`](swift-ui/text)                                           | Text component for displaying styled text with support for nested texts.                            |
+| [`TextField`](swift-ui/textfield)                                 | TextField component for text input.                                                                 |
+| [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                     |
+| [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                              |
+| [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                           |
+
+### Universal
+
+| Component                              | Description                                                                                               |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
+| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
+| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
+| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
+| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
+| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
+| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
+| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
+| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
+| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
+| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
+| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
+| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
+| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
+| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
+| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
+| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
+| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
+
+### Drop-in replacements
+
+| Component                                                   | Description                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
+| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
+| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
+| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
+| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
+| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
+| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
+| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
@@ -16,6 +16,8 @@ Components are available for the following platforms:
 - **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
 - **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 - **[Universal](universal)**: Cross-platform components that run on Android, iOS, and web from a single source
+- **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
+- **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 
 ## Drop-in replacements
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
@@ -25,6 +25,42 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 
 {/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
 
+### Drop-in replacements
+
+| Component                                                   | Description                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
+| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
+| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
+| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
+| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
+| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
+| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
+| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
+
+### Universal
+
+| Component                              | Description                                                                                               |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
+| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
+| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
+| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
+| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
+| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
+| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
+| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
+| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
+| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
+| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
+| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
+| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
+| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
+| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
+| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
+| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
+| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
+
 ### Jetpack Compose
 
 | Component                                                                | Description                                                                                                      |
@@ -120,41 +156,5 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 | [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                     |
 | [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                              |
 | [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                           |
-
-### Universal
-
-| Component                              | Description                                                                                               |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [`BottomSheet`](universal/bottomsheet) | A modal sheet that slides up from the bottom of the screen.                                               |
-| [`Button`](universal/button)           | A pressable button with multiple visual variants.                                                         |
-| [`Checkbox`](universal/checkbox)       | A toggle control that represents a checked or unchecked state.                                            |
-| [`Collapsible`](universal/collapsible) | A labelled tappable header that toggles visibility of its content.                                        |
-| [`Column`](universal/column)           | A vertical layout container for universal @expo/ui components.                                            |
-| [`FieldGroup`](universal/fieldgroup)   | A scrollable container of grouped settings-style rows.                                                    |
-| [`Host`](universal/host)               | A cross-platform Host component that wraps universal @expo/ui content.                                    |
-| [`Icon`](universal/icon)               | A platform-native icon — SF Symbol on iOS, Material Symbol on Android.                                    |
-| [`List`](universal/list)               | A virtualized vertical container of rows, paired with a tappable ListItem primitive.                      |
-| [`Picker`](universal/picker)           | A single-selection input with menu and wheel appearances.                                                 |
-| [`RNHostView`](universal/rnhostview)   | A cross-platform component for hosting React Native views inside @expo/ui views.                          |
-| [`Row`](universal/row)                 | A horizontal layout container for universal @expo/ui components.                                          |
-| [`ScrollView`](universal/scrollview)   | A scrollable container that supports vertical or horizontal scrolling.                                    |
-| [`Slider`](universal/slider)           | A control for selecting a value from a continuous or stepped range.                                       |
-| [`Spacer`](universal/spacer)           | A layout spacer that produces empty space between siblings.                                               |
-| [`Switch`](universal/switch)           | A toggle control that switches between on and off states.                                                 |
-| [`Text`](universal/text)               | A component for displaying styled text content.                                                           |
-| [`TextInput`](universal/textinput)     | A text input backed by native SwiftUI and Jetpack Compose components, with a React Native-compatible API. |
-
-### Drop-in replacements
-
-| Component                                                   | Description                                                                            |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`BottomSheet`](drop-in-replacements/bottomsheet)           | A bottom sheet compatible with @gorhom/bottom-sheet.                                   |
-| [`DateTimePicker`](drop-in-replacements/datetimepicker)     | A date and time picker compatible with @react-native-community/datetimepicker.         |
-| [`MaskedView`](drop-in-replacements/maskedview)             | A masked view compatible with @react-native-masked-view/masked-view.                   |
-| [`Menu`](drop-in-replacements/menu)                         | A menu compatible with @react-native-menu/menu.                                        |
-| [`PagerView`](drop-in-replacements/pagerview)               | A horizontally paged view compatible with react-native-pager-view.                     |
-| [`Picker`](drop-in-replacements/picker)                     | A picker compatible with @react-native-picker/picker.                                  |
-| [`SegmentedControl`](drop-in-replacements/segmentedcontrol) | A segmented control compatible with @react-native-segmented-control/segmented-control. |
-| [`Slider`](drop-in-replacements/slider)                     | A slider compatible with @react-native-community/slider.                               |
 
 {/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/index.mdx
@@ -5,7 +5,6 @@ description: Jetpack Compose components for building native Android interfaces w
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-56/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'expo-go']
-hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -31,3 +30,57 @@ export function SaveButton() {
   );
 }
 ```
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+| Component                                                | Description                                                                                                      |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`AlertDialog`](alertdialog)                             | AlertDialog component for displaying native alert dialogs.                                                       |
+| [`Badge`](badge)                                         | Badge component for displaying status indicators and counts.                                                     |
+| [`BadgedBox`](badgedbox)                                 | BadgedBox component for overlaying badges on content.                                                            |
+| [`BasicAlertDialog`](basicalertdialog)                   | BasicAlertDialog component for displaying dialogs with custom content.                                           |
+| [`Box`](box)                                             | Box component for stacking child elements.                                                                       |
+| [`Button`](button)                                       | Button components for displaying native Material3 buttons.                                                       |
+| [`Card`](card)                                           | Card component for displaying content in a styled container.                                                     |
+| [`Carousel`](carousel)                                   | Carousel components for displaying scrollable collections of items.                                              |
+| [`Checkbox`](checkbox)                                   | Checkbox component for selection controls.                                                                       |
+| [`Chip`](chip)                                           | Chip components for displaying compact elements.                                                                 |
+| [`Column`](column)                                       | Column component for placing children vertically.                                                                |
+| [`DateTimePicker`](datetimepicker)                       | DateTimePicker component for selecting dates and times.                                                          |
+| [`Divider`](divider)                                     | Divider components for creating visual separators.                                                               |
+| [`DockedSearchBar`](dockedsearchbar)                     | DockedSearchBar component for displaying an inline search input.                                                 |
+| [`DropdownMenu`](dropdownmenu)                           | DropdownMenu component for displaying dropdown menus.                                                            |
+| [`ExposedDropdownMenuBox`](exposeddropdownmenubox)       | ExposedDropdownMenuBox component for displaying a dropdown menu with a customizable anchor.                      |
+| [`FloatingActionButton`](floatingactionbutton)           | FloatingActionButton components following Material Design 3.                                                     |
+| [`FlowRow`](flowrow)                                     | FlowRow component for wrapping children horizontally.                                                            |
+| [`HorizontalFloatingToolbar`](horizontalfloatingtoolbar) | HorizontalFloatingToolbar component for displaying a floating action bar.                                        |
+| [`HorizontalPager`](horizontalpager)                     | HorizontalPager component for swipeable pages.                                                                   |
+| [`Host`](host)                                           | Host component for bridging React Native and Jetpack Compose.                                                    |
+| [`Icon`](icon)                                           | Icon component for displaying icons.                                                                             |
+| [`IconButton`](iconbutton)                               | IconButton components for displaying native Material3 icon buttons.                                              |
+| [`LazyColumn`](lazycolumn)                               | LazyColumn component for displaying scrollable lists.                                                            |
+| [`LazyRow`](lazyrow)                                     | LazyRow component for displaying horizontally scrolling lists.                                                   |
+| [`ListItem`](listitem)                                   | ListItem component for displaying structured list entries.                                                       |
+| [`ModalBottomSheet`](bottomsheet)                        | ModalBottomSheet component that presents content from the bottom of the screen.                                  |
+| [`NavigationBar`](navigationbar)                         | NavigationBar component for Material 3 bottom navigation.                                                        |
+| [`Progress Indicators`](progress)                        | Progress indicator components for displaying operation status.                                                   |
+| [`PullToRefreshBox`](pulltorefreshbox)                   | PullToRefreshBox component for pull-to-refresh interactions.                                                     |
+| [`RadioButton`](radiobutton)                             | RadioButton component for single-selection controls.                                                             |
+| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside Jetpack Compose.                                              |
+| [`Row`](row)                                             | Row component for placing children horizontally.                                                                 |
+| [`SearchBar`](searchbar)                                 | SearchBar component for search input functionality.                                                              |
+| [`SegmentedButton`](segmentedbutton)                     | Segmented Button components for single or multi-choice selection.                                                |
+| [`Shape`](shape)                                         | Shape component for drawing geometric shapes.                                                                    |
+| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                                              |
+| [`Snackbar`](snackbar)                                   | A brief notification that appears at the bottom of the screen to provide feedback without interrupting the user. |
+| [`Spacer`](spacer)                                       | Spacer component for adding flexible space between elements.                                                     |
+| [`Surface`](surface)                                     | Surface component for styled content containers.                                                                 |
+| [`Switch`](switch)                                       | Switch component for toggle controls.                                                                            |
+| [`Text`](text)                                           | Text component for displaying styled text.                                                                       |
+| [`TextField`](textfield)                                 | TextField components for native Material3 text input.                                                            |
+| [`ToggleButton`](togglebutton)                           | ToggleButton components for displaying native Material3 toggle buttons.                                          |
+| [`Tooltip`](tooltip)                                     | Tooltip components for displaying contextual information on long-press.                                          |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/index.mdx
@@ -62,3 +62,53 @@ For more information, see the following resources:
   title="Expo UI iOS Liquid Glass Tutorial"
   description="Learn how to build real SwiftUI views in your React Native app with the new Expo UI."
 />
+
+## Available components
+
+{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
+
+| Component                                                | Description                                                                                         |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
+| [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
+| [`Button`](button)                                       | Button component for displaying native buttons.                                                     |
+| [`ColorPicker`](colorpicker)                             | ColorPicker component for selecting colors.                                                         |
+| [`ConfirmationDialog`](confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
+| [`ContextMenu`](contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
+| [`ControlGroup`](controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
+| [`DatePicker`](datepicker)                               | DatePicker component for selecting dates and times.                                                 |
+| [`DisclosureGroup`](disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
+| [`Divider`](divider)                                     | Divider component for creating visual separators.                                                   |
+| [`Form`](form)                                           | Form component for collecting user input in a structured layout.                                    |
+| [`Gauge`](gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
+| [`Group`](group)                                         | Group component for grouping views without affecting layout.                                        |
+| [`Host`](host)                                           | Host component that enables SwiftUI components in React Native.                                     |
+| [`HStack`](hstack)                                       | HStack component for horizontal layouts.                                                            |
+| [`Image`](image)                                         | Image component for displaying SF Symbols.                                                          |
+| [`Label`](label)                                         | Label component for displaying text with an icon.                                                   |
+| [`LazyHStack`](lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
+| [`LazyVStack`](lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
+| [`Link`](link)                                           | Link component for displaying clickable links.                                                      |
+| [`List`](list)                                           | List component for displaying scrollable lists of items.                                            |
+| [`Menu`](menu)                                           | Menu component for displaying dropdown menus.                                                       |
+| [`Namespace`](namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
+| [`Overlay`](overlay)                                     | Overlay component for layering content on top of another view.                                      |
+| [`Picker`](picker)                                       | Picker component for selecting options from a list.                                                 |
+| [`Popover`](popover)                                     | Popover component for displaying content in a floating overlay.                                     |
+| [`ProgressView`](progressview)                           | ProgressView component for displaying progress indicators.                                          |
+| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
+| [`ScrollView`](scrollview)                               | ScrollView component for scrollable content.                                                        |
+| [`Section`](section)                                     | Section component for grouping content within lists and forms.                                      |
+| [`SecureField`](securefield)                             | SecureField component for password input.                                                           |
+| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                                 |
+| [`Spacer`](spacer)                                       | Spacer component for flexible spacing.                                                              |
+| [`SwipeActions`](swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
+| [`TabView`](tabview)                                     | TabView component for paged or tabbed content.                                                      |
+| [`Text`](text)                                           | Text component for displaying styled text with support for nested texts.                            |
+| [`TextField`](textfield)                                 | TextField component for text input.                                                                 |
+| [`Toggle`](toggle)                                       | Toggle component for displaying native toggles.                                                     |
+| [`VStack`](vstack)                                       | VStack component for vertical layouts.                                                              |
+| [`ZStack`](zstack)                                       | ZStack component for overlapping layouts.                                                           |
+
+{/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/index.mdx
@@ -5,7 +5,6 @@ description: Cross-platform components for building shared UIs across Android, i
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'web', 'expo-go']
-hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -35,16 +34,18 @@ export default function Example() {
 }
 ```
 
-## Components
+## Available components
 
-- **Container:** [`Host`](host) — the required root for every universal subtree.
-- **Layout:** [`Column`](column), [`Row`](row), [`Spacer`](spacer), [`ScrollView`](scrollview).
-- **Display:** [`Text`](text), [`Icon`](icon).
-- **Controls:** [`Button`](button), [`Switch`](switch), [`Checkbox`](checkbox), [`Slider`](slider), [`TextInput`](textinput), [`Picker`](picker).
-- **Disclosure and presentation:** [`BottomSheet`](bottomsheet), [`Collapsible`](collapsible).
-- **Collections and forms:** [`List`](list) (with `ListItem`), [`FieldGroup`](fieldgroup).
+| Category                    | Components                                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Container                   | [`Host`](host), the required root for every universal subtree.                                                                   |
+| Layout                      | [`Column`](column), [`Row`](row), [`Spacer`](spacer), [`ScrollView`](scrollview)                                                 |
+| Display                     | [`Text`](text), [`Icon`](icon)                                                                                                   |
+| Controls                    | [`Button`](button), [`Switch`](switch), [`Checkbox`](checkbox), [`Slider`](slider), [`TextInput`](textinput), [`Picker`](picker) |
+| Disclosure and presentation | [`BottomSheet`](bottomsheet), [`Collapsible`](collapsible)                                                                       |
+| Collections and forms       | [`List`](list) (with `ListItem`), [`FieldGroup`](fieldgroup)                                                                     |
 
-## When to use this versus `swift-ui` / `jetpack-compose`
+## When to use this versus `jetpack-compose`/`swift-ui`
 
 - Reach for **universal** components when you want one component tree that runs unmodified on Android, iOS, and web. The platform-native look and feel is preserved on Android and iOS because the components delegate to Jetpack Compose/SwiftUI under the hood.
-- Reach for **[`@expo/ui/swift-ui`](../swift-ui)** or **[`@expo/ui/jetpack-compose`](../jetpack-compose)** directly when you need platform-specific controls, modifiers, or behavior that the universal API doesn't surface.
+- Reach for **[`@expo/ui/jetpack-compose`](../jetpack-compose)** or **[`@expo/ui/swift-ui`](../swift-ui)** directly when you need platform-specific controls, modifiers, or behavior that the universal API doesn't surface.

--- a/docs/scripts/generate-ui-component-tables.ts
+++ b/docs/scripts/generate-ui-component-tables.ts
@@ -1,0 +1,172 @@
+// Generates the @expo/ui component tables from page frontmatter. Run: pnpm generate-ui-component-tables
+
+import fm from 'front-matter';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PAGES_DIR = path.join(process.cwd(), 'pages', 'versions');
+
+// latest/ is a build-time copy of v<version> (copy-latest.js), so we never write to it.
+const { version } = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+const VERSIONS = ['unversioned', `v${version}`];
+
+interface SectionConfig {
+  dir: string;
+  label: string;
+  platformPrefix: string | null;
+  // false for sections that already ship a curated list we don't want to clobber.
+  generateSectionTable: boolean;
+}
+
+const SECTIONS: SectionConfig[] = [
+  {
+    dir: 'jetpack-compose',
+    label: 'Jetpack Compose',
+    platformPrefix: 'Jetpack Compose',
+    generateSectionTable: true,
+  },
+  { dir: 'swift-ui', label: 'SwiftUI', platformPrefix: 'SwiftUI', generateSectionTable: true },
+  { dir: 'universal', label: 'Universal', platformPrefix: null, generateSectionTable: false },
+  {
+    dir: 'drop-in-replacements',
+    label: 'Drop-in replacements',
+    platformPrefix: null,
+    generateSectionTable: false,
+  },
+];
+
+// Non-component pages (overview, concepts, hooks) excluded from every table.
+const EXCLUDED_SLUGS = new Set(['index', 'modifiers', 'colors', 'usenativestate']);
+
+const MARKER_START =
+  '{/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}';
+const MARKER_END = '{/* @generated:ui-component-table:end */}';
+const BLOCK_RE =
+  /{\/\* @generated:ui-component-table(?!:end)[\S\s]*?@generated:ui-component-table:end \*\/}/;
+
+interface ComponentEntry {
+  title: string;
+  slug: string;
+  description: string;
+}
+
+interface Frontmatter {
+  title?: string;
+  description?: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+}
+
+function cleanDescription(description: string, platformPrefix: string | null): string {
+  const text = description.trim();
+  if (!platformPrefix) {
+    return text;
+  }
+  const stripped = text.replace(new RegExp(`^(?:An? )?${escapeRegExp(platformPrefix)}\\s+`), '');
+  return stripped !== text && stripped.length > 0
+    ? stripped[0].toUpperCase() + stripped.slice(1)
+    : text;
+}
+
+function readComponents(uiDir: string, section: SectionConfig): ComponentEntry[] {
+  const dir = path.join(uiDir, section.dir);
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries: ComponentEntry[] = [];
+  for (const file of fs.readdirSync(dir)) {
+    const slug = file.replace(/\.mdx$/, '');
+    if (!file.endsWith('.mdx') || EXCLUDED_SLUGS.has(slug)) {
+      continue;
+    }
+
+    const attributes = (fm(fs.readFileSync(path.join(dir, file), 'utf8')).attributes ??
+      {}) as Frontmatter;
+    const title = (attributes.title ?? '').trim();
+    if (!title) {
+      continue;
+    }
+
+    entries.push({
+      title,
+      slug,
+      description: cleanDescription(attributes.description ?? '', section.platformPrefix),
+    });
+  }
+
+  return entries.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+function renderTable(entries: ComponentEntry[], linkPrefix: string): string {
+  const rows = entries.map(
+    entry => `| [\`${entry.title}\`](${linkPrefix}${entry.slug}) | ${entry.description} |`
+  );
+  return ['| Component | Description |', '| --- | --- |', ...rows].join('\n');
+}
+
+function wrapGenerated(inner: string): string {
+  return `${MARKER_START}\n\n${inner}\n\n${MARKER_END}`;
+}
+
+const COMPONENTS_HEADING = '## Available components';
+const STRIP_RE = new RegExp(`\\n*(?:#{1,6} [^\\n]*\\n+)?${BLOCK_RE.source}`);
+
+// Strip any previous block, then append a fresh one at the end of the page (idempotent).
+function upsertGeneratedBlock(filePath: string, inner: string): 'updated' | 'inserted' {
+  const original = fs.readFileSync(filePath, 'utf8');
+  const existed = BLOCK_RE.test(original);
+  const body = original.replace(STRIP_RE, '').replace(/\s*$/, '');
+  fs.writeFileSync(filePath, `${body}\n\n${COMPONENTS_HEADING}\n\n${wrapGenerated(inner)}\n`);
+  return existed ? 'updated' : 'inserted';
+}
+
+function main(): void {
+  const summary: string[] = [];
+
+  for (const versionDir of VERSIONS) {
+    const uiDir = path.join(PAGES_DIR, versionDir, 'sdk', 'ui');
+    if (!fs.existsSync(uiDir)) {
+      console.warn(`Skipping ${versionDir}: ${uiDir} not found`);
+      continue;
+    }
+
+    const aggregated: string[] = [];
+    for (const section of SECTIONS) {
+      const components = readComponents(uiDir, section);
+      if (components.length === 0) {
+        continue;
+      }
+
+      aggregated.push(`### ${section.label}\n\n${renderTable(components, `${section.dir}/`)}`);
+
+      if (!section.generateSectionTable) {
+        summary.push(`${versionDir}/${section.dir}: section table skipped (curated list kept)`);
+        continue;
+      }
+
+      const indexPath = path.join(uiDir, section.dir, 'index.mdx');
+      if (fs.existsSync(indexPath)) {
+        const result = upsertGeneratedBlock(indexPath, renderTable(components, ''));
+        summary.push(`${versionDir}/${section.dir}: ${result} (${components.length} components)`);
+      }
+    }
+
+    const overviewPath = path.join(uiDir, 'index.mdx');
+    if (fs.existsSync(overviewPath) && aggregated.length > 0) {
+      summary.push(
+        `${versionDir}/ (overview): ${upsertGeneratedBlock(overviewPath, aggregated.join('\n\n'))}`
+      );
+    }
+  }
+
+  console.log(summary.join('\n'));
+
+  console.log('Running pnpm format...');
+  execSync('pnpm format', { stdio: 'inherit' });
+}
+
+main();

--- a/docs/scripts/generate-ui-component-tables.ts
+++ b/docs/scripts/generate-ui-component-tables.ts
@@ -21,19 +21,19 @@ interface SectionConfig {
 
 const SECTIONS: SectionConfig[] = [
   {
+    dir: 'drop-in-replacements',
+    label: 'Drop-in replacements',
+    platformPrefix: null,
+    generateSectionTable: false,
+  },
+  { dir: 'universal', label: 'Universal', platformPrefix: null, generateSectionTable: false },
+  {
     dir: 'jetpack-compose',
     label: 'Jetpack Compose',
     platformPrefix: 'Jetpack Compose',
     generateSectionTable: true,
   },
   { dir: 'swift-ui', label: 'SwiftUI', platformPrefix: 'SwiftUI', generateSectionTable: true },
-  { dir: 'universal', label: 'Universal', platformPrefix: null, generateSectionTable: false },
-  {
-    dir: 'drop-in-replacements',
-    label: 'Drop-in replacements',
-    platformPrefix: null,
-    generateSectionTable: false,
-  },
 ];
 
 // Non-component pages (overview, concepts, hooks) excluded from every table.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21766

The `@expo/ui` section pages didn't list their components inline, so readers and AI agents had to scan the sidebar to discover what each platform offers.

# How

Add a `generate-ui-component-tables.ts` script (`pnpm generate-ui-component-tables`) that reads each component page's frontmatter and writes an idempotent, marker-fenced `Available components` table into the Jetpack Compose, SwiftUI, and overview pages. The universal and drop-in replacement lists were converted to tables by hand and `hideTOC` adjusted on the affected pages, across both `unversioned` and `v56.0.0`.

# Test Plan

See preview for:
- https://pr-46708.expo-docs.pages.dev/versions/latest/sdk/ui/
- https://pr-46708.expo-docs.pages.dev/versions/latest/sdk/ui/drop-in-replacements/
- https://pr-46708.expo-docs.pages.dev/versions/latest/sdk/ui/jetpack-compose/
- https://pr-46708.expo-docs.pages.dev/versions/latest/sdk/ui/swift-ui/
- https://pr-46708.expo-docs.pages.dev/versions/latest/sdk/ui/universal/

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).