### PR TITLE
[docs][ui] Add scrollable content examples to BottomSheet docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -145,7 +145,7 @@ export default function BottomSheetScrollableExample() {
           nestedScrollEnabled
           style={{ flex: 1 }}
           data={DATA}
-          keyExtractor={(item) => item}
+          keyExtractor={item => item}
           contentContainerStyle={{ padding: 24 }}
           renderItem={({ item }) => <Text style={{ paddingVertical: 16 }}>{item}</Text>}
         />

--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -122,6 +122,39 @@ export default function DynamicBottomSheetExample() {
 }
 ```
 
+### Scrollable React Native content
+
+The bottom sheet supports a React Native `FlatList` or `ScrollView` (or a high-performance list like [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list)) as a child for scrollable content. With `nestedScrollEnabled`, the list scrolls its own content first. Once it reaches the top edge, the remaining drag moves the sheet. `BottomSheetFlatList` and `BottomSheetScrollView` are also exported for `@gorhom/bottom-sheet` compatibility, but they are plain re-exports of the React Native components.
+
+```tsx BottomSheetScrollableExample.tsx
+import { useRef } from 'react';
+import { Button, FlatList, Text, View } from 'react-native';
+import BottomSheet from '@expo/ui/community/bottom-sheet';
+
+const DATA = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
+
+export default function BottomSheetScrollableExample() {
+  const sheetRef = useRef<BottomSheet>(null);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Button title="Open" onPress={() => sheetRef.current?.snapToIndex(0)} />
+
+      <BottomSheet ref={sheetRef} snapPoints={['50%', '90%']} index={-1} enablePanDownToClose>
+        <FlatList
+          nestedScrollEnabled
+          style={{ flex: 1 }}
+          data={DATA}
+          keyExtractor={(item) => item}
+          contentContainerStyle={{ padding: 24 }}
+          renderItem={({ item }) => <Text style={{ paddingVertical: 16 }}>{item}</Text>}
+        />
+      </BottomSheet>
+    </View>
+  );
+}
+```
+
 ## Platform behavior
 
 `@gorhom/bottom-sheet` renders inline at the bottom of its parent view. This component uses native modal presentation on Android and iOS, and a drawer overlay on web.

--- a/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
@@ -100,6 +100,42 @@ export default function BottomSheetSnapPointsExample() {
 
 > On Android, `{ fraction }` and `{ height }` snap to the nearest of `'half'` / `'full'` — the underlying `ModalBottomSheet` only supports two resting states. The partial state is only visible when content is tall enough to exceed Material's partial threshold; give the content an explicit height or fill the available space if you need the half state on short content.
 
+### Scrollable React Native content
+
+The bottom sheet supports a React Native list such as `FlatList` (or a high-performance list like [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list)) as a child when wrapped in [`RNHostView`](rnhostview). [`snapPoints`](#snappoints) sizes the sheet, and the list scrolls within that height. With `nestedScrollEnabled`, the list scrolls its own content first; once it reaches the top edge, the remaining drag moves the sheet.
+
+```tsx BottomSheetScrollableExample.tsx
+import { useState } from 'react';
+import { FlatList, Text } from 'react-native';
+import { Host, BottomSheet, Button, RNHostView } from '@expo/ui';
+
+const DATA = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
+
+export default function BottomSheetScrollableExample() {
+  const [isPresented, setIsPresented] = useState(false);
+
+  return (
+    <Host matchContents>
+      <Button label="Open" onPress={() => setIsPresented(true)} />
+      <BottomSheet
+        isPresented={isPresented}
+        onDismiss={() => setIsPresented(false)}
+        snapPoints={['half', 'full']}>
+        <RNHostView>
+          <FlatList
+            nestedScrollEnabled
+            style={{ flex: 1 }}
+            data={DATA}
+            keyExtractor={(item) => item}
+            renderItem={({ item }) => <Text style={{ padding: 16 }}>{item}</Text>}
+          />
+        </RNHostView>
+      </BottomSheet>
+    </Host>
+  );
+}
+```
+
 ## API
 
 ```tsx

