### PR TITLE
[core][android] Fix crash flushing a shadow node size update to a destroyed state

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [android] Add a synchronous shadow node size update path, fixing a layout shift for `Host` `matchContents` views. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix `NullPointerException` crash when a `matchContents` view is unmounted while a shadow node size update is pending (e.g. closing a bottom sheet mid-resize). ([#46785](https://github.com/expo/expo/pull/46785) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Accept JS `Double` timestamps in `Date` Convertible. JS numbers arrive across the JSI bridge as Swift `Double`; the prior `as? Int` branch never matched, throwing `ConvertingException<Date>` whenever a JS caller passed `someDate.getTime()` to a `Date` / `Date?` argument. ([#46340](https://github.com/expo/expo/pull/46340) by [@kyleasaff](https://github.com/kyleasaff))
 - [Android] Fix events being silently dropped for Compose views in custom modules. ([#46623](https://github.com/expo/expo/issues/46623) by [@benjaminkomen](https://github.com/benjaminkomen)) ([#46624](https://github.com/expo/expo/pull/46624) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix nested `Host` double-composing children. ([#46282](https://github.com/expo/expo/issues/46282) by [@sadbytes](https://github.com/sadbytes)) ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.cpp
@@ -9,8 +9,8 @@ namespace expo {
 void NativeStatePropsGetter::registerNatives() {
   javaClassLocal()->registerNatives({
                                       makeNativeMethod("getStateProps", NativeStatePropsGetter::getStateProps),
-                                      makeNativeMethod("updateStyleSizeImmediate", NativeStatePropsGetter::updateStyleSizeImmediate),
-                                      makeNativeMethod("updateViewSizeImmediate", NativeStatePropsGetter::updateViewSizeImmediate),
+                                      makeNativeMethod("updateStyleSizeImmediateImpl", NativeStatePropsGetter::updateStyleSizeImmediate),
+                                      makeNativeMethod("updateViewSizeImmediateImpl", NativeStatePropsGetter::updateViewSizeImmediate),
                                     });
 }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/fabric/NativeStatePropsGetter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/fabric/NativeStatePropsGetter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.jni.fabric
 
+import com.facebook.jni.HybridData
 import com.facebook.yoga.annotations.DoNotStrip
 
 @DoNotStrip
@@ -8,8 +9,31 @@ class NativeStatePropsGetter {
   external fun getStateProps(stateWrapper: Any): Map<String, Any?>?
 
   // Synchronously flush a style property size update in the current frame (pass NaN for "unset").
-  external fun updateStyleSizeImmediate(stateWrapper: Any, styleWidth: Double, styleHeight: Double)
+  fun updateStyleSizeImmediate(stateWrapper: Any, styleWidth: Double, styleHeight: Double) {
+    if (!isStateValid(stateWrapper)) {
+      return
+    }
+    updateStyleSizeImmediateImpl(stateWrapper, styleWidth, styleHeight)
+  }
 
   // Synchronously flush a size update in the current frame.
-  external fun updateViewSizeImmediate(stateWrapper: Any, width: Double, height: Double)
+  fun updateViewSizeImmediate(stateWrapper: Any, width: Double, height: Double) {
+    if (!isStateValid(stateWrapper)) {
+      return
+    }
+    updateViewSizeImmediateImpl(stateWrapper, width, height)
+  }
+
+  private external fun updateStyleSizeImmediateImpl(
+    stateWrapper: Any,
+    styleWidth: Double,
+    styleHeight: Double
+  )
+
+  private external fun updateViewSizeImmediateImpl(stateWrapper: Any, width: Double, height: Double)
+
+  // The only `StateWrapper` is RN's `StateWrapperImpl`, a fbjni `HybridData`. When the shadow node is
+  // destroyed its native pointer is reset and calling into it throws. Skip the update like RN does
+  // before its own native state accesses.
+  private fun isStateValid(stateWrapper: Any): Boolean = (stateWrapper as? HybridData)?.isValid == true
 }


### PR DESCRIPTION
## Why

Closing a `@expo/ui` bottom sheet (or unmounting any `Host` `matchContents` view mid-resize) crashes on Android with a native `NullPointerException`:

```
java.lang.NullPointerException
  expo.modules.kotlin.jni.fabric.NativeStatePropsGetter.updateViewSizeImmediate(Native Method)
  expo.modules.kotlin.views.ShadowNodeProxy.setViewSize$lambda$0(ShadowNodeProxy.kt:20)
  expo.modules.kotlin.views.ShadowNodeProxy$scheduleFlush$listener$1.onPreDraw(ShadowNodeProxy.kt:46)
```

## How

The synchronous shadow node size update is deferred to an `onPreDraw` listener. If the view is unmounted before that listener fires, the Fabric `StateWrapper`'s native state has already been destroyed (`destroyState()` -> `resetNative()`), so calling into it throws from native.

The fix mirrors what React Native does for its own native state accesses: skip the flush when the wrapper's native side is gone. `ExpoView.stateWrapper` is always RN's `StateWrapperImpl`, which is a fbjni `HybridData`, so we check `HybridData.isValid`.

## Test Plan

Open a bottom sheet with `matchContents` content on Android and close it during the resize/close animation.

- Before: crashes with the NPE above.
- After: closes cleanly.

## Checklist

- [x] Added a `CHANGELOG.md` entry
