### PR TITLE
[expo/cli] Focus booted device in Device Hub via deep link

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Focus the booted device in Device Hub using its `devices://` deep link instead of only bringing the app forward. ([#46757](https://github.com/expo/expo/pull/46757) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Focus the booted device in Device Hub using its `devices://` deep link instead of only bringing the app forward. ([#46809](https://github.com/expo/expo/pull/46809) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Focus the booted device in Device Hub using its `devices://` deep link instead of only bringing the app forward. ([#46757](https://github.com/expo/expo/pull/46757) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
@@ -34,6 +34,47 @@ it('should activate the window when Simulator.app is not running', async () => {
   ]);
 });
 
+it('should open DeviceHub focused on the device via deep link when Simulator.app is unavailable', async () => {
+  jest
+    .mocked(spawnAppleScriptAsync)
+    .mockResolvedValueOnce({ stdout: '0\n' } as any)
+    .mockResolvedValueOnce({ stdout: '1\n' } as any);
+
+  // Xcode 27+ ships DeviceHub instead of Simulator.app, so `open -a Simulator` fails.
+  jest
+    .mocked(spawnAsync)
+    .mockRejectedValueOnce(new Error("Unable to find application named 'Simulator'"))
+    .mockResolvedValueOnce({} as any);
+
+  await ensureSimulatorAppRunningAsync({ udid: '123' });
+
+  expect(spawnAsync).toHaveBeenNthCalledWith(1, 'open', [
+    '-a',
+    'Simulator',
+    '--args',
+    '-CurrentDeviceUDID',
+    '123',
+  ]);
+  expect(spawnAsync).toHaveBeenNthCalledWith(2, 'open', ['devices://device/open?id=123']);
+});
+
+it('should fall back to opening DeviceHub without a device when no udid is provided', async () => {
+  jest
+    .mocked(spawnAppleScriptAsync)
+    .mockResolvedValueOnce({ stdout: '0\n' } as any)
+    .mockResolvedValueOnce({ stdout: '1\n' } as any);
+
+  jest
+    .mocked(spawnAsync)
+    .mockRejectedValueOnce(new Error("Unable to find application named 'Simulator'"))
+    .mockResolvedValueOnce({} as any);
+
+  await ensureSimulatorAppRunningAsync({});
+
+  expect(spawnAsync).toHaveBeenNthCalledWith(1, 'open', ['-a', 'Simulator']);
+  expect(spawnAsync).toHaveBeenNthCalledWith(2, 'open', ['-a', 'DeviceHub']);
+});
+
 it('should throw a timeout warning when Simulator.app takes too long to start', async () => {
   jest.mocked(spawnAppleScriptAsync).mockRejectedValue(new Error('Application isn’t running'));
 

--- a/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ensureSimulatorAppRunning.ts
@@ -71,8 +71,13 @@ async function openSimulatorAppAsync(device: { udid?: string }) {
     }
     await spawnAsync('open', args);
   } catch {
-    // Device Hub does not allow us to focus to the right device
-    await spawnAsync('open', ['-a', 'DeviceHub']).catch(() => {
+    // Xcode 27+ replaces Simulator.app with DeviceHub, so `open -a Simulator` fails.
+    // DeviceHub registers the `devices://` URL scheme, which lets us focus the right
+    // device by its UDID — `open -a DeviceHub` can only bring the app forward.
+    const deviceHubArgs = device.udid
+      ? [`devices://device/open?id=${device.udid}`]
+      : ['-a', 'DeviceHub'];
+    await spawnAsync('open', deviceHubArgs).catch(() => {
       // Noop - we can't do much more here
     });
   }


### PR DESCRIPTION


https://github.com/user-attachments/assets/bd066ede-c64c-4b21-8ad5-d0dc0ecfbbe1



# Why

[#46757](https://github.com/expo/expo/pull/46757) added Device Hub support as a Simulator replacement for Xcode 27+. When `open -a Simulator` fails (Xcode 27+ ships DeviceHub instead of Simulator.app), the CLI fell back to `open -a DeviceHub`, which only brings the app forward and cannot select the device the user is launching — the old code even noted `// Device Hub does not allow us to focus to the right device`.

DeviceHub registers a `devices://` URL scheme. `devicectl list devices` exposes it per device as `screenViewingURL` (e.g. `devices://device/open?id=<identifier>`), and it works for booted simulators using their CoreSimulator UDID. We can use it to focus the right device.

# How

In `ensureSimulatorAppRunning.ts`, the DeviceHub fallback now opens `devices://device/open?id=<udid>` when a device UDID is available, focusing that device. Without a UDID it keeps the previous `open -a DeviceHub` behavior.

# Test Plan

- Added unit tests covering the deep-link fallback (with UDID) and the plain `-a DeviceHub` fallback (no UDID); `ensureSimulatorAppRunning-test.ts` passes (5/5).
- Manually verified `open "devices://device/open?id=<sim-udid>"` launches DeviceHub focused on the simulator

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [ ] This change is tested by automated tests where possible.
- [x] Conforms to the [documentation style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).