### PR TITLE
[docs] update expo plugin install instructions

### DIFF
--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -21,9 +21,19 @@ Expo Skills are structured instruction files that teach AI agents how to build, 
 
 <Tab label="Claude Code">
 
-Run the following commands to add and install Expo Skills from the plugin marketplace:
+Run the following command to install the official Expo plugin from the `claude-plugins-official` marketplace:
 
-<Terminal cmd={['$ /plugin marketplace add expo/skills', '', '$ /plugin install expo']} />
+<Terminal cmd={['$ /plugin install expo@claude-plugins-official']} />
+
+</Tab>
+
+<Tab label="Codex">
+
+From the command line, run the following command to install the official Expo plugin:
+
+<Terminal cmd={['$ codex plugin add expo@openai-curated']} />
+
+You can also open `/plugins` in Codex and install `expo` from the `openai-curated` marketplace.
 
 </Tab>
 


### PR DESCRIPTION
[ENG-21803](https://linear.app/expo/issue/ENG-21803/update-the-docs-with-the-latest-skill-install-instructions)

- Updates the Expo Skills install docs to use the official Claude Code plugin from the claude-plugins-official marketplace.
- Adds Codex install instructions for the openai-curated Expo plugin