### PR TITLE
Don't clone submodules in most workflows

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -36,13 +36,6 @@ inputs:
   git-lfs:
     description: 'Restore Git LFS cache'
     required: false
-  hermes-engine-aar:
-    description: 'Restore prebuilt hermes-engine AAR'
-    required: false
-  rebuild-hermes-engine-aar-if-needed:
-    description: 'Rebuild hermes-engine AAR when cache missed'
-    default: 'true'
-    required: false
   react-native-gradle-downloads:
     description: 'Restore Gradle downloads cache for React Native libraries'
     required: false
@@ -69,9 +62,6 @@ outputs:
   git-lfs-hit:
     description: 'Returns true, if Git LFS cache is up-to-date'
     value: ${{ steps.git-lfs-cache.outputs.cache-hit }}
-  hermes-engine-aar-hit:
-    description: 'Returns true, if prebuilt hermes-engine AAR cache is up-to-date'
-    value: ${{ steps.cache-hermes-engine-aar.outputs.cache-hit }}
 
 runs:
   using: 'composite'
@@ -193,41 +183,6 @@ runs:
       with:
         path: .git/lfs
         key: ${{ steps.git-lfs.outputs.sha256 }}
-
-    - name: ♻️ Restore hermes-engine AAR cache
-      if: inputs.hermes-engine-aar == 'true'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: android/prebuiltHermes
-        key: hermes-engine-aar-v2-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
-    - name: Check hermes-engine cache-hit
-      if: inputs.hermes-engine-aar == 'true'
-      id: cache-hermes-engine-aar
-      shell: bash
-      run: |
-        CURRENT_VERSION=$(test -f android/prebuiltHermes/.hermesversion && cat android/prebuiltHermes/.hermesversion) || true
-        TARGET_VERSION=$(test -f react-native-lab/react-native/packages/react-native/sdks/.hermesversion && cat react-native-lab/react-native/packages/react-native/sdks/.hermesversion) || true
-        if [[ $CURRENT_VERSION == $TARGET_VERSION ]]; then
-          echo "cache-hit=true" >> $GITHUB_OUTPUT
-        else
-          echo "cache-hit=false" >> $GITHUB_OUTPUT
-        fi
-    - name: 🛠 Rebuild hermes-engine AAR when cache missed
-      if: inputs.hermes-engine-aar == 'true' && inputs.rebuild-hermes-engine-aar-if-needed == 'true' && steps.cache-hermes-engine-aar.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        # Ensure node packages are installed when cache miss
-        pnpm install --frozen-lockfile
-        mkdir -p prebuiltHermes
-        cp -f ../react-native-lab/react-native/packages/react-native/sdks/.hermesversion prebuiltHermes/
-        ./gradlew :packages:react-native:ReactAndroid:hermes-engine:assembleRelease
-        ./gradlew :packages:react-native:ReactAndroid:hermes-engine:assembleDebug
-        cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-release.aar prebuiltHermes/
-        cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-debug.aar prebuiltHermes/
-      env:
-        # Reset reactNativeArchitectures to build all architectures
-        ORG_GRADLE_PROJECT_reactNativeArchitectures:
-      working-directory: android
 
     - name: 🛠 Setup "REACT_NATIVE_DOWNLOADS_DIR" environment variable
       if: inputs.react-native-gradle-downloads == 'true'

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -59,8 +59,6 @@ jobs:
     steps:
       - name: 👀 Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:

--- a/.github/workflows/expo-go-android-lint.yml
+++ b/.github/workflows/expo-go-android-lint.yml
@@ -1,33 +1,23 @@
-name: Android Unit Tests
+name: Expo Go Android Lint
 
 on:
   workflow_dispatch: {}
   push:
     branches: [main]
     paths:
-      - .github/workflows/android-unit-tests.yml
-      - fastlane/**
-      - packages/**/android/**
-      - tools/**
-      - pnpm-lock.yaml
-      - '!packages/@expo/cli/**'
-      - '!tools/src/commands/GenerateDocsAPIData.ts'
+      - .github/workflows/expo-go-android-lint.yml
+      - apps/expo-go/android/**
   pull_request:
     paths:
-      - .github/workflows/android-unit-tests.yml
-      - fastlane/**
-      - packages/**/android/**
-      - tools/**
-      - pnpm-lock.yaml
-      - '!packages/@expo/cli/**'
-      - '!tools/src/commands/GenerateDocsAPIData.ts'
+      - .github/workflows/expo-go-android-lint.yml
+      - apps/expo-go/android/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  spotless:
     runs-on: ubuntu-24.04
     timeout-minutes: 100
     env:
@@ -36,6 +26,8 @@ jobs:
     steps:
       - name: 👀 Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
@@ -62,13 +54,9 @@ jobs:
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
-      - name: 🎸 Run native Android unit tests
-        if: always()
-        timeout-minutes: 30
-        run: pnpm expotools native-unit-tests --platform android
-      - name: 💾 Save test results
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: test-results
-          path: packages/*/android/build/test-results/**/*xml
+      - name: 📦 Install react-native submodule dependencies
+        run: yarn install
+        working-directory: react-native-lab/react-native
+      - name: 💅 Run Spotless lint check
+        working-directory: apps/expo-go/android
+        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` from `apps/expo-go/android` to automatically fix formatting.' && exit 1; }

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -35,9 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
-
       - name: Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
 

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🔨 Add bin to GITHUB_PATH

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🍺 Install required tools

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          submodules: true
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -94,8 +92,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          submodules: true
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -163,8 +159,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          submodules: true
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -243,8 +243,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          submodules: true
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:


### PR DESCRIPTION
# Why

Our CI started failing on checkout with a 403 when cloning the `react-native-lab/react-native` submodule. The cause is upstream: `react-native` was transferred to the new `react` GitHub org, and that repo (the root of the fork network) is currently disabled, so every fork in the network, including ours, is blocked from git access. The submodule clone fails before any job can run.

While investigating, it turned out most workflows don't actually need the fork at all. Only Expo Go (and `eas-expo-go`) builds React Native from the fork's source. Everything else builds against the published `react-native` package from npm.

So those workflows were cloning a large submodule on every run for nothing, and the upstream outage took them all down even though none of them depend on the fork.

# How

- Removed `submodules: true` from the workflows that build against published `react-native` (unit tests, test suites, xcframework/prebuild jobs, native-component-list, lint).
- Moved the only Expo Go specific CI step (the Android `spotlessCheck`, which configures the fork via Gradle `includeBuild`) into a new `expo-go-android-lint` workflow that owns the submodule. `android-unit-tests` no longer touches the fork.
- Removed the unused `hermes-engine-aar` cache from the `expo-caches` action. No workflow set the input or read the output, and its only consumer is an Expo Go source build that doesn't run in CI.

The result is that `react-native-lab` is referenced by Expo Go specific workflows only, so an upstream fork outage can no longer break unrelated jobs.

# Test Plan

CI is the test here. Since the fork is currently unreachable, any workflow that still cloned it was failing at checkout, so the decoupled workflows flipping back to green confirms they don't need it. Validated each edited file parses as valid YAML and that `react-native-lab` / `submodules: true` now appears only in the Expo Go workflow.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
