### PR TITLE
[ios][image-picker] add event to user finishes selecting media and selector sheet closes

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Allow `launchCameraAsync` to be invoked on the simulator. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))
-- [iOS] Add an event that notifies when the user has finished selecting media and the selector sheet closes. ([#46708](ADD_PR_URL) by [@AbeUribe831](https://github.com/AbeUribe831))
+- [iOS] Add an event that notifies when the user has finished selecting media and the selector sheet closes. ([#46708](https://github.com/expo/expo/pull/46837) by [@AbeUribe831](https://github.com/AbeUribe831))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Allow `launchCameraAsync` to be invoked on the simulator. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))
+- [iOS] Add an event that notifies when the user has finished selecting media and the selector sheet closes. ([#46708](ADD_PR_URL) by [@AbeUribe831](https://github.com/AbeUribe831))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -25,6 +25,9 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     // TODO: (@bbarthec) change to "ExpoImagePicker" and propagate to other platforms
     Name("ExponentImagePicker")
 
+    // Emitted when user finishes media selection, but before processing media which can take time to download from iCloud.
+    Events("onSelectionFinished")
+
     OnCreate {
       self.appContext?.permissions?.register([
         CameraPermissionRequester(),
@@ -201,6 +204,11 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
   }
 
   func didPickMultipleMedia(selection: [PHPickerResult]) {
+    self.sendEvent("onSelectionFinished", [
+      "selectionCount": selection.count,
+      "assetIds": selection.compactMap { $0.assetIdentifier }
+    ])
+
     guard let options = self.currentPickingContext?.options,
           let promise = self.currentPickingContext?.promise else {
       log.error("Picking operation context has been lost.")


### PR DESCRIPTION
# Why
When user selects lots of media that is stored in iCloud, especially larger videos, the selector closes but the method `ImagePicker.launchImageLibraryAsync` does not resolve until all the media has been downloaded. Between the time when the image selector closes and when the media downloads can take minutes. Developers have no option to continue their UI flow or add their own loading state as their is no indication that the selector closed. 

# How
* Add a `onSelectionFinished` event that emits when the selector closes and before the media (assets) are processed. 

```
// code snipped on how to use
const ExponentImagePicker = requireNativeModule('ExponentImagePicker') as {
  addListener: (
    eventName: 'onSelectionFinished',
    listener: (event: SelectionFinishedEvent) => void
  ) => EventSubscription
}


export function addSelectionFinishedListener(
  listener: (event: SelectionFinishedEvent) => void
): EventSubscription {
  return ExponentImagePicker.addListener('onSelectionFinished', listener)
}

--------------------

const selectionFinishedListener = addSelectionFinishedListener(() => navigation.navigate('NextScreen'));
```



# Test Plan
* To test without the fix, [this branch](https://github.com/AbeUribe831/expo-fork/tree/expo-image-picker-select-media-bug) has a demo screen with a screen recording to go with it below
* Similar branch but with the fix [here](https://github.com/AbeUribe831/expo-fork/tree/expo-image-picker-listener-demo), and screen recording below


https://github.com/user-attachments/assets/396d2420-a022-4d13-95b3-1e94e1c339cd


https://github.com/user-attachments/assets/c50185d9-7f4e-4dae-b578-48c14d166d43




# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
