### PR TITLE
[ios][dev-launcher] Improve dev server discovery reliability

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Improve the Updates tab empty state with clearer guidance on how to publish an update. ([#46759](https://github.com/expo/expo/pull/46759) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Present the development server info dialog as a native sheet. ([#46760](https://github.com/expo/expo/pull/46760) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Reduce accidental logout in the account selector with a confirmation step and a less prominent button, and add more spacing around the header title. ([#46761](https://github.com/expo/expo/pull/46761) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Make the development server list reliable: keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found".
+- [iOS] Make the development server list reliable, keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found". ([#46811](https://github.com/expo/expo/pull/46811) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Improve the Updates tab empty state with clearer guidance on how to publish an update. ([#46759](https://github.com/expo/expo/pull/46759) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Present the development server info dialog as a native sheet. ([#46760](https://github.com/expo/expo/pull/46760) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Reduce accidental logout in the account selector with a confirmation step and a less prominent button, and add more spacing around the header title. ([#46761](https://github.com/expo/expo/pull/46761) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Make the development server list reliable: keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found".
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -260,9 +260,12 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   private func refreshIfNeeded() async {
+    guard let browser else {
+      return
+    }
     if devServers.isEmpty {
       await restartBrowser()
-    } else if browser?.browseResults.isEmpty ?? true {
+    } else if browser.browseResults.isEmpty {
       updateDevServers([])
     } else {
       await pingCurrentBrowseResults()

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -62,6 +62,9 @@ class DevLauncherViewModel: ObservableObject {
 
   private var browser: NWBrowser?
   private var pingTask: Task<Void, Never>?
+  private var periodicRefreshTask: Task<Void, Never>?
+  private var pendingEmptyVerification = false
+  private static let refreshInterval: UInt64 = 10_000_000_000
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -97,6 +100,16 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   private func updateDevServers(_ servers: [DevServer]) {
+    if servers.isEmpty && !devServers.isEmpty && !pendingEmptyVerification {
+      pendingEmptyVerification = true
+      stopServerDiscovery()
+      startServerDiscovery()
+      return
+    }
+    pendingEmptyVerification = false
+    if !servers.isEmpty {
+      markNetworkPermissionGranted()
+    }
     devServers = servers.sorted(by: <)
   }
 
@@ -204,9 +217,62 @@ class DevLauncherViewModel: ObservableObject {
 
     stopServerDiscovery()
     startDevServerBrowser()
+    startPeriodicRefresh()
+  }
+
+  func refreshDevServers() async {
+    await restartBrowser()
+  }
+
+  private func restartBrowser() async {
+    pingTask?.cancel()
+    browser?.cancel()
+    pingTask = nil
+    browser = nil
+    startDevServerBrowser()
+    try? await Task.sleep(nanoseconds: 3_000_000_000)
+    await pingCurrentBrowseResults()
+  }
+
+  private func pingCurrentBrowseResults() async {
+    guard let browser, !browser.browseResults.isEmpty else {
+      return
+    }
+    await pingDiscoveryResults(browser.browseResults.map { result in
+      DiscoveryResult(
+        name: NetworkUtilities.getNWBrowserResultName(result),
+        endpoint: result.endpoint
+      )
+    })
+  }
+
+  private func startPeriodicRefresh() {
+    periodicRefreshTask?.cancel()
+    periodicRefreshTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: Self.refreshInterval)
+        guard !Task.isCancelled else {
+          return
+        }
+        await self?.refreshIfNeeded()
+      }
+    }
+  }
+
+  private func refreshIfNeeded() async {
+    if devServers.isEmpty {
+      await restartBrowser()
+    } else if browser?.browseResults.isEmpty ?? true {
+      updateDevServers([])
+    } else {
+      await pingCurrentBrowseResults()
+    }
   }
 
   func markNetworkPermissionGranted() {
+    guard permissionStatus != .granted else {
+      return
+    }
     UserDefaults.standard.set(true, forKey: networkPermissionGrantedKey)
     permissionStatus = .granted
   }
@@ -272,8 +338,10 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   func stopServerDiscovery() {
+    periodicRefreshTask?.cancel()
     pingTask?.cancel()
     browser?.cancel()
+    periodicRefreshTask = nil
     pingTask = nil
     browser = nil
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -76,6 +76,12 @@ public struct DevLauncherRootView: View {
 #endif
 
     navigationStack
+    .onAppear {
+      viewModel.startServerDiscovery()
+    }
+    .onDisappear {
+      viewModel.stopServerDiscovery()
+    }
     .sheet(isPresented: $showingUserProfile) {
       AccountSheet()
         .environmentObject(viewModel)

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -49,11 +49,19 @@ struct DevServersView: View {
 
       LazyVStack(alignment: .leading, spacing: 6) {
         if viewModel.devServers.isEmpty {
-          Text("No development servers found")
-            .foregroundColor(.primary)
-            .multilineTextAlignment(.leading)
+          // When local network permission is denied the banner above explains why
+          // discovery can't work, so don't pretend to search
+          if viewModel.permissionStatus != .denied {
+            HStack {
+              Text("Searching for development servers...")
+                .foregroundColor(.secondary)
+              Spacer()
+              ProgressView()
+                .controlSize(.small)
+            }
             .padding()
-          Divider()
+            Divider()
+          }
         } else {
           ForEach(viewModel.devServers, id: \.self) { server in
             DevServerRow(server: server) {
@@ -66,12 +74,6 @@ struct DevServersView: View {
         }
         enterUrl
       }
-    }
-    .onAppear {
-      viewModel.startServerDiscovery()
-    }
-    .onDisappear {
-      viewModel.stopServerDiscovery()
     }
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -49,8 +49,6 @@ struct DevServersView: View {
 
       LazyVStack(alignment: .leading, spacing: 6) {
         if viewModel.devServers.isEmpty {
-          // When local network permission is denied the banner above explains why
-          // discovery can't work, so don't pretend to search
           if viewModel.permissionStatus != .denied {
             HStack {
               Text("Searching for development servers...")

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -55,6 +55,11 @@ struct HomeTabView: View {
         }
         .padding()
       }
+      #if !os(tvOS)
+      .refreshable {
+        await viewModel.refreshDevServers()
+      }
+      #endif
     }
     #if os(tvOS)
     .background()


### PR DESCRIPTION
# Why
The Home tab's dev server list was unreliable, it sometimes showed "No development servers found" while a server was running, only updated after navigating away and back, and had no way to force a refresh. The Recently Opened online dots were also wrong whenever the list was stale. Discovery was torn down on every tab switch (onAppear/onDisappear on DevServersView), and an NWBrowser left idle for a while stops reporting services even though one is running, and re-querying its stale results can never recover.

# How
- Moved the discovery lifecycle up to DevLauncherRootView, which stays mounted while the launcher is open, so browsing runs continuously instead of restarting per tab switch.
- Added a periodic refresh every 10s
- Added pull-to-refresh on the Home tab
- Replaced "No development servers found" with a "Searching for development servers…" row since discovery
is always active while the list is empty. 

# Test Plan
Bare expo
On a device with a dev server running:
- Leave the launcher idle for an extended period, the list refreshes in place without flashing the searching state and without user interaction.
- Pull to refresh, re-syncs immediately.
- Fresh launch with no server running, the searching row shows immediately.

