### PR TITLE
[docs][file-system] Improve FileHandle TSDoc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -241,6 +241,39 @@ try {
 
 </Collapsible>
 
+<Collapsible summary="Random-access reads with FileHandle">
+
+Use [`FileHandle`](#filehandle) for efficient, random-access reads of large files without loading the entire file into memory. Obtain a handle by calling `file.open()`, read or write at any position using the `offset` property, and always close the handle when finished.
+
+```ts example.ts
+import { File, Paths, FileMode } from 'expo-file-system';
+
+const file = new File(Paths.document, 'recording.wav');
+const handle = file.open(FileMode.ReadOnly);
+
+// Read the WAV header (first 44 bytes)
+const header = handle.readBytesSync(44);
+const sampleRate = new DataView(header.buffer).getUint32(24, true);
+console.log(`Sample rate: ${sampleRate} Hz`);
+
+// Seek to a specific offset and read a chunk
+handle.offset = 1024;
+const chunk = await handle.readBytes(4096);
+console.log(`Read ${chunk.length} bytes from offset 1024`);
+
+// Read an entire file in 64 KB chunks
+handle.offset = 0;
+const CHUNK_SIZE = 64 * 1024;
+while (handle.offset! < handle.size!) {
+  const data = await handle.readBytes(CHUNK_SIZE);
+  // Process data...
+}
+
+handle.close();
+```
+
+</Collapsible>
+
 <Collapsible summary="Using legacy FileSystem API">
 
 ```ts example.ts

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 💡 Others
 
 - Improve read/write performance on Android by applying `withContext(Dispatchers.IO)` when possible. ([#46376](https://github.com/expo/expo/pull/46376) by [@wh201906](https://github.com/wh201906))
-- Improved `FileHandle` docs.
+- Improved `FileHandle` docs. ([#46849](https://github.com/expo/expo/pull/46849) by [@barthap](https://github.com/barthap))
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - Improve read/write performance on Android by applying `withContext(Dispatchers.IO)` when possible. ([#46376](https://github.com/expo/expo/pull/46376) by [@wh201906](https://github.com/wh201906))
+- Improved `FileHandle` docs.
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-file-system/src/File.ts
+++ b/packages/expo-file-system/src/File.ts
@@ -173,10 +173,25 @@ export class File extends ExpoFileSystem.FileSystemFile implements Blob {
     return Paths.basename(this.uri);
   }
 
+  /**
+   * Creates a `ReadableStream` that reads from this file using a `FileHandle` internally.
+   *
+   * The stream reads in 1024-byte chunks by default. The underlying file handle is
+   * closed automatically when the stream is fully consumed or cancelled.
+   *
+   * @return A byte-oriented `ReadableStream` backed by this file.
+   */
   readableStream() {
     return new ReadableStream(new FileSystemReadableStreamSource(super.open(FileMode.ReadOnly)));
   }
 
+  /**
+   * Creates a `WritableStream` that writes to this file using a `FileHandle` internally.
+   *
+   * The underlying file handle is closed automatically when the stream is closed or aborted.
+   *
+   * @return A `WritableStream` that accepts `Uint8Array` chunks.
+   */
   writableStream() {
     return new WritableStream<Uint8Array>(
       new FileSystemWritableSink(super.open(FileMode.WriteOnly))
@@ -198,6 +213,12 @@ export class File extends ExpoFileSystem.FileSystemFile implements Blob {
     }).formData();
   }
 
+  /**
+   * Returns a `ReadableStream` for this file. This is an alias for `readableStream()`
+   * and implements the `Blob.stream()` interface.
+   *
+   * @return A byte-oriented `ReadableStream` backed by this file.
+   */
   stream(): ReadableStream<Uint8Array<ArrayBuffer>> {
     return this.readableStream();
   }

--- a/packages/expo-file-system/src/File.types.ts
+++ b/packages/expo-file-system/src/File.types.ts
@@ -105,7 +105,7 @@ export enum FileMode {
  * const file = new File(Paths.cache, 'data.bin');
  * const handle = file.open(FileMode.ReadOnly);
  *
- * // Read the first 4 bytes (e.g., a magic number)
+ * // Read the first 4 bytes (for example, a magic number)
  * const header = handle.readBytesSync(4);
  *
  * // Seek to byte 100 and read 50 bytes

--- a/packages/expo-file-system/src/File.types.ts
+++ b/packages/expo-file-system/src/File.types.ts
@@ -87,39 +87,95 @@ export enum FileMode {
   Truncate = 'wt',
 }
 
+/**
+ * Provides low-level, random-access read and write operations on a file.
+ *
+ * Obtain a `FileHandle` by calling [`File.open()`](#openmode) on a `File` instance.
+ * The handle maintains an internal byte offset that advances automatically with each
+ * read or write. Set the `offset` property to seek to an arbitrary position.
+ *
+ * Always call `close()` when finished to release the underlying file descriptor.
+ * Failing to close a handle may prevent the file from being deleted, moved, or
+ * opened by another process.
+ *
+ * @example
+ * ```ts
+ * import { File, Paths, FileMode } from 'expo-file-system';
+ *
+ * const file = new File(Paths.cache, 'data.bin');
+ * const handle = file.open(FileMode.ReadOnly);
+ *
+ * // Read the first 4 bytes (e.g., a magic number)
+ * const header = handle.readBytesSync(4);
+ *
+ * // Seek to byte 100 and read 50 bytes
+ * handle.offset = 100;
+ * const chunk = await handle.readBytes(50);
+ *
+ * handle.close();
+ * ```
+ */
 export declare class FileHandle {
-  /*
-   * Closes the file handle. This allows the file to be deleted, moved or read by a different process. Subsequent calls to `readBytes`, `writeBytes`, `readBytesSync` or `writeBytesSync` will throw an error.
+  /**
+   * Closes the file handle and releases the underlying file descriptor.
+   *
+   * After closing, the `offset` and `size` properties return `null`, and any
+   * subsequent call to `readBytes`, `readBytesSync`, `writeBytes`, or
+   * `writeBytesSync` throws an error.
    */
   close(): void;
-  /*
-   * Reads the specified amount of bytes from the file at the current offset. Max amount of bytes read at once is capped by ArrayBuffer max size (32 bit signed MAX_INT on Android and 64 bit on iOS), but you can read from a FileHandle multiple times.
+  /**
+   * Reads up to `length` bytes from the file starting at the current offset.
+   *
+   * The returned `Uint8Array` may contain fewer than `length` bytes if the end of the
+   * file is reached. Returns an empty `Uint8Array` when the offset is already at or
+   * past the end of the file. The `offset` advances by the number of bytes actually read.
+   *
+   * The maximum number of bytes that can be read in a single call is limited by the
+   * platform's `ArrayBuffer` size: 2 GB (signed 32-bit max) on Android, and the 64-bit
+   * limit on iOS. To read larger files, call this method in a loop.
+   *
    * @param length The number of bytes to read.
+   * @return A promise fulfilled with a `Uint8Array` containing the bytes read.
    */
   readBytes(length: number): Promise<Uint8Array<ArrayBuffer>>;
-  /*
-   * Reads the specified amount of bytes from the file at the current offset. Max amount of bytes read at once is capped by ArrayBuffer max size (32 bit signed MAX_INT on Android and 64 bit on iOS), but you can read from a FileHandle multiple times.
+  /**
+   * Reads up to `length` bytes from the file starting at the current offset, synchronously.
+   *
+   * Behaves identically to `readBytes` but blocks the JS thread until the data is available.
+   *
    * @param length The number of bytes to read.
+   * @return A `Uint8Array` containing the bytes read.
    */
   readBytesSync(length: number): Uint8Array<ArrayBuffer>;
-  /*
-   * Writes the specified bytes to the file at the current offset.
-   * @param bytes A `Uint8Array` array containing bytes to write.
+  /**
+   * Writes the provided bytes to the file at the current offset, then advances the
+   * offset by the number of bytes written.
+   *
+   * @param bytes A `Uint8Array` containing the bytes to write.
    */
   writeBytes(bytes: Uint8Array): Promise<void>;
-  /*
-   * Writes the specified bytes to the file at the current offset.
-   * @param bytes A `Uint8Array` array containing bytes to write.
+  /**
+   * Writes the provided bytes to the file at the current offset synchronously, then
+   * advances the offset by the number of bytes written.
+   *
+   * @param bytes A `Uint8Array` containing the bytes to write.
    */
   writeBytesSync(bytes: Uint8Array): void;
-  /*
-   * A property that indicates the current byte offset in the file. Calling `readBytes`, `writeBytes`, `readBytesSync` or `writeBytesSync` will read or write a specified amount of bytes starting from this offset. The offset is incremented by the number of bytes read or written.
-   * The offset can be set to any value within the file size. If the offset is set to a value greater than the file size, the next write operation will append data to the end of the file.
-   * Null if the file handle is closed.
+  /**
+   * The current byte offset in the file.
+   *
+   * Reading or writing advances the offset by the number of bytes processed. Set this
+   * property to seek to an arbitrary position before the next read or write. If set to
+   * a value greater than the file size, the next write appends data at the end of the file.
+   *
+   * Returns `null` after the handle has been closed.
    */
   offset: number | null;
-  /*
-   * A size of the file in bytes or `null` if the file handle is closed.
+  /**
+   * The total size of the file in bytes, or `null` if the handle has been closed.
+   *
+   * Reading this property does not change the current offset.
    */
   size: number | null;
 }


### PR DESCRIPTION
# Why

`FileHandle` is the recommended API for bounded, random-access reads of large local files — especially useful for media and container parsers — but the existing TSDoc was sparse and the docs site had no usage example showing this pattern.

# How

- Rewrote `FileHandle` class and method TSDoc with detailed descriptions, `@param`/`@return` tags, and a class-level `@example`.
- Added TSDoc to `File.readableStream()`, `File.writableStream()`, and `File.stream()`.
- Added a "Random-access reads with FileHandle" collapsible section to the `expo-file-system` docs page with a WAV-header parsing example and a chunked-read loop.

# Test Plan

Generated API data and previewed docs website locally

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
