### PR TITLE
[jsi] Ignore already-settled promises

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -75,15 +75,16 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     guard let runtime else {
       return
     }
-    guard !resolveFunction.isEmpty else {
-      preconditionFailure("Cannot settle a promise more than once")
-    }
 
     // `resolve` is not isolated, so make sure to jump to JS thread.
     runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+      // If the promise is already settled, do nothing.
+      guard let resolver = resolveFunction.take() else {
+        return
+      }
       // Call the actual resolver given in the Promise setup.
       // This will also call `deferredPromise.resolve` in the `then` handler.
-      _ = try! resolveFunction.take().getFunction().call(arguments: value)
+      _ = try! resolver.getFunction().call(arguments: value)
 
       // Release the rejecter, we cannot call it anymore.
       rejectFunction.release()
@@ -94,19 +95,20 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     guard let runtime else {
       return
     }
-    guard !rejectFunction.isEmpty else {
-      preconditionFailure("Cannot settle a promise more than once")
-    }
 
     // `reject` is not isolated, so make sure to jump to JS thread.
     runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+      // If the promise is already settled, do nothing.
+      guard let rejecter = rejectFunction.take() else {
+        return
+      }
       // Create a JS error from any (native) error.
       let errorMessage = String(describing: error)
       let errorValue = JavaScriptError(runtime, message: errorMessage).asValue()
 
       // Call the actual rejecter given in the Promise setup.
       // This will also call `deferredPromise.reject` in the `then` handler.
-      _ = try! rejectFunction.take().getFunction().call(arguments: errorValue)
+      _ = try! rejecter.getFunction().call(arguments: errorValue)
 
       // Release the resolver, we cannot call it anymore.
       resolveFunction.release()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -280,6 +280,23 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
+  func `settling promise more than once is ignored`() async throws {
+    struct TestError: Error, Sendable {}
+
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+
+    runtime.global().setProperty("testPromise", value: promise.asValue())
+    promise.resolve(42)
+    promise.reject(TestError())
+    promise.resolve(100)
+
+    let result = try await promise.await()
+
+    #expect(result.getInt() == 42)
+  }
+
+  @Test
   func `promise all`() async throws {
     let runtime = JavaScriptRuntime()
 


### PR DESCRIPTION
# Why

`JavaScriptPromise.resolve` / `reject` could race when called multiple times because resolver refs were checked before jumping to the JS runtime.

Also, according to [ECMAScript](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects), repeated attempts to resolve or reject an already-settled promise should be ignored.

# How

Handle settlement in the scheduled JS runtime work. The first resolve/reject consumes the resolver ref and clears the other; later attempts will be ignored.

# Test Plan

- Run resolve/reject multiple times.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)