### PR TITLE
[ios][precompile] Auto-run external XCFramework prebuild on dependency changes

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -16,13 +16,146 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    branches:
+      - main
+      - 'sdk-*'
+    # Cheap path pre-filter; the `detect` job confirms a supported external
+    # package's pinned version, patch, or SPM config actually changed.
+    # `patches/**` is intentionally broad — detect maps each changed patch back
+    # to its package via pnpm-workspace.yaml and ignores unrelated patches.
+    paths: &trigger_paths
+      - 'apps/bare-expo/package.json'
+      - 'patches/**'
+      - 'packages/expo-modules-autolinking/external-configs/ios/**'
+      - '.github/workflows/ios-prebuild-external-xcframeworks.yml'
+  pull_request:
+    # Validate-only: builds the changed external package(s) but never publishes
+    # to GCS (publish steps are gated to push / manual dispatch).
+    paths: *trigger_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: Detect changed external packages
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+      packages: ${{ steps.detect.outputs.packages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: false
+          # Start shallow; the detect step fetches the event base if needed.
+          fetch-depth: 2
+
+      - name: Detect changed external packages
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          build_all() {
+            echo "$1"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Manual runs always proceed and honor the user-provided package list
+          # (handled downstream via github.event.inputs.packages).
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            build_all "Manual run requested; building requested external packages."
+          fi
+
+          case "$EVENT_NAME" in
+            push)
+              base="$PUSH_BEFORE_SHA"
+              ;;
+            pull_request)
+              base="$PR_BASE_SHA"
+              ;;
+            *)
+              base="$(git rev-parse HEAD^ 2>/dev/null || true)"
+              ;;
+          esac
+
+          if [ -z "$base" ] || [[ "$base" =~ ^0+$ ]]; then
+            build_all "No base commit to diff against; building all external packages."
+          fi
+
+          if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$base" || \
+              build_all "Could not fetch base commit; building all external packages."
+          fi
+
+          config_root="packages/expo-modules-autolinking/external-configs/ios"
+          manifest="apps/bare-expo/package.json"
+          changed=()
+
+          # Derive the package -> patch-file map from pnpm's own source of truth
+          # (the `patchedDependencies` block in pnpm-workspace.yaml) so adding a
+          # patched package needs no edits here. Keys may carry an `@version`
+          # suffix (e.g. `@shopify/react-native-skia@2.6.2`); strip it to get the
+          # bare package name that matches the external-config directory.
+          declare -A package_patches=()
+          while IFS= read -r line; do
+            raw_key="${line%%:*}"
+            patch_path="${line#*: }"
+            name="$(printf '%s' "$raw_key" | sed -E "s/^[[:space:]]*//; s/[[:space:]]*$//; s/^['\"]//; s/['\"]$//; s/@[0-9][^@]*$//")"
+            patch_path="$(printf '%s' "$patch_path" | sed -E "s/^[[:space:]]*//; s/[[:space:]]*$//")"
+            [ -n "$name" ] && package_patches["$name"]="$patch_path"
+          done < <(awk '/^patchedDependencies:/{f=1;next} f&&/^[^[:space:]]/{f=0} f&&NF' pnpm-workspace.yaml)
+
+          while IFS= read -r cfg; do
+            dir="$(dirname "$cfg")"
+            pkg="${dir#"$config_root/"}"
+
+            # The SPM config for this package changed.
+            if ! git diff --quiet "$base" HEAD -- "$dir"; then
+              changed+=("$pkg")
+              continue
+            fi
+
+            # The pnpm patch for this package changed.
+            patch="${package_patches[$pkg]:-}"
+            if [ -n "$patch" ] && ! git diff --quiet "$base" HEAD -- "$patch"; then
+              changed+=("$pkg")
+              continue
+            fi
+
+            # The version pinned in bare-expo's manifest changed.
+            before_ver="$(git show "$base:$manifest" 2>/dev/null \
+              | jq -r --arg p "$pkg" '.dependencies[$p] // .devDependencies[$p] // empty')"
+            after_ver="$(jq -r --arg p "$pkg" '.dependencies[$p] // .devDependencies[$p] // empty' "$manifest")"
+            if [ "$before_ver" != "$after_ver" ]; then
+              changed+=("$pkg")
+            fi
+          done < <(find "$config_root" -name spm.config.json)
+
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No supported external package versions, patches, or configs changed; skipping prebuild."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed external packages: ${changed[*]}"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "packages=${changed[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
   prebuild:
