### PR TITLE
[expo-video][e2e] Gate player output viewshot on first frame render

### DIFF
--- a/apps/bare-expo/e2e/expo-video/player-output-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/player-output-test.yaml
@@ -8,6 +8,10 @@ jsEngine: graaljs
     visible: 'Players ready'
     timeout: 30000
 - tapOn: 'Move player 1 to the next video view'
+- extendedWaitUntil:
+    visible:
+      id: 'viewshot-ready'
+    timeout: 10000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -18,6 +22,10 @@ jsEngine: graaljs
     text: 'Move player 2 to the next video view'
     repeat: 2
 - tapOn: 'Move player 1 to the next video view'
+- extendedWaitUntil:
+    visible:
+      id: 'viewshot-ready'
+    timeout: 10000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -26,6 +34,10 @@ jsEngine: graaljs
       mode: 'keep-originals'
 - tapOn: 'Move player 1 to first video view'
 - tapOn: 'Move player 2 to first video view'
+- extendedWaitUntil:
+    visible:
+      id: 'viewshot-ready'
+    timeout: 10000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -40,6 +52,10 @@ jsEngine: graaljs
 - tapOn:
     text: 'Move player 1 to the next video view'
     repeat: 2
+- extendedWaitUntil:
+    visible:
+      id: 'viewshot-ready'
+    timeout: 10000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:

--- a/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
@@ -1,7 +1,7 @@
 import { useEvent } from 'expo';
 import { useVideoPlayer, VideoPlayer, VideoView } from 'expo-video';
 import React, { useCallback, useRef, useState } from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import { Platform, View, StyleSheet, Text } from 'react-native';
 
 import { bigBuckBunnySource, elephantsDreamSource } from './videoSources';
 import { styles } from './videoStyles';
@@ -39,6 +39,27 @@ export default function VideoChangePlayerOutputScreen() {
 
   const [viewPlayers, setViewPlayers] = useState([player, player2, null, null]);
 
+  // Per-view "frame painted" state to gate e2e screenshots: a swapped iOS VideoView stays blank until
+  // ready, so we mark it not-ready on swap and flip it back from `onFirstFrameRender`. Optimistic so
+  // other platforms don't gate.
+  const [readyViews, setReadyViews] = useState([true, true, true, true]);
+
+  const framesSettled = viewPlayers.every(
+    (viewPlayer, index) => viewPlayer == null || readyViews[index]
+  );
+
+  const markViewRendered = useCallback((viewIndex: number) => {
+    setReadyViews((prev) => {
+      if (prev[viewIndex]) {
+        return prev;
+      }
+
+      const next = [...prev];
+      next[viewIndex] = true;
+      return next;
+    });
+  }, []);
+
   const advancePlayer = useCallback(
     (playerIndex: number) => {
       const currentIndex = players.current[playerIndex].viewIndex;
@@ -58,6 +79,15 @@ export default function VideoChangePlayerOutputScreen() {
       }
       newViewPlayers[newViewIndex] = players.current[playerIndex].ref;
       setViewPlayers(newViewPlayers);
+
+      // The view receiving the player must repaint; mark it not-ready until `onFirstFrameRender` fires.
+      if (Platform.OS === 'ios') {
+        setReadyViews((prev) => {
+          const next = [...prev];
+          next[newViewIndex] = false;
+          return next;
+        });
+      }
 
       players.current[playerIndex].viewIndex = newViewIndex;
     },
@@ -79,6 +109,7 @@ export default function VideoChangePlayerOutputScreen() {
               player={viewPlayers[i]}
               nativeControls={nativeControls}
               allowsVideoFrameAnalysis={false}
+              onFirstFrameRender={() => markViewRendered(i)}
             />
           ))}
       </E2EViewShotContainer>
@@ -112,6 +143,7 @@ export default function VideoChangePlayerOutputScreen() {
         }}
       />
       {e2eSetupDone && bothReady && <Text>Players ready</Text>}
+      {framesSettled && <Text testID="viewshot-ready">Viewshot ready</Text>}
     </View>
   );
 }


### PR DESCRIPTION
# Why

The expo-video `player-output` e2e test is flaky on iOS. After a player is swapped to a different `VideoView`, that view stays blank for a frame or two while it repaints. The flow sometimes screenshots during that gap, so the viewshot comparison fails even though nothing is broken.

# How

Added a per-view "frame painted" gate in `VideoChangePlayerOutputScreen`. On iOS, a view that receives a player is marked not-ready on swap and flipped back from its `onFirstFrameRender` callback. Once every visible view has painted, the screen renders a `viewshot-ready` testID. State starts optimistic (all ready) so other platforms never gate.

The maestro flow now waits for `viewshot-ready` before each `viewshot-comparison`, so screenshots only happen after the swapped views have actually rendered.

# Test Plan

Ran the `player-output` e2e flow on iOS several times: it waits for `viewshot-ready` at each step and the viewshot comparisons pass consistently instead of intermittently failing.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

# Screenshot

<img width="599" height="608" src="https://github.com/user-attachments/assets/e6527412-970d-4b10-8c5f-76faa636b3ca" />