### PR TITLE
[expo-doctor] Recognize the React Native Directory `new-arch-only` status

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Recognize the React Native Directory `new-arch-only` status so New-Architecture-only libraries aren't flagged
+- Recognize the React Native Directory `new-arch-only` status so New-Architecture-only libraries aren't flagged ([#46755](https://github.com/expo/expo/pull/46755) by [@zoontek](https://github.com/zoontek))
 - Fix SDK 55 Metro config check for missing `metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Recognize the React Native Directory `new-arch-only` status so New-Architecture-only libraries aren't flagged
 - Fix SDK 55 Metro config check for missing `metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
@@ -166,6 +166,34 @@ describe('ReactNativeDirectoryCheck', () => {
     `);
   });
 
+  it('treats new-arch-only packages as supported', async () => {
+    jest.mocked(checkLibraries).mockResolvedValueOnce({
+      newArchOnly: { newArchitecture: 'new-arch-only' },
+      working: { newArchitecture: 'supported' },
+    });
+
+    const check = new ReactNativeDirectoryCheck();
+    const result = await check.runAsync(
+      {
+        pkg: {
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            newArchOnly: '*',
+            working: '*',
+          },
+        },
+        ...additionalProjectProps,
+      },
+      {
+        resolutions: Promise.reject(new Error()),
+      }
+    );
+
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toEqual([]);
+  });
+
   it('success and no errors if only unknown libraries are in the result', async () => {
     jest.mocked(checkLibraries).mockResolvedValueOnce({
       working: { unmaintained: false, newArchitecture: 'supported' },

--- a/packages/expo-doctor/src/utils/reactNativeDirectoryApi.ts
+++ b/packages/expo-doctor/src/utils/reactNativeDirectoryApi.ts
@@ -1,7 +1,7 @@
 // note(Simek): reference https://github.com/react-native-community/directory/blob/main/pages/api/libraries/check.ts
 export type ReactNativeDirectoryCheckResult = {
-  unmaintained: boolean;
-  newArchitecture: 'supported' | 'unsupported' | 'untested';
+  unmaintained?: boolean;
+  newArchitecture: 'supported' | 'unsupported' | 'untested' | 'new-arch-only';
 };
 
 export type DirectoryCheckResponse = Record<string, ReactNativeDirectoryCheckResult>;


### PR DESCRIPTION
# Why

Fixes #46751.

Reference: https://github.com/react-native-community/directory/blob/main/assets/check-data.json

React Native Directory added a `new-arch-only` status a while ago (react-native-community/directory#1812), but expo-doctor never knew about it. Our `newArchitecture` type only listed `supported | unsupported | untested`, so the new value wasn't typed and wasn't explicitly handled. While there, the API also omits `unmaintained` when it's `false`, which our type marked as required.

# How

- Added `new-arch-only` to the `newArchitecture` union. Libraries that only support the New Architecture (the default) are now treated as supported and no longer flagged.
- Made `unmaintained` optional to match what the Directory actually returns.

# Test Plan

Added a test covering a `new-arch-only` package (with `unmaintained` omitted): the check passes with no issues. Full suite green:

```
yarn jest DirectoryCheck
Tests: 9 passed, 9 total
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
