### PR TITLE
[core][Android] Fix publish task registration on AGP 9

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -100,25 +100,31 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
     .applyPublishingVariant()
 
   afterEvaluate {
-    val publicationInfo = PublicationInfo(this)
+    val project = this
+    // AGP 9's built-in Kotlin registers the "release" software component later than our
+    // afterEvaluate, so react when it becomes available instead of reading it eagerly. On AGP 8
+    // the component already exists, so this fires immediately.
+    components.matching { it.name == "release" }.all {
+      val publicationInfo = PublicationInfo(project)
 
-    publishingExtension()
-      .publications
-      .createReleasePublication(
-        publicationInfo,
-        expoModulesExtension.pomConfigurator
-      )
+      project.publishingExtension()
+        .publications
+        .createReleasePublication(
+          publicationInfo,
+          expoModulesExtension.pomConfigurator
+        )
 
-    createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
+      project.createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
 
-    val npmLocalRepositoryRelativePath = "local-maven-repo"
-    val npmLocalRepository = File("${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}").toURI()
-    publishingExtension().repositories.mavenLocal { mavenRepo ->
-      mavenRepo.name = "NPMPackage"
-      mavenRepo.url = npmLocalRepository
+      val npmLocalRepositoryRelativePath = "local-maven-repo"
+      val npmLocalRepository = File("${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}").toURI()
+      project.publishingExtension().repositories.mavenLocal { mavenRepo ->
+        mavenRepo.name = "NPMPackage"
+        mavenRepo.url = npmLocalRepository
+      }
+
+      project.createExpoPublishTask(publicationInfo, expoModulesExtension, npmLocalRepositoryRelativePath)
     }
-
-    createExpoPublishTask(publicationInfo, expoModulesExtension, npmLocalRepositoryRelativePath)
   }
 }
 


### PR DESCRIPTION
# Why


The expo-module-gradle-plugin's publishing tasks fail to register when building with AGP 9. AGP 9 switches to a built-in Kotlin plugin that registers the `release` software component later than the plugin's `afterEvaluate` block runs. Because the plugin read the `release` component eagerly inside `afterEvaluate`, the component didn't exist yet on AGP 9 and publication setup never happened.

# Test Plan

- bare-expo ✅ 