### PR TITLE
fix(font): Resolve package-style font paths

### DIFF
--- a/packages/expo-font/plugin/build/utils.js
+++ b/packages/expo-font/plugin/build/utils.js
@@ -6,7 +6,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.toValidAndroidResourceName = toValidAndroidResourceName;
 exports.resolveFontPaths = resolveFontPaths;
 const promises_1 = __importDefault(require("fs/promises"));
+const node_module_1 = __importDefault(require("node:module"));
 const path_1 = __importDefault(require("path"));
+function isErrorWithCode(error, code) {
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
+}
+function resolveFontPath(p, projectRoot) {
+    return node_module_1.default.createRequire(path_1.default.join(projectRoot, 'package.json')).resolve(p);
+}
 // rule: File-based resource names must contain only lowercase a-z, 0-9, or underscore
 function toValidAndroidResourceName(value) {
     const valueWithoutFileExtension = path_1.default.parse(value).name;
@@ -20,8 +27,18 @@ function toValidAndroidResourceName(value) {
 }
 async function resolveFontPaths(fonts, projectRoot) {
     const promises = fonts.map(async (p) => {
-        const resolvedPath = path_1.default.resolve(projectRoot, p);
-        const stat = await promises_1.default.stat(resolvedPath);
+        let resolvedPath = path_1.default.resolve(projectRoot, p);
+        let stat;
+        try {
+            stat = await promises_1.default.stat(resolvedPath);
+        }
+        catch (error) {
+            if (!isErrorWithCode(error, 'ENOENT')) {
+                throw error;
+            }
+            resolvedPath = resolveFontPath(p, projectRoot);
+            stat = await promises_1.default.stat(resolvedPath);
+        }
         if (stat.isDirectory()) {
             const dir = await promises_1.default.readdir(resolvedPath);
             return dir.map((file) => path_1.default.join(resolvedPath, file));

--- a/packages/expo-font/plugin/src/__tests__/utils-test.ts
+++ b/packages/expo-font/plugin/src/__tests__/utils-test.ts
@@ -1,4 +1,8 @@
-import { toValidAndroidResourceName } from '../utils';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { resolveFontPaths, toValidAndroidResourceName } from '../utils';
 
 describe(toValidAndroidResourceName, () => {
   it('converts strings to valid Android resource names', () => {
@@ -23,5 +27,73 @@ describe(toValidAndroidResourceName, () => {
     );
     expect(toValidAndroidResourceName('SF Pro Display.ttf')).toBe('sf_pro_display');
     expect(toValidAndroidResourceName('Noto Sans JP')).toBe('noto_sans_jp');
+  });
+});
+
+describe(resolveFontPaths, () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'expo-font-plugin-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, { force: true, recursive: true });
+  });
+
+  it('resolves relative file paths from the project root', async () => {
+    const fontPath = path.join(projectRoot, 'assets', 'fonts', 'Inter.ttf');
+    await fs.mkdir(path.dirname(fontPath), { recursive: true });
+    await fs.writeFile(fontPath, '');
+
+    await expect(resolveFontPaths(['./assets/fonts/Inter.ttf'], projectRoot)).resolves.toEqual([
+      fontPath,
+    ]);
+  });
+
+  it('expands directory contents and filters to supported font files', async () => {
+    const fontsDir = path.join(projectRoot, 'assets', 'fonts');
+    await fs.mkdir(fontsDir, { recursive: true });
+    await fs.writeFile(path.join(fontsDir, 'Inter.ttf'), '');
+    await fs.writeFile(path.join(fontsDir, 'Inter.otf'), '');
+    await fs.writeFile(path.join(fontsDir, 'README.md'), '');
+
+    const result = await resolveFontPaths(['./assets/fonts'], projectRoot);
+
+    expect(result.sort()).toEqual([
+      path.join(fontsDir, 'Inter.otf'),
+      path.join(fontsDir, 'Inter.ttf'),
+    ]);
+  });
+
+  it('resolves scoped package-style font paths relative to the project root', async () => {
+    const fontPath = path.join(
+      projectRoot,
+      'node_modules',
+      '@expo-google-fonts',
+      'inter',
+      '400Regular',
+      'Inter_400Regular.ttf'
+    );
+    await fs.mkdir(path.dirname(fontPath), { recursive: true });
+    await fs.writeFile(fontPath, '');
+
+    await expect(
+      resolveFontPaths(['@expo-google-fonts/inter/400Regular/Inter_400Regular.ttf'], projectRoot)
+    ).resolves.toEqual([await fs.realpath(fontPath)]);
+  });
+
+  it('resolves unscoped package-style font paths relative to the project root', async () => {
+    const fontPath = path.join(projectRoot, 'node_modules', 'some-font-package', 'fonts', 'Foo.ttf');
+    await fs.mkdir(path.dirname(fontPath), { recursive: true });
+    await fs.writeFile(fontPath, '');
+
+    await expect(
+      resolveFontPaths(['some-font-package/fonts/Foo.ttf'], projectRoot)
+    ).resolves.toEqual([await fs.realpath(fontPath)]);
+  });
+
+  it('rejects missing font paths', async () => {
+    await expect(resolveFontPaths(['./assets/fonts/Missing.ttf'], projectRoot)).rejects.toThrow();
   });
 });

--- a/packages/expo-font/plugin/src/__tests__/utils-test.ts
+++ b/packages/expo-font/plugin/src/__tests__/utils-test.ts
@@ -84,7 +84,13 @@ describe(resolveFontPaths, () => {
   });
 
   it('resolves unscoped package-style font paths relative to the project root', async () => {
-    const fontPath = path.join(projectRoot, 'node_modules', 'some-font-package', 'fonts', 'Foo.ttf');
+    const fontPath = path.join(
+      projectRoot,
+      'node_modules',
+      'some-font-package',
+      'fonts',
+      'Foo.ttf'
+    );
     await fs.mkdir(path.dirname(fontPath), { recursive: true });
     await fs.writeFile(fontPath, '');
 

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -1,5 +1,14 @@
 import fs from 'fs/promises';
+import Module from 'node:module';
 import path from 'path';
+
+function isErrorWithCode(error: unknown, code: string) {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
+}
+
+function resolveFontPath(p: string, projectRoot: string) {
+  return Module.createRequire(path.join(projectRoot, 'package.json')).resolve(p);
+}
 
 // rule: File-based resource names must contain only lowercase a-z, 0-9, or underscore
 export function toValidAndroidResourceName(value: string) {
@@ -17,8 +26,19 @@ export function toValidAndroidResourceName(value: string) {
 
 export async function resolveFontPaths(fonts: string[], projectRoot: string) {
   const promises = fonts.map(async (p) => {
-    const resolvedPath = path.resolve(projectRoot, p);
-    const stat = await fs.stat(resolvedPath);
+    let resolvedPath = path.resolve(projectRoot, p);
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+
+    try {
+      stat = await fs.stat(resolvedPath);
+    } catch (error) {
+      if (!isErrorWithCode(error, 'ENOENT')) {
+        throw error;
+      }
+
+      resolvedPath = resolveFontPath(p, projectRoot);
+      stat = await fs.stat(resolvedPath);
+    }
 
     if (stat.isDirectory()) {
       const dir = await fs.readdir(resolvedPath);


### PR DESCRIPTION
## Summary

- Resolve expo-font config plugin font paths through Node module resolution after filesystem resolution fails
- Preserve existing relative, absolute, and directory font path behavior
- Add plugin tests for relative paths, directory expansion, package-style paths, and missing paths

## Root cause

`resolveFontPaths` always used `path.resolve(projectRoot, p)` before statting configured font paths. In monorepos, package-style font paths such as `@expo-google-fonts/inter/400Regular/Inter_400Regular.ttf` were treated as project-relative filesystem paths instead of package subpaths resolvable from the app project.

## Test plan

- `pnpm --filter expo-font test:plugin`
- `pnpm --filter expo-font build:plugin`
- `pnpm --filter expo-font lint`
- `pnpm --filter expo-font test`
