### PR TITLE
[core][ui][android] Fix compose view ref methods racing view mount and first composition

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix view ref `AsyncFunction`s rejecting with "Unable to find the … view with tag" or "No handler registered" when called right after mounting, e.g. in the first `useEffect`. ([#46302](https://github.com/expo/expo/issues/46302) by [@vladcristianmarin](https://github.com/vladcristianmarin)) ([#46789](https://github.com/expo/expo/pull/46789) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix a crash when a deferred shadow node size flush ran after the view unmounted. ([#46789](https://github.com/expo/expo/pull/46789) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Add a synchronous shadow node size update path, fixing a layout shift for `Host` `matchContents` views. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Accept JS `Double` timestamps in `Date` Convertible. JS numbers arrive across the JSI bridge as Swift `Double`; the prior `as? Int` branch never matched, throwing `ConvertingException<Date>` whenever a JS caller passed `someDate.getTime()` to a `Date` / `Date?` argument. ([#46340](https://github.com/expo/expo/pull/46340) by [@kyleasaff](https://github.com/kyleasaff))
 - [Android] Fix events being silently dropped for Compose views in custom modules. ([#46623](https://github.com/expo/expo/issues/46623) by [@benjaminkomen](https://github.com/benjaminkomen)) ([#46624](https://github.com/expo/expo/pull/46624) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -517,7 +517,7 @@ class ComposeFunctionHolder<Props : ComposeProps>(
   val propsMutableState = mutableStateOf(props)
 
   @PublishedApi
-  internal val functionHandlers = mutableMapOf<String, suspend (Array<out Any?>) -> Any?>()
+  internal val functionHandlers = ViewFunctionHandlers(name)
 
   /**
    * Per-instance cache of [ViewEventCallback]s keyed by event name. Populated
@@ -544,6 +544,12 @@ class ComposeFunctionHolder<Props : ComposeProps>(
     val props by propsMutableState
     with(FunctionalComposableScope(this@ComposeFunctionHolder, this@Content)) {
       composableContent(props)
+    }
+    // Effects run in composition order, so this completes after every
+    // `handle { }` binding declared inside the content above.
+    DisposableEffect(Unit) {
+      functionHandlers.markInitiallyBound()
+      onDispose {}
     }
   }
 }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -323,8 +323,7 @@ class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal const
       arrayOf(AnyType(viewType))
     ) { args ->
       val view = args[0] as ComposeFunctionHolder<*>
-      val handler = view.functionHandlers[fnName]
-        ?: error("No handler registered for AsyncFunction '$fnName' on view '${view.name}'. Did you forget to bind it with `$fnName.handle { ... }` inside the Content { } block?")
+      val handler = view.functionHandlers.resolve(fnName)
       handler(emptyArray())
     }
   }
@@ -336,8 +335,7 @@ class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal const
     }
     asyncFunctions[fnName] = SuspendFunctionComponent(fnName, argsTypes) { args ->
       val view = args[0] as ComposeFunctionHolder<*>
-      val handler = view.functionHandlers[fnName]
-        ?: error("No handler registered for AsyncFunction '$fnName' on view '${view.name}'. Did you forget to bind it with `$fnName.handle { ... }` inside the Content { } block?")
+      val handler = view.functionHandlers.resolve(fnName)
       handler(args.sliceArray(1 until args.size))
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -1,7 +1,10 @@
 package expo.modules.kotlin.functions
 
+import android.view.View
 import expo.modules.BuildConfig
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
@@ -9,6 +12,7 @@ import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.weak
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
@@ -17,6 +21,15 @@ class SuspendFunctionComponent(
   desiredArgsTypes: Array<AnyType>,
   private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
 ) : BaseAsyncFunctionComponent(name, desiredArgsTypes) {
+  private val takesViewAsOwner: Boolean
+    get() {
+      if (!takesOwner) {
+        return false
+      }
+      val firstArgClass = desiredArgsTypes.firstOrNull()?.typeDescriptor?.jClass ?: return false
+      return View::class.java.isAssignableFrom(firstArgClass)
+    }
+
   override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
     val appContextHolder = appContext.weak()
     jsObject.registerAsyncFunction(
@@ -44,7 +57,12 @@ class SuspendFunctionComponent(
           exceptionDecorator({
             FunctionCallException(name, moduleName, it)
           }) {
-            val result = body.invoke(this, convertArgs(args, appContext))
+            val convertedArgs = if (takesViewAsOwner) {
+              retryOnViewNotFound { convertArgs(args, appContext) }
+            } else {
+              convertArgs(args, appContext)
+            }
+            val result = body.invoke(this, convertedArgs)
             if (isActive) {
               promiseImpl.resolve(result)
             }
@@ -59,3 +77,40 @@ class SuspendFunctionComponent(
     }
   }
 }
+
+/**
+ * Retries [attempt] across UI frames while it fails with [Exceptions.ViewNotFound].
+ * A view function dispatched right after a commit (e.g. from the first `useEffect`)
+ * can reach the main queue before the UIManager mounts the target view, so the
+ * lookup succeeds once the mounting layer flushes on a subsequent frame.
+ */
+internal suspend fun <T> retryOnViewNotFound(
+  maxFrames: Int = VIEW_MOUNT_MAX_FRAMES,
+  awaitNextFrame: suspend () -> Unit = { awaitFrame() },
+  attempt: () -> T
+): T {
+  repeat(maxFrames) {
+    try {
+      return attempt()
+    } catch (e: CodedException) {
+      if (!e.isCausedByViewNotFound()) {
+        throw e
+      }
+    }
+    awaitNextFrame()
+  }
+  return attempt()
+}
+
+private fun CodedException.isCausedByViewNotFound(): Boolean {
+  var cause: Throwable? = this
+  while (cause != null) {
+    if (cause is Exceptions.ViewNotFound) {
+      return true
+    }
+    cause = cause.cause
+  }
+  return false
+}
+
+private const val VIEW_MOUNT_MAX_FRAMES = 60

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ShadowNodeProxy.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ShadowNodeProxy.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.views
 
 import android.view.ViewTreeObserver
+import com.facebook.jni.HybridClassBase
 import expo.modules.kotlin.jni.fabric.NativeStatePropsGetter
 import java.lang.ref.WeakReference
 
@@ -43,7 +44,12 @@ class ShadowNodeProxy(expoView: ExpoView) {
         weakExpoView.get()?.viewTreeObserver?.takeIf { it.isAlive }?.removeOnPreDrawListener(this)
         val flushNow = pendingFlush
         pendingFlush = null
-        weakExpoView.get()?.stateWrapper?.let { flushNow?.invoke(it) }
+        // The C++ state dies with the shadow node, so a flush scheduled before
+        // unmount can fire against a destroyed wrapper — same isValid guard
+        // StateWrapperImpl uses for its own JNI calls.
+        weakExpoView.get()?.stateWrapper
+          ?.takeIf { it !is HybridClassBase || it.isValid }
+          ?.let { flushNow?.invoke(it) }
         return true
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewFunctionHandlers.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewFunctionHandlers.kt
@@ -1,0 +1,57 @@
+package expo.modules.kotlin.views
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+
+typealias ViewFunctionHandler = suspend (args: Array<out Any?>) -> Any?
+
+/**
+ * Handlers for a view's async functions when they're bound after the view is
+ * created — a Compose view binds them during its first composition, one or more
+ * frames after the view is mounted. A call that arrives in that window suspends
+ * in [resolve] until the initial binding pass completes instead of failing with
+ * a missing-handler error.
+ */
+class ViewFunctionHandlers(private val viewName: String) {
+  private val handlers = mutableMapOf<String, ViewFunctionHandler>()
+  private val initialBinding = CompletableDeferred<Unit>()
+
+  operator fun set(name: String, handler: ViewFunctionHandler) {
+    handlers[name] = handler
+  }
+
+  fun remove(name: String) {
+    handlers.remove(name)
+  }
+
+  /**
+   * Marks the initial binding pass as finished — for Compose views, the moment
+   * the first composition is applied and every `handle { }` binding has run.
+   */
+  fun markInitiallyBound() {
+    initialBinding.complete(Unit)
+  }
+
+  /**
+   * Returns the handler bound under [name], waiting for the initial binding
+   * pass when the call arrives before the view has composed.
+   */
+  suspend fun resolve(name: String): ViewFunctionHandler {
+    handlers[name]?.let { return it }
+    withTimeoutOrNull(INITIAL_BINDING_TIMEOUT_MS) { initialBinding.await() }
+      ?: throw IllegalStateException(
+        "AsyncFunction '$name' was called on view '$viewName', but the view was never composed. " +
+          "Make sure the component is rendered inside a <Host> and stays mounted while calling its functions."
+      )
+    return handlers[name]
+      ?: error(
+        "No handler registered for AsyncFunction '$name' on view '$viewName'. " +
+          "Did you forget to bind it with `$name.handle { ... }` inside the Content { } block? " +
+          "This can also happen when the view is removed before the call is delivered."
+      )
+  }
+
+  private companion object {
+    const val INITIAL_BINDING_TIMEOUT_MS = 1_000L
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/RetryOnViewNotFoundTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/RetryOnViewNotFoundTest.kt
@@ -1,0 +1,65 @@
+package expo.modules.kotlin.functions
+
+import android.view.View
+import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.Exceptions
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RetryOnViewNotFoundTest {
+  private fun viewNotFound() =
+    CodedException("argument cast failed", Exceptions.ViewNotFound(View::class.java, 42))
+
+  @Test
+  fun `returns the result without waiting when the view resolves`() = runTest {
+    var frames = 0
+
+    val result = retryOnViewNotFound(awaitNextFrame = { frames++ }) { "ok" }
+
+    Truth.assertThat(result).isEqualTo("ok")
+    Truth.assertThat(frames).isEqualTo(0)
+  }
+
+  @Test
+  fun `retries across frames until the view mounts`() = runTest {
+    var frames = 0
+    var attempts = 0
+
+    val result = retryOnViewNotFound(awaitNextFrame = { frames++ }) {
+      if (++attempts < 3) {
+        throw viewNotFound()
+      }
+      "mounted"
+    }
+
+    Truth.assertThat(result).isEqualTo("mounted")
+    Truth.assertThat(frames).isEqualTo(2)
+  }
+
+  @Test
+  fun `rethrows other errors immediately`() = runTest {
+    var frames = 0
+
+    val error = runCatching {
+      retryOnViewNotFound(awaitNextFrame = { frames++ }) { throw CodedException("boom") }
+    }.exceptionOrNull()
+
+    Truth.assertThat(error).hasMessageThat().contains("boom")
+    Truth.assertThat(frames).isEqualTo(0)
+  }
+
+  @Test
+  fun `gives up once the frame budget is exhausted`() = runTest {
+    var frames = 0
+
+    val error = runCatching {
+      retryOnViewNotFound(maxFrames = 5, awaitNextFrame = { frames++ }) {
+        throw viewNotFound()
+      }
+    }.exceptionOrNull()
+
+    Truth.assertThat(error).isInstanceOf(CodedException::class.java)
+    Truth.assertThat(frames).isEqualTo(5)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewFunctionHandlersTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewFunctionHandlersTest.kt
@@ -1,0 +1,60 @@
+package expo.modules.kotlin.views
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ViewFunctionHandlersTest {
+  private val handlers = ViewFunctionHandlers("TestView")
+
+  @Test
+  fun `resolves a bound handler immediately`() = runTest {
+    val handler: ViewFunctionHandler = { "result" }
+    handlers["expand"] = handler
+
+    Truth.assertThat(handlers.resolve("expand")).isSameInstanceAs(handler)
+  }
+
+  @Test
+  fun `suspends a call that arrives before the initial binding pass`() = runTest {
+    val pendingCall = async { handlers.resolve("expand")(emptyArray<Any?>()) }
+    testScheduler.runCurrent()
+    Truth.assertThat(pendingCall.isCompleted).isFalse()
+
+    handlers["expand"] = { "result" }
+    handlers.markInitiallyBound()
+
+    Truth.assertThat(pendingCall.await()).isEqualTo("result")
+  }
+
+  @Test
+  fun `fails for a handler missing after the initial binding pass`() = runTest {
+    handlers.markInitiallyBound()
+
+    val error = runCatching { handlers.resolve("expand") }.exceptionOrNull()
+
+    Truth.assertThat(error).isInstanceOf(IllegalStateException::class.java)
+    Truth.assertThat(error).hasMessageThat()
+      .contains("No handler registered for AsyncFunction 'expand' on view 'TestView'")
+  }
+
+  @Test
+  fun `fails for a removed handler`() = runTest {
+    handlers.markInitiallyBound()
+    handlers["expand"] = { "result" }
+    handlers.remove("expand")
+
+    val error = runCatching { handlers.resolve("expand") }.exceptionOrNull()
+
+    Truth.assertThat(error).hasMessageThat().contains("No handler registered")
+  }
+
+  @Test
+  fun `fails after the timeout when the view never binds`() = runTest {
+    val error = runCatching { handlers.resolve("expand") }.exceptionOrNull()
+
+    Truth.assertThat(error).isInstanceOf(IllegalStateException::class.java)
+    Truth.assertThat(error).hasMessageThat().contains("never composed")
+  }
+}

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix `ModalBottomSheet` imperative calls (`expand()`, `partialExpand()`, `hide()`) being no-opped or overridden by the entrance animation when called right after presenting, which left a multi-snap-point `BottomSheet` at the wrong snap point. ([#46302](https://github.com/expo/expo/issues/46302) by [@vladcristianmarin](https://github.com/vladcristianmarin)) ([#46789](https://github.com/expo/expo/pull/46789) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Fix React Native `ScrollView` nested scrolling inside `BottomSheet`. ([#46544](https://github.com/expo/expo/pull/46544) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Fix layout shift when `Host` with `matchContents` is used inside React Native Screens. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `PagerView` offsetting `ScrollView` by safe area insets. ([#46637](https://github.com/expo/expo/pull/46637) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModalBottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModalBottomSheetView.kt
@@ -7,10 +7,12 @@ import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.OptimizedRecord
@@ -18,6 +20,7 @@ import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.views.OptimizedComposeProps
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -50,9 +53,18 @@ fun FunctionalComposableScope.ModalBottomSheetContent(
   val sheetState = rememberModalBottomSheetState(props.skipPartiallyExpanded)
   val scope = rememberCoroutineScope()
 
+  // Material animates the sheet in (via its internal show()) only after the sheet
+  // window composes and its anchors are laid out. A call dispatched right after
+  // presenting would run before that and be no-opped or overridden by show(), so
+  // wait for the entrance animation to start before retargeting it.
+  suspend fun awaitSheetShown() {
+    snapshotFlow { sheetState.targetValue != SheetValue.Hidden }.first { it }
+  }
+
   hide.handle {
     try {
       withContext(scope.coroutineContext) {
+        awaitSheetShown()
         sheetState.hide()
       }
     } catch (_: CancellationException) {
@@ -64,6 +76,7 @@ fun FunctionalComposableScope.ModalBottomSheetContent(
   expand.handle {
     try {
       withContext(scope.coroutineContext) {
+        awaitSheetShown()
         sheetState.expand()
       }
     } catch (_: CancellationException) {
@@ -75,6 +88,7 @@ fun FunctionalComposableScope.ModalBottomSheetContent(
   partialExpand.handle {
     try {
       withContext(scope.coroutineContext) {
+        awaitSheetShown()
         sheetState.partialExpand()
       }
     } catch (_: CancellationException) {


### PR DESCRIPTION
# Why

Fixes #46302. Proper fix for the races that PR #46367 works around at the JS layer.

Calling a compose view's ref `AsyncFunction` right after mounting (e.g. from the first `useEffect`, which is exactly what the community `BottomSheet` wrapper does on present) failed two ways:

1. `Unable to find the ComposeFunctionHolder view with tag N` — the JSI call posts to the main `Handler`, which can run before Fabric's mount queue drains at the next vsync, so the tag lookup fails. This race exists for every expo view function; RN's own view commands are immune because they're queued through the mount pipeline itself (and retried via `RetryableMountingLayerException` when early).

2. `No handler registered for AsyncFunction 'expand'` — compose view handlers bind via `DisposableEffect` inside `Content { }` during the **first composition**, which the parent `Host` schedules a frame after the view exists. Classic views have no such window: their function bodies act directly on the view instance.

There was also a third, adjacent issue surfaced while verifying: presenting at the last snap point opened the sheet at the partial one, because the early `expand()` ran before Material's internal entrance animation set up the sheet anchors, and was then overridden by it.

# How

- `SuspendFunctionComponent`: when the function takes its owner view as the first argument, a failed arg conversion caused by `ViewNotFound` is retried each UI frame (bounded at 60 frames) until the mounting layer flushes — mirroring RN's retry for early `DispatchCommandMountItem`s.
- New `ViewFunctionHandlers` registry: compose dispatch now suspends until the initial binding pass completes instead of failing. A `DisposableEffect` placed after the `Content { }` body marks the pass complete (effects run in composition order, so every `handle { }` binding precedes it). Missing handlers still fail fast once the view has composed, and a timeout covers views that never compose.
- `ShadowNodeProxy`: apply the same `isValid` guard `StateWrapperImpl` uses for its own JNI calls — a deferred size flush could fire on predraw after unmount against a destroyed state wrapper and hard-crash (NPE from JNI). Reproduced by dismissing and re-presenting the sheet.
- `ModalBottomSheetView` (expo-ui): gate `hide`/`expand`/`partialExpand` on the entrance animation having started (`snapshotFlow { sheetState.targetValue != Hidden }`), so an early call retargets it instead of being no-opped or overridden. No JS API changes needed.

# Test Plan

- New unit tests: `ViewFunctionHandlersTest` (suspends until initial binding, fails fast after it, times out when never composed) and `RetryOnViewNotFoundTest` (retries across frames, rethrows other errors, bounded budget) — `et native-unit-tests -p android --packages expo-modules-core` passes.
- Manual verification on a Pixel emulator (API 36) in `bare-expo` with the exact repro from the issue (`BottomSheetModal` with `snapPoints={['50%', '90%']}` and `enablePanDownToClose`):
  - Present → opens at 50%, **no promise rejection** (previously rejected with the tag error as promise id 0).
  - Drag up → 90%; drag down → collapses to 50% with no error; drag down → dismisses.
  - `snapToIndex(1)` on a closed sheet → opens at 90% (previously crashed, or opened at 50% with the core fix alone).
  - Dismiss → re-present cycles — no `ShadowNodeProxy` crash (previously a hard NPE crash).
- `spotlessCheck` passes for both packages.

# Checklist

- [x] I added a `CHANGELOG.md` entry and rebuilt the package sources
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build
- [ ] Conforms with the Documentation Writing Style Guide