### PR TITLE
[brownfield][test] Fix iOS e2e simulator lookup on iOS 26.4

### DIFF
--- a/packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
+++ b/packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
@@ -6,7 +6,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Setup simulator
 source $DIR/setup-simulator.sh
-start_simulator
+if ! start_simulator || [[ -z "$DEVICE_ID" ]]; then
+  echo " ❌ Could not find or boot the target iOS simulator. Check that the runtime is installed (xcrun simctl list runtimes) and matches DEVICE/IOS_VERSION in setup-simulator.sh."
+  exit 1
+fi
 
 # Install app
 source $DIR/install-app-ios.sh $DEVICE_ID

--- a/packages/expo-brownfield/e2e/scripts/setup-simulator.sh
+++ b/packages/expo-brownfield/e2e/scripts/setup-simulator.sh
@@ -33,7 +33,7 @@ function start_simulator() {
 
   echo " 🔍 Looking for device: $DEVICE with iOS version: $IOS_VERSION..."
 
-  DEVICE_ID=$(xcrun simctl list devices iPhone available --json | jq -r --arg device "$DEVICE" --arg ios_version "$IOS_VERSION" '.devices | to_entries[] | select(.key | contains("com.apple.CoreSimulator.SimRuntime.iOS-" + $ios_version + "-2")) | .value[] | select(.name == $device) | .udid' | head -n1)
+  DEVICE_ID=$(xcrun simctl list devices iPhone available --json | jq -r --arg device "$DEVICE" --arg ios_version "$IOS_VERSION" '.devices | to_entries[] | select(.key | contains("com.apple.CoreSimulator.SimRuntime.iOS-" + $ios_version + "-")) | .value[] | select(.name == $device) | .udid' | head -n1)
   if [[ -z "$DEVICE_ID" ]]; then
       echo " ⚠️  No device found for $DEVICE with iOS $IOS_VERSION"
       return 1

--- a/packages/expo-brownfield/e2e/utils/process.ts
+++ b/packages/expo-brownfield/e2e/utils/process.ts
@@ -1,4 +1,4 @@
-import spawnAsync from '@expo/spawn-async';
+import spawnAsync, { SpawnResult } from '@expo/spawn-async';
 
 export const CLI_PATH = require.resolve('../../bin/cli.js');
 export const CREATE_EXPO_BIN = require.resolve('create-expo/bin/create-expo.js');
@@ -10,79 +10,34 @@ export interface ExecuteCLIOptions {
 /**
  * Execute the CLI
  */
-export const executeCLIASync = async (
+export const executeCLIASync = (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  try {
-    const { stdout, stderr, status } = await spawnAsync(CLI_PATH, args, {
-      cwd,
-      stdio: 'pipe',
-    });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
-  }
+  return executeCommandAsync(cwd, CLI_PATH, args, options);
 };
 
 /**
  * Execute Expo CLI
  */
-export const executeExpoCLIAsync = async (
+export const executeExpoCLIAsync = (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  try {
-    const { stdout, stderr, status } = await spawnAsync('pnpm', ['expo', ...args], {
-      cwd,
-      stdio: 'pipe',
-    });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
-  }
+  return executeCommandAsync(cwd, 'pnpm', ['expo', ...args], options);
 };
 
 /**
  * Execute Create Expo CLI
  */
-export const executeCreateExpoCLIAsync = async (
+export const executeCreateExpoCLIAsync = (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  try {
-    const { stdout, stderr, status } = await spawnAsync(CREATE_EXPO_BIN, args, {
-      cwd,
-      stdio: 'pipe',
-    });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
-  }
+  return executeCommandAsync(cwd, CREATE_EXPO_BIN, args, options);
 };
 
 /**
@@ -102,12 +57,19 @@ export const executeCommandAsync = async (
 
     return processOutput({ stdout, stderr, status });
   } catch (error) {
+    const { stdout, stderr, status } = error as SpawnResult;
+
     if (!options.ignoreErrors) {
-      console.error(error);
+      console.error(`Command "${[command, ...args].join(' ')}" exited with code ${status ?? 1}`);
+      if (stdout) {
+        console.error(`stdout:\n${stripAnsi(stdout)}`);
+      }
+      if (stderr) {
+        console.error(`stderr:\n${stripAnsi(stderr)}`);
+      }
       throw error;
     }
 
-    const { stdout, stderr, status } = error;
     return processOutput({ stdout, stderr, status });
   }
 };

--- a/packages/expo-brownfield/e2e/utils/project.ts
+++ b/packages/expo-brownfield/e2e/utils/project.ts
@@ -138,11 +138,11 @@ const listWorkspaces = async (): Promise<Record<string, string>> => {
   const { stdout } = await spawnAsync('pnpm', ['list', '--depth=-1', '-r', '--json'], {
     cwd: path.join(__dirname, '../../'),
   });
-  const workspaces: { name: string; path: string; }[] = JSON.parse(stdout);
-  return workspaces.reduce((acc, entry) => {
+  const workspaces: { name: string; path: string }[] = JSON.parse(stdout);
+  return workspaces.reduce<Record<string, string>>((acc, entry) => {
     acc[entry.name] = entry.path;
     return acc;
-  }, {} as Record<string, string>);
+  }, {});
 };
 
 /**


### PR DESCRIPTION
# Why

The brownfield iOS e2e job started failing with an empty device id (`simctl install <empty> ...` dumps usage and the launch fails). The simulator lookup in `setup-simulator.sh` hardcoded the runtime match to `iOS-26-2`, so when CI moved to iOS 26.4 no device matched and `DEVICE_ID` was never set.

# How

- Drop the hardcoded minor-version suffix in the jq runtime filter so any `iOS-26-x` runtime matches.
- Make `run-e2e-ios.sh` exit with a clear error when `start_simulator` fails or `DEVICE_ID` is empty, instead of silently falling through to the confusing `simctl` usage output.

# Test Plan

Re-run the brownfield `ios` e2e job: the `iPhone 17 Pro` / iOS 26.4 simulator is found and booted, the app installs and launches, and Maestro flows run.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
