### PR TITLE
[ios][dev-launcher] Provide more info in updates tab

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Present Local Network permission as a status row instead of a toggle, and make the Settings debug actions native, full-row-tappable list rows.
+- [iOS] Improve the Updates tab empty state with clearer guidance on how to publish an update.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -172,22 +172,44 @@ struct UpdatesListView: View {
   }
 
   private var emptyUpdates: some View {
-    Section {
-      VStack(spacing: 16) {
-        Image(systemName: "tray")
-          .font(.largeTitle)
-          .foregroundColor(.gray)
+    VStack(spacing: 16) {
+      Image(systemName: "tray")
+        .resizable()
+        .scaledToFit()
+        .frame(width: 44, height: 44)
+        .foregroundColor(.gray)
 
-        Text("No updates available")
-          .font(.headline)
+      if filterByCompatibility {
+        VStack(spacing: 8) {
+          Text("No compatible updates")
+            .font(.headline)
+            .multilineTextAlignment(.center)
 
-        Text(filterByCompatibility ? "No compatible updates found for this runtime version." : "No updates found.")
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
+          Text("No updates match this runtime version. Turn off \"Compatible only\" to see all updates.")
+            .font(.system(size: 14))
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+        }
+      } else {
+        VStack(spacing: 8) {
+          Text("No updates yet")
+            .font(.headline)
+            .multilineTextAlignment(.center)
+
+          Text("Publish an update with EAS Update and it will appear here.")
+            .font(.system(size: 14))
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+
+          if let destination = URL(string: "https://docs.expo.dev/eas-update/getting-started/") {
+            Link("Learn how to publish", destination: destination)
+              .font(.system(size: 14))
+              .foregroundColor(.blue)
+          }
+        }
       }
-      .padding()
     }
+    .padding()
   }
 }
 // swiftlint:enable closure_body_length


### PR DESCRIPTION
# Why
When there was no updates available we provided no reasoning for why. Updated the copy to be more descriptive of what is happening

# How
Added more info when no updates are available

# Test Plan
Bare expo
