### PR TITLE
[ci] Fix ccache key hashFiles timeout on iOS

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -160,7 +160,7 @@ runs:
         path: ${{ runner.temp }}/.ccache
         # It is necessary to include Xcode version in the cache key, because each Xcode version introduces changes to clang compiler,
         # which is a part of ccache hashes. After an Xcode version change the hit rate would drop to 0% until a new cache is built.
-        key: ${{ runner.os }}-ccache-${{ steps.xcode-version.outputs.hash }}-${{ hashFiles('**/Podfile.lock', 'pnpm-lock.yaml', 'packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/*.mm', 'packages/**/*.m') }}
+        key: ${{ runner.os }}-ccache-${{ steps.xcode-version.outputs.hash }}-${{ hashFiles('apps/*/ios/Podfile.lock', 'apps/*/macos/Podfile.lock', 'apps/*/*/ios/Podfile.lock', 'pnpm-lock.yaml', 'packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/*.mm', 'packages/**/*.m') }}
         restore-keys: ${{ runner.os }}-ccache-${{ steps.xcode-version.outputs.hash }}-
 
     - name: ♻️ Restore ccache (Android)


### PR DESCRIPTION
# Why

The iOS `Restore ccache` step intermittently fails the whole job with:

> `hashFiles('**/Podfile.lock, ...')` couldn't finish within 120 seconds.

`**/Podfile.lock` forces `hashFiles` to walk the entire workspace. At post-job time that includes the installed `node_modules` (20k+ dirs) and `Pods` trees, so the walk blows past its 120s limit even though the build itself passed.

# How

Replaced `**/Podfile.lock` with `*`-anchored patterns (`apps/*/ios/Podfile.lock`, `apps/*/macos/Podfile.lock`, `apps/*/*/ios/Podfile.lock`). Without `**`, `hashFiles` only lists each app's top-level dir and prunes anything that doesn't match the literal `ios`/`macos` segment, so it never descends into `node_modules`/`Pods`. These patterns still match every app Podfile.lock, so the cache-busting behavior is unchanged.

The `packages/**/*` patterns stay as-is: they're bounded inside `packages/` (no `node_modules` there) and weren't part of the timeout.

# Test Plan

CI: the `Restore ccache` step completes without the timeout, and ccache hit rates stay the same across runs.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
