### PR TITLE
[core][Android] Use `kotlin.srcDirs` instead of `java.srcDirs`

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -180,7 +180,7 @@ android {
 
   sourceSets {
     main {
-      java {
+      kotlin {
         if (shouldIncludeCompose) {
           srcDirs += 'src/compose'
         } else {


### PR DESCRIPTION
# Why

Uses `kotlin.srcDirs` instead of deprecated `java.srcDirs`.
The new configuration works with both AGP 8 and 9.

# Test Plan

- bare-expo ✅ 