### PR TITLE
[ci] Attempt to fix React Native nightly and Publish Canaries workflows

### DIFF
--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -1,10 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { mergeJsonFilesAsync, readJsonFileAsync } from './JsonFile.js';
+import { readJsonFileAsync } from './JsonFile.js';
 import { runAsync } from './Processes.js';
-
-const cachedPackages: Package[] | null = null;
 
 const EXCLUDE_PACKAGES = [
   '@expo/fingerprint',

--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { readJsonFileAsync } from './JsonFile.js';
 import { runAsync } from './Processes.js';
 
 const EXCLUDE_PACKAGES = [
@@ -68,39 +67,20 @@ export async function getReactNativeTransitivePackagesAsync(
 
 /**
  * Get the names of every Expo package in the expo repo that can be linked from
- * local source, i.e. everything matched by the `packages/*` and
- * `packages/@expo/*` workspace globs minus the excluded packages.
+ * local source, i.e. every workspace package under `packages/` minus the
+ * excluded ones.
  */
 export async function getExpoPackageNamesAsync(expoRepoPath: string): Promise<Set<string>> {
-  const cwd = path.join(expoRepoPath, 'packages');
+  const { stdout } = await runAsync('pnpm', ['list', '--depth=-1', '--recursive', '--json'], {
+    cwd: expoRepoPath,
+  });
 
-  const relativePaths = (
-    await Promise.all([
-      Array.fromAsync(fs.promises.glob('*/package.json', { cwd })),
-      Array.fromAsync(fs.promises.glob('@expo/*/package.json', { cwd })),
-    ])
-  ).flat();
+  const workspaces = JSON.parse(stdout) as Package[];
+  const packagesRoot = path.join(expoRepoPath, 'packages') + path.sep;
 
-  const names = await Promise.all(
-    relativePaths.map(async (relativePath) => {
-      const pkg = await createPackageAsync(path.join(cwd, path.dirname(relativePath)));
-      return pkg?.name ?? null;
-    })
-  );
+  const names = workspaces
+    .filter(({ name, path }) => path.startsWith(packagesRoot) && !EXCLUDE_PACKAGES.includes(name))
+    .map(({ name }) => name);
 
-  return new Set(names.filter((name) => name != null));
-}
-
-async function createPackageAsync(packageRoot: string): Promise<Package | null> {
-  const packageJsonPath = path.join(packageRoot, 'package.json');
-  const packagePath = path.dirname(packageJsonPath);
-  const packageJson = await readJsonFileAsync(packageJsonPath);
-  const name = packageJson.name as string;
-  if (EXCLUDE_PACKAGES.includes(name)) {
-    return null;
-  }
-  return {
-    name,
-    path: packagePath,
-  };
+  return new Set(names);
 }

--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -68,6 +68,31 @@ export async function getReactNativeTransitivePackagesAsync(
   return packages;
 }
 
+/**
+ * Get the names of every Expo package in the expo repo that can be linked from
+ * local source, i.e. everything matched by the `packages/*` and
+ * `packages/@expo/*` workspace globs minus the excluded packages.
+ */
+export async function getExpoPackageNamesAsync(expoRepoPath: string): Promise<Set<string>> {
+  const cwd = path.join(expoRepoPath, 'packages');
+
+  const relativePaths = (
+    await Promise.all([
+      Array.fromAsync(fs.promises.glob('*/package.json', { cwd })),
+      Array.fromAsync(fs.promises.glob('@expo/*/package.json', { cwd })),
+    ])
+  ).flat();
+
+  const names = await Promise.all(
+    relativePaths.map(async (relativePath) => {
+      const pkg = await createPackageAsync(path.join(cwd, path.dirname(relativePath)));
+      return pkg?.name ?? null;
+    })
+  );
+
+  return new Set(names.filter((name) => name != null));
+}
+
 async function createPackageAsync(packageRoot: string): Promise<Package | null> {
   const packageJsonPath = path.join(packageRoot, 'package.json');
   const packagePath = path.dirname(packageJsonPath);

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -7,11 +7,10 @@ import {
   type JSONArray,
   type JSONObject,
   type JSONValue,
-  mergeJsonFilesAsync,
   readJsonFileAsync,
   writeJsonFileAsync,
 } from './JsonFile.js';
-import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages.js';
+import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES, getExpoPackageNamesAsync } from './Packages.js';
 import { runAsync } from './Processes.js';
 
 export interface ProjectProperties {
@@ -77,22 +76,32 @@ async function setupProjectPackageJsonAsync(
   const packageJsonPath = path.join(projectRoot, 'package.json');
   const packageJson = await readJsonFileAsync(packageJsonPath);
 
-  let workspacePrefix: string;
-  const relativePath = path.relative(projectRoot, expoRepoPath);
-  if (relativePath.startsWith('..')) {
-    workspacePrefix = expoRepoPath;
-  } else {
-    workspacePrefix = relativePath;
-  }
-
   const resolutions: Record<string, string> =
     (packageJson.resolutions as Record<string, string>) ?? {};
   for (const name of REACT_NATIVE_TRANSITIVE_DEPENDENCIES) {
     resolutions[name] = `${nightlyVersion}`;
   }
-  await mergeJsonFilesAsync(packageJsonPath, {
-    // Add workspaces
-    workspaces: [`${workspacePrefix}/packages/*`, `${workspacePrefix}/packages/@expo/*`],
+
+  // Point repo dependencies at the local workspace copy so the build tests the
+  // code under test, not the published canary. Only the `workspace:` protocol
+  // forces this; pnpm won't link a workspace package whose version doesn't
+  // satisfy the declared range, and the canary template pins different versions.
+  const repoPackageNames = await getExpoPackageNamesAsync(expoRepoPath);
+
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const deps = packageJson[field] as Record<string, string> | undefined;
+
+    if (deps != null) {
+      for (const name of Object.keys(deps)) {
+        if (repoPackageNames.has(name)) {
+          deps[name] = 'workspace:*';
+        }
+      }
+    }
+  }
+
+  await writeJsonFileAsync(packageJsonPath, {
+    ...packageJson,
 
     // Exclude templates from autolinking
     expo: {
@@ -104,6 +113,17 @@ async function setupProjectPackageJsonAsync(
     // Pin the versions of transitive dependencies
     resolutions,
   });
+
+  // pnpm ignores the package.json `workspaces` field, so the repo packages must
+  // be declared as workspace members here for the `workspace:*` specifiers to
+  // resolve to local source.
+  const relativePrefix = path.relative(projectRoot, expoRepoPath);
+  const workspaceGlobs = [`${relativePrefix}/packages/*`, `${relativePrefix}/packages/@expo/*`];
+
+  await fs.promises.writeFile(
+    path.join(projectRoot, 'pnpm-workspace.yaml'),
+    ['packages:', ...workspaceGlobs.map((glob) => `  - '${glob}'`), ''].join('\n')
+  );
 }
 
 /**

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -60,9 +60,6 @@ async function runAsync(programName: string) {
   );
   const expoRepoPath = await createExpoApp(projectRoot, projectProps);
 
-  // NOTE(@kitten): We used to set dependencies to `workspace:*` specifiers here manually for all packages
-  // However, this isn't needed as long as `preferWorkspacePackages: true` is set in `pnpm-workspace.yaml`
-
   console.log(chalk.cyan(`Reinstalling packages`));
   await reinstallPackagesAsync(projectRoot);
 

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
-import { TaskArgs } from '../types';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan } = chalk;
 
@@ -14,7 +14,14 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
     name: 'checkEnvironmentTask',
     required: true,
   },
-  async (): Promise<void | symbol> => {
+  async (_parcels: Parcel[], options: CommandOptions): Promise<void | symbol> => {
+    // A dry run doesn't publish anything, so it doesn't require NPM auth. Skip
+    // the login check so dry runs work without a token (e.g. on Dependabot
+    // pull requests and forks, which don't have access to repository secrets).
+    if (options.dry) {
+      return;
+    }
+
     const npmUser = await Npm.whoamiAsync();
 
     if (!npmUser) {


### PR DESCRIPTION
# Why

Two scheduled CI workflows were failing (and also fail on Dependabot PRs that touch their workflow files):

- **Test React Native nightly build**: Android JS bundling failed because RN nightly's `EventEmitter.js` uses newer Flow syntax (`readonly` property modifiers) that `hermes-parser@0.33.3` can't parse.
- **Publish Canaries**: the dry run failed with `You must be logged in to NPM to publish packages` (https://github.com/expo/expo/actions/runs/27276517920/job/80559164326).

# How

Two separate root causes.

**`create-expo-nightly` was never testing the local repo.** Since the pnpm migration (#44057) it relied on the package.json `workspaces` field plus `preferWorkspacePackages`, but pnpm ignores `workspaces` (it wants a `pnpm-workspace.yaml`), and `preferWorkspacePackages` won't link a workspace package whose version doesn't satisfy the requested range. The canary template pins different versions than the repo, so the build silently used the published canary packages.

That is also why bumping `hermes-parser` in the repo (#46636) had no effect: the canary `@expo/metro-config` was doing the bundling. Fixed by rewriting the project's expo dependencies to `workspace:*` and writing a real `pnpm-workspace.yaml`, so the local `@expo/metro-config` (already on `hermes-parser@^0.36.0`) is used.

**The canary dry run shouldn't require NPM auth.** `checkEnvironmentTask` always ran `npm whoami`, but Dependabot runs and forks have no repository secrets, so the token is empty and it throws. A `--dry` run never publishes (downstream side effects are already gated on `!options.dry`), so it now returns early when `options.dry` is set. The real publish path (manual `workflow_dispatch`, no `--dry`) still requires login.

# Test Plan

- `tsc` and `eslint` pass for both `create-expo-nightly` and `tools`.
- Confirmed `hermes-parser@0.33.3` fails on `readonly context: unknown;` with the exact CI error while `0.35`/`0.36` parse it.
- Reproduced the pnpm linking in a minimal workspace: `workspace:*` links the local package even on a version mismatch, and its transitive `workspace:*` deps resolve to local too; `preferWorkspacePackages` alone does not.
- Both workflows trigger on changes to their own files, so they validate the fixes on this PR.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
