### PR TITLE
[expo-location][Android] Fix timeInterval/distanceInterval ignored for background location updates

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates — `Double` values from the task options map were dropped by non-coercing safe-casts, so the fused provider always ran at the accuracy preset default interval. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
+
 ### 💡 Others
 
 - Simplify re-export of `LocationEventEmitter` ([#46719](https://github.com/expo/expo/pull/46719) by [@kitten](https://github.com/kitten))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates — `Double` values from the task options map were dropped by non-coercing safe-casts, so the fused provider always ran at the accuracy preset default interval. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
+- [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationArguments.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationArguments.kt
@@ -43,10 +43,15 @@ internal open class LocationOptions(
   @Field var timeInterval: Long? = null
 ) : Record, Serializable {
   constructor(map: Map<String, Any?>) : this(
-    accuracy = map["accuracy"] as? Int ?: ACCURACY_BALANCED,
-    distanceInterval = map["distanceInterval"] as? Int?,
+    // Numbers in the task options map arrive as Double (RN bridge / TaskManager
+    // persistence). Safe-casts like `as? Long` don't coerce numeric types and
+    // return null, silently dropping the configured intervals and falling back
+    // to the accuracy preset defaults. Coerce via Number instead, matching
+    // LocationTaskConsumer.shouldReportDeferredLocations.
+    accuracy = (map["accuracy"] as? Number)?.toInt() ?: ACCURACY_BALANCED,
+    distanceInterval = (map["distanceInterval"] as? Number)?.toInt(),
     mayShowUserSettingsDialog = map["mayShowUserSettingsDialog"] as? Boolean? ?: true,
-    timeInterval = map["timeInterval"] as? Long
+    timeInterval = (map["timeInterval"] as? Number)?.toLong()
   )
 }
 


### PR DESCRIPTION
# Why

`Location.startLocationUpdatesAsync()` on Android ignores `timeInterval` and `distanceInterval`. The background task's location request always runs at the accuracy preset defaults — for `Accuracy.Balanced` that is a 3-second interval — regardless of what the app configured. This causes far more frequent updates than requested and significant battery drain (the fused provider runs a continuous 3-second-interval request for the lifetime of the background task).

Filed as #46788 (auto-closed by the bot for a missing repro project; full root-cause analysis there).

Only the background `TaskManager` path is affected. Foreground `watchPositionAsync` goes through the typed `Record` converter, which coerces numbers correctly.

# How

In `LocationOptions`'s map-based constructor (`LocationArguments.kt`), numbers from the task options map arrive as `Double` — both across the RN bridge and from TaskManager's persisted options. Kotlin's safe-cast does not coerce numeric types: `Double as? Long` and `Double as? Int` return `null`, so `timeInterval` and `distanceInterval` were silently discarded and `LocationHelpers.mapOptionsToLocationParams` fell through to the accuracy preset defaults.

Fix: coerce via `Number`, matching the existing pattern in `LocationTaskConsumer.shouldReportDeferredLocations`:

```kotlin
accuracy = (map["accuracy"] as? Number)?.toInt() ?: ACCURACY_BALANCED,
distanceInterval = (map["distanceInterval"] as? Number)?.toInt(),
timeInterval = (map["timeInterval"] as? Number)?.toLong()
```

(`accuracy` had the same latent issue: a `Double` from the persisted options map fell back to `ACCURACY_BALANCED` instead of the configured value.)

# Test Plan

- Running this exact change as a `patch-package` patch in a production app (Expo SDK 55, RN 0.83): with `timeInterval: 15 * 60 * 1000` and `Accuracy.Balanced`, before the patch `LocationHelpers.prepareLocationRequest` built the request with `interval == 3000` and updates arrived minutes apart on a stationary device (wifi-scan cadence); after the patch the request is built with the configured interval and delivered `locations[].timestamp` spacing matches configuration.
- The coercion itself is a Kotlin language fact: `(15.0 as? Long)` is `null`, `(15.0 as? Number)?.toLong()` is `15L`.

# Checklist

- [x] Documentation is up to date to reflect these changes (no API change — fix makes existing documented options work).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
