### PR TITLE
[expo][Android] Use `proguard-android-optimize.txt`

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
         benchmark {
             initWith buildTypes.release

--- a/apps/minimal-tester/android/app/build.gradle
+++ b/apps/minimal-tester/android/app/build.gradle
@@ -116,7 +116,7 @@ android {
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             def enablePngCrunchInRelease = findProperty('android.enablePngCrunchInReleaseBuilds') ?: 'true'
             crunchPngs enablePngCrunchInRelease.toBoolean()
         }

--- a/packages/@expo/cli/src/prebuild/__tests__/fixtures/react-native-project.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/fixtures/react-native-project.ts
@@ -1149,7 +1149,7 @@ export default {
               release {
                   signingConfig signingConfigs.debug
                   minifyEnabled enableMinifyInReleaseBuilds
-                  proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+                  proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
               }
           }
           applicationVariants.all { variant ->

--- a/packages/@expo/config-plugins/src/android/__tests__/fixtures/build-with-incorrect-create-manifest-android-path.gradle
+++ b/packages/@expo/config-plugins/src/android/__tests__/fixtures/build-with-incorrect-create-manifest-android-path.gradle
@@ -162,7 +162,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 

--- a/packages/@expo/config-plugins/src/android/__tests__/fixtures/build-without-create-manifest-android.gradle
+++ b/packages/@expo/config-plugins/src/android/__tests__/fixtures/build-without-create-manifest-android.gradle
@@ -161,7 +161,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 

--- a/packages/expo-build-properties/src/__tests__/android-pch-test.ts
+++ b/packages/expo-build-properties/src/__tests__/android-pch-test.ts
@@ -43,7 +43,7 @@ android {
         release {
             signingConfig signingConfigs.debug
             minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidResources {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `Record` arguments crashing with a `NullPointerException` in R8-optimized release builds when converted through the reflection fallback path. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Keep the `Record` marker interface so its consumer ProGuard rule keeps matching after R8 optimization removes empty marker interfaces. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
 - [android] Add a synchronous shadow node size update path, fixing a layout shift for `Host` `matchContents` views. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `NullPointerException` crash when a `matchContents` view is unmounted while a shadow node size update is pending (e.g. closing a bottom sheet mid-resize). ([#46785](https://github.com/expo/expo/pull/46785) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Accept JS `Double` timestamps in `Date` Convertible. JS numbers arrive across the JSI bridge as Swift `Double`; the prior `as? Int` branch never matched, throwing `ConvertingException<Date>` whenever a JS caller passed `someDate.getTime()` to a `Date` / `Date?` argument. ([#46340](https://github.com/expo/expo/pull/46340) by [@kyleasaff](https://github.com/kyleasaff))

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -3,13 +3,18 @@
   @expo.modules.core.interfaces.DoNotStrip *;
 }
 
+-keep interface expo.modules.kotlin.records.Record
+
 -keep class * implements expo.modules.kotlin.records.Record {
   *;
 }
+
 -keep class * extends expo.modules.kotlin.sharedobjects.SharedObject
+
 -keep enum * implements expo.modules.kotlin.types.Enumerable {
   *;
 }
+
 -keepnames class kotlin.Pair
 
 -keep,allowoptimization,allowobfuscation class * extends expo.modules.kotlin.modules.Module {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -52,7 +52,7 @@ class ReflectionRecordConversionStrategy<T : Record>(
 ) {
   private data class PropertyDescriptor(
     val typeConverter: TypeConverter<*>,
-    val fieldAnnotation: Field,
+    val key: String,
     val isRequired: Boolean
   )
 
@@ -66,10 +66,11 @@ class ReflectionRecordConversionStrategy<T : Record>(
         val typeConverter = converterProvider.obtainTypeConverter(
           property.returnType.toTypeDescriptor()
         )
+        val key = fieldAnnotation.key.takeUnless { it.isBlank() } ?: property.name
 
         return@mapNotNull property to PropertyDescriptor(
           typeConverter,
-          fieldAnnotation,
+          key,
           isRequired = property.findAnnotation<Required>() != null
         )
       }
@@ -82,7 +83,7 @@ class ReflectionRecordConversionStrategy<T : Record>(
 
     propertyDescriptors
       .forEach { (property, descriptor) ->
-        val jsKey = descriptor.fieldAnnotation.key.takeUnless { it.isBlank() } ?: property.name
+        val jsKey = descriptor.key
 
         if (!jsMap.hasKey(jsKey)) {
           if (descriptor.isRequired) {
@@ -114,7 +115,7 @@ class ReflectionRecordConversionStrategy<T : Record>(
 
     propertyDescriptors
       .forEach { (property, descriptor) ->
-        val key = descriptor.fieldAnnotation.key.takeUnless { it.isBlank() } ?: property.name
+        val key = descriptor.key
 
         if (!map.containsKey(key)) {
           if (descriptor.isRequired) {

--- a/packages/expo-test-runner/templates/detox/android/app/build.gradle
+++ b/packages/expo-test-runner/templates/detox/android/app/build.gradle
@@ -250,7 +250,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 

--- a/packages/install-expo-modules/src/plugins/cli/__tests__/fixtures/appBuild-rn072-updated.gradle
+++ b/packages/install-expo-modules/src/plugins/cli/__tests__/fixtures/appBuild-rn072-updated.gradle
@@ -104,7 +104,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/packages/install-expo-modules/src/plugins/cli/__tests__/fixtures/appBuild-rn072.gradle
+++ b/packages/install-expo-modules/src/plugins/cli/__tests__/fixtures/appBuild-rn072.gradle
@@ -99,7 +99,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -116,7 +116,7 @@ android {
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             def enablePngCrunchInRelease = findProperty('android.enablePngCrunchInReleaseBuilds') ?: 'true'
             crunchPngs enablePngCrunchInRelease.toBoolean()
         }


### PR DESCRIPTION
# Why

Switching to `proguard-android-optimize.txt` enables the optimizing R8 ruleset, producing smaller and faster release builds. This is Google's recommended default for new apps, and ProGuard/R8 optimizations are considered safe for the vast majority of projects.

# Test Plan

- `et check-packages @expo/cli @expo/config-plugins expo-build-properties install-expo-modules` ✅ 
- `bare-expo` ✅ 