### PR TITLE
[core][android] Make module gradle plugin compatible with Android Gradle Plugin 9

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 💡 Others
 
+- [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9.
 - [iOS] `@ExpoModule` now synthesizes a `_decorateModule` that binds the module's `@JS` functions directly onto the JS object, letting the module holder skip the dynamic definition path for synthesized modules. ([#46612](https://github.com/expo/expo/pull/46612) by [@tsapeta](https://github.com/tsapeta))
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 💡 Others
 
-- [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9.
+- [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9. ([#46769](https://github.com/expo/expo/pull/46769) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] `@ExpoModule` now synthesizes a `_decorateModule` that binds the module's `@JS` functions directly onto the JS object, letting the module holder skip the dynamic definition path for synthesized modules. ([#46612](https://github.com/expo/expo/pull/46612) by [@tsapeta](https://github.com/tsapeta))
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -2,7 +2,8 @@
 
 package expo.modules.plugin
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.variant.AndroidComponentsExtension
 import expo.modules.plugin.android.PublicationInfo
 import expo.modules.plugin.android.applyLinterOptions
 import expo.modules.plugin.android.applyPublishingVariant
@@ -20,25 +21,29 @@ import org.gradle.internal.extensions.core.extra
 import java.io.File
 
 internal fun Project.applyDefaultPlugins() {
-  if (!plugins.hasPlugin("com.android.library")) {
-    plugins.apply("com.android.library")
+  applyPluginIfNeeded("com.android.library")
+
+  if (!hasBuiltInKotlinSupport()) {
+    // AGP 9 ships built-in Kotlin support (enabled by default), so applying `kotlin-android` on top
+    // of it fails with "Cannot add extension with name 'kotlin', …".
+    applyPluginIfNeeded("kotlin-android")
   }
-  if (!plugins.hasPlugin("kotlin-android")) {
-    plugins.apply("kotlin-android")
-  }
-  if (!plugins.hasPlugin("maven-publish")) {
-    plugins.apply("maven-publish")
-  }
+
+  applyPluginIfNeeded("maven-publish")
 }
 
 internal fun Project.applyPikaPlugin() {
-  if (!plugins.hasPlugin("io.github.lukmccall.pika")) {
-    plugins.apply("io.github.lukmccall.pika")
-  }
-
+  applyPluginIfNeeded("io.github.lukmccall.pika")
+  
   val pika = extensions.getByType(PikaGradleExtension::class.java)
   pika.introspectableAnnotation("expo.modules.kotlin.types.OptimizedRecord")
   pika.introspectableAnnotation("expo.modules.kotlin.views.OptimizedComposeProps")
+}
+
+private fun Project.applyPluginIfNeeded(id: String) {
+  if (!plugins.hasPlugin(id)) {
+    plugins.apply(id)
+  }
 }
 
 internal fun Project.configurePika(shouldBeEnabled: Boolean = true) {
@@ -72,9 +77,7 @@ internal fun Project.applyDefaultAndroidSdkVersions() {
       compileSdk = rootProject.extra.safeGet("compileSdkVersion")
         ?: logger.warnIfNotDefined("compileSdkVersion", 36),
       minSdk = rootProject.extra.safeGet("minSdkVersion")
-        ?: logger.warnIfNotDefined("minSdkVersion", 24),
-      targetSdk = rootProject.extra.safeGet("targetSdkVersion")
-        ?: logger.warnIfNotDefined("targetSdkVersion", 36)
+        ?: logger.warnIfNotDefined("minSdkVersion", 24)
     )
     applyLinterOptions()
   }
@@ -117,6 +120,21 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
 
     createExpoPublishTask(publicationInfo, expoModulesExtension, npmLocalRepositoryRelativePath)
   }
+}
+
+private const val AGP_BUILT_IN_KOTLIN_MAJOR = 9
+
+/**
+ * Whether AGP's built-in Kotlin support is active, meaning the `kotlin-android` plugin must not be
+ * applied. True on AGP 9+ unless the project explicitly opts out with `android.builtInKotlin=false`.
+ */
+internal fun Project.hasBuiltInKotlinSupport(): Boolean {
+  val androidComponents = extensions.findByType(AndroidComponentsExtension::class.java)
+    ?: return false
+  if (androidComponents.pluginVersion.major < AGP_BUILT_IN_KOTLIN_MAJOR) {
+    return false
+  }
+  return findProperty("android.builtInKotlin")?.toString()?.toBoolean() ?: true
 }
 
 internal fun Project.androidLibraryExtension() = extensions.getByType(LibraryExtension::class.java)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
@@ -1,22 +1,21 @@
 package expo.modules.plugin.android
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 
-internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int, targetSdk: Int) {
+internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int) {
   this.compileSdk = compileSdk
   defaultConfig {
     this@defaultConfig.minSdk = minSdk
-    this@defaultConfig.targetSdk = targetSdk
   }
 }
 
 internal fun LibraryExtension.applyLinterOptions() {
-  lintOptions.isAbortOnError = false
+  lint.abortOnError = false
 }
 
 internal fun LibraryExtension.applyPublishingVariant() {
-  publishing { publishing ->
-    publishing.singleVariant("release") {
+  publishing {
+    singleVariant("release") {
       withSourcesJar()
     }
   }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -23,9 +23,7 @@ import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
-import java.nio.file.Path
-import kotlin.io.path.exists
-import kotlin.io.path.toPath
+import java.io.File
 
 internal data class PublicationInfo(
   val components: SoftwareComponent,
@@ -41,17 +39,15 @@ internal data class PublicationInfo(
     artifactId = requireNotNull(project.androidLibraryExtension().namespace) {
       "'android.namespace' is not defined"
     },
-    version = requireNotNull(project.androidLibraryExtension().defaultConfig.versionName) {
-      "'android.defaultConfig.versionName' is not defined"
+    version = requireNotNull(project.version.toString().takeUnless { it == "unspecified" }) {
+      "'project.version' is not defined. Set `version = \"<x.y.z>\"` in the module's android/build.gradle."
     },
   )
 
-  fun resolvePath(repositoryPath: Path): Path {
+  fun resolvePath(repositoryPath: File): File {
     val groupPath = groupId.replace('.', '/')
     val artifactPath = "$groupPath/$artifactId/$version"
-    val publicationPath = repositoryPath.resolve(artifactPath)
-
-    return publicationPath
+    return File(repositoryPath, artifactPath)
   }
 
   override fun toString(): String {
@@ -180,7 +176,7 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, expoModule
 
   if (pathToRepository == null) {
     val mavenLocal = publishingExtension().repositories.mavenLocal()
-    val mavenLocalPath = mavenLocal.url.toPath()
+    val mavenLocalPath = File(mavenLocal.url)
     val publicationPath = publicationInfo.resolvePath(mavenLocalPath)
 
     if (!publicationPath.exists()) {


### PR DESCRIPTION
# Why

Makes the module Gradle plugin compatible with Android Gradle Plugin 9

# How

- Applied kotlin plugin conditionally based on whether the build in kotlin is supported by the project
- Migrated to the new Gradle API 

# Test Plan

- bare-expo ✅ 
- publish task ✅ 