### PR TITLE
[docs][ui] Note FieldGroup needs a fixed-size parent

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/universal/fieldgroup.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/fieldgroup.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 A scrollable container for grouped settings-style rows, mirroring the look of an iOS Settings screen. Compose `FieldGroup.Section` (for explicit groups), `FieldGroup.SectionHeader`, and `FieldGroup.SectionFooter` slots inside.
 
+> **Note:** `FieldGroup` scrolls and has no height of its own. It stretches to fill its parent, so give it a parent with a definite size, such as a `<Host style={{ flex: 1 }}>` or a host with an explicit height. It will not appear inside a size-to-fit container like `<Host matchContents>`, because there is no bounded height for the group to fill.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/fieldgroup.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/fieldgroup.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 A scrollable container for grouped settings-style rows, mirroring the look of an iOS Settings screen. Compose `FieldGroup.Section` (for explicit groups), `FieldGroup.SectionHeader`, and `FieldGroup.SectionFooter` slots inside.
 
+> **Note:** `FieldGroup` scrolls and has no height of its own. It stretches to fill its parent, so give it a parent with a definite size, such as a `<Host style={{ flex: 1 }}>` or a host with an explicit height. It will not appear inside a size-to-fit container like `<Host matchContents>`, because there is no bounded height for the group to fill.
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

`FieldGroup` renders nothing on iOS inside `<Host matchContents>`. 

Fixes - https://github.com/expo/expo/issues/46203

# How

- Add a note to the `FieldGroup` docs (unversioned and v56.0.0): it scrolls, has no intrinsic height, and needs a parent with a definite size (`<Host style={{ flex: 1 }}>` or an explicit height), not `matchContents`.

# Test Plan

Docs-only change.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).