### PR TITLE
[e2e] Reduce flakiness from cold-start deep links and slow video startup

### DIFF
--- a/apps/bare-expo/e2e/expo-video/playback-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/playback-test.yaml
@@ -24,7 +24,7 @@ jsEngine: graaljs
 # asserting instantly to avoid a startup race.
 - extendedWaitUntil:
     visible: 'isPlaying = true'
-    timeout: 10000
+    timeout: 30000
 - assertVisible: 'isAtStart = false'
 
 - tapOn: Pause

--- a/apps/bare-expo/e2e/expo-video/player-output-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/player-output-test.yaml
@@ -11,7 +11,7 @@ jsEngine: graaljs
 - extendedWaitUntil:
     visible:
       id: 'viewshot-ready'
-    timeout: 10000
+    timeout: 30000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -25,7 +25,7 @@ jsEngine: graaljs
 - extendedWaitUntil:
     visible:
       id: 'viewshot-ready'
-    timeout: 10000
+    timeout: 30000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -37,7 +37,7 @@ jsEngine: graaljs
 - extendedWaitUntil:
     visible:
       id: 'viewshot-ready'
-    timeout: 10000
+    timeout: 30000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -55,7 +55,7 @@ jsEngine: graaljs
 - extendedWaitUntil:
     visible:
       id: 'viewshot-ready'
-    timeout: 10000
+    timeout: 30000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -57,6 +57,13 @@ jsEngine: graaljs
 - tapOn:
     text: "Open"
     optional: true
+# Wait for the cold start + deep link to land before the per-test loop fires more
+# deep links. Otherwise the next openLink races app boot and is swallowed, flaking
+# the first test case.
+- extendedWaitUntil:
+    visible:
+      id: "test_suite_selection_query_text"
+    timeout: 60000
 `);
   }
 


### PR DESCRIPTION
# Why

Reduce iOS 26 `ios-test-e2e` retries that slow CI and hide real failures.

# How

- Gate the generated test-suite flow on the app being up (`test_suite_selection_query_text` visible) before the per-test loop fires deep links, so the second `openLink` no longer races a cold start and gets swallowed.
- Raise the `playback-test` (`isPlaying`) and `player-output-test` (`viewshot-ready`) waits from 10s to 30s to ride out slow simulators.

# Test Plan

E2E flow changes covered by the existing `ios-test-e2e` job. After this, the Native modules suite should pass on attempt 1 and the two video flows should stop retrying on slow runners.

# Checklist

<!-- Test-only change (bare-expo e2e flows + generator script); no shipped sources, no CHANGELOG/rebuild/prebuild impact. -->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
