### PR TITLE
[expo-video] Fix lock screen controls breaking after expo-audio playback

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback.
+- [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback. ([#46753](https://github.com/expo/expo/pull/46753) by [@zoontek](https://github.com/zoontek))
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback.
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -226,6 +226,14 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
         }
         return .commandFailed
       }
+
+      // `MPRemoteCommandCenter` is a process-wide singleton that other modules (e.g. expo-audio) disable on
+      // teardown, so re-enable the commands we handle to keep the lock screen controls working. (issue #46711)
+      commandCenter.playCommand.isEnabled = true
+      commandCenter.pauseCommand.isEnabled = true
+      commandCenter.skipForwardCommand.isEnabled = true
+      commandCenter.skipBackwardCommand.isEnabled = true
+      commandCenter.changePlaybackPositionCommand.isEnabled = true
     }
   }
 


### PR DESCRIPTION
# Why

Fixes [#46711](https://github.com/expo/expo/issues/46711).

`MPRemoteCommandCenter` is a process-wide singleton. expo-audio disables its commands when a player is torn down. Since expo-video only added and removed command targets but never touched `isEnabled`, the lock screen controls stayed dead after audio had played and stopped: a video played afterwards showed disabled transport buttons and no working scrubbing.

# How

When expo-video registers its now playing command targets, it now also re-enables the commands it handles (play, pause, skip forward, skip backward, change playback position). This mirrors what expo-audio already does and makes the two modules play nicely with the shared command center regardless of order.

# Test Plan

Tested on a physical iOS device with the reproduction from the issue:

1. Play a video, lock the device, confirm controls and metadata are correct.
2. Stop the video, play an audio source, stop it.
3. Play the video again and lock the device.

Before: the second video showed disabled controls with no metadata. After: controls and metadata are correct in every order.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
