### PR TITLE
[jsi] Cache the runtime as `IRuntime` on the argument-decode hot path

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 💡 Others
 
+- [iOS] `JavaScriptUnownedValue` and `JavaScriptValuesBuffer` now cache the runtime as the immortal `facebook.jsi.IRuntime` instead of the ARC-managed `JavaScriptRuntime` wrapper, removing per-call retain/release on the argument-decode hot path (measured ~16% faster `addNumbers`, ~24% faster `addStrings`). ([#46678](https://github.com/expo/expo/pull/46678) by [@tsapeta](https://github.com/tsapeta))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -213,7 +213,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
     let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc))
       .toOpaque()
-    let setterPointer: (@convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>, UnsafeMutableRawPointer) -> Void)? = setter
+    let setterPointer:
+      (@convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>, UnsafeMutableRawPointer) -> Void)? = setter
     // Pass a null setter to C++ when the Swift setter is nil so that JS assignment
     // raises a `jsi::JSError` directly, without crossing the Swift boundary.
     let callbacks = expo.HostObjectCallbacks(

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -8,6 +8,12 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   // so the runtime is always alive while the buffer exists.
   internal unowned let runtime: JavaScriptRuntime
 
+  // The raw `facebook.jsi.IRuntime`, cached alongside the `JavaScriptRuntime` wrapper. `IRuntime` is
+  // an immortal reference (`jsi.apinotes`), so reading it costs no ARC, whereas reading `.pointee`
+  // off the `unowned` wrapper emits an unowned retain/release on every access. The hot decode path
+  // (`unownedValue(at:)`, `set`) reads this; `subscript`/`copy` still need the wrapper.
+  internal nonisolated(unsafe) let iRuntime: facebook.jsi.IRuntime
+
   internal nonisolated(unsafe) let bufferPointer: UnsafeMutableBufferPointer<facebook.jsi.Value>
   private let ownsMemory: Bool
 
@@ -34,6 +40,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     ownsMemory: Bool = false
   ) {
     self.runtime = runtime
+    self.iRuntime = runtime.pointee
     self.bufferPointer = buffer
     self.ownsMemory = ownsMemory
   }
@@ -69,7 +76,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   /// `baseAddress`, so passing any index into an empty buffer crashes, and an out-of-range index reads past
   /// the buffer. The caller is responsible for the bounds check.
   public func unownedValue(at index: Int) -> JavaScriptUnownedValue {
-    return JavaScriptUnownedValue(runtime, bufferPointer.baseAddress! + index)
+    return JavaScriptUnownedValue(iRuntime, bufferPointer.baseAddress! + index)
   }
 
   @discardableResult
@@ -78,7 +85,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     guard (0..<count).contains(index) else {
       FatalError.valuesBufferIndexOutRange(index: index, capacity: count)
     }
