### PR TITLE
[docs][ui] Document lazy rendering limitation in List and lazy stacks

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded vertical list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyColumn` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazyrow.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazyrow.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded horizontal list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyRow` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyhstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyhstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyHStack matches the official SwiftUI [LazyHStack API](https://developer.apple.com/documentation/swiftui/lazyhstack) and arranges its children horizontally, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyHStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyvstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyvstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyVStack matches the official SwiftUI [LazyVStack API](https://developer.apple.com/documentation/swiftui/lazyvstack) and arranges its children vertically, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyVStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
@@ -14,6 +14,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 Expo UI List matches the official SwiftUI [List API](https://developer.apple.com/documentation/swiftui/list) and supports styling via the [`listStyle`](modifiers/#liststylestyle) modifier, various row/section modifiers, as well as selection, reordering, and editing capabilities.
 
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/unversioned/sdk/ui/universal/list.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/list.mdx
@@ -9,7 +9,9 @@ platforms: ['android', 'ios', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh).`ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh). `ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded vertical list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyColumn` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazyrow.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazyrow.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded horizontal list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyRow` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/lazyhstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/lazyhstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyHStack matches the official SwiftUI [LazyHStack API](https://developer.apple.com/documentation/swiftui/lazyhstack) and arranges its children horizontally, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyHStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/lazyvstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/lazyvstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyVStack matches the official SwiftUI [LazyVStack API](https://developer.apple.com/documentation/swiftui/lazyvstack) and arranges its children vertically, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyVStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/list.mdx
@@ -14,6 +14,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 Expo UI List matches the official SwiftUI [List API](https://developer.apple.com/documentation/swiftui/list) and supports styling via the [`listStyle`](modifiers/#liststylestyle) modifier, various row/section modifiers, as well as selection, reordering, and editing capabilities.
 
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/list.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/list.mdx
@@ -9,7 +9,9 @@ platforms: ['android', 'ios', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh).`ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh). `ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
 
 ## Installation
 


### PR DESCRIPTION
# Why

Expo UI lists are not truly lazy yet: React creates every child up front, so large lists can be slow to mount. The docs should mention this limitation and recommend virtualized lists in the meantime.

# How

- Added an info callout to `List` (universal, swift-ui), `LazyColumn`/`LazyRow` (jetpack-compose), and `LazyVStack`/`LazyHStack` (swift-ui) pages, recommending [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list) for large lists.
- Applied to both `unversioned` and `v56.0.0` docs.

# Test Plan

Docs-only change.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)