### PR TITLE
[log-box][Android] Use `kotlin.srcDirs` instead of `java.srcDirs`

### DIFF
--- a/packages/@expo/log-box/android/build.gradle
+++ b/packages/@expo/log-box/android/build.gradle
@@ -24,7 +24,7 @@ android {
 
   sourceSets {
     main {
-      java.srcDirs += "src/main"
+      kotlin.srcDirs += "src/main"
     }
     if (isEnabled) {
       debug {


### PR DESCRIPTION
# Why

Uses `kotlin.srcDirs` instead of `java.srcDirs`. The current version won't work with AGP 9

# Test Plan

- bare-expo ✅ 