### PR TITLE
[expo-type-information][fix] Fix unsupported module structure, add runOnQueue preprocessing and matching CLI option to remove it

### DIFF
--- a/packages/expo-type-information/__tests__/typeInformation.test.ts
+++ b/packages/expo-type-information/__tests__/typeInformation.test.ts
@@ -23,6 +23,7 @@ const defaultArgs: GetFileTypeInformationOptions = {
   input: { inputFileAbsolutePaths: [swiftFile], type: 'file' },
   typeInference: TypeInferenceOption.PREPROCESS_AND_INFERENCE,
   mapUnicodeCharacters: true,
+  runOnQueue: true,
 };
 
 let defaultArgsFileInfo: FileTypeInformation | null = null;
@@ -108,6 +109,7 @@ it('Generation from string is the same as generation from file. Preprocessing.',
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.PREPROCESS_AND_INFERENCE,
     mapUnicodeCharacters: true,
+    runOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
@@ -117,11 +119,13 @@ it('Generation from string is the same as generation from file. Simple type infe
     input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
     typeInference: TypeInferenceOption.NO_INFERENCE,
     mapUnicodeCharacters: true,
+    runOnQueue: true,
   });
   const fileInfoForString = await getFileTypeInformation({
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.NO_INFERENCE,
     mapUnicodeCharacters: true,
+    runOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
@@ -131,21 +135,24 @@ it('Generation from string is the same as generation from file. No type inferenc
     input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
     typeInference: TypeInferenceOption.SIMPLE_INFERENCE,
     mapUnicodeCharacters: true,
+    runOnQueue: true,
   });
   const fileInfoForString = await getFileTypeInformation({
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.SIMPLE_INFERENCE,
     mapUnicodeCharacters: true,
+    runOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
 
-it('Generation without mapUnicodeCharacters and without typeInference does nothing.', async () => {
+it('Generation without any preprocessing options does nothing.', async () => {
   await withPreparedSingleFile(
     {
       input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
       typeInference: TypeInferenceOption.NO_INFERENCE,
       mapUnicodeCharacters: false,
+      runOnQueue: false,
     },
     async (filePath: string) => {
       const [preparedFileContent, originalFileContent] = await Promise.all([

--- a/packages/expo-type-information/__tests__/typeInformation.test.ts
+++ b/packages/expo-type-information/__tests__/typeInformation.test.ts
@@ -23,7 +23,7 @@ const defaultArgs: GetFileTypeInformationOptions = {
   input: { inputFileAbsolutePaths: [swiftFile], type: 'file' },
   typeInference: TypeInferenceOption.PREPROCESS_AND_INFERENCE,
   mapUnicodeCharacters: true,
-  runOnQueue: true,
+  removeRunOnQueue: true,
 };
 
 let defaultArgsFileInfo: FileTypeInformation | null = null;
@@ -109,7 +109,7 @@ it('Generation from string is the same as generation from file. Preprocessing.',
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.PREPROCESS_AND_INFERENCE,
     mapUnicodeCharacters: true,
-    runOnQueue: true,
+    removeRunOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
@@ -119,13 +119,13 @@ it('Generation from string is the same as generation from file. Simple type infe
     input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
     typeInference: TypeInferenceOption.NO_INFERENCE,
     mapUnicodeCharacters: true,
-    runOnQueue: true,
+    removeRunOnQueue: true,
   });
   const fileInfoForString = await getFileTypeInformation({
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.NO_INFERENCE,
     mapUnicodeCharacters: true,
-    runOnQueue: true,
+    removeRunOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
@@ -135,13 +135,13 @@ it('Generation from string is the same as generation from file. No type inferenc
     input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
     typeInference: TypeInferenceOption.SIMPLE_INFERENCE,
     mapUnicodeCharacters: true,
-    runOnQueue: true,
+    removeRunOnQueue: true,
   });
   const fileInfoForString = await getFileTypeInformation({
     input: { type: 'string', fileContent: fs.readFileSync(swiftFile, 'utf8'), language: 'Swift' },
     typeInference: TypeInferenceOption.SIMPLE_INFERENCE,
     mapUnicodeCharacters: true,
-    runOnQueue: true,
+    removeRunOnQueue: true,
   });
   expect(fileInfo).toEqual(fileInfoForString);
 });
@@ -152,7 +152,7 @@ it('Generation without any preprocessing options does nothing.', async () => {
       input: { type: 'file', inputFileAbsolutePaths: [swiftFile] },
       typeInference: TypeInferenceOption.NO_INFERENCE,
       mapUnicodeCharacters: false,
-      runOnQueue: false,
+      removeRunOnQueue: false,
     },
     async (filePath: string) => {
       const [preparedFileContent, originalFileContent] = await Promise.all([

--- a/packages/expo-type-information/src/commands/commandUtils.ts
+++ b/packages/expo-type-information/src/commands/commandUtils.ts
@@ -19,6 +19,7 @@ export type TypeInformationCommandCommonAllArguments = {
   outputPath?: string;
   typeInference?: 'NO_INFERENCE' | 'SIMPLE_INFERENCE' | 'PREPROCESS_AND_INFERENCE';
   skipUnicodeCharacterMapping?: boolean;
+  disableRunOnQueuePreprocessing?: boolean;
   watcher?: boolean;
   appJson?: string;
 };
@@ -42,6 +43,7 @@ export interface ParsedArguments {
   realOutputPath?: string;
   typeInference: TypeInferenceOption;
   mapUnicodeCharacters: boolean;
+  runOnQueuePreprocessing: boolean;
   watcher: boolean;
   appJsonPath?: string;
 }
@@ -66,6 +68,7 @@ export function addCommonOptions(command: commander.Command): commander.Command 
       '-s, --skip-unicode-character-mapping',
       'skip mapping all non-ASCII characters in a file to ASCII strings. By default this mapping is performed as SourceKitten is inconsistent when calculating offsets of non-ASCII characters.'
     )
+    .option('-d, --disable-run-on-queue-preprocessing', 'Disable preprocessing runOnQueue.')
     .option('-w --watcher', 'Starts a watcher that checks for changes in input-path file.');
 }
 
@@ -254,6 +257,7 @@ export function parseCommandArguments(
   }
 
   const mapUnicodeCharacters = !options.skipUnicodeCharacterMapping;
+  const runOnQueuePreprocessing = !options.disableRunOnQueuePreprocessing;
   const watcher = options.watcher ?? false;
   return {
     realInputPaths,
@@ -262,6 +266,7 @@ export function parseCommandArguments(
     mapUnicodeCharacters,
     watcher,
     appJsonPath,
+    runOnQueuePreprocessing,
   };
 }
 
@@ -269,15 +274,18 @@ export async function getFileTypeInformationFromArgs({
   realInputPaths,
   typeInference,
   mapUnicodeCharacters,
+  runOnQueuePreprocessing,
 }: {
   realInputPaths: string[];
   typeInference: TypeInferenceOption;
   mapUnicodeCharacters: boolean;
+  runOnQueuePreprocessing: boolean;
 }): Promise<FileTypeInformation | null> {
   const typeInfo = await getFileTypeInformation({
     input: { type: 'file', inputFileAbsolutePaths: realInputPaths },
     typeInference,
     mapUnicodeCharacters,
+    runOnQueue: runOnQueuePreprocessing,
   });
 
   if (!typeInfo) {

--- a/packages/expo-type-information/src/commands/commandUtils.ts
+++ b/packages/expo-type-information/src/commands/commandUtils.ts
@@ -65,10 +65,10 @@ export function addCommonOptions(command: commander.Command): commander.Command 
       'PREPROCESS_AND_INFERENCE'
     )
     .option(
-      '-s, --skip-unicode-character-mapping',
+      '--skip-unicode-character-mapping',
       'skip mapping all non-ASCII characters in a file to ASCII strings. By default this mapping is performed as SourceKitten is inconsistent when calculating offsets of non-ASCII characters.'
     )
-    .option('-d, --disable-run-on-queue-preprocessing', 'Disable preprocessing runOnQueue.')
+    .option('--disable-run-on-queue-preprocessing', 'Disable preprocessing runOnQueue.')
     .option('-w --watcher', 'Starts a watcher that checks for changes in input-path file.');
 }
 
@@ -285,7 +285,7 @@ export async function getFileTypeInformationFromArgs({
     input: { type: 'file', inputFileAbsolutePaths: realInputPaths },
     typeInference,
     mapUnicodeCharacters,
-    runOnQueue: runOnQueuePreprocessing,
+    removeRunOnQueue: runOnQueuePreprocessing,
   });
 
   if (!typeInfo) {

--- a/packages/expo-type-information/src/commands/inlineModulesInterfaceCommand.ts
+++ b/packages/expo-type-information/src/commands/inlineModulesInterfaceCommand.ts
@@ -53,6 +53,7 @@ async function generateInlineModuleTSFiles({
     typeInference,
     watcher: false,
     mapUnicodeCharacters,
+    runOnQueuePreprocessing: false,
   });
 }
 

--- a/packages/expo-type-information/src/commands/preprocessFileCommand.ts
+++ b/packages/expo-type-information/src/commands/preprocessFileCommand.ts
@@ -22,7 +22,8 @@ export function preprocessFileCommand(cli: commander.Command) {
       if (!parsedArgs) {
         return;
       }
-      const { realInputPaths, typeInference, mapUnicodeCharacters } = parsedArgs;
+      const { realInputPaths, typeInference, mapUnicodeCharacters, runOnQueuePreprocessing } =
+        parsedArgs;
 
       const command = async () => {
         withPreparedSingleFile(
@@ -30,6 +31,7 @@ export function preprocessFileCommand(cli: commander.Command) {
             input: { type: 'file', inputFileAbsolutePaths: realInputPaths },
             typeInference,
             mapUnicodeCharacters,
+            runOnQueue: runOnQueuePreprocessing,
           },
           async (filePath) => {
             console.log(await fs.promises.readFile(filePath, 'utf-8'));

--- a/packages/expo-type-information/src/commands/preprocessFileCommand.ts
+++ b/packages/expo-type-information/src/commands/preprocessFileCommand.ts
@@ -31,7 +31,7 @@ export function preprocessFileCommand(cli: commander.Command) {
             input: { type: 'file', inputFileAbsolutePaths: realInputPaths },
             typeInference,
             mapUnicodeCharacters,
-            runOnQueue: runOnQueuePreprocessing,
+            removeRunOnQueue: runOnQueuePreprocessing,
           },
           async (filePath) => {
             console.log(await fs.promises.readFile(filePath, 'utf-8'));

--- a/packages/expo-type-information/src/mockgen.ts
+++ b/packages/expo-type-information/src/mockgen.ts
@@ -356,6 +356,7 @@ export async function getAllExpoModulesInWorkingDirectory(): Promise<FileTypeInf
             inputFileAbsolutePaths: [fs.realpathSync(file)],
           },
           mapUnicodeCharacters: true,
+          runOnQueue: true,
         })
       )
     )

--- a/packages/expo-type-information/src/mockgen.ts
+++ b/packages/expo-type-information/src/mockgen.ts
@@ -356,7 +356,7 @@ export async function getAllExpoModulesInWorkingDirectory(): Promise<FileTypeInf
             inputFileAbsolutePaths: [fs.realpathSync(file)],
           },
           mapUnicodeCharacters: true,
-          runOnQueue: true,
+          removeRunOnQueue: true,
         })
       )
     )

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -1345,6 +1345,7 @@ function returnExpressionEnd(fileContent: string, returnIndex: number): Expressi
 type SourceKittenPreprocessingOptions = {
   preprocessReturns?: boolean;
   mapUnicodeCharacters?: boolean;
+  runOnQueue: boolean;
 };
 
 function getSpaceIndentationCount(fileContent: string, index: number): number {
@@ -1356,6 +1357,23 @@ function getSpaceIndentationCount(fileContent: string, index: number): number {
     i += 1;
   }
   return spaceCount;
+}
+
+export function preprocessSwiftFile(
+  originalFileContent: string,
+  { preprocessReturns, runOnQueue, mapUnicodeCharacters }: SourceKittenPreprocessingOptions
+): string {
+  let fileContent = removeComments(originalFileContent);
+  if (preprocessReturns) {
+    fileContent = preprocessReturnStatements(fileContent);
+  }
+  if (runOnQueue) {
+    fileContent = preprocessRunOnQueue(fileContent);
+  }
+  if (mapUnicodeCharacters) {
+    fileContent = preprocessUnicodeCharacters(fileContent);
+  }
+  return fileContent;
 }
 
 // Preprocessing to help sourcekitten functions
@@ -1416,16 +1434,8 @@ function preprocessUnicodeCharacters(fileConent: string): string {
   });
 }
 
-export function preprocessSwiftFile(
-  originalFileContent: string,
-  { preprocessReturns, mapUnicodeCharacters }: SourceKittenPreprocessingOptions
-): string {
-  let fileContent = originalFileContent;
-  if (preprocessReturns) {
-    fileContent = preprocessReturnStatements(fileContent);
-  }
-  if (mapUnicodeCharacters) {
-    fileContent = preprocessUnicodeCharacters(fileContent);
-  }
-  return fileContent;
+function preprocessRunOnQueue(originalFileContent: string): string {
+  const regex = /\.runOnQueue\s*\([^)]*\)/g;
+  // Note that this won't work if there are nested parentheses inside the runOnQueue, e.g. .runOnQueue(function1()) won't work
+  return originalFileContent.replace(regex, '');
 }

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -1345,7 +1345,7 @@ function returnExpressionEnd(fileContent: string, returnIndex: number): Expressi
 type SourceKittenPreprocessingOptions = {
   preprocessReturns?: boolean;
   mapUnicodeCharacters?: boolean;
-  runOnQueue: boolean;
+  removeRunOnQueue: boolean;
 };
 
 function getSpaceIndentationCount(fileContent: string, index: number): number {
@@ -1361,13 +1361,13 @@ function getSpaceIndentationCount(fileContent: string, index: number): number {
 
 export function preprocessSwiftFile(
   originalFileContent: string,
-  { preprocessReturns, runOnQueue, mapUnicodeCharacters }: SourceKittenPreprocessingOptions
+  { preprocessReturns, removeRunOnQueue, mapUnicodeCharacters }: SourceKittenPreprocessingOptions
 ): string {
   let fileContent = removeComments(originalFileContent);
   if (preprocessReturns) {
     fileContent = preprocessReturnStatements(fileContent);
   }
-  if (runOnQueue) {
+  if (removeRunOnQueue) {
     fileContent = preprocessRunOnQueue(fileContent);
   }
   if (mapUnicodeCharacters) {
@@ -1436,6 +1436,6 @@ function preprocessUnicodeCharacters(fileConent: string): string {
 
 function preprocessRunOnQueue(originalFileContent: string): string {
   const regex = /\.runOnQueue\s*\([^)]*\)/g;
-  // Note that this won't work if there are nested parentheses inside the runOnQueue, e.g. .runOnQueue(function1()) won't work
+  // TODO(@HubertBer): This won't work if there are nested parentheses inside the runOnQueue, e.g. .runOnQueue(function1()) won't work
   return originalFileContent.replace(regex, '');
 }

--- a/packages/expo-type-information/src/typeInformation.ts
+++ b/packages/expo-type-information/src/typeInformation.ts
@@ -382,6 +382,8 @@ export type GetFileTypeInformationOptions = {
   typeInference?: TypeInferenceOption;
   /** An option to map unicode code points to ASCII strings to fix underlying SourceKit issue. */
   mapUnicodeCharacters: boolean;
+  /** Preprocess the file to remove all `runOnQueue(.*)` from it. */
+  runOnQueue: boolean;
 };
 
 async function mergeFileContents(absoluteFilePaths: string[]): Promise<string> {
@@ -404,11 +406,13 @@ async function withTempFile<T>(content: string, fn: (filePath: string) => Promis
 }
 
 export async function withPreparedSingleFile<T>(
-  { input, typeInference, mapUnicodeCharacters }: GetFileTypeInformationOptions,
+  { input, typeInference, mapUnicodeCharacters, runOnQueue }: GetFileTypeInformationOptions,
   fn: (filePath: string) => Promise<T>
 ): Promise<T> {
   const shouldPreprocessFile =
-    typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE || mapUnicodeCharacters;
+    typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE ||
+    mapUnicodeCharacters ||
+    runOnQueue;
   if (!shouldPreprocessFile && input.type === 'file' && input.inputFileAbsolutePaths.length === 0) {
     return fn(input.inputFileAbsolutePaths[0] as string);
   }
@@ -421,6 +425,7 @@ export async function withPreparedSingleFile<T>(
   const preprocessFileOptions = {
     preprocessReturns: shouldPreprocessFile,
     mapUnicodeCharacters,
+    runOnQueue,
   };
   if (shouldPreprocessFile) {
     return withTempFile(preprocessSwiftFile(fileContent, preprocessFileOptions), fn);
@@ -440,9 +445,12 @@ export async function getFileTypeInformation({
   input,
   typeInference,
   mapUnicodeCharacters,
+  runOnQueue,
 }: GetFileTypeInformationOptions): Promise<FileTypeInformation | null> {
   const shouldPreprocessFile =
-    typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE || mapUnicodeCharacters;
+    typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE ||
+    runOnQueue ||
+    mapUnicodeCharacters;
   const typeInferenceOn = typeInference !== TypeInferenceOption.NO_INFERENCE;
   if (!shouldPreprocessFile && input.type === 'file' && input.inputFileAbsolutePaths.length === 0) {
     return getSwiftFileTypeInformation(input.inputFileAbsolutePaths[0] as string, {
@@ -451,7 +459,7 @@ export async function getFileTypeInformation({
   }
 
   return withPreparedSingleFile(
-    { input, typeInference, mapUnicodeCharacters },
+    { input, typeInference, mapUnicodeCharacters, runOnQueue },
     async (tempFilePath) => {
       return getSwiftFileTypeInformation(tempFilePath, { typeInference: typeInferenceOn });
     }

--- a/packages/expo-type-information/src/typeInformation.ts
+++ b/packages/expo-type-information/src/typeInformation.ts
@@ -383,7 +383,7 @@ export type GetFileTypeInformationOptions = {
   /** An option to map unicode code points to ASCII strings to fix underlying SourceKit issue. */
   mapUnicodeCharacters: boolean;
   /** Preprocess the file to remove all `runOnQueue(.*)` from it. */
-  runOnQueue: boolean;
+  removeRunOnQueue: boolean;
 };
 
 async function mergeFileContents(absoluteFilePaths: string[]): Promise<string> {
@@ -406,13 +406,13 @@ async function withTempFile<T>(content: string, fn: (filePath: string) => Promis
 }
 
 export async function withPreparedSingleFile<T>(
-  { input, typeInference, mapUnicodeCharacters, runOnQueue }: GetFileTypeInformationOptions,
+  { input, typeInference, mapUnicodeCharacters, removeRunOnQueue }: GetFileTypeInformationOptions,
   fn: (filePath: string) => Promise<T>
 ): Promise<T> {
   const shouldPreprocessFile =
     typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE ||
     mapUnicodeCharacters ||
-    runOnQueue;
+    removeRunOnQueue;
   if (!shouldPreprocessFile && input.type === 'file' && input.inputFileAbsolutePaths.length === 0) {
     return fn(input.inputFileAbsolutePaths[0] as string);
   }
@@ -425,7 +425,7 @@ export async function withPreparedSingleFile<T>(
   const preprocessFileOptions = {
     preprocessReturns: shouldPreprocessFile,
     mapUnicodeCharacters,
-    runOnQueue,
+    removeRunOnQueue,
   };
   if (shouldPreprocessFile) {
     return withTempFile(preprocessSwiftFile(fileContent, preprocessFileOptions), fn);
@@ -445,11 +445,11 @@ export async function getFileTypeInformation({
   input,
   typeInference,
   mapUnicodeCharacters,
-  runOnQueue,
+  removeRunOnQueue,
 }: GetFileTypeInformationOptions): Promise<FileTypeInformation | null> {
   const shouldPreprocessFile =
     typeInference === TypeInferenceOption.PREPROCESS_AND_INFERENCE ||
-    runOnQueue ||
+    removeRunOnQueue ||
     mapUnicodeCharacters;
   const typeInferenceOn = typeInference !== TypeInferenceOption.NO_INFERENCE;
   if (!shouldPreprocessFile && input.type === 'file' && input.inputFileAbsolutePaths.length === 0) {
@@ -459,7 +459,7 @@ export async function getFileTypeInformation({
   }
 
   return withPreparedSingleFile(
-    { input, typeInference, mapUnicodeCharacters, runOnQueue },
+    { input, typeInference, mapUnicodeCharacters, removeRunOnQueue },
     async (tempFilePath) => {
       return getSwiftFileTypeInformation(tempFilePath, { typeInference: typeInferenceOn });
     }


### PR DESCRIPTION
# Why
When using `runOnQueue(/** something */)` on for example AsyncFunction DSL declaration, `SourceKitten` ignores the closure definition and doesn't parse it. This lead to some AsyncFunction's not being parsed.

# How
Added a preprocessing option `preprocessRunOnQueue`, if this option is set then the file is preprocessed such that each `.runOnQueue(.*)` is removed.

# Test Plan
- [x] Added new test, checked and Updated snapshots in local-test.
- [x] Checked manually for `expo-file-system` package where the issue was found 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
