### PR TITLE
[ci] Add Spotless to android-unit-tests.yml

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -62,6 +62,9 @@ jobs:
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
+      - name: 💅 Run Spotless lint check
+        working-directory: apps/bare-expo/android
+        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` from `apps/bare-expo/android` to automatically fix formatting.' && exit 1; }
       - name: 🎸 Run native Android unit tests
         if: always()
         timeout-minutes: 30

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
@@ -16,10 +16,10 @@ class MainApplication : Application(), ReactApplication {
     ExpoReactHostFactory.getDefaultReactHost(
       context = applicationContext,
       packageList =
-        expo.modules.benchmark.withBenchmarkingPackages(PackageList(this).packages).apply {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
-        }
+      expo.modules.benchmark.withBenchmarkingPackages(PackageList(this).packages).apply {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // add(MyReactNativePackage())
+      }
     )
   }
 

--- a/apps/bare-expo/macrobenchmark/src/main/java/dev/expo/payments/macrobenchmark/StartupBenchmark.kt
+++ b/apps/bare-expo/macrobenchmark/src/main/java/dev/expo/payments/macrobenchmark/StartupBenchmark.kt
@@ -22,7 +22,7 @@ class StartupBenchmark {
       packageName = "dev.expo.payments",
       metrics = listOf(StartupTimingMetric()),
       iterations = 5,
-      startupMode = StartupMode.COLD,
+      startupMode = StartupMode.COLD
     ) {
       startActivityAndWait(
         Intent(Intent.ACTION_MAIN).apply {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -14,7 +14,6 @@ import expo.modules.appmetrics.storage.JsDebugSession
 import expo.modules.appmetrics.storage.JsLogRecord
 import expo.modules.appmetrics.storage.JsMetric
 import expo.modules.appmetrics.storage.LogRecord
-import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.storage.SessionMetricInput
 import expo.modules.appmetrics.storage.SessionSharedObject
@@ -209,7 +208,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
           observer.setFilter(filter)
         }
       }
-      
+
       Class("Session", SessionSharedObject::class) {
         // TODO(@ubax): Allow for user session creation from JS
         Constructor { ->

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/appstartup/AppStartupManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/appstartup/AppStartupManager.kt
@@ -50,8 +50,11 @@ object AppStartupManager {
   // and the JS thread. @Volatile guarantees writes are visible across threads so the
   // one-shot guards (hasRecorded*) don't spuriously fire twice.
   @Volatile private var bundleLoadStartTime: Long? = null
+
   @Volatile private var launchTimeInMillis: Long? = null
+
   @Volatile private var hasRecordedInteractive = false
+
   @Volatile private var hasRecordedFirstRender = false
 
   @Volatile

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -213,7 +213,9 @@ internal fun buildSnapshot(
       ?: originalRequest.body?.contentLength()?.takeIf { it > 0 }
       ?: 0L
     requestHeaderBytes + body
-  } else null
+  } else {
+    null
+  }
   val responseBytesReceived: Long? = response?.let {
     val body = phases?.responseBodyBytes?.takeIf { it > 0 }
       ?: it.body?.contentLength()?.takeIf { it > 0 }
@@ -548,4 +550,3 @@ private fun serializedHeaderBytes(headers: Headers): Long {
   }
   return total
 }
-

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/JsonAny.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/JsonAny.kt
@@ -48,10 +48,11 @@ object JsonAny {
       is JsonNull -> null
       is JsonPrimitive -> when {
         element.isString -> element.content
-        else -> element.booleanOrNull
-          ?: element.longOrNull
-          ?: element.doubleOrNull
-          ?: element.content
+        else ->
+          element.booleanOrNull
+            ?: element.longOrNull
+            ?: element.doubleOrNull
+            ?: element.content
       }
       is JsonObject -> element.mapValues { (_, v) -> fromElement(v) }
       is JsonArray -> element.map { fromElement(it) }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/GlobalAttributesTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/GlobalAttributesTest.kt
@@ -104,5 +104,4 @@ class GlobalAttributesTest {
     assertEquals(1, merged!!.size)
     assertEquals("pro", merged["tier"])
   }
-
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/appstartup/AppStartupManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/appstartup/AppStartupManagerTest.kt
@@ -20,6 +20,7 @@ class AppStartupManagerTest {
     val field = AppStartupManager::class.java.getDeclaredField("_metrics").apply {
       isAccessible = true
     }
+
     @Suppress("UNCHECKED_CAST")
     val backing = field.get(AppStartupManager) as MutableList<Metric>
     backing.clear()

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
@@ -1,7 +1,6 @@
 package expo.modules.appmetrics.logevents
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -184,6 +184,7 @@ class SessionMappersTest {
     // Both should decode the nested user object the same way.
     @Suppress("UNCHECKED_CAST")
     val metricUser = metricResult?.get("user") as? Map<String, Any?>
+
     @Suppress("UNCHECKED_CAST")
     val logUser = logResult?.get("user") as? Map<String, Any?>
     assertEquals(metricUser, logUser)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreAudio.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreAudio.kt
@@ -26,7 +26,7 @@ data class MediaStoreAudio(
         displayName = getNullableString(columnIndexes.displayName),
         dateTaken = getNullableLong(columnIndexes.dateTaken),
         dateModified = getNullableLong(columnIndexes.dateModified),
-        duration =  getNullableLong(columnIndexes.duration),
+        duration = getNullableLong(columnIndexes.duration),
         data = getNullableString(columnIndexes.data),
         isFavorite = columnIndexes.isFavorite?.let { getNullableInt(it) }
       )


### PR DESCRIPTION
# Why
The `spotless apply` step used to run during `android-unit-test` on `expo-go` but was removed in this PR: https://github.com/expo/expo/pull/46729

# How 
Adds the `spotless apply` step which is executed in `apps/bare-expo/android`. Also, fixed existing lint errors.

# Test Plan
Green CI ✅ 