### PR TITLE
[image][Android] Remove unused `kapt` plugin

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
 plugins {
   id 'com.android.library'
-  id 'kotlin-kapt'
   id 'expo-module-gradle-plugin'
 }
 


### PR DESCRIPTION
# Why

Removes unused `kapt` plugin.
Also, it would break the AGP integration. 


# Test Plan

- bare-expo ✅ 