### PR TITLE
[skills] Add native ABI check to deep-code-review

### DIFF
--- a/.claude/skills/deep-code-review/SKILL.md
+++ b/.claude/skills/deep-code-review/SKILL.md
@@ -65,6 +65,7 @@ Evaluate the diff against the context gathered. Single checklist:
 - **Performance** - Unbounded growth? Blocking operations?
 - **Testing** - Coverage adequate? Happy path + edge cases + error cases?
 - **Breaking changes** - API contracts preserved? Migration needed?
+- **Native ABI** (prebuilt Swift/Kotlin packages: `expo-modules-core`, `expo-modules-jsi`) - A change can be source-compatible but binary-incompatible: consumers prebuilt against the old artifact fail at link/load. Removing/renaming a `public`/`open` symbol? Moving a method into a protocol extension (remangles it)? Changing a signature/generics/`@available`, or a conformance that alters the `.swiftinterface`? Only real if the symbol is already released on the PR's target branch (exempt if it's new there); a PR targeting an `sdk-*` release branch is the riskiest case. A forwarding shim preserves the old symbol. If practically-exposed, flag it as a `critical` inline comment on the symbol and recommend the `breaking: ABI` label (suggest only — don't apply it).
 - **Stack coherence** (stacked PRs only) - Does the aggregate diff across the stack make sense as a whole?
 - **Adversarial examples** - Study the public API and any example code in the PR(s). Devise alternative examples that exercise edge cases, misuse the API, or pass unexpected inputs. Report any that produce bugs, crashes, or incorrect behavior.
 


### PR DESCRIPTION
## Why

A recent change ([#46555](https://github.com/expo/expo/pull/46555)) moved the `emit(...)` methods from `SharedObject` (a class) into a shared `EventEmitter` protocol extension. That kind of change is **source-compatible but binary-incompatible**: for packages we distribute as prebuilt artifacts (`expo-modules-core`, `expo-modules-jsi`), a consumer compiled against the old artifact resolves mangled symbols at link/load time, so relocating or removing a `public`/`open` symbol can fail dyld even though every in-repo call site still compiles. The existing review checklist only had a generic "Breaking changes" item, which doesn't capture this native-ABI nuance, so it's easy to wave off as "source still compiles, looks fine."

## How

Adds a dedicated **Native ABI** item to the deep-code-review skill's Phase 2 checklist. It prompts the reviewer to watch for the binary-break patterns (symbol removal/rename, class method → protocol extension relocation, signature/generics/`@available` changes, conformances that alter the `.swiftinterface`), distinguish a *technically*-a-break from a *practically*-exposed one (a symbol that lived only a single unreleased SDK cycle can't be mismatched), notes the heightened risk of backporting such a change to a release branch, and points to forwarding shims as the fix.

For a practically-exposed break it directs the skill to flag a `critical` inline comment on the changed symbol (so it isn't skimmed past in the summary) and recommend the `breaking: ABI` label — suggest-only, consistent with the skill's existing no-auto-write rule. A matching `breaking: ABI` repo label was created alongside this change.

## Test Plan

Docs-only change to a skill (`.claude/skills/deep-code-review/SKILL.md`); no build or test step applies. Reviewed the rendered checklist item for accuracy against the ABI scenario that motivated it.
