### PR TITLE
[iOS][expo-modules-core] Guard async function dispatch against a torn-down app context (headless background task EXC_BAD_ACCESS)

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Throw an actionable error when a worklet is used but `react-native-worklets`'s native adapter isn't linked, instead of a misleading "not an instance of Worklet" failure. ([#46571](https://github.com/expo/expo/pull/46571) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix `canAskAgain` returning `false` for re-requestable permissions in the "Ask every time" state. ([#46683](https://github.com/expo/expo/pull/46683) by [@alanjhughes](https://github.com/alanjhughes))
 - [Internal] Remove `EventEmitter` re-export global type indirection ([#46719](https://github.com/expo/expo/pull/46719) by [@kitten](https://github.com/kitten))
+- [iOS] Fix `EXC_BAD_ACCESS` crash when an async function resolves against a torn-down app context (e.g. a headless background task finishing after the context is deallocated). ([#46783](https://github.com/expo/expo/pull/46783) by [@ctmayhew](https://github.com/ctmayhew))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -159,6 +159,17 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
     let maxRetryCount = 3
 
     queue.async {
+      // The app context's JS runtime can be torn down between this block being
+      // queued and running — e.g. when iOS deallocates a headless background
+      // task's context after the task finishes. Touching it then (resolving the
+      // promise in `block()`, or the view-registry lookup below) dereferences
+      // freed memory and crashes with EXC_BAD_ACCESS. Bail gracefully instead;
+      // the JS context is gone, so there is nothing to resolve back into.
+      // Mirrors the nil-guards added for ExpoFabricViewObjC (#42634) and
+      // SwiftUIVirtualView (#45175).
+      guard (try? appContext.runtime) != nil else {
+        return
+      }
       // Checks if this is a view function unregistered in the view registry. The check can be performed from the main thread only.
       if retryCount < maxRetryCount,
         let viewTag = arguments.first as? Int,


### PR DESCRIPTION
## Why

On iOS, when the OS headless-launches an app to run a registered `expo-task-manager` background task (e.g. an `expo-location` `startLocationUpdatesAsync` task), the task's async completion can run **after** the app's `AppContext` / JS runtime has been torn down. The completion then resolves its `Promise` (or does the view-registry lookup) against a deallocated runtime, dereferencing freed memory and crashing with `EXC_BAD_ACCESS` (`KERN_INVALID_ADDRESS at 0x8`).

Symbolicated production stack:

```
EXC_BAD_ACCESS: KERN_INVALID_ADDRESS at 0x8
closure in AsyncFunctionDefinition.dispatchOnQueueUntilViewRegisters (AsyncFunctionDefinition.swift)
closure in AsyncFunctionDefinition.call (AsyncFunctionDefinition.swift)
closure in TaskManagerModule.definition (TaskManagerModule.swift)
-[EXTaskService notifyTaskWithName:forAppId:didFinishWithResponse:] (EXTaskService.m)
-[EXTaskExecutionRequest _maybeExecuteCallback] (EXTaskExecutionRequest.m)
-[EXTaskService _runTasksSupportingLaunchReason:userInfo:callback:]_block_invoke (EXTaskService.m)
```

`build(appContext:)` already weakly captures and guards the context for the **synchronous** JS entry (`guard let appContext else { throw Exceptions.AppContextLost() }`), but once `call(...)` hands a strong `appContext` into `dispatchOnQueueUntilViewRegisters`, the `queue.async` block can run later — after teardown — with no validity check.

This is the same class of "dispatch against a deallocated context" bug already fixed with nil-guards in:
- `ExpoFabricViewObjC.mm` — #42634 (expo-modules-core 55.0.6)
- `SwiftUIVirtualView.dispatchEvent` — #45175 (expo-modules-core 55.0.24, fixes #45054)

## How

Guard the top of the `queue.async` block in `dispatchOnQueueUntilViewRegisters`, bailing when the runtime is gone via the existing throwing `AppContext.runtime` accessor (which throws `RuntimeLost` once `_runtime` is niled on teardown). This is the same idiom already used a few lines above (`(try? appContext.runtime.supportsAsyncScheduling) ?? false`), so it only trips on genuine teardown — for a live context the guard passes and behaviour is unchanged.

```swift
guard (try? appContext.runtime) != nil else {
  return
}
```

## Notes / reproduction

This is a teardown race on a headless background launch, so there's no deterministic minimal repro (which is why the corresponding issue, #46782, was auto-closed by the bot). It reproduces in production across multiple devices and iOS versions at low frequency for apps running an `expo-location` background task. The change is defensive and mirrors established precedent. Happy to move the guard into `Promise.resolve` / `call` instead if a maintainer prefers.

## Test Plan

- Inspected: the guard uses `AppContext.runtime`'s existing `get throws` accessor, which throws `RuntimeLost` when `_runtime == nil` — exactly the teardown condition — so the late completion degrades gracefully instead of crashing. For a live context the guard is a no-op.
- I was not able to build expo-modules-core in CI locally; please run the iOS unit tests / a background-task smoke test as part of review.

Marked as draft pending maintainer review of the guard placement + a CI build.
