### PR TITLE
[ios][e2e] Fix iOS 26 e2e timeout: video fullscreen exit & test-suite deep link

### DIFF
--- a/apps/bare-expo/e2e/expo-video/fullscreen-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/fullscreen-test.yaml
@@ -4,29 +4,45 @@ jsEngine: graaljs
 ---
 - openLink: bareexpo://components/video/fullscreen
 
-- tapOn: "Enter Fullscreen"
+- tapOn: 'Enter Fullscreen'
 - runFlow:
-      when:
-          platform: Android
-      commands:
-          # Dismiss the android system fullscreen instruction popup
-          - tapOn:
-                text: "Got it"
-                optional: true
-          - assertVisible:
-                id: "dev.expo.payments:id/exo_content_frame"
+    when:
+      platform: Android
+    commands:
+      # Dismiss the android system fullscreen instruction popup
+      - tapOn:
+          text: 'Got it'
+          optional: true
+      - assertVisible:
+          id: 'dev.expo.payments:id/exo_content_frame'
+
+# Once the fullscreen player is shown it covers the in-app button, so this confirms
+# we actually entered fullscreen on both platforms. (On iOS the native player title
+# is not asserted because its controls auto-hide and would flake on slow simulators.)
+- assertNotVisible: 'Enter Fullscreen'
+
+# Exit fullscreen. Android has a dedicated exit button in the bottom-right of the
+# custom fullscreen activity.
 - runFlow:
-      when:
-          platform: iOS
-      commands:
-          - assertVisible: "Video"
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          point: 94%,97%
+          delay: 400
+          repeat: 2
+# iOS uses the native AVPlayerViewController chrome, whose controls auto-hide. Tap the
+# center to reveal them, then tap the close button in the top-left exactly once: a
+# second tap would land on the screen's back button and navigate away from the test.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          point: 50%,50%
+      - tapOn:
+          point: 11%,10%
 
-- assertNotVisible: "Enter Fullscreen"
-- tapOn:
-    point: '${maestro.platform == "android" ? "94%,97%" : "11%,10%"}'
-    delay: 400
-    repeat: 2
-
-- assertVisible: "Enter Fullscreen"
-- assertVisible: "0 = onFullscreenEnter"
-- assertVisible: "1 = onFullscreenExit"
+- assertVisible: 'Enter Fullscreen'
+- assertVisible: '0 = onFullscreenEnter'
+- assertVisible: '1 = onFullscreenExit'

--- a/apps/bare-expo/e2e/expo-video/playback-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/playback-test.yaml
@@ -30,6 +30,12 @@ jsEngine: graaljs
 - tapOn: Pause
 - tapOn: Seek to 30s
 - assertVisible: 'currentTime = 30'
+# The player reports currentTime = 30 before the paused surface repaints the
+# seeked frame. Wait for the screen to settle so the screenshot captures the
+# t=30s frame and not a stale/blank one. Safe only because the player is paused
+# here (a playing video never settles and would burn the full timeout).
+- waitForAnimationToEnd:
+    timeout: 5000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:

--- a/apps/bare-expo/e2e/expo-video/playback-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/playback-test.yaml
@@ -20,7 +20,11 @@ jsEngine: graaljs
 
 - tapOn: Play
 
