### PR TITLE
[core][ios] Decode Fabric view props from JSI on the JS thread

### DIFF
--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkView.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkView.swift
@@ -1,0 +1,89 @@
+import ExpoModulesCore
+import QuartzCore
+import UIKit
+
+/// A record-typed prop, exercising the `@Record` decode path.
+@Record
+struct BenchmarkStyle {
+  var opacity: Double = 1
+  var cornerRadius: Double = 0
+  var label: String = ""
+  var weight: Int = 0
+}
+
+/// A UIView with a wide, varied set of JS-thread-decodable props (primitives, strings, an array,
+/// and a record) so a prop-update loop exercises the decoding path meaningfully. A few props are
+/// rendered for live confirmation that decode → apply lands the right values: `color` → background,
+/// `title`/`count` → an overlaid label. The setters are still cheap, but note the label text +
+/// background updates add a little real apply work (per the benchmark, that's representative —
+/// real views do work in their setters).
+final class BenchmarkView: ExpoView {
+  // The label (fully owned, fills bounds) doubles as the colored background. We can't use the
+  // view's own `backgroundColor`: `RCTViewComponentView` (this view's Fabric base) overrides that
+  // setter to only stash the color and apply it via a private backing layer during ITS prop-diff —
+  // so a direct `backgroundColor =` never repaints. Setting it on the label sidesteps RN's layer
+  // management.
+  private let label = UILabel()
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    label.textColor = .white
+    label.font = .monospacedSystemFont(ofSize: 13, weight: .semibold)
+    label.textAlignment = .center
+    addSubview(label)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    label.frame = bounds
+  }
+
+  private func updateLabel() {
+    label.text = "\(title)  ·  #\(count)"
+  }
+
+  var color: UIColor = .clear {
+    didSet {
+      label.backgroundColor = color
+    }
+  }
+  var title: String = "" {
+    didSet {
+      updateLabel()
+    }
+  }
+  var count: Int = 0 {
+    didSet {
+      updateLabel()
+    }
+  }
+  var decoration = BenchmarkStyle()
+  var values: [Double] = []
+
+  // MARK: - Benchmark instrumentation
+  //
+  // Bracket the main-thread apply phase via core's lifecycle hooks instead of timing inside core.
+  // `viewWillUpdateProps` runs at the start of `finalizeUpdates`, `viewDidUpdateProps` at the end.
+
+  private var applyStart: CFTimeInterval = 0
+
+  override func viewWillUpdateProps() {
+    applyStart = CACurrentMediaTime()
+  }
+
+  override func viewDidUpdateProps() {
+    ViewPropsBenchmark.applySeconds += CACurrentMediaTime() - applyStart
+    ViewPropsBenchmark.applyPassCount += 1
+  }
+
+  override func updateProps(_ props: [String: Any]) {
+    // Reached only on the legacy dictionary path (the JSI path applies via `applyDecodedProps`).
+    // Counts props *presented* to the legacy path, not props applied: the legacy `propsMap` is
+    // sticky (it carries the full prop set every update), so even a single-prop change presents
+    // all props here. The gap between this and the changed-prop count (one per pass in single
+    // mode) is exactly the work the legacy path can't skip, which the JSI path avoids by reading
+    // only the changed props from the rawProps diff.
+    ViewPropsBenchmark.legacyPresentedPropCount += props.count
+    super.updateProps(props)
+  }
+}

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -1,5 +1,7 @@
 import ExpoModulesCore
 import ExpoModulesJSI