+    needs: detect
+    # Skip when no relevant package changed; never auto-run on forks' pushes.
+    if: >-
+      needs.detect.outputs.should_run == 'true' &&
+      (github.event_name != 'push' || github.repository == 'expo/expo')
     runs-on: macos-26
     timeout-minutes: 120
     permissions:
@@ -58,7 +191,8 @@ jobs:
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         id: prebuild_xcframeworks
         env:
-          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          # Manual runs use the dispatch input; push runs use the detected list.
+          INPUT_PACKAGES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.packages || needs.detect.outputs.packages }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
         run: |
           ARGS="-f ${{ matrix.flavor }} -v --external-only"
@@ -84,20 +218,20 @@ jobs:
           include-hidden-files: true
 
       - name: Authenticate to Google Cloud
-        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
+        if: ${{ success() && (github.event.inputs.publish == 'true' || github.event_name == 'push') && github.repository == 'expo/expo' }}
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
+        if: ${{ success() && (github.event.inputs.publish == 'true' || github.event_name == 'push') && github.repository == 'expo/expo' }}
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
         with:
           project_id: exponentjs
 
       - name: Upload XCFramework directory structure to GCS
-        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
+        if: ${{ success() && (github.event.inputs.publish == 'true' || github.event_name == 'push') && github.repository == 'expo/expo' }}
         run: |
           SYNC_ROOT="$RUNNER_TEMP/precompiled-modules-upload"
           rm -rf "$SYNC_ROOT"


### PR DESCRIPTION
## Why

Prebuilt external (third-party) iOS XCFrameworks were only ever regenerated by manually dispatching the workflow. When a supported external package's pinned version or patch changed, someone had to remember to run the prebuild and publish the new tarballs to GCS by hand.

## How

Added `push` (main, sdk-*) and `pull_request` triggers. 

Path is pre-filtered to the files that can affect an external prebuild: `apps/bare-expo/package.json`, patches/**, external SPM configs, and the workflow itself. 

Added a fast `detect` job that diffs the event base against HEAD and emits the list of supported external packages whose SPM config, pnpm patch, or pinned version actually changed. 

The patch -> package map is derived at runtime from pnpm-workspace.yaml's patchedDependencies, so adding a patched package needs no edits here. `patches/**` is intentionally broad; detect ignores patches that don't map to a supported package.

Gate `prebuild` on detect: it runs only when something relevant changed and builds just those packages (via INPUT_PACKAGES) instead of all externals. push runs publish to GCS automatically; pull_request validates only (publish stays gated to push / manual dispatch with repo == expo/expo). Manual workflow_dispatch behaves exactly as before.

Stop checking out submodules for the prebuild/detect jobs; the external prebuild resolves sources from node_modules and doesn't need them.

## Test Plan

- Validated the workflow YAML parses and the shared `paths:` anchor resolves identically for push and pull_request.
- Simulated the detect script against the repo: the patch map derived from pnpm-workspace.yaml resolves all patched dependencies correctly (scoped names and @version suffixes handled), and every external config dir maps to its expected patch (incl. react-native-gesture-handler for when a config is added).
- Confirmed `et prebuild --external-only <name>` accepts the npm package name detect emits (getExternalPackageByName resolves external-configs/ios/<name>).
- Before merge, verify on a branch: (1) bump one external dep in apps/bare-expo/package.json -> detect lists only that package and prebuild runs scoped; (2) edit an unrelated patch -> detect reports nothing and prebuild is skipped; (3) one workflow_dispatch run still honors its inputs.

