### PR TITLE
[bare-expo] Add Playground tab for local repros

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -1,5 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {
+  BottomTabNavigationOptions,
+  createBottomTabNavigator,
+} from '@react-navigation/bottom-tabs';
 import { LinkingOptions } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
@@ -12,7 +15,11 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { AppMetrics } from 'expo-observe';
 import { ObserveNavigationContainer } from 'expo-observe/integrations/react-navigation';
 
-type NavigationRouteConfigMap = React.ComponentType;
+import Playground from './Playground';
+
+type NavigationRouteConfigMap = React.ComponentType & {
+  navigationOptions?: BottomTabNavigationOptions;
+};
 
 const testSuiteRouteName = 'test-suite';
 
@@ -20,6 +27,7 @@ type RoutesConfig = {
   [testSuiteRouteName]: NavigationRouteConfigMap;
   apis?: NavigationRouteConfigMap;
   components?: NavigationRouteConfigMap;
+  playground: NavigationRouteConfigMap;
 };
 
 type NativeComponentListExportsType = null | {
@@ -38,6 +46,7 @@ export function optionalRequire(requirer: () => { default: React.ComponentType }
 }
 const routes: RoutesConfig = {
   [testSuiteRouteName]: TestStackNavigator,
+  playground: Playground,
 };
 
 // TODO vonovak there's potential for skipping the require of APIs tab as it's not used in CI
@@ -108,14 +117,16 @@ function TabNavigator() {
         default: undefined,
       })}
       initialRouteName={testSuiteRouteName}>
-      {Object.keys(routes).map((name) => (
-        <Tab.Screen
-          name={name}
-          key={name}
-          component={routes[name]}
-          options={routes[name].navigationOptions}
-        />
-      ))}
+      {Object.entries(routes).map(([name, component]) =>
+        component ? (
+          <Tab.Screen
+            name={name}
+            key={name}
+            component={component}
+            options={component.navigationOptions}
+          />
+        ) : null
+      )}
     </Tab.Navigator>
   );
 }

--- a/apps/bare-expo/Playground.tsx
+++ b/apps/bare-expo/Playground.tsx
@@ -1,0 +1,47 @@
+import { useTheme } from 'ThemeProvider';
+import { TabBackground } from 'native-component-list/src/components/TabBackground';
+import TabIcon from 'native-component-list/src/components/TabIcon';
+import * as React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+// Empty scratch screen for isolating reproductions. Replace the contents with your repro code
+// and open it from the Playground tab. Revert your changes before committing unrelated work.
+export default function Playground() {
+  const { theme } = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background.default }]}>
+      <TabIcon name="flask-outline" size={48} />
+      <Text style={[styles.title, { color: theme.text.default }]}>Playground</Text>
+      <Text style={[styles.subtitle, { color: theme.text.secondary }]}>
+        Replace the contents of apps/bare-expo/Playground.tsx with your repro code.
+      </Text>
+    </View>
+  );
+}
+
+Playground.navigationOptions = {
+  title: 'Playground',
+  tabBarLabel: 'Playground',
+  tabBarIcon: ({ focused }: { focused: boolean }) => {
+    return <TabIcon name="flask-outline" focused={focused} />;
+  },
+  tabBarBackground: () => <TabBackground />,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  subtitle: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
# Why

Add an empty scratch screen to bare-expo for quickly isolating reproductions without touching test-suite or NCL screens.

# How

- Added `Playground.tsx`, a placeholder screen wired as a new bottom tab in `MainNavigator`.
- Typed the route map iteration with `Object.entries` and declared the `navigationOptions` static on `NavigationRouteConfigMap`, fixing the implicit-`any` indexing in `TabNavigator`.

# Test Plan

Opened the Playground tab in bare-expo on iOS and Android. Screenshot below.

<img width="300" height="auto" alt="simulator_screenshot_733E6539-639D-42E8-BA36-46A772B0AA6A" src="https://github.com/user-attachments/assets/2e2c33e5-8f8b-4938-90a0-e216a38cbc54" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)