+import QuartzCore
+import UIKit
 
 struct Point: Record {
   @Field
@@ -23,6 +25,12 @@ final class SharedPoint: SharedObject {
 @ExpoModule
 public final class BenchmarkingExpoModule: Module {
   public func definition() -> ModuleDefinition {
+    OnCreate {
+      // Attach the JS-thread decode timing observer to expo-modules-core (no-op cost in core when
+      // unset; only this benchmark module sets it).
+      ViewPropsBenchmark.installDecodeObserver()
+    }
+
     Function("nothing") {}
     Function("nothingOptimized", nothingOptimized())
 
@@ -84,6 +92,44 @@ public final class BenchmarkingExpoModule: Module {
 
       Property("y") { (point: SharedPoint) in
         return point.y
+      }
+    }
+
+    // MARK: - View-props benchmark
+    //
+    // `getViewPropsBenchmark` / `resetViewPropsBenchmark` read the process-wide counters that
+    // expo-modules-core accumulates around view-prop decode (JS thread) and apply (main
+    // thread). Drive the `BenchmarkView` below with changing props, then read the totals.
+
+    Function("resetViewPropsBenchmark") {
+      ViewPropsBenchmark.reset()
+    }
+
+    Function("getViewPropsBenchmark") { () -> [String: Any] in
+      return ViewPropsBenchmark.snapshot()
+    }
+
+    View(BenchmarkView.self) {
+      Prop("color") { (view: BenchmarkView, color: UIColor) in
+        view.color = color
+      }
+      Prop("decoration") { (view: BenchmarkView, decoration: BenchmarkStyle) in
+        view.decoration = decoration
+      }
+      Prop("values") { (view: BenchmarkView, values: [Double]) in
+        view.values = values
+      }
+      Prop("count") { (view: BenchmarkView, count: Int) in
+        view.count = count
+      }
+      Prop("ratio") { (view: BenchmarkView, ratio: Double) in
+        _ = ratio
+      }
+      Prop("title") { (view: BenchmarkView, title: String) in
+        view.title = title
+      }
+      Prop("subtitle") { (view: BenchmarkView, subtitle: String) in
+        view.accessibilityHint = subtitle
       }
     }
 

--- a/apps/bare-expo/modules/benchmarking/ios/ViewPropsBenchmark.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/ViewPropsBenchmark.swift
@@ -1,0 +1,73 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import QuartzCore
+import ExpoModulesCore
+
+/// Process-wide counters for benchmarking the JSI view-props decoding path against the legacy
+/// `folly::dynamic` / `NSDictionary` path. Fed by the benchmark harness via expo-modules-core's
+/// view lifecycle hooks (`viewWillUpdateProps`/`viewDidUpdateProps` bracket the main-thread apply)
+/// and the `ViewPropsJSIDecoder.onDecodePass` observer (JS-thread decode). No timing is wired into
+/// core itself.
+///
+/// Times accumulate in seconds (via `CACurrentMediaTime`, a monotonic clock). Reads/writes aren't
+/// synchronized: the harness drives updates serially (Fabric parses props on the JS thread, applies
+/// on the main thread, and the harness waits between batches), and the small races that remain don't
+/// matter for a benchmark counter.
+///
+/// Every counter is `nonisolated(unsafe)` deliberately: without it, Swift guards each access to a
+/// mutable static with a `swift_once` lazy-init check, which on the per-prop / per-pass hot path
+/// measurably inflates the very numbers being measured.
+enum ViewPropsBenchmark {
+  /// Accumulated seconds spent decoding props from JS values on the JavaScript thread.
+  nonisolated(unsafe) static var decodeSeconds: Double = 0
+
+  /// Accumulated seconds spent applying props to views on the main thread.
+  nonisolated(unsafe) static var applySeconds: Double = 0
+
+  /// Number of individual props decoded straight from their JS value on the JS thread.
+  nonisolated(unsafe) static var decodedPropCount: Int = 0
+
+  /// Number of props *presented* to the legacy (dictionary) path, summed across passes. Not the
+  /// number applied: the legacy `propsMap` is sticky, so a single-prop change still presents the
+  /// full set. Stays zero while the JSI descriptor is in use, so it doubles as a "did anything
+  /// fall back" signal.
+  nonisolated(unsafe) static var legacyPresentedPropCount: Int = 0
+
+  /// Number of decode passes that ran on the JS thread. Fabric may call `cloneProps` more than
+  /// once per visual update, so this can exceed the number of apply passes.
+  nonisolated(unsafe) static var decodePassCount: Int = 0
+
+  /// Number of apply passes that ran on the main thread (one per `finalizeUpdates`).
+  nonisolated(unsafe) static var applyPassCount: Int = 0
+
+  /// Returns the accumulated counters as a dictionary, with times converted to milliseconds.
+  static func snapshot() -> [String: Any] {
+    return [
+      "decodeMs": decodeSeconds * 1000,
+      "applyMs": applySeconds * 1000,
+      "decodedPropCount": decodedPropCount,
+      "legacyPresentedPropCount": legacyPresentedPropCount,
+      "decodePassCount": decodePassCount,
+      "applyPassCount": applyPassCount
+    ]
+  }
+
+  /// Resets all counters to zero. Call before a measured run.
+  static func reset() {
+    decodeSeconds = 0
+    applySeconds = 0
+    decodedPropCount = 0
+    legacyPresentedPropCount = 0
+    decodePassCount = 0
+    applyPassCount = 0
+  }
+
+  /// Attaches the JS-thread decode observer. Call once during module setup.
+  static func installDecodeObserver() {
+    ViewPropsJSIDecoder.onDecodePass = { seconds, propCount in
+      decodeSeconds += seconds
+      decodePassCount += 1
+      decodedPropCount += propCount
+    }
+  }
+}

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkView.tsx
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkView.tsx
@@ -1,0 +1,28 @@
+import { requireNativeViewManager } from 'expo-modules-core';
+import * as React from 'react';
+import { ViewProps } from 'react-native';
+
+export type BenchmarkViewProps = ViewProps & {
+  /** A UIColor-decoded color prop. */
+  color?: string;
+  /** A record-typed prop (exercises the `@Record` decode path on the JS thread).
+   *  Named `decoration`, not `style`, to avoid colliding with RN's reserved layout `style`. */
+  decoration?: {
+    opacity?: number;
+    cornerRadius?: number;
+    label?: string;
+    weight?: number;
+  };
+  /** An array prop. */
+  values?: number[];
+  count?: number;
+  ratio?: number;
+  title?: string;
+  subtitle?: string;
+};
+
+const NativeBenchmarkView = requireNativeViewManager<BenchmarkViewProps>('BenchmarkingExpoModule');
+
+export default function BenchmarkView(props: BenchmarkViewProps) {
+  return <NativeBenchmarkView {...props} />;
+}

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -36,6 +36,28 @@ declare class BenchmarkingExpoModule extends NativeModule {
   executeAsyncSync(iterations: number): Promise<number>;
   /** iOS only — measures async `runtime.execute` with an async closure. */
   executeAsyncAsync(iterations: number): Promise<number>;
+
+  // MARK: - View-props benchmark (iOS only)
+
+  /** Resets the process-wide view-prop decode/apply counters. */
+  resetViewPropsBenchmark(): void;
+  /** Reads the accumulated view-prop decode/apply counters. */
+  getViewPropsBenchmark(): ViewPropsBenchmark;
 }
+
+export type ViewPropsBenchmark = {
+  /** Total time spent decoding props from JS values on the JS thread (ms). */
+  decodeMs: number;
+  /** Total time spent applying props to views on the main thread (ms). */
+  applyMs: number;
+  /** Number of props decoded straight from their JS value (JSI path). */
+  decodedPropCount: number;
+  /** Number of props presented to the legacy (dictionary) path (sticky full set, not applied count). */
+  legacyPresentedPropCount: number;
+  /** Number of decode passes (cloneProps calls that reached the decoder; can exceed apply passes). */
+  decodePassCount: number;
+  /** Number of apply passes (finalizeUpdates → updateProps calls on the main thread). */
+  applyPassCount: number;
+};
 
 export default requireNativeModule<BenchmarkingExpoModule>('BenchmarkingExpoModule');

--- a/apps/bare-expo/modules/benchmarking/src/ViewPropsBenchmarkScreen.tsx
+++ b/apps/bare-expo/modules/benchmarking/src/ViewPropsBenchmarkScreen.tsx
@@ -1,0 +1,398 @@
+import { useTheme } from 'ThemeProvider';
+import * as React from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import BenchmarkView from './BenchmarkView';
+import BenchmarkingModule, { type ViewPropsBenchmark } from './BenchmarkingExpoModule';
+
+// How many prop-update passes to run in a measured batch (after warmup).
+const ITERATIONS = 2000;
+// Discarded warmup passes so component registration / first-allocation costs don't pollute
+// the measured window.
+const WARMUP = 200;
+
+type BenchMode = 'all' | 'single';
+
+/**
+ * Opaque ARGB int for pass `i`: a hue that drifts slowly (~0.6°/pass) at full saturation.
+ * Deterministic (not random — idle screen is stable, runs reproducible) and changes every pass (a
+ * real diff for the benchmark), but the small step keeps consecutive colors close so on screen it
+ * reads as a smooth sweep rather than a strobe. (`Math.random()` would be a render side effect; a
+ * bit-scrambled hash changes every pass too but jumps to unrelated colors → strobes too fast.)
+ */
+function colorForPass(i: number): number {
+  const h = ((((i * 0.6) % 360) + 360) % 360) / 60; // hue sector 0–6
+  const x = Math.round(255 * (1 - Math.abs((h % 2) - 1)));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 1) [r, g, b] = [255, x, 0];
+  else if (h < 2) [r, g, b] = [x, 255, 0];
+  else if (h < 3) [r, g, b] = [0, 255, x];
+  else if (h < 4) [r, g, b] = [0, x, 255];
+  else if (h < 5) [r, g, b] = [x, 0, 255];
+  else [r, g, b] = [255, 0, x];
+  return (0xff000000 | (r << 16) | (g << 8) | b) >>> 0;
+}
+
+const ALL_PROP_KEYS = [
+  'color',
+  'decoration',
+  'values',
+  'count',
+  'ratio',
+  'title',
+  'subtitle',
+] as const;
+
+function valueForKey(key: (typeof ALL_PROP_KEYS)[number], i: number) {
+  switch (key) {
+    case 'color':
+      // Opaque ARGB int (fastest decode path: straight to colorFromArgb, no string parsing; and
+      // representative, since RN's `processColor` hands native an int). A slow hue sweep — see
+      // `colorForPass`: changes every pass (real diff) but reads as a smooth sweep, not a strobe.
+      return colorForPass(i);
+    case 'decoration':
+      return { opacity: (i % 100) / 100, cornerRadius: i % 24, label: `label-${i}`, weight: i % 7 };
+    case 'values':
+      return [i, i + 1, i + 2, i + 3, i + 4];
+    case 'count':
+      return i;
+    case 'ratio':
+      return (i % 50) / 50;
+    case 'title':
+      return `title-${i}`;
+    case 'subtitle':
+      return `subtitle-${i}`;
+  }
+}
+
+/**
+ * Builds prop values for pass `i`.
+ *
+ * - `'all'`: every prop changes each pass — worst case, measures a full re-decode.
+ * - `'single'`: exactly ONE prop changes per pass relative to the *previous* pass (round-robin
+ *   over the props). Each prop holds the value from the most recent pass that touched it and keeps
+ *   it until its next turn — so advancing one prop doesn't revert another. (Naively spreading a
+ *   fixed base and overriding one key changes TWO props per transition — the new one, plus the
+ *   prior pass's prop reverting to base — which is the realistic single-prop scenario broken.)
+ *   This mirrors a real update where Fabric's rawProps diff carries a single changed prop.
+ */
+// `valueForKey` builds fresh objects/arrays for `decoration`/`values` each call. In single mode a
+// prop keeps the same `lastTouch` index across many passes, but a new object reference each render
+// would make React diff it as changed — breaking the one-prop-per-pass invariant. Memoize by
+// (key, index) so a given index always yields the same reference. (Harmless in all-props mode,
+// where the index changes every pass anyway.)
+const valueCache = new Map<string, unknown>();
+function stableValueForKey(key: (typeof ALL_PROP_KEYS)[number], i: number): unknown {
+  const cacheKey = `${key}:${i}`;
+  if (!valueCache.has(cacheKey)) {
+    valueCache.set(cacheKey, valueForKey(key, i));
+  }
+  return valueCache.get(cacheKey);
+}
+
+function propsForPass(i: number, mode: BenchMode): Record<string, unknown> {
+  if (mode === 'all') {
+    return Object.fromEntries(ALL_PROP_KEYS.map((k) => [k, valueForKey(k, i)]));
+  }
+  const n = ALL_PROP_KEYS.length;
+  return Object.fromEntries(
+    ALL_PROP_KEYS.map((key, k) => {
+      // The most recent pass (≤ i) whose turn was prop `k`; clamp to 0 so props sit at their
+      // pass-0 value until their first turn. Only the prop whose turn is `i` gets a new value
+      // this pass, so the diff vs. the previous pass is exactly one prop. `stableValueForKey`
+      // keeps object/array values reference-stable across passes with the same index.
+      const lastTouch = Math.max(0, i - (((i - k) % n) + n) % n);
+      return [key, stableValueForKey(key, lastTouch)];
+    })
+  );
+}
+
+type Result = ViewPropsBenchmark & {
+  decodeUsPerPass: number;
+  applyUsPerPass: number;
+};
+
+export default function ViewPropsBenchmarkScreen() {
+  const { theme } = useTheme();
+  const [pass, setPass] = React.useState(0);
+  const [running, setRunning] = React.useState(false);
+  const [result, setResult] = React.useState<Result | null>(null);
+  const [mode, setMode] = React.useState<BenchMode>('all');
+
+  // Drives ITERATIONS+WARMUP passes via rAF, resetting the native counters right after warmup
+  // so only the steady-state window is measured. We bump `pass` each frame; the rendered
+  // BenchmarkView receives fresh props, which flows through Fabric → cloneProps (decode) →
+  // finalizeUpdates (apply).
+  const run = React.useCallback((runMode: BenchMode) => {
+    setResult(null);
+    setMode(runMode);
+    setRunning(true);
+    let i = 0;
+
+    const tick = () => {
+      if (i === WARMUP) {
+        BenchmarkingModule.resetViewPropsBenchmark();
+      }
+      setPass(i);
+      i += 1;
+
+      if (i <= WARMUP + ITERATIONS) {
+        requestAnimationFrame(tick);
+      } else {
+        // Let the last commit flush before reading.
+        requestAnimationFrame(() => {
+          const snap = BenchmarkingModule.getViewPropsBenchmark();
+          // Normalize each side by its OWN pass count: Fabric may call cloneProps (decode)
+          // more than once per visual update, while apply runs once per finalizeUpdates.
+          const decodePasses = Math.max(snap.decodePassCount, 1);
+          const applyPasses = Math.max(snap.applyPassCount, 1);
+          const measured: Result = {
+            ...snap,
+            decodeUsPerPass: (snap.decodeMs * 1000) / decodePasses,
+            applyUsPerPass: (snap.applyMs * 1000) / applyPasses,
+          };
+          console.log('[view-props-benchmark]', {
+            mode: runMode,
+            iterations: ITERATIONS,
+            warmup: WARMUP,
+            decodeMs: Number(measured.decodeMs.toFixed(2)),
+            applyMs: Number(measured.applyMs.toFixed(2)),
+            decodeUsPerPass: Number(measured.decodeUsPerPass.toFixed(2)),
+            applyUsPerPass: Number(measured.applyUsPerPass.toFixed(2)),
+            decodedPropCount: measured.decodedPropCount,
+            legacyPresentedPropCount: measured.legacyPresentedPropCount,
+            decodePassCount: measured.decodePassCount,
+            applyPassCount: measured.applyPassCount,
+          });
+          setResult(measured);
+          setRunning(false);
+        });
+      }
+    };
+    requestAnimationFrame(tick);
+  }, []);
+
+  const props = propsForPass(pass, mode);
+
+  const decodedViaJSI = (result?.decodePassCount ?? 0) > 0;
+  const cardStyle = {
+    backgroundColor: theme.background.element,
+    borderColor: theme.border.default,
+  };
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.background.screen }}
+      contentContainerStyle={styles.container}>
+      <View style={styles.header}>
+        <Text style={[styles.heading, { color: theme.text.default }]}>View-props decoding</Text>
+        <Text style={[styles.subheading, { color: theme.text.secondary }]}>
+          {ITERATIONS.toLocaleString()} passes · {WARMUP} warmup
+        </Text>
+      </View>
+
+      <Text style={[styles.note, { color: theme.text.default }]}>
+        UIKit ExpoViews decode props from JSI on the JS thread. To compare against the legacy
+        path, point <Text style={styles.code}>+componentDescriptorProvider</Text> at{' '}
+        <Text style={styles.code}>ExpoViewComponentDescriptor</Text> and rebuild, then all cost
+        lands in apply (main thread). "All props" changes every prop each pass (worst case);
+        "1 prop" changes one per pass (realistic update).
+      </Text>
+
+      <View style={[styles.card, cardStyle, styles.previewCard]}>
+        <BenchmarkView style={styles.benchView} {...props} />
+      </View>
+
+      <View style={styles.buttonRow}>
+        <RunButton label="All props" running={running} onPress={() => run('all')} />
+        <RunButton label="1 prop" running={running} onPress={() => run('single')} />
+      </View>
+
+      {result ? (
+        <View style={[styles.card, cardStyle]}>
+          <View style={styles.resultHeader}>
+            <Text style={[styles.resultTitle, { color: theme.text.default }]}>
+              {mode === 'all' ? 'All props' : '1 prop'} · {ITERATIONS.toLocaleString()} passes
+            </Text>
+            <View
+              style={[
+                styles.badge,
+                { backgroundColor: theme.background.subtle, borderColor: theme.border.secondary },
+              ]}>
+              <Text
+                style={[
+                  styles.badgeText,
+                  { color: decodedViaJSI ? theme.text.success : theme.text.quaternary },
+                ]}>
+                {decodedViaJSI ? 'JSI descriptor' : 'legacy descriptor'}
+              </Text>
+            </View>
+          </View>
+
+          <Section title="JS thread" theme={theme}>
+            <Row label="decode total" value={`${result.decodeMs.toFixed(1)} ms`} theme={theme} />
+            <Row
+              label="decode / pass"
+              value={`${result.decodeUsPerPass.toFixed(1)} µs`}
+              theme={theme}
+              emphasize
+            />
+          </Section>
+
+          <Section title="Main thread" theme={theme}>
+            <Row label="apply total" value={`${result.applyMs.toFixed(1)} ms`} theme={theme} />
+            <Row
+              label="apply / pass"
+              value={`${result.applyUsPerPass.toFixed(1)} µs`}
+              theme={theme}
+              emphasize
+            />
+          </Section>
+
+          <Section title="Counts" theme={theme} last>
+            <Row label="decoded props" value={`${result.decodedPropCount}`} theme={theme} />
+            <Row label="legacy props (presented)" value={`${result.legacyPresentedPropCount}`} theme={theme} />
+            <Row
+              label="decode / apply passes"
+              value={`${result.decodePassCount} / ${result.applyPassCount}`}
+              theme={theme}
+            />
+          </Section>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function RunButton({
+  label,
+  running,
+  onPress,
+}: {
+  label: string;
+  running: boolean;
+  onPress: () => void;
+}) {
+  const { theme } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={running}
+      style={({ pressed }) => [
+        styles.button,
+        {
+          backgroundColor: theme.background.element,
+          borderColor: theme.border.default,
+          opacity: running ? 0.4 : pressed ? 0.7 : 1,
+        },
+      ]}>
+      <Text style={[styles.buttonText, { color: theme.text.link }]}>
+        {running ? 'Running…' : label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function Section({
+  title,
+  theme,
+  last,
+  children,
+}: {
+  title: string;
+  theme: ReturnType<typeof useTheme>['theme'];
+  last?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={[styles.section, !last && { borderBottomColor: theme.border.secondary, borderBottomWidth: StyleSheet.hairlineWidth }]}>
+      <Text style={[styles.sectionTitle, { color: theme.text.quaternary }]}>{title.toUpperCase()}</Text>
+      {children}
+    </View>
+  );
+}
+
+function Row({
+  label,
+  value,
+  theme,
+  emphasize,
+}: {
+  label: string;
+  value: string;
+  theme: ReturnType<typeof useTheme>['theme'];
+  emphasize?: boolean;
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.rowLabel, { color: theme.text.secondary }]}>{label}</Text>
+      <Text
+        style={[
+          styles.rowValue,
+          { color: emphasize ? theme.text.default : theme.text.secondary },
+          emphasize && styles.rowValueEmphasized,
+        ]}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, gap: 16 },
+
+  header: { gap: 2 },
+  heading: { fontSize: 24, fontWeight: '700', letterSpacing: -0.5 },
+  subheading: { fontSize: 13, fontVariant: ['tabular-nums'] },
+
+  note: { fontSize: 14, lineHeight: 21 },
+  code: {
+    fontFamily: 'Courier',
+    fontSize: 11,
+  },
+
+  card: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  previewCard: { height: 72 },
+  benchView: { flex: 1 },
+
+  buttonRow: { flexDirection: 'row', gap: 10 },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+  },
+  buttonText: { fontSize: 15, fontWeight: '600' },
+
+  resultHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 10,
+  },
+  resultTitle: { fontSize: 14, fontWeight: '600' },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  badgeText: { fontSize: 11, fontWeight: '600' },
+
+  section: { paddingHorizontal: 14, paddingVertical: 10, gap: 6 },
+  sectionTitle: { fontSize: 10, fontWeight: '700', letterSpacing: 0.6, marginBottom: 2 },
+
+  row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'baseline' },
+  rowLabel: { fontSize: 13 },
+  rowValue: { fontSize: 13, fontVariant: ['tabular-nums'] },
+  rowValueEmphasized: { fontSize: 15, fontWeight: '700' },
+});

