### PR TITLE
[ios][dev-launcher] Implement settings screen feedback

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4098,7 +4098,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: 5466888598cde67aedb4d3a819adf471d1a3d8c9
-  hermes-engine: df3b0063b8e94b47727a7a6bbb771666586e8408
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4738,7 +4738,7 @@ SPEC CHECKSUMS:
   ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
   ExpoMailComposer: ea650b89d3b93c7a277b11a8ab7010a7be6d595e
   ExpoMediaLibrary: 5ab82b8ace3f9ab7ac4ca3b2060bd915a4f1568f
-  ExpoModulesCore: 5a10a35abd5a8fbff4d21975d6593ad535831738
+  ExpoModulesCore: 00076ada6b1f6abf05088c211487ef0bbe68ef19
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesTestCore: 768a9a2b0401e87090bc7280cdb0607ab4cad382
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
@@ -4782,7 +4782,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: d5c6d584ad5c5461ad9e34e0afb5d40d56e428f5
+  hermes-engine: 42f0ed2cf70592b35e2ca49a6b725d31c8ad4136
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Present Local Network permission as a status row instead of a toggle, and make the Settings debug actions native, full-row-tappable list rows.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -69,7 +69,7 @@ import ExpoModulesCore
       hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
       hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
-      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     ])
 
 #if !os(macOS)

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -13,7 +13,7 @@ public struct DevLauncherRootView: View {
       || UserDefaults.standard.bool(forKey: "expo.devlauncher.hasGrantedNetworkPermission")
     _hasCompletedPermissionFlow = State(initialValue: shouldSkipPermissionFlow)
   }
-  
+
   private static var isSimulator: Bool {
     #if targetEnvironment(simulator)
     return true
@@ -31,7 +31,7 @@ public struct DevLauncherRootView: View {
       mainContent
     }
   }
