### PR TITLE
[ci] Update setup-java action

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 💎 Install cocoapods
         run: sudo gem install cocoapods
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/expo-go-android-lint.yml
+++ b/.github/workflows/expo-go-android-lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -116,7 +116,7 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           bun-version: 1.x
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -357,7 +357,7 @@ jobs:
         with:
           bun-version: 1.x
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
# Why

<img width="1399" height="164" src="https://github.com/user-attachments/assets/2d4386a9-e3e0-406e-b54e-256f1d0dcc21" />

# How

Bump `setup-java` action to v5

# Test Plan

Wait for the CI to pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
