### PR TITLE
[gha][docs] Sync bundled native module versions on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,6 +82,11 @@ jobs:
           fail_on_error: true
           # Override vale-action's older bundled reviewdog to avoid large-diff limits.
           reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.21.0/reviewdog_0.21.0_Linux_x86_64.tar.gz
+      - name: 🔄 Sync bundled native module versions
+        working-directory: docs
+        run: pnpm versions-schema-sync
+        continue-on-error: true
+        timeout-minutes: 1
       - name: 🏗️ Build Docs website for deploy
         working-directory: docs
         run: pnpm export

--- a/docs/scripts/fetch-versions-schema.js
+++ b/docs/scripts/fetch-versions-schema.js
@@ -47,11 +47,21 @@ export async function getSchemaAsync(sdkVersion, isUnversioned = false) {
 }
 
 const versionedVersions = VERSIONS.filter(version => version.includes('.'));
-const nextVersion = inc(BETA_VERSION ?? LATEST_VERSION, 'major');
+const nextVersion = inc(BETA_VERSION || LATEST_VERSION, 'major');
 
-await Promise.all([
+const labels = [...versionedVersions, `${nextVersion} (unversioned)`];
+const results = await Promise.allSettled([
   ...versionedVersions.map(version => getSchemaAsync(version)),
   getSchemaAsync(nextVersion, true),
 ]);
 
-console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully fetched versions schemas`);
+results.forEach((result, index) => {
+  if (result.status === 'rejected') {
+    console.warn(
+      ` \x1b[1m\x1b[33m⚠\x1b[0m Kept committed snapshot for ${labels[index]}: ${result.reason.message}`
+    );
+  }
+});
+
+const fetched = results.filter(result => result.status === 'fulfilled').length;
+console.log(` \x1b[1m\x1b[32m✓\x1b[0m Fetched ${fetched}/${results.length} versions schemas`);


### PR DESCRIPTION
# Why

Follow-up https://github.com/expo/expo/pull/46709

The "Bundled version" shown on SDK pages comes from checked-in snapshots that are only refreshed by a manual sync, so pages drift from the actual published versions (for example, `@expo/ui` on SDK 56 showed `~56.0.6` while the API serves `~56.0.16`).

# How

Add a `pnpm versions-schema-sync` step to the deploy job in `docs.yml` before `pnpm export`, so every deploy bakes in freshly fetched versions. In `fetch-versions-schema.js`, switch to `Promise.allSettled` so a failed fetch logs a warning and falls back to the committed snapshot instead of failing the build, and fix `BETA_VERSION ?? LATEST_VERSION` passing `false` to `semver.inc()`, which silently skipped the unversioned snapshot outside beta windows.

# Test Plan

- Locally: Run `pnpm versions-schema-sync` and confirm it reports 4/4 schemas fetched, with `@expo/ui` at `~56.0.16` in the v56 snapshot.
- CI: View the logs [here](https://github.com/expo/expo/actions/runs/27231510717/job/80412593009?pr=46710) and verify the job added in this PR runs successfully.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).