### PR TITLE
[metrics][Android] Remove `kotlin-android` plugin

### DIFF
--- a/packages/expo-app-metrics/android/build.gradle
+++ b/packages/expo-app-metrics/android/build.gradle
@@ -2,37 +2,36 @@ import expo.modules.plugin.gradle.ExpoModuleExtension
 
 apply plugin: 'com.android.library'
 apply plugin: 'expo-module-gradle-plugin'
-apply plugin: 'org.jetbrains.kotlin.android'
 
 buildscript {
-    ext {
-        getKspVersion = {
-            if (rootProject.hasProperty("kspVersion")) {
-                return rootProject["kspVersion"]
-            }
+  ext {
+    getKspVersion = {
+      if (rootProject.hasProperty("kspVersion")) {
+        return rootProject["kspVersion"]
+      }
 
-            def kotlinVersion = rootProject.hasProperty("kotlinVersion") ? rootProject["kotlinVersion"] : "2.0.21"
-            if (kotlinVersion == "2.1.20") {
-                return "2.1.20-2.0.1"
-            } else if (kotlinVersion == "2.0.21") {
-                return "2.0.21-1.0.28"
-            } else if (kotlinVersion == "1.9.25") {
-                return "1.9.25-1.0.20"
-            }
-            return "1.9.24-1.0.20"
-        }
+      def kotlinVersion = rootProject.hasProperty("kotlinVersion") ? rootProject["kotlinVersion"] : "2.0.21"
+      if (kotlinVersion == "2.1.20") {
+        return "2.1.20-2.0.1"
+      } else if (kotlinVersion == "2.0.21") {
+        return "2.0.21-1.0.28"
+      } else if (kotlinVersion == "1.9.25") {
+        return "1.9.25-1.0.20"
+      }
+      return "1.9.24-1.0.20"
     }
+  }
 
-    repositories
+  repositories
     {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+      google()
+      mavenCentral()
+      gradlePluginPortal()
     }
 
-    dependencies {
-        classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:${getKspVersion()}"
-    }
+  dependencies {
+    classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:${getKspVersion()}"
+  }
 }
 apply plugin: 'com.google.devtools.ksp'
 
@@ -44,54 +43,54 @@ version = packageJson.version
 def reactNativeVersion = project.extensions.getByType(ExpoModuleExtension).reactNativeVersion
 
 def expoSdkVersion = providers.exec {
-    commandLine("node", "--print", "require('expo/package.json').version")
+  commandLine("node", "--print", "require('expo/package.json').version")
 }.standardOutput.asText.get().trim()
 
 def easBuildId = System.getenv("EAS_BUILD_ID")
 
 android {
-    namespace "expo.modules.appmetrics"
+  namespace "expo.modules.appmetrics"
 
-    defaultConfig {
-        versionCode 1
-        versionName packageJson.version
+  defaultConfig {
+    versionCode 1
+    versionName packageJson.version
 
-        buildConfigField "String", "REACT_NATIVE_VERSION",
-                "\"${reactNativeVersion.major}.${reactNativeVersion.minor}.${reactNativeVersion.patch}\""
-        buildConfigField "String", "EXPO_APP_METRICS_VERSION", "\"${packageJson.version}\""
-        buildConfigField "String", "EXPO_SDK_VERSION", "\"${expoSdkVersion}\""
-        buildConfigField "String", "EXPO_EAS_BUILD_ID",
-                easBuildId != null ? "\"${easBuildId}\"" : "null"
-    }
+    buildConfigField "String", "REACT_NATIVE_VERSION",
+      "\"${reactNativeVersion.major}.${reactNativeVersion.minor}.${reactNativeVersion.patch}\""
+    buildConfigField "String", "EXPO_APP_METRICS_VERSION", "\"${packageJson.version}\""
+    buildConfigField "String", "EXPO_SDK_VERSION", "\"${expoSdkVersion}\""
+    buildConfigField "String", "EXPO_EAS_BUILD_ID",
+      easBuildId != null ? "\"${easBuildId}\"" : "null"
+  }
 }
 
 repositories {
-    google()
-    mavenCentral()
+  google()
+  mavenCentral()
 }
 
 dependencies {
-    implementation project(':expo-updates-interface')
-    implementation "com.facebook.react:react-android"
-    // `api` because `NetworkRequestInterceptor` and `NetworkRequestEventListener` are part of the
-    // public surface (apps with their own `OkHttpClient.Builder` opt in by adding our interceptor
-    // and event listener factory), and consumers need `okhttp3.Interceptor` /
-    // `okhttp3.EventListener.Factory` on the classpath to write that wiring. RN already exposes
-    // OkHttp via its own `api` dep, but we don't want to rely on that.
-    api "com.squareup.okhttp3:okhttp:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
-    // This is a workaround for IDE warning - https://youtrack.jetbrains.com/issue/KTIJ-31549
-    implementation "androidx.annotation:annotation-experimental:1.5.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
+  implementation project(':expo-updates-interface')
+  implementation "com.facebook.react:react-android"
+  // `api` because `NetworkRequestInterceptor` and `NetworkRequestEventListener` are part of the
+  // public surface (apps with their own `OkHttpClient.Builder` opt in by adding our interceptor
+  // and event listener factory), and consumers need `okhttp3.Interceptor` /
+  // `okhttp3.EventListener.Factory` on the classpath to write that wiring. RN already exposes
+  // OkHttp via its own `api` dep, but we don't want to rely on that.
+  api "com.squareup.okhttp3:okhttp:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
+  // This is a workaround for IDE warning - https://youtrack.jetbrains.com/issue/KTIJ-31549
+  implementation "androidx.annotation:annotation-experimental:1.5.1"
+  implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 
-    def room_version = "2.8.3"
-    implementation "androidx.room:room-runtime:$room_version"
-    implementation "androidx.room:room-ktx:$room_version"
-    ksp "androidx.room:room-compiler:$room_version"
+  def room_version = "2.8.3"
+  implementation "androidx.room:room-runtime:$room_version"
+  implementation "androidx.room:room-ktx:$room_version"
+  ksp "androidx.room:room-compiler:$room_version"
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.11.1'
-    testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'io.mockk:mockk:1.13.8'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-    testImplementation "com.squareup.okhttp3:mockwebserver:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.11.1'
+  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation 'io.mockk:mockk:1.13.8'
+  testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+  testImplementation "com.squareup.okhttp3:mockwebserver:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
 }


### PR DESCRIPTION
# Why

Removes `kotlin-android` plugin. It's added automatically by `expo-module-gradle-plugin`. I've also formatted the file. 

We have to remove this plugin to ensure the package works with AGP 9.

# Test Plan

- bare-expo ✅ 