### PR TITLE
fix(metro-runtime): Add missing global declarations

### DIFF
--- a/packages/@expo/metro-runtime/build/location/Location.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/location/Location.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"Location.native.d.ts","sourceRoot":"","sources":["../../src/location/Location.native.ts"],"names":[],"mappings":"AA6LA,wBAAgB,eAAe,CAAC,IAAI,EAAE,MAAM,QAE3C;AAED,wBAAgB,OAAO,SAgBtB"}
+{"version":3,"file":"Location.native.d.ts","sourceRoot":"","sources":["../../src/location/Location.native.ts"],"names":[],"mappings":"AA6LA,wBAAgB,eAAe,CAAC,IAAI,EAAE,MAAM,QAE3C;AAKD,wBAAgB,OAAO,SAgBtB"}

--- a/packages/@expo/metro-runtime/src/location/Location.native.ts
+++ b/packages/@expo/metro-runtime/src/location/Location.native.ts
@@ -191,6 +191,9 @@ export function setLocationHref(href: string) {
   location = new Location(href);
 }
 
+declare const global: typeof globalThis;
+declare const window: typeof globalThis;
+
 export function install() {
   Object.defineProperty(global, 'Location', {
     value: Location,

--- a/packages/@expo/metro-runtime/src/location/install.native.ts
+++ b/packages/@expo/metro-runtime/src/location/install.native.ts
@@ -73,6 +73,8 @@ export function wrapFetchWithWindowLocation(fetch: Function & { [polyfillSymbol]
   return _fetch;
 }
 
+declare const global: typeof globalThis;
+
 const extra = manifest?.extra as ExpoExtraRouterConfig | null;
 if (extra?.router?.origin !== false) {
   // Polyfill window.location in native runtimes.

--- a/packages/@expo/metro-runtime/src/ts-declarations/react-native.d.ts
+++ b/packages/@expo/metro-runtime/src/ts-declarations/react-native.d.ts
@@ -9,7 +9,8 @@ declare module 'react-native/Libraries/Utilities/DevLoadingView' {
 }
 
 declare module 'react-native/Libraries/Core/ExceptionsManager' {
-  declare class SyntheticError extends Error {}
+  class SyntheticError extends Error {}
+
   const ExceptionsManager: {
     parseException(e: any, isFatal: boolean): void;
     handleException(e: any): void;


### PR DESCRIPTION
## Summary

Related to #46720

Upstreaming from Turborepo branch: [`@kitten/chore/add-turborepo-3`](https://github.com/kitten-agent/expo/tree/%40kitten/chore/add-turborepo-3) / [`@kitten/chore/add-turborepo-2`](https://github.com/expo/expo/tree/%40kitten/chore/add-turborepo-2)

Depending on the `tsconfig.json` and resolution of `@expo/metro-runtime` it won't be guaranteed to have `window` / `global` typings available to it, and they shouldn't be treated as essential to `@expo/metro-runtime`'s behaviour either, so we can declare them as one-offs.

## Set of changes

- Add `declare const global` / `declare const window` definitions where applicable
- Remove redundant `declare` from `react-native`'s `SyntheticError` declaration (already in declare block)

## Checklist

**No user-facing changes**

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