-  
+
   @ViewBuilder
   private var mainContent: some View {
     let tabView = TabView {

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -33,7 +33,7 @@ func buildHttpHost(endpoint: NWEndpoint) -> String? {
 private final class AtomicFlag: @unchecked Sendable {
   private var _value = false
   private let lock = NSLock()
-  
+
   func testAndSet() -> Bool {
     lock.lock()
     defer { lock.unlock() }
@@ -51,7 +51,7 @@ func connectionStart(
   try await withTaskCancellationHandler {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
       let didResume = AtomicFlag()
-      
+
       let timeoutWork = DispatchWorkItem { [weak connection] in
         guard didResume.testAndSet() else { return }
         connection?.stateUpdateHandler = nil
@@ -59,7 +59,7 @@ func connectionStart(
         cont.resume(throwing: ConnectionError.failedConnection)
       }
       queue.asyncAfter(deadline: .now() + timeout, execute: timeoutWork)
-      
+
       connection.stateUpdateHandler = { [weak connection] state in
         switch state {
         case .ready:

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -48,10 +48,14 @@ struct SettingsTabView: View {
           Text("system".uppercased())
             .font(.caption)
             .foregroundColor(.primary.opacity(0.6))
-          Divider()
-          version
-          Divider()
-          copyToClipboardButton
+
+          VStack(spacing: 0) {
+            version
+            Divider()
+            copyToClipboardButton
+          }
+          .background(Color.expoSecondarySystemBackground)
+          .cornerRadius(12)
         }
 
         if isAdminUser {
@@ -139,33 +143,37 @@ struct SettingsTabView: View {
       Text(viewModel.buildInfo["appVersion"] as? String ?? "")
         .foregroundColor(.secondary)
     }
+    .padding(.horizontal)
     .padding(.vertical, 12)
   }
 
   private var copyToClipboardButton: some View {
-    HStack {
 #if os(tvOS)
-      Button("Clipboard not available on tvOS") {}
+    Text("Clipboard not available on tvOS")
+      .padding(.horizontal)
+      .padding(.vertical, 12)
 #else
-      Button(showCopiedMessage ? "Copied to clipboard!" : "Copy system info") {
-        let buildInfoJSON = createBuildInfoJSON()
-        let clipboard = UIPasteboard.general
-        clipboard.string = buildInfoJSON
-        showCopiedMessage = true
+    Button {
+      UIPasteboard.general.string = createBuildInfoJSON()
+      showCopiedMessage = true
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-          showCopiedMessage = false
-        }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        showCopiedMessage = false
       }
-      Spacer()
-      Image(systemName: "clipboard")
-        .resizable()
-        .scaledToFit()
-        .frame(width: 16, height: 16)
-        .foregroundColor(.blue)
-#endif
+    } label: {
+      HStack {
+        Text(showCopiedMessage ? "Copied to clipboard!" : "Copy system info")
+        Spacer()
+        Image(systemName: showCopiedMessage ? "checkmark" : "clipboard")
+          .foregroundColor(.secondary)
+      }
+      .contentShape(Rectangle())
     }
+    .buttonStyle(.plain)
+    .foregroundColor(showCopiedMessage ? .green : .primary)
+    .padding(.horizontal)
     .padding(.vertical, 12)
+#endif
   }
 
   private var isAdminUser: Bool {
@@ -173,37 +181,74 @@ struct SettingsTabView: View {
   }
 
   private var debugSettings: some View {
-    Section("Debug Settings") {
-      Button(showCacheClearedMessage ? "Network cache cleared!" : "Clear network cache") {
-        clearNetworkCache()
-      }
-      .foregroundColor(showCacheClearedMessage ? .green : nil)
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Debug Settings".uppercased())
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
 
-      VStack(alignment: .leading) {
-        Text("Default Page Size")
-        Text("Sets the number of items fetched for branches and updates")
-          .foregroundStyle(.secondary)
-          .font(.footnote)
-        Picker("", selection: $defaultPageSize) {
-          Text("1").tag(1)
-          Text("5").tag(5)
-          Text("10").tag(10)
-        }
-        .pickerStyle(.segmented)
+      VStack(spacing: 0) {
+        clearNetworkCacheRow
+        Divider()
+        defaultPageSizeRow
       }
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
     }
   }
 
+  private var clearNetworkCacheRow: some View {
+    Button {
+      clearNetworkCache()
+    } label: {
+      HStack {
+        Text(showCacheClearedMessage ? "Network cache cleared!" : "Clear network cache")
+        Spacer()
+        Image(systemName: showCacheClearedMessage ? "checkmark" : "trash")
+          .foregroundColor(showCacheClearedMessage ? .green : .secondary)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .foregroundColor(showCacheClearedMessage ? .green : .primary)
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
+  private var defaultPageSizeRow: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Default Page Size")
+      Text("Sets the number of items fetched for branches and updates")
+        .foregroundStyle(.secondary)
+        .font(.footnote)
+      Picker("", selection: $defaultPageSize) {
+        Text("1").tag(1)
+        Text("5").tag(5)
+        Text("10").tag(10)
+      }
+      .pickerStyle(.segmented)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
   private var easUpdateConfig: some View {
-    Section("EAS Update Configuration") {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("EAS Update Configuration".uppercased())
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
       VStack(alignment: .leading, spacing: 8) {
         Text(createEASConfigJSON())
           .font(.system(.caption, design: .monospaced))
         #if !os(tvOS)
           .textSelection(.enabled)
         #endif
-          .padding(.vertical, 4)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal)
+      .padding(.vertical, 12)
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
     }
   }
 
@@ -233,36 +278,70 @@ struct SettingsTabView: View {
   }
 
   #if !targetEnvironment(simulator)
+  private var localNetworkStatus: (text: String, icon: String, color: Color)? {
+    switch viewModel.permissionStatus {
+    case .granted:
+      return ("Allowed", "checkmark.circle.fill", .green)
+    case .denied:
+      return ("Not allowed", "xmark.circle.fill", .red)
+    case .checking, .unknown:
+      return nil
+    }
+  }
+
   private var localNetworkDebugSettings: some View {
     VStack(alignment: .leading, spacing: 8) {
       VStack(spacing: 0) {
-        Toggle("Local Network", isOn: .constant(viewModel.permissionStatus == .granted))
-          .disabled(true)
-          .padding()
+        localNetworkStatusRow
 
         if viewModel.permissionStatus == .denied {
           Divider()
-
-          #if os(iOS)
-          Button {
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-              UIApplication.shared.open(url)
-            }
-          } label: {
-            HStack {
-              Text("Open App Settings")
-              Spacer()
-              Image(systemName: "gear")
-                .foregroundColor(.blue)
-            }
-          }
-          .padding()
-          #endif
+          openAppSettingsRow
         }
       }
       .background(Color.expoSecondarySystemBackground)
       .cornerRadius(12)
     }
+  }
+
+  private var localNetworkStatusRow: some View {
+    HStack {
+      Text("Local Network")
+      Spacer()
+      if let status = localNetworkStatus {
+        Text(status.text)
+          .foregroundColor(.secondary)
+        Image(systemName: status.icon)
+          .foregroundColor(status.color)
+      } else {
+        ProgressView()
+      }
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
+  @ViewBuilder
+  private var openAppSettingsRow: some View {
+    #if os(iOS)
+    Button {
+      if let url = URL(string: UIApplication.openSettingsURLString) {
+        UIApplication.shared.open(url)
+      }
+    } label: {
+      HStack {
+        Text("Open App Settings")
+        Spacer()
+        Image(systemName: "gear")
+          .foregroundColor(.secondary)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .foregroundColor(.primary)
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+    #endif
   }
   #endif
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7973,85 +7973,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -8397,42 +8384,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -9047,28 +9028,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -9689,49 +9666,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -12897,28 +12866,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -18922,7 +18887,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
# Why
Follow up on more dev launcher feedback

# How
- Local Network is now a status row (label + "Allowed"/"Not allowed" with a colored SF Symbol), showing a spinner while the status is still resolving so it no longer flickers on→off. "Open App Settings" is a full-row-tappable row.
- "Copy system info" and "Clear network cache" are full-row Buttons with secondary-tinted trailing icons instead of the misleading blue clipboard.

# Test Plan
Bare expo