--- a/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
@@ -126,7 +126,7 @@ export default function BottomSheetScrollableExample() {
             nestedScrollEnabled
             style={{ flex: 1 }}
             data={DATA}
-            keyExtractor={(item) => item}
+            keyExtractor={item => item}
             renderItem={({ item }) => <Text style={{ padding: 16 }}>{item}</Text>}
           />
         </RNHostView>

--- a/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -145,7 +145,7 @@ export default function BottomSheetScrollableExample() {
           nestedScrollEnabled
           style={{ flex: 1 }}
           data={DATA}
-          keyExtractor={(item) => item}
+          keyExtractor={item => item}
           contentContainerStyle={{ padding: 24 }}
           renderItem={({ item }) => <Text style={{ paddingVertical: 16 }}>{item}</Text>}
         />

--- a/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -122,6 +122,39 @@ export default function DynamicBottomSheetExample() {
 }
 ```
 
+### Scrollable React Native content
+
+The bottom sheet supports a React Native `FlatList` or `ScrollView` (or a high-performance list like [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list)) as a child for scrollable content. With `nestedScrollEnabled`, the list scrolls its own content first; once it reaches the top edge, the remaining drag moves the sheet. `BottomSheetFlatList` and `BottomSheetScrollView` are also exported for `@gorhom/bottom-sheet` compatibility, but they are plain re-exports of the React Native components.
+
+```tsx BottomSheetScrollableExample.tsx
+import { useRef } from 'react';
+import { Button, FlatList, Text, View } from 'react-native';
+import BottomSheet from '@expo/ui/community/bottom-sheet';
+
+const DATA = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
+
+export default function BottomSheetScrollableExample() {
+  const sheetRef = useRef<BottomSheet>(null);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Button title="Open" onPress={() => sheetRef.current?.snapToIndex(0)} />
+
+      <BottomSheet ref={sheetRef} snapPoints={['50%', '90%']} index={-1} enablePanDownToClose>
+        <FlatList
+          nestedScrollEnabled
+          style={{ flex: 1 }}
+          data={DATA}
+          keyExtractor={(item) => item}
+          contentContainerStyle={{ padding: 24 }}
+          renderItem={({ item }) => <Text style={{ paddingVertical: 16 }}>{item}</Text>}
+        />
+      </BottomSheet>
+    </View>
+  );
+}
+```
+
 ## Platform behavior
 
 `@gorhom/bottom-sheet` renders inline at the bottom of its parent view. This component uses native modal presentation on Android and iOS, and a drawer overlay on web.

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
@@ -100,6 +100,42 @@ export default function BottomSheetSnapPointsExample() {
 
 > On Android, `{ fraction }` and `{ height }` snap to the nearest of `'half'` / `'full'` — the underlying `ModalBottomSheet` only supports two resting states. The partial state is only visible when content is tall enough to exceed Material's partial threshold; give the content an explicit height or fill the available space if you need the half state on short content.
 
+### Scrollable React Native content
+
+The bottom sheet supports a React Native list such as `FlatList` (or a high-performance list like [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list)) as a child when wrapped in [`RNHostView`](rnhostview). [`snapPoints`](#snappoints) sizes the sheet, and the list scrolls within that height. With `nestedScrollEnabled`, the list scrolls its own content first; once it reaches the top edge, the remaining drag moves the sheet.
+
+```tsx BottomSheetScrollableExample.tsx
+import { useState } from 'react';
+import { FlatList, Text } from 'react-native';
+import { Host, BottomSheet, Button, RNHostView } from '@expo/ui';
+
+const DATA = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
+
+export default function BottomSheetScrollableExample() {
+  const [isPresented, setIsPresented] = useState(false);
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <Button label="Open" onPress={() => setIsPresented(true)} />
+      <BottomSheet
+        isPresented={isPresented}
+        onDismiss={() => setIsPresented(false)}
+        snapPoints={['half', 'full']}>
+        <RNHostView>
+          <FlatList
+            nestedScrollEnabled
+            style={{ flex: 1 }}
+            data={DATA}
+            keyExtractor={(item) => item}
+            renderItem={({ item }) => <Text style={{ padding: 16 }}>{item}</Text>}
+          />
+        </RNHostView>
+      </BottomSheet>
+    </Host>
+  );
+}
+```
+
 ## API
 
 ```tsx

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
@@ -115,7 +115,7 @@ export default function BottomSheetScrollableExample() {
   const [isPresented, setIsPresented] = useState(false);
 
   return (
-    <Host style={{ flex: 1 }}>
+    <Host matchContents>
       <Button label="Open" onPress={() => setIsPresented(true)} />
       <BottomSheet
         isPresented={isPresented}

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
@@ -126,7 +126,7 @@ export default function BottomSheetScrollableExample() {
             nestedScrollEnabled
             style={{ flex: 1 }}
             data={DATA}
-            keyExtractor={(item) => item}
+            keyExtractor={item => item}
             renderItem={({ item }) => <Text style={{ padding: 16 }}>{item}</Text>}
           />
         </RNHostView>


### PR DESCRIPTION
## Why

The universal and community (drop-in) `BottomSheet` docs had no scrollable content example, unlike the swift-ui and jetpack-compose docs.

## How

Added a scrollable content section to both. Uses a React Native `FlatList` with `nestedScrollEnabled`, wrapped in `RNHostView` for the universal sheet (the community sheet wraps children in `RNHostView` internally).

## Test Plan

Docs-only. Examples verified against the component APIs.
