### PR TITLE
[@expo/cli] Simplify 2FA now that SMS is no longer supported

### DIFF
--- a/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
@@ -2,7 +2,7 @@ import { isInteractive } from '../../../utils/interactive';
 import { promptAsync } from '../../../utils/prompts';
 import { ApiV2Error } from '../../rest/client';
 import { showLoginPromptAsync } from '../actions';
-import { retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } from '../otp';
+import { retryUsernamePasswordAuthWithOTPAsync } from '../otp';
 import { loginAsync, browserLoginAsync } from '../user';
 
 jest.mock('../../../log');
@@ -46,34 +46,14 @@ describe(showLoginPromptAsync, () => {
         throw new ApiV2Error({
           message: 'An OTP is required',
           code: 'ONE_TIME_PASSWORD_REQUIRED',
-          metadata: {
-            secondFactorDevices: [
-              {
-                id: 'p0',
-                is_primary: true,
-                method: UserSecondFactorDeviceMethod.SMS,
-                sms_phone_number: 'testphone',
-              },
-            ],
-            smsAutomaticallySent: true,
-          },
+          requestId: '1',
         });
       })
       .mockImplementation(async () => {});
 
     await showLoginPromptAsync();
 
-    expect(retryUsernamePasswordAuthWithOTPAsync).toHaveBeenCalledWith('hello', 'world', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.SMS,
-          sms_phone_number: 'testphone',
-        },
-      ],
-      smsAutomaticallySent: true,
-    });
+    expect(retryUsernamePasswordAuthWithOTPAsync).toHaveBeenCalledWith('hello', 'world');
   });
 
   it('does not prompt if all required credentials are provided', async () => {

--- a/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
@@ -1,9 +1,6 @@
-import nock from 'nock';
-
 import * as Log from '../../../log';
 import { promptAsync, selectAsync } from '../../../utils/prompts';
-import { getExpoApiBaseUrl } from '../../endpoint';
-import { retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } from '../otp';
+import { retryUsernamePasswordAuthWithOTPAsync } from '../otp';
 import { loginAsync } from '../user';
 
 jest.mock('../../../utils/prompts');
@@ -22,7 +19,7 @@ beforeEach(() => {
 });
 
 describe(retryUsernamePasswordAuthWithOTPAsync, () => {
-  it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
+  it('shows authenticator OTP prompt', async () => {
     jest
       .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: 'hello' }))
@@ -30,88 +27,13 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
         throw new Error("shouldn't happen");
       });
 
-    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.SMS,
-          sms_phone_number: 'testphone',
-        },
-      ],
-      smsAutomaticallySent: true,
-    });
-
-    expect(Log.log).toHaveBeenCalledWith(
-      'One-time password was sent to the phone number ending in testphone.'
-    );
-
-    expect(loginAsync).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows authenticator OTP prompt when authenticator is primary', async () => {
-    jest
-      .mocked(promptAsync)
-      .mockImplementationOnce(async () => ({ otp: 'hello' }))
-      .mockImplementation(() => {
-        throw new Error("shouldn't happen");
-      });
-
-    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-      ],
-      smsAutomaticallySent: false,
-    });
+    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah');
 
     expect(Log.log).toHaveBeenCalledWith('One-time password from authenticator required.');
     expect(loginAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('shows menu when user bails on primary', async () => {
-    jest
-      .mocked(promptAsync)
-      .mockImplementationOnce(async () => ({ otp: null }))
-      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-      .mockImplementation(() => {
-        throw new Error("shouldn't happen");
-      });
-
-    jest
-      .mocked(selectAsync)
-      .mockImplementationOnce(async () => -1)
-      .mockImplementation(async () => {
-        throw new Error("shouldn't happen");
-      });
-
-    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-        {
-          id: 'p2',
-          is_primary: false,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-      ],
-      smsAutomaticallySent: false,
-    });
-
-    expect(selectAsync).toHaveBeenCalledTimes(1);
-    expect(loginAsync).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows a warning when when user bails on primary and does not have any secondary set up', async () => {
+  it('exits when user bails on OTP/backup', async () => {
     jest
       .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
@@ -119,139 +41,8 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
         throw new Error("shouldn't happen");
       });
 
-    await expect(
-      retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-        ],
-        smsAutomaticallySent: false,
-      })
-    ).rejects.toThrow(
-      'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
+    await expect(retryUsernamePasswordAuthWithOTPAsync('blah', 'blah')).rejects.toThrow(
+      'Interactive prompt was cancelled.'
     );
-  });
-
-  it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
-    jest
-      .mocked(promptAsync)
-      .mockImplementationOnce(async () => ({ otp: null }))
-      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-      .mockImplementation(() => {
-        throw new Error("shouldn't happen");
-      });
-
-    jest
-      .mocked(selectAsync)
-      .mockImplementationOnce(async () => -1)
-      .mockImplementation(async () => {
-        throw new Error("shouldn't happen");
-      });
-
-    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-        {
-          id: 'p2',
-          is_primary: false,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-      ],
-      smsAutomaticallySent: false,
-    });
-
-    expect(promptAsync).toHaveBeenCalledTimes(2); // first OTP, second OTP
-  });
-
-  it('requests SMS OTP and prompts for SMS OTP when user selects SMS secondary', async () => {
-    jest
-      .mocked(promptAsync)
-      .mockImplementationOnce(async () => ({ otp: null }))
-      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-      .mockImplementation(() => {
-        throw new Error("shouldn't happen");
-      });
-
-    jest
-      .mocked(selectAsync)
-      .mockImplementationOnce(async () => 0)
-      .mockImplementation(async () => {
-        throw new Error("shouldn't happen");
-      });
-
-    const scope = nock(getExpoApiBaseUrl())
-      .post('/v2/auth/send-sms-otp', {
-        username: 'blah',
-        password: 'blah',
-        secondFactorDeviceID: 'p2',
-      })
-      .reply(200, {});
-
-    await retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-      secondFactorDevices: [
-        {
-          id: 'p0',
-          is_primary: true,
-          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-          sms_phone_number: null,
-        },
-        {
-          id: 'p2',
-          is_primary: false,
-          method: UserSecondFactorDeviceMethod.SMS,
-          sms_phone_number: 'wat',
-        },
-      ],
-      smsAutomaticallySent: false,
-    });
-
-    expect(promptAsync).toHaveBeenCalledTimes(2); // first OTP, second OTP
-    expect(scope.isDone()).toBe(true);
-  });
-
-  it('exits when user bails on primary and backup', async () => {
-    jest
-      .mocked(promptAsync)
-      .mockImplementationOnce(async () => ({ otp: null }))
-      .mockImplementation(() => {
-        throw new Error("shouldn't happen");
-      });
-
-    jest
-      .mocked(selectAsync)
-      .mockImplementationOnce(async () => -2)
-      .mockImplementation(async () => {
-        throw new Error("shouldn't happen");
-      });
-
-    await expect(
-      retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-          {
-            id: 'p2',
-            is_primary: false,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-        ],
-        smsAutomaticallySent: false,
-      })
-    ).rejects.toThrow('Interactive prompt was cancelled.');
   });
 });

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -88,11 +88,7 @@ export async function showLoginPromptAsync({
     });
   } catch (e) {
     if (e instanceof ApiV2Error && e.expoApiV2ErrorCode === 'ONE_TIME_PASSWORD_REQUIRED') {
-      await retryUsernamePasswordAuthWithOTPAsync(
-        username,
-        password,
-        e.expoApiV2ErrorMetadata as any
-      );
+      await retryUsernamePasswordAuthWithOTPAsync(username, password);
     } else {
       throw e;
     }

--- a/packages/@expo/cli/src/api/user/otp.ts
+++ b/packages/@expo/cli/src/api/user/otp.ts
@@ -1,25 +1,10 @@
-import assert from 'assert';
 import chalk from 'chalk';
 
 import { loginAsync } from './user';
 import * as Log from '../../log';
-import { AbortCommandError, CommandError } from '../../utils/errors';
+import { AbortCommandError } from '../../utils/errors';
 import { learnMore } from '../../utils/link';
-import { promptAsync, selectAsync } from '../../utils/prompts';
-import { fetchAsync } from '../rest/client';
-
-export enum UserSecondFactorDeviceMethod {
-  AUTHENTICATOR = 'authenticator',
-  SMS = 'sms',
-}
-
-/** Device properties for 2FA */
-export type SecondFactorDevice = {
-  id: string;
-  method: UserSecondFactorDeviceMethod;
-  sms_phone_number: string | null;
-  is_primary: boolean;
-};
+import { promptAsync } from '../../utils/prompts';
 
 const nonInteractiveHelp = `Use the EXPO_TOKEN environment variable to authenticate in CI (${learnMore(
   'https://docs.expo.dev/accounts/programmatic-access/'
@@ -28,11 +13,8 @@ const nonInteractiveHelp = `Use the EXPO_TOKEN environment variable to authentic
 /**
  * Prompt for an OTP with the option to cancel the question by answering empty (pressing return key).
  */
-async function promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<string | null> {
-  const enterMessage =
-    cancelBehavior === 'cancel'
-      ? chalk`press {bold Enter} to cancel`
-      : chalk`press {bold Enter} for more options`;
+async function promptForOTPAsync(): Promise<string | null> {
+  const enterMessage = chalk`press {bold Enter} to cancel`;
   const { otp } = await promptAsync(
     {
       type: 'text',
@@ -45,123 +27,14 @@ async function promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<str
 }
 
 /**
- * Prompt for user to choose a backup OTP method. If selected method is SMS, a request
- * for a new OTP will be sent to that method. Then, prompt for the OTP, and retry the user login.
- */
-async function promptForBackupOTPAsync(
-  username: string,
-  password: string,
-  secondFactorDevices: SecondFactorDevice[]
-): Promise<string | null> {
-  const nonPrimarySecondFactorDevices = secondFactorDevices.filter((device) => !device.is_primary);
-
-  if (nonPrimarySecondFactorDevices.length === 0) {
-    throw new CommandError(
-      'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
-    );
-  }
-
-  const hasAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
-    (device) => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
-  );
-
-  const smsNonPrimarySecondFactorDevices = nonPrimarySecondFactorDevices.filter(
-    (device) => device.method === UserSecondFactorDeviceMethod.SMS
-  );
-
-  const authenticatorChoiceSentinel = -1;
-  const cancelChoiceSentinel = -2;
-
-  const deviceChoices = smsNonPrimarySecondFactorDevices.map((device, idx) => ({
-    title: device.sms_phone_number!,
-    value: idx,
-  }));
-
-  if (hasAuthenticatorSecondFactorDevice) {
-    deviceChoices.push({
-      title: 'Authenticator',
-      value: authenticatorChoiceSentinel,
-    });
-  }
-
-  deviceChoices.push({
-    title: 'Cancel',
-    value: cancelChoiceSentinel,
-  });
-
-  const selectedValue = await selectAsync('Select a second-factor device:', deviceChoices, {
-    nonInteractiveHelp,
-  });
-  if (selectedValue === cancelChoiceSentinel) {
-    return null;
-  } else if (selectedValue === authenticatorChoiceSentinel) {
-    return await promptForOTPAsync('cancel');
-  }
-
-  const device = smsNonPrimarySecondFactorDevices[selectedValue];
-
-  await fetchAsync('auth/send-sms-otp', {
-    method: 'POST',
-    body: JSON.stringify({
-      username,
-      password,
-      secondFactorDeviceID: device?.id,
-    }),
-  });
-
-  return await promptForOTPAsync('cancel');
-}
-
-/**
- * Handle the special case error indicating that a second-factor is required for
- * authentication.
- *
- * There are three cases we need to handle:
- * 1. User's primary second-factor device was SMS, OTP was automatically sent by the server to that
- *    device already. In this case we should just prompt for the SMS OTP (or backup code), which the
- *    user should be receiving shortly. We should give the user a way to cancel and the prompt and move
- *    to case 3 below.
- * 2. User's primary second-factor device is authenticator. In this case we should prompt for authenticator
- *    OTP (or backup code) and also give the user a way to cancel and move to case 3 below.
- * 3. User doesn't have a primary device or doesn't have access to their primary device. In this case
- *    we should show a picker of the SMS devices that they can have an OTP code sent to, and when
- *    the user picks one we show a prompt() for the sent OTP.
+ * Handle the special case error indicating that a second-factor is required for authentication.
  */
 export async function retryUsernamePasswordAuthWithOTPAsync(
   username: string,
-  password: string,
-  metadata: {
-    secondFactorDevices?: SecondFactorDevice[];
-    smsAutomaticallySent?: boolean;
-  }
+  password: string
 ): Promise<void> {
-  const { secondFactorDevices, smsAutomaticallySent } = metadata;
-  assert(
-    secondFactorDevices !== undefined && smsAutomaticallySent !== undefined,
-    `Malformed OTP error metadata: ${metadata}`
-  );
-
-  const primaryDevice = secondFactorDevices.find((device) => device.is_primary);
-  let otp: string | null = null;
-
-  if (smsAutomaticallySent) {
-    assert(primaryDevice, 'OTP should only automatically be sent when there is a primary device');
-    Log.log(
-      `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
-    );
-    otp = await promptForOTPAsync('menu');
-  }
-
-  if (primaryDevice?.method === UserSecondFactorDeviceMethod.AUTHENTICATOR) {
-    Log.log('One-time password from authenticator required.');
-    otp = await promptForOTPAsync('menu');
-  }
-
-  // user bailed on case 1 or 2, wants to move to case 3
-  if (!otp) {
-    otp = await promptForBackupOTPAsync(username, password, secondFactorDevices);
-  }
-
+  Log.log('One-time password from authenticator required.');
+  const otp = await promptForOTPAsync();
   if (!otp) {
     throw new AbortCommandError();
   }


### PR DESCRIPTION
# Why

SMS 2FA is no longer supported, only authenticator (TOTP). Therefore, we can remove parts of the no-browser login flow that supported SMS 2FA.

Equivalent of https://github.com/expo/eas-cli/pull/3859.

# How

Remove the fallback device picker and SMS logic. The flow is now:
1. Try login with username/password
2. Catch `ONE_TIME_PASSWORD_REQUIRED` error, ask for OTP/backup code.
3. User enters it or cancels.
4. Login call with username/password/otp.

# Test Plan

`nexpo login --no-browser` to an account that has 2fa set up.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
