### PR TITLE
[expo-cli] Make browser-based login default

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
+
 ### 🎉 New features
 
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -41,7 +41,8 @@ it('runs `npx expo login --help`', async () => {
         -p, --password <string>  Password ("-" for stdin)
         --otp <string>           One-time password from your 2FA device
         -s, --sso                Log in with SSO
-        -b, --browser            Log in with a browser
+        -b, --browser            Log in with a browser (default)
+        --no-browser             Log in with username and password instead of a browser
         -h, --help               Usage info
     "
   `);

--- a/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
@@ -1,3 +1,4 @@
+import { isInteractive } from '../../../utils/interactive';
 import { promptAsync } from '../../../utils/prompts';
 import { ApiV2Error } from '../../rest/client';
 import { showLoginPromptAsync } from '../actions';
@@ -5,6 +6,7 @@ import { retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } f
 import { loginAsync, browserLoginAsync } from '../user';
 
 jest.mock('../../../log');
+jest.mock('../../../utils/interactive');
 jest.mock('../../../utils/prompts');
 jest.mock('../../rest/client', () => {
   const { ApiV2Error } = jest.requireActual('../../rest/client');
@@ -23,6 +25,10 @@ beforeEach(() => {
 
   jest.mocked(loginAsync).mockClear();
   jest.mocked(browserLoginAsync).mockClear();
+
+  // Default to a non-interactive environment so the credential prompt path is
+  // exercised unless a test opts into an interactive terminal.
+  jest.mocked(isInteractive).mockReturnValue(false);
 });
 
 describe(showLoginPromptAsync, () => {
@@ -117,5 +123,53 @@ describe(showLoginPromptAsync, () => {
 
     expect(browserLoginAsync).toHaveBeenCalledTimes(1);
     expect(browserLoginAsync).toHaveBeenCalledWith({ sso: false });
+  });
+
+  it('defaults to browser login in an interactive terminal when browser is unset', async () => {
+    jest.mocked(isInteractive).mockReturnValue(true);
+
+    await showLoginPromptAsync();
+
+    expect(browserLoginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).toHaveBeenCalledWith({ sso: false });
+    expect(loginAsync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to username/password login in a non-interactive environment', async () => {
+    jest.mocked(isInteractive).mockReturnValue(false);
+    jest
+      .mocked(promptAsync)
+      .mockReset()
+      .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }));
+    jest.mocked(loginAsync).mockImplementation(async () => {});
+
+    await showLoginPromptAsync();
+
+    expect(loginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).not.toHaveBeenCalled();
+  });
+
+  it('uses username/password login when credentials are provided, even in an interactive terminal', async () => {
+    jest.mocked(isInteractive).mockReturnValue(true);
+    jest.mocked(loginAsync).mockImplementation(async () => {});
+
+    await showLoginPromptAsync({ username: 'hello', password: 'world' });
+
+    expect(loginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).not.toHaveBeenCalled();
+  });
+
+  it('uses username/password login when browser is explicitly false', async () => {
+    jest.mocked(isInteractive).mockReturnValue(true);
+    jest
+      .mocked(promptAsync)
+      .mockReset()
+      .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }));
+    jest.mocked(loginAsync).mockImplementation(async () => {});
+
+    await showLoginPromptAsync({ browser: false });
+
+    expect(loginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -31,7 +31,9 @@ export async function showLoginPromptAsync({
   }
   const hasCredentials = options.username && options.password;
   const sso = options.sso;
-  const browser = options.browser;
+
+  // Browser-based login is the default.
+  const browser = options.browser ?? (!hasCredentials && isInteractive());
 
   if (printNewLine) {
     Log.log();

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -41,6 +41,7 @@ export async function showLoginPromptAsync({
 
   if (sso || browser) {
     await browserLoginAsync({ sso: !!sso });
+    Log.log('Logged in');
     return;
   }
 
@@ -96,6 +97,8 @@ export async function showLoginPromptAsync({
       throw e;
     }
   }
+
+  Log.log('Logged in');
 }
 
 export async function tryGetUserAsync(): Promise<Actor | null> {

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -13,6 +13,7 @@ export const expoLogin: Command = async (argv) => {
       '--otp': String,
       '--sso': Boolean,
       '--browser': Boolean,
+      '--no-browser': Boolean,
       // Aliases
       '-h': '--help',
       '-u': '--username',
@@ -32,13 +33,16 @@ export const expoLogin: Command = async (argv) => {
         `-p, --password <string>  Password ("-" for stdin)`,
         `--otp <string>           One-time password from your 2FA device`,
         `-s, --sso                Log in with SSO`,
-        `-b, --browser            Log in with a browser`,
+        `-b, --browser            Log in with a browser (default)`,
+        `--no-browser             Log in with username and password instead of a browser`,
         `-h, --help               Usage info`,
       ].join('\n')
     );
   }
 
   const password = args['--password'] === '-' ? await readWordFromStdin() : args['--password'];
+
+  const browser = args['--no-browser'] ? false : args['--browser'] ? true : undefined;
 
   const { showLoginPromptAsync } = await import('../api/user/actions.js');
   return showLoginPromptAsync({
@@ -47,7 +51,7 @@ export const expoLogin: Command = async (argv) => {
     password,
     otp: args['--otp'],
     sso: !!args['--sso'],
-    browser: !!args['--browser'],
+    browser,
   }).catch(logCmdError);
 };
 


### PR DESCRIPTION
# Why
Closes ENG-21850 , and gets expo-cli up-to-date with eas-cli: https://github.com/expo/eas-cli/pull/3746

# How
Added a --no-browser option for parity with eas-cli, and for anyone that wants to keep the current behavior. Made the --browser option the default when in an interactive env.

# Test Plan
Run tests. Also verified happy-path manually.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
