### PR TITLE
[sdk-56][jsi]
  Ignore already-settled promises (#46765)

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-06-10

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -75,15 +75,16 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     guard let runtime else {
       return
     }
-    guard !resolveFunction.isEmpty else {
-      preconditionFailure("Cannot settle a promise more than once")
-    }
 
     // `resolve` is not isolated, so make sure to jump to JS thread.
     runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+      // If the promise is already settled, do nothing.
+      guard let resolver = resolveFunction.take() else {
+        return
+      }
       // Call the actual resolver given in the Promise setup.
       // This will also call `deferredPromise.resolve` in the `then` handler.
-      _ = try! resolveFunction.take().getFunction().call(arguments: value)
+      _ = try! resolver.getFunction().call(arguments: value)
 
       // Release the rejecter, we cannot call it anymore.
       rejectFunction.release()
@@ -94,19 +95,20 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     guard let runtime else {
       return
     }
-    guard !rejectFunction.isEmpty else {
-      preconditionFailure("Cannot settle a promise more than once")
-    }
 
     // `reject` is not isolated, so make sure to jump to JS thread.
     runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+      // If the promise is already settled, do nothing.
+      guard let rejecter = rejectFunction.take() else {
+        return
+      }
       // Create a JS error from any (native) error.
       let errorMessage = String(describing: error)
       let errorValue = JavaScriptError(runtime, message: errorMessage).asValue()
 
       // Call the actual rejecter given in the Promise setup.
       // This will also call `deferredPromise.reject` in the `then` handler.
-      _ = try! rejectFunction.take().getFunction().call(arguments: errorValue)
+      _ = try! rejecter.getFunction().call(arguments: errorValue)
 
       // Release the resolver, we cannot call it anymore.
       resolveFunction.release()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -280,6 +280,23 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
+  func `settling promise more than once is ignored`() async throws {
+    struct TestError: Error, Sendable {}
+
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+
+    runtime.global().setProperty("testPromise", value: promise.asValue())
+    promise.resolve(42)
+    promise.reject(TestError())
+    promise.resolve(100)
+
+    let result = try await promise.await()
+
+    #expect(result.getInt() == 42)
+  }
+
+  @Test
   func `promise all`() async throws {
     let runtime = JavaScriptRuntime()
 


### PR DESCRIPTION
Backport of #46765 to the `sdk-56` release branch.

## Why

#46765 fixed `JavaScriptPromise.resolve`/`reject` to ignore already-settled promises (per ECMAScript) instead of trapping via `preconditionFailure`. It merged to `main` (now the SDK 57 line), so SDK 56 users still crash.

This is the fix for #46512 — `expo-media-library`'s `getAssetInfoAsync` double-settles its promise on iOS Live Photos, hitting the `preconditionFailure` / `try!` path. The latest published `expo-modules-jsi@56.0.9` still ships the pre-fix code.

## How

Straight cherry-pick of e2aa893 (original author @jakex7). Only the CHANGELOG placement was adjusted to the sdk-56 Unpublished section.

## Test Plan

- The `JavaScriptPromiseTests.swift` "settling promise more than once is ignored" test added in #46765.

> Note: this only changes Swift sources; the prebuilt xcframework may need a rebuild as part of cutting the release.

cc @jakex7 @tsapeta