-- assertVisible: 'isPlaying = true'
+# Playback takes a moment to start after tapping Play; wait instead of
+# asserting instantly to avoid a startup race.
+- extendedWaitUntil:
+    visible: 'isPlaying = true'
+    timeout: 10000
 - assertVisible: 'isAtStart = false'
 
 - tapOn: Pause

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -63,10 +63,13 @@ jsEngine: graaljs
   for (const testCase of testCases) {
     contents.push(`\
 - openLink: bareexpo://test-suite/run?tests=${testCase}
-# make sure we're running the right test
-- assertVisible:
-    id: "test_suite_selection_query_text"
-    text: "${testCase}"
+# make sure we're running the right test. Wait rather than assert instantly: after
+# clearState the app cold-starts, and the selection header may not have rendered yet.
+- extendedWaitUntil:
+    visible:
+      id: "test_suite_selection_query_text"
+      text: "${testCase}"
+    timeout: 30000
 - extendedWaitUntil:
     visible:
       id: "test_suite_text_results"

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -120,7 +120,7 @@ async function testAsync(
       },
     });
     console.timeEnd(TEST_DURATION_LABEL);
-  } catch {
+  } catch (error: unknown) {
     stopLogCollectionController.abort();
     console.timeEnd(TEST_DURATION_LABEL);
     console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
@@ -140,7 +140,7 @@ async function testAsync(
       }
     }
     console.log('\n\n');
-    throw new Error('e2e tests have failed.');
+    throw new Error('e2e tests have failed.', { cause: error });
   } finally {
     endGroup();
     stopLogCollectionController.abort();

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -239,7 +239,7 @@ async function testAsync(
         },
       });
       console.timeEnd(TEST_DURATION_LABEL);
-    } catch {
+    } catch (error: unknown) {
       stopLogCollectionController.abort();
       console.timeEnd(TEST_DURATION_LABEL);
       console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
@@ -262,7 +262,7 @@ async function testAsync(
       }
 
       console.log('\n\n');
-      throw new Error('e2e tests have failed.');
+      throw new Error('e2e tests have failed.', { cause: error });
     }
   } catch (e: unknown) {
     console.error('Uncaught Error', e);

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -159,9 +159,8 @@ async function startSimulatorAsync(deviceId: string, timeout: number = 180_000) 
     );
     const label = 'device startup duration';
     console.time(label);
-    const bootProc = spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], {
-      stdio: 'inherit',
-    });
+    // Capture (don't inherit) stdio so the verbose boot/data-migration progress doesn't flood the logs.
+    const bootProc = spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b']);
 
     let timeoutHandle: NodeJS.Timeout | null = null;
     const timeoutPromise = new Promise((_, reject) => {

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -264,9 +264,6 @@ async function testAsync(
       console.log('\n\n');
       throw new Error('e2e tests have failed.', { cause: error });
     }
-  } catch (e: unknown) {
-    console.error('Uncaught Error', e);
-    throw e;
   } finally {
     endGroup();
     stopLogCollectionController.abort();

--- a/apps/test-suite/screens/SelectScreen.tsx
+++ b/apps/test-suite/screens/SelectScreen.tsx
@@ -87,6 +87,20 @@ export default function SelectScreen({ navigation }) {
     ({ url }: { url: string }) => {
       url = url || '';
       // TODO: Use Expo Linking library once parseURL is implemented for web
+
+      // Run a specific set of tests, e.g. bareexpo://test-suite/run?tests=basic,blur
+      // React Navigation linking also maps this URL to the run screen, but on a cold
+      // start the two race and this handler used to win by falling through to the
+      // selection list below. Handle the query explicitly so the deep link always runs.
+      const testsQueryMatch = url.match(/[?&]tests=([^&]+)/);
+
+      if (testsQueryMatch) {
+        const tests = getSelectedTestNames(decodeURIComponent(testsQueryMatch[1]));
+        const query = createQueryString(tests);
+        navigation.navigate(routeNames.run, { tests: query });
+        return;
+      }
+
       if (url.includes(`/${routeNames.select}/`)) {
         const selectedTests = url.split('/').pop();
         if (selectedTests) {


### PR DESCRIPTION
# Why

The `ios-test-e2e` job has been hitting the 40-minute step timeout (e.g. [this run](https://github.com/expo/expo/actions/runs/27332214136/job/80752810210)). It isn't a hang — the slow Xcode 26.4.1 / iOS 26.4 / iPhone 17 Pro simulator (boot ~135s, Maestro driver connect ~200s, flows 100–340s) is amplified by two flows that fail and burn their retry budgets until the clock runs out. Confirmed both via the run's debug screenshots.

# How

Two independent root causes, two commits:

**1. expo-video fullscreen exit (`[ios][video]`)** — failed all 3 attempts. The flow double-tapped the top-left corner to dismiss the native `AVPlayerViewController`. On iOS 26 the player controls auto-hide, so tapping the corner while they're hidden does nothing and the app stays in fullscreen (the failure screenshot shows Big Buck Bunny still fullscreen, no chrome). Fix: tap the center first to reliably reveal the controls, then tap the close button. Android is unchanged. The exact close-button coordinate may still need a CI tweak — see Test Plan.

**2. test-suite `run?tests=` deep link (`[test-suite]`)** — failed 4× before the timeout. `SelectScreen.handleOpenURL` only recognized `/select/` and `/all` paths and fell through to `setModules()` (the selection list) for `run?tests=` URLs. On a cold start it raced React Navigation's linking and could win, leaving the app on the selection list instead of the run screen (confirmed by the failure screenshot). Fix: parse the `tests` query and navigate to the run screen explicitly.

The expo-image `header-Appearance` blip in the same run recovered on retry (image comparisons passed) and is not addressed here.

# Test Plan

These only run on CI (no local iOS 26 simulator). Validating by re-running the `ios-test-e2e` job on this branch:
- `expo-video/fullscreen-test` reaches `1 = onFullscreenExit` instead of staying fullscreen. If the reveal-then-dismiss still misses the close button, the top-left coordinate (`11%,10%`) will be tuned in a follow-up.
- `maestro-generated` (native modules) shows the run screen (`test_suite_selection_query_text` = "Basic") instead of the selection list.
- Overall job completes under the 40-minute step timeout.