### PR TITLE
[audio] Add a `fileSize` field to `RecorderState` 

### DIFF
--- a/apps/native-component-list/src/screens/Audio/Recorder.tsx
+++ b/apps/native-component-list/src/screens/Audio/Recorder.tsx
@@ -277,12 +277,23 @@ export default function Recorder({ onDone, style }: RecorderProps) {
         <BodyText style={{ fontWeight: 'bold', marginVertical: 10 }}>
           {_formatTime(recorderState.durationMillis / 1000)}
         </BodyText>
+        <BodyText>File size: {_formatFileSize(recorderState.fileSize)}</BodyText>
       </View>
       <AudioInputSelector recorder={audioRecorder} canRecord={recorderState.canRecord} />
       {maybeRenderErrorOverlay()}
     </View>
   );
 }
+
+const _formatFileSize = (bytes: number) => {
+  if (bytes < 1000) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1000 * 1000) {
+    return `${(bytes / 1000).toFixed(1)} kB`;
+  }
+  return `${(bytes / (1000 * 1000)).toFixed(2)} MB`;
+};
 
 const _formatTime = (duration: number) => {
   const paddedSecs = _leftPad(`${Math.floor(duration % 60)}`, '0', 2);

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added support for storing recordings in the app document directory on Android and iOS. ([#46189](https://github.com/expo/expo/pull/46189) by [@shubh73](https://github.com/shubh73))
 - Support lockscreen controls with playlists. ([#46020](https://github.com/expo/expo/pull/46020) by [@alanjhughes](https://github.com/alanjhughes))
+- Added a `fileSize` field to `RecorderState` reporting the current size of the recording file in bytes. ([#46808](https://github.com/expo/expo/pull/46808) by [@behenate](https://github.com/behenate))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -59,6 +59,9 @@ class AudioRecorder(
   private fun currentFileUrl(): String? =
     filePath?.let(::File)?.toUri()?.toString()
 
+  val fileSize: Long
+    get() = filePath?.let { File(it).length() } ?: 0L
+
   private fun getAudioRecorderLevels(): Double? {
     if (!meteringEnabled || recorder == null || !isRecording) {
       return null
@@ -310,6 +313,7 @@ class AudioRecorder(
       putBoolean("canRecord", isPrepared)
       putBoolean("isRecording", isRecording)
       putLong("durationMillis", getAudioRecorderDurationMillis())
+      putLong("fileSize", fileSize)
       getAudioRecorderLevels()?.let {
         putDouble("metering", it)
       }
@@ -320,6 +324,7 @@ class AudioRecorder(
       putBoolean("canRecord", false)
       putBoolean("isRecording", false)
       putLong("durationMillis", 0)
+      putLong("fileSize", 0)
       putString("url", null)
     }
   }

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -53,6 +53,11 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     ref.url.absoluteString
   }
 
+  var fileSize: Int64 {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: ref.url.path(percentEncoded: false))
+    return (attributes?[.size] as? Int64) ?? 0
+  }
+
   private var currentSessionDuration: Int {
     guard startTimestamp > 0, currentState == .recording else {
       return 0
@@ -173,6 +178,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       "canRecord": isPrepared,
       "isRecording": currentState == .recording,
       "durationMillis": totalDuration,
+      "fileSize": fileSize,
       "mediaServicesDidReset": mediaServicesDidReset,
       "url": ref.url.absoluteString
     ]

--- a/packages/expo-audio/src/Audio.types.ts
+++ b/packages/expo-audio/src/Audio.types.ts
@@ -297,6 +297,15 @@ export type RecorderState = {
   isRecording: boolean;
   /** Duration of the current recording in milliseconds. */
   durationMillis: number;
+  /**
+   * Current size of the recording file in bytes, or `0` if no recording file exists yet.
+   *
+   * The value reflects the bytes already flushed to disk, so during an active recording it can lag
+   * slightly behind real time. On web, it updates when the browser delivers recorded data
+   * (typically when the recording stops), and the value is an approximation that may differ
+   * slightly from the final file size.
+   */
+  fileSize: number;
   /** Whether the media services have been reset (typically indicates a system interruption). */
   mediaServicesDidReset: boolean;
   /** Current audio level/volume being recorded (if metering is enabled). */

--- a/packages/expo-audio/src/AudioRecorder.web.ts
+++ b/packages/expo-audio/src/AudioRecorder.web.ts
@@ -40,6 +40,7 @@ export class AudioRecorderWeb
   private analyserBuffer: Float32Array<ArrayBuffer> | null = null;
   private analyserSource: MediaStreamAudioSourceNode | null = null;
   private meteringEnabled = false;
+  private recordedBytes = 0;
 
   get isRecording(): boolean {
     return this.mediaRecorder?.state === 'recording';
@@ -108,6 +109,7 @@ export class AudioRecorderWeb
         this.mediaRecorder?.state === 'recording' || this.mediaRecorder?.state === 'inactive',
       isRecording: this.mediaRecorder?.state === 'recording',
       durationMillis: this.getAudioRecorderDurationMillis(),
+      fileSize: this.recordedBytes,
       mediaServicesDidReset: false,
       url: this.uri,
     };
@@ -183,6 +185,7 @@ export class AudioRecorderWeb
 
     this.mediaRecorderUptimeOfLastStartResume = 0;
     this.currentTime = 0;
+    this.recordedBytes = 0;
 
     const audioConstraints = this.selectedDeviceId
       ? { deviceId: { exact: this.selectedDeviceId } }
@@ -242,6 +245,10 @@ export class AudioRecorderWeb
       this.mediaRecorderUptimeOfLastStartResume = Date.now();
       this.currentTime = 0;
       this.mediaRecorderIsRecording = true;
+    });
+
+    mediaRecorder.addEventListener('dataavailable', (event) => {
+      this.recordedBytes += event.data.size;
     });
 
     mediaRecorder?.addEventListener('stop', () => {

--- a/packages/expo-audio/src/__tests__/AudioRecorderWeb-test.ts
+++ b/packages/expo-audio/src/__tests__/AudioRecorderWeb-test.ts
@@ -1,0 +1,89 @@
+// Minimal stubs for the web environment the recorder expects.
+class FakeSharedObject {
+  emit() {}
+  addListener() {}
+  removeListener() {}
+}
+
+(globalThis as any).expo = { SharedObject: FakeSharedObject };
+
+class FakeMediaRecorder extends EventTarget {
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  static isTypeSupported() {
+    return true;
+  }
+  start() {
+    this.state = 'recording';
+    this.dispatchEvent(new Event('start'));
+  }
+  stop() {
+    this.state = 'inactive';
+    this.dispatchEvent(new Event('stop'));
+  }
+  pause() {
+    this.state = 'paused';
+    this.dispatchEvent(new Event('pause'));
+  }
+  resume() {
+    this.state = 'recording';
+    this.dispatchEvent(new Event('resume'));
+  }
+  emitData(bytes: number) {
+    const event = new Event('dataavailable') as any;
+    event.data = { size: bytes };
+    this.dispatchEvent(event);
+  }
+}
+
+(globalThis as any).MediaRecorder = FakeMediaRecorder;
+
+jest.mock('../AudioUtils.web', () => ({
+  nextId: () => 1,
+  getAudioContext: jest.fn(),
+  getUserMedia: jest.fn(async () => ({
+    getAudioTracks: () => [],
+    getTracks: () => [],
+  })),
+}));
+
+// Import after the globals are in place.
+const { AudioRecorderWeb } = require('../AudioRecorder.web');
+
+function mockMediaDevices() {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      enumerateDevices: jest.fn(async () => []),
+    },
+    configurable: true,
+  });
+}
+
+describe('AudioRecorderWeb fileSize', () => {
+  beforeEach(() => {
+    mockMediaDevices();
+  });
+
+  it('is 0 before any data is recorded', () => {
+    const recorder = new AudioRecorderWeb({});
+    expect(recorder.getStatus().fileSize).toBe(0);
+  });
+
+  it('accumulates the size of recorded chunks', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    const mediaRecorder = (recorder as any).mediaRecorder as InstanceType<typeof FakeMediaRecorder>;
+    mediaRecorder.emitData(1024);
+    mediaRecorder.emitData(512);
+    expect(recorder.getStatus().fileSize).toBe(1536);
+  });
+
+  it('resets when the recorder is prepared again', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    ((recorder as any).mediaRecorder as InstanceType<typeof FakeMediaRecorder>).emitData(100);
+    await recorder.prepareToRecordAsync();
+    expect(recorder.getStatus().fileSize).toBe(0);
+  });
+});


### PR DESCRIPTION
# Why

This feature was requested in-person during App.js. I think it's a good idea.

# How

Add `fileSize` field to `RecorderState` - it reports the current size of the file on disk.
Due to platform limitations, on Web it only reports the size after the the recording stops.

# Test Plan

Tested in BareExpo on iOS, Android and Web.