-    bufferPointer.initializeElement(at: index, to: value.toJSIValue(in: runtime.pointee))
+    bufferPointer.initializeElement(at: index, to: value.toJSIValue(in: iRuntime))
     return self
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -40,7 +40,14 @@ public struct JavaScriptUnownedValue: ~Copyable {
   /// Materializes an owning ``JavaScriptValue`` by copying the borrowed `jsi::Value`. Use it when the
   /// value must outlive the decode call (stored, captured, handed to a `Promise`). Takes the
   /// `JavaScriptRuntime` wrapper since the owning value needs it; the caller has it in scope.
+  ///
+  /// `runtime` must be the runtime that owns the borrowed value. Copying a reference value (string,
+  /// object, function, array, bigint) clones its `PointerValue` against `runtime`, so passing a
+  /// different runtime would clone a handle from another heap and corrupt it; the assert guards that.
   public func copied(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    assert(
+      Unmanaged.passUnretained(runtime.pointee).toOpaque() == Unmanaged.passUnretained(self.runtime).toOpaque(),
+      "`copied(in:)` must be passed the runtime that owns the borrowed value")
     return JavaScriptValue(runtime, pointer.pointee)
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -20,24 +20,27 @@ internal import jsi
 /// > class refs, there is no trap on use-after-free. The contract is "valid only within the synchronous
 /// > decode call, while the owner is alive" — which the buffer-driven decode path honors because it
 /// > reads the value inline on the JS thread before the buffer is torn down. Do not store, capture, or
-/// > escape it; call ``copied()`` to materialize an owning value when escape is needed.
+/// > escape it; call ``copied(in:)`` to materialize an owning value when escape is needed.
 public struct JavaScriptUnownedValue: ~Copyable {
   // Borrows the `jsi::Value` at this address; it does not own it and must not outlive the owner.
   internal let pointer: UnsafePointer<facebook.jsi.Value>
 
-  // Non-optional `unowned`, matching `JavaScriptValuesBuffer.runtime`: it is strictly call-scoped and
-  // cannot outlive the runtime executing the call, so we skip both the ARC traffic and the optional unwrap
-  // that the owning `JavaScriptValue` pays.
-  internal unowned let runtime: JavaScriptRuntime
+  // The JSI runtime, stored as the raw `facebook.jsi.IRuntime` rather than the `JavaScriptRuntime`
+  // wrapper. `IRuntime` is imported as an immortal reference (see `jsi.apinotes`), so storing and
+  // copying it emits no ARC, unlike a `JavaScriptRuntime` field whose every per-call access pays an
+  // unowned retain/release. Only `getString` reads it; the type checks and numeric accessors touch
+  // only `pointer`.
+  internal let runtime: facebook.jsi.IRuntime
 
-  internal init(_ runtime: JavaScriptRuntime, _ pointer: UnsafePointer<facebook.jsi.Value>) {
+  internal init(_ runtime: facebook.jsi.IRuntime, _ pointer: UnsafePointer<facebook.jsi.Value>) {
     self.runtime = runtime
     self.pointer = pointer
   }
 
   /// Materializes an owning ``JavaScriptValue`` by copying the borrowed `jsi::Value`. Use it when the
-  /// value must outlive the decode call (stored, captured, handed to a `Promise`).
-  public func copied() -> JavaScriptValue {
+  /// value must outlive the decode call (stored, captured, handed to a `Promise`). Takes the
+  /// `JavaScriptRuntime` wrapper since the owning value needs it; the caller has it in scope.
+  public func copied(in runtime: JavaScriptRuntime) -> JavaScriptValue {
     return JavaScriptValue(runtime, pointer.pointee)
   }
 
@@ -98,7 +101,7 @@ public struct JavaScriptUnownedValue: ~Copyable {
   /// Returns the value as a string, or asserts if not a string.
   public func getString() -> String {
     assert(isString(), "Value is not a string")
-    return String(pointer.pointee.getString(runtime.pointee).utf8(runtime.pointee))
+    return String(pointer.pointee.getString(runtime).utf8(runtime))
   }
 
   // MARK: - Throwing conversions ("as functions")

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptUnownedValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptUnownedValueTests.swift
@@ -61,7 +61,7 @@ struct JavaScriptUnownedValueTests {
   @Test
   func `copied materializes an owning value`() throws {
     let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: "owned")
-    let owning = buffer.unownedValue(at: 0).copied()
+    let owning = buffer.unownedValue(at: 0).copied(in: runtime)
 
     #expect(try owning.asString() == "owned")
   }


### PR DESCRIPTION
## Why

Decoding host-function arguments is on the hottest JSI path. `JavaScriptUnownedValue` and `JavaScriptValuesBuffer` stored the runtime as the `JavaScriptRuntime` wrapper — an ARC-managed Swift class — so reading it to decode each argument emitted an unowned retain/release on every access.

## How

Both types now cache the raw `facebook.jsi.IRuntime`, which is imported as an immortal reference (via `jsi.apinotes`) and therefore carries no ARC.

- `JavaScriptUnownedValue` only ever needed the raw runtime (`getString` calls into it; the type checks and numeric accessors touch only the value pointer), so it stores `IRuntime` outright. `copied()` becomes `copied(in:)` since materializing an owning `JavaScriptValue` needs the wrapper, and the caller has it in scope.
- `JavaScriptValuesBuffer` keeps its `JavaScriptRuntime` (its `subscript`/`copy` build wrapped values) and additionally caches `IRuntime` for the hot `unownedValue(at:)` / `set` paths.

## Test Plan

Existing `JavaScriptUnownedValueTests` updated for the `copied(in:)` signature and passing.

Measured on iPhone 16 Pro (release, 3M iterations, wall-clock):

- `addNumbers`: ~16% faster (1111ms → 932ms)
- `addStrings`: ~24% faster (1509ms → 1145ms)
