### PR TITLE
[expo-image] Fixed image staying blank when its source changes while a transition cross-fade

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed image staying blank when its `source` changes while a `transition` cross-fade is still running.
+
 ### 💡 Others
 
 - [web] Deprecated `webMaxViewportWidth`. With layout-based selection it is now only used to emit fallback `sizes` breakpoints for browsers that don't yet support `sizes="auto"`. ([#46425](https://github.com/expo/expo/pull/46425) by [@sebholl](https://github.com/sebholl))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed image staying blank when its `source` changes while a `transition` cross-fade is still running.
+- [Android] Fixed image staying blank when its `source` changes while a `transition` cross-fade is still running. ([#46752](https://github.com/expo/expo/pull/46752) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -312,11 +312,17 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
             newView.bringToFront()
             previousView.alpha = 1f
             newView.alpha = 0f
+            // A newer source can reuse this view as its `newView` before the fade-out ends. That
+            // cancels this animation, and the end action runs on cancel too, so without this guard
+            // it would recycle the view now holding the new image. See issue #46703.
+            val previousTarget = previousView.currentTarget
             previousView.animate().apply {
               duration = transitionDuration
               alpha(0f)
               withEndAction {
-                clearPreviousView()
+                if (previousView.currentTarget === previousTarget) {
+                  clearPreviousView()
+                }
               }
             }
             newView.animate().apply {


### PR DESCRIPTION
# Why

Fixes [#46703](https://github.com/expo/expo/issues/46703).

On Android, an `<Image>` with a `transition` goes blank if its `source` changes while the cross-fade is still running. `onLoad` fires and the bitmap is in memory, but nothing shows.

# How

The cross-fade recycles the outgoing view in a `withEndAction`. Since the wrapper reuses two views, a mid-transition source change can hand the new image to that same view. Starting its fade-in cancels the old animation, and `ViewPropertyAnimator` runs the end action on cancel, so the stale recycle clears the view that now holds the new image.

Now we capture which target the outgoing view holds and only recycle it if the view still holds that target, so a repurposed view is left alone.

# Test Plan

No native test harness for this package, so verified manually with the repro from the issue (`transition={200}`, placeholder swapped for a remote URI after a `setTimeout`):

- Before: image stays blank after the remote loads.
- After: remote image cross-fades in.

Also confirmed `transition={0}` and static sources still work.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
