### PR TITLE
[ios][dev-launcher] Use native sheet for dev server info

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Present Local Network permission as a status row instead of a toggle, and make the Settings debug actions native, full-row-tappable list rows.
 - [iOS] Improve the Updates tab empty state with clearer guidance on how to publish an update.
+- [iOS] Present the development server info dialog as a native sheet.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
@@ -3,50 +3,35 @@
 import SwiftUI
 
 struct DevServerInfoModal: View {
-  @Binding var showingInfoDialog: Bool
+  @Environment(\.dismiss) private var dismiss
 
   var body: some View {
-    Group {
-      if #available(iOS 15.0, tvOS 16.0, *) {
-        if showingInfoDialog {
-          Color.black.opacity(0.4)
-            .ignoresSafeArea(.all)
-            .onTapGesture {
-              showingInfoDialog = false
-            }
-          content
-        }
-      }
-    }
-    .animation(.easeInOut(duration: 0.3), value: showingInfoDialog)
-  }
-
-  private var content: some View {
-    VStack(spacing: 16) {
+    VStack(alignment: .leading, spacing: 16) {
       header
-      Divider()
       info
+      Spacer()
     }
     .padding(20)
-    .background(Color.expoSystemBackground)
-    .clipShape(RoundedRectangle(cornerRadius: 16))
-    .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 5)
-    .padding(.horizontal, 40)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    #if os(iOS)
+    .presentationDetents([.medium])
+    #endif
   }
 
   private var header: some View {
     HStack {
       Text("Development Servers")
-        .font(.headline)
-        .fontWeight(.semibold)
+        .font(.title2)
+        .fontWeight(.bold)
       Spacer()
       Button {
-        showingInfoDialog = false
+        dismiss()
       } label: {
-        Image(systemName: "xmark")
-          .font(.title3)
+        Image(systemName: "xmark.circle.fill")
+          .font(.title2)
           .foregroundColor(.secondary)
       }
+      .buttonStyle(.plain)
     }
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -143,13 +143,17 @@ struct DevServersView: View {
         Text("Load embedded bundle")
           .foregroundColor(.primary)
         Spacer()
-        if viewModel.isLoadingLocalBundle {
-          ProgressView()
-        } else {
-          Image(systemName: "chevron.right")
-            .font(.caption)
-            .foregroundColor(.secondary)
+        Group {
+          if viewModel.isLoadingLocalBundle {
+            ProgressView()
+              .controlSize(.small)
+          } else {
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
         }
+        .frame(width: 20, height: 20)
       }
       .padding()
       .background(Color.expoSecondarySystemBackground)
@@ -232,13 +236,17 @@ struct DevServerRow: View {
 
         Spacer()
 
-        if viewModel.isLoadingServer {
-          ProgressView()
-        } else {
-          Image(systemName: "chevron.right")
-            .font(.caption)
-            .foregroundColor(.secondary)
+        Group {
+          if viewModel.isLoadingServer {
+            ProgressView()
+              .controlSize(.small)
+          } else {
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
         }
+        .frame(width: 20, height: 20)
       }
       .padding()
       .background(Color.expoSecondarySystemBackground)

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -59,9 +59,9 @@ struct HomeTabView: View {
     #if os(tvOS)
     .background()
     #endif
-    .overlay(
-      DevServerInfoModal(showingInfoDialog: $showingInfoDialog)
-    )
+    .sheet(isPresented: $showingInfoDialog) {
+      DevServerInfoModal()
+    }
   }
 
   private var crashReportBanner: some View {


### PR DESCRIPTION
# Why
We can now use SwiftUI's sheet api so we can remove the custom dialog.

# Test Plan
Bare expo

