### PR TITLE
[docs] point llms links to markdown urls

### DIFF
--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { home, learn, general, eas, reference } from '../../constants/navigation.js';
-import { generateCrossLinksSection, toBlockquote } from './shared.js';
+import { generateCrossLinksSection, getMarkdownUrl, toBlockquote } from './shared.js';
 import { EXPO_DESCRIPTION, PAGE_DESCRIPTION_OVERRIDES } from './transforms/descriptions.js';
 import { MISCONCEPTIONS_SECTION } from './transforms/misconceptions.js';
 import { PERFORMANCE_SECTION } from './transforms/performance.js';
@@ -109,7 +109,7 @@ function processPageData(pageHref, pageName) {
   return title || pageName
     ? {
         title: title ?? pageName,
-        url: `https://docs.expo.dev${pageHref}`,
+        url: getMarkdownUrl(pageHref),
         description: finalDescription,
       }
     : null;

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -49,7 +49,7 @@ const DOC_INDEX_BLOCKQUOTE =
   '> For the complete documentation index, see [llms.txt](/llms.txt). Use this Use this file to discover all available pages.';
 
 function splitUrlSuffix(url) {
-  const suffixIndex = url.search(/[?#]/);
+  const suffixIndex = url.search(/[#?]/);
   if (suffixIndex === -1) {
     return { pathname: url, suffix: '' };
   }
@@ -61,7 +61,10 @@ function splitUrlSuffix(url) {
 }
 
 function hasFileExtension(pathname) {
-  return /\.[^/]+$/.test(pathname);
+  const match = pathname.match(/\.([^./]+)$/);
+  // A purely numeric "extension" (e.g. the trailing `0` in `/versions/v51.0.0`) is part of a
+  // version segment, not a real file extension, so such hrefs should still be converted to `.md`.
+  return match !== null && !/^\d+$/.test(match[1]);
 }
 
 export function getMarkdownHref(href) {
@@ -84,39 +87,58 @@ export function getMarkdownUrl(href) {
   return `${DOCS_BASE_URL}${getMarkdownHref(href)}`;
 }
 
+// Matches the opening or closing line of a fenced code block. CommonMark allows up to three
+// leading spaces and supports both backtick and tilde fences, so we accept indented fences
+// (e.g. those nested inside list items) and `~~~` fences, not only ``` at column 0.
+const CODE_FENCE_REGEX = /^\s{0,3}(`{3,}|~{3,})/;
+
+function rewriteMarkdownLinks(line) {
+  return line.replace(
+    /(!?\[[^\n\]]+]\()([^\s)]+)((?:\s+["'][^\n)]*["'])?\))/g,
+    (match, prefix, url, suffix) => {
+      if (prefix.startsWith('!')) {
+        return match;
+      }
+
+      if (url.startsWith(DOCS_BASE_URL_WITH_SLASH)) {
+        return `${prefix}${getMarkdownUrl(url.slice(DOCS_BASE_URL.length))}${suffix}`;
+      }
+
+      if (url.startsWith('/') && !url.startsWith('//')) {
+        return `${prefix}${getMarkdownHref(url)}${suffix}`;
+      }
+
+      return match;
+    }
+  );
+}
+
 export function rewriteDocsLinksToMarkdown(content) {
-  let inFencedCodeBlock = false;
+  // The fence marker (`` ` `` or `~`) that opened the current code block, or null when outside one.
+  // Tracking the marker keeps a ``` line from prematurely closing a ~~~ block and vice versa.
+  let fenceMarker = null;
 
   return content
     .split('\n')
     .map(line => {
-      if (/^```/.test(line)) {
-        inFencedCodeBlock = !inFencedCodeBlock;
-        return line;
-      }
-
-      if (inFencedCodeBlock) {
-        return line;
-      }
-
-      return line.replace(
-        /(!?\[[^\]\n]+\]\()([^)\s]+)((?:\s+["'][^)\n]*["'])?\))/g,
-        (match, prefix, url, suffix) => {
-          if (prefix.startsWith('!')) {
-            return match;
-          }
-
-          if (url.startsWith(DOCS_BASE_URL_WITH_SLASH)) {
-            return `${prefix}${getMarkdownUrl(url.slice(DOCS_BASE_URL.length))}${suffix}`;
-          }
-
-          if (url.startsWith('/') && !url.startsWith('//')) {
-            return `${prefix}${getMarkdownHref(url)}${suffix}`;
-          }
-
-          return match;
+      const fenceMatch = line.match(CODE_FENCE_REGEX);
+      if (fenceMatch) {
+        const marker = fenceMatch[1][0];
+        if (fenceMarker === null) {
+          fenceMarker = marker;
+          return line;
         }
-      );
+        if (marker === fenceMarker) {
+          fenceMarker = null;
+          return line;
+        }
+      }
+
+      if (fenceMarker !== null) {
+        return line;
+      }
+
+      return rewriteMarkdownLinks(line);
     })
     .join('\n');
 }

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -2,12 +2,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { buildAgentInstructions } from '../agent-instructions.ts';
+import {
+  DOCS_BASE_URL,
+  getMarkdownHref,
+  getMarkdownUrl,
+  rewriteDocsLinksToMarkdown,
+} from '../markdown-link-utils.ts';
+
+export { DOCS_BASE_URL, getMarkdownHref, getMarkdownUrl, rewriteDocsLinksToMarkdown };
 
 export const OUTPUT_DIRECTORY_NAME = 'public';
 export const BUILD_OUTPUT_DIR = 'out';
-export const DOCS_BASE_URL = 'https://docs.expo.dev';
 
-const DOCS_BASE_URL_WITH_SLASH = `${DOCS_BASE_URL}/`;
 const LLMS_FILES = [
   { filename: 'llms.txt', description: 'A list of all available documentation files' },
   {
@@ -47,101 +53,6 @@ const AGENT_INSTRUCTIONS_BLOCK_REGEX = /<AgentInstructions>[\S\s]*?<\/AgentInstr
 
 const DOC_INDEX_BLOCKQUOTE =
   '> For the complete documentation index, see [llms.txt](/llms.txt). Use this Use this file to discover all available pages.';
-
-function splitUrlSuffix(url) {
-  const suffixIndex = url.search(/[#?]/);
-  if (suffixIndex === -1) {
-    return { pathname: url, suffix: '' };
-  }
-
-  return {
-    pathname: url.slice(0, suffixIndex),
-    suffix: url.slice(suffixIndex),
-  };
-}
-
-function hasFileExtension(pathname) {
-  const match = pathname.match(/\.([^./]+)$/);
-  // A purely numeric "extension" (e.g. the trailing `0` in `/versions/v51.0.0`) is part of a
-  // version segment, not a real file extension, so such hrefs should still be converted to `.md`.
-  return match !== null && !/^\d+$/.test(match[1]);
-}
-
-export function getMarkdownHref(href) {
-  if (!href || href.startsWith('#')) {
-    return href;
-  }
-
-  const { pathname, suffix } = splitUrlSuffix(href);
-  if (!pathname || hasFileExtension(pathname)) {
-    return href;
-  }
-
-  const normalizedPathname =
-    pathname === '/' ? '/index' : pathname.replace(/\/+$/g, '').replace(/^([^/])/, '/$1');
-
-  return `${normalizedPathname}.md${suffix}`;
-}
-
-export function getMarkdownUrl(href) {
-  return `${DOCS_BASE_URL}${getMarkdownHref(href)}`;
-}
-
-// Matches the opening or closing line of a fenced code block. CommonMark allows up to three
-// leading spaces and supports both backtick and tilde fences, so we accept indented fences
-// (e.g. those nested inside list items) and `~~~` fences, not only ``` at column 0.
-const CODE_FENCE_REGEX = /^\s{0,3}(`{3,}|~{3,})/;
-
-function rewriteMarkdownLinks(line) {
-  return line.replace(
-    /(!?\[[^\n\]]+]\()([^\s)]+)((?:\s+["'][^\n)]*["'])?\))/g,
-    (match, prefix, url, suffix) => {
-      if (prefix.startsWith('!')) {
-        return match;
-      }
-
-      if (url.startsWith(DOCS_BASE_URL_WITH_SLASH)) {
-        return `${prefix}${getMarkdownUrl(url.slice(DOCS_BASE_URL.length))}${suffix}`;
-      }
-
-      if (url.startsWith('/') && !url.startsWith('//')) {
-        return `${prefix}${getMarkdownHref(url)}${suffix}`;
-      }
-
-      return match;
-    }
-  );
-}
-
-export function rewriteDocsLinksToMarkdown(content) {
-  // The fence marker (`` ` `` or `~`) that opened the current code block, or null when outside one.
-  // Tracking the marker keeps a ``` line from prematurely closing a ~~~ block and vice versa.
-  let fenceMarker = null;
-
-  return content
-    .split('\n')
-    .map(line => {
-      const fenceMatch = line.match(CODE_FENCE_REGEX);
-      if (fenceMatch) {
-        const marker = fenceMatch[1][0];
-        if (fenceMarker === null) {
-          fenceMarker = marker;
-          return line;
-        }
-        if (marker === fenceMarker) {
-          fenceMarker = null;
-          return line;
-        }
-      }
-
-      if (fenceMarker !== null) {
-        return line;
-      }
-
-      return rewriteMarkdownLinks(line);
-    })
-    .join('\n');
-}
 
 export function stripAgentInstructions(content) {
   return content.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, '');

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -7,6 +7,7 @@ export const OUTPUT_DIRECTORY_NAME = 'public';
 export const BUILD_OUTPUT_DIR = 'out';
 export const DOCS_BASE_URL = 'https://docs.expo.dev';
 
+const DOCS_BASE_URL_WITH_SLASH = `${DOCS_BASE_URL}/`;
 const LLMS_FILES = [
   { filename: 'llms.txt', description: 'A list of all available documentation files' },
   {
@@ -46,6 +47,79 @@ const AGENT_INSTRUCTIONS_BLOCK_REGEX = /<AgentInstructions>[\S\s]*?<\/AgentInstr
 
 const DOC_INDEX_BLOCKQUOTE =
   '> For the complete documentation index, see [llms.txt](/llms.txt). Use this Use this file to discover all available pages.';
+
+function splitUrlSuffix(url) {
+  const suffixIndex = url.search(/[?#]/);
+  if (suffixIndex === -1) {
+    return { pathname: url, suffix: '' };
+  }
+
+  return {
+    pathname: url.slice(0, suffixIndex),
+    suffix: url.slice(suffixIndex),
+  };
+}
+
+function hasFileExtension(pathname) {
+  return /\.[^/]+$/.test(pathname);
+}
+
+export function getMarkdownHref(href) {
+  if (!href || href.startsWith('#')) {
+    return href;
+  }
+
+  const { pathname, suffix } = splitUrlSuffix(href);
+  if (!pathname || hasFileExtension(pathname)) {
+    return href;
+  }
+
+  const normalizedPathname =
+    pathname === '/' ? '/index' : pathname.replace(/\/+$/g, '').replace(/^([^/])/, '/$1');
+
+  return `${normalizedPathname}.md${suffix}`;
+}
+
+export function getMarkdownUrl(href) {
+  return `${DOCS_BASE_URL}${getMarkdownHref(href)}`;
+}
+
+export function rewriteDocsLinksToMarkdown(content) {
+  let inFencedCodeBlock = false;
+
+  return content
+    .split('\n')
+    .map(line => {
+      if (/^```/.test(line)) {
+        inFencedCodeBlock = !inFencedCodeBlock;
+        return line;
+      }
+
+      if (inFencedCodeBlock) {
+        return line;
+      }
+
+      return line.replace(
+        /(!?\[[^\]\n]+\]\()([^)\s]+)((?:\s+["'][^)\n]*["'])?\))/g,
+        (match, prefix, url, suffix) => {
+          if (prefix.startsWith('!')) {
+            return match;
+          }
+
+          if (url.startsWith(DOCS_BASE_URL_WITH_SLASH)) {
+            return `${prefix}${getMarkdownUrl(url.slice(DOCS_BASE_URL.length))}${suffix}`;
+          }
+
+          if (url.startsWith('/') && !url.startsWith('//')) {
+            return `${prefix}${getMarkdownHref(url)}${suffix}`;
+          }
+
+          return match;
+        }
+      );
+    })
+    .join('\n');
+}
 
 export function stripAgentInstructions(content) {
   return content.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, '');
@@ -144,7 +218,9 @@ export function readUniqueMarkdownContent(markdownPaths, { warnOnMissing = false
       continue;
     }
 
-    const content = stripDocIndexBlockquote(stripAgentInstructions(rawContent)).trim();
+    const content = rewriteDocsLinksToMarkdown(
+      stripDocIndexBlockquote(stripAgentInstructions(rawContent))
+    ).trim();
     if (!content) {
       continue;
     }

--- a/docs/scripts/generate-llms/shared.test.js
+++ b/docs/scripts/generate-llms/shared.test.js
@@ -1,0 +1,74 @@
+import {
+  getMarkdownHref,
+  getMarkdownUrl,
+  rewriteDocsLinksToMarkdown,
+} from './shared.js';
+
+describe('getMarkdownHref', () => {
+  it('converts docs page hrefs to sibling markdown hrefs', () => {
+    expect(getMarkdownHref('/get-started/create-a-project/')).toBe(
+      '/get-started/create-a-project.md'
+    );
+    expect(getMarkdownHref('/versions/latest/sdk/filesystem#installation')).toBe(
+      '/versions/latest/sdk/filesystem.md#installation'
+    );
+    expect(getMarkdownHref('/search?query=updates')).toBe('/search.md?query=updates');
+    expect(getMarkdownHref('/')).toBe('/index.md');
+  });
+
+  it('preserves non-page hrefs', () => {
+    expect(getMarkdownHref('/llms.txt')).toBe('/llms.txt');
+    expect(getMarkdownHref('/get-started/create-a-project.md')).toBe(
+      '/get-started/create-a-project.md'
+    );
+    expect(getMarkdownHref('#installation')).toBe('#installation');
+  });
+});
+
+describe('getMarkdownUrl', () => {
+  it('converts docs page hrefs to absolute markdown URLs', () => {
+    expect(getMarkdownUrl('/get-started/create-a-project/')).toBe(
+      'https://docs.expo.dev/get-started/create-a-project.md'
+    );
+  });
+});
+
+describe('rewriteDocsLinksToMarkdown', () => {
+  it('rewrites internal markdown links to markdown page targets', () => {
+    const content = [
+      '[Create a project](/get-started/create-a-project/)',
+      '[Files](https://docs.expo.dev/versions/latest/sdk/filesystem/#usage)',
+      '[Titled](/guides/overview/ "Guides overview")',
+      '[llms](/llms.txt)',
+      '[External](https://expo.dev)',
+    ].join('\n');
+
+    expect(rewriteDocsLinksToMarkdown(content)).toBe(
+      [
+        '[Create a project](/get-started/create-a-project.md)',
+        '[Files](https://docs.expo.dev/versions/latest/sdk/filesystem.md#usage)',
+        '[Titled](/guides/overview.md "Guides overview")',
+        '[llms](/llms.txt)',
+        '[External](https://expo.dev)',
+      ].join('\n')
+    );
+  });
+
+  it('does not rewrite links inside fenced code blocks', () => {
+    const content = [
+      '[Outside](/get-started/create-a-project/)',
+      '```md',
+      '[Inside](/get-started/create-a-project/)',
+      '```',
+    ].join('\n');
+
+    expect(rewriteDocsLinksToMarkdown(content)).toBe(
+      [
+        '[Outside](/get-started/create-a-project.md)',
+        '```md',
+        '[Inside](/get-started/create-a-project/)',
+        '```',
+      ].join('\n')
+    );
+  });
+});

--- a/docs/scripts/generate-llms/shared.test.js
+++ b/docs/scripts/generate-llms/shared.test.js
@@ -1,8 +1,4 @@
-import {
-  getMarkdownHref,
-  getMarkdownUrl,
-  rewriteDocsLinksToMarkdown,
-} from './shared.js';
+import { getMarkdownHref, getMarkdownUrl, rewriteDocsLinksToMarkdown } from './shared.js';
 
 describe('getMarkdownHref', () => {
   it('converts docs page hrefs to sibling markdown hrefs', () => {
@@ -14,6 +10,11 @@ describe('getMarkdownHref', () => {
     );
     expect(getMarkdownHref('/search?query=updates')).toBe('/search.md?query=updates');
     expect(getMarkdownHref('/')).toBe('/index.md');
+  });
+
+  it('converts versioned page hrefs whose last segment ends in a number', () => {
+    expect(getMarkdownHref('/versions/v51.0.0')).toBe('/versions/v51.0.0.md');
+    expect(getMarkdownHref('/versions/v51.0.0/')).toBe('/versions/v51.0.0.md');
   });
 
   it('preserves non-page hrefs', () => {
@@ -70,5 +71,37 @@ describe('rewriteDocsLinksToMarkdown', () => {
         '```',
       ].join('\n')
     );
+  });
+
+  it('does not rewrite links inside indented or tilde fenced code blocks', () => {
+    const content = [
+      '1. Step one:',
+      '   ```md',
+      '   [Indented](/get-started/create-a-project/)',
+      '   ```',
+      '~~~md',
+      '[Tilde](/get-started/create-a-project/)',
+      '~~~',
+      '[Outside](/get-started/create-a-project/)',
+    ].join('\n');
+
+    expect(rewriteDocsLinksToMarkdown(content)).toBe(
+      [
+        '1. Step one:',
+        '   ```md',
+        '   [Indented](/get-started/create-a-project/)',
+        '   ```',
+        '~~~md',
+        '[Tilde](/get-started/create-a-project/)',
+        '~~~',
+        '[Outside](/get-started/create-a-project.md)',
+      ].join('\n')
+    );
+  });
+
+  it('does not let a ``` line close a ~~~ fenced block', () => {
+    const content = ['~~~md', '```', '[Inside](/get-started/create-a-project/)', '~~~'].join('\n');
+
+    expect(rewriteDocsLinksToMarkdown(content)).toBe(content);
   });
 });

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -362,7 +362,7 @@ describe('convertHtmlToMarkdown', () => {
       '<html><head><meta http-equiv="refresh" content="0; url=/get-started/create-a-project/"></head><body><div id="__next"></div></body></html>';
     const result = convertHtmlToMarkdown(html);
     expect(result).toContain('/get-started/create-a-project/');
-    expect(result).toContain('https://docs.expo.dev/get-started/create-a-project/');
+    expect(result).toContain('https://docs.expo.dev/get-started/create-a-project.md');
     expect(result).toContain('redirects to');
   });
 
@@ -388,6 +388,28 @@ describe('convertHtmlToMarkdown', () => {
     const html = '<main><pre><code class="language-js">const x = 1;</code></pre></main>';
     const md = convertHtmlToMarkdown(html);
     expect(md).toContain('```js\nconst x = 1;\n```');
+  });
+
+  it('rewrites internal links to markdown URLs', () => {
+    const html = `<main>
+      <h1>Links</h1>
+      <p>
+        <a href="/more/expo-cli#install">CLI</a>
+        <a href="https://docs.expo.dev/versions/v56.0.0/sdk/contacts#contactgetalloptions">Contacts</a>
+        <a href="/llms.txt">llms</a>
+        <a href="https://expo.dev">External</a>
+      </p>
+      <pre><code class="language-md">[Inside](/more/expo-cli#install)</code></pre>
+    </main>`;
+    const md = convertHtmlToMarkdown(html);
+
+    expect(md).toContain('[CLI](/more/expo-cli.md#install)');
+    expect(md).toContain(
+      '[Contacts](https://docs.expo.dev/versions/v56.0.0/sdk/contacts.md#contactgetalloptions)'
+    );
+    expect(md).toContain('[llms](/llms.txt)');
+    expect(md).toContain('[External](https://expo.dev)');
+    expect(md).toContain('[Inside](/more/expo-cli#install)');
   });
 });
 
@@ -440,7 +462,7 @@ describe('card links', () => {
       </a>
     </main>`;
     const md = convertHtmlToMarkdown(html);
-    expect(md).toContain('[My Guide](/guide)');
+    expect(md).toContain('[My Guide](/guide.md)');
     expect(md).toContain('Guide description.');
   });
 });
@@ -809,7 +831,7 @@ describe('convertHtmlToMarkdown with real page structure', () => {
     expect(md).toContain('[Node.js (LTS)](https://nodejs.org)');
     expect(md).toContain('```sh\nnpx create-expo-app@latest\n```');
     expect(md).toContain('## Next step');
-    expect(md).toContain('[development environment](/get-started/set-up-your-environment)');
+    expect(md).toContain('[development environment](/get-started/set-up-your-environment.md)');
 
     // Non-content is removed
     expect(md).not.toContain('Home');

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
 
+import { rewriteDocsLinksToMarkdown } from './markdown-link-utils.ts';
+
 /**
  * Find the MDX source file corresponding to an output HTML path.
  * Returns the absolute path to the .mdx file, or null if not found.
@@ -976,7 +978,9 @@ export function convertHtmlToMarkdown(html: string): string {
     const match = refreshMeta.match(/url=(\S+)/i);
     if (match) {
       const target = match[1];
-      return `This page redirects to [${target}](https://docs.expo.dev${target}).\n`;
+      return rewriteDocsLinksToMarkdown(
+        `This page redirects to [${target}](https://docs.expo.dev${target}).`
+      ) + '\n';
     }
   }
 
@@ -994,6 +998,7 @@ export function convertHtmlToMarkdown(html: string): string {
 
   let markdown = turndown.turndown(mainHtml);
   markdown = cleanMarkdown(markdown);
+  markdown = rewriteDocsLinksToMarkdown(markdown);
 
   return markdown ? markdown + '\n' : NO_CONTENT_FALLBACK;
 }

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -978,9 +978,11 @@ export function convertHtmlToMarkdown(html: string): string {
     const match = refreshMeta.match(/url=(\S+)/i);
     if (match) {
       const target = match[1];
-      return rewriteDocsLinksToMarkdown(
-        `This page redirects to [${target}](https://docs.expo.dev${target}).`
-      ) + '\n';
+      return (
+        rewriteDocsLinksToMarkdown(
+          `This page redirects to [${target}](https://docs.expo.dev${target}).`
+        ) + '\n'
+      );
     }
   }
 

--- a/docs/scripts/markdown-link-utils.ts
+++ b/docs/scripts/markdown-link-utils.ts
@@ -1,0 +1,94 @@
+export const DOCS_BASE_URL = 'https://docs.expo.dev';
+
+const DOCS_BASE_URL_WITH_SLASH = `${DOCS_BASE_URL}/`;
+const CODE_FENCE_REGEX = /^\s{0,3}(`{3,}|~{3,})/;
+
+function splitUrlSuffix(url: string): { pathname: string; suffix: string } {
+  const suffixIndex = url.search(/[#?]/);
+  if (suffixIndex === -1) {
+    return { pathname: url, suffix: '' };
+  }
+
+  return {
+    pathname: url.slice(0, suffixIndex),
+    suffix: url.slice(suffixIndex),
+  };
+}
+
+function hasFileExtension(pathname: string): boolean {
+  const match = pathname.match(/\.([^./]+)$/);
+  // A purely numeric "extension" (e.g. the trailing `0` in `/versions/v51.0.0`) is part of a
+  // version segment, not a real file extension, so such hrefs should still be converted to `.md`.
+  return match !== null && !/^\d+$/.test(match[1]);
+}
+
+export function getMarkdownHref(href: string): string {
+  if (!href || href.startsWith('#')) {
+    return href;
+  }
+
+  const { pathname, suffix } = splitUrlSuffix(href);
+  if (!pathname || hasFileExtension(pathname)) {
+    return href;
+  }
+
+  const normalizedPathname =
+    pathname === '/' ? '/index' : pathname.replace(/\/+$/g, '').replace(/^([^/])/, '/$1');
+
+  return `${normalizedPathname}.md${suffix}`;
+}
+
+export function getMarkdownUrl(href: string): string {
+  return `${DOCS_BASE_URL}${getMarkdownHref(href)}`;
+}
+
+function rewriteMarkdownLinks(line: string): string {
+  return line.replace(
+    /(!?\[[^\n\]]+]\()([^\s)]+)((?:\s+["'][^\n)]*["'])?\))/g,
+    (match, prefix: string, url: string, suffix: string) => {
+      if (prefix.startsWith('!')) {
+        return match;
+      }
+
+      if (url.startsWith(DOCS_BASE_URL_WITH_SLASH)) {
+        return `${prefix}${getMarkdownUrl(url.slice(DOCS_BASE_URL.length))}${suffix}`;
+      }
+
+      if (url.startsWith('/') && !url.startsWith('//')) {
+        return `${prefix}${getMarkdownHref(url)}${suffix}`;
+      }
+
+      return match;
+    }
+  );
+}
+
+export function rewriteDocsLinksToMarkdown(content: string): string {
+  // The fence marker (`` ` `` or `~`) that opened the current code block, or null when outside one.
+  // Tracking the marker keeps a ``` line from prematurely closing a ~~~ block and vice versa.
+  let fenceMarker: string | null = null;
+
+  return content
+    .split('\n')
+    .map(line => {
+      const fenceMatch = line.match(CODE_FENCE_REGEX);
+      if (fenceMatch) {
+        const marker = fenceMatch[1][0];
+        if (fenceMarker === null) {
+          fenceMarker = marker;
+          return line;
+        }
+        if (marker === fenceMarker) {
+          fenceMarker = null;
+          return line;
+        }
+      }
+
+      if (fenceMarker !== null) {
+        return line;
+      }
+
+      return rewriteMarkdownLinks(line);
+    })
+    .join('\n');
+}


### PR DESCRIPTION
The links in llms.txt should point to the .md versions of the pages. This seems to be the standard, see i.e. Mintlify: https://www.mintlify.com/docs/llms.txt