--- a/apps/bare-expo/modules/benchmarking/src/index.ts
+++ b/apps/bare-expo/modules/benchmarking/src/index.ts
@@ -3,3 +3,6 @@ import ExpoModule from './BenchmarkingExpoModule';
 import TurboModule from './NativeBenchmarkingTurboModule';
 
 export { TurboModule, ExpoModule, BridgeModule };
+export { default as BenchmarkView } from './BenchmarkView';
+export { default as ViewPropsBenchmarkScreen } from './ViewPropsBenchmarkScreen';
+export type { ViewPropsBenchmark } from './BenchmarkingExpoModule';

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
@@ -1,4 +1,4 @@
-import { isRunningInExpoGo } from 'expo';
+import { isRunningInExpoGo, Platform } from 'expo';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
@@ -28,6 +28,17 @@ if (!isRunningInExpoGo()) {
       return optionalRequire(() => require('./Benchmarks/ModulesBenchmarksScreen'));
     },
   });
+  // The view-props decoding benchmark is iOS-only (the native `BenchmarkView` and the
+  // view-props counters aren't implemented on Android).
+  if (Platform.OS === 'ios') {
+    ModulesCoreScreens.push({
+      name: 'View props decoding benchmark',
+      route: 'modulescore/view-props-benchmark',
+      getComponent() {
+        return optionalRequire(() => require('./ViewPropsBenchmarkScreen'));
+      },
+    });
+  }
 }
 
 export default function ModulesCoreScreen() {

--- a/apps/native-component-list/src/screens/ModulesCore/ViewPropsBenchmarkScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ViewPropsBenchmarkScreen.tsx
@@ -1,0 +1,4 @@
+// Re-exports the view-props decoding benchmark screen that lives alongside the native
+// `BenchmarkView` in the bare-expo `benchmarking` module, so it can be lazy-required as a
+// native-component-list screen.
+export { ViewPropsBenchmarkScreen as default } from 'benchmarking';

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [iOS] Added the `@Record` macro that synthesizes a record from a type's stored properties, with no `@Field` wrappers needed. ([#46547](https://github.com/expo/expo/pull/46547) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `Module.emit` that sends an event directly to the module's own JavaScript object, mirroring `SharedObject.emit`. Both now share an `EventEmitter` protocol. ([#46555](https://github.com/expo/expo/pull/46555) by [@tsapeta](https://github.com/tsapeta))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
+- [iOS] Decode Fabric view props from their JavaScript values on the JavaScript thread (via a dedicated `ExpoViewJSIComponentDescriptor`), instead of lowering to `folly::dynamic` / `NSDictionary` and decoding on the main thread. Moves per-prop decode off the main thread for UIKit `ExpoView`s. ([#46872](https://github.com/expo/expo/pull/46872) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -88,7 +88,7 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule',
     'OTHER_SWIFT_FLAGS' => "$(inherited) #{new_arch_enabled ? new_arch_compiler_flags : ''}",
     'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
-    'GCC_PREPROCESSOR_DEFINITIONS' => "$(inherited) EXPO_MODULES_CORE_VERSION=" + package['version'],
+    'GCC_PREPROCESSOR_DEFINITIONS' => "$(inherited) EXPO_MODULES_CORE_VERSION=#{package['version']}",
   }
   s.user_target_xcconfig = {
     "HEADER_SEARCH_PATHS" => [

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
@@ -32,13 +32,35 @@ ExpoViewProps::ExpoViewProps(
   const react::PropsParserContext &context,
   const ExpoViewProps &sourceProps,
   const react::RawProps &rawProps,
-  [[maybe_unused]] const std::function<bool(const std::string &)> &filterObjectKeys
+  const std::function<bool(const std::string &)> &filterObjectKeys
+) : ExpoViewProps(context, sourceProps, rawProps, filterObjectKeys, /* buildPropsMap */ true) {}
+
+ExpoViewProps::ExpoViewProps(
+  const react::PropsParserContext &context,
+  const ExpoViewProps &sourceProps,
+  const react::RawProps &rawProps,
+  [[maybe_unused]] const std::function<bool(const std::string &)> &filterObjectKeys,
+  bool buildPropsMap
 )
 #if EXPO_VIEW_PROPS_SUPPORTS_FILTER_OBJECT_KEYS
-  : react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
+  : react::ViewProps(context, sourceProps, rawProps, filterObjectKeys)
 #else
-  : react::ViewProps(context, sourceProps, rawProps),
+  : react::ViewProps(context, sourceProps, rawProps)
 #endif
-    propsMap(propsMapFromProps(sourceProps, rawProps)) {}
+{
+  if (buildPropsMap) {
+    // Legacy path: lower the raw props into `propsMap` (via the dynamic representation) and read
+    // `disableForceFlatten` from there. We must not also parse it with `convertRawProp` below,
+    // because the parser path and the `folly::dynamic` cast can't both consume the same `RawProps`.
+    propsMap = propsMapFromProps(sourceProps, rawProps);
+
+    const auto it = propsMap.find("disableForceFlatten");
+    disableForceFlatten = (it != propsMap.end()) && it->second.isBool() && it->second.getBool();
+  } else {
+    // JSI path: there's no `propsMap`, so parse `disableForceFlatten` straight from the raw props.
+    disableForceFlatten = react::convertRawProp(
+      context, rawProps, "disableForceFlatten", sourceProps.disableForceFlatten, false);
+  }
+}
 
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.h
@@ -32,13 +32,47 @@ public:
     const std::function<bool(const std::string &)> &filterObjectKeys = nullptr
   );
 
+protected:
+  /**
+   Designated constructor. When `buildPropsMap` is `false`, the `folly::dynamic` lowering into
+   `propsMap` is skipped. Used by `ExpoJSIViewProps`, which decodes props straight from their
+   JavaScript values and never reads `propsMap`. The public constructor builds it (the classic
+   `folly::dynamic` path used by SwiftUI and Android).
+   */
+  ExpoViewProps(
+    const facebook::react::PropsParserContext &context,
+    const ExpoViewProps &sourceProps,
+    const facebook::react::RawProps &rawProps,
+    const std::function<bool(const std::string &)> &filterObjectKeys,
+    bool buildPropsMap
+  );
+
+public:
 #pragma mark - Props
 
   /**
-   A map with props stored as `folly::dynamic` objects.
+   Typed prop read by `ExpoViewShadowNode` during layout to decide view flattening. Parsed as a
+   first-class `bool` (via `convertRawProp`) rather than looked up in `propsMap`, so the shadow
+   node doesn't depend on `propsMap` being materialized.
    */
-  std::unordered_map<std::string, folly::dynamic> propsMap;
+  bool disableForceFlatten = false;
+
+  /**
+   A map with props stored as `folly::dynamic` objects.
+
+   `mutable` because the JSI component descriptor populates it in `cloneProps` after the props
+   object is already held as `const`, for views that fall back to the dictionary path.
+   */
+  mutable std::unordered_map<std::string, folly::dynamic> propsMap;
 };
+
+/**
+ Borrows the props map from the source props and applies the update given in the raw props.
+ */
+std::unordered_map<std::string, folly::dynamic> propsMapFromProps(
+  const ExpoViewProps &sourceProps,
+  const facebook::react::RawProps &rawProps
+);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
@@ -62,10 +62,7 @@ private:
     }
 
     if (YGNodeStyleGetDisplay(&this->yogaNode_) == YGDisplayContents) {
-      auto it = viewProps.propsMap.find("disableForceFlatten");
-      bool disableForceFlatten = (it != viewProps.propsMap.end()) && it->second.getBool();
-
-      if (disableForceFlatten) {
+      if (viewProps.disableForceFlatten) {
         this->traits_.unset(react::ShadowNodeTraits::Trait::ForceFlattenView);
       }
     }

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -12,6 +12,13 @@ public protocol AnyViewDefinition: Sendable {
   var name: String { get }
 
   /**
+   Whether the view is backed by SwiftUI. SwiftUI views apply props from the lowered
+   `folly::dynamic` / dictionary path (`updateRawProps`), so they opt out of JSI view-props
+   decoding.
+   */
+  var isSwiftUI: Bool { get }
+
+  /**
    Names of the events that the view can send to JavaScript.
    */
   var eventNames: [String] { get }

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -189,24 +189,71 @@ internal func allMirrorChildren(_ mirror: Mirror) -> [Mirror.Child] {
 }
 
 /**
+ The static field layout of a record type: for each `@Field`-wrapped property, the index of its
+ child in `allMirrorChildren(...)` (in order) and its resolved dictionary key.
+
+ The layout is the same for every instance of a given record type, so it's computed once (by
+ reflecting the first instance) and cached. Caching skips, on every subsequent decode, the
+ per-child `as? AnyFieldInternal` conformance check on non-field children, the
+ `convertLabelToKey` key derivation, and the key lookup — which a Time Profiler trace showed to
+ be the bulk of `fieldsOf` cost. The `@Field` instances themselves are per-object (they hold the
+ wrapped values), so those are still read from the instance's mirror.
+ */
+private struct RecordFieldLayout {
+  /// For each field child, its index in `allMirrorChildren(...)` and its resolved key.
+  let fields: [(index: Int, key: String)]
+}
+
+private let recordFieldLayoutCache = Mutex<[ObjectIdentifier: RecordFieldLayout]>([:])
+
+private func recordFieldLayout(for children: [Mirror.Child], type: ObjectIdentifier) -> RecordFieldLayout {
+  if let cached = recordFieldLayoutCache.withLock({ $0[type] }) {
+    return cached
+  }
+  var fields: [(index: Int, key: String)] = []
+  for (index, child) in children.enumerated() {
+    guard let field = child.value as? AnyFieldInternal,
+          let key = field.key ?? convertLabelToKey(child.label) else {
+      continue
+    }
+    fields.append((index: index, key: key))
+  }
+  let layout = RecordFieldLayout(fields: fields)
+  recordFieldLayoutCache.withLock { $0[type] = layout }
+  return layout
+}
+
+/**
  Returns an array of fields found in record's mirror. If the field is missing the `key`,
  it gets assigned to the property label, so after all it's safe to enforce unwrapping it (using `key!`).
- This function now supports inheritance by recursively traversing the superclass hierarchy.
+ This function supports inheritance by recursively traversing the superclass hierarchy.
+
+ The field layout (which children are fields, and their keys) is cached per record type; only the
+ per-instance `@Field` objects and the idempotent key injection happen on each call.
  */
 internal func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
   let mirror = Mirror(reflecting: record)
-  return allMirrorChildren(mirror).compactMap { (label: String?, value: Any) in
-    guard let field = value as? AnyFieldInternal, let key = field.key ?? convertLabelToKey(label) else {
-      return nil
+  let children = allMirrorChildren(mirror)
+  let layout = recordFieldLayout(for: children, type: ObjectIdentifier(type(of: record)))
+
+  var result: [AnyFieldInternal] = []
+  result.reserveCapacity(layout.fields.count)
+
+  for entry in layout.fields {
+    // The layout was built from a mirror of the same type, so the index maps to the matching
+    // field child here too; the cast is on a known field child (no wasted casts on non-fields).
+    guard let field = children[entry.index].value as? AnyFieldInternal else {
+      continue
     }
     field.withOptions { options in
       let alreadyKeyed = options.contains { $0.rawValue == FieldOption.keyed("").rawValue }
       if !alreadyKeyed {
-        options.insert(.keyed(key))
+        options.insert(.keyed(entry.key))
       }
     }
-    return field
+    result.append(field)
   }
+  return result
 }
 
 /**

--- a/packages/expo-modules-core/ios/Core/Views/AnyViewProp.swift
+++ b/packages/expo-modules-core/ios/Core/Views/AnyViewProp.swift
@@ -1,3 +1,5 @@
+import ExpoModulesJSI
+
 /**
  Type-erased protocol for view props classes.
  */
@@ -11,4 +13,19 @@ public protocol AnyViewProp: AnyViewDefinitionElement {
    Function that sets the underlying prop value for given view.
    */
   func set(value: Any, onView: UIView, appContext: AppContext) throws
+
+  /**
+   Decodes the given JavaScript value into the prop's native representation, without
+   touching the view. Must be run on the JavaScript thread. The returned value is detached
+   from the runtime and safe to hand to `applyDecoded(value:onView:)` on the main thread.
+   */
+  @JavaScriptActor
+  func decode(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any
+
+  /**
+   Applies an already-decoded value (produced by `decode(jsValue:appContext:)`) to the view.
+   Must be run on the main thread.
+   */
+  @MainActor
+  func applyDecoded(value: Any, onView: UIView, appContext: AppContext) throws
 }

--- a/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
@@ -61,6 +61,29 @@ public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: An
       setter(view, value)
     }
   }
+
+  // MARK: - JavaScript-thread decoding
+
+  @JavaScriptActor
+  public func decode(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    // Runs on the JavaScript thread. `cast(jsValue:)` produces the final native value
+    // already coerced through the dynamic type; no view is touched here.
+    return try propType.cast(jsValue: jsValue, appContext: appContext)
+  }
+
+  @MainActor
+  public func applyDecoded(value: Any, onView view: UIView, appContext: AppContext) throws {
+    guard let view = view as? ViewType else {
+      throw IncompatibleViewException((propName: name, viewType: ViewType.self))
+    }
+    if Optional.isNil(value), let defaultValue {
+      return setter(view, defaultValue)
+    }
+    guard let value = value as? PropType else {
+      throw Conversions.CastingException<PropType>(value)
+    }
+    setter(view, value)
+  }
 }
 
 /**

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -85,6 +85,8 @@ extension ExpoSwiftUI {
     // and there doesn't seem to be a better way to do this right now.
     private lazy var dummyPropsMirror: Mirror = Mirror(reflecting: Props())
 
+    public override var isSwiftUI: Bool { true }
+
     convenience init(_ viewType: ViewType.Type) {
       // We assume SwiftUI views are exported as named views under the class name
       let nameDefinitionElement = ViewNameDefinition(name: String(describing: viewType))

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -17,6 +17,12 @@ public class ViewDefinition<ViewType>: ObjectDefinition, AnyViewDefinition, @unc
   public var name: String
 
   /**
+   Whether the view is backed by SwiftUI. `false` for the base (UIKit) view definition;
+   `SwiftUIViewDefinition` overrides it.
+   */
+  public var isSwiftUI: Bool { false }
+
+  /**
    Names of the events that the view can send to JavaScript.
    */
   public let eventNames: [String]

--- a/packages/expo-modules-core/ios/Fabric/ExpoAppContextHolder.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoAppContextHolder.h
@@ -1,0 +1,44 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <memory>
+
+namespace expo {
+
+/**
+ Carries a weak reference to the Expo `AppContext` (as an opaque Objective-C object)
+ so it can be stored in React Native's per-host `ContextContainer` and read back inside
+ the `ExpoViewProps` constructor on the JavaScript thread.
+
+ The actual weak storage lives in an Objective-C box (`ExpoAppContextBox`) implemented in
+ `ExpoViewPropsDecoder.mm`, because ARC's `__weak` is not available in the pure-C++
+ translation units under `common/cpp`. This header therefore only forward-declares the box
+ and exposes a copyable handle (a `shared_ptr` to the box) that is safe to store in the
+ `ContextContainer`. The reference is weak so a torn-down app context doesn't leak or
+ dangle; readers must null-check before use.
+ */
+
+// Opaque, defined in ExpoViewPropsDecoder.mm.
+class ExpoAppContextBox;
+
+class ExpoAppContextHolder {
+public:
+  static constexpr const char *kContextContainerKey = "expo.appContext";
+
+  ExpoAppContextHolder() = default;
+  explicit ExpoAppContextHolder(std::shared_ptr<ExpoAppContextBox> box) : _box(std::move(box)) {}
+
+  const std::shared_ptr<ExpoAppContextBox> &box() const {
+    return _box;
+  }
+
+private:
+  std::shared_ptr<ExpoAppContextBox> _box;
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -81,12 +81,17 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   // MARK: - ExpoFabricViewInterface
 
   @MainActor
-  public override func updateProps(_ props: [String: Any]) {
+  open override func updateProps(_ props: [String: Any]) {
     guard let context = appContext, let propsDict = viewManagerPropDict else {
       return
     }
-    for (key, prop) in propsDict {
-      let newValue = props[key] as Any
+    // Iterate the props actually present in this update, not every declared prop. A removed prop
+    // arrives as an explicit null value (a present key), so this still resets it; an absent key
+    // carries no information and must not be treated as a change to nil.
+    for (key, newValue) in props {
+      guard let prop = propsDict[key] else {
+        continue
+      }
       let convertedNewValue = Conversions.fromNSObject(newValue)
       let previousValue = previousProps[key]
 
@@ -98,6 +103,50 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
         try? prop.set(value: convertedNewValue, onView: self, appContext: context)
 
         previousProps[key] = convertedNewValue
+      }
+    }
+  }
+
+  /**
+   Applies view props that were decoded straight from their JavaScript values on the
+   JavaScript thread (see the JSI view-props decoding design). The values are already in
+   their native representation, so this only runs each prop's setter; no `cast` happens
+   here. Decoded and undecoded props are disjoint, so any remaining props are applied
+   separately by `updateProps(_:)`.
+   */
+  @MainActor
+  @objc
+  open override func applyDecodedProps(_ decodedProps: Any) {
+    // Typed as `Any` to match the Objective-C `id` parameter (see `ExpoFabricViewObjC.h` for why
+    // the header can't reference `EXDecodedViewProps` directly); always a `DecodedViewProps`.
+    guard let decodedProps = decodedProps as? DecodedViewProps else {
+      return
+    }
+    guard let context = appContext, let propsDict = viewManagerPropDict else {
+      return
+    }
+    for (key, value) in decodedProps.values {
+      guard let prop = propsDict[key] else {
+        continue
+      }
+      let previousValue = previousProps[key]
+
+      if !areValuesEqual(previousValue, value) {
+        do {
+          try prop.applyDecoded(value: value, onView: self, appContext: context)
+          // Record as previous only on success, so a value that failed to apply is retried on the
+          // next update rather than short-circuited by `areValuesEqual`.
+          previousProps[key] = value
+        } catch {
+          // TODO: React Native's `convertRawProp` resets a prop to its default value when
+          // conversion fails; here (and on the legacy `updateProps` path) we only log and leave
+          // the prop at its previous value. This also covers prop *removal*: a removed prop arrives
+          // as an explicit JS `null`, which resets an optional prop (via `Optional.isNil`) but makes
+          // a non-optional prop's `cast` throw and land here, so it keeps its stale value instead of
+          // resetting. Align both paths with RN's reset-to-default behavior, and add a
+          // set-then-remove test on a non-optional prop.
+          log.error("Applying decoded prop '\(key)' failed: \(error.localizedDescription)")
+        }
       }
     }
   }
@@ -118,10 +167,24 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     }
   }
   /**
-   Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
+   Framework entry point called at the start of a props update (from `finalizeUpdates:`), before
+   any prop is applied. `final` so its bookkeeping always runs; subclasses customize by overriding
+   `viewWillUpdateProps()` instead, which doesn't need to call `super`.
    */
   @MainActor
-  public override func viewDidUpdateProps() {
+  public final override func callViewWillUpdateLifecycleMethods() {
+    viewWillUpdateProps()
+  }
+
+  /**
+   Framework entry point called at the end of a props update (from `finalizeUpdates:`). `final` so
+   the registered `OnViewDidUpdateProps` lifecycle methods always run; subclasses customize by
+   overriding `viewDidUpdateProps()` instead, which doesn't need to call `super`.
+   */
+  @MainActor
+  public final override func callViewDidUpdateLifecycleMethods() {
+    viewDidUpdateProps()
+
     guard let viewDefinition else {
       return
     }
@@ -132,9 +195,24 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   }
 
   /**
+   Called at the start of a props update, before any prop is applied. Pairs with
+   `viewDidUpdateProps()` so subclasses can bracket the apply phase (e.g. for benchmarking).
+   No-op by default; overrides don't need to call `super`.
+   */
+  @MainActor
+  open func viewWillUpdateProps() {}
+
+  /**
+   Called at the end of a props update, after all props are applied. No-op by default; overrides
+   don't need to call `super`.
+   */
+  @MainActor
+  open func viewDidUpdateProps() {}
+
+  /**
    Returns a bool value whether the view supports prop with the given name.
    */
-  public override func supportsProp(withName name: String) -> Bool {
+  open override func supportsProp(withName name: String) -> Bool {
     return viewManagerPropDict?.index(forKey: name) != nil
   }
 
@@ -183,6 +261,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     if let viewClass = viewClassesRegistry[className] {
       inject(appContext: appContext)
       injectInitializer(appContext: appContext, moduleName: moduleName, viewName: viewName, toViewClass: viewClass)
+      registerPropsDictForJSIDecoding(appContext: appContext, moduleName: moduleName, viewName: viewName, className: className)
       return viewClass
     }
     guard let viewClass = objc_allocateClassPair(ExpoFabricView.self, className, 0) else {
@@ -190,6 +269,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     }
     inject(appContext: appContext)
     injectInitializer(appContext: appContext, moduleName: moduleName, viewName: viewName, toViewClass: viewClass)
+    registerPropsDictForJSIDecoding(appContext: appContext, moduleName: moduleName, viewName: viewName, className: className)
 
     // Save the allocated view class in the registry for the later use (e.g. when the app is reloaded).
     viewClassesRegistry[className] = viewClass
@@ -203,6 +283,25 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     let appContextBlock: @convention(block) () -> AppContext? = { weakAppContext }
     let appContextBlockImp: IMP = imp_implementationWithBlock(appContextBlock)
     class_replaceMethod(object_getClass(ExpoFabricView.self), #selector(appContextFromClass), appContextBlockImp, "@@:")
+  }
+
+  /**
+   Resolves the prop definitions for the given module/view and caches them under the dynamic
+   view class name, so JSI view-props decoding can look them up at Fabric props-parse time
+   (before any view instance exists). Best-effort: silently does nothing if the module or
+   view definition can't be resolved.
+   */
+  internal static func registerPropsDictForJSIDecoding(appContext: AppContext, moduleName: String, viewName: String, className: String) {
+    guard let moduleHolder = appContext.moduleRegistry.get(moduleHolderForName: moduleName),
+          let viewDefinition = moduleHolder.definition.views[viewName] else {
+      return
+    }
+    // SwiftUI views apply props from the lowered dictionary (`updateRawProps`), not from the
+    // JS-thread-decoded values, so they stay on the legacy path and aren't registered here.
+    guard !viewDefinition.isSwiftUI else {
+      return
+    }
+    ViewPropsJSIDecoder.register(propsDict: viewDefinition.propsDict(), forClassName: className)
   }
 
   internal static func injectInitializer(appContext: AppContext, moduleName: String, viewName: String, toViewClass viewClass: AnyClass) {

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -45,6 +45,14 @@
 // We use the protocol for AppContext to allow proper Swift type bridging
 @protocol EXAppContextProtocol;
 
+// Swift class (`@objc(EXDecodedViewProps)`) holding view-prop values decoded on the JS thread.
+// The method below types this parameter as `id` rather than `EXDecodedViewProps *`: in the
+// precompiled-xcframework build the Swift target imports this header as an external Clang module,
+// where a forward-declared Swift class does not unify with the local Swift definition, so an
+// `EXDecodedViewProps *` parameter would make the Swift override fail to match. `ExpoFabricView`
+// downcasts to `DecodedViewProps` internally.
+@class EXDecodedViewProps;
+
 // Addition to the interface that is visible in both Swift and Objective-C
 @interface ExpoFabricViewObjC (ExpoFabricViewInterface)
 
@@ -52,7 +60,21 @@
 
 - (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props;
 
-- (void)viewDidUpdateProps NS_SWIFT_UI_ACTOR;
+/**
+ Applies view props that were decoded straight from their JavaScript values on the JS thread.
+ Implemented in `ExpoFabricView.swift`. No-op in the base class.
+ */
+- (void)applyDecodedProps:(nonnull id)decodedProps NS_SWIFT_UI_ACTOR;
+
+/**
+ Framework entry points invoked from `finalizeUpdates:` to bracket the props apply phase.
+ Implemented in `ExpoFabricView.swift`, where they run the overridable `viewWillUpdateProps()`
+ / `viewDidUpdateProps()` hooks and dispatch the registered lifecycle methods. Not meant to be
+ overridden directly.
+ */
+- (void)callViewWillUpdateLifecycleMethods NS_SWIFT_UI_ACTOR;
+
+- (void)callViewDidUpdateLifecycleMethods NS_SWIFT_UI_ACTOR;
 
 - (void)setShadowNodeSize:(float)width height:(float)height;
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -5,7 +5,7 @@
 
 #import <ExpoModulesCore/EXAppContextProtocol.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
-#import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
+#import <ExpoModulesCore/ExpoViewJSIComponentDescriptor.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
 
 #import <React/RCTComponentViewFactory.h>
@@ -84,7 +84,7 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor<>::Flavor> _c
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const expo::ExpoViewProps>();
+    static const auto defaultProps = std::make_shared<const expo::ExpoJSIViewProps>();
     _props = defaultProps;
   }
   return self;
@@ -107,11 +107,15 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor<>::Flavor> _c
   react::ComponentName componentName = react::ComponentName { flavor->c_str() };
   react::ComponentHandle componentHandle = reinterpret_cast<react::ComponentHandle>(componentName);
 
+  // Toggle between the JSI decode-on-the-JS-thread path and the legacy
+  // folly::dynamic / NSDictionary path by swapping the descriptor here:
+  // `ExpoViewJSIComponentDescriptor<>` (JSI) or `ExpoViewComponentDescriptor<>` (legacy).
+  // `finalizeUpdates:` handles both.
   return react::ComponentDescriptorProvider {
     componentHandle,
     componentName,
     flavor,
-    &facebook::react::concreteComponentDescriptorConstructor<expo::ExpoViewComponentDescriptor<>>
+    &facebook::react::concreteComponentDescriptorConstructor<expo::ExpoViewJSIComponentDescriptor<>>
   };
 }
 
@@ -121,19 +125,40 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor<>::Flavor> _c
 
   if (updateMask & RNComponentViewUpdateMaskProps) {
     const auto &newProps = static_cast<const ExpoViewProps &>(*_props);
-    NSMutableDictionary<NSString *, id> *propsMap = [[NSMutableDictionary alloc] init];
 
-    for (const auto &item : newProps.propsMap) {
-      NSString *propName = [NSString stringWithUTF8String:item.first.c_str()];
+    [self callViewWillUpdateLifecycleMethods];
 
-      // Ignore props inherited from the base view and Yoga.
-      if ([self supportsPropWithName:propName]) {
-        propsMap[propName] = convertFollyDynamicToId(item.second);
+    // JSI path (`ExpoViewJSIComponentDescriptor`): props are decoded straight from their
+    // JavaScript values on the JS thread and applied directly here; `propsMap` is empty, so the
+    // dictionary path below is skipped. The `dynamic_cast` is what makes the descriptor choice a
+    // clean toggle: under the legacy descriptor the props are a plain `ExpoViewProps` and this is
+    // null, so only the dictionary path runs.
+    if (const auto *jsiProps = dynamic_cast<const ExpoJSIViewProps *>(&newProps)) {
+      if (jsiProps->decodedProps) {
+        EXDecodedViewProps *decodedProps = (__bridge EXDecodedViewProps *)jsiProps->decodedProps.get();
+        [self applyDecodedProps:decodedProps];
       }
     }
 
-    [self updateProps:propsMap];
-    [self viewDidUpdateProps];
+    // Legacy path (`ExpoViewComponentDescriptor`): props were lowered to `folly::dynamic` in
+    // `propsMap`; re-materialize them into an `NSDictionary` and apply on the main thread. Empty
+    // on the JSI path, so this allocates and runs only when the legacy descriptor is in use.
+    if (!newProps.propsMap.empty()) {
+      NSMutableDictionary<NSString *, id> *propsMap = [[NSMutableDictionary alloc] init];
+
+      for (const auto &item : newProps.propsMap) {
+        NSString *propName = [NSString stringWithUTF8String:item.first.c_str()];
+
+        // Ignore props inherited from the base view and Yoga.
+        if ([self supportsPropWithName:propName]) {
+          propsMap[propName] = convertFollyDynamicToId(item.second);
+        }
+      }
+
+      [self updateProps:propsMap];
+    }
+
+    [self callViewDidUpdateLifecycleMethods];
   }
 }
 
@@ -158,12 +183,22 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor<>::Flavor> _c
   // Implemented in `ExpoFabricView.swift`
 }
 
+- (void)applyDecodedProps:(nonnull id)decodedProps
+{
+  // Implemented in `ExpoFabricView.swift`
+}
+
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState
 {
   _state = std::static_pointer_cast<const ExpoViewShadowNode<>::ConcreteState>(state);
 }
 
-- (void)viewDidUpdateProps
+- (void)callViewWillUpdateLifecycleMethods
+{
+  // Implemented in `ExpoFabricView.swift`
+}
+
+- (void)callViewDidUpdateLifecycleMethods
 {
   // Implemented in `ExpoFabricView.swift`
 }

--- a/packages/expo-modules-core/ios/Fabric/ExpoJSIViewProps.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoJSIViewProps.h
@@ -1,0 +1,47 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <memory>
+
+#include <ExpoModulesCore/ExpoViewProps.h>
+
+namespace expo {
+
+/**
+ iOS-only `ExpoViewProps` subclass used by `ExpoViewJSIComponentDescriptor`. It carries the
+ props that were decoded straight from their JavaScript values on the JavaScript thread, so
+ the shared `ExpoViewProps` (which is also compiled into the Android build) stays free of any
+ JSI/Objective-C dependency.
+ */
+class ExpoJSIViewProps : public ExpoViewProps {
+public:
+  ExpoJSIViewProps() = default;
+
+  ExpoJSIViewProps(
+    const facebook::react::PropsParserContext &context,
+    const ExpoJSIViewProps &sourceProps,
+    const facebook::react::RawProps &rawProps,
+    const std::function<bool(const std::string &)> &filterObjectKeys = nullptr
+    // Skip the `folly::dynamic` lowering into `propsMap`: these props are decoded straight from
+    // their JavaScript values and `propsMap` is never read on this path.
+  ) : ExpoViewProps(context, sourceProps, rawProps, filterObjectKeys, /* buildPropsMap */ false) {}
+
+  /**
+   View props decoded straight from their JavaScript values during props parsing (see the JSI
+   view-props decoding design). Type-erased to a `void` shared pointer that retains a Swift
+   `EXDecodedViewProps` object; the deleter releases it via `CFBridgingRelease`. Set by
+   `ExpoViewJSIComponentDescriptor::cloneProps`, read on the main thread in `finalizeUpdates:`.
+
+   `shared_ptr` so the (copyable, value-semantic) props object can be cloned by Fabric while
+   the decoded container is released exactly once. `mutable` because it is filled in by
+   `cloneProps` after the props object is already held as `const`.
+   */
+  mutable std::shared_ptr<void> decodedProps;
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Fabric/ExpoRawPropsAccess.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoRawPropsAccess.h
@@ -1,0 +1,84 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+#include <react/renderer/core/RawProps.h>
+
+// Accessors for `RawProps`'s private `runtime_` / `value_` / `mode_` members.
+//
+// React Native keeps these private and only befriends `RawPropsParser`. We need the
+// whole-object `jsi::Value` (and its runtime) to decode Expo view props directly from
+// the live JSI value on the JavaScript thread, without lowering to `folly::dynamic`
+// and without forcing each prop name to be pre-registered with the parser.
+//
+// This uses the explicit template instantiation trick: explicit instantiation of a
+// template is allowed to name otherwise-inaccessible members ([temp.explicit] in the
+// C++ standard), so it lets us bind a pointer-to-member to a private member without
+// modifying React Native. It is standard-conforming (NOT undefined behavior, unlike
+// `#define private public` or hardcoded offsets), and if React Native ever renames or
+// retypes these members it fails loudly at compile time rather than silently.
+//
+// Keep this hack isolated to this header.
+
+namespace expo::rawPropsAccess {
+
+// One tag per stolen member. The tag's `friend ptr(Tag)` returns the pointer-to-member; its
+// body is supplied by explicitly instantiating `Steal` with the (otherwise private) member as
+// a template argument — the one context where naming a private member is allowed. `MemberPtr`
+// must be spelled out (not `auto`/`decltype`) so the friend has a concrete, callable type.
+template<typename Tag, typename MemberPtr, MemberPtr Member>
+struct Steal {
+  friend MemberPtr ptr(Tag) { return Member; }
+};
+
+#define EXPO_STEAL_RAWPROPS_MEMBER(name, type)                                            \
+  using name##Ptr = type facebook::react::RawProps::*;                                    \
+  struct name##Tag {                                                                      \
+    friend name##Ptr ptr(name##Tag);                                                      \
+  };                                                                                      \
+  template struct Steal<name##Tag, name##Ptr, &facebook::react::RawProps::name##_>;       \
+  inline name##Ptr name##Member() { return ptr(name##Tag{}); }
+
+EXPO_STEAL_RAWPROPS_MEMBER(value, facebook::jsi::Value)
+EXPO_STEAL_RAWPROPS_MEMBER(runtime, facebook::jsi::Runtime *)
+EXPO_STEAL_RAWPROPS_MEMBER(mode, facebook::react::RawProps::Mode)
+
+#undef EXPO_STEAL_RAWPROPS_MEMBER
+
+} // namespace expo::rawPropsAccess
+
+namespace expo {
+
+/**
+ Returns `true` when the given `RawProps` is backed by a live `jsi::Value`
+ (i.e. `Mode::JSI`). Only in that mode is the JSI value safe to read.
+ */
+inline bool rawPropsIsJSIBacked(const facebook::react::RawProps &rawProps)
+{
+  return rawProps.*(rawPropsAccess::modeMember()) == facebook::react::RawProps::Mode::JSI;
+}
+
+/**
+ Returns the `jsi::Runtime` backing the given JSI-mode `RawProps`.
+ Must only be called when `rawPropsIsJSIBacked()` is `true`.
+ */
+inline facebook::jsi::Runtime *rawPropsRuntime(const facebook::react::RawProps &rawProps)
+{
+  return rawProps.*(rawPropsAccess::runtimeMember());
+}
+
+/**
+ Returns the whole props object as a `jsi::Value` for a JSI-mode `RawProps`.
+ Must only be called when `rawPropsIsJSIBacked()` is `true`, on the JavaScript thread.
+ */
+inline const facebook::jsi::Value &rawPropsValue(const facebook::react::RawProps &rawProps)
+{
+  return rawProps.*(rawPropsAccess::valueMember());
+}
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Fabric/ExpoViewJSIComponentDescriptor.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoViewJSIComponentDescriptor.h
@@ -1,0 +1,98 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <react/utils/ContextContainer.h>
+
+#include <ExpoModulesCore/ExpoViewComponentDescriptor.h>
+
+#include "ExpoAppContextHolder.h"
+#include "ExpoJSIViewProps.h"
+#include "ExpoRawPropsAccess.h"
+#include "ExpoViewPropsDecoder.h"
+
+namespace expo {
+
+/**
+ Component descriptor that decodes view props straight from their JavaScript values on the
+ JavaScript thread, during props parsing, instead of lowering them to `folly::dynamic` and
+ decoding on the main thread. Used by UIKit `ExpoView`s; SwiftUI and Android keep using the
+ plain `ExpoViewComponentDescriptor`.
+
+ Lives in `ios/Fabric` (not `common/cpp`) so none of the JSI/Objective-C machinery it pulls in
+ is reachable from the Android build.
+ */
+template<typename ShadowNodeType = ExpoViewShadowNode<ExpoJSIViewProps, ExpoViewState>>
+class ExpoViewJSIComponentDescriptor : public ExpoViewComponentDescriptor<ShadowNodeType> {
+public:
+  using ExpoViewComponentDescriptor<ShadowNodeType>::ExpoViewComponentDescriptor;
+
+  /**
+   Decodes view props from their live `jsi::Value` before delegating to the base
+   implementation. This runs synchronously during `createNode`/`cloneNode`, on the JS thread,
+   while `rawProps` still holds the live `jsi::Value`. The decoded values are stashed on the
+   resulting `ExpoJSIViewProps` and applied to the view later on the main thread.
+
+   The props of an `ExpoView` always arrive JSI-backed (the only non-JSI-backed path,
+   `setNativeProps_DEPRECATED`, is never used on `ExpoView`s), so there is no `folly::dynamic`
+   fallback here. If the app context can't be resolved (which can only happen for a clone that
+   races host setup before the context is injected), the decode is skipped and the props apply
+   on the next update; a debug assert flags it so it surfaces during development.
+   */
+  facebook::react::Props::Shared cloneProps(
+    const facebook::react::PropsParserContext &context,
+    const facebook::react::Props::Shared &props,
+    facebook::react::RawProps rawProps
+  ) const override {
+    // Decode *before* delegating to the base implementation, which consumes `rawProps` by
+    // value (moves it in); afterwards its `jsi::Value` would be gone. We're on the JS thread
+    // here (synchronous `createNode`/`cloneNode`), so the live JSI value is safe to read.
+    // `decodeViewProps` returns null for views not registered for JSI decoding (e.g. SwiftUI,
+    // which applies props from the lowered dictionary), so those fall back to `propsMap` below.
+    void *decoded = nullptr;
+    if (rawPropsIsJSIBacked(rawProps)) {
+      if (const auto holderPtr = context.contextContainer.find<ExpoAppContextHolder>(
+            ExpoAppContextHolder::kContextContainerKey)) {
+        decoded = decodeViewProps(
+          this->getComponentName(),
+          *rawPropsRuntime(rawProps),
+          rawPropsValue(rawProps),
+          holderPtr.value());
+      }
+    }
+
+    // When nothing decoded (props not JSI-backed, or a view that doesn't JSI-decode such as
+    // SwiftUI), build `propsMap` from the still-live `rawProps` before the base moves it, so the
+    // view's legacy dictionary path still has props to apply. The source props seed the map (it's
+    // null on `createNode`, in which case the map starts empty).
+    std::unordered_map<std::string, folly::dynamic> propsMap;
+    if (decoded == nullptr) {
+      static const ExpoViewProps emptyProps{};
+      const auto sourceProps = std::dynamic_pointer_cast<const ExpoViewProps>(props);
+      propsMap = propsMapFromProps(sourceProps ? *sourceProps : emptyProps, rawProps);
+    }
+
+    auto cloned = ExpoViewComponentDescriptor<ShadowNodeType>::cloneProps(
+      context, props, std::move(rawProps));
+
+    if (const auto expoProps = std::dynamic_pointer_cast<const ExpoJSIViewProps>(cloned)) {
+      if (decoded != nullptr) {
+        // Adopt the retained Swift object into a shared_ptr that releases it via
+        // CFBridgingRelease (an ObjC bridge call) when the last props clone is gone.
+        expoProps->decodedProps = makeDecodedPropsHandle(decoded);
+      } else {
+        expoProps->propsMap = std::move(propsMap);
+      }
+    } else if (decoded != nullptr) {
+      // Couldn't attach it; release to avoid leaking the retained Swift object.
+      makeDecodedPropsHandle(decoded);
+    }
+    return cloned;
+  }
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Fabric/ExpoViewPropsDecoder.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoViewPropsDecoder.h
@@ -1,0 +1,77 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <jsi/jsi.h>
+
+#include <ExpoModulesCore/ExpoAppContextHolder.h>
+
+namespace expo {
+
+/**
+ The Objective-C box that weakly holds the Expo `AppContext`. Declared opaque in
+ `ExpoAppContextHolder.h`; defined in `ExpoViewPropsDecoder.mm`.
+ */
+class ExpoAppContextBox {
+public:
+  explicit ExpoAppContextBox(id appContext);
+  ~ExpoAppContextBox();
+
+  /**
+   The boxed app context if still alive, or `nil`. Returned as a `void *` to keep this
+   header includable from pure-C++ translation units; callers in Objective-C++ bridge it
+   back to the app context type.
+   */
+  void *appContext() const;
+
+private:
+  // Opaque storage for the `__weak id` (size of a pointer). Manipulated only in the .mm.
+  void *_storage;
+};
+
+/**
+ Creates a holder weakly wrapping the given Expo `AppContext` (passed as an opaque `id`).
+ Called from `ExpoReactNativeFactory.mm` when injecting into the `ContextContainer`.
+ */
+ExpoAppContextHolder makeAppContextHolder(id appContext);
+
+/**
+ Decodes the given JSI-backed view props on the JavaScript thread, using the Swift
+ `ViewDefinition` reachable from the app context boxed in `holder`.
+
+ - `componentName`: the dynamic view class name (e.g. `ViewManagerAdapter_ExpoImage_<appId>`),
+   used to resolve the module + view definition.
+ - `runtime` / `propsObject`: the live props object to read each declared prop's value from.
+ - `holder`: the app context holder previously stored in the `ContextContainer`.
+
+ Returns a retained Objective-C container (an `NSDictionary *` boxed as a `void *`, ownership
+ transferred to the caller via `CFBridgingRetain`) mapping prop names to decoded Swift values,
+ or `nullptr` if nothing could be decoded (no app context, no view definition, etc.). Props not
+ declared by the view, or that fail to decode, are omitted and left for the legacy path.
+
+ MUST be called on the JavaScript thread.
+ */
+void *decodeViewProps(
+  const std::string &componentName,
+  facebook::jsi::Runtime &runtime,
+  const facebook::jsi::Value &propsObject,
+  const ExpoAppContextHolder &holder
+);
+
+/**
+ Adopts a retained Objective-C container previously returned by `decodeViewProps` into a
+ type-erased `shared_ptr<void>`, whose deleter releases the object (via `CFBridgingRelease`)
+ when the last reference goes away. This lets the decoded props ride along with the
+ (copyable, value-semantic) `ExpoViewProps` and be released exactly once.
+ */
+std::shared_ptr<void> makeDecodedPropsHandle(void *retainedDecodedProps);
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Fabric/ExpoViewPropsDecoder.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoViewPropsDecoder.mm
@@ -1,0 +1,112 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+#import <ExpoModulesCore/ExpoViewPropsDecoder.h>
+
+// We can't import the generated `ExpoModulesCore-Swift.h` here: in the precompiled-xcframework
+// build the Objective-C++ target compiles before the Swift target, so that header doesn't exist
+// yet. Instead we hand-declare the `EXViewPropsJSIDecoder` Swift class (the symbol links from the
+// Swift target), mirroring the pattern in `WorkletIntegrationLoader.mm`. Keep this in sync with
+// `ViewPropsJSIDecoder.decodeProps(forClassName:appContext:propsObjectPointer:)` in
+// `ExpoViewPropsJSIDecoding.swift`.
+@class EXAppContext;
+@class EXDecodedViewProps;
+
+@interface EXViewPropsJSIDecoder : NSObject
++ (nullable EXDecodedViewProps *)decodePropsForClassName:(nonnull NSString *)className
+                                              appContext:(nonnull EXAppContext *)appContext
+                                      propsObjectPointer:(nonnull const void *)propsObjectPointer;
+@end
+
+namespace expo {
+
+#pragma mark - ExpoAppContextBox
+
+// The box stores a `__weak id` inside an opaque pointer. We manage the ARC lifetime
+// manually (this file is compiled with ARC, but the storage crosses into pure-C++ headers).
+
+ExpoAppContextBox::ExpoAppContextBox(id appContext)
+{
+  // Value-initialize the weak slot (`{}`) so ARC sees a valid (nil) `__weak` before the
+  // assignment; `new __weak id` alone would leave it uninitialized and crash on assign.
+  __weak id *slot = new __weak id{};
+  *slot = appContext;
+  _storage = static_cast<void *>(slot);
+}
+
+ExpoAppContextBox::~ExpoAppContextBox()
+{
+  __weak id *slot = static_cast<__weak id *>(_storage);
+  delete slot;
+}
+
+void *ExpoAppContextBox::appContext() const
+{
+  __weak id *slot = static_cast<__weak id *>(_storage);
+  // Promote the weak reference to a strong local; returns nil if the context was deallocated.
+  // The returned pointer is only used synchronously by the caller on the same thread.
+  id strong = *slot;
+  return (__bridge void *)strong;
+}
+
+#pragma mark - Holder factory
+
+ExpoAppContextHolder makeAppContextHolder(id appContext)
+{
+  return ExpoAppContextHolder(std::make_shared<ExpoAppContextBox>(appContext));
+}
+
+#pragma mark - Decoding
+
+void *decodeViewProps(
+  const std::string &componentName,
+  facebook::jsi::Runtime &runtime,
+  const facebook::jsi::Value &propsObject,
+  const ExpoAppContextHolder &holder
+)
+{
+  const auto &box = holder.box();
+  if (!box) {
+    return nullptr;
+  }
+
+  id appContext = (__bridge id)box->appContext();
+  if (appContext == nil) {
+    // The app context has been deallocated.
+    return nullptr;
+  }
+
+  NSString *className = [NSString stringWithUTF8String:componentName.c_str()];
+
+  // Hand the props object to Swift as a raw pointer; Swift copies it against the runtime
+  // (already the runtime backing this value) and decodes each declared prop.
+  const void *propsPointer = static_cast<const void *>(&propsObject);
+
+  EXDecodedViewProps *decoded =
+      [EXViewPropsJSIDecoder decodePropsForClassName:className
+                                          appContext:(EXAppContext *)appContext
+                                  propsObjectPointer:propsPointer];
+
+  if (decoded == nil) {
+    return nullptr;
+  }
+
+  // Transfer ownership to the caller; balanced by `CFBridgingRelease` on the C++ side.
+  return (void *)CFBridgingRetain(decoded);
+}
+
+std::shared_ptr<void> makeDecodedPropsHandle(void *retainedDecodedProps)
+{
+  if (retainedDecodedProps == nullptr) {
+    return nullptr;
+  }
+  return std::shared_ptr<void>(retainedDecodedProps, [](void *ptr) {
+    if (ptr != nullptr) {
+      // Balances the `CFBridgingRetain` in `decodeViewProps`.
+      CFBridgingRelease(ptr);
+    }
+  });
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/ios/Fabric/ExpoViewPropsJSIDecoding.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoViewPropsJSIDecoding.swift
@@ -1,0 +1,150 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import QuartzCore
+
+/// An opaque container of view-prop values that were decoded straight from their JavaScript
+/// values on the JavaScript thread (see the JSI view-props decoding design).
+///
+/// The decoded values are arbitrary Swift values (primitives, records, shared object
+/// references, …), so they cannot be bridged through an `NSDictionary`. Instead this class is
+/// passed back to native as an opaque `NSObject` and unboxed again in Swift when applying the
+/// props to the view on the main thread.
+@objc(EXDecodedViewProps)
+public final class DecodedViewProps: NSObject {
+  // `nonisolated(unsafe)` because the values are produced on the JS thread and read on the
+  // main thread; the design guarantees only thread-safe (detached) values land here, and the
+  // two accesses never overlap (decode fully completes before apply begins).
+  nonisolated(unsafe) internal let values: [String: Any]
+
+  internal init(values: [String: Any]) {
+    self.values = values
+  }
+}
+
+/// Decodes Fabric view props straight from their JavaScript values on the JavaScript thread.
+///
+/// This is a standalone, **non-`@MainActor`** type on purpose: `ExpoFabricView` is a `UIView`
+/// subclass and therefore main-actor-isolated, so a method on it could not be called from the
+/// JS (props-parse) thread without tripping the main-actor isolation check. The registry of
+/// prop definitions is keyed by the dynamic view class name and guarded by a mutex because it's
+/// written on the main thread (during component registration) and read on the JS thread (during
+/// props parsing).
+@objc(EXViewPropsJSIDecoder)
+public final class ViewPropsJSIDecoder: NSObject {
+  /// Maps a dynamic view class name to its prop definitions. Written on the main thread (once per
+  /// view, at module-registration time) and read on the JavaScript thread (per Fabric props-parse),
+  /// so it's guarded by a `Mutex`.
+  private static let registry = Mutex<[String: [String: AnyViewProp]]>([:])
+
+  /// Optional observer invoked once per decode pass, on the JavaScript thread, with the elapsed
+  /// seconds and the number of props decoded. Used to benchmark the JS-thread decode without
+  /// wiring timing into the decode path: when this is `nil` (the default) decoding doesn't even
+  /// read the clock. Set it from a benchmark harness.
+  ///
+  /// `@JavaScriptActor`-isolated because it's invoked from `decodeProps` while isolated to the
+  /// JavaScript actor; the type makes that contract explicit and lets the closure body be
+  /// checked against it.
+  nonisolated(unsafe) public static var onDecodePass: (@JavaScriptActor (_ seconds: Double, _ propCount: Int) -> Void)?
+
+  /// Registers the prop definitions for the given dynamic view class name, so props can be
+  /// resolved at Fabric props-parse time (before any view instance exists). Runs at
+  /// module-registration time (`AppContext.registerNativeViews`).
+  @MainActor
+  public static func register(propsDict: [String: AnyViewProp], forClassName className: String) {
+    registry.withLock { entries in
+      entries[className] = propsDict
+    }
+  }
+
+  /// Decodes JSI-backed view props on the JavaScript thread.
+  ///
+  /// Called from the Objective-C++ decode shim during Fabric props parsing. Resolves the prop
+  /// definitions for `className`, reads each declared prop's value off the props object, decodes
+  /// it through the regular dynamic-type machinery, and returns the decoded values boxed in a
+  /// `DecodedViewProps`. Props not declared by the view (inherited base-view / Yoga props), or
+  /// that fail to decode, are skipped here and left for the legacy main-thread dictionary path.
+  ///
+  /// - Parameters:
+  ///   - className: the dynamic view class name used to resolve the prop definitions.
+  ///   - appContext: the app context whose runtime owns `propsObjectPointer`.
+  ///   - propsObjectPointer: a raw pointer to the props object as a `facebook::jsi::Value`.
+  /// - Returns: a `DecodedViewProps`, or `nil` if there's nothing to decode.
+  ///
+  /// Must be called on the JavaScript thread.
+  @objc
+  public static func decodeProps(
+    forClassName className: String,
+    appContext: AppContext,
+    propsObjectPointer: UnsafeRawPointer
+  ) -> DecodedViewProps? {
+    guard let propsDict = registry.withLock({ $0[className] }) else {
+      return nil
+    }
+    guard let runtime = try? appContext.runtime else {
+      return nil
+    }
+
+    // Gate on the reliable pthread-id check rather than `JavaScriptActor`'s thread-*name*
+    // heuristic: Fabric's props-parse thread is the JS pthread, but `NSThread.current.name`
+    // isn't set there. If for any reason we're not on the JS thread, bail to the legacy path.
+    guard runtime.isOnJavaScriptThread() else {
+      return nil
+    }
+
+    // `assumeIsolatedOnJavaScriptThread` runs the closure synchronously on the current thread
+    // (no hop), so these captures don't actually escape. They aren't `Sendable`, so silence
+    // Swift 6's conservative cross-isolation check explicitly.
+    nonisolated(unsafe) let unsafePropsPointer = propsObjectPointer
+    nonisolated(unsafe) let unsafePropsDict = propsDict
+
+    return runtime.assumeIsolatedOnJavaScriptThread {
+      // Only sample the clock when an observer is attached, so production decoding pays nothing.
+      let observer = ViewPropsJSIDecoder.onDecodePass
+      let decodeStart = observer != nil ? CACurrentMediaTime() : 0
+
+      let propsValue = JavaScriptValue(runtime, unsafeValuePointer: unsafePropsPointer)
+
+      guard propsValue.isObject() else {
+        return nil
+      }
+      let propsObject = propsValue.getObject()
+
+      // Iterate the props object's OWN keys, not the full prop definition list. On a Fabric
+      // update the rawProps object holds only the props that changed (it's the diff React
+      // passes to `cloneNodeWithNewProps`), so this scales with the number of changed props
+      // rather than the total number of declared props, a win for wide views where only a
+      // few props change per update. (At initial mount the object holds all props.)
+      let changedKeys = propsObject.getPropertyNames()
+
+      var decoded: [String: Any] = [:]
+
+      for key in changedKeys {
+        guard let prop = unsafePropsDict[key] else {
+          // Not a prop the view declares (e.g. inherited base-view / Yoga props). Those are
+          // handled by React Native's own view, not the Expo decoder, so skip it here.
+          continue
+        }
+        let propValue = propsObject.getProperty(key)
+
+        do {
+          decoded[key] = try prop.decode(jsValue: propValue, appContext: appContext)
+        } catch {
+          // The value couldn't be decoded; skip it. It isn't applied this update (the JSI
+          // descriptor builds no `propsMap`, so there's no dictionary fallback) and will apply
+          // on a later update if it changes again and decodes. Log it (mirroring the apply-side
+          // catch) so a prop that consistently fails to decode is at least observable.
+          log.error("Decoding prop '\(key)' from its JavaScript value failed: \(error.localizedDescription)")
+          continue
+        }
+      }
+
+      observer?(CACurrentMediaTime() - decodeStart, decoded.count)
+
+      if decoded.isEmpty {
+        return nil
+      }
+      return DecodedViewProps(values: decoded)
+    }
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -526,6 +526,27 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     assert(isOnJavaScriptThread(), "Function '\(function)' is not run on the JavaScript thread (\(file):\(line))")
   }
 
+  /// Runs `operation` with `@JavaScriptActor` isolation, gating on the reliable pthread-id
+  /// check (`isOnJavaScriptThread()`) rather than `JavaScriptActor.assumeIsolated`'s thread-
+  /// *name* heuristic. Use this from synchronous native entry points that are known to run on
+  /// the JS pthread but where `NSThread.current.name` may not be set. Traps if not actually on
+  /// the JavaScript thread.
+  public final func assumeIsolatedOnJavaScriptThread<T: ~Copyable>(
+    _ operation: @JavaScriptActor () throws -> T
+  ) rethrows -> T {
+    precondition(
+      isOnJavaScriptThread(),
+      "assumeIsolatedOnJavaScriptThread must be called on the JavaScript thread")
+
+    typealias YesActor = @JavaScriptActor () throws -> T
+    typealias NoActor = () throws -> T
+
+    return try withoutActuallyEscaping(operation) { (_ fn: @escaping YesActor) throws -> T in
+      let rawFn = unsafeBitCast(fn, to: NoActor.self)
+      return try rawFn()
+    }
+  }
+
   /// Priority of the scheduled task.
   /// - Note: Keep it in sync with the equivalent C++ enum from React Native (see `SchedulerPriority.h` from `React-callinvoker`).
   public enum SchedulerPriority: Int32 {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -40,6 +40,18 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     self.pointee = facebook.jsi.Value(runtime.pointee, facebook.jsi.BigInt.fromUint64(runtime.pointee, bigInt))
   }
 
+  /// Wraps a raw pointer to an existing `facebook::jsi::Value` into a `JavaScriptValue`,
+  /// copying the value against the given runtime. Used to bridge values that originate in
+  /// C++ into the Swift JSI layer so they can be decoded with the regular value APIs.
+  /// The pointer must point to a live `jsi::Value` valid on `runtime`'s thread; the call
+  /// must happen on the JavaScript thread. The value is copied, so the source pointer does
+  /// not need to outlive the returned `JavaScriptValue`.
+  public init(_ runtime: JavaScriptRuntime, unsafeValuePointer pointer: UnsafeRawPointer) {
+    let value = pointer.assumingMemoryBound(to: facebook.jsi.Value.self)
+    self.runtime = runtime
+    self.pointee = facebook.jsi.Value(runtime.pointee, value.pointee)
+  }
+
   /// Creates a JS value from a JS representable.
   public init(_ runtime: JavaScriptRuntime, _ value: JavaScriptRepresentable) {
     self.runtime = runtime

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -22,6 +22,11 @@
 #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #import <ExpoModulesCore/EXReactSchedulerDispatch.h>
 
+#import <React/RCTSurfacePresenter.h>
+#import <react/utils/ContextContainer.h>
+#import <ExpoModulesCore/ExpoAppContextHolder.h>
+#import <ExpoModulesCore/ExpoViewPropsDecoder.h>
+
 @implementation EXReactNativeFactory {
   EXAppContext *_appContext;
 }
@@ -60,6 +65,20 @@
   [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
   [_appContext registerNativeModules];
+
+  // Make the app context reachable (weakly) from the Fabric props-parse path so view props
+  // can be decoded straight from their JavaScript values on the JavaScript thread. The
+  // ContextContainer is per-host and `insert` is safe to call through the const pointee.
+  // `insert` is a no-op when the key already exists, so on a JS reload (a second
+  // `didInitializeRuntime:` reusing the same container) it would leave the stale holder in
+  // place — erase first so the new `_appContext` always wins.
+  auto contextContainer = host.surfacePresenter.contextContainer;
+  if (contextContainer) {
+    contextContainer->erase(expo::ExpoAppContextHolder::kContextContainerKey);
+    contextContainer->insert(
+      expo::ExpoAppContextHolder::kContextContainerKey,
+      expo::makeAppContextHolder(_appContext));
+  }
 }
 
 @end


### PR DESCRIPTION
# Why

Fabric props for an `ExpoView` get lowered to `folly::dynamic`, then to an `NSDictionary`, then decoded with `AnyDynamicType.cast(_:)`, all on the main thread in `finalizeUpdates:`. The lowered map always carries the full prop set, so a one-prop update costs about the same as a seven-prop update, and all of it lands on the UI thread.

This adds a path that decodes straight from the live `jsi::Value` on the JS thread, reading only the keys in the `RawProps` diff. It's opt-in per view class and off for everything that exists today. `@ExpoView` views will turn it on once their core side lands. iOS only.

# How

- A view class opts in by overriding `ExpoFabricView.receivesDecodedProps`. `makeViewClass` reads it off the definition's view type and stamps it on the dynamic class as `+viewReceivesDecodedProps`; `+componentDescriptorProvider` gives those classes `ExpoViewJSIComponentDescriptor`. Every other class keeps `ExpoViewComponentDescriptor` / `ExpoViewProps` unchanged.
- `ExpoViewJSIComponentDescriptor::cloneProps` decodes on the JS thread through `AnyDynamicType.cast(jsValue:)`, the same path module-function arguments take, and carries the values on `ExpoJSIViewProps`. `finalizeUpdates:` applies them via `applyDecodedProps:`. No `folly::dynamic` map is built on this path.
- `AnyViewProp.decode` / `applyDecoded` and `AnyViewDefinition.receivesDecodedProps` are new requirements with default implementations, so existing conformers are unaffected.
- `ExpoRawPropsAccess.h` reads `RawProps`' private `runtime_` / `value_` / `mode_` through explicit template instantiation. Standard-conforming, no RN patch, and it fails at compile time if RN changes those members.
- `ExpoReactNativeFactory` stores the `AppContext` weakly in the host `ContextContainer` so `cloneProps` can resolve the view definition.
- `@Record` types decode through the macro's `from(object:)`; `@Field` records go through the existing reflection path.
- Everything JSI-specific lives in `ios/Fabric` and stays out of the Android build.

# Test Plan

`benchmarking` in bare-expo exports `BenchmarkView` (opts in) and `LegacyBenchmarkView` (dictionary path) with the same seven props. NCL → Modules Core → View props decoding benchmark runs 2000 passes on one view at a time and compares the two. iOS simulator, Debug build, per pass:

| | Legacy main | Decoded main | Decoded JS | Legacy total | Decoded total |
|---|---|---|---|---|---|
| 1 prop changed | 91.5 µs | 44.7 µs (−51%) | 13.2 µs | 91.5 µs | 57.9 µs (−37%) |
| All 7 changed | 172.3 µs | 93.4 µs (−46%) | 29.6 µs | 172.3 µs | 122.9 µs (−29%) |

Main thread is the number that matters for jank; total is both threads together. The decoded path wins on both even when every prop changes, and the gap widens when one prop changes, because the decoded view touches only that prop while the legacy view still presents all seven (14 007 vs 2001 props over the run). Apply is timed inside `updateProps` / `applyDecodedProps`, so the legacy column leaves out the `NSDictionary` build that `finalizeUpdates:` does first; the legacy numbers are understated, not the other way round. Absolute numbers drift between sessions, the ratios hold.

`common/cpp/fabric` still builds on Android for all ABIs.

A longer write-up of the design, the measurements and their caveats is at https://claude.ai/artifact/9qSkML8jQiuqdZqXHDviEB (visible to Expo org members only).

Follow-ups: decode `@ViewProps` through `JavaScriptCodable` once `AnyViewProps` lands and drop the interim `Any` container; profile `applyDecodedProps`, since apply grows about 8 µs per decoded prop; match RN's reset-to-default on decode failure and prop removal.
