### PR TITLE
feature(cli): support `DeviceHub` as `Simulator` replacement for Xcode 27+

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
+- Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/__mocks__/@expo/osascript.ts
+++ b/packages/@expo/cli/__mocks__/@expo/osascript.ts
@@ -1,1 +1,17 @@
+const osascript = jest.requireActual('@expo/osascript') as typeof import('@expo/osascript');
+
+export const escapeString = osascript.escapeString;
+
+export const chooseAppAsync = jest.fn(async () => {});
+export const chooseEditorAppAsync = jest.fn(async () => {});
+export const chooseTerminalAppAsync = jest.fn(async () => {});
 export const execAsync = jest.fn(async () => {});
+export const isAppRunningAsync = jest.fn(async () => {});
+export const openFinderToFolderAsync = jest.fn(async () => {});
+export const openFolderInTerminalAppAsync = jest.fn(async () => {});
+export const openInAppAsync = jest.fn(async () => {});
+export const openInEditorAsync = jest.fn(async () => {});
+export const openItermToSpecificFolderAsync = jest.fn(async () => {});
+export const openTerminalToSpecificFolderAsync = jest.fn(async () => {});
+export const safeIdOfAppAsync = jest.fn(async () => {});
+export const spawnAsync = jest.fn(async () => {});

--- a/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
@@ -1,83 +1,58 @@
-import { execAsync } from '@expo/osascript';
+import { safeIdOfAppAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
-import path from 'path';
+import path from 'node:path';
 
-import * as Log from '../../../log';
+import { Log } from '../../../log';
 import { Prerequisite, PrerequisiteCommandError } from '../Prerequisite';
 
 const debug = require('debug')('expo:doctor:apple:simulatorApp') as typeof console.log;
 
-/**
- * Get the bundle ID of the Simulator.app via AppleScript / LaunchServices.
- * May return null if the Simulator.app is not registered in LaunchServices
- * (e.g. when Xcode lives on an external or renamed volume).
- */
-async function getSimulatorAppIdViaAppleScriptAsync(): Promise<string | null> {
-  try {
-    return (await execAsync('id of app "Simulator"')).trim();
-  } catch {
-    // This error may occur in CI where the user intends to install just the simulators but no
-    // Xcode, or when Simulator.app is not registered in LaunchServices (e.g. Xcode on an
-    // external or renamed volume).
-  }
-  return null;
-}
-
-/**
- * Fallback: locate Simulator.app via the active Xcode developer directory and read its
- * CFBundleIdentifier directly from the app bundle's Info.plist.
- * This works even when LaunchServices hasn't indexed Simulator.app.
- */
-async function getSimulatorAppIdFromBundleAsync(): Promise<string | null> {
-  try {
-    const { stdout: developerDir } = await spawnAsync('xcode-select', ['--print-path']);
-    const simulatorInfoPlist = path.join(
-      developerDir.trim(),
-      'Applications',
-      'Simulator.app',
-      'Contents',
-      'Info.plist'
-    );
-    const { stdout: bundleId } = await spawnAsync('defaults', [
-      'read',
-      simulatorInfoPlist,
-      'CFBundleIdentifier',
-    ]);
-    return bundleId.trim() || null;
-  } catch {
-    // Simulator.app not found at the expected path or xcode-select is unavailable.
-  }
-  return null;
-}
-
-async function getSimulatorAppIdAsync(): Promise<string | null> {
-  return (
-    (await getSimulatorAppIdViaAppleScriptAsync()) ?? (await getSimulatorAppIdFromBundleAsync())
-  );
-}
+// NOTE(cedric): Xcode 27 Beta moved the `<xcode>/Contents/Developer/Applications` to `<xcode>/Contents/Applications`
+const XCODE_DEVICE_HUB_PATH = '../Applications/DeviceHub.app/Contents/Info.plist';
+const XCODE_SIMULATOR_PATH = './Applications/Simulator.app/Contents/Info.plist';
 
 export class SimulatorAppPrerequisite extends Prerequisite {
   static instance = new SimulatorAppPrerequisite();
 
   async assertImplementation(): Promise<void> {
-    const result = await getSimulatorAppIdAsync();
-    if (!result) {
-      // This error may occur in CI where the users intends to install just the simulators but no Xcode.
+    // Xcode 27 replaces Simulator with DeviceHub
+    // See: https://developer.apple.com/documentation/xcode/device-hub
+    // TODO(cedric): once Xcode 27 stable is released, resolve DeviceHub first
+    let appId = await safeIdOfAppAsync('Simulator').then((appId) => {
+      return appId || safeIdOfAppAsync('DeviceHub');
+    });
+
+    if (!appId) {
+      const xcodePath = await getXcodeSelectPath();
+      debug('Xcode select path: %s', xcodePath);
+      if (xcodePath) {
+        appId = await getXcodeInfoPlistBundlId(path.join(xcodePath, XCODE_SIMULATOR_PATH)).then(
+          (appId) => {
+            return appId || getXcodeInfoPlistBundlId(path.join(xcodePath, XCODE_DEVICE_HUB_PATH));
+          }
+        );
+      }
+    }
+
+    if (!appId) {
       throw new PrerequisiteCommandError(
         'SIMULATOR_APP',
-        "Can't determine id of Simulator app; the Simulator is most likely not installed on this machine. Run `sudo xcode-select -s /Applications/Xcode.app`"
+        "Can't determine id of Device Hub or Simulator app; the Device Hub or Simulator is most likely not installed on this machine. Run `sudo xcode-select -s /Applications/Xcode.app`"
       );
     }
+
     if (
-      result !== 'com.apple.iphonesimulator' &&
-      result !== 'com.apple.CoreSimulator.SimulatorTrampoline'
+      appId !== 'com.apple.dt.Devices' &&
+      appId !== 'com.apple.iphonesimulator' &&
+      appId !== 'com.apple.CoreSimulator.SimulatorTrampoline'
     ) {
       throw new PrerequisiteCommandError(
         'SIMULATOR_APP',
-        "Simulator is installed but is identified as '" + result + "'; don't know what that is."
+        `Device Hub or Simulator is installed but is identified as '${appId}'; don't know what that is.`
       );
     }
-    debug(`Simulator app id: ${result}`);
+
+    debug('Xcode simulator app id: %s', appId);
 
     try {
       // make sure we can run simctl
@@ -89,5 +64,27 @@ export class SimulatorAppPrerequisite extends Prerequisite {
         'xcrun is not configured correctly. Ensure `sudo xcode-select --reset` works before running this command again.'
       );
     }
+  }
+}
+
+async function getXcodeSelectPath() {
+  try {
+    const result = await spawnAsync('xcode-select', ['--print-path']);
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the Info.plist of an app within Xcode and return the bundle ID.
+ * This uses `defaults read <path>/Info.plist CFBundleIdentifier`.
+ */
+async function getXcodeInfoPlistBundlId(infoPlistPath: string) {
+  try {
+    const result = await spawnAsync('defaults', ['read', infoPlistPath, 'CFBundleIdentifier']);
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
   }
 }

--- a/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/SimulatorAppPrerequisite.ts
@@ -26,9 +26,9 @@ export class SimulatorAppPrerequisite extends Prerequisite {
       const xcodePath = await getXcodeSelectPath();
       debug('Xcode select path: %s', xcodePath);
       if (xcodePath) {
-        appId = await getXcodeInfoPlistBundlId(path.join(xcodePath, XCODE_SIMULATOR_PATH)).then(
+        appId = await getXcodeInfoPlistBundleId(path.join(xcodePath, XCODE_SIMULATOR_PATH)).then(
           (appId) => {
-            return appId || getXcodeInfoPlistBundlId(path.join(xcodePath, XCODE_DEVICE_HUB_PATH));
+            return appId || getXcodeInfoPlistBundleId(path.join(xcodePath, XCODE_DEVICE_HUB_PATH));
           }
         );
       }
@@ -80,7 +80,7 @@ async function getXcodeSelectPath() {
  * Read the Info.plist of an app within Xcode and return the bundle ID.
  * This uses `defaults read <path>/Info.plist CFBundleIdentifier`.
  */
-async function getXcodeInfoPlistBundlId(infoPlistPath: string) {
+async function getXcodeInfoPlistBundleId(infoPlistPath: string) {
   try {
     const result = await spawnAsync('defaults', ['read', infoPlistPath, 'CFBundleIdentifier']);
     return result.stdout.trim() || null;

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
@@ -1,4 +1,4 @@
-import { execAsync } from '@expo/osascript';
+import { safeIdOfAppAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 
 import { SimulatorAppPrerequisite } from '../SimulatorAppPrerequisite';
@@ -7,68 +7,117 @@ jest.mock(`../../../../log`);
 jest.mock('@expo/spawn-async');
 
 beforeEach(() => {
-  jest.mocked(execAsync).mockReset();
+  jest.mocked(safeIdOfAppAsync).mockReset();
   jest.mocked(spawnAsync).mockReset();
 });
 
-it(`detects that Simulator.app is installed`, async () => {
-  // Mock Simulator.app installed for CI
-  jest.mocked(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
-  jest.mocked(spawnAsync).mockResolvedValueOnce({} as any);
+it('detects DeviceHub.app from Apple scripts', async () => {
+  jest
+    .mocked(safeIdOfAppAsync)
+    .mockResolvedValueOnce(null)
+    .mockResolvedValueOnce('com.apple.dt.Devices');
+  jest.mocked(spawnAsync).mockResolvedValue({} as any);
 
   await SimulatorAppPrerequisite.instance.assertImplementation();
 
-  expect(execAsync).toHaveBeenCalledWith('id of app "Simulator"');
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('Simulator');
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('DeviceHub');
   expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });
 
-it(`falls back to reading Info.plist when LaunchServices lookup fails`, async () => {
-  // Simulate LaunchServices not having Simulator.app registered (e.g. Xcode on external volume).
-  jest.mocked(execAsync).mockRejectedValueOnce(new Error('not registered'));
+it('detects DeviceHub.app from LaunchServices', async () => {
+  jest.mocked(safeIdOfAppAsync).mockResolvedValue(null);
   jest
     .mocked(spawnAsync)
     // xcode-select --print-path
     .mockResolvedValueOnce({ stdout: '/Applications/Xcode.app/Contents/Developer\n' } as any)
-    // defaults read … CFBundleIdentifier
+    // defaults read …/Simulator.app/… CFBundleIdentifier
+    .mockRejectedValueOnce({ stderr: 'The domain/default par of ... does not exist' } as any)
+    // defaults read …/DeviceHub.app/… CFBundleIdentifier
+    .mockResolvedValueOnce({ stdout: 'com.apple.dt.Devices\n' } as any)
+    // xcrun simctl help
+    .mockResolvedValueOnce({} as any);
+
+  await SimulatorAppPrerequisite.instance.assertImplementation();
+
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('Simulator');
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('DeviceHub');
+  expect(spawnAsync).toHaveBeenCalledWith('defaults', [
+    'read',
+    expect.stringContaining('/Developer/Applications/Simulator.app/Contents/Info.plist'),
+    'CFBundleIdentifier',
+  ]);
+  expect(spawnAsync).toHaveBeenCalledWith('defaults', [
+    'read',
+    expect.stringContaining('/Applications/DeviceHub.app/Contents/Info.plist'),
+    'CFBundleIdentifier',
+  ]);
+  expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
+});
+
+it(`detects Simulator.app from Apple scripts`, async () => {
+  jest
+    .mocked(safeIdOfAppAsync)
+    .mockResolvedValueOnce('com.apple.CoreSimulator.SimulatorTrampoline');
+  jest.mocked(spawnAsync).mockResolvedValue({} as any);
+
+  await SimulatorAppPrerequisite.instance.assertImplementation();
+
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('Simulator');
+  expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
+});
+
+it(`detects Simulator.app from LaunchServices`, async () => {
+  // Simulate LaunchServices not having Simulator.app registered (e.g. Xcode on external volume).
+  jest.mocked(safeIdOfAppAsync).mockResolvedValue(null);
+  jest
+    .mocked(spawnAsync)
+    // xcode-select --print-path
+    .mockResolvedValueOnce({ stdout: '/Applications/Xcode.app/Contents/Developer\n' } as any)
+    // defaults read …/Simulator.app/… CFBundleIdentifier
     .mockResolvedValueOnce({ stdout: 'com.apple.iphonesimulator\n' } as any)
     // xcrun simctl help
     .mockResolvedValueOnce({} as any);
 
   await SimulatorAppPrerequisite.instance.assertImplementation();
 
-  expect(execAsync).toHaveBeenCalledWith('id of app "Simulator"');
-  expect(spawnAsync).toHaveBeenCalledWith('xcode-select', ['--print-path']);
+  expect(safeIdOfAppAsync).toHaveBeenCalledWith('Simulator');
   expect(spawnAsync).toHaveBeenCalledWith('defaults', [
     'read',
-    expect.stringContaining('Simulator.app'),
+    '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/Contents/Info.plist',
     'CFBundleIdentifier',
   ]);
   expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });
 
-it(`throws when both LaunchServices and Info.plist fallback cannot find Simulator.app`, async () => {
+it(`throws when no simulator app identifier was found`, async () => {
   // Both lookups fail — Simulator really isn't available.
-  jest.mocked(execAsync).mockRejectedValueOnce(new Error('not registered'));
+  jest.mocked(safeIdOfAppAsync).mockResolvedValue(null);
   jest.mocked(spawnAsync).mockRejectedValueOnce(new Error('xcode-select not found'));
 
   await expect(SimulatorAppPrerequisite.instance.assertImplementation()).rejects.toThrow(
-    /Simulator is most likely not installed/
+    /Device Hub or Simulator is most likely not installed/
   );
+
   expect(spawnAsync).not.toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });
 
-it(`asserts that Simulator.app is installed with invalid Simulator.app`, async () => {
+it(`asserts that simulator is installed with invalid bundle identifier`, async () => {
   // Mock Simulator.app installed with invalid binary
-  jest.mocked(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.bacon`);
-  jest.mocked(spawnAsync).mockReset();
+  jest.mocked(safeIdOfAppAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.custom`);
 
-  await expect(SimulatorAppPrerequisite.instance.assertImplementation()).rejects.toThrow(/\.bacon/);
-  expect(spawnAsync).not.toHaveBeenCalled();
+  await expect(SimulatorAppPrerequisite.instance.assertImplementation()).rejects.toThrow(
+    /\.CoreSimulator\.custom/
+  );
+
+  expect(spawnAsync).not.toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });
 
-it(`asserts that Simulator.app is installed but simctl doesn't work`, async () => {
+it(`asserts that simulator is installed but simctl doesn't work`, async () => {
   // Mock Simulator.app installed for CI
-  jest.mocked(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
+  jest
+    .mocked(safeIdOfAppAsync)
+    .mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
   jest.mocked(spawnAsync).mockImplementationOnce(() => {
     throw new Error('foobar');
   });
@@ -76,4 +125,6 @@ it(`asserts that Simulator.app is installed but simctl doesn't work`, async () =
   await expect(SimulatorAppPrerequisite.instance.assertImplementation()).rejects.toThrow(
     /xcrun is not configured correctly/
   );
+
+  expect(spawnAsync).toHaveBeenCalledWith('xcrun', ['simctl', 'help']);
 });

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -217,11 +217,11 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     if (isInteractive()) {
       // TODO: Focus the individual window
       await spawnAppleScriptAsync([
-        `try`,
+        `if application "Simulator" is running then`,
         `tell application "Simulator" to activate`,
-        `on error`,
+        `else if application "DeviceHub" is running then`,
         `tell application "DeviceHub" to activate`,
-        `end try`,
+        `end if`,
       ]);
     }
   }

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -1,4 +1,4 @@
-import * as osascript from '@expo/osascript';
+import { spawnAsync as spawnAppleScriptAsync } from '@expo/osascript';
 import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs';
@@ -216,7 +216,13 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     // In non-interactive mode, we should assume this is an agent and not attempt to focus the Simulator app since it doesn't need focus.
     if (isInteractive()) {
       // TODO: Focus the individual window
-      await osascript.execAsync(`tell application "Simulator" to activate`);
+      await spawnAppleScriptAsync([
+        `try`,
+        `tell application "Simulator" to activate`,
+        `on error`,
+        `tell application "DeviceHub" to activate`,
+        `end try`,
+      ]);
     }
   }
 

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
@@ -1,13 +1,14 @@
-import { execAsync } from '@expo/osascript';
+import { spawnAsync as spawnAppleScriptAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 
 import * as Log from '../../../../log';
 import { ensureSimulatorAppRunningAsync } from '../ensureSimulatorAppRunning';
 
 jest.mock(`../../../../log`);
+jest.mock('@expo/osascript');
 
 it('should do nothing when the Simulator.app is running', async () => {
-  jest.mocked(execAsync).mockResolvedValueOnce('1');
+  jest.mocked(spawnAppleScriptAsync).mockResolvedValueOnce({ stdout: '1\n' } as any);
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 
@@ -16,7 +17,7 @@ it('should do nothing when the Simulator.app is running', async () => {
 });
 
 it('should activate the window when Simulator.app is not running', async () => {
-  jest.mocked(execAsync).mockResolvedValueOnce('0').mockResolvedValueOnce('1');
+  jest.mocked(spawnAppleScriptAsync).mockResolvedValueOnce({ stdout: '0\n' } as any).mockResolvedValueOnce({ stdout: '1\n' } as any);
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 
@@ -31,13 +32,13 @@ it('should activate the window when Simulator.app is not running', async () => {
 });
 
 it('should throw a timeout warning when Simulator.app takes too long to start', async () => {
-  jest.mocked(execAsync).mockRejectedValue(new Error('Application isn’t running'));
+  jest.mocked(spawnAppleScriptAsync).mockRejectedValue(new Error('Application isn’t running'));
 
   await expect(
     ensureSimulatorAppRunningAsync({ udid: '123' }, { maxWaitTime: 100 })
   ).rejects.toThrow(/Simulator app did not open fast enough/);
 
   // initial call (1) + interval / timeout (2)
-  expect(jest.mocked(execAsync).mock.calls.length).toBeGreaterThanOrEqual(3);
+  expect(jest.mocked(spawnAppleScriptAsync).mock.calls.length).toBeGreaterThanOrEqual(3);
   expect(spawnAsync).toHaveBeenCalledTimes(1);
 });

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
@@ -17,7 +17,10 @@ it('should do nothing when the Simulator.app is running', async () => {
 });
 
 it('should activate the window when Simulator.app is not running', async () => {
-  jest.mocked(spawnAppleScriptAsync).mockResolvedValueOnce({ stdout: '0\n' } as any).mockResolvedValueOnce({ stdout: '1\n' } as any);
+  jest
+    .mocked(spawnAppleScriptAsync)
+    .mockResolvedValueOnce({ stdout: '0\n' } as any)
+    .mockResolvedValueOnce({ stdout: '1\n' } as any);
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 

--- a/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
@@ -71,7 +71,7 @@ async function openSimulatorAppAsync(device: { udid?: string }) {
     }
     await spawnAsync('open', args);
   } catch {
-    // DevieHub does not allow us to focus to the right device
+    // Device Hub does not allow us to focus to the right device
     await spawnAsync('open', ['-a', 'DeviceHub']).catch(() => {
       // Noop - we can't do much more here
     });

--- a/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
@@ -1,4 +1,4 @@
-import * as osascript from '@expo/osascript';
+import { spawnAsync as spawnAppleScriptAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 
 import type { Device } from './simctl';
@@ -46,12 +46,10 @@ async function waitForSimulatorAppToStart({
 // I think the app can be open while no simulators are booted.
 async function isSimulatorAppRunningAsync(): Promise<boolean> {
   try {
-    const zeroMeansNo = (
-      await osascript.execAsync(
-        'tell app "System Events" to count processes whose name is "Simulator"'
-      )
-    ).trim();
-    if (zeroMeansNo === '0') {
+    const result = await spawnAppleScriptAsync(
+      'tell app "System Events" to count processes whose name is "Simulator" or name is "DeviceHub"'
+    );
+    if (result.stdout.trim() === '0') {
       return false;
     }
   } catch (error: any) {
@@ -65,10 +63,14 @@ async function isSimulatorAppRunningAsync(): Promise<boolean> {
 }
 
 async function openSimulatorAppAsync(device: { udid?: string }) {
-  const args = ['-a', 'Simulator'];
-  if (device.udid) {
-    // This has no effect if the app is already running.
-    args.push('--args', '-CurrentDeviceUDID', device.udid);
+  try {
+    const args = ['-a', 'Simulator'];
+    if (device.udid) {
+      // This has no effect if the app is already running.
+      args.push('--args', '-CurrentDeviceUDID', device.udid);
+    }
+    await spawnAsync('open', args);
+  } catch {
+    // This is now a noop, device hub does not have the ability to open and focus a specific simulator
   }
-  await spawnAsync('open', args);
 }

--- a/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
@@ -71,6 +71,9 @@ async function openSimulatorAppAsync(device: { udid?: string }) {
     }
     await spawnAsync('open', args);
   } catch {
-    // This is now a noop, device hub does not have the ability to open and focus a specific simulator
+    // DevieHub does not allow us to focus to the right device
+    await spawnAsync('open', ['-a', 'DeviceHub']).catch(() => {
+      // Noop - we can't do much more here
+    });
   }
 }


### PR DESCRIPTION
Closes #46701
Closes #46694

# Why

This is the minimum required change to support Device Hub, which replaces Simulator, in Xcode 27. Crafted to be backportable as much as possible.

# How

- Simplify the `SimulatorAppPrerequisite` with newer `@expo/osascript` helpers
- Verify `Simulator` and `DeviceHub` (in this order, until Xcode 27 becomes stable)
- Include `DeviceHub` in `isSimulatorRunning` checks
- Attempt to activate the "Simulator", when this fails with Device Hub, continue
  - Unfortunately, there is no way for us to change the focused simulator in the device hub.

> Note that we still attempt to hit `Simulator` before `DeviceHub`, as the majority should not use a Beta Xcode version. That also means that once this is stable, we should reverse these code paths, hitting `DeviceHub` before `Simulator`.

# Test Plan

- `expo run ios`
- `expo start --ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
