### PR TITLE
[app-metrics][sqlite] tvOS needs to write DB to caches directory

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - fix race condition between db inserts ([#46702](https://github.com/expo/expo/pull/46702) by [@Ubax](https://github.com/Ubax))
+- [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -49,9 +49,15 @@ final class MetricsDatabase: Sendable {
   }
 
   private static func defaultDirectoryUrl() throws -> URL {
+    #if os(tvOS)
+    return try FileManager.default
+      .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+      .appendingPathComponent("ExpoAppMetrics")
+    #else
     return try FileManager.default
       .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
       .appendingPathComponent("ExpoAppMetrics")
+    #endif
   }
 
   /**

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed a fatal JNI crash on Android when using `useLibSQL: true`, caused by the libSQL session bindings still declaring `byte[]` signatures after [#42638](https://github.com/expo/expo/pull/42638) switched Kotlin and the default native bindings to `ByteBuffer`. ([#46651](https://github.com/expo/expo/pull/46651) by [@zoontek](https://github.com/zoontek))
+- [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -24,7 +24,11 @@ public final class SQLiteModule: Module {
 
     Constants {
       let defaultDatabaseDirectory =
+      #if os(tvOS)
+        appContext?.config.cacheDirectory?.appendingPathComponent("SQLite").standardized.path
+      #else
         appContext?.config.documentDirectory?.appendingPathComponent("SQLite").standardized.path
+      #endif
       return [
         "defaultDatabaseDirectory": defaultDatabaseDirectory
       ]

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -403,7 +403,7 @@ async function preparePackageJson(
       dependencies: {
         ...packageJson.dependencies,
         glob: '^11.0.0',
-        'react-native-tvos': '0.86.0-0rc2',
+        'react-native-tvos': '0.86.0-0rc3',
         '@react-native-tvos/config-tv': '^0.1.6',
       },
     };

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/SceneDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/SceneDelegate.swift
@@ -1,4 +1,4 @@
-import Expo
+internal import Expo
 
 @objc(SceneDelegate)
 class SceneDelegate: ExpoAppSceneDelegate {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix path for database writes on tvOS.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change from documents directory to caches directory.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Testflight app sends metrics as expected. The tvOS simulator will allow writes to the documents directory, a real device will not.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)