### PR TITLE
[core][Android] Ignore already-settled promises

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `SharedObject::NativeState` now derives from `expo::NativeState` so the Swift wrapper can be recovered from the JS side via `getNativeState`, laying the groundwork for native-state-based shared object lookup. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Ignore already-settled promises.
+- [Android] Ignore already-settled promises. ([#46770](https://github.com/expo/expo/pull/46770) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `SharedObject::NativeState` now derives from `expo::NativeState` so the Swift wrapper can be recovered from the JS side via `getNativeState`, laying the groundwork for native-state-based shared object lookup. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Ignore already-settled promises.
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -1,11 +1,8 @@
 package expo.modules.kotlin.jni
 
-import expo.modules.BuildConfig
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.PromiseAlreadySettledException
-import expo.modules.kotlin.logger
 import java.lang.ref.WeakReference
 
 @DoNotStrip
@@ -61,17 +58,7 @@ class PromiseImpl @DoNotStrip internal constructor(
 
   private inline fun checkIfWasSettled(body: () -> Unit) {
     if (wasSettled) {
-      val exception = PromiseAlreadySettledException(fullFunctionName ?: "unknown")
-      val jsLogger = appContextHolder?.get()?.jsLogger
-      // We want to report that a promise was settled twice in the development build.
-      // However, in production, the app should crash.
-      if (BuildConfig.DEBUG && jsLogger != null) {
-        jsLogger.error("Trying to resolve promise that was already settled", exception)
-        logger.error("Trying to resolve promise that was already settled", exception)
-        return
-      }
-
-      throw exception
+      return
     }
 
     body()


### PR DESCRIPTION
# Why

Mirror https://github.com/expo/expo/pull/46765
According to [ECMAScript](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects), repeated attempts to resolve or reject an already-settled promise should be ignored without error/warning.

# How

Remove exception/warning on repeated attempts to settle a promise. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
