### PR TITLE
[docs][tutorial] Fix missing highlight annotations in gesture tutorial

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -100,13 +100,14 @@ In the **EmojiSticker.tsx** file:
 2. To recognize the tap on the sticker, import `useAnimatedStyle`, `useSharedValue`, and `withSpring` from `react-native-reanimated` to animate the style of the `<Animated.Image>`.
 3. Inside the `EmojiSticker` component, create a reference called `scaleImage` using the `useSharedValue()` hook. It will take the value of `imageSize` as its initial value.
 
+{/* prettier-ignore */}
 ```tsx components/EmojiSticker.tsx
 // ...rest of the import statements remain same
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+/* @tutinfo Import `Gesture` and `GestureDetector` from `react-native-gesture-handler`. */import { Gesture, GestureDetector } from 'react-native-gesture-handler';/* @end */
+/* @tutinfo Import `useAnimatedStyle`, `useSharedValue`, and `withSpring` from `react-native-reanimated`. */import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';/* @end */
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
-  const scaleImage = useSharedValue(imageSize);
+  /* @tutinfo Create a `scaleImage` shared value and set `imageSize` as its initial value. */const scaleImage = useSharedValue(imageSize);/* @end */
 
   return (
     // ...rest of the code remains same


### PR DESCRIPTION
# Why

Closes #46842.

The “Add a tap gesture” section in the gestures tutorial had a code snippet where the newly added lines were not highlighted in green, unlike the rest of the tutorial. This made the step less clear for readers following the tutorial.

# How

Added `@tutinfo` annotations around the newly introduced imports and `scaleImage` shared value in `docs/pages/tutorial/gestures.mdx`.

These annotations are transformed by the docs renderer into `tutorial-code-annotation with-tooltip`, which applies the green tutorial highlight and tooltip behavior.

I also added `prettier-ignore` before the snippet so the inline annotation comments are preserved consistently with nearby tutorial code blocks.

# Test Plan

- Checked the surrounding tutorial snippets to confirm the existing annotation pattern.
- Verified there is no corresponding `docs/pages/versions/unversioned/tutorial/gestures.mdx` file to update.
- Confirmed the changed snippet now uses `@tutinfo` annotations for the affected lines.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)