### PR TITLE
[expo][iOS] Fix reload crash when the previous AppContext deallocates before the old runtime finishes teardown

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix a crash on reload (`EXC_BAD_ACCESS` in `ModuleHolder.deinit` → ExpoModulesJSI) when the previous `AppContext` was deallocated before the old runtime finished tearing down. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@HaiyiMei](https://github.com/HaiyiMei))
+- [iOS] Fix a crash on reload (`EXC_BAD_ACCESS` in `ModuleHolder.deinit` → ExpoModulesJSI) when the previous `AppContext` was deallocated before the old runtime finished tearing down. ([#46853](https://github.com/expo/expo/pull/46853) by [@HaiyiMei](https://github.com/HaiyiMei))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a crash on reload (`EXC_BAD_ACCESS` in `ModuleHolder.deinit` → ExpoModulesJSI) when the previous `AppContext` was deallocated before the old runtime finished tearing down. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@HaiyiMei](https://github.com/HaiyiMei))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
 - Include JavaScript and React component stacks in web dev server error logs. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -39,6 +39,25 @@
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {
+  // On reload, this callback runs on the new instance's JS thread while the
+  // previous instance may still be tearing down its runtime on another thread.
+  // Replacing the ivar must not drop the last strong reference to the previous
+  // AppContext at this point: if it deallocates before the old runtime's
+  // teardown reaches the `expo.modules` host object finalizer, the finalizer's
+  // weak reference is already nil so `AppContext.destroy()` never runs, and the
+  // deinit cascade releases the module holders' cached JavaScriptObjects
+  // against a runtime that is being destroyed (EXC_BAD_ACCESS in
+  // `ModuleHolder.deinit` → ExpoModulesJSI). Defer the release so the old
+  // runtime can finish tearing down — its finalizer runs `destroy()` and
+  // clears all JSI wrappers — making the deferred deinit JSI-free.
+  if (_appContext != nil) {
+    EXAppContext *previousAppContext = _appContext;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      // The block's strong capture keeps the previous context alive until here;
+      // it deallocates with the block right after this runs.
+      (void)previousAppContext;
+    });
+  }
   _appContext = [[EXAppContext alloc] init];
 
   // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto


### PR DESCRIPTION
# Why

Fixes a race that segfaults the app during reload — in our case, every few `expo-updates` `reloadAsync()` OTA applies in TestFlight builds (Expo SDK 56, new architecture, prebuilt ExpoModulesCore/ExpoModulesJSI xcframeworks):

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
KERN_INVALID_ADDRESS at 0x0000000000000000

Thread 15 Crashed (com.facebook.react.runtime.JavaScript):
0  ExpoModulesJSI    <deduplicated_symbol>
2  ExpoModulesCore   ModuleHolder.deinit (ModuleHolder.swift:146)
6  libswiftCore      _DictionaryStorage.deinit
14 ExpoModulesCore   ModuleRegistry.__deallocating_deinit
17 ExpoModulesCore   @objc AppContext.__ivar_destroyer
21 ExpoModulesCore   AppContext.__deallocating_deinit (AppContext.swift:630)
23 app binary        -[EXReactNativeFactory host:didInitializeRuntime:] (ExpoReactNativeFactory.mm:42)
24 React             -[RCTHost instance:didInitializeRuntime:]
25 React             RCTInstance _start
```

On reload, the old `RCTInstance` tears down its runtime on the old JS thread while the new instance initializes on a new JS thread — the two are not ordered. The intended cleanup path is the one #45082 fixed: the old runtime's heap finalization runs the `expo.modules` host object `dealloc`, which calls `AppContext.destroy()` via a **weak** reference, releasing every `ModuleHolder`'s cached `JavaScriptObject` while the runtime can still do so.

The remaining window: `host:didInitializeRuntime:` does `_appContext = [[EXAppContext alloc] init]`, and when the new runtime wins the race this reassignment drops the **last strong reference** to the previous `AppContext` before the old runtime's finalizers run. The host object finalizer then finds a nil weak reference, `destroy()` never runs, and the `AppContext` deinit cascade releases live `jsi::Object`s against a runtime that is concurrently being destroyed → `EXC_BAD_ACCESS`.

JS-side workarounds (delaying `reloadAsync`, draining interactions first) only shift when the reload happens; they cannot order the two native threads — we confirmed the crash reproduces with such mitigations in place.

# How

In `host:didInitializeRuntime:`, capture the previous `AppContext` and release it via `dispatch_after` (5s, main queue) instead of dropping it synchronously. By the time the deferred release runs, the old runtime has finished teardown, its host object finalizer has run `destroy()`, and every JSI wrapper is already cleared — so the deferred deinit cascade no longer touches JSI. Module `OnDestroy` handlers also end up running on the main thread instead of an arbitrary new JS thread.

The fixed delay is deliberately simple and contained to `packages/expo`. A more structural alternative would be tying the old context's lifetime to the runtime teardown itself (e.g. having the `expo.modules` host object hold the `AppContext` strongly, so the context dies exactly when its runtime's heap finalizes) — happy to rework in that direction if you prefer.

# Test Plan

- Applied this exact change as a dependency patch on `expo@56.0.11` in a production Expo app (new architecture, Hermes, prebuilt ExpoModulesCore 56.0.16).
- Compiled clean for device and simulator.
- Added temporary `NSLog` markers on the defer and on the deferred release, then drove repeated full reloads through the dev client on an iPhone 16 Pro simulator. Both markers fired on every reload; the deferred release — the exact deallocation cascade that crashes today — completed cleanly 5 seconds after each reload, with the app fully functional afterwards and no crash reports generated.
- Before the patch, the same deallocation crashed in TestFlight with the stack above.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)