### PR TITLE
[expo][iOS] Mark `ExpoAppSceneDelegate` as unavailable in extensions

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))
 - Prevent fatal `The stream is not in a state that permits close` in `expo/fetch` when native delivers `didComplete`/`didFailWithError` after the consumer has already canceled the body stream. ([#44909](https://github.com/expo/expo/pull/44909) by [@safaiyeh](https://github.com/safaiyeh))
 - Adopted the UIKit scene-based life cycle on iOS so apps built with the iOS 27 SDK launch correctly. ([#46733](https://github.com/expo/expo/pull/46733) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Mark `ExpoAppSceneDelegate` as unavailable in extensions. ([#46799](https://github.com/expo/expo/pull/46799) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
@@ -15,6 +15,7 @@ import React
  - Re-feed scene life-cycle, URL, and user-activity events to the existing
    `ExpoAppDelegateSubscriberManager`, so app delegate subscribers keep working unchanged.
  */
+@available(iOSApplicationExtension, unavailable)
 @objc(EXExpoAppSceneDelegate)
 open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
   open var window: UIWindow?


### PR DESCRIPTION
# Why

`expo-widgets` depends on the `expo` module, so any use of `UIApplication.shared` needs to be guarded.
```
'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.
```

# How

Add `@available(iOSApplicationExtension, unavailable)` to `ExpoAppSceneDelegate`.

# Test Plan

Build the app with `expo-widgets`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)