### PR TITLE
[expo-app-metrics] add android crash reports

### DIFF
--- a/apps/observe-tester/app/(tabs)/(sessions)/sessions/index.tsx
+++ b/apps/observe-tester/app/(tabs)/(sessions)/sessions/index.tsx
@@ -36,9 +36,9 @@ type SessionRowData = {
   href: Href;
 };
 
-// A startup crash not attributed to any session (from `getOrphanedCrashReports`).
-// Keyed by position since crash reports have no id; the detail screen re-fetches
-// the same ordered list and looks the report up by index.
+// A startup crash not attributed to any session — the orphans (`sessionId` null)
+// among `getAllCrashReports`. Keyed by position since crash reports have no id;
+// the detail screen re-fetches the same ordered list and looks the report up by index.
 type OrphanRowData = {
   kind: 'orphan';
   index: number;
@@ -78,9 +78,12 @@ export default function SessionsList() {
       .map(inactiveSessionToRow)
       .sort((a, b) => (a.startDate < b.startDate ? 1 : -1));
 
-    // Startup crashes that predate any session — Android only, hence the optional call.
-    const orphanReports = (await AppMetrics.getOrphanedCrashReports?.()) ?? [];
-    const orphans: OrphanRowData[] = orphanReports.map(orphanCrashToRow);
+    // Startup crashes that predate any session — the orphans among all reports.
+    // Android only, hence the optional call.
+    const allReports = (await AppMetrics.getAllCrashReports?.()) ?? [];
+    const orphans: OrphanRowData[] = allReports
+      .filter((report) => report.sessionId == null)
+      .map(orphanCrashToRow);
 
     setSections([
       ...(active.length ? [{ title: 'Active', data: active }] : []),

--- a/apps/observe-tester/app/(tabs)/(sessions)/sessions/orphaned/[index].tsx
+++ b/apps/observe-tester/app/(tabs)/(sessions)/sessions/orphaned/[index].tsx
@@ -10,10 +10,11 @@ import { Divider } from '@/components/Divider';
 import { useTheme } from '@/utils/theme';
 
 // Detail for a startup crash that isn't attributed to any session. The list passes
-// the report's position in `getOrphanedCrashReports`; we re-fetch that ordered list
-// and look it up by index, since crash reports have no stable id. The index is only
-// stable within a launch, but orphaned crashes are only produced at startup — never
-// while the app is foregrounded — so the list can't shift under an open detail screen.
+// the report's position among the orphans (`sessionId` null) in `getAllCrashReports`;
+// we re-fetch and filter that same ordered list and look it up by index, since crash
+// reports have no stable id. The index is only stable within a launch, but orphaned
+// crashes are only produced at startup — never while the app is foregrounded — so the
+// list can't shift under an open detail screen.
 export default function OrphanedCrashScreen() {
   const theme = useTheme();
   const { index } = useLocalSearchParams<{ index: string }>();
@@ -23,9 +24,10 @@ export default function OrphanedCrashScreen() {
   useFocusEffect(
     useCallback(() => {
       let cancelled = false;
-      AppMetrics.getOrphanedCrashReports?.().then((reports) => {
+      AppMetrics.getAllCrashReports?.().then((reports) => {
         if (cancelled) return;
-        setReport(reports[Number(index)] ?? null);
+        const orphans = reports.filter((report) => report.sessionId == null);
+        setReport(orphans[Number(index)] ?? null);
         setLoaded(true);
       });
       return () => {

--- a/apps/observe-tester/components/CallStackTreeView.tsx
+++ b/apps/observe-tester/components/CallStackTreeView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Chevron } from '@/components/Chevron';
+import { FrameRow } from '@/components/FrameRow';
 import { useTheme } from '@/utils/theme';
 
 export function CallStackTreeView({ tree }: { tree: CallStackTree }) {
@@ -115,33 +116,6 @@ function flattenFrames(rootFrames: CallStackFrame[]): CallStackFrame[] {
   return result;
 }
 
-function FrameRow({ frame }: { frame: CallStackFrame }) {
-  const theme = useTheme();
-  return (
-    <Text style={[styles.frame, { color: theme.text.default }]}>
-      <Text style={{ color: theme.text.tertiary }}>{formatAddress(frame.address)} </Text>
-      <Text style={{ color: theme.text.default }}>{frame.binaryName ?? '(unknown)'}</Text>
-      {frame.symbol ? (
-        <Text style={{ color: theme.text.default }}> {frame.symbol}</Text>
-      ) : (
-        <Text style={{ color: theme.text.secondary }}>
-          {formatOffset(frame.offsetIntoBinaryTextSegment)}
-        </Text>
-      )}
-    </Text>
-  );
-}
-
-function formatAddress(address: number | null | undefined) {
-  if (address == null) return '0x0000000000000000';
-  return '0x' + address.toString(16).padStart(16, '0');
-}
-
-function formatOffset(offset: number | null | undefined) {
-  if (offset == null) return '';
-  return ' +0x' + offset.toString(16);
-}
-
 const styles = StyleSheet.create({
   thread: {
     borderWidth: 1,
@@ -172,11 +146,6 @@ const styles = StyleSheet.create({
   frameCount: {
     fontSize: 12,
     fontWeight: '500',
-  },
-  frame: {
-    fontFamily: 'Menlo',
-    fontSize: 11,
-    paddingVertical: 2,
   },
   empty: {
     fontSize: 13,

--- a/apps/observe-tester/components/CrashReportPanel.tsx
+++ b/apps/observe-tester/components/CrashReportPanel.tsx
@@ -29,7 +29,8 @@ export function CrashReportPanel({ report }: { report: CrashReport }) {
       {report.exceptionReason != null ? <ExceptionReason reason={report.exceptionReason} /> : null}
       <View style={styles.timing}>
         <Text style={[styles.timingText, { color: theme.text.secondary }]}>
-          Window: {formatDate(report.timestampBegin)} → {formatDate(report.timestampEnd)}
+          Window: {formatDate(report.timestampBegin)} →{' '}
+          {report.timestampEnd ? formatDate(report.timestampEnd) : ''}
         </Text>
         <Text style={[styles.timingText, { color: theme.text.secondary }]}>
           Ingested: {formatDate(report.ingestedAt)}

--- a/apps/observe-tester/components/CrashReportPanel.tsx
+++ b/apps/observe-tester/components/CrashReportPanel.tsx
@@ -1,6 +1,7 @@
 import type { CrashReport } from 'expo-app-metrics';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { ExceptionReason } from '@/components/ExceptionReason';
 import { useTheme } from '@/utils/theme';
 
 export function CrashReportPanel({ report }: { report: CrashReport }) {
@@ -25,16 +26,7 @@ export function CrashReportPanel({ report }: { report: CrashReport }) {
       {report.virtualMemoryRegionInfo ? (
         <Field label="VM region" value={report.virtualMemoryRegionInfo} mono />
       ) : null}
-      {report.exceptionReason ? (
-        <View style={styles.exceptionReason}>
-          <Text style={[styles.exceptionMessage, { color: theme.text.default }]}>
-            {report.exceptionReason.composedMessage}
-          </Text>
-          <Text style={[styles.exceptionMeta, { color: theme.text.secondary }]}>
-            {report.exceptionReason.className} · {report.exceptionReason.exceptionType}
-          </Text>
-        </View>
-      ) : null}
+      {report.exceptionReason != null ? <ExceptionReason reason={report.exceptionReason} /> : null}
       <View style={styles.timing}>
         <Text style={[styles.timingText, { color: theme.text.secondary }]}>
           Window: {formatDate(report.timestampBegin)} → {formatDate(report.timestampEnd)}
@@ -151,17 +143,6 @@ const styles = StyleSheet.create({
   fieldValueMono: {
     fontFamily: 'Menlo',
     fontSize: 12,
-  },
-  exceptionReason: {
-    gap: 4,
-  },
-  exceptionMessage: {
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  exceptionMeta: {
-    fontSize: 12,
-    fontWeight: '500',
   },
   timing: {
     gap: 2,

--- a/apps/observe-tester/components/CrashReportsSection.tsx
+++ b/apps/observe-tester/components/CrashReportsSection.tsx
@@ -1,18 +1,9 @@
 import { StyleSheet, Text } from 'react-native';
 
 import { Button } from '@/components/Button';
-import CrashTester, { type CrashKind } from '@/modules/crash-tester';
+import { CRASH_TRIGGERS } from '@/components/crashTriggers';
+import CrashTester from '@/modules/crash-tester';
 import { useTheme } from '@/utils/theme';
-
-const CRASH_TRIGGERS: { kind: CrashKind; title: string; description: string }[] = [
-  { kind: 'badAccess', title: 'Bad access', description: 'EXC_BAD_ACCESS / SIGSEGV' },
-  { kind: 'fatalError', title: 'Fatal error', description: 'EXC_CRASH / SIGABRT' },
-  { kind: 'divideByZero', title: 'Divide by zero', description: 'EXC_ARITHMETIC / SIGFPE' },
-  { kind: 'forceUnwrapNil', title: 'Force-unwrap nil', description: 'EXC_BAD_INSTRUCTION' },
-  { kind: 'arrayOutOfBounds', title: 'Array out of bounds', description: 'EXC_BAD_INSTRUCTION' },
-  { kind: 'objcException', title: 'NSException', description: 'Uncaught Objective-C exception' },
-  { kind: 'stackOverflow', title: 'Stack overflow', description: 'Unbounded recursion' },
-];
 
 // Throws from a timer callback so the error is genuinely uncaught: it unwinds to React Native's
 // global error handler (where expo-app-metrics' handler is chained) instead of being swallowed by

--- a/apps/observe-tester/components/ExceptionReason.android.tsx
+++ b/apps/observe-tester/components/ExceptionReason.android.tsx
@@ -1,0 +1,22 @@
+import type { CrashReport } from 'expo-app-metrics';
+import { StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// On Android the exception reason is a plain string: the throwable's composed
+// message plus its `Caused by:` chain.
+export function ExceptionReason({
+  reason,
+}: {
+  reason: NonNullable<CrashReport['exceptionReason']>;
+}) {
+  const theme = useTheme();
+  return <Text style={[styles.message, { color: theme.text.default }]}>{reason as string}</Text>;
+}
+
+const styles = StyleSheet.create({
+  message: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+  },
+});

--- a/apps/observe-tester/components/ExceptionReason.ios.tsx
+++ b/apps/observe-tester/components/ExceptionReason.ios.tsx
@@ -1,0 +1,37 @@
+import type { CrashReport } from 'expo-app-metrics';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// On iOS the exception reason is MetricKit's structured object (unhandled Objective-C exceptions).
+export function ExceptionReason({
+  reason,
+}: {
+  reason: NonNullable<CrashReport['exceptionReason']>;
+}) {
+  const theme = useTheme();
+  const detail = reason as Exclude<NonNullable<CrashReport['exceptionReason']>, string>;
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.message, { color: theme.text.default }]}>{detail.composedMessage}</Text>
+      <Text style={[styles.meta, { color: theme.text.secondary }]}>
+        {detail.className} · {detail.exceptionType}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 4,
+  },
+  message: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  meta: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+});

--- a/apps/observe-tester/components/ExceptionReason.ios.tsx
+++ b/apps/observe-tester/components/ExceptionReason.ios.tsx
@@ -10,13 +10,19 @@ export function ExceptionReason({
   reason: NonNullable<CrashReport['exceptionReason']>;
 }) {
   const theme = useTheme();
-  const detail = reason as Exclude<NonNullable<CrashReport['exceptionReason']>, string>;
+
+  // `exceptionReason` can be a plain string; render it as-is rather than reading
+  // structured fields off it.
+  if (typeof reason === 'string') {
+    console.warn('exceptionReason should not be a string on iOS');
+    return null;
+  }
 
   return (
     <View style={styles.container}>
-      <Text style={[styles.message, { color: theme.text.default }]}>{detail.composedMessage}</Text>
+      <Text style={[styles.message, { color: theme.text.default }]}>{reason.composedMessage}</Text>
       <Text style={[styles.meta, { color: theme.text.secondary }]}>
-        {detail.className} · {detail.exceptionType}
+        {reason.className} · {reason.exceptionType}
       </Text>
     </View>
   );

--- a/apps/observe-tester/components/ExceptionReason.tsx
+++ b/apps/observe-tester/components/ExceptionReason.tsx
@@ -1,0 +1,20 @@
+import type { CrashReport } from 'expo-app-metrics';
+import { StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// Default fallback (e.g. web): crash reports only carry an exception reason on native.
+export function ExceptionReason(_props: { reason: NonNullable<CrashReport['exceptionReason']> }) {
+  const theme = useTheme();
+  return (
+    <Text style={[styles.message, { color: theme.text.secondary }]}>
+      Exception details aren&apos;t available on this platform.
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  message: {
+    fontSize: 13,
+  },
+});

--- a/apps/observe-tester/components/FrameRow.android.tsx
+++ b/apps/observe-tester/components/FrameRow.android.tsx
@@ -1,0 +1,21 @@
+import type { CallStackFrame } from 'expo-app-metrics';
+import { StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// Android frames are JVM stack-trace strings (e.g. `com.example.Foo.bar(Foo.kt:42)`) and carry
+// no binary image or address, so we render the symbol on its own.
+export function FrameRow({ frame }: { frame: CallStackFrame }) {
+  const theme = useTheme();
+  return (
+    <Text style={[styles.frame, { color: theme.text.default }]}>{frame.symbol ?? '(unknown)'}</Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    paddingVertical: 2,
+  },
+});

--- a/apps/observe-tester/components/FrameRow.ios.tsx
+++ b/apps/observe-tester/components/FrameRow.ios.tsx
@@ -1,0 +1,41 @@
+import type { CallStackFrame } from 'expo-app-metrics';
+import { StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// iOS frames carry a binary image and an address; the symbol is filled in by on-device
+// symbolication, falling back to the binary offset when it couldn't be resolved.
+export function FrameRow({ frame }: { frame: CallStackFrame }) {
+  const theme = useTheme();
+  return (
+    <Text style={[styles.frame, { color: theme.text.default }]}>
+      <Text style={{ color: theme.text.tertiary }}>{formatAddress(frame.address)} </Text>
+      <Text style={{ color: theme.text.default }}>{frame.binaryName ?? '(unknown)'}</Text>
+      {frame.symbol ? (
+        <Text style={{ color: theme.text.default }}> {frame.symbol}</Text>
+      ) : (
+        <Text style={{ color: theme.text.secondary }}>
+          {formatOffset(frame.offsetIntoBinaryTextSegment)}
+        </Text>
+      )}
+    </Text>
+  );
+}
+
+function formatAddress(address: number | null | undefined) {
+  if (address == null) return '0x0000000000000000';
+  return '0x' + address.toString(16).padStart(16, '0');
+}
+
+function formatOffset(offset: number | null | undefined) {
+  if (offset == null) return '';
+  return ' +0x' + offset.toString(16);
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    fontFamily: 'Menlo',
+    fontSize: 11,
+    paddingVertical: 2,
+  },
+});

--- a/apps/observe-tester/components/FrameRow.tsx
+++ b/apps/observe-tester/components/FrameRow.tsx
@@ -1,0 +1,17 @@
+import type { CallStackFrame } from 'expo-app-metrics';
+import { StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// Default fallback (e.g. web): crash reports only carry call stacks on native.
+export function FrameRow(_props: { frame: CallStackFrame }) {
+  const theme = useTheme();
+  return <Text style={[styles.frame, { color: theme.text.secondary }]}>(unsupported)</Text>;
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    fontSize: 11,
+    paddingVertical: 2,
+  },
+});

--- a/apps/observe-tester/components/crashTriggers.android.ts
+++ b/apps/observe-tester/components/crashTriggers.android.ts
@@ -1,0 +1,18 @@
+import type { CrashTrigger } from '@/components/crashTriggers.types';
+
+// Descriptions name the JVM throwable each trigger produces on Android. `badAccess` is a bare
+// SIGSEGV (process death without a tombstone), which is outside the crash allowlist, so it stores
+// no report — unlike the JVM kinds below.
+export const CRASH_TRIGGERS: CrashTrigger[] = [
+  { kind: 'badAccess', title: 'Bad access', description: 'SIGSEGV signal — no report stored' },
+  { kind: 'fatalError', title: 'Fatal error', description: 'RuntimeException' },
+  { kind: 'divideByZero', title: 'Divide by zero', description: 'ArithmeticException' },
+  { kind: 'forceUnwrapNil', title: 'Null dereference', description: 'NullPointerException' },
+  {
+    kind: 'arrayOutOfBounds',
+    title: 'Array out of bounds',
+    description: 'IndexOutOfBoundsException',
+  },
+  { kind: 'objcException', title: 'Uncaught exception', description: 'IllegalStateException' },
+  { kind: 'stackOverflow', title: 'Stack overflow', description: 'StackOverflowError' },
+];

--- a/apps/observe-tester/components/crashTriggers.android.ts
+++ b/apps/observe-tester/components/crashTriggers.android.ts
@@ -1,10 +1,11 @@
 import type { CrashTrigger } from '@/components/crashTriggers.types';
 
 // Descriptions name the JVM throwable each trigger produces on Android. `badAccess` is a bare
-// SIGSEGV (process death without a tombstone), which is outside the crash allowlist, so it stores
-// no report — unlike the JVM kinds below.
+// SIGSEGV (process death without a tombstone); the OS records it as a signal kill, which now
+// counts as a crash, so it stores a signal-only report with no Java stack trace — unlike the JVM
+// kinds below.
 export const CRASH_TRIGGERS: CrashTrigger[] = [
-  { kind: 'badAccess', title: 'Bad access', description: 'SIGSEGV signal — no report stored' },
+  { kind: 'badAccess', title: 'Bad access', description: 'SIGSEGV signal — signal-only report' },
   { kind: 'fatalError', title: 'Fatal error', description: 'RuntimeException' },
   { kind: 'divideByZero', title: 'Divide by zero', description: 'ArithmeticException' },
   { kind: 'forceUnwrapNil', title: 'Null dereference', description: 'NullPointerException' },

--- a/apps/observe-tester/components/crashTriggers.ios.ts
+++ b/apps/observe-tester/components/crashTriggers.ios.ts
@@ -1,0 +1,12 @@
+import type { CrashTrigger } from '@/components/crashTriggers.types';
+
+// Descriptions name the Mach exception / Unix signal each trigger produces on iOS.
+export const CRASH_TRIGGERS: CrashTrigger[] = [
+  { kind: 'badAccess', title: 'Bad access', description: 'EXC_BAD_ACCESS / SIGSEGV' },
+  { kind: 'fatalError', title: 'Fatal error', description: 'EXC_CRASH / SIGABRT' },
+  { kind: 'divideByZero', title: 'Divide by zero', description: 'EXC_ARITHMETIC / SIGFPE' },
+  { kind: 'forceUnwrapNil', title: 'Force-unwrap nil', description: 'EXC_BAD_INSTRUCTION' },
+  { kind: 'arrayOutOfBounds', title: 'Array out of bounds', description: 'EXC_BAD_INSTRUCTION' },
+  { kind: 'objcException', title: 'NSException', description: 'Uncaught Objective-C exception' },
+  { kind: 'stackOverflow', title: 'Stack overflow', description: 'Unbounded recursion' },
+];

--- a/apps/observe-tester/components/crashTriggers.ts
+++ b/apps/observe-tester/components/crashTriggers.ts
@@ -1,0 +1,4 @@
+import type { CrashTrigger } from '@/components/crashTriggers.types';
+
+// Default fallback (e.g. web): no native crash tester, so there are no triggers to offer.
+export const CRASH_TRIGGERS: CrashTrigger[] = [];

--- a/apps/observe-tester/components/crashTriggers.types.ts
+++ b/apps/observe-tester/components/crashTriggers.types.ts
@@ -1,0 +1,3 @@
+import type { CrashKind } from '@/modules/crash-tester';
+
+export type CrashTrigger = { kind: CrashKind; title: string; description: string };

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Observe HTTP requests on iOS and Android and expose them to JS via the `NetworkRequestObserver` class and `useNetworkRequestObserver` hook. The TTI metric also carries an `expo.network.requests.*` summary for requests that completed in the launch window. ([#46475](https://github.com/expo/expo/pull/46475) by [@tsapeta](https://github.com/tsapeta))
 - Add native-side filtering to `NetworkRequestObserver` by host and method, configurable at construction or at runtime via `setFilter`, so non-matching requests never cross into JS. ([#46775](https://github.com/expo/expo/pull/46775) by [@tsapeta](https://github.com/tsapeta))
 - Capture unhandled JavaScript errors on iOS and Android by wrapping React Native's `global.ErrorUtils` handler, recording each as an `exception` log event following OpenTelemetry's exception conventions (`exception.type`/`exception.message`/`exception.stacktrace`). Fatal errors are written to disk synchronously before the process terminates and ingested on the next launch. ([#46923](https://github.com/expo/expo/pull/46923) by [@tsapeta](https://github.com/tsapeta))
+- Add android crash reports ([#46869](https://github.com/expo/expo/pull/46869) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsApplicationLifecycleListeners.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsApplicationLifecycleListeners.kt
@@ -2,6 +2,8 @@ package expo.modules.appmetrics
 
 import android.app.Application
 import expo.modules.appmetrics.appstartup.AppStartupManager
+import expo.modules.appmetrics.crashreporting.CrashFileWriter
+import expo.modules.appmetrics.crashreporting.JvmCrashHandler
 import expo.modules.appmetrics.networkrequests.OkHttpClientProviderHook
 import expo.modules.core.interfaces.ApplicationLifecycleListener
 
@@ -9,6 +11,12 @@ class AppMetricsApplicationLifecycleListeners : ApplicationLifecycleListener {
   override fun onCreate(application: Application) {
     super.onCreate(application)
     AppStartupManager.recordAppCreated(application)
+    // Crash capture starts at process start, not at module creation: the module
+    // system spins up lazily (when JS first touches a module), and a crash
+    // during startup would otherwise be missed entirely. The session id is null
+    // until the module creates its main session (see `JvmCrashHandler.currentSessionId`),
+    // so a crash before then is captured as an orphan rather than misattributed.
+    JvmCrashHandler.install(CrashFileWriter.forContext(application).also { it.prepare() })
     // Install the OkHttp factory hook as early as possible - before React Native lazily caches
     // its client. See `OkHttpClientProviderHook` for the race we're trying to win.
     //

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsApplicationLifecycleListeners.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsApplicationLifecycleListeners.kt
@@ -16,7 +16,7 @@ class AppMetricsApplicationLifecycleListeners : ApplicationLifecycleListener {
     // during startup would otherwise be missed entirely. The session id is null
     // until the module creates its main session (see `JvmCrashHandler.currentSessionId`),
     // so a crash before then is captured as an orphan rather than misattributed.
-    JvmCrashHandler.install(CrashFileWriter.forContext(application).also { it.prepare() })
+    JvmCrashHandler.install(CrashFileWriter.forContext(application))
     // Install the OkHttp factory hook as early as possible - before React Native lazily caches
     // its client. See `OkHttpClientProviderHook` for the race we're trying to win.
     //

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -153,8 +153,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         scope.launch { sessionManager.deactivateAllSessionsBefore(appSessionStartTimestamp) }
 
         // Turn the previous process's death evidence (pending JVM crash files,
-        // OS exit records) into stored crash reports. Runs after the session
-        // persist and orphan sweep — `modulesQueue` executes these in order.
+        // OS exit records) into stored crash reports.
         // The processor builds the reports; `attributeAndStoreCrashReport` owns
         // the session attribution and storage.
         scope.launch {
@@ -231,11 +230,15 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         sessionManager.getInactiveSessions().map { JsDebugSession.fromSessionWithChildren(it) }
       }
 
-      // Crash reports not attributed to any session — startup crashes captured
-      // before the session existed, or native crashes that couldn't be attributed.
-      // They never appear under a session in `getInactiveSessions`.
-      AsyncFunction("getOrphanedCrashReports") Coroutine { ->
-        sessionManager.getOrphanCrashReportPayloads().mapNotNull { JsonAny.decodeJsonStringToMap(it) }
+      // Every stored crash report, newest first — attributed reports plus
+      // orphans (startup crashes before the session existed, or native crashes
+      // that couldn't be attributed). Orphans carry a null session id.
+      AsyncFunction("getAllCrashReports") Coroutine { ->
+        sessionManager.getAllCrashReports().mapNotNull { entity ->
+          // `sessionId` lives on the DB row, not in the payload — merge it in so
+          // callers can spot orphans (null session id).
+          JsonAny.decodeJsonStringToMap(entity.payload)?.plus("sessionId" to entity.sessionId)
+        }
       }
 
       AsyncFunction("takeMemoryUsageSnapshotAsync") Coroutine { sessionId: String? ->

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -5,6 +5,12 @@ import expo.modules.appmetrics.appstartup.AppStartupManager
 import expo.modules.appmetrics.jserrors.ErrorReport
 import expo.modules.appmetrics.jserrors.PendingErrorStore
 import expo.modules.appmetrics.jserrors.toLogRecord
+import expo.modules.appmetrics.crashreporting.CrashFileReader
+import expo.modules.appmetrics.crashreporting.CrashReportProcessor
+import expo.modules.appmetrics.crashreporting.ExitInfoProviderImpl
+import expo.modules.appmetrics.crashreporting.JvmCrashHandler
+import expo.modules.appmetrics.crashreporting.PreferencesLastProcessedExitStore
+import expo.modules.appmetrics.crashreporting.attributeAndStoreCrashReport
 import expo.modules.appmetrics.logevents.LogEventOptions
 import expo.modules.appmetrics.networkrequests.NetworkRequestFilter
 import expo.modules.appmetrics.networkrequests.NetworkRequestObserver
@@ -133,6 +139,8 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
           runtime = appContext.runtime
         )
 
+        JvmCrashHandler.currentSessionId = mainSession.sessionId
+
         // Persist the session row eagerly so it's visible to readers
         // (`getMainSession`, …) as soon as possible. Idempotent:
         // a racing write triggers (and joins) the same single start job.
@@ -143,6 +151,28 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         // survives while older ones are swept — order vs the INSERT doesn't
         // matter. Relies on `<`, not `<=` (see SessionManagerTest).
         scope.launch { sessionManager.deactivateAllSessionsBefore(appSessionStartTimestamp) }
+
+        // Turn the previous process's death evidence (pending JVM crash files,
+        // OS exit records) into stored crash reports. Runs after the session
+        // persist and orphan sweep — `modulesQueue` executes these in order.
+        // The processor builds the reports; `attributeAndStoreCrashReport` owns
+        // the session attribution and storage.
+        scope.launch {
+          CrashReportProcessor(
+            crashFileReader = CrashFileReader.forContext(context),
+            exitInfoProvider = ExitInfoProviderImpl(context),
+            lastProcessedExitStore = PreferencesLastProcessedExitStore(context),
+            appVersion = metadata?.appVersion
+          ) { sessionId, origin, report ->
+            attributeAndStoreCrashReport(
+              sessionManager = sessionManager,
+              currentSessionId = mainSession.sessionId,
+              sessionId = sessionId,
+              origin = origin,
+              report = report
+            )
+          }.process()
+        }
 
         memoryMetricsManager = MemoryMetricsManager(
           context = context,
@@ -188,12 +218,24 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         runBlocking {
           mainSession.stop()
         }
+        // The session has ended; stop stamping it onto crashes. A crash after
+        // this is captured as an orphan rather than misattributed
+        if (JvmCrashHandler.currentSessionId == mainSession.sessionId) {
+          JvmCrashHandler.currentSessionId = null
+        }
       }
 
       // Debug-only: surfaces the inactive (ended) sessions for on-device
       // inspection (e.g. the ObserveTester app)
       AsyncFunction("getInactiveSessions") Coroutine { ->
-        sessionManager.getInactiveSessions().map { JsDebugSession.fromSessionWithMetrics(it) }
+        sessionManager.getInactiveSessions().map { JsDebugSession.fromSessionWithChildren(it) }
+      }
+
+      // Crash reports not attributed to any session — startup crashes captured
+      // before the session existed, or native crashes that couldn't be attributed.
+      // They never appear under a session in `getInactiveSessions`.
+      AsyncFunction("getOrphanedCrashReports") Coroutine { ->
+        sessionManager.getOrphanCrashReportPayloads().mapNotNull { JsonAny.decodeJsonStringToMap(it) }
       }
 
       AsyncFunction("takeMemoryUsageSnapshotAsync") Coroutine { sessionId: String? ->

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsPreferences.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsPreferences.kt
@@ -5,8 +5,26 @@ import androidx.core.content.edit
 
 private const val PREFS_NAME = "dev.expo.app-metrics"
 private const val KEY_ENVIRONMENT = "environment"
+private const val KEY_LAST_PROCESSED_EXIT_MILLIS = "lastProcessedExitMillis"
 
 object AppMetricsPreferences {
+  /**
+   * Timestamp (epoch millis) of the newest `ApplicationExitInfo` record already
+   * turned into a crash report. `0` (the default) means none processed yet.
+   */
+  fun getLastProcessedExitTimestampMillis(context: Context): Long {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return prefs.getLong(KEY_LAST_PROCESSED_EXIT_MILLIS, 0L)
+  }
+
+  fun setLastProcessedExitTimestampMillis(
+    context: Context,
+    millis: Long
+  ) {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    prefs.edit(commit = true) { putLong(KEY_LAST_PROCESSED_EXIT_MILLIS, millis) }
+  }
+
   fun getEnvironment(context: Context): String? {
     val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     return prefs.getString(KEY_ENVIRONMENT, null) ?: getDefaultEnvironment()

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CallStackTreeBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CallStackTreeBuilder.kt
@@ -1,0 +1,37 @@
+package expo.modules.appmetrics.crashreporting
+
+/**
+ * Maps a JVM stack trace into the cross-platform `CrashReport.CallStackTree` shape.
+ */
+object CallStackTreeBuilder {
+  /**
+   * Frame cap per stack. `StackOverflowError` traces routinely reach the JVM's
+   * 1024-element limit; beyond this cap the repeating tail adds payload size
+   * without diagnostic value, so it's replaced by a marker frame.
+   */
+  const val MAX_FRAMES = 256
+
+  fun fromStackTrace(stackTrace: Array<StackTraceElement>): CrashReport.CallStackTree =
+    fromSymbols(stackTrace.map { it.toString() })
+
+  /** Builds the tree from already-formatted frame strings (the pending-crash-file path). */
+  fun fromSymbols(symbols: List<String>): CrashReport.CallStackTree {
+    val frames = symbols.take(MAX_FRAMES).map { symbol ->
+      CrashReport.CallStackTree.Frame(symbol = symbol)
+    }
+    val truncatedCount = symbols.size - MAX_FRAMES
+    val allFrames = if (truncatedCount > 0) {
+      frames + CrashReport.CallStackTree.Frame(symbol = "… $truncatedCount more frames")
+    } else {
+      frames
+    }
+    return CrashReport.CallStackTree(
+      callStacks = listOf(
+        CrashReport.CallStackTree.CallStack(
+          threadAttributed = true,
+          callStackRootFrames = allFrames
+        )
+      )
+    )
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
@@ -1,0 +1,65 @@
+package expo.modules.appmetrics.crashreporting
+
+/**
+ * The on-disk contract for pending-crash files, shared by `CrashFileWriter` and
+ * `CrashFileReader`. Keeping the format in one place means the writer and reader
+ * can't drift apart on the separator or the escaping rules.
+ */
+internal object CrashFileFormat {
+  /** Separates the `key=value` header block from the stack frames below it. */
+  const val HEADER_SEPARATOR = "---"
+
+  /**
+   * Suffix for the temp file the writer fills in before atomically renaming it to its final
+   * `crash-{pid}-{timestamp}.txt` name. The write happens on the crash path inside a dying process,
+   * so a write can be truncated or orphaned at any point; staging under `.tmp` and committing with a
+   * rename makes the final file appear all-at-once or not at all. Because `FILE_NAME_PATTERN` only
+   * matches the final `.txt` name, the reader never picks up a `.tmp` file that is still being
+   * written (or was left behind by a process that died mid-write), so it only ever parses complete
+   * files. An orphan left by a mid-write death is swept on the next launch by
+   * `CrashFileReader.deleteOrphanedTempFiles`.
+   */
+  const val TEMP_SUFFIX = ".tmp"
+
+  /** Matches a finished pending-crash file (`crash-{pid}-{timestamp}.txt`); skips `.tmp` by design. */
+  val FILE_NAME_PATTERN = Regex("""crash-\d+-\d+\.txt""")
+
+  /** Matches an orphaned/in-progress temp file (`crash-{pid}-{timestamp}.txt.tmp`); group 1 is the pid. */
+  val TEMP_FILE_PATTERN = Regex("""crash-(\d+)-\d+\.txt\.tmp""")
+
+  /**
+   * The canonical pending-crash directory — `noBackupFilesDir` so stale crash
+   * files never ride along in device-to-device restores. Shared by `CrashFileWriter`
+   * and `CrashFileReader` so the two always agree on where crashes live.
+   */
+  fun crashesDir(context: android.content.Context): java.io.File =
+    java.io.File(context.noBackupFilesDir, "expo-app-metrics/crashes")
+
+  fun escape(value: String): String =
+    value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r")
+
+  fun unescape(value: String): String {
+    val result = StringBuilder(value.length)
+    var index = 0
+    while (index < value.length) {
+      val char = value[index]
+      if (char == '\\' && index + 1 < value.length) {
+        val next = value[index + 1]
+        val unescaped = when (next) {
+          'n' -> '\n'
+          'r' -> '\r'
+          '\\' -> '\\'
+          else -> null
+        }
+        if (unescaped != null) {
+          result.append(unescaped)
+          index += 2
+          continue
+        }
+      }
+      result.append(char)
+      index++
+    }
+    return result.toString()
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
@@ -17,22 +17,20 @@ internal object CrashFileFormat {
   }
 
   /**
-   * Suffix for the temp file the writer fills in before atomically renaming it to its final
-   * `crash-{pid}-{timestamp}.json` name. The write happens on the crash path inside a dying process,
-   * so a write can be truncated or orphaned at any point; staging under `.tmp` and committing with a
-   * rename makes the final file appear all-at-once or not at all. Because `FILE_NAME_PATTERN` only
-   * matches the final `.json` name, the reader never picks up a `.tmp` file that is still being
-   * written (or was left behind by a process that died mid-write), so it only ever parses complete
-   * files. An orphan left by a mid-write death is swept on the next launch by
-   * `CrashFileReader.deleteOrphanedTempFiles`.
+   * Matches a finished pending-crash file (`crash-{pid}-{timestamp}.json`). The writer commits
+   * through `AtomicFile`, so the final `.json` only appears after the atomic rename — an interrupted
+   * write never matches this, and the reader only ever parses complete files.
    */
-  const val TEMP_SUFFIX = ".tmp"
-
-  /** Matches a finished pending-crash file (`crash-{pid}-{timestamp}.json`); skips `.tmp` by design. */
   val FILE_NAME_PATTERN = Regex("""crash-\d+-\d+\.json""")
 
-  /** Matches an orphaned/in-progress temp file (`crash-{pid}-{timestamp}.json.tmp`); group 1 is the pid. */
-  val TEMP_FILE_PATTERN = Regex("""crash-(\d+)-\d+\.json\.tmp""")
+  /**
+   * Matches any non-final sibling of a crash file: a `crash-{pid}-{timestamp}.json` base name with
+   * an extra extension. `AtomicFile` stages and backs up under suffixes like `.new`/`.bak`, but
+   * rather than enumerate them, anything carrying a crash base name that isn't the final `.json` is
+   * a temp the reader can sweep. Group 1 is the pid, so the current process's in-flight temp is
+   * spared.
+   */
+  val TEMP_FILE_PATTERN = Regex("""crash-(\d+)-\d+\.json\..+""")
 
   /**
    * The canonical pending-crash directory — `noBackupFilesDir` so stale crash

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileFormat.kt
@@ -1,31 +1,38 @@
 package expo.modules.appmetrics.crashreporting
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
 /**
  * The on-disk contract for pending-crash files, shared by `CrashFileWriter` and
- * `CrashFileReader`. Keeping the format in one place means the writer and reader
- * can't drift apart on the separator or the escaping rules.
+ * `CrashFileReader`. Each file is a JSON-encoded `PendingJvmCrashPayload`; keeping
+ * the format and its `Json` instance in one place means the writer and reader
+ * can't drift apart.
  */
 internal object CrashFileFormat {
-  /** Separates the `key=value` header block from the stack frames below it. */
-  const val HEADER_SEPARATOR = "---"
+  /** Encodes/decodes the pending-crash payload. Lenient so an older file still parses. */
+  val json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+  }
 
   /**
    * Suffix for the temp file the writer fills in before atomically renaming it to its final
-   * `crash-{pid}-{timestamp}.txt` name. The write happens on the crash path inside a dying process,
+   * `crash-{pid}-{timestamp}.json` name. The write happens on the crash path inside a dying process,
    * so a write can be truncated or orphaned at any point; staging under `.tmp` and committing with a
    * rename makes the final file appear all-at-once or not at all. Because `FILE_NAME_PATTERN` only
-   * matches the final `.txt` name, the reader never picks up a `.tmp` file that is still being
+   * matches the final `.json` name, the reader never picks up a `.tmp` file that is still being
    * written (or was left behind by a process that died mid-write), so it only ever parses complete
    * files. An orphan left by a mid-write death is swept on the next launch by
    * `CrashFileReader.deleteOrphanedTempFiles`.
    */
   const val TEMP_SUFFIX = ".tmp"
 
-  /** Matches a finished pending-crash file (`crash-{pid}-{timestamp}.txt`); skips `.tmp` by design. */
-  val FILE_NAME_PATTERN = Regex("""crash-\d+-\d+\.txt""")
+  /** Matches a finished pending-crash file (`crash-{pid}-{timestamp}.json`); skips `.tmp` by design. */
+  val FILE_NAME_PATTERN = Regex("""crash-\d+-\d+\.json""")
 
-  /** Matches an orphaned/in-progress temp file (`crash-{pid}-{timestamp}.txt.tmp`); group 1 is the pid. */
-  val TEMP_FILE_PATTERN = Regex("""crash-(\d+)-\d+\.txt\.tmp""")
+  /** Matches an orphaned/in-progress temp file (`crash-{pid}-{timestamp}.json.tmp`); group 1 is the pid. */
+  val TEMP_FILE_PATTERN = Regex("""crash-(\d+)-\d+\.json\.tmp""")
 
   /**
    * The canonical pending-crash directory — `noBackupFilesDir` so stale crash
@@ -34,32 +41,23 @@ internal object CrashFileFormat {
    */
   fun crashesDir(context: android.content.Context): java.io.File =
     java.io.File(context.noBackupFilesDir, "expo-app-metrics/crashes")
-
-  fun escape(value: String): String =
-    value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r")
-
-  fun unescape(value: String): String {
-    val result = StringBuilder(value.length)
-    var index = 0
-    while (index < value.length) {
-      val char = value[index]
-      if (char == '\\' && index + 1 < value.length) {
-        val next = value[index + 1]
-        val unescaped = when (next) {
-          'n' -> '\n'
-          'r' -> '\r'
-          '\\' -> '\\'
-          else -> null
-        }
-        if (unescaped != null) {
-          result.append(unescaped)
-          index += 2
-          continue
-        }
-      }
-      result.append(char)
-      index++
-    }
-    return result.toString()
-  }
 }
+
+/**
+ * The JSON shape persisted for a pending JVM crash. Written on the crash path by
+ * `CrashFileWriter` and read back on the next launch by `CrashFileReader`.
+ */
+@Serializable
+data class PendingJvmCrashPayload(
+  /** Session that crashed, or `null` when the crash predated the session identity. */
+  val sessionId: String? = null,
+  val pid: Int,
+  val crashedAtMillis: Long,
+  /** Fully-qualified throwable class name. */
+  val exceptionClass: String,
+  /** `Throwable.toString()` plus the `Caused by:` chain. */
+  val composedMessage: String,
+  val threadName: String? = null,
+  /** Symbolic frames of the primary exception, crash site first. */
+  val stackFrames: List<String>
+)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
@@ -1,5 +1,6 @@
 package expo.modules.appmetrics.crashreporting
 
+import android.content.Context
 import expo.modules.appmetrics.utils.TimeUtils
 import kotlinx.serialization.decodeFromString
 import java.io.File
@@ -12,17 +13,17 @@ import java.io.File
 class CrashFileReader(private val directory: File) {
   /**
    * Parses every pending-crash file in the directory. Corrupt or partially
-   * written files are skipped (a `.tmp` that never got renamed is invisible by
-   * construction, and is later reclaimed by `deleteOrphanedTempFiles`).
+   * written files are skipped (an `AtomicFile` temp that never got committed is
+   * invisible by construction, and is later reclaimed by `deleteOrphanedTempFiles`).
    */
   fun listPendingCrashes(): List<PendingJvmCrash> = finalCrashFiles().mapNotNull { parse(it) }
 
   /**
-   * Deletes `.tmp` files orphaned by a process that died mid-write.
+   * Deletes the temp files `AtomicFile` orphans when a process dies mid-write.
    *
-   * A completed write atomically renames its temp to a `.json`, so any `.tmp` still on disk is dead
-   * weight the reader will never parse. Skips temp files for `currentPid`, which may belong to an
-   * in-flight crash write happening right now — deleting it would drop a live crash report.
+   * A completed write atomically renames its temp onto the final `.json`, so any temp still on disk
+   * is dead weight the reader will never parse. Skips temp files for `currentPid`, which may belong
+   * to an in-flight crash write happening right now — deleting it would drop a live crash report.
    */
   fun deleteOrphanedTempFiles(currentPid: Int = android.os.Process.myPid()) {
     val files = directory.listFiles() ?: return
@@ -54,7 +55,7 @@ class CrashFileReader(private val directory: File) {
     }
   }
 
-  /** Final pending-crash files (`.json`); excludes `.tmp` and unrelated files by name. */
+  /** Final pending-crash files (`.json`); excludes `AtomicFile` temps and unrelated files by name. */
   private fun finalCrashFiles(): List<File> =
     directory.listFiles { file -> CrashFileFormat.FILE_NAME_PATTERN.matches(file.name) }?.toList() ?: emptyList()
 
@@ -74,7 +75,7 @@ class CrashFileReader(private val directory: File) {
     }.getOrNull()
 
   companion object {
-    fun forContext(context: android.content.Context): CrashFileReader =
+    fun forContext(context: Context): CrashFileReader =
       CrashFileReader(CrashFileFormat.crashesDir(context))
   }
 }
@@ -99,20 +100,17 @@ data class PendingJvmCrash(
 ) {
   /**
    * Normalizes the parsed file into the cross-platform `CrashReport` shape.
-   * Timestamps use the package's millisecond ISO format so they compare
+   * `timestampBegin` uses the package's millisecond ISO format so it compares
    * lexicographically against session rows. (iOS emits whole-second ISO in the
-   * same fields — both are valid ISO 8601 and consumers must parse, not
+   * same field — both are valid ISO 8601 and consumers must parse, not
    * string-compare, across platforms.)
    */
-  fun toCrashReport(ingestedAt: String, appVersion: String): CrashReport {
-    val crashTimestamp = TimeUtils.millisToTimestamp(crashedAtMillis)
-    return CrashReport(
+  fun toCrashReport(ingestedAt: String, appVersion: String): CrashReport =
+    CrashReport(
       exceptionReason = composedMessage,
       callStackTree = CallStackTreeBuilder.fromSymbols(stackFrames),
       appVersion = appVersion,
-      timestampBegin = crashTimestamp,
-      timestampEnd = crashTimestamp,
+      timestampBegin = TimeUtils.millisToTimestamp(crashedAtMillis),
       ingestedAt = ingestedAt
     )
-  }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
@@ -1,12 +1,13 @@
 package expo.modules.appmetrics.crashreporting
 
 import expo.modules.appmetrics.utils.TimeUtils
+import kotlinx.serialization.decodeFromString
 import java.io.File
 
 /**
  * Next-launch read side of the pending-crash store written by `CrashFileWriter`. Runs where
  * allocation is safe, so unlike the write path it can parse freely and assemble the structured
- * `PendingJvmCrash`. Reads the format defined by `CrashFileFormat`.
+ * `PendingJvmCrash`. Decodes the JSON `PendingJvmCrashPayload` defined by `CrashFileFormat`.
  */
 class CrashFileReader(private val directory: File) {
   /**
@@ -19,7 +20,7 @@ class CrashFileReader(private val directory: File) {
   /**
    * Deletes `.tmp` files orphaned by a process that died mid-write.
    *
-   * A completed write atomically renames its temp to a `.txt`, so any `.tmp` still on disk is dead
+   * A completed write atomically renames its temp to a `.json`, so any `.tmp` still on disk is dead
    * weight the reader will never parse. Skips temp files for `currentPid`, which may belong to an
    * in-flight crash write happening right now — deleting it would drop a live crash report.
    */
@@ -38,11 +39,11 @@ class CrashFileReader(private val directory: File) {
   }
 
   /**
-   * Deletes corrupt final `.txt` files — ones that parse to null because a crash-path IO failure
-   * truncated them before the atomic rename (`PrintWriter` swallows write errors). The reader skips
-   * them forever otherwise, so the processor reclaims them on the same run. Needs no current-pid
-   * guard like `deleteOrphanedTempFiles`: a `.txt` exists only after the rename, so a live crash file
-   * is always complete and parses fine — only genuinely corrupt files, which hold no recoverable
+   * Deletes corrupt final `.json` files — ones that fail to decode because a crash-path IO failure
+   * truncated them before the atomic rename. The reader skips them forever otherwise, so the
+   * processor reclaims them on the same run. Needs no current-pid guard like
+   * `deleteOrphanedTempFiles`: a `.json` exists only after the rename, so a live crash file is
+   * always complete and parses fine — only genuinely corrupt files, which hold no recoverable
    * report, are removed.
    */
   fun deleteMalformedFiles() {
@@ -53,37 +54,21 @@ class CrashFileReader(private val directory: File) {
     }
   }
 
-  /** Final pending-crash files (`.txt`); excludes `.tmp` and unrelated files by name. */
+  /** Final pending-crash files (`.json`); excludes `.tmp` and unrelated files by name. */
   private fun finalCrashFiles(): List<File> =
     directory.listFiles { file -> CrashFileFormat.FILE_NAME_PATTERN.matches(file.name) }?.toList() ?: emptyList()
 
   private fun parse(file: File): PendingJvmCrash? =
     runCatching {
-      val lines = file.readLines()
-      val separatorIndex = lines.indexOf(CrashFileFormat.HEADER_SEPARATOR)
-      if (separatorIndex < 0) {
-        return null
-      }
-      val header = lines.take(separatorIndex).mapNotNull { line ->
-        val separator = line.indexOf('=')
-        if (separator < 0) null else line.substring(0, separator) to line.substring(separator + 1)
-      }.toMap()
-      val pid = header["pid"]?.toIntOrNull() ?: return null
-      val crashedAtMillis = header["crashedAt"]?.toLongOrNull() ?: return null
-      val exceptionClass = header["exceptionClass"]?.takeIf { it.isNotEmpty() } ?: return null
-
-      val stackFrames = lines.drop(separatorIndex + 1)
-        .filter { it.isNotEmpty() }
-        .map(CrashFileFormat::unescape)
-
+      val payload = CrashFileFormat.json.decodeFromString<PendingJvmCrashPayload>(file.readText())
       PendingJvmCrash(
-        sessionId = header["sessionId"]?.takeIf { it.isNotEmpty() }?.let(CrashFileFormat::unescape),
-        pid = pid,
-        crashedAtMillis = crashedAtMillis,
-        exceptionClass = CrashFileFormat.unescape(exceptionClass),
-        composedMessage = header["composedMessage"]?.let(CrashFileFormat::unescape) ?: exceptionClass,
-        threadName = header["thread"]?.takeIf { it.isNotEmpty() }?.let(CrashFileFormat::unescape),
-        stackFrames = stackFrames,
+        sessionId = payload.sessionId,
+        pid = payload.pid,
+        crashedAtMillis = payload.crashedAtMillis,
+        exceptionClass = payload.exceptionClass,
+        composedMessage = payload.composedMessage,
+        threadName = payload.threadName,
+        stackFrames = payload.stackFrames,
         file = file
       )
     }.getOrNull()

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileReader.kt
@@ -1,0 +1,133 @@
+package expo.modules.appmetrics.crashreporting
+
+import expo.modules.appmetrics.utils.TimeUtils
+import java.io.File
+
+/**
+ * Next-launch read side of the pending-crash store written by `CrashFileWriter`. Runs where
+ * allocation is safe, so unlike the write path it can parse freely and assemble the structured
+ * `PendingJvmCrash`. Reads the format defined by `CrashFileFormat`.
+ */
+class CrashFileReader(private val directory: File) {
+  /**
+   * Parses every pending-crash file in the directory. Corrupt or partially
+   * written files are skipped (a `.tmp` that never got renamed is invisible by
+   * construction, and is later reclaimed by `deleteOrphanedTempFiles`).
+   */
+  fun listPendingCrashes(): List<PendingJvmCrash> = finalCrashFiles().mapNotNull { parse(it) }
+
+  /**
+   * Deletes `.tmp` files orphaned by a process that died mid-write.
+   *
+   * A completed write atomically renames its temp to a `.txt`, so any `.tmp` still on disk is dead
+   * weight the reader will never parse. Skips temp files for `currentPid`, which may belong to an
+   * in-flight crash write happening right now — deleting it would drop a live crash report.
+   */
+  fun deleteOrphanedTempFiles(currentPid: Int = android.os.Process.myPid()) {
+    val files = directory.listFiles() ?: return
+    for (file in files) {
+      val match = CrashFileFormat.TEMP_FILE_PATTERN.matchEntire(file.name) ?: continue
+      if (match.groupValues[1].toIntOrNull() != currentPid) {
+        file.delete()
+      }
+    }
+  }
+
+  fun delete(pendingCrash: PendingJvmCrash) {
+    pendingCrash.file.delete()
+  }
+
+  /**
+   * Deletes corrupt final `.txt` files — ones that parse to null because a crash-path IO failure
+   * truncated them before the atomic rename (`PrintWriter` swallows write errors). The reader skips
+   * them forever otherwise, so the processor reclaims them on the same run. Needs no current-pid
+   * guard like `deleteOrphanedTempFiles`: a `.txt` exists only after the rename, so a live crash file
+   * is always complete and parses fine — only genuinely corrupt files, which hold no recoverable
+   * report, are removed.
+   */
+  fun deleteMalformedFiles() {
+    for (file in finalCrashFiles()) {
+      if (parse(file) == null) {
+        file.delete()
+      }
+    }
+  }
+
+  /** Final pending-crash files (`.txt`); excludes `.tmp` and unrelated files by name. */
+  private fun finalCrashFiles(): List<File> =
+    directory.listFiles { file -> CrashFileFormat.FILE_NAME_PATTERN.matches(file.name) }?.toList() ?: emptyList()
+
+  private fun parse(file: File): PendingJvmCrash? =
+    runCatching {
+      val lines = file.readLines()
+      val separatorIndex = lines.indexOf(CrashFileFormat.HEADER_SEPARATOR)
+      if (separatorIndex < 0) {
+        return null
+      }
+      val header = lines.take(separatorIndex).mapNotNull { line ->
+        val separator = line.indexOf('=')
+        if (separator < 0) null else line.substring(0, separator) to line.substring(separator + 1)
+      }.toMap()
+      val pid = header["pid"]?.toIntOrNull() ?: return null
+      val crashedAtMillis = header["crashedAt"]?.toLongOrNull() ?: return null
+      val exceptionClass = header["exceptionClass"]?.takeIf { it.isNotEmpty() } ?: return null
+
+      val stackFrames = lines.drop(separatorIndex + 1)
+        .filter { it.isNotEmpty() }
+        .map(CrashFileFormat::unescape)
+
+      PendingJvmCrash(
+        sessionId = header["sessionId"]?.takeIf { it.isNotEmpty() }?.let(CrashFileFormat::unescape),
+        pid = pid,
+        crashedAtMillis = crashedAtMillis,
+        exceptionClass = CrashFileFormat.unescape(exceptionClass),
+        composedMessage = header["composedMessage"]?.let(CrashFileFormat::unescape) ?: exceptionClass,
+        threadName = header["thread"]?.takeIf { it.isNotEmpty() }?.let(CrashFileFormat::unescape),
+        stackFrames = stackFrames,
+        file = file
+      )
+    }.getOrNull()
+
+  companion object {
+    fun forContext(context: android.content.Context): CrashFileReader =
+      CrashFileReader(CrashFileFormat.crashesDir(context))
+  }
+}
+
+/**
+ * A crash captured by `JvmCrashHandler` in a previous process, parsed back from
+ * its pending file on the next launch.
+ */
+data class PendingJvmCrash(
+  /** Session that crashed, or `null` when the crash predated the session identity. */
+  val sessionId: String?,
+  val pid: Int,
+  val crashedAtMillis: Long,
+  /** Fully-qualified throwable class name. */
+  val exceptionClass: String,
+  /** `Throwable.toString()` plus the `Caused by:` chain. */
+  val composedMessage: String,
+  val threadName: String?,
+  /** Symbolic frames of the primary exception, crash site first. */
+  val stackFrames: List<String>,
+  val file: File
+) {
+  /**
+   * Normalizes the parsed file into the cross-platform `CrashReport` shape.
+   * Timestamps use the package's millisecond ISO format so they compare
+   * lexicographically against session rows. (iOS emits whole-second ISO in the
+   * same fields — both are valid ISO 8601 and consumers must parse, not
+   * string-compare, across platforms.)
+   */
+  fun toCrashReport(ingestedAt: String, appVersion: String): CrashReport {
+    val crashTimestamp = TimeUtils.millisToTimestamp(crashedAtMillis)
+    return CrashReport(
+      exceptionReason = composedMessage,
+      callStackTree = CallStackTreeBuilder.fromSymbols(stackFrames),
+      appVersion = appVersion,
+      timestampBegin = crashTimestamp,
+      timestampEnd = crashTimestamp,
+      ingestedAt = ingestedAt
+    )
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
@@ -4,16 +4,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import java.io.BufferedWriter
+import kotlinx.serialization.encodeToString
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStreamWriter
-import java.io.PrintWriter
 
 /**
  * Crash-time persistence for JVM crashes. The write path runs inside a dying
- * process, so it stays minimal: a few escaped `key=value` header lines plus one
- * escaped stack frame per line, written to a temp file and atomically renamed.
+ * process, so it stays minimal: build a `PendingJvmCrashPayload`, JSON-encode it,
+ * write to a temp file and atomically rename.
  *
  * One file per pid+timestamp, so a crash burst (crash → relaunch → crash)
  * can't overwrite a file the processor hasn't read yet.
@@ -42,24 +39,22 @@ class CrashFileWriter(
       if (!directory.isDirectory && !directory.mkdirs()) {
         return null
       }
-      val file = File(directory, "crash-$pid-$crashedAtMillis.txt")
+      val file = File(directory, "crash-$pid-$crashedAtMillis.json")
       val tempFile = File(directory, file.name + CrashFileFormat.TEMP_SUFFIX)
-      PrintWriter(BufferedWriter(OutputStreamWriter(FileOutputStream(tempFile), Charsets.UTF_8))).use { writer ->
-        writer.append("sessionId=").append(CrashFileFormat.escape(sessionId ?: "")).append('\n')
-        writer.append("pid=").append(pid.toString()).append('\n')
-        writer.append("crashedAt=").append(crashedAtMillis.toString()).append('\n')
-        writer.append("thread=").append(CrashFileFormat.escape(threadName)).append('\n')
-        writer.append("exceptionClass=").append(CrashFileFormat.escape(throwable.javaClass.name)).append('\n')
-        writer.append("composedMessage=").append(CrashFileFormat.escape(CrashReport.composeMessage(throwable))).append('\n')
-        writer.append(CrashFileFormat.HEADER_SEPARATOR).append('\n')
-        // One escaped frame per line, from the same source `fromThrowable` uses.
-        for (element in throwable.stackTrace) {
-          writer.append(CrashFileFormat.escape(element.toString())).append('\n')
-        }
-      }
+      val payload = PendingJvmCrashPayload(
+        sessionId = sessionId,
+        pid = pid,
+        crashedAtMillis = crashedAtMillis,
+        exceptionClass = throwable.javaClass.name,
+        composedMessage = CrashReport.composeMessage(throwable),
+        threadName = threadName,
+        // Same frame source `fromThrowable` uses.
+        stackFrames = throwable.stackTrace.map { it.toString() }
+      )
+      tempFile.writeText(CrashFileFormat.json.encodeToString(payload))
       // Commit with an atomic rename: the reader only matches the final
-      // `.txt` name, so it never sees a half-written file. A crash mid-write
-      // leaves the `.txt.tmp` behind, swept later by `deleteOrphanedTempFiles`.
+      // `.json` name, so it never sees a half-written file. A crash mid-write
+      // leaves the `.json.tmp` behind, swept later by `deleteOrphanedTempFiles`.
       if (tempFile.renameTo(file)) {
         file
       } else {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
@@ -1,29 +1,18 @@
 package expo.modules.appmetrics.crashreporting
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import android.util.AtomicFile
 import kotlinx.serialization.encodeToString
 import java.io.File
 
 /**
  * Crash-time persistence for JVM crashes. The write path runs inside a dying
  * process, so it stays minimal: build a `PendingJvmCrashPayload`, JSON-encode it,
- * write to a temp file and atomically rename.
+ * and hand it to `AtomicFile`, which stages the bytes, fsyncs, then commits.
  *
  * One file per pid+timestamp, so a crash burst (crash → relaunch → crash)
  * can't overwrite a file the processor hasn't read yet.
  */
-class CrashFileWriter(
-  private val directory: File,
-  private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
-) {
-  /**
-   * Creates the crash directory, to keep the write path leaner.
-   */
-  fun prepare(): Job = scope.launch { runCatching { directory.mkdirs() } }
-
+class CrashFileWriter(private val directory: File) {
   /**
    * Writes one pending-crash file. Returns the file, or `null` on any failure —
    * this runs on the crash path and must never throw into the handler chain.
@@ -40,7 +29,6 @@ class CrashFileWriter(
         return null
       }
       val file = File(directory, "crash-$pid-$crashedAtMillis.json")
-      val tempFile = File(directory, file.name + CrashFileFormat.TEMP_SUFFIX)
       val payload = PendingJvmCrashPayload(
         sessionId = sessionId,
         pid = pid,
@@ -51,16 +39,21 @@ class CrashFileWriter(
         // Same frame source `fromThrowable` uses.
         stackFrames = throwable.stackTrace.map { it.toString() }
       )
-      tempFile.writeText(CrashFileFormat.json.encodeToString(payload))
-      // Commit with an atomic rename: the reader only matches the final
-      // `.json` name, so it never sees a half-written file. A crash mid-write
-      // leaves the `.json.tmp` behind, swept later by `deleteOrphanedTempFiles`.
-      if (tempFile.renameTo(file)) {
-        file
-      } else {
-        tempFile.delete()
-        null
+      // `AtomicFile` stages the bytes in a sibling temp, fsyncs, then renames it
+      // onto `file`. The reader only matches the final `.json`, so it never sees a
+      // half-written file; a crash mid-write leaves only an orphaned temp, swept
+      // later by `deleteOrphanedTempFiles`. The fsync also survives a power loss
+      // the bare rename wouldn't.
+      val atomicFile = AtomicFile(file)
+      val stream = atomicFile.startWrite()
+      try {
+        stream.write(CrashFileFormat.json.encodeToString(payload).toByteArray())
+        atomicFile.finishWrite(stream)
+      } catch (e: Throwable) {
+        atomicFile.failWrite(stream)
+        return null
       }
+      file
     } catch (_: Throwable) {
       null
     }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashFileWriter.kt
@@ -1,0 +1,78 @@
+package expo.modules.appmetrics.crashreporting
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+
+/**
+ * Crash-time persistence for JVM crashes. The write path runs inside a dying
+ * process, so it stays minimal: a few escaped `key=value` header lines plus one
+ * escaped stack frame per line, written to a temp file and atomically renamed.
+ *
+ * One file per pid+timestamp, so a crash burst (crash → relaunch → crash)
+ * can't overwrite a file the processor hasn't read yet.
+ */
+class CrashFileWriter(
+  private val directory: File,
+  private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+) {
+  /**
+   * Creates the crash directory, to keep the write path leaner.
+   */
+  fun prepare(): Job = scope.launch { runCatching { directory.mkdirs() } }
+
+  /**
+   * Writes one pending-crash file. Returns the file, or `null` on any failure —
+   * this runs on the crash path and must never throw into the handler chain.
+   */
+  fun write(
+    throwable: Throwable,
+    threadName: String,
+    sessionId: String?,
+    pid: Int,
+    crashedAtMillis: Long
+  ): File? {
+    return try {
+      if (!directory.isDirectory && !directory.mkdirs()) {
+        return null
+      }
+      val file = File(directory, "crash-$pid-$crashedAtMillis.txt")
+      val tempFile = File(directory, file.name + CrashFileFormat.TEMP_SUFFIX)
+      PrintWriter(BufferedWriter(OutputStreamWriter(FileOutputStream(tempFile), Charsets.UTF_8))).use { writer ->
+        writer.append("sessionId=").append(CrashFileFormat.escape(sessionId ?: "")).append('\n')
+        writer.append("pid=").append(pid.toString()).append('\n')
+        writer.append("crashedAt=").append(crashedAtMillis.toString()).append('\n')
+        writer.append("thread=").append(CrashFileFormat.escape(threadName)).append('\n')
+        writer.append("exceptionClass=").append(CrashFileFormat.escape(throwable.javaClass.name)).append('\n')
+        writer.append("composedMessage=").append(CrashFileFormat.escape(CrashReport.composeMessage(throwable))).append('\n')
+        writer.append(CrashFileFormat.HEADER_SEPARATOR).append('\n')
+        // One escaped frame per line, from the same source `fromThrowable` uses.
+        for (element in throwable.stackTrace) {
+          writer.append(CrashFileFormat.escape(element.toString())).append('\n')
+        }
+      }
+      // Commit with an atomic rename: the reader only matches the final
+      // `.txt` name, so it never sees a half-written file. A crash mid-write
+      // leaves the `.txt.tmp` behind, swept later by `deleteOrphanedTempFiles`.
+      if (tempFile.renameTo(file)) {
+        file
+      } else {
+        tempFile.delete()
+        null
+      }
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  companion object {
+    fun forContext(context: android.content.Context): CrashFileWriter =
+      CrashFileWriter(CrashFileFormat.crashesDir(context))
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
@@ -16,10 +16,12 @@ data class CrashReport(
   val callStackTree: CallStackTree? = null,
   /** App version at the time of the crash. */
   val appVersion: String,
-  /** Crash window start. Android knows the exact crash moment, so begin == end. */
+  /**
+   * The exact crash moment. iOS reports a diagnostic window (`timestampBegin`..`timestampEnd`);
+   * Android knows the precise instant, so it emits only the start and the cross-platform
+   * `timestampEnd` is resolved from it in JS.
+   */
   val timestampBegin: String,
-  /** Crash window end. Android knows the exact crash moment, so begin == end. */
-  val timestampEnd: String,
   /**
    * When this device processed the crash and constructed the report — the next
    * launch after the crash, not the crash moment itself.
@@ -55,8 +57,8 @@ data class CrashReport(
 
     /**
      * Builds a report from a JVM throwable caught by the uncaught-exception handler.
-     * `crashTimestamp` is the crash moment (used as a zero-width window); `ingestedAt`
-     * is when the report was assembled on the next launch.
+     * `crashTimestamp` is the crash moment; `ingestedAt` is when the report was
+     * assembled on the next launch.
      */
     fun fromThrowable(
       throwable: Throwable,
@@ -69,7 +71,6 @@ data class CrashReport(
         callStackTree = CallStackTreeBuilder.fromStackTrace(throwable.stackTrace),
         appVersion = appVersion,
         timestampBegin = crashTimestamp,
-        timestampEnd = crashTimestamp,
         ingestedAt = ingestedAt
       )
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
@@ -1,0 +1,96 @@
+package expo.modules.appmetrics.crashreporting
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class CrashReport(
+  /** Unix signal number (e.g. SIGSEGV = 11), from `ApplicationExitInfo.getStatus()` for native crashes. */
+  val signal: Int? = null,
+  /** Human-readable description of the termination, from `ApplicationExitInfo.getDescription()`. */
+  val terminationReason: String? = null,
+  /** Exception summary. */
+  val exceptionReason: String? = null,
+  /** Call stack of the crashing thread. */
+  val callStackTree: CallStackTree? = null,
+  /** App version at the time of the crash. */
+  val appVersion: String,
+  /** Crash window start. Android knows the exact crash moment, so begin == end. */
+  val timestampBegin: String,
+  /** Crash window end. Android knows the exact crash moment, so begin == end. */
+  val timestampEnd: String,
+  /**
+   * When this device processed the crash and constructed the report — the next
+   * launch after the crash, not the crash moment itself.
+   */
+  val ingestedAt: String
+) {
+  @Serializable
+  data class CallStackTree(
+    val callStacks: List<CallStack>? = null
+  ) {
+    @Serializable
+    data class CallStack(
+      val threadAttributed: Boolean? = null,
+      val callStackRootFrames: List<Frame>? = null
+    )
+
+    @Serializable
+    data class Frame(
+      val symbol: String? = null
+    )
+  }
+
+  fun encodeToJsonString(): String = json.encodeToString(this)
+
+  companion object {
+    private val json = Json {
+      ignoreUnknownKeys = true
+      explicitNulls = false
+    }
+
+    fun decodeFromJsonString(payload: String): CrashReport? =
+      runCatching { json.decodeFromString<CrashReport>(payload) }.getOrNull()
+
+    /**
+     * Builds a report from a JVM throwable caught by the uncaught-exception handler.
+     * `crashTimestamp` is the crash moment (used as a zero-width window); `ingestedAt`
+     * is when the report was assembled on the next launch.
+     */
+    fun fromThrowable(
+      throwable: Throwable,
+      crashTimestamp: String,
+      ingestedAt: String,
+      appVersion: String
+    ): CrashReport =
+      CrashReport(
+        exceptionReason = composeMessage(throwable),
+        callStackTree = CallStackTreeBuilder.fromStackTrace(throwable.stackTrace),
+        appVersion = appVersion,
+        timestampBegin = crashTimestamp,
+        timestampEnd = crashTimestamp,
+        ingestedAt = ingestedAt
+      )
+
+    /**
+     * `Throwable.toString()` plus the cause chain — the root cause is usually
+     * the diagnostic that matters, and `toString()` alone drops it. Mirrors the
+     * `Caused by:` lines of `printStackTrace`. Depth-capped defensively against
+     * cyclic cause chains.
+     */
+    fun composeMessage(throwable: Throwable): String {
+      val message = StringBuilder(throwable.toString())
+      var cause = throwable.cause
+      var depth = 0
+      while (cause != null && depth < MAX_CAUSE_DEPTH) {
+        message.append("\nCaused by: ").append(cause.toString())
+        cause = cause.cause
+        depth++
+      }
+      return message.toString()
+    }
+
+    private const val MAX_CAUSE_DEPTH = 5
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
@@ -18,7 +18,7 @@ suspend fun attributeAndStoreCrashReport(
   runCatching {
     // A null target stores the report as an orphan.
     val target: String? = when {
-      // JVM file with a real session id → stored under that id. 
+      // JVM file with a real session id → stored under that id.
       sessionId != null -> sessionId.takeIf { sessionManager.getSessionRow(it) != null }
       // Native crash (exit record) → attributed to the previous main session,
       // unless that session already has a crash report, in which case it's stored

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
@@ -1,0 +1,36 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.util.Log
+import expo.modules.appmetrics.TAG
+import expo.modules.appmetrics.storage.SessionManager
+
+/**
+ * Attributes a crash report to a session and persists it. Failures are logged and
+ * swallowed so a bad report can't crash the next launch.
+ */
+suspend fun attributeAndStoreCrashReport(
+  sessionManager: SessionManager,
+  currentSessionId: String?,
+  sessionId: String?,
+  origin: CrashOrigin,
+  report: CrashReport
+) {
+  runCatching {
+    // A null target stores the report as an orphan.
+    val target: String? = when {
+      // JVM file with a real session id → stored under that id. 
+      sessionId != null -> sessionId.takeIf { sessionManager.getSessionRow(it) != null }
+      // Native crash (exit record) → attributed to the previous main session,
+      // unless that session already has a crash report, in which case it's stored
+      // as an orphan so the existing report isn't overwritten.
+      origin == CrashOrigin.EXIT_RECORD ->
+        sessionManager.getPreviousMainSessionId(currentSessionId)
+          ?.takeIf { sessionManager.getCrashReport(it) == null }
+      // id-less JVM file (a crash before the main session existed) → orphan.
+      else -> null
+    }
+    sessionManager.setCrashReport(target, report.encodeToJsonString())
+  }.onFailure {
+    Log.e(TAG, "Failed to persist a crash report", it)
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
@@ -62,6 +62,11 @@ class CrashReportProcessor(
 
     // Advance the cursor past every record we saw; the next launch only processes
     // records newer than this.
+    // Durability gap: if the process dies between a `delete(file)` above and this
+    // `set`, the cursor never advances, so the next launch reprocesses that
+    // record — but its JVM file is gone, so the death resurfaces once as a bare
+    // EXIT_RECORD orphan. Narrow (needs a second crash on the launch path) and
+    // bounded to a single duplicate, so we accept it rather than add a journal.
     val newCursor = allRecords.maxOfOrNull { it.timestampMillis } ?: cursor
     lastProcessedExitStore.set(maxOf(newCursor, cursor))
   }
@@ -91,6 +96,10 @@ class CrashReportProcessor(
       crashFileReader.delete(file)
     }
 
+    // No record-vs-record dedup: the OS emits one `ApplicationExitInfo` per
+    // process death, so two crash-class records (e.g. CRASH_NATIVE and SIGNALED)
+    // never describe the same death. `consumedRecordKeys` only suppresses a
+    // record already covered by a richer JVM file above.
     for (record in newRecords) {
       if (record.key in consumedRecordKeys || !record.isStandaloneCrash) {
         continue

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
@@ -1,0 +1,105 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.content.Context
+import expo.modules.appmetrics.AppMetricsPreferences
+import expo.modules.appmetrics.utils.TimeUtils
+
+/**
+ * Where a crash report came from. Lets the attribution callback treat an id-less
+ * JVM file (a crash before the session existed → orphan) differently from an
+ * id-less native record (attributable to the previous session).
+ */
+enum class CrashOrigin {
+  JVM_FILE,
+  EXIT_RECORD
+}
+
+/**
+ * Stores the timestamp of the newest OS exit record already turned into a crash
+ * report, so each launch only processes records newer than it.
+ */
+interface LastProcessedExitStore {
+  fun get(): Long
+
+  fun set(timestampMillis: Long)
+}
+
+class PreferencesLastProcessedExitStore(private val context: Context) : LastProcessedExitStore {
+  override fun get(): Long = AppMetricsPreferences.getLastProcessedExitTimestampMillis(context)
+
+  override fun set(timestampMillis: Long) {
+    AppMetricsPreferences.setLastProcessedExitTimestampMillis(context, timestampMillis)
+  }
+}
+
+/**
+ * Next-launch crash processing: turns the previous process's death evidence —
+ * pending JVM crash files from `JvmCrashHandler` and OS exit records from
+ * `ExitInfoProvider` — into `CrashReport`s, and hands each to `storeReport`.
+ */
+class CrashReportProcessor(
+  private val crashFileReader: CrashFileReader,
+  private val exitInfoProvider: ExitInfoProvider,
+  private val lastProcessedExitStore: LastProcessedExitStore,
+  private val appVersion: String?,
+  private val storeReport: suspend (sessionId: String?, origin: CrashOrigin, report: CrashReport) -> Unit
+) {
+  suspend fun process() {
+    crashFileReader.deleteOrphanedTempFiles()
+
+    val allRecords = exitInfoProvider.getExitRecords()
+    val cursor = lastProcessedExitStore.get()
+    val newRecords = allRecords.filter { it.timestampMillis > cursor }
+    val pendingFiles = crashFileReader.listPendingCrashes()
+
+    if (newRecords.isNotEmpty() || pendingFiles.isNotEmpty()) {
+      processCrashes(newRecords, pendingFiles)
+    }
+
+    // `processCrashes` deleted the files it parsed; sweep any corrupt final files left behind so they
+    // don't sit unreadable on disk forever.
+    crashFileReader.deleteMalformedFiles()
+
+    // Advance the cursor past every record we saw; the next launch only processes
+    // records newer than this.
+    val newCursor = allRecords.maxOfOrNull { it.timestampMillis } ?: cursor
+    lastProcessedExitStore.set(maxOf(newCursor, cursor))
+  }
+
+  private suspend fun processCrashes(
+    newRecords: List<ExitRecord>,
+    pendingFiles: List<PendingJvmCrash>
+  ) {
+    val resolvedAppVersion = appVersion ?: "unknown"
+    val ingestedAt = TimeUtils.getCurrentTimestampInISOFormat()
+    val consumedRecordKeys = mutableSetOf<String>()
+
+    // Files first: when a crash is both a file and a record, the file wins (it
+    // has the stack) and its matching record is consumed below.
+    for (file in pendingFiles) {
+      val matchingRecord = newRecords.firstOrNull { record ->
+        record.key !in consumedRecordKeys && record.matches(file)
+      }
+      // Consume the matching record so it isn't also delivered as its own bare report.
+      matchingRecord?.let { consumedRecordKeys += it.key }
+
+      storeReport(
+        file.sessionId,
+        CrashOrigin.JVM_FILE,
+        file.toCrashReport(ingestedAt, resolvedAppVersion)
+      )
+      crashFileReader.delete(file)
+    }
+
+    for (record in newRecords) {
+      if (record.key in consumedRecordKeys || !record.isStandaloneCrash) {
+        continue
+      }
+      storeReport(
+        null,
+        CrashOrigin.EXIT_RECORD,
+        record.toCrashReport(ingestedAt, resolvedAppVersion)
+      )
+    }
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
@@ -3,6 +3,7 @@ package expo.modules.appmetrics.crashreporting
 import android.content.Context
 import expo.modules.appmetrics.AppMetricsPreferences
 import expo.modules.appmetrics.utils.TimeUtils
+import java.lang.ref.WeakReference
 
 /**
  * Where a crash report came from. Lets the attribution callback treat an id-less
@@ -24,11 +25,14 @@ interface LastProcessedExitStore {
   fun set(timestampMillis: Long)
 }
 
-class PreferencesLastProcessedExitStore(private val context: Context) : LastProcessedExitStore {
-  override fun get(): Long = AppMetricsPreferences.getLastProcessedExitTimestampMillis(context)
+class PreferencesLastProcessedExitStore(context: Context) : LastProcessedExitStore {
+  private val contextRef = WeakReference(context)
+
+  override fun get(): Long =
+    contextRef.get()?.let { AppMetricsPreferences.getLastProcessedExitTimestampMillis(it) } ?: 0L
 
   override fun set(timestampMillis: Long) {
-    AppMetricsPreferences.setLastProcessedExitTimestampMillis(context, timestampMillis)
+    contextRef.get()?.let { AppMetricsPreferences.setLastProcessedExitTimestampMillis(it, timestampMillis) }
   }
 }
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
@@ -59,7 +59,6 @@ data class ExitRecord(
       terminationReason = description,
       appVersion = appVersion,
       timestampBegin = crashTimestamp,
-      timestampEnd = crashTimestamp,
       ingestedAt = ingestedAt
     )
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
@@ -25,12 +25,17 @@ data class ExitRecord(
     get() = "$timestampMillis:$pid:$reason"
 
   /**
-   * Only true crashes count, matching how Play Console separates crash rate 
-   * from ANR rate. ANRs, low-memory kills, and bare signals are deliberately excluded.
+   * Only true crashes count: managed (`REASON_CRASH`), native
+   * (`REASON_CRASH_NATIVE`), and signal kills (`REASON_SIGNALED`, e.g. a SIGSEGV
+   * the OS records as a bare signal rather than a native crash). Every other
+   * reason — ANRs, low-memory kills, user-requested stops, and the rest — is
+   * explicitly disregarded, matching how Play Console separates crash rate from
+   * ANR rate.
    */
   val isStandaloneCrash: Boolean
     get() = reason == ApplicationExitInfo.REASON_CRASH ||
-      reason == ApplicationExitInfo.REASON_CRASH_NATIVE
+      reason == ApplicationExitInfo.REASON_CRASH_NATIVE ||
+      reason == ApplicationExitInfo.REASON_SIGNALED
 
   /**
    * Whether this record describes the same death as a pending JVM crash file:
@@ -42,7 +47,15 @@ data class ExitRecord(
   fun toCrashReport(ingestedAt: String, appVersion: String): CrashReport {
     val crashTimestamp = TimeUtils.millisToTimestamp(timestampMillis)
     return CrashReport(
-      signal = if (reason == ApplicationExitInfo.REASON_CRASH_NATIVE) status else null,
+      // `status` carries the killing signal for native and signal-based deaths;
+      // for a managed (`REASON_CRASH`) death it's an exit code, not a signal.
+      signal = if (reason == ApplicationExitInfo.REASON_CRASH_NATIVE ||
+        reason == ApplicationExitInfo.REASON_SIGNALED
+      ) {
+        status
+      } else {
+        null
+      },
       terminationReason = description,
       appVersion = appVersion,
       timestampBegin = crashTimestamp,
@@ -66,7 +79,7 @@ fun interface ExitInfoProvider {
 }
 
 /**
- * Decouples `CrashReportProcessor` from the API-30 framework type 
+ * Decouples `CrashReportProcessor` from the API-30 framework type
  * so its logic runs and tests on every SDK level.
  */
 class ExitInfoProviderImpl(private val context: Context) : ExitInfoProvider {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/ExitInfoProvider.kt
@@ -1,0 +1,102 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.app.ActivityManager
+import android.app.Application
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import expo.modules.appmetrics.utils.TimeUtils
+import kotlin.math.abs
+
+data class ExitRecord(
+  /** One of the `ApplicationExitInfo.REASON_*` constants. */
+  val reason: Int,
+  val status: Int,
+  val description: String?,
+  val timestampMillis: Long,
+  val pid: Int
+) {
+  /**
+   * Identity for in-pass dedup: marks a record consumed once it's matched to a
+   * crash file, so the same death isn't also emitted as its own bare report.
+   */
+  val key: String
+    get() = "$timestampMillis:$pid:$reason"
+
+  /**
+   * Only true crashes count, matching how Play Console separates crash rate 
+   * from ANR rate. ANRs, low-memory kills, and bare signals are deliberately excluded.
+   */
+  val isStandaloneCrash: Boolean
+    get() = reason == ApplicationExitInfo.REASON_CRASH ||
+      reason == ApplicationExitInfo.REASON_CRASH_NATIVE
+
+  /**
+   * Whether this record describes the same death as a pending JVM crash file:
+   * the same pid within a narrow time window.
+   */
+  fun matches(file: PendingJvmCrash): Boolean =
+    pid == file.pid && abs(timestampMillis - file.crashedAtMillis) <= PID_TIME_WINDOW_MS
+
+  fun toCrashReport(ingestedAt: String, appVersion: String): CrashReport {
+    val crashTimestamp = TimeUtils.millisToTimestamp(timestampMillis)
+    return CrashReport(
+      signal = if (reason == ApplicationExitInfo.REASON_CRASH_NATIVE) status else null,
+      terminationReason = description,
+      appVersion = appVersion,
+      timestampBegin = crashTimestamp,
+      timestampEnd = crashTimestamp,
+      ingestedAt = ingestedAt
+    )
+  }
+
+  companion object {
+    private const val PID_TIME_WINDOW_MS = 1 * 60 * 1000L // 1 minute
+  }
+}
+
+/**
+ * Abstraction over `ActivityManager.getHistoricalProcessExitReasons` so
+ * `CrashReportProcessor` can be unit-tested with canned records: production uses
+ * `ExitInfoProviderImpl`, tests pass a lambda returning fixture `ExitRecord`s.
+ */
+fun interface ExitInfoProvider {
+  fun getExitRecords(): List<ExitRecord>
+}
+
+/**
+ * Decouples `CrashReportProcessor` from the API-30 framework type 
+ * so its logic runs and tests on every SDK level.
+ */
+class ExitInfoProviderImpl(private val context: Context) : ExitInfoProvider {
+  override fun getExitRecords(): List<ExitRecord> {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      return emptyList()
+    }
+    return runCatching { queryExitRecords() }.getOrElse { emptyList() }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun queryExitRecords(): List<ExitRecord> {
+    val activityManager = context.getSystemService(ActivityManager::class.java) ?: return emptyList()
+    val processName = Application.getProcessName()
+    return activityManager
+      .getHistoricalProcessExitReasons(context.packageName, NO_PID_FILTER, NO_MAX)
+      .filter { it.processName == processName }
+      .map { info ->
+        ExitRecord(
+          reason = info.reason,
+          status = info.status,
+          description = info.description,
+          timestampMillis = info.timestamp,
+          pid = info.pid
+        )
+      }
+  }
+
+  companion object {
+    private const val NO_PID_FILTER = 0
+    private const val NO_MAX = 0
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/JvmCrashHandler.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/JvmCrashHandler.kt
@@ -1,0 +1,65 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.os.Process
+
+/**
+ * Uncaught-exception handler that captures the Java stack trace, which
+ * `ApplicationExitInfo` doesn't provide. Writes one pending-crash file via
+ * `CrashFileWriter`, then delegates to the previously installed handler so the
+ * process still dies and other reporters keep working.
+ */
+class JvmCrashHandler internal constructor(
+  private val fileWriter: CrashFileWriter,
+  private val previousHandler: Thread.UncaughtExceptionHandler?,
+  // Injectable for tests; production uses the real pid and clock.
+  private val pidProvider: () -> Int = { Process.myPid() },
+  private val clock: () -> Long = { System.currentTimeMillis() }
+) : Thread.UncaughtExceptionHandler {
+  override fun uncaughtException(thread: Thread, throwable: Throwable) {
+    try {
+      fileWriter.write(
+        throwable = throwable,
+        threadName = thread.name,
+        sessionId = currentSessionId,
+        pid = pidProvider(),
+        crashedAtMillis = clock()
+      )
+    } catch (_: Throwable) {
+      // Nothing on the capture path may interfere with the chain below.
+    } finally {
+      previousHandler?.uncaughtException(thread, throwable)
+    }
+  }
+
+  companion object {
+    private val installed = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    /**
+     * The current main session id, stamped into pending-crash files. `null` from
+     * process start until the module creates its main session, so a crash before
+     * then is captured as an orphan; the module sets it once the session exists.
+     */
+    @Volatile
+    var currentSessionId: String? = null
+
+    /**
+     * Installs the handler in front of the current default handler. Idempotent
+     * per process: repeated calls (re-created module, multiple init paths)
+     * leave the existing chain untouched.
+     */
+    fun install(fileWriter: CrashFileWriter) {
+      if (!installed.compareAndSet(false, true)) {
+        return
+      }
+      val current = Thread.getDefaultUncaughtExceptionHandler()
+      Thread.setDefaultUncaughtExceptionHandler(
+        JvmCrashHandler(fileWriter, current)
+      )
+    }
+
+    internal fun resetForTesting() {
+      installed.set(false)
+      currentSessionId = null
+    }
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/JvmCrashHandler.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/JvmCrashHandler.kt
@@ -34,6 +34,11 @@ class JvmCrashHandler internal constructor(
   companion object {
     private val installed = java.util.concurrent.atomic.AtomicBoolean(false)
 
+    // The handler `install` displaced, kept so `resetForTesting` can put it back.
+    // Without restoring it, the next `install` would capture our own leftover
+    // handler as its previous one and stack a second instance in front of it.
+    private var displacedHandler: Thread.UncaughtExceptionHandler? = null
+
     /**
      * The current main session id, stamped into pending-crash files. `null` from
      * process start until the module creates its main session, so a crash before
@@ -51,14 +56,17 @@ class JvmCrashHandler internal constructor(
       if (!installed.compareAndSet(false, true)) {
         return
       }
-      val current = Thread.getDefaultUncaughtExceptionHandler()
+      displacedHandler = Thread.getDefaultUncaughtExceptionHandler()
       Thread.setDefaultUncaughtExceptionHandler(
-        JvmCrashHandler(fileWriter, current)
+        JvmCrashHandler(fileWriter, displacedHandler)
       )
     }
 
     internal fun resetForTesting() {
-      installed.set(false)
+      if (installed.getAndSet(false)) {
+        Thread.setDefaultUncaughtExceptionHandler(displacedHandler)
+        displacedHandler = null
+      }
       currentSessionId = null
     }
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -23,8 +23,8 @@ object MetricsConstants {
 }
 
 @Database(
-  entities = [Metric::class, LogRecord::class, Session::class],
-  version = 15,
+  entities = [Metric::class, LogRecord::class, Session::class, CrashReportEntity::class],
+  version = 16,
   exportSchema = false
 )
 abstract class MetricsDatabase : RoomDatabase() {
@@ -33,6 +33,8 @@ abstract class MetricsDatabase : RoomDatabase() {
   abstract fun logDao(): LogDao
 
   abstract fun sessionDao(): SessionDao
+
+  abstract fun crashReportDao(): CrashReportDao
 
   companion object {
     @Volatile
@@ -166,6 +168,46 @@ data class SessionWithLogs(
   val logs: List<LogRecord>
 )
 
+@Entity(
+  tableName = "crash_reports",
+  indices = [Index(value = ["sessionId"], unique = true)],
+  foreignKeys = [
+    ForeignKey(
+      entity = Session::class,
+      parentColumns = ["id"],
+      childColumns = ["sessionId"],
+      onDelete = ForeignKey.CASCADE
+    )
+  ]
+)
+data class CrashReportEntity(
+  /** unique id, so that orphaned crash reports can be identified */
+  @PrimaryKey val id: String = UUID.randomUUID().toString(),
+  /** Owning session id, or `null` for an orphan report. Unique among non-null values. */
+  val sessionId: String? = null,
+  /** JSON-encoded `CrashReport` payload. */
+  val payload: String,
+  /**
+   * ISO 8601 insert time. Only used to age out orphan reports (`sessionId` is
+   * null) — attributed reports are pruned with their session via the FK cascade.
+   */
+  val createdAt: String
+)
+
+data class SessionWithChildren(
+  @Embedded val session: Session,
+  @Relation(parentColumn = "id", entityColumn = "sessionId")
+  val metrics: List<Metric>,
+  @Relation(parentColumn = "id", entityColumn = "sessionId")
+  val logs: List<LogRecord> = emptyList(),
+  @Relation(parentColumn = "id", entityColumn = "sessionId")
+  val crashReports: List<CrashReportEntity> = emptyList()
+) {
+  /** The session's attributed crash report payload, or `null` if it didn't crash. */
+  val crashReportPayload: String?
+    get() = crashReports.firstOrNull()?.payload
+}
+
 @Dao
 interface MetricDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
@@ -197,12 +239,44 @@ interface LogDao {
 }
 
 @Dao
+interface CrashReportDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(crashReport: CrashReportEntity)
+
+  @Query("SELECT * FROM crash_reports WHERE sessionId = :sessionId")
+  suspend fun getBySessionId(sessionId: String): CrashReportEntity?
+
+  // Orphan reports — crashes not attributed to any session (startup crashes
+  // before the session existed, or native crashes that couldn't be attributed).
+  @Query("SELECT * FROM crash_reports WHERE sessionId IS NULL ORDER BY createdAt DESC")
+  suspend fun getOrphans(): List<CrashReportEntity>
+
+  // Ages out orphan reports (no owning session) past the retention window.
+  // Attributed reports need no query here — the FK cascade prunes them with
+  // their session in `deleteSessionsOlderThan`.
+  @Query("DELETE FROM crash_reports WHERE createdAt < :cutoffTimestamp AND sessionId IS NULL")
+  suspend fun deleteOrphansOlderThan(cutoffTimestamp: String)
+
+  @Query("DELETE FROM crash_reports")
+  suspend fun deleteAll()
+}
+
+@Dao
 interface SessionDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
   suspend fun insert(session: Session)
 
   @Query("SELECT * FROM sessions WHERE id = :id")
   suspend fun getById(id: String): Session?
+
+  // The most recent session other than `:currentSessionId` (null matches all
+  // rows, so it returns the latest of any).
+  @Query(
+    "SELECT id FROM sessions " +
+      "WHERE :currentSessionId IS NULL OR id != :currentSessionId " +
+      "ORDER BY startTimestamp DESC LIMIT 1"
+  )
+  suspend fun getPreviousMainSessionId(currentSessionId: String?): String?
 
   @Query("UPDATE sessions SET isActive = 0, endTimestamp = :endTimestamp WHERE id = :id")
   suspend fun stopSessionAt(
@@ -237,7 +311,7 @@ interface SessionDao {
 
   @Transaction
   @Query("SELECT * FROM sessions WHERE isActive = 0 ORDER BY startTimestamp DESC")
-  suspend fun getInactive(): List<SessionWithMetrics>
+  suspend fun getInactive(): List<SessionWithChildren>
 
   @Transaction
   @Query("SELECT * FROM sessions WHERE id = :id")

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -246,10 +246,10 @@ interface CrashReportDao {
   @Query("SELECT * FROM crash_reports WHERE sessionId = :sessionId")
   suspend fun getBySessionId(sessionId: String): CrashReportEntity?
 
-  // Orphan reports — crashes not attributed to any session (startup crashes
-  // before the session existed, or native crashes that couldn't be attributed).
-  @Query("SELECT * FROM crash_reports WHERE sessionId IS NULL ORDER BY createdAt DESC")
-  suspend fun getOrphans(): List<CrashReportEntity>
+  // Every stored crash report, newest first. Orphans (no owning session) have a
+  // null `sessionId`; attributed reports carry theirs.
+  @Query("SELECT * FROM crash_reports ORDER BY createdAt DESC")
+  suspend fun getAll(): List<CrashReportEntity>
 
   // Ages out orphan reports (no owning session) past the retention window.
   // Attributed reports need no query here — the FK cascade prunes them with

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -113,11 +113,55 @@ class SessionManager(
     }
   }
 
-  suspend fun getInactiveSessions(): List<SessionWithMetrics> = database.sessionDao().getInactive()
+  /**
+   * Inactive sessions with their metrics, logs, and crash report attached, most
+   * recent first. The crash report joins via the `sessionId` foreign key, so only
+   * attributed reports map back; orphans (null sessionId) are excluded.
+   */
+  suspend fun getInactiveSessions(): List<SessionWithChildren> =
+    database.sessionDao().getInactive()
+
+  /**
+   * Persists a crash report. A non-null `sessionId` attributes the report to an
+   * existing session (the FK requires the row to exist) and replaces any previous
+   * report for it — only one crash per session is meaningful. A null `sessionId`
+   * stores an orphan — see `CrashReportEntity`.
+   */
+  suspend fun setCrashReport(
+    sessionId: String?,
+    payload: String,
+    createdAt: String = TimeUtils.getCurrentTimestampInISOFormat()
+  ) {
+    database.crashReportDao().upsert(
+      CrashReportEntity(sessionId = sessionId, payload = payload, createdAt = createdAt)
+    )
+  }
+
+  suspend fun getCrashReport(sessionId: String): String? =
+    database.crashReportDao().getBySessionId(sessionId)?.payload
+
+  /**
+   * Payloads of crash reports not attributed to any session — startup crashes
+   * captured before the session existed, or native crashes that couldn't be
+   * attributed. Newest first. These never surface through the session-keyed
+   * query (`getInactiveSessions`), so they're fetched here.
+   */
+  suspend fun getOrphanCrashReportPayloads(): List<String> =
+    database.crashReportDao().getOrphans().map { it.payload }
 
   suspend fun getSessionById(id: String): SessionWithMetrics? = database.sessionDao().getSessionWithMetricsBySessionId(id)
 
   suspend fun getSessionRow(id: String): Session? = database.sessionDao().getById(id)
+
+  /**
+   * The most recent main session other than `currentSessionId`, or `null` when
+   * none exists. Used to attribute crashes that carry no session id of their own
+   * (native crashes, lost crash files) to the session that most likely produced
+   * them — the previous process's. Android has no session `type` column yet, so
+   * every stored session is treated as main.
+   */
+  suspend fun getPreviousMainSessionId(currentSessionId: String?): String? =
+    database.sessionDao().getPreviousMainSessionId(currentSessionId)
 
   suspend fun getMetricsForSession(sessionId: String): List<Metric> =
     database.metricDao().getMetricsForSession(sessionId)
@@ -127,6 +171,9 @@ class SessionManager(
 
   suspend fun clearAllData() {
     database.sessionDao().deleteAll()
+    // Deleting the sessions cascades to their attributed reports, but orphan
+    // reports (null sessionId) don't cascade, so wipe the table explicitly too.
+    database.crashReportDao().deleteAll()
   }
 
   suspend fun deactivateAllSessionsBefore(timestamp: String) {
@@ -134,11 +181,14 @@ class SessionManager(
   }
 
   /**
-   * Prunes inactive sessions whose `startTimestamp` is older than the
-   * retention window. Their metrics are removed via the foreign-key cascade.
+   * Prunes inactive sessions whose `startTimestamp` is older than the retention
+   * window. Their metrics and attributed crash reports are removed via the
+   * foreign-key cascade; orphan reports (null sessionId) have no session to
+   * cascade from and are aged out separately by `createdAt`.
    */
   suspend fun cleanupOldSessions() {
     val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)
+    database.crashReportDao().deleteOrphansOlderThan(cutoffTimestamp)
     database.sessionDao().deleteSessionsOlderThan(cutoffTimestamp)
   }
 
@@ -222,7 +272,7 @@ class SessionManager(
 
   /**
    * Decodes a JSON-encoded `params` / `attributes` column, folds the current
-   * [GlobalAttributes] snapshot into it, and re-encodes. Returns the original
+   * `GlobalAttributes` snapshot into it, and re-encodes. Returns the original
    * string when there's nothing to merge in — empty globals, or a non-null
    * input that couldn't be parsed as a JSON object (we preserve whatever the
    * caller wrote rather than silently replacing it).

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -141,13 +141,13 @@ class SessionManager(
     database.crashReportDao().getBySessionId(sessionId)?.payload
 
   /**
-   * Payloads of crash reports not attributed to any session — startup crashes
-   * captured before the session existed, or native crashes that couldn't be
-   * attributed. Newest first. These never surface through the session-keyed
-   * query (`getInactiveSessions`), so they're fetched here.
+   * Every stored crash report, newest first — both reports attributed to a
+   * session and orphans (startup crashes before the session existed, or native
+   * crashes that couldn't be attributed). Returns the entities so callers can
+   * read each report's `sessionId` (null for an orphan) alongside its payload.
    */
-  suspend fun getOrphanCrashReportPayloads(): List<String> =
-    database.crashReportDao().getOrphans().map { it.payload }
+  suspend fun getAllCrashReports(): List<CrashReportEntity> =
+    database.crashReportDao().getAll()
 
   suspend fun getSessionById(id: String): SessionWithMetrics? = database.sessionDao().getSessionWithMetricsBySessionId(id)
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -21,8 +21,6 @@ import kotlinx.serialization.json.JsonObject
  *
  * TODO(@ubax): surface all session types — add a real `type` column and lifecycle
  *   hooks for foreground/screen/custom sessions.
- * TODO(@ubax): add crash report support on Android — `crashReport` is an iOS-only
- *   MetricKit feature today, so the record omits it (optional in the TS type).
  */
 @OptimizedRecord
 data class JsDebugSession(
@@ -31,17 +29,19 @@ data class JsDebugSession(
   @Field val startDate: String,
   @Field val endDate: String?,
   @Field val metrics: List<JsMetric>,
-  @Field val logs: List<JsLogRecord>
+  @Field val logs: List<JsLogRecord>,
+  @Field val crashReport: Map<String, Any?>? = null
 ) : Record {
   companion object {
-    fun fromSessionWithMetrics(value: SessionWithMetrics): JsDebugSession =
+    fun fromSessionWithChildren(value: SessionWithChildren): JsDebugSession =
       JsDebugSession(
         id = value.session.id,
         type = "main",
         startDate = value.session.startTimestamp,
         endDate = value.session.endTimestamp,
         metrics = value.metrics.map { JsMetric.fromMetric(it) },
-        logs = value.logs.map { JsLogRecord.fromLogRecord(it) }
+        logs = value.logs.map { JsLogRecord.fromLogRecord(it) },
+        crashReport = decodeJsonObject(value.crashReportPayload)
       )
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
@@ -21,6 +21,8 @@ object TimeUtils {
   // Cannot use Instant.now() as it's only available in API 26+
   fun getCurrentTimestampInISOFormat(): String = dateToTimestamp(Date())
 
+  fun millisToTimestamp(millis: Long): String = dateToTimestamp(Date(millis))
+
   fun getTimestampInISOFormatFromPast(secondsFromNow: Long): String =
     dateToTimestamp(
       Date(System.currentTimeMillis() - secondsFromNow * 1000)

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
@@ -47,4 +47,15 @@ class AppMetricsPreferencesTest {
     val expected = if (BuildConfig.DEBUG) "development" else null
     assertEquals(expected, AppMetricsPreferences.getDefaultEnvironment())
   }
+
+  @Test
+  fun `last processed exit timestamp defaults to zero`() {
+    assertEquals(0L, AppMetricsPreferences.getLastProcessedExitTimestampMillis(context))
+  }
+
+  @Test
+  fun `last processed exit timestamp round-trips`() {
+    AppMetricsPreferences.setLastProcessedExitTimestampMillis(context, 1_700_000_000_500)
+    assertEquals(1_700_000_000_500, AppMetricsPreferences.getLastProcessedExitTimestampMillis(context))
+  }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CallStackTreeBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CallStackTreeBuilderTest.kt
@@ -1,0 +1,72 @@
+package expo.modules.appmetrics.crashreporting
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallStackTreeBuilderTest {
+  private fun element(
+    className: String = "com.example.Foo",
+    methodName: String = "bar",
+    fileName: String? = "Foo.kt",
+    lineNumber: Int = 42
+  ) = StackTraceElement(className, methodName, fileName, lineNumber)
+
+  @Test
+  fun `produces a single attributed call stack`() {
+    val tree = CallStackTreeBuilder.fromStackTrace(arrayOf(element()))
+
+    val stacks = requireNotNull(tree.callStacks)
+    assertEquals(1, stacks.size)
+    assertEquals(true, stacks[0].threadAttributed)
+  }
+
+  @Test
+  fun `formats symbols like printStackTrace frames`() {
+    val tree = CallStackTreeBuilder.fromStackTrace(
+      arrayOf(element(className = "com.example.Foo", methodName = "bar", fileName = "Foo.kt", lineNumber = 42))
+    )
+
+    val frames = requireNotNull(tree.callStacks?.first()?.callStackRootFrames)
+    assertEquals("com.example.Foo.bar(Foo.kt:42)", frames[0].symbol)
+  }
+
+  @Test
+  fun `keeps frames in stack order with the crash site first`() {
+    val tree = CallStackTreeBuilder.fromStackTrace(
+      arrayOf(
+        element(methodName = "crashSite"),
+        element(methodName = "caller"),
+        element(methodName = "main")
+      )
+    )
+
+    val frames = requireNotNull(tree.callStacks?.first()?.callStackRootFrames)
+    assertEquals(3, frames.size)
+    assertTrue(frames[0].symbol!!.contains("crashSite"))
+    assertTrue(frames[2].symbol!!.contains("main"))
+  }
+
+  @Test
+  fun `truncates oversized stacks and appends a marker frame`() {
+    val oversized = Array(CallStackTreeBuilder.MAX_FRAMES + 10) { index ->
+      element(methodName = "frame$index")
+    }
+
+    val tree = CallStackTreeBuilder.fromStackTrace(oversized)
+
+    val frames = requireNotNull(tree.callStacks?.first()?.callStackRootFrames)
+    // MAX_FRAMES real frames plus one truncation marker.
+    assertEquals(CallStackTreeBuilder.MAX_FRAMES + 1, frames.size)
+    assertTrue(frames.last().symbol!!.contains("10"))
+    assertTrue(frames[CallStackTreeBuilder.MAX_FRAMES - 1].symbol!!.contains("frame${CallStackTreeBuilder.MAX_FRAMES - 1}"))
+  }
+
+  @Test
+  fun `handles an empty stack trace`() {
+    val tree = CallStackTreeBuilder.fromStackTrace(emptyArray())
+
+    val frames = requireNotNull(tree.callStacks?.first()?.callStackRootFrames)
+    assertEquals(0, frames.size)
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
@@ -1,0 +1,318 @@
+package expo.modules.appmetrics.crashreporting
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Reads back what `CrashFileWriter` wrote: every test writes a fixture with a real writer and parses
+ * it with a `CrashFileReader` over the same directory, so the two stay honest about the shared
+ * `CrashFileFormat`.
+ */
+class CrashFileReaderTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  private fun writer(directory: File = tmp.root): CrashFileWriter =
+    CrashFileWriter(directory).also { it.prepare() }
+
+  private fun reader(directory: File = tmp.root): CrashFileReader = CrashFileReader(directory)
+
+  private fun throwable(message: String? = "boom"): Throwable = IllegalStateException(message)
+
+  // region parse round-trip
+
+  @Test
+  fun `round-trips the crash metadata`() {
+    writer().write(throwable("boom"), "worker-thread", "session-1", 123, 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertEquals("session-1", pending.sessionId)
+    assertEquals(123, pending.pid)
+    assertEquals(1_700_000_000_000, pending.crashedAtMillis)
+    assertEquals("java.lang.IllegalStateException", pending.exceptionClass)
+    assertEquals("java.lang.IllegalStateException: boom", pending.composedMessage)
+    assertEquals("worker-thread", pending.threadName)
+  }
+
+  @Test
+  fun `round-trips the cause chain in the composed message`() {
+    val wrapped = RuntimeException("wrapper", IllegalStateException("root cause"))
+    writer().write(wrapped, "main", "session-1", 123, 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertEquals(
+      "java.lang.RuntimeException: wrapper\nCaused by: java.lang.IllegalStateException: root cause",
+      pending.composedMessage
+    )
+  }
+
+  @Test
+  fun `round-trips the stack frames in order`() {
+    writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertTrue(pending.stackFrames.isNotEmpty())
+    // The crash site (this test class) leads the frames.
+    assertTrue(pending.stackFrames.first().contains("CrashFileReaderTest"))
+  }
+
+  @Test
+  fun `round-trips a null session id`() {
+    // Crashes before the session identity exists must still be recorded.
+    writer().write(throwable(), "main", sessionId = null, pid = 123, crashedAtMillis = 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertNull(pending.sessionId)
+  }
+
+  @Test
+  fun `round-trips a message-less exception`() {
+    writer().write(throwable(message = null), "main", "session-1", 123, 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertEquals("java.lang.IllegalStateException", pending.composedMessage)
+  }
+
+  @Test
+  fun `round-trips messages containing newlines and equals signs`() {
+    writer().write(
+      throwable("first line\nsecond=line"),
+      "main",
+      "session-1",
+      123,
+      1_700_000_000_000
+    )
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertEquals(
+      "java.lang.IllegalStateException: first line\nsecond=line",
+      pending.composedMessage
+    )
+  }
+
+  @Test
+  fun `a multi-line message cannot inject or truncate stack frames`() {
+    // Frame lines are written escaped below the separator; the message never
+    // appears there, so "\n\tat …" / "\nCaused by:" payloads can't pollute
+    // the parsed frames.
+    writer().write(
+      throwable("first\n\tat com.fake.Injected.method(Fake.java:1)\nCaused by: com.fake.FakeCause"),
+      "main",
+      "session-1",
+      123,
+      1_700_000_000_000
+    )
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertTrue(pending.stackFrames.first().contains("CrashFileReaderTest"))
+    assertTrue(pending.stackFrames.none { it.contains("com.fake.Injected") })
+  }
+
+  @Test
+  fun `a message line of exactly the header separator does not break parsing`() {
+    writer().write(throwable("before\n---\nafter"), "main", "session-1", 123, 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes().single()
+
+    assertEquals(
+      "java.lang.IllegalStateException: before\n---\nafter",
+      pending.composedMessage
+    )
+    assertTrue(pending.stackFrames.first().contains("CrashFileReaderTest"))
+  }
+
+  @Test
+  fun `the file path and fromThrowable produce the same report content`() {
+    // Two builders, one contract: a report normalized from the pending file
+    // must match what `fromThrowable` would have produced at crash time.
+    val throwable = RuntimeException("boom", IllegalStateException("root"))
+    writer().write(throwable, "main", "session-1", 123, 1_700_000_000_000)
+    val pending = reader().listPendingCrashes().single()
+
+    val fromFile = pending.toCrashReport(ingestedAt = "2026-06-12T10:05:00.000Z", appVersion = "1.0.0")
+    val direct = CrashReport.fromThrowable(
+      throwable = throwable,
+      crashTimestamp = fromFile.timestampBegin,
+      ingestedAt = "2026-06-12T10:05:00.000Z",
+      appVersion = "1.0.0"
+    )
+
+    assertEquals(direct.exceptionReason, fromFile.exceptionReason)
+    assertEquals(direct.callStackTree, fromFile.callStackTree)
+  }
+
+  @Test
+  fun `keeps separate files for separate crashes`() {
+    val writer = writer()
+    writer.write(throwable(), "main", "session-1", pid = 123, crashedAtMillis = 1_700_000_000_000)
+    writer.write(throwable(), "main", "session-2", pid = 456, crashedAtMillis = 1_700_000_000_500)
+
+    val pending = reader().listPendingCrashes()
+
+    assertEquals(2, pending.size)
+    assertEquals(setOf("session-1", "session-2"), pending.map { it.sessionId }.toSet())
+  }
+
+  @Test
+  fun `a second write with the same pid and timestamp overwrites cleanly`() {
+    // Same filename by construction (double-installed handlers in one tick) —
+    // last write wins; the file must stay parseable, never corrupt.
+    val writer = writer()
+    writer.write(throwable("first"), "main", "session-1", pid = 123, crashedAtMillis = 1_700_000_000_000)
+    writer.write(throwable("second"), "main", "session-1", pid = 123, crashedAtMillis = 1_700_000_000_000)
+
+    val pending = reader().listPendingCrashes()
+
+    assertEquals(1, pending.size)
+    assertEquals("java.lang.IllegalStateException: second", pending.single().composedMessage)
+  }
+
+  // endregion
+
+  // region listPendingCrashes hygiene
+
+  @Test
+  fun `skips corrupt files without throwing`() {
+    writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+    tmp.newFile("crash-999-1700000000001.txt").writeText("complete garbage")
+
+    val pending = reader().listPendingCrashes()
+
+    assertEquals(1, pending.size)
+    assertEquals("session-1", pending.single().sessionId)
+  }
+
+  @Test
+  fun `ignores temp files and unrelated files`() {
+    tmp.newFile("crash-1-2.txt.tmp").writeText("partial write")
+    tmp.newFile("unrelated.json").writeText("{}")
+
+    assertEquals(emptyList<PendingJvmCrash>(), reader().listPendingCrashes())
+  }
+
+  @Test
+  fun `returns an empty list when the directory does not exist`() {
+    assertEquals(emptyList<PendingJvmCrash>(), reader(File(tmp.root, "missing")).listPendingCrashes())
+  }
+
+  @Test
+  fun `delete removes the pending crash file`() {
+    writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+    val reader = reader()
+    val pending = reader.listPendingCrashes().single()
+
+    reader.delete(pending)
+
+    assertEquals(emptyList<PendingJvmCrash>(), reader.listPendingCrashes())
+  }
+
+  // endregion
+
+  // region deleteOrphanedTempFiles
+
+  @Test
+  fun `deletes orphaned temp files left by a dead process`() {
+    val orphan = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("partial write") }
+
+    reader().deleteOrphanedTempFiles(currentPid = 999)
+
+    assertFalse(orphan.exists())
+  }
+
+  @Test
+  fun `keeps temp files belonging to the current process`() {
+    // The current process may be writing this temp file right now (a crash while
+    // processing); deleting it would drop a live crash report.
+    val inFlight = tmp.newFile("crash-999-2.txt.tmp").apply { writeText("partial write") }
+
+    reader().deleteOrphanedTempFiles(currentPid = 999)
+
+    assertTrue(inFlight.exists())
+  }
+
+  @Test
+  fun `sweeps every foreign-pid orphan while keeping the current pid's temp`() {
+    val orphanA = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("a") }
+    val orphanB = tmp.newFile("crash-2-3.txt.tmp").apply { writeText("b") }
+    val inFlight = tmp.newFile("crash-999-4.txt.tmp").apply { writeText("c") }
+
+    reader().deleteOrphanedTempFiles(currentPid = 999)
+
+    assertFalse(orphanA.exists())
+    assertFalse(orphanB.exists())
+    assertTrue(inFlight.exists())
+  }
+
+  @Test
+  fun `leaves finished and unrelated files untouched`() {
+    val finished = tmp.newFile("crash-1-2.txt").apply { writeText("crash") }
+    val unrelated = tmp.newFile("unrelated.json").apply { writeText("{}") }
+
+    reader().deleteOrphanedTempFiles(currentPid = 999)
+
+    assertTrue(finished.exists())
+    assertTrue(unrelated.exists())
+  }
+
+  @Test
+  fun `does not throw when the directory does not exist`() {
+    reader(File(tmp.root, "missing")).deleteOrphanedTempFiles(currentPid = 999)
+  }
+
+  // endregion
+
+  // region deleteMalformedFiles
+
+  @Test
+  fun `deletes a corrupt final file while keeping a valid one`() {
+    writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+    val corrupt = tmp.newFile("crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+
+    reader().deleteMalformedFiles()
+
+    assertFalse(corrupt.exists())
+    assertEquals("session-1", reader().listPendingCrashes().single().sessionId)
+  }
+
+  @Test
+  fun `deletes an empty final file`() {
+    // A truncated write — the most likely corruption from a swallowed IO error — leaves a
+    // zero-byte final file that can never parse.
+    val empty = tmp.newFile("crash-999-1700000000001.txt")
+
+    reader().deleteMalformedFiles()
+
+    assertFalse(empty.exists())
+  }
+
+  @Test
+  fun `leaves temp files and unrelated files untouched`() {
+    val temp = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("partial write") }
+    val unrelated = tmp.newFile("unrelated.json").apply { writeText("{}") }
+
+    reader().deleteMalformedFiles()
+
+    assertTrue(temp.exists())
+    assertTrue(unrelated.exists())
+  }
+
+  @Test
+  fun `deleteMalformedFiles does not throw when the directory does not exist`() {
+    reader(File(tmp.root, "missing")).deleteMalformedFiles()
+  }
+
+  // endregion
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
@@ -7,19 +7,24 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 
 /**
  * Reads back what `CrashFileWriter` wrote: every test writes a fixture with a real writer and parses
  * it with a `CrashFileReader` over the same directory, so the two stay honest about the shared
- * `CrashFileFormat`.
+ * `CrashFileFormat`. Robolectric for the real `android.util.AtomicFile` the writer commits through.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
 class CrashFileReaderTest {
   @get:Rule
   val tmp = TemporaryFolder()
 
   private fun writer(directory: File = tmp.root): CrashFileWriter =
-    CrashFileWriter(directory).also { it.prepare() }
+    CrashFileWriter(directory)
 
   private fun reader(directory: File = tmp.root): CrashFileReader = CrashFileReader(directory)
 
@@ -183,7 +188,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `ignores temp files and unrelated files`() {
-    tmp.newFile("crash-1-2.json.tmp").writeText("partial write")
+    tmp.newFile("crash-1-2.json.new").writeText("partial write")
     tmp.newFile("unrelated.json").writeText("{}")
 
     assertEquals(emptyList<PendingJvmCrash>(), reader().listPendingCrashes())
@@ -211,7 +216,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `deletes orphaned temp files left by a dead process`() {
-    val orphan = tmp.newFile("crash-1-2.json.tmp").apply { writeText("partial write") }
+    val orphan = tmp.newFile("crash-1-2.json.new").apply { writeText("partial write") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -222,7 +227,7 @@ class CrashFileReaderTest {
   fun `keeps temp files belonging to the current process`() {
     // The current process may be writing this temp file right now (a crash while
     // processing); deleting it would drop a live crash report.
-    val inFlight = tmp.newFile("crash-999-2.json.tmp").apply { writeText("partial write") }
+    val inFlight = tmp.newFile("crash-999-2.json.new").apply { writeText("partial write") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -231,9 +236,9 @@ class CrashFileReaderTest {
 
   @Test
   fun `sweeps every foreign-pid orphan while keeping the current pid's temp`() {
-    val orphanA = tmp.newFile("crash-1-2.json.tmp").apply { writeText("a") }
-    val orphanB = tmp.newFile("crash-2-3.json.tmp").apply { writeText("b") }
-    val inFlight = tmp.newFile("crash-999-4.json.tmp").apply { writeText("c") }
+    val orphanA = tmp.newFile("crash-1-2.json.new").apply { writeText("a") }
+    val orphanB = tmp.newFile("crash-2-3.json.new").apply { writeText("b") }
+    val inFlight = tmp.newFile("crash-999-4.json.new").apply { writeText("c") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -286,7 +291,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `leaves temp files and unrelated files untouched`() {
-    val temp = tmp.newFile("crash-1-2.json.tmp").apply { writeText("partial write") }
+    val temp = tmp.newFile("crash-1-2.json.new").apply { writeText("partial write") }
     val unrelated = tmp.newFile("unrelated.json").apply { writeText("{}") }
 
     reader().deleteMalformedFiles()

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileReaderTest.kt
@@ -85,9 +85,9 @@ class CrashFileReaderTest {
   }
 
   @Test
-  fun `round-trips messages containing newlines and equals signs`() {
+  fun `round-trips messages containing newlines and quotes`() {
     writer().write(
-      throwable("first line\nsecond=line"),
+      throwable("first line\nsecond \"quoted\" line"),
       "main",
       "session-1",
       123,
@@ -97,16 +97,15 @@ class CrashFileReaderTest {
     val pending = reader().listPendingCrashes().single()
 
     assertEquals(
-      "java.lang.IllegalStateException: first line\nsecond=line",
+      "java.lang.IllegalStateException: first line\nsecond \"quoted\" line",
       pending.composedMessage
     )
   }
 
   @Test
-  fun `a multi-line message cannot inject or truncate stack frames`() {
-    // Frame lines are written escaped below the separator; the message never
-    // appears there, so "\n\tat …" / "\nCaused by:" payloads can't pollute
-    // the parsed frames.
+  fun `a frame-like message cannot pollute the parsed stack frames`() {
+    // `stackFrames` comes from the throwable, not the message — and JSON keeps the
+    // two as separate fields, so frame-like text in the message can't leak in.
     writer().write(
       throwable("first\n\tat com.fake.Injected.method(Fake.java:1)\nCaused by: com.fake.FakeCause"),
       "main",
@@ -119,19 +118,6 @@ class CrashFileReaderTest {
 
     assertTrue(pending.stackFrames.first().contains("CrashFileReaderTest"))
     assertTrue(pending.stackFrames.none { it.contains("com.fake.Injected") })
-  }
-
-  @Test
-  fun `a message line of exactly the header separator does not break parsing`() {
-    writer().write(throwable("before\n---\nafter"), "main", "session-1", 123, 1_700_000_000_000)
-
-    val pending = reader().listPendingCrashes().single()
-
-    assertEquals(
-      "java.lang.IllegalStateException: before\n---\nafter",
-      pending.composedMessage
-    )
-    assertTrue(pending.stackFrames.first().contains("CrashFileReaderTest"))
   }
 
   @Test
@@ -187,7 +173,7 @@ class CrashFileReaderTest {
   @Test
   fun `skips corrupt files without throwing`() {
     writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
-    tmp.newFile("crash-999-1700000000001.txt").writeText("complete garbage")
+    tmp.newFile("crash-999-1700000000001.json").writeText("complete garbage")
 
     val pending = reader().listPendingCrashes()
 
@@ -197,7 +183,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `ignores temp files and unrelated files`() {
-    tmp.newFile("crash-1-2.txt.tmp").writeText("partial write")
+    tmp.newFile("crash-1-2.json.tmp").writeText("partial write")
     tmp.newFile("unrelated.json").writeText("{}")
 
     assertEquals(emptyList<PendingJvmCrash>(), reader().listPendingCrashes())
@@ -225,7 +211,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `deletes orphaned temp files left by a dead process`() {
-    val orphan = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("partial write") }
+    val orphan = tmp.newFile("crash-1-2.json.tmp").apply { writeText("partial write") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -236,7 +222,7 @@ class CrashFileReaderTest {
   fun `keeps temp files belonging to the current process`() {
     // The current process may be writing this temp file right now (a crash while
     // processing); deleting it would drop a live crash report.
-    val inFlight = tmp.newFile("crash-999-2.txt.tmp").apply { writeText("partial write") }
+    val inFlight = tmp.newFile("crash-999-2.json.tmp").apply { writeText("partial write") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -245,9 +231,9 @@ class CrashFileReaderTest {
 
   @Test
   fun `sweeps every foreign-pid orphan while keeping the current pid's temp`() {
-    val orphanA = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("a") }
-    val orphanB = tmp.newFile("crash-2-3.txt.tmp").apply { writeText("b") }
-    val inFlight = tmp.newFile("crash-999-4.txt.tmp").apply { writeText("c") }
+    val orphanA = tmp.newFile("crash-1-2.json.tmp").apply { writeText("a") }
+    val orphanB = tmp.newFile("crash-2-3.json.tmp").apply { writeText("b") }
+    val inFlight = tmp.newFile("crash-999-4.json.tmp").apply { writeText("c") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
 
@@ -258,7 +244,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `leaves finished and unrelated files untouched`() {
-    val finished = tmp.newFile("crash-1-2.txt").apply { writeText("crash") }
+    val finished = tmp.newFile("crash-1-2.json").apply { writeText("crash") }
     val unrelated = tmp.newFile("unrelated.json").apply { writeText("{}") }
 
     reader().deleteOrphanedTempFiles(currentPid = 999)
@@ -279,7 +265,7 @@ class CrashFileReaderTest {
   @Test
   fun `deletes a corrupt final file while keeping a valid one`() {
     writer().write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
-    val corrupt = tmp.newFile("crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+    val corrupt = tmp.newFile("crash-999-1700000000001.json").apply { writeText("complete garbage") }
 
     reader().deleteMalformedFiles()
 
@@ -291,7 +277,7 @@ class CrashFileReaderTest {
   fun `deletes an empty final file`() {
     // A truncated write — the most likely corruption from a swallowed IO error — leaves a
     // zero-byte final file that can never parse.
-    val empty = tmp.newFile("crash-999-1700000000001.txt")
+    val empty = tmp.newFile("crash-999-1700000000001.json")
 
     reader().deleteMalformedFiles()
 
@@ -300,7 +286,7 @@ class CrashFileReaderTest {
 
   @Test
   fun `leaves temp files and unrelated files untouched`() {
-    val temp = tmp.newFile("crash-1-2.txt.tmp").apply { writeText("partial write") }
+    val temp = tmp.newFile("crash-1-2.json.tmp").apply { writeText("partial write") }
     val unrelated = tmp.newFile("unrelated.json").apply { writeText("{}") }
 
     reader().deleteMalformedFiles()

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
@@ -34,6 +34,7 @@ class CrashFileWriterTest {
     assertNotNull(file)
     assertTrue(file!!.exists())
     assertTrue(file.name.startsWith("crash-123-1700000000000"))
+    assertTrue(file.name.endsWith(".json"))
     assertFalse(file.name.endsWith(".tmp"))
   }
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
@@ -1,21 +1,25 @@
 package expo.modules.appmetrics.crashreporting
 
-import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 
+// Robolectric for the real `android.util.AtomicFile` the writer commits through.
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
 class CrashFileWriterTest {
   @get:Rule
   val tmp = TemporaryFolder()
 
   private fun writer(directory: File = tmp.root): CrashFileWriter =
-    CrashFileWriter(directory).also { it.prepare() }
+    CrashFileWriter(directory)
 
   private fun throwable(message: String? = "boom"): Throwable = IllegalStateException(message)
 
@@ -35,7 +39,6 @@ class CrashFileWriterTest {
     assertTrue(file!!.exists())
     assertTrue(file.name.startsWith("crash-123-1700000000000"))
     assertTrue(file.name.endsWith(".json"))
-    assertFalse(file.name.endsWith(".tmp"))
   }
 
   @Test
@@ -44,20 +47,8 @@ class CrashFileWriterTest {
 
     writer.write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
 
-    assertTrue(tmp.root.listFiles()!!.none { it.name.endsWith(".tmp") })
-  }
-
-  @Test
-  fun `prepare creates the directory off the calling thread`() = runTest {
-    val dir = File(tmp.root, "crashes")
-    val writer = CrashFileWriter(dir, backgroundScope)
-
-    val job = writer.prepare()
-    // StandardTestDispatcher defers the launch, so nothing has run yet.
-    assertFalse(dir.exists())
-
-    job.join()
-    assertTrue(dir.isDirectory)
+    // No `AtomicFile` staging artifacts survive a committed write.
+    assertTrue(tmp.root.listFiles()!!.none { it.name.endsWith(".new") || it.name.endsWith(".bak") })
   }
 
   @Test
@@ -65,7 +56,6 @@ class CrashFileWriterTest {
     // Point the writer at a path occupied by a regular file so every write fails.
     val blocked = tmp.newFile("not-a-directory")
     val writer = CrashFileWriter(blocked)
-    writer.prepare()
 
     val file = writer.write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashFileWriterTest.kt
@@ -1,0 +1,73 @@
+package expo.modules.appmetrics.crashreporting
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class CrashFileWriterTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  private fun writer(directory: File = tmp.root): CrashFileWriter =
+    CrashFileWriter(directory).also { it.prepare() }
+
+  private fun throwable(message: String? = "boom"): Throwable = IllegalStateException(message)
+
+  @Test
+  fun `writes one parseable file per crash`() {
+    val writer = writer()
+
+    val file = writer.write(
+      throwable = throwable(),
+      threadName = "main",
+      sessionId = "session-1",
+      pid = 123,
+      crashedAtMillis = 1_700_000_000_000
+    )
+
+    assertNotNull(file)
+    assertTrue(file!!.exists())
+    assertTrue(file.name.startsWith("crash-123-1700000000000"))
+    assertFalse(file.name.endsWith(".tmp"))
+  }
+
+  @Test
+  fun `leaves no temp files behind`() {
+    val writer = writer()
+
+    writer.write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+
+    assertTrue(tmp.root.listFiles()!!.none { it.name.endsWith(".tmp") })
+  }
+
+  @Test
+  fun `prepare creates the directory off the calling thread`() = runTest {
+    val dir = File(tmp.root, "crashes")
+    val writer = CrashFileWriter(dir, backgroundScope)
+
+    val job = writer.prepare()
+    // StandardTestDispatcher defers the launch, so nothing has run yet.
+    assertFalse(dir.exists())
+
+    job.join()
+    assertTrue(dir.isDirectory)
+  }
+
+  @Test
+  fun `returns null instead of throwing when the directory is not writable`() {
+    // Point the writer at a path occupied by a regular file so every write fails.
+    val blocked = tmp.newFile("not-a-directory")
+    val writer = CrashFileWriter(blocked)
+    writer.prepare()
+
+    val file = writer.write(throwable(), "main", "session-1", 123, 1_700_000_000_000)
+
+    assertNull(file)
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
@@ -64,6 +64,10 @@ class CrashReportAttributionTest {
       ?.let { CrashReport.decodeFromJsonString(it) }
       ?.exceptionReason
 
+  // Reports stored unattributed — the orphans among all stored reports.
+  private suspend fun orphanCount(): Int =
+    sessionManager.getAllCrashReports().count { it.sessionId == null }
+
   // region JVM crash files (embedded id)
 
   @Test
@@ -84,7 +88,7 @@ class CrashReportAttributionTest {
       attribute("never-persisted", CrashOrigin.JVM_FILE)
 
       assertNull(sessionManager.getCrashReport("never-persisted"))
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, orphanCount())
     }
 
   @Test
@@ -93,7 +97,7 @@ class CrashReportAttributionTest {
       // A crash before the main session existed carries no id.
       attribute(null, CrashOrigin.JVM_FILE)
 
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, orphanCount())
     }
 
   // endregion
@@ -121,7 +125,7 @@ class CrashReportAttributionTest {
 
       // Never blame the live session — stored unattributed instead.
       assertNull(sessionManager.getCrashReport("current"))
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, orphanCount())
     }
 
   @Test
@@ -129,7 +133,7 @@ class CrashReportAttributionTest {
     runTest {
       attribute(null, CrashOrigin.EXIT_RECORD, currentSessionId = "current")
 
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, orphanCount())
     }
 
   @Test
@@ -144,7 +148,7 @@ class CrashReportAttributionTest {
 
       assertEquals("java.lang.IllegalStateException: from file", storedMessage("previous"))
       // The native crash landed as a separate orphan, not overwriting "previous".
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, orphanCount())
     }
 
   // endregion

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
@@ -1,0 +1,165 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.SessionManager
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Covers `attributeAndStoreCrashReport` — the session-aware half of crash processing. */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class CrashReportAttributionTest {
+  private lateinit var database: MetricsDatabase
+  private lateinit var sessionManager: SessionManager
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    sessionManager = SessionManager(context, database)
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun attribute(
+    sessionId: String?,
+    origin: CrashOrigin,
+    currentSessionId: String? = "current",
+    message: String = "boom"
+  ) =
+    attributeAndStoreCrashReport(
+      sessionManager = sessionManager,
+      currentSessionId = currentSessionId,
+      sessionId = sessionId,
+      origin = origin,
+      report = report(message)
+    )
+
+  private fun report(message: String = "boom"): CrashReport =
+    CrashReport.fromThrowable(
+      throwable = IllegalStateException(message),
+      crashTimestamp = "2026-06-12T10:00:00.000Z",
+      ingestedAt = "2026-06-12T10:05:00.000Z",
+      appVersion = "1.0.0"
+    )
+
+  private suspend fun storedMessage(sessionId: String): String? =
+    sessionManager.getCrashReport(sessionId)
+      ?.let { CrashReport.decodeFromJsonString(it) }
+      ?.exceptionReason
+
+  // region JVM crash files (embedded id)
+
+  @Test
+  fun `stores a file report under its embedded session id`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("crashed-session", "2023-11-14T22:00:00.000Z")
+
+      attribute("crashed-session", CrashOrigin.JVM_FILE)
+
+      assertEquals("java.lang.IllegalStateException: boom", storedMessage("crashed-session"))
+    }
+
+  @Test
+  fun `stores a file report as an orphan when its session row never persisted`() =
+    runTest {
+      // A crash whose session row never landed can't satisfy the FK, so it's
+      // stored unattributed rather than dropped.
+      attribute("never-persisted", CrashOrigin.JVM_FILE)
+
+      assertNull(sessionManager.getCrashReport("never-persisted"))
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  @Test
+  fun `stores an id-less file report as an orphan`() =
+    runTest {
+      // A crash before the main session existed carries no id.
+      attribute(null, CrashOrigin.JVM_FILE)
+
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  // endregion
+
+  // region Native crashes (no id) → previous main session
+
+  @Test
+  fun `attributes a native crash to the previous main session`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("older", "2023-11-14T20:00:00.000Z")
+      sessionManager.startSessionWithIdAt("previous", "2023-11-14T22:00:00.000Z")
+
+      attribute(null, CrashOrigin.EXIT_RECORD, currentSessionId = "current", message = "native")
+
+      assertEquals("java.lang.IllegalStateException: native", storedMessage("previous"))
+      assertNull(sessionManager.getCrashReport("older"))
+    }
+
+  @Test
+  fun `stores a native crash as an orphan when only the current session exists`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("current", "2023-11-14T22:00:00.000Z")
+
+      attribute(null, CrashOrigin.EXIT_RECORD, currentSessionId = "current")
+
+      // Never blame the live session — stored unattributed instead.
+      assertNull(sessionManager.getCrashReport("current"))
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  @Test
+  fun `stores a native crash as an orphan when there are no sessions at all`() =
+    runTest {
+      attribute(null, CrashOrigin.EXIT_RECORD, currentSessionId = "current")
+
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  @Test
+  fun `orphans a native crash when the previous session already has a report`() =
+    runTest {
+      // A file already stored a (richer) report for "previous" this run, so a
+      // native crash resolving to "previous" must not overwrite it.
+      sessionManager.startSessionWithIdAt("previous", "2023-11-14T22:00:00.000Z")
+
+      attribute("previous", CrashOrigin.JVM_FILE, message = "from file")
+      attribute(null, CrashOrigin.EXIT_RECORD, message = "from record")
+
+      assertEquals("java.lang.IllegalStateException: from file", storedMessage("previous"))
+      // The native crash landed as a separate orphan, not overwriting "previous".
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  // endregion
+
+  // region Failure
+
+  @Test
+  fun `swallows a database write failure`() =
+    runTest {
+      database.close()
+
+      // Must not throw — a failed persist is logged and swallowed so it can't
+      // crash the next launch.
+      attribute("crashed-session", CrashOrigin.JVM_FILE)
+    }
+
+  // endregion
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
@@ -1,0 +1,358 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.app.ApplicationExitInfo
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The processor is session-agnostic: it builds reports from crash evidence and
+ * hands each to the `storeReport` callback. These tests assert on the callback
+ * invocations (and file/cursor bookkeeping); session attribution and storage
+ * are tested separately against the module's attribution callback.
+ *
+ * Robolectric only for `android.util.Log`; there is no database here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class CrashReportProcessorTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  private lateinit var crashFileWriter: CrashFileWriter
+  private lateinit var crashFileReader: CrashFileReader
+
+  private val exitRecords = mutableListOf<ExitRecord>()
+  private var cursor = 0L
+
+  private val exitInfoProvider = ExitInfoProvider { exitRecords.toList() }
+
+  private val lastProcessedExitStore = object : LastProcessedExitStore {
+    override fun get(): Long = cursor
+
+    override fun set(timestampMillis: Long) {
+      cursor = timestampMillis
+    }
+  }
+
+  data class StoreCall(val sessionId: String?, val origin: CrashOrigin, val report: CrashReport)
+
+  private val storeCalls = mutableListOf<StoreCall>()
+
+  private val storeReport: suspend (String?, CrashOrigin, CrashReport) -> Unit =
+    { sessionId, origin, report ->
+      storeCalls += StoreCall(sessionId, origin, report)
+    }
+
+  @Before
+  fun setUp() {
+    crashFileWriter = CrashFileWriter(tmp.root).also { it.prepare() }
+    crashFileReader = CrashFileReader(tmp.root)
+  }
+
+  private fun processor(): CrashReportProcessor =
+    CrashReportProcessor(
+      crashFileReader = crashFileReader,
+      exitInfoProvider = exitInfoProvider,
+      lastProcessedExitStore = lastProcessedExitStore,
+      appVersion = "1.2.3",
+      storeReport = storeReport
+    )
+
+  private fun writeCrashFile(
+    sessionId: String? = "crashed-session",
+    pid: Int = 123,
+    crashedAtMillis: Long = 1_700_000_000_000
+  ) {
+    crashFileWriter.write(
+      throwable = IllegalStateException("boom"),
+      threadName = "main",
+      sessionId = sessionId,
+      pid = pid,
+      crashedAtMillis = crashedAtMillis
+    )
+  }
+
+  private fun exitRecord(
+    reason: Int = ApplicationExitInfo.REASON_CRASH,
+    status: Int = 0,
+    timestampMillis: Long = 1_700_000_000_500,
+    pid: Int = 123,
+    description: String? = null
+  ): ExitRecord = ExitRecord(
+    reason = reason,
+    status = status,
+    description = description,
+    timestampMillis = timestampMillis,
+    pid = pid
+  )
+
+  // region JVM crash files
+
+  @Test
+  fun `hands a crash file to the callback with its embedded session id`() =
+    runTest {
+      writeCrashFile(sessionId = "crashed-session")
+
+      processor().process()
+
+      val call = storeCalls.single()
+      assertEquals("crashed-session", call.sessionId)
+      assertEquals(CrashOrigin.JVM_FILE, call.origin)
+      assertEquals("java.lang.IllegalStateException: boom", call.report.exceptionReason)
+      assertEquals("1.2.3", call.report.appVersion)
+    }
+
+  @Test
+  fun `hands an id-less crash file to the callback with a null session id`() =
+    runTest {
+      // A crash before the session was created carries no id — the callback
+      // turns it into an orphan.
+      writeCrashFile(sessionId = null)
+
+      processor().process()
+
+      val call = storeCalls.single()
+      assertNull(call.sessionId)
+      assertEquals(CrashOrigin.JVM_FILE, call.origin)
+    }
+
+  @Test
+  fun `promotes a crash file with no matching record`() =
+    runTest {
+      // No build-type distinction anymore: a file is promoted on its own evidence.
+      writeCrashFile()
+
+      processor().process()
+
+      assertEquals("crashed-session", storeCalls.single().sessionId)
+    }
+
+  @Test
+  fun `deletes the crash file once the callback handles it`() =
+    runTest {
+      writeCrashFile()
+
+      processor().process()
+
+      assertEquals(emptyList<PendingJvmCrash>(), crashFileReader.listPendingCrashes())
+    }
+
+  @Test
+  fun `deletes a malformed crash file in the same run as a valid one`() =
+    runTest {
+      writeCrashFile(sessionId = "crashed-session")
+      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+
+      processor().process()
+
+      // The valid crash was delivered, and the corrupt leftover is reclaimed, not left forever.
+      assertEquals("crashed-session", storeCalls.single().sessionId)
+      assertFalse(malformed.exists())
+    }
+
+  @Test
+  fun `deletes a malformed crash file even when there is nothing else to process`() =
+    runTest {
+      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+
+      processor().process()
+
+      assertTrue(storeCalls.isEmpty())
+      assertFalse(malformed.exists())
+    }
+
+  @Test
+  fun `sweeps temp files orphaned by a dead process`() =
+    runTest {
+      // A `.tmp` from a process that died mid-write is never read; the processor
+      // must reclaim it so it doesn't leak. Use a foreign pid so it isn't treated
+      // as an in-flight write by the current process.
+      val foreignPid = android.os.Process.myPid() + 1
+      val orphan = java.io.File(tmp.root, "crash-$foreignPid-1.txt.tmp").apply { writeText("partial") }
+
+      processor().process()
+
+      assertTrue(!orphan.exists())
+    }
+
+  // endregion
+
+  // region Dedup between files and records
+
+  @Test
+  fun `a matching record is consumed and not delivered as its own report`() =
+    runTest {
+      writeCrashFile(sessionId = "crashed-session", pid = 123, crashedAtMillis = 1_700_000_000_000)
+      exitRecords += exitRecord(pid = 123, timestampMillis = 1_700_000_000_500, description = "bare AEI description")
+
+      processor().process()
+
+      // One report — the file's, carrying its composed exceptionReason — not two.
+      val call = storeCalls.single()
+      assertEquals("crashed-session", call.sessionId)
+      assertEquals("java.lang.IllegalStateException: boom", call.report.exceptionReason)
+      assertNull(call.report.terminationReason)
+    }
+
+  @Test
+  fun `a record matches only one file`() =
+    runTest {
+      // Two crash-burst files from different pids; the single death record
+      // matches one only — the other stands on its own evidence.
+      writeCrashFile(sessionId = "first", pid = 123, crashedAtMillis = 1_700_000_000_000)
+      writeCrashFile(sessionId = "second", pid = 456, crashedAtMillis = 1_700_000_100_000)
+      exitRecords += exitRecord(pid = 123, timestampMillis = 1_700_000_001_000)
+
+      processor().process()
+
+      // Both files promoted; the record matched only "first" and was
+      // consumed, so it produced no extra (null) report.
+      assertEquals(setOf("first", "second"), storeCalls.map { it.sessionId }.toSet())
+      assertEquals(2, storeCalls.size)
+    }
+
+  @Test
+  fun `a record outside the pid time window does not match the file`() =
+    runTest {
+      // Pids get reused — same pid but 6 minutes apart is a different death, so
+      // the record isn't consumed: the file is promoted AND the record surfaces
+      // on its own as a bare report.
+      writeCrashFile(sessionId = "crashed-session", pid = 123, crashedAtMillis = 1_700_000_000_000)
+      exitRecords += exitRecord(pid = 123, timestampMillis = 1_700_000_000_000 + 6 * 60 * 1000)
+
+      processor().process()
+
+      assertEquals(listOf("crashed-session", null), storeCalls.map { it.sessionId })
+    }
+
+  @Test
+  fun `a record of a different pid does not match the file`() =
+    runTest {
+      writeCrashFile(sessionId = "crashed-session", pid = 123)
+      exitRecords += exitRecord(pid = 456)
+
+      processor().process()
+
+      assertEquals(listOf("crashed-session", null), storeCalls.map { it.sessionId })
+    }
+
+  @Test
+  fun `hands files to the callback before bare records`() =
+    runTest {
+      // The callback relies on this order so a file's richer report wins over a
+      // bare record that resolves to the same session.
+      writeCrashFile(sessionId = "from-file", pid = 123, crashedAtMillis = 1_700_000_000_000)
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_CRASH_NATIVE, status = 11, pid = 456)
+
+      processor().process()
+
+      assertEquals(listOf("from-file", null), storeCalls.map { it.sessionId })
+      assertEquals(listOf(CrashOrigin.JVM_FILE, CrashOrigin.EXIT_RECORD), storeCalls.map { it.origin })
+    }
+
+  // endregion
+
+  // region Bare exit records
+
+  @Test
+  fun `hands a native crash to the callback with no session id and a signal`() =
+    runTest {
+      exitRecords += exitRecord(
+        reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+        status = 11,
+        description = "Native crash in libhermes"
+      )
+
+      processor().process()
+
+      val call = storeCalls.single()
+      assertNull(call.sessionId)
+      assertEquals(CrashOrigin.EXIT_RECORD, call.origin)
+      assertEquals(11, call.report.signal)
+      assertEquals("Native crash in libhermes", call.report.terminationReason)
+      assertNull(call.report.exceptionReason)
+      assertEquals("1.2.3", call.report.appVersion)
+    }
+
+  @Test
+  fun `hands a lost-file JVM crash to the callback with no session id and no signal`() =
+    runTest {
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_CRASH)
+
+      processor().process()
+
+      val call = storeCalls.single()
+      assertNull(call.sessionId)
+      // A Java crash's status is an exit code, not a signal — must stay null.
+      assertNull(call.report.signal)
+    }
+
+  @Test
+  fun `ignores exit reasons outside the crash allowlist`() =
+    runTest {
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_ANR)
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_LOW_MEMORY)
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_SIGNALED)
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_USER_REQUESTED)
+
+      processor().process()
+
+      assertTrue(storeCalls.isEmpty())
+    }
+
+  // endregion
+
+  // region Cursor (no reprocessing)
+
+  @Test
+  fun `advances the cursor to the newest record seen`() =
+    runTest {
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_CRASH, timestampMillis = 1_000)
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_ANR, timestampMillis = 2_000)
+
+      processor().process()
+
+      // Advances past the non-crash record too, so it's never reconsidered.
+      assertEquals(2_000, cursor)
+    }
+
+  @Test
+  fun `does not reprocess exit records on later runs`() =
+    runTest {
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_CRASH)
+      processor().process()
+      storeCalls.clear()
+
+      processor().process()
+
+      assertTrue(storeCalls.isEmpty())
+    }
+
+  @Test
+  fun `processes only records newer than the cursor`() =
+    runTest {
+      cursor = 1_700_000_000_400
+      // Older than the cursor — already processed on a prior launch.
+      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_CRASH, timestampMillis = 1_700_000_000_000)
+      // Newer — must be processed.
+      val fresh = exitRecord(reason = ApplicationExitInfo.REASON_CRASH, timestampMillis = 1_700_000_000_500)
+      exitRecords += fresh
+
+      processor().process()
+
+      assertEquals(1, storeCalls.size)
+      assertEquals(fresh.timestampMillis, cursor)
+    }
+
+  // endregion
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
@@ -55,7 +55,7 @@ class CrashReportProcessorTest {
 
   @Before
   fun setUp() {
-    crashFileWriter = CrashFileWriter(tmp.root).also { it.prepare() }
+    crashFileWriter = CrashFileWriter(tmp.root)
     crashFileReader = CrashFileReader(tmp.root)
   }
 
@@ -174,11 +174,11 @@ class CrashReportProcessorTest {
   @Test
   fun `sweeps temp files orphaned by a dead process`() =
     runTest {
-      // A `.tmp` from a process that died mid-write is never read; the processor
-      // must reclaim it so it doesn't leak. Use a foreign pid so it isn't treated
-      // as an in-flight write by the current process.
+      // An `AtomicFile` temp from a process that died mid-write is never read; the
+      // processor must reclaim it so it doesn't leak. Use a foreign pid so it isn't
+      // treated as an in-flight write by the current process.
       val foreignPid = android.os.Process.myPid() + 1
-      val orphan = java.io.File(tmp.root, "crash-$foreignPid-1.json.tmp").apply { writeText("partial") }
+      val orphan = java.io.File(tmp.root, "crash-$foreignPid-1.json.new").apply { writeText("partial") }
 
       processor().process()
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
@@ -151,7 +151,7 @@ class CrashReportProcessorTest {
   fun `deletes a malformed crash file in the same run as a valid one`() =
     runTest {
       writeCrashFile(sessionId = "crashed-session")
-      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.json").apply { writeText("complete garbage") }
 
       processor().process()
 
@@ -163,7 +163,7 @@ class CrashReportProcessorTest {
   @Test
   fun `deletes a malformed crash file even when there is nothing else to process`() =
     runTest {
-      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.txt").apply { writeText("complete garbage") }
+      val malformed = java.io.File(tmp.root, "crash-999-1700000000001.json").apply { writeText("complete garbage") }
 
       processor().process()
 
@@ -178,7 +178,7 @@ class CrashReportProcessorTest {
       // must reclaim it so it doesn't leak. Use a foreign pid so it isn't treated
       // as an in-flight write by the current process.
       val foreignPid = android.os.Process.myPid() + 1
-      val orphan = java.io.File(tmp.root, "crash-$foreignPid-1.txt.tmp").apply { writeText("partial") }
+      val orphan = java.io.File(tmp.root, "crash-$foreignPid-1.json.tmp").apply { writeText("partial") }
 
       processor().process()
 
@@ -302,12 +302,31 @@ class CrashReportProcessorTest {
     runTest {
       exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_ANR)
       exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_LOW_MEMORY)
-      exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_SIGNALED)
       exitRecords += exitRecord(reason = ApplicationExitInfo.REASON_USER_REQUESTED)
 
       processor().process()
 
       assertTrue(storeCalls.isEmpty())
+    }
+
+  @Test
+  fun `hands a signaled crash to the callback with no session id and a signal`() =
+    runTest {
+      // SIGSEGV/SIGABRT deaths the OS records as REASON_SIGNALED rather than
+      // REASON_CRASH_NATIVE — these count as crashes too. `status` is the signal.
+      exitRecords += exitRecord(
+        reason = ApplicationExitInfo.REASON_SIGNALED,
+        status = 11,
+        description = "Signal 11 (SIGSEGV)"
+      )
+
+      processor().process()
+
+      val call = storeCalls.single()
+      assertNull(call.sessionId)
+      assertEquals(CrashOrigin.EXIT_RECORD, call.origin)
+      assertEquals(11, call.report.signal)
+      assertEquals("Signal 11 (SIGSEGV)", call.report.terminationReason)
     }
 
   // endregion

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
@@ -1,0 +1,212 @@
+package expo.modules.appmetrics.crashreporting
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashReportTest {
+  private val crashTimestamp = "2026-06-12T10:00:00Z"
+  private val ingestedAt = "2026-06-12T10:05:00Z"
+
+  private fun reportFromThrowable(throwable: Throwable = IllegalStateException("boom")): CrashReport =
+    CrashReport.fromThrowable(
+      throwable = throwable,
+      crashTimestamp = crashTimestamp,
+      ingestedAt = ingestedAt,
+      appVersion = "1.2.3"
+    )
+
+  // MARK: fromThrowable
+
+  @Test
+  fun `fromThrowable maps the exception into exceptionReason`() {
+    val report = reportFromThrowable(IllegalStateException("boom"))
+
+    assertEquals("java.lang.IllegalStateException: boom", report.exceptionReason)
+  }
+
+  @Test
+  fun `fromThrowable composes the message from toString for null messages`() {
+    val report = reportFromThrowable(NullPointerException())
+
+    assertEquals("java.lang.NullPointerException", report.exceptionReason)
+  }
+
+  @Test
+  fun `fromThrowable includes the cause chain in the composed message`() {
+    val root = ArithmeticException("div by zero")
+    val wrapper = RuntimeException("wrapper", IllegalStateException("middle", root))
+
+    val report = reportFromThrowable(wrapper)
+
+    assertEquals(
+      "java.lang.RuntimeException: wrapper" +
+        "\nCaused by: java.lang.IllegalStateException: middle" +
+        "\nCaused by: java.lang.ArithmeticException: div by zero",
+      report.exceptionReason
+    )
+  }
+
+  @Test
+  fun `composeMessage caps cyclic cause chains`() {
+    val a = RuntimeException("a")
+    val b = RuntimeException("b", a)
+    a.initCause(b)
+
+    // Must terminate; depth cap keeps the message finite.
+    val message = CrashReport.composeMessage(a)
+
+    assertTrue(message.lines().size <= 7)
+  }
+
+  @Test
+  fun `fromThrowable leaves the OS-only fields null`() {
+    // `signal` is a Unix number rendered through SIG* lookup tables by consumers,
+    // and `terminationReason` comes from the OS exit record — a JVM crash has neither.
+    val report = reportFromThrowable()
+
+    assertNull(report.signal)
+    assertNull(report.terminationReason)
+  }
+
+  @Test
+  fun `fromThrowable uses the crash moment as a zero-width window`() {
+    val report = reportFromThrowable()
+
+    assertEquals(crashTimestamp, report.timestampBegin)
+    assertEquals(crashTimestamp, report.timestampEnd)
+    assertEquals(ingestedAt, report.ingestedAt)
+    assertEquals("1.2.3", report.appVersion)
+  }
+
+  @Test
+  fun `fromThrowable captures the call stack`() {
+    val throwable = IllegalStateException("boom").apply { fillInStackTrace() }
+    val report = reportFromThrowable(throwable)
+
+    val frames = report.callStackTree?.callStacks?.firstOrNull()?.callStackRootFrames
+    assertNotNull(frames)
+    assertTrue(frames!!.isNotEmpty())
+    // The crash site (this test) must appear before JUnit infrastructure frames.
+    assertTrue(frames.first().symbol!!.contains("CrashReportTest"))
+  }
+
+  // MARK: JSON encoding — the payload is the cross-platform contract with types.ts
+
+  @Test
+  fun `encodes with the TypeScript field names`() {
+    val payload = reportFromThrowable().encodeToJsonString()
+    val element = Json.parseToJsonElement(payload).jsonObject
+
+    assertTrue("exceptionReason" in element)
+    assertTrue("callStackTree" in element)
+    assertEquals(crashTimestamp, element["timestampBegin"]?.jsonPrimitive?.content)
+    assertEquals(crashTimestamp, element["timestampEnd"]?.jsonPrimitive?.content)
+    assertEquals(ingestedAt, element["ingestedAt"]?.jsonPrimitive?.content)
+    assertEquals("1.2.3", element["appVersion"]?.jsonPrimitive?.content)
+
+    // Android encodes `exceptionReason` as a plain string (the composed message).
+    assertEquals("java.lang.IllegalStateException: boom", element["exceptionReason"]?.jsonPrimitive?.content)
+
+    val stack = element["callStackTree"]!!.jsonObject["callStacks"]!!.let { it as kotlinx.serialization.json.JsonArray }
+    val firstStack = stack.first().jsonObject
+    assertTrue("threadAttributed" in firstStack)
+    assertTrue("callStackRootFrames" in firstStack)
+    val firstFrame = (firstStack["callStackRootFrames"] as kotlinx.serialization.json.JsonArray).first().jsonObject
+    assertTrue("symbol" in firstFrame)
+  }
+
+  @Test
+  fun `omits null fields like the iOS encoder`() {
+    // iOS's JSONEncoder drops nil Optionals; consumers rely on absence, not explicit null.
+    val payload = reportFromThrowable().encodeToJsonString()
+    val element = Json.parseToJsonElement(payload).jsonObject
+
+    assertFalse("signal" in element)
+    assertFalse("terminationReason" in element)
+  }
+
+  @Test
+  fun `round-trips through JSON`() {
+    val original = reportFromThrowable()
+
+    val decoded = CrashReport.decodeFromJsonString(original.encodeToJsonString())
+
+    assertEquals(original, decoded)
+  }
+
+  @Test
+  fun `decodes an iOS-shaped payload`() {
+    // MetricKit payloads carry iOS-only fields the Android model doesn't have —
+    // the Mach codes (`exceptionType`/`exceptionCode`/`virtualMemoryRegionInfo`)
+    // and the per-frame binary/address fields. Decoding must tolerate all of them
+    // as unknown keys and still read the shared fields and the frame symbols.
+    val payload = """
+      {
+        "exceptionType": 1,
+        "exceptionCode": 2,
+        "virtualMemoryRegionInfo": "0x0 is not in any region",
+        "signal": 11,
+        "terminationReason": "Namespace SIGNAL, Code 0xb",
+        "callStackTree": {
+          "callStacks": [
+            {
+              "threadAttributed": true,
+              "callStackRootFrames": [
+                {
+                  "binaryName": "MyApp",
+                  "binaryUUID": "12345678-1234-1234-1234-123456789012",
+                  "address": 18446744073709551600,
+                  "offsetIntoBinaryTextSegment": 1234,
+                  "sampleCount": 1,
+                  "symbol": "-[MyClass crash]"
+                }
+              ]
+            }
+          ]
+        },
+        "appVersion": "1.0.0",
+        "timestampBegin": "2026-06-11T10:00:00Z",
+        "timestampEnd": "2026-06-11T11:00:00Z",
+        "ingestedAt": "2026-06-12T08:30:15Z"
+      }
+    """.trimIndent()
+
+    val report = requireNotNull(CrashReport.decodeFromJsonString(payload))
+
+    assertEquals(11, report.signal)
+    assertEquals("Namespace SIGNAL, Code 0xb", report.terminationReason)
+    val frame = report.callStackTree?.callStacks?.first()?.callStackRootFrames?.first()
+    assertEquals("-[MyClass crash]", frame?.symbol)
+  }
+
+  @Test
+  fun `decoding tolerates unknown keys`() {
+    val payload = """
+      {
+        "someFutureField": {"nested": true},
+        "appVersion": "1.0.0",
+        "timestampBegin": "2026-06-11T10:00:00Z",
+        "timestampEnd": "2026-06-11T11:00:00Z",
+        "ingestedAt": "2026-06-12T08:30:15Z"
+      }
+    """.trimIndent()
+
+    val report = CrashReport.decodeFromJsonString(payload)
+
+    assertNotNull(report)
+    assertEquals("1.0.0", report?.appVersion)
+  }
+
+  @Test
+  fun `decoding malformed payloads returns null`() {
+    assertNull(CrashReport.decodeFromJsonString("not json"))
+    assertNull(CrashReport.decodeFromJsonString("[1, 2, 3]"))
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
@@ -76,11 +76,10 @@ class CrashReportTest {
   }
 
   @Test
-  fun `fromThrowable uses the crash moment as a zero-width window`() {
+  fun `fromThrowable stamps the crash moment and metadata`() {
     val report = reportFromThrowable()
 
     assertEquals(crashTimestamp, report.timestampBegin)
-    assertEquals(crashTimestamp, report.timestampEnd)
     assertEquals(ingestedAt, report.ingestedAt)
     assertEquals("1.2.3", report.appVersion)
   }
@@ -107,7 +106,9 @@ class CrashReportTest {
     assertTrue("exceptionReason" in element)
     assertTrue("callStackTree" in element)
     assertEquals(crashTimestamp, element["timestampBegin"]?.jsonPrimitive?.content)
-    assertEquals(crashTimestamp, element["timestampEnd"]?.jsonPrimitive?.content)
+    // Android collapses the window to the exact moment: only the start is emitted,
+    // and JS resolves the end from it.
+    assertFalse("timestampEnd" in element)
     assertEquals(ingestedAt, element["ingestedAt"]?.jsonPrimitive?.content)
     assertEquals("1.2.3", element["appVersion"]?.jsonPrimitive?.content)
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
@@ -61,7 +61,7 @@ class CrashReportingPipelineTest {
       // Launch 1: session starts, handler is installed, the app crashes.
       sessionManager.startSessionWithIdAt(crashedSessionId, "2023-11-14T22:00:00.000Z")
       JvmCrashHandler.currentSessionId = crashedSessionId
-      val writer = CrashFileWriter(tmp.root).also { it.prepare() }
+      val writer = CrashFileWriter(tmp.root)
       val reader = CrashFileReader(tmp.root)
       val handler = JvmCrashHandler(
         fileWriter = writer,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
@@ -1,0 +1,140 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.app.ApplicationExitInfo
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.appmetrics.storage.JsDebugSession
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.SessionManager
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * End-to-end seam test: real handler → real pending file → real processor →
+ * real `attributeAndStoreCrashReport` → real Room storage → real JS mapper. Each
+ * link is unit-tested in isolation; this pins the contracts *between* them (field
+ * names, timestamp formats, the embedded-id attribution flow) so they can't
+ * drift apart while every unit test stays green.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class CrashReportingPipelineTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  private lateinit var database: MetricsDatabase
+  private lateinit var sessionManager: SessionManager
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    sessionManager = SessionManager(context, database)
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+    JvmCrashHandler.resetForTesting()
+  }
+
+  @Test
+  fun `a JVM crash surfaces in getInactiveSessions on the next launch`() =
+    runTest {
+      val crashedSessionId = "8f3aa536-7497-4c5e-a097-4b9e2c9b2f1e"
+      val crashedAtMillis = 1_700_000_000_000
+
+      // Launch 1: session starts, handler is installed, the app crashes.
+      sessionManager.startSessionWithIdAt(crashedSessionId, "2023-11-14T22:00:00.000Z")
+      JvmCrashHandler.currentSessionId = crashedSessionId
+      val writer = CrashFileWriter(tmp.root).also { it.prepare() }
+      val reader = CrashFileReader(tmp.root)
+      val handler = JvmCrashHandler(
+        fileWriter = writer,
+        previousHandler = null,
+        pidProvider = { 123 },
+        clock = { crashedAtMillis }
+      )
+      handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+      // Launch 2: a new session starts, the sweep closes the crashed one, the
+      // processor matches the file against the OS death record.
+      val currentSessionId = "2c9c3a82-9a3e-4f12-9302-0c2a44bb1d11"
+      sessionManager.deactivateAllSessionsBefore("2023-11-14T22:20:00.000Z")
+      sessionManager.startSessionWithIdAt(currentSessionId, "2023-11-14T22:20:00.000Z")
+      CrashReportProcessor(
+        crashFileReader = reader,
+        exitInfoProvider = ExitInfoProvider {
+          listOf(
+            // Matches the JVM crash file by pid + time window; attribution
+            // flows through the file's embedded session id, not this record.
+            ExitRecord(
+              reason = ApplicationExitInfo.REASON_CRASH,
+              status = 0,
+              description = null,
+              timestampMillis = crashedAtMillis + 100,
+              pid = 123
+            )
+          )
+        },
+        lastProcessedExitStore = object : LastProcessedExitStore {
+          private var cursor = 0L
+
+          override fun get(): Long = cursor
+
+          override fun set(timestampMillis: Long) {
+            cursor = timestampMillis
+          }
+        },
+        appVersion = "3.1.4"
+      ) { sessionId, origin, report ->
+        attributeAndStoreCrashReport(
+          sessionManager = sessionManager,
+          currentSessionId = currentSessionId,
+          sessionId = sessionId,
+          origin = origin,
+          report = report
+        )
+      }.process()
+
+      // What JS sees through getInactiveSessions.
+      val sessions = sessionManager.getInactiveSessions()
+        .map { JsDebugSession.fromSessionWithChildren(it) }
+
+      val crashed = sessions.single { it.id == crashedSessionId }
+      val crashReport = requireNotNull(crashed.crashReport)
+      assertEquals("3.1.4", crashReport["appVersion"])
+      assertEquals("java.lang.IllegalStateException: boom", crashReport["exceptionReason"])
+      @Suppress("UNCHECKED_CAST")
+      val tree = crashReport["callStackTree"] as? Map<String, Any?>
+      assertNotNull(tree)
+      @Suppress("UNCHECKED_CAST")
+      val stacks = tree?.get("callStacks") as? List<Map<String, Any?>>
+
+      @Suppress("UNCHECKED_CAST")
+      val frames = stacks?.first()?.get("callStackRootFrames") as? List<Map<String, Any?>>
+      assertTrue((frames?.first()?.get("symbol") as? String)!!.contains("CrashReportingPipelineTest"))
+
+      // The crash timestamp uses the package's lexicographically-comparable format.
+      assertEquals("2023-11-14T22:13:20.000Z", crashReport["timestampBegin"])
+
+      // The live session carries no crash report.
+      assertTrue(sessions.none { it.id == currentSessionId && it.crashReport != null })
+      // The pending file is consumed.
+      assertEquals(emptyList<PendingJvmCrash>(), reader.listPendingCrashes())
+    }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/ExitInfoProviderImplTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/ExitInfoProviderImplTest.kt
@@ -1,0 +1,79 @@
+package expo.modules.appmetrics.crashreporting
+
+import android.app.ActivityManager
+import android.app.Application
+import android.app.ApplicationExitInfo
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowActivityManager
+
+@RunWith(RobolectricTestRunner::class)
+class ExitInfoProviderImplTest {
+  private val context: Context
+    get() = ApplicationProvider.getApplicationContext()
+
+  private fun seedExitInfo(
+    reason: Int = ApplicationExitInfo.REASON_CRASH,
+    status: Int = 0,
+    timestamp: Long = 1_700_000_000_000,
+    pid: Int = 123,
+    processName: String = Application.getProcessName(),
+    description: String? = null
+  ) {
+    val activityManager = context.getSystemService(ActivityManager::class.java)
+    val builder = ShadowActivityManager.ApplicationExitInfoBuilder.newBuilder()
+      .setReason(reason)
+      .setStatus(status)
+      .setTimestamp(timestamp)
+      .setPid(pid)
+      .setProcessName(processName)
+    description?.let { builder.setDescription(it) }
+    shadowOf(activityManager).addApplicationExitInfo(builder.build())
+  }
+
+  @Test
+  @Config(manifest = Config.NONE, sdk = [30])
+  fun `maps exit records into ExitRecord`() {
+    seedExitInfo(
+      reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+      status = 11,
+      timestamp = 1_700_000_000_000,
+      pid = 123,
+      description = "Native crash"
+    )
+
+    val records = ExitInfoProviderImpl(context).getExitRecords()
+
+    val record = records.single()
+    assertEquals(ApplicationExitInfo.REASON_CRASH_NATIVE, record.reason)
+    assertEquals(11, record.status)
+    assertEquals(1_700_000_000_000, record.timestampMillis)
+    assertEquals(123, record.pid)
+    assertEquals("Native crash", record.description)
+  }
+
+  @Test
+  @Config(manifest = Config.NONE, sdk = [30])
+  fun `filters out records from other processes of the package`() {
+    // ApplicationExitInfo reports every process of the package; a future
+    // `:background` worker's death must not be attributed to the main session.
+    seedExitInfo(processName = Application.getProcessName(), pid = 1)
+    seedExitInfo(processName = "com.example.app:background", pid = 2)
+
+    val records = ExitInfoProviderImpl(context).getExitRecords()
+
+    assertEquals(listOf(1), records.map { it.pid })
+  }
+
+  @Test
+  @Config(manifest = Config.NONE, sdk = [28])
+  fun `returns no records below API 30`() {
+    assertEquals(emptyList<ExitRecord>(), ExitInfoProviderImpl(context).getExitRecords())
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/JvmCrashHandlerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/JvmCrashHandlerTest.kt
@@ -31,12 +31,14 @@ class JvmCrashHandlerTest {
 
   @After
   fun restoreDefaultHandler() {
-    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+    // Reset first: it restores the handler `install` displaced. Then force the
+    // real original back, so a test that set a custom default can't leak it.
     JvmCrashHandler.resetForTesting()
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
   }
 
   private fun writer(directory: File = tmp.root): CrashFileWriter =
-    CrashFileWriter(directory).also { it.prepare() }
+    CrashFileWriter(directory)
 
   private fun reader(directory: File = tmp.root): CrashFileReader = CrashFileReader(directory)
 
@@ -124,6 +126,20 @@ class JvmCrashHandlerTest {
     JvmCrashHandler.install(writer())
 
     assertSame(first, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `resetForTesting restores the handler that was installed in front of`() {
+    // Without restoring it, our handler stays the process default after reset, so
+    // the next install would wrap it — stacking two handlers that each record the
+    // same crash.
+    val original = RecordingHandler()
+    Thread.setDefaultUncaughtExceptionHandler(original)
+    JvmCrashHandler.install(writer())
+
+    JvmCrashHandler.resetForTesting()
+
+    assertSame(original, Thread.getDefaultUncaughtExceptionHandler())
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/JvmCrashHandlerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/JvmCrashHandlerTest.kt
@@ -1,0 +1,166 @@
+package expo.modules.appmetrics.crashreporting
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+// Robolectric for `android.os.Process.myPid()` in the handler's default pid provider.
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class JvmCrashHandlerTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  private var originalHandler: Thread.UncaughtExceptionHandler? = null
+
+  @Before
+  fun saveDefaultHandler() {
+    originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+    JvmCrashHandler.resetForTesting()
+  }
+
+  @After
+  fun restoreDefaultHandler() {
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+    JvmCrashHandler.resetForTesting()
+  }
+
+  private fun writer(directory: File = tmp.root): CrashFileWriter =
+    CrashFileWriter(directory).also { it.prepare() }
+
+  private fun reader(directory: File = tmp.root): CrashFileReader = CrashFileReader(directory)
+
+  private class RecordingHandler : Thread.UncaughtExceptionHandler {
+    var receivedThread: Thread? = null
+    var receivedThrowable: Throwable? = null
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+      receivedThread = thread
+      receivedThrowable = throwable
+    }
+  }
+
+  @Test
+  fun `writes a pending crash file with the current session id`() {
+    JvmCrashHandler.currentSessionId = "session-1"
+    val writer = writer()
+    val handler = JvmCrashHandler(writer, previousHandler = null)
+
+    handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+    val pending = reader().listPendingCrashes().single()
+    assertEquals("session-1", pending.sessionId)
+    assertEquals("java.lang.IllegalStateException: boom", pending.composedMessage)
+  }
+
+  @Test
+  fun `records a null session id when the identity is not ready yet`() {
+    // `currentSessionId` is left null (reset in @Before) — a crash before the
+    // main session exists is captured as an orphan.
+    val writer = writer()
+    val handler = JvmCrashHandler(writer, previousHandler = null)
+
+    handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+    assertNull(reader().listPendingCrashes().single().sessionId)
+  }
+
+  @Test
+  fun `always delegates to the previous handler`() {
+    val previous = RecordingHandler()
+    val handler = JvmCrashHandler(writer(), previous)
+    val thread = Thread.currentThread()
+    val throwable = IllegalStateException("boom")
+
+    handler.uncaughtException(thread, throwable)
+
+    assertSame(thread, previous.receivedThread)
+    assertSame(throwable, previous.receivedThrowable)
+  }
+
+  @Test
+  fun `delegates even when writing the crash file fails`() {
+    // A writer pointed at a file-as-directory fails every write.
+    val blocked = tmp.newFile("not-a-directory")
+    val previous = RecordingHandler()
+    val handler = JvmCrashHandler(CrashFileWriter(blocked), previous)
+    val throwable = IllegalStateException("boom")
+
+    handler.uncaughtException(Thread.currentThread(), throwable)
+
+    assertSame(throwable, previous.receivedThrowable)
+  }
+
+  @Test
+  fun `install chains to whatever handler was registered before`() {
+    val previous = RecordingHandler()
+    Thread.setDefaultUncaughtExceptionHandler(previous)
+
+    JvmCrashHandler.install(writer())
+    val installed = Thread.getDefaultUncaughtExceptionHandler() as JvmCrashHandler
+    val throwable = IllegalStateException("boom")
+    installed.uncaughtException(Thread.currentThread(), throwable)
+
+    assertSame(throwable, previous.receivedThrowable)
+  }
+
+  @Test
+  fun `install is idempotent`() {
+    // Repeated installs (re-created module, Fast Refresh) must not build a
+    // wrapper chain that would record the same crash twice.
+    JvmCrashHandler.install(writer())
+    val first = Thread.getDefaultUncaughtExceptionHandler()
+
+    JvmCrashHandler.install(writer())
+
+    assertSame(first, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `install stays a no-op after another SDK wraps our handler`() {
+    // Sentry-style reporters installed after us hold our handler as their
+    // previous one. A later re-install here must not add a second instance in
+    // front of them — that would double-record every crash.
+    JvmCrashHandler.install(writer())
+    val wrappingSdk = RecordingHandler()
+    Thread.setDefaultUncaughtExceptionHandler(wrappingSdk)
+
+    JvmCrashHandler.install(writer())
+
+    assertSame(wrappingSdk, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `a crash through a doubly-installed chain writes exactly once`() {
+    // Counting write invocations, not files: a doubled chain would write the
+    // same pid+millis filename twice and still leave one file behind.
+    val writer = io.mockk.spyk(writer())
+    Thread.setDefaultUncaughtExceptionHandler(RecordingHandler())
+    JvmCrashHandler.install(writer)
+    JvmCrashHandler.install(writer)
+
+    val installed = Thread.getDefaultUncaughtExceptionHandler() as JvmCrashHandler
+    installed.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+    io.mockk.verify(exactly = 1) { writer.write(any(), any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun `does not throw without a previous handler`() {
+    val handler = JvmCrashHandler(writer(), previousHandler = null)
+
+    handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+    assertTrue(true)
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/CrashReportStorageTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/CrashReportStorageTest.kt
@@ -75,14 +75,18 @@ class CrashReportStorageTest {
       sessionManager.setCrashReport(null, """{"appVersion":"2.0.0"}""")
 
       // Both coexist — the unique sessionId index treats nulls as distinct.
-      assertEquals(2, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(2, sessionManager.getAllCrashReports().count { it.sessionId == null })
     }
 
   @Test
-  fun `getOrphanCrashReportPayloads returns only unattributed reports, newest first`() =
+  fun `getAllCrashReports returns attributed and orphan reports, newest first`() =
     runTest {
       startSession("session-1")
-      sessionManager.setCrashReport("session-1", """{"appVersion":"attributed"}""")
+      sessionManager.setCrashReport(
+        "session-1",
+        """{"appVersion":"attributed"}""",
+        createdAt = "2025-01-15T12:00:00.000Z"
+      )
       sessionManager.setCrashReport(
         null,
         """{"appVersion":"older-orphan"}""",
@@ -94,12 +98,14 @@ class CrashReportStorageTest {
         createdAt = "2025-01-15T11:00:00.000Z"
       )
 
-      val orphans = sessionManager.getOrphanCrashReportPayloads()
+      val all = sessionManager.getAllCrashReports()
 
+      // Every report, newest createdAt first; orphans carry a null sessionId.
       assertEquals(
-        listOf("""{"appVersion":"newer-orphan"}""", """{"appVersion":"older-orphan"}"""),
-        orphans
+        listOf("""{"appVersion":"attributed"}""", """{"appVersion":"newer-orphan"}""", """{"appVersion":"older-orphan"}"""),
+        all.map { it.payload }
       )
+      assertEquals(listOf("session-1", null, null), all.map { it.sessionId })
     }
 
   @Test
@@ -227,7 +233,7 @@ class CrashReportStorageTest {
 
       sessionManager.cleanupOldSessions()
 
-      assertEquals(emptyList<String>(), sessionManager.getOrphanCrashReportPayloads())
+      assertEquals(0, sessionManager.getAllCrashReports().count { it.sessionId == null })
     }
 
   @Test
@@ -239,7 +245,7 @@ class CrashReportStorageTest {
 
       sessionManager.cleanupOldSessions()
 
-      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+      assertEquals(1, sessionManager.getAllCrashReports().count { it.sessionId == null })
     }
 
   @Test
@@ -252,7 +258,7 @@ class CrashReportStorageTest {
       sessionManager.clearAllData()
 
       assertNull(sessionManager.getCrashReport("session-1"))
-      assertEquals(emptyList<String>(), sessionManager.getOrphanCrashReportPayloads())
+      assertEquals(emptyList<CrashReportEntity>(), sessionManager.getAllCrashReports())
     }
 
   // endregion

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/CrashReportStorageTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/CrashReportStorageTest.kt
@@ -1,0 +1,259 @@
+package expo.modules.appmetrics.storage
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.appmetrics.utils.TimeUtils
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class CrashReportStorageTest {
+  private lateinit var database: MetricsDatabase
+  private lateinit var sessionManager: SessionManager
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    sessionManager = SessionManager(context, database)
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun startSession(
+    id: String,
+    startTimestamp: String = "2025-01-15T10:30:00.000Z"
+  ) {
+    sessionManager.startSessionWithIdAt(id, startTimestamp)
+  }
+
+  // region DAO
+
+  @Test
+  fun `stores and reads back a crash report payload`() =
+    runTest {
+      startSession("session-1")
+
+      sessionManager.setCrashReport("session-1", """{"appVersion":"1.0.0"}""")
+
+      assertEquals("""{"appVersion":"1.0.0"}""", sessionManager.getCrashReport("session-1"))
+    }
+
+  @Test
+  fun `replaces a previously stored report for the same session`() =
+    runTest {
+      startSession("session-1")
+
+      sessionManager.setCrashReport("session-1", """{"appVersion":"1.0.0"}""")
+      sessionManager.setCrashReport("session-1", """{"appVersion":"2.0.0"}""")
+
+      assertEquals("""{"appVersion":"2.0.0"}""", sessionManager.getCrashReport("session-1"))
+    }
+
+  @Test
+  fun `stores an orphan crash report with a null session id`() =
+    runTest {
+      // A crash that can't be attributed (fired before the session row existed,
+      // or a native crash with nowhere to attach) lands as an orphan: null
+      // sessionId, kept distinct by its own id.
+      sessionManager.setCrashReport(null, """{"appVersion":"1.0.0"}""")
+      sessionManager.setCrashReport(null, """{"appVersion":"2.0.0"}""")
+
+      // Both coexist — the unique sessionId index treats nulls as distinct.
+      assertEquals(2, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  @Test
+  fun `getOrphanCrashReportPayloads returns only unattributed reports, newest first`() =
+    runTest {
+      startSession("session-1")
+      sessionManager.setCrashReport("session-1", """{"appVersion":"attributed"}""")
+      sessionManager.setCrashReport(
+        null,
+        """{"appVersion":"older-orphan"}""",
+        createdAt = "2025-01-15T10:00:00.000Z"
+      )
+      sessionManager.setCrashReport(
+        null,
+        """{"appVersion":"newer-orphan"}""",
+        createdAt = "2025-01-15T11:00:00.000Z"
+      )
+
+      val orphans = sessionManager.getOrphanCrashReportPayloads()
+
+      assertEquals(
+        listOf("""{"appVersion":"newer-orphan"}""", """{"appVersion":"older-orphan"}"""),
+        orphans
+      )
+    }
+
+  @Test
+  fun `cascade deletes the report when its session is deleted`() =
+    runTest {
+      startSession("session-1")
+      sessionManager.setCrashReport("session-1", """{"appVersion":"1.0.0"}""")
+
+      database.sessionDao().deleteAll()
+
+      assertNull(sessionManager.getCrashReport("session-1"))
+    }
+
+  @Test
+  fun `returns null for a session without a crash report`() =
+    runTest {
+      startSession("session-1")
+
+      assertNull(sessionManager.getCrashReport("session-1"))
+    }
+
+  // endregion
+
+  // region getInactiveSessions
+
+  @Test
+  fun `attaches crash payloads to their sessions`() =
+    runTest {
+      startSession("crashed", startTimestamp = "2025-01-15T10:00:00.000Z")
+      startSession("clean", startTimestamp = "2025-01-15T11:00:00.000Z")
+      sessionManager.stopSession("crashed")
+      sessionManager.stopSession("clean")
+      sessionManager.setCrashReport("crashed", """{"appVersion":"1.0.0"}""")
+
+      val sessions = sessionManager.getInactiveSessions()
+
+      val crashed = sessions.first { it.session.id == "crashed" }
+      val clean = sessions.first { it.session.id == "clean" }
+      assertEquals("""{"appVersion":"1.0.0"}""", crashed.crashReportPayload)
+      assertNull(clean.crashReportPayload)
+    }
+
+  @Test
+  fun `keeps the inactive-session ordering of getInactiveSessions`() =
+    runTest {
+      startSession("older", startTimestamp = "2025-01-15T10:00:00.000Z")
+      startSession("newer", startTimestamp = "2025-01-15T11:00:00.000Z")
+      sessionManager.stopSession("older")
+      sessionManager.stopSession("newer")
+
+      val sessions = sessionManager.getInactiveSessions()
+
+      assertEquals(
+        listOf("newer", "older"),
+        sessions.map { it.session.id }
+      )
+    }
+
+  @Test
+  fun `excludes active sessions`() =
+    runTest {
+      startSession("active")
+      sessionManager.setCrashReport("active", """{"appVersion":"1.0.0"}""")
+
+      val sessions = sessionManager.getInactiveSessions()
+
+      assertEquals(emptyList<SessionWithChildren>(), sessions)
+    }
+
+  // endregion
+
+  // region Pruning
+
+  @Test
+  fun `cleanupOldSessions removes crash reports of pruned sessions`() =
+    runTest {
+      val oldTimestamp = "2020-01-01T00:00:00.000Z"
+      startSession("ancient", startTimestamp = oldTimestamp)
+      sessionManager.stopSession("ancient")
+      sessionManager.setCrashReport("ancient", """{"appVersion":"1.0.0"}""")
+
+      sessionManager.cleanupOldSessions()
+
+      assertNull(sessionManager.getCrashReport("ancient"))
+    }
+
+  @Test
+  fun `cleanupOldSessions keeps the crash report of an old but still-active session`() =
+    runTest {
+      // `deleteSessionsOlderThan` protects live sessions; their crash reports
+      // must be protected the same way (and must not be aged out as orphans —
+      // the session row exists).
+      startSession("long-lived", startTimestamp = "2020-01-01T00:00:00.000Z")
+      sessionManager.setCrashReport(
+        "long-lived",
+        """{"appVersion":"1.0.0"}""",
+        createdAt = "2020-01-01T00:00:00.000Z"
+      )
+
+      sessionManager.cleanupOldSessions()
+
+      assertEquals("""{"appVersion":"1.0.0"}""", sessionManager.getCrashReport("long-lived"))
+    }
+
+  @Test
+  fun `cleanupOldSessions keeps crash reports of recent sessions`() =
+    runTest {
+      startSession("recent", startTimestamp = TimeUtils.getCurrentTimestampInISOFormat())
+      sessionManager.stopSession("recent")
+      sessionManager.setCrashReport("recent", """{"appVersion":"1.0.0"}""")
+
+      sessionManager.cleanupOldSessions()
+
+      assertEquals("""{"appVersion":"1.0.0"}""", sessionManager.getCrashReport("recent"))
+    }
+
+  @Test
+  fun `cleanupOldSessions removes orphan crash reports past the retention window`() =
+    runTest {
+      sessionManager.setCrashReport(
+        null,
+        """{"appVersion":"1.0.0"}""",
+        createdAt = "2020-01-01T00:00:00.000Z"
+      )
+
+      sessionManager.cleanupOldSessions()
+
+      assertEquals(emptyList<String>(), sessionManager.getOrphanCrashReportPayloads())
+    }
+
+  @Test
+  fun `cleanupOldSessions keeps recent orphan crash reports`() =
+    runTest {
+      // A recent orphan (no owning session) must survive pruning until the
+      // retention window passes.
+      sessionManager.setCrashReport(null, """{"appVersion":"1.0.0"}""")
+
+      sessionManager.cleanupOldSessions()
+
+      assertEquals(1, sessionManager.getOrphanCrashReportPayloads().size)
+    }
+
+  @Test
+  fun `clearAllData wipes crash reports`() =
+    runTest {
+      startSession("session-1")
+      sessionManager.setCrashReport("session-1", """{"appVersion":"1.0.0"}""")
+      sessionManager.setCrashReport(null, """{"appVersion":"1.0.0"}""")
+
+      sessionManager.clearAllData()
+
+      assertNull(sessionManager.getCrashReport("session-1"))
+      assertEquals(emptyList<String>(), sessionManager.getOrphanCrashReportPayloads())
+    }
+
+  // endregion
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -791,6 +791,37 @@ class SessionManagerTest {
       droppedAttributesCount = 0
     )
 
+  // region getPreviousMainSessionId
+
+  @Test
+  fun `getPreviousMainSessionId returns the most recent session excluding the current one`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("older", "2025-01-01T00:00:00.000Z")
+      sessionManager.startSessionWithIdAt("previous", "2025-01-01T01:00:00.000Z")
+      sessionManager.startSessionWithIdAt("current", "2025-01-01T02:00:00.000Z")
+
+      assertEquals("previous", sessionManager.getPreviousMainSessionId("current"))
+    }
+
+  @Test
+  fun `getPreviousMainSessionId returns the latest session when none is current`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("older", "2025-01-01T00:00:00.000Z")
+      sessionManager.startSessionWithIdAt("newer", "2025-01-01T01:00:00.000Z")
+
+      assertEquals("newer", sessionManager.getPreviousMainSessionId(null))
+    }
+
+  @Test
+  fun `getPreviousMainSessionId returns null when only the current session exists`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("current", "2025-01-01T00:00:00.000Z")
+
+      assertNull(sessionManager.getPreviousMainSessionId("current"))
+    }
+
+  // endregion
+
   private fun createTestMetadata(
     appName: String? = "TestApp",
     appIdentifier: String = "com.test.app",

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -52,13 +52,13 @@ class SessionMappersTest {
   )
 
   @Test
-  fun `JsSession_fromSessionWithMetrics exposes the JS-facing field names`() {
-    val swm = SessionWithMetrics(
+  fun `JsSession_fromSessionWithChildren exposes the JS-facing field names`() {
+    val swc = SessionWithChildren(
       session = makeSession(id = "abc", startTimestamp = "2025-06-15T10:00:00.000Z"),
       metrics = emptyList()
     )
 
-    val js = JsDebugSession.fromSessionWithMetrics(swm)
+    val js = JsDebugSession.fromSessionWithChildren(swc)
 
     assertEquals("abc", js.id)
     assertEquals("main", js.type)
@@ -68,13 +68,13 @@ class SessionMappersTest {
   }
 
   @Test
-  fun `JsSession_fromSessionWithMetrics surfaces endDate when set`() {
-    val swm = SessionWithMetrics(
+  fun `JsSession_fromSessionWithChildren surfaces endDate when set`() {
+    val swc = SessionWithChildren(
       session = makeSession(endTimestamp = "2025-01-02T00:00:00.000Z"),
       metrics = emptyList()
     )
 
-    val js = JsDebugSession.fromSessionWithMetrics(swm)
+    val js = JsDebugSession.fromSessionWithChildren(swc)
 
     assertEquals("2025-01-02T00:00:00.000Z", js.endDate)
   }
@@ -118,8 +118,8 @@ class SessionMappersTest {
   }
 
   @Test
-  fun `JsSession_fromSessionWithMetrics surfaces stored logs`() {
-    val swm = SessionWithMetrics(
+  fun `JsSession_fromSessionWithChildren surfaces stored logs`() {
+    val swc = SessionWithChildren(
       session = makeSession(),
       metrics = emptyList(),
       logs = listOf(
@@ -128,7 +128,7 @@ class SessionMappersTest {
       )
     )
 
-    val js = JsDebugSession.fromSessionWithMetrics(swm)
+    val js = JsDebugSession.fromSessionWithChildren(swc)
 
     assertEquals(2, js.logs.size)
     assertEquals("first.event", js.logs[0].name)
@@ -260,5 +260,48 @@ class SessionMappersTest {
     val metric = input.toMetric("session-42")
 
     assertNull(metric.params)
+  }
+
+  @Test
+  fun `JsSession_fromSessionWithChildren decodes the crash report payload`() {
+    val payload =
+      """{"appVersion":"1.0.0","timestampBegin":"2026-06-12T10:00:00Z",""" +
+        """"exceptionReason":"java.lang.IllegalStateException: boom"}"""
+    val value = SessionWithChildren(
+      session = makeSession(),
+      metrics = emptyList(),
+      crashReports = listOf(CrashReportEntity(payload = payload, createdAt = "2026-06-12T10:00:00Z"))
+    )
+
+    val js = JsDebugSession.fromSessionWithChildren(value)
+
+    val crashReport = js.crashReport
+    assertEquals("1.0.0", crashReport?.get("appVersion"))
+    assertEquals("java.lang.IllegalStateException: boom", crashReport?.get("exceptionReason"))
+  }
+
+  @Test
+  fun `JsSession_fromSessionWithChildren yields null crashReport when no payload is stored`() {
+    val value = SessionWithChildren(
+      session = makeSession(),
+      metrics = emptyList()
+    )
+
+    val js = JsDebugSession.fromSessionWithChildren(value)
+
+    assertNull(js.crashReport)
+  }
+
+  @Test
+  fun `JsSession_fromSessionWithChildren yields null crashReport for a malformed payload`() {
+    val value = SessionWithChildren(
+      session = makeSession(),
+      metrics = emptyList(),
+      crashReports = listOf(CrashReportEntity(payload = "{ this is not valid json", createdAt = "2026-06-12T10:00:00Z"))
+    )
+
+    val js = JsDebugSession.fromSessionWithChildren(value)
+
+    assertNull(js.crashReport)
   }
 }

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -203,18 +203,27 @@ export type SessionType = 'main' | 'foreground' | 'screen' | 'custom' | 'unknown
 export type MetricInput = Omit<Metric, 'sessionId'>;
 
 export type CallStackFrame = {
+  /** @platform ios */
   binaryName?: string | null;
+  /** @platform ios */
   binaryUUID?: string | null;
+  /** @platform ios */
   address?: number | null;
+  /** @platform ios */
   offsetIntoBinaryTextSegment?: number | null;
+  /** @platform ios */
   sampleCount?: number | null;
   subFrames?: CallStackFrame[] | null;
   /**
-   * Resolved symbol from on-device `dladdr` symbolication. Swift and Itanium-ABI C++
+   * Human-readable symbol for the frame.
+   *
+   * On iOS, resolved by on-device `dladdr` symbolication: Swift and Itanium-ABI C++
    * names are demangled; Objective-C selectors and plain C symbols are returned as-is.
    * `null` when the binary is not loaded in this process or `dladdr` could not resolve it.
    *
-   * @platform ios
+   * On Android, the frame string of the JVM stack trace
+   * (for example `com.example.MainActivity.onCreate(MainActivity.kt:42)`) —
+   * always present since JVM stacks are symbolic by construction.
    */
   symbol?: string | null;
 };
@@ -228,23 +237,75 @@ export type CallStackTree = {
   callStacks?: CallStack[] | null;
 };
 
+/**
+ * A crash attributed to a session. The populated fields depend on the platform
+ * and crash type:
+ *
+ * - iOS (MetricKit): the numeric `exceptionType`/`exceptionCode`/`signal`
+ *   fields, plus `exceptionReason` for unhandled Objective-C exceptions.
+ * - Android JVM crashes: `exceptionReason` is the throwable's composed message
+ *   string (numeric fields stay `null` — they're Mach/Unix codes that don't
+ *   exist for JVM exceptions).
+ * - Android native crashes: `signal` and `terminationReason` from the OS exit
+ *   record; no call stack.
+ */
 export type CrashReport = {
+  /**
+   * Mach exception type (e.g. `EXC_BAD_ACCESS`).
+   * @platform ios
+   */
   exceptionType?: number | null;
+  /**
+   * Processor-specific exception code.
+   * @platform ios
+   */
   exceptionCode?: number | null;
+  /** Unix signal number (e.g. SIGSEGV = 11). */
   signal?: number | null;
+  /** Human-readable description of the termination reason. */
   terminationReason?: string | null;
+  /**
+   * Memory region info for bad-access crashes.
+   * @platform ios
+   */
   virtualMemoryRegionInfo?: string | null;
-  exceptionReason?: {
-    composedMessage: string;
-    formatString: string;
-    arguments: string[];
-    exceptionType: string;
-    className: string;
-    exceptionName: string;
-  } | null;
+  /**
+   * Exception details. The shape differs by platform:
+   * - iOS: a structured object from MetricKit's exception reason, set for
+   *   unhandled Objective-C exceptions.
+   * - Android: a plain string — the throwable's composed message
+   *   (`Throwable.toString()` plus the `Caused by:` chain), set for every JVM
+   *   crash.
+   *
+   * Narrow with `typeof` before reading object fields.
+   */
+  exceptionReason?:
+    | {
+        composedMessage: string;
+        formatString: string;
+        arguments: string[];
+        exceptionType: string;
+        className: string;
+        exceptionName: string;
+      }
+    | string
+    | null;
   callStackTree?: CallStackTree | null;
+  /** App version at the time of the crash. */
+  appVersion: string;
+  /**
+   * Start of the diagnostic window. On iOS this is MetricKit's payload window
+   * (typically a 24-hour bucket); on Android the exact crash moment
+   * (`timestampBegin` equals `timestampEnd`). ISO 8601 — sub-second precision
+   * differs between platforms, so parse rather than string-compare.
+   */
   timestampBegin: string;
+  /** End of the diagnostic window. See `timestampBegin`. */
   timestampEnd: string;
+  /**
+   * When this device learned about the crash and constructed the report —
+   * the next launch after the crash, not the crash moment itself.
+   */
   ingestedAt: string;
 };
 
@@ -411,7 +472,7 @@ export type DebugSession = {
   metrics: Metric[];
   /** Log events recorded during the session. */
   logs: LogRecord[];
-  /** Crash report attached to the session, if any. Never present on Android (MetricKit is iOS-only). */
+  /** Crash report attached to the session, if any. */
   crashReport?: CrashReport | null;
 };
 
@@ -455,6 +516,19 @@ export interface ExpoAppMetricsModuleType {
    * @private This API is unstable and may change without notice.
    */
   getInactiveSessions(): Promise<DebugSession[]>;
+
+  /* 
+   * Returns crash reports that aren't attributed to any session — startup
+   * crashes captured before a session existed, or native crashes that couldn't
+   * be attributed — ordered with the most recent first. These never appear under
+   * a session in `getInactiveSessions`.
+   *
+   * Debug-only: intended for inspecting on-device history, not for production use.
+   *
+   * @private This API is unstable and may change without notice.
+   * @platform android
+   */
+  getOrphanedCrashReports?: () => Promise<CrashReport[]>;
 
   /**
    * Reports an unhandled JavaScript error captured by the JS-side `global.ErrorUtils`

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -291,6 +291,13 @@ export type CrashReport = {
     | string
     | null;
   callStackTree?: CallStackTree | null;
+  /**
+   * Id of the session the crash is attributed to, or `null` for an orphan —
+   * a startup crash captured before a session existed, or a native crash that
+   * couldn't be attributed. Only populated by `getAllCrashReports`.
+   * @platform android
+   */
+  sessionId?: string | null;
   /** App version at the time of the crash. */
   appVersion: string;
   /**
@@ -517,18 +524,18 @@ export interface ExpoAppMetricsModuleType {
    */
   getInactiveSessions(): Promise<DebugSession[]>;
 
-  /* 
-   * Returns crash reports that aren't attributed to any session — startup
+  /**
+   * Returns every stored crash report, ordered with the most recent first.
+   * Includes reports attributed to a session as well as orphans — startup
    * crashes captured before a session existed, or native crashes that couldn't
-   * be attributed — ordered with the most recent first. These never appear under
-   * a session in `getInactiveSessions`.
+   * be attributed. Orphans have a `sessionId` of `null`.
    *
    * Debug-only: intended for inspecting on-device history, not for production use.
    *
    * @private This API is unstable and may change without notice.
    * @platform android
    */
-  getOrphanedCrashReports?: () => Promise<CrashReport[]>;
+  getAllCrashReports?: () => Promise<CrashReport[]>;
 
   /**
    * Reports an unhandled JavaScript error captured by the JS-side `global.ErrorUtils`

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -302,13 +302,18 @@ export type CrashReport = {
   appVersion: string;
   /**
    * Start of the diagnostic window. On iOS this is MetricKit's payload window
-   * (typically a 24-hour bucket); on Android the exact crash moment
-   * (`timestampBegin` equals `timestampEnd`). ISO 8601 — sub-second precision
-   * differs between platforms, so parse rather than string-compare.
+   * (typically a 24-hour bucket); on Android the exact crash moment. ISO 8601 —
+   * sub-second precision differs between platforms, so parse rather than
+   * string-compare.
    */
   timestampBegin: string;
-  /** End of the diagnostic window. See `timestampBegin`. */
-  timestampEnd: string;
+  /**
+   * End of the diagnostic window. Present on iOS (the window end). Absent on
+   * Android, which captures the exact crash moment — treat a missing value as
+   * equal to `timestampBegin` (a zero-width window).
+   * @platform ios
+   */
+  timestampEnd?: string;
   /**
    * When this device learned about the crash and constructed the report —
    * the next launch after the crash, not the crash moment itself.


### PR DESCRIPTION
# Why

Crash reporting in `expo-app-metrics` was iOS-only (MetricKit). This adds the Android side so crashes are captured, attributed to a session, and surfaced the same way across platforms.

Android has no MetricKit equivalent, so this composes two OS signals: `ApplicationExitInfo` (available on next launch, gives the exit reason/signal but no JVM stack) and an uncaught-exception handler (gives the Java stack trace, but only for JVM crashes). 

# How

Android has no single crash API, so two signals are combined: an uncaught-exception handler gives the Java stack trace, and `ApplicationExitInfo` gives the exit reason on the next launch. The pipeline captures crashes when they happen, then turns them into reports on the next start.

- **Capture (process start):** install `JvmCrashHandler` before the module starts up, so startup crashes aren't missed.
  - On an uncaught exception, write one small crash file (temp file + atomic rename), then hand off to the previous handler so the process still dies and other reporters still run.
  - Stamp the current session id onto the file, or leave it empty (→ orphan) if no session exists yet.
- **Process (next launch):** `CrashReportProcessor` builds `CrashReport`s from the previous process's leftovers.
  - Read pending JVM crash files (`CrashFileReader`) and OS exit records (`ExitInfoProvider`).
  - Keep only real crashes (`REASON_CRASH` / `REASON_CRASH_NATIVE`); skip ANRs, low-memory kills, and bare signals, matching how Play Console splits crash rate from ANR rate.
  - Dedupe a JVM file and a native record for the same death by pid + time window, and only process records newer than the last processed one (stored in `AppMetricsPreferences`).
- **Attribute & store:** `attributeAndStoreCrashReport` decides which session a report belongs to.
  - A JVM file with a session id → that session; a native crash → the previous main session (unless it already has a report); no id → orphan.
  - Failures are logged and swallowed so a bad report can't crash the next launch.
- **Surface:** new debug-only `getOrphanedCrashReports()` returns reports not attached to any session (startup/native crashes), most recent first.
- **observe-tester:** platform-split `FrameRow`, `ExceptionReason`, and `crashTriggers` so the tester renders Android crash data and can trigger JVM/native crashes on-device.

# Test Plan

Observe tester app

<img height="512" alt="Screenshot_1781700795" src="https://github.com/user-attachments/assets/863582a5-7ceb-4045-bc0d-44afb18d4996" />
<img height="512" alt="Screenshot_1781700792" src="https://github.com/user-attachments/assets/5ae17e51-1b01-4771-b0de-e4aee2704f3c" />
<img height="512" alt="Screenshot_1781700787" src="https://github.com/user-attachments/assets/bd5522d7-746f-4e34-a887-5e7216b30701" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
