### PR TITLE
Update import statement for MediaLibrary with highlighted color in tutorial 

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -126,7 +126,7 @@ Inside **app/(tabs)/index.tsx**, update the `onSaveImageAsync()` function with t
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 import * as ImagePicker from 'expo-image-picker';
-import * as MediaLibrary from 'expo-media-library/legacy';
+/* @tutinfo Import `MediaLibrary`. */import * as MediaLibrary from 'expo-media-library/legacy';/* @end */
 import { useEffect, useRef, useState } from 'react';
 import { ImageSourcePropType, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';


### PR DESCRIPTION
# Why


In Expo Tutorial, chapter 9 Take a screenshot, section 4 Capture a screenshot and save it , code snippet for importing `MediaLibrary` was missing highlighted color while i was going through documentation.


# How

I have forked the repo and changed locally with necessary change by adding @tutinfo annotations around the newly introduced imports. Also added simple tooltip as well.


# Test Plan


Tested locally to see my changes applied highlighted color (class) properly.
<img width="2861" height="1203" alt="Image 2026-06-12 at 2 34 PM" src="https://github.com/user-attachments/assets/60d8ccdc-01f0-4bf1-9909-c4cf511b9c09" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
