### PR TITLE
[docs] Fix append-dates crash on Node 24

### DIFF
--- a/docs/scripts/append-dates.js
+++ b/docs/scripts/append-dates.js
@@ -27,7 +27,7 @@ async function appendModificationDate(dir = './pages') {
     const files = await readdir(dir, { recursive: true, withFileTypes: true });
     const mdxFiles = files
       .filter(file => !file.isDirectory() && file.name.endsWith('.mdx'))
-      .map(file => path.join(file.path, file.name));
+      .map(file => path.join(file.parentPath, file.name));
 
     // Process files in batches with limited concurrency
     for (let i = 0; i < mdxFiles.length; i += CONCURRENCY) {


### PR DESCRIPTION
# Why

Node 24 removed `Dirent.path`, so `pnpm export` fails during `export-prep`:

```
> TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

We will run into this issue when CI starts using Node 24.

# How

Replace `file.path` with `file.parentPath` in `scripts/append-dates.js`. It is the official rename of the removed property, returns the same value, and is available since Node 20.12, so the docs CI workflows on Node 22 are unaffected.

# Test Plan

On Node 24, run `pnpm export-prep` in `docs/` and confirm it completes and inserts `modificationDate` into page frontmatter as before.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).