### PR TITLE
[test-suite] Register AppMetrics in the bare-expo e2e test list

### DIFF
--- a/apps/bare-expo/e2e/TestSuite-test.native.js
+++ b/apps/bare-expo/e2e/TestSuite-test.native.js
@@ -1,8 +1,10 @@
 /**
- * The test cases for bare-expo E2E testing.
- * When adding or removing tests, also update the paths in .github/workflows/test-suite.yml
+ * The test cases for bare-expo E2E testing. The Maestro flow is generated from this list
+ * (see `createMaestroFlowAsync`), so adding or removing an entry is all that's needed; each
+ * test must also be registered in `apps/test-suite/TestModules.ts` so the app can run it.
  */
 const TESTS = [
+  'AppMetrics',
   'Basic',
   // 'Asset',
   // 'FileSystem',


### PR DESCRIPTION
## Why

The `AppMetrics` test-suite module (`apps/test-suite/tests/AppMetrics.ts`) is registered in `TestModules.ts` and runs in the in-app test runner, but it was not part of the bare-expo e2e `TESTS` array, so its cases never ran in the e2e suite. This enables them, covering the `NetworkRequestObserver` tests (the original observer tests and the new host/method filtering tests added in #46775).

## How

Added `'AppMetrics'` to the `TESTS` array in `apps/bare-expo/e2e/TestSuite-test.native.js`. The Maestro flow is generated from that array (`createMaestroFlowAsync` in `apps/bare-expo/scripts/lib/e2e-common.ts`), so adding the name is what wires the test into the e2e run. No `test-suite.yml` change is needed: the workflow generates the flow from this array, and `expo-app-metrics` is already covered by the existing `packages/**` path filters.

Also refreshed the now-stale comment above `TESTS` (it instructed updating paths in `test-suite.yml`, which no longer lists tests individually) to describe the actual mechanism: the flow is generated from this list, and each test must be registered in `TestModules.ts`.

## Test Plan

The bare-expo e2e job picks up the new entry and runs the `AppMetrics` test-suite cases (network request observation and filtering) on iOS and Android.
