### PR TITLE
[ui] Fix BottomSheet blocking touches after dismiss

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS][android] Fix `community/bottom-sheet` blocking touches behind the sheet after it's dismissed. ([#46805](https://github.com/expo/expo/pull/46805) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Fix React Native touchables (e.g. `Pressable`) on `community/pager-view` pages not responding, or triggering the wrong page's handler, after navigating between pages. ([#46778](https://github.com/expo/expo/pull/46778) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `font`, `dynamicTypeSize`, and `resizable` modifiers not applying to the SwiftUI `Image`. SF Symbols scale with Dynamic Type when a `font` modifier sets a `textStyle`. ([#46714](https://github.com/expo/expo/pull/46714) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [android] Fix React Native `ScrollView` nested scrolling inside `BottomSheet`. ([#46544](https://github.com/expo/expo/pull/46544) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
@@ -197,7 +197,7 @@ export function BottomSheet(props: BottomSheetProps) {
   return (
     <BottomSheetInternalContext.Provider value={internalContextValue}>
       <BottomSheetContext.Provider value={methods}>
-        <Host style={{ position: 'absolute', width }}>
+        <Host style={{ position: 'absolute', width }} pointerEvents="none">
           <ModalBottomSheet
             ref={sheetRef}
             onDismissRequest={handleDismiss}

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
@@ -230,7 +230,7 @@ export function BottomSheet(props: BottomSheetProps) {
   return (
     <BottomSheetInternalContext.Provider value={internalContextValue}>
       <BottomSheetContext.Provider value={methods}>
-        <Host style={{ position: 'absolute', width }}>
+        <Host style={{ position: 'absolute', width }} pointerEvents="none">
           <NativeBottomSheet
             isPresented={isPresented}
             onIsPresentedChange={handlePresentedChange}


### PR DESCRIPTION
# Why

The community `BottomSheet` host is absolutely positioned over the screen at all times. After the sheet is dismissed it kept intercepting touches in the area the sheet used to occupy, so controls behind it stopped responding.

Closes #45810.

# How

Set `pointerEvents="none"` on the `Host` wrapper (iOS + Android). The native sheet is presented in its own window, so it still receives touches while open — the anchor host just no longer blocks anything behind it.

# Test Plan

Repro from #45810: open the sheet, close via `dismiss()` / `close()` / `snapToIndex(-1)`, then tap a control where the sheet was — it's interactive again. Verified on iOS and Android with a bare-expo Tester screen.