### PR TITLE
chore: Align ncc dependencies and update `tsconfig.json`s

### DIFF
--- a/packages/create-expo-module/tsconfig.json
+++ b/packages/create-expo-module/tsconfig.json
@@ -3,7 +3,8 @@
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./build"
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "rootDir": "./src"
   }
 }

--- a/packages/create-expo/tsconfig.json
+++ b/packages/create-expo/tsconfig.json
@@ -3,11 +3,8 @@
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./build",
     "module": "preserve",
     "moduleResolution": "bundler",
-    "declaration": false,
-    "types": ["jest"]
+    "rootDir": "./src"
   }
 }

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -45,7 +45,7 @@
     "@types/debug": "^4.1.8",
     "@types/getenv": "^1.0.0",
     "@types/semver": "^7.5.8",
-    "@vercel/ncc": "0.38.3",
+    "@vercel/ncc": "^0.38.3",
     "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "expo-modules-autolinking": "workspace:*",

--- a/packages/expo-doctor/tsconfig.json
+++ b/packages/expo-doctor/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "expo-module-scripts/tsconfig.node",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./build"
-  },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "rootDir": "./src"
+  }
 }

--- a/packages/uri-scheme/tsconfig.json
+++ b/packages/uri-scheme/tsconfig.json
@@ -3,7 +3,8 @@
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
-    "rootDir": "src",
-    "declaration": false
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "rootDir": "./src"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4294,8 +4294,8 @@ importers:
         specifier: ^7.5.8
         version: 7.7.1
       '@vercel/ncc':
-        specifier: 0.38.3
-        version: 0.38.3
+        specifier: ^0.38.3
+        version: 0.38.4
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -9752,10 +9752,6 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
-
-  '@vercel/ncc@0.38.3':
-    resolution: {integrity: sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==}
-    hasBin: true
 
   '@vercel/ncc@0.38.4':
     resolution: {integrity: sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==}
@@ -18922,7 +18918,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -19918,8 +19916,6 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
-
-  '@vercel/ncc@0.38.3': {}
 
   '@vercel/ncc@0.38.4': {}
 


### PR DESCRIPTION
## Summary

Upstreaming from Turborepo branch: [`@kitten/chore/add-turborepo-3`](https://github.com/kitten-agent/expo/tree/%40kitten/chore/add-turborepo-3) / [`@kitten/chore/add-turborepo-2`](https://github.com/expo/expo/tree/%40kitten/chore/add-turborepo-2)

This deduplicates one extra version of `@vercel/ncc` and aligns `tsconfig.json` files for all ncc-built packages.

## Set of changes

- Loosen dependency in `expo-doctor` to deduplicate `@vercel/ncc`
- Update and align `tsconfig.json`s across ncc-built packages

## Checklist

**No user-facing changes**

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
