### PR TITLE
[network-addons][Android] Use `compilerOptions` instead of `kotlinOptions`

### DIFF
--- a/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
+++ b/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -22,8 +23,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 


### PR DESCRIPTION
# Why

Uses `compilerOptions` instead of `kotlinOptions`. 
The `kotlinOptions` is deprecated and won't work with AGP 9.

# Test Plan

- bare-expo ✅ 