### PR TITLE
[test-suite][app-metrics] Add tests for sessions, metrics, logs, and global attributes

### DIFF
--- a/apps/test-suite/tests/AppMetrics.ts
+++ b/apps/test-suite/tests/AppMetrics.ts
@@ -1,5 +1,7 @@
 import { fetch } from 'expo/fetch';
 import AppMetrics, {
+  type LogRecord,
+  type Metric,
   type NetworkRequestCompletedEvent,
   type NetworkRequestFilter,
   type NetworkRequestObserver,
@@ -79,7 +81,202 @@ async function waitForCompletion(
   throw new Error(`Timed out after ${timeoutMs}ms waiting for ${target}`);
 }
 
-export function test({ describe, expect, it, beforeAll }) {
+/**
+ * Polls `read` until `predicate` is satisfied or the timeout elapses, returning the value that
+ * satisfied it. `logEvent` and `addMetric` are fire-and-forget on the JS side — the native write
+ * lands on a background actor/coroutine before the SQLite store reflects it — so reads have to be
+ * retried rather than asserted immediately after the write.
+ */
+async function pollUntil<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  description: string,
+  timeoutMs = EVENT_TIMEOUT_MS
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T;
+  do {
+    last = await read();
+    if (predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  } while (Date.now() < deadline);
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}`);
+}
+
+/**
+ * Generates a label unique to this test run so a query can pick out the records it just wrote,
+ * ignoring anything left in the on-device store from earlier runs or background activity. The
+ * store is shared and not cleared between tests (`clearStoredEntries` is a no-op on iOS), so every
+ * assertion has to be scoped this way.
+ */
+function uniqueLabel(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+export function test({ describe, expect, it, afterEach }) {
+  describe('getMainSession', () => {
+    it('returns a non-null main session with the documented shape', () => {
+      const session = AppMetrics.getMainSession();
+      expect(session).toBeDefined();
+      expect(typeof session.id).toBe('string');
+      expect(session.id.length).toBeGreaterThan(0);
+      expect(session.type).toBe('main');
+      expect(session.startDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('returns the same shared object on repeated calls', () => {
+      // The native side hands back the process-lifetime singleton, so the JS handles must be
+      // identity-equal while the object stays referenced.
+      expect(AppMetrics.getMainSession()).toBe(AppMetrics.getMainSession());
+    });
+
+    it('reports the main session as active', async () => {
+      const session = AppMetrics.getMainSession();
+      expect(await session.isActive()).toBe(true);
+      // An active session has no end date yet.
+      expect(await session.getEndDate()).toBeNull();
+    });
+  });
+
+  describe('addMetric', () => {
+    it('records a custom metric and reads it back with the session id filled in', async () => {
+      const session = AppMetrics.getMainSession();
+      const name = uniqueLabel('custom-metric');
+
+      // `category` is a closed enum on the native side; an unknown string is dropped to `null`
+      // (see `SessionMetricInput` native tests). `navigation` is one of the categories supported on
+      // both iOS and Android.
+      await session.addMetric({
+        timestamp: new Date().toISOString(),
+        category: 'navigation',
+        name,
+        value: 42,
+      });
+
+      // `addMetric` resolves only after the native write completes, so a plain read sees it — no
+      // polling needed (unlike `logEvent`, which is fire-and-forget).
+      const metrics = await session.getMetrics();
+      const recorded = metrics.find((metric) => metric.name === name) as Metric;
+      expect(recorded).toBeDefined();
+      expect(recorded.value).toBe(42);
+      expect(recorded.category).toBe('navigation');
+      // `MetricInput` omits `sessionId`; the receiver supplies it.
+      expect(recorded.sessionId).toBe(session.id);
+    });
+
+    it('preserves custom params on the recorded metric', async () => {
+      const session = AppMetrics.getMainSession();
+      const name = uniqueLabel('custom-metric-params');
+
+      await session.addMetric({
+        timestamp: new Date().toISOString(),
+        category: 'navigation',
+        name,
+        value: 1,
+        params: { screen: 'home', count: 3 },
+      });
+
+      const metrics = await session.getMetrics();
+      const recorded = metrics.find((metric) => metric.name === name) as Metric;
+      expect(recorded).toBeDefined();
+      expect(recorded.params).toBeDefined();
+      expect(recorded.params!.screen).toBe('home');
+      expect(recorded.params!.count).toBe(3);
+    });
+  });
+
+  describe('logEvent', () => {
+    /** Reads back the log this run wrote, polling until the async store reflects it. */
+    async function readBackLog(name: string): Promise<LogRecord> {
+      const session = AppMetrics.getMainSession();
+      const logs = await pollUntil(
+        () => session.getLogs(),
+        (all) => all.some((log) => log.name === name),
+        `log "${name}" to appear in getLogs()`
+      );
+      return logs.find((log) => log.name === name) as LogRecord;
+    }
+
+    it('records a log event and reads it back with all documented fields', async () => {
+      const name = uniqueLabel('log');
+      AppMetrics.logEvent(name, {
+        body: 'hello from test-suite',
+        severity: 'warn',
+        attributes: { feature: 'app-metrics', retries: 2, enabled: true },
+      });
+
+      const log = await readBackLog(name);
+      expect(log.name).toBe(name);
+      expect(log.body).toBe('hello from test-suite');
+      expect(log.severity).toBe('warn');
+      expect(typeof log.timestamp).toBe('string');
+      expect(log.attributes).toBeDefined();
+      expect(log.attributes!.feature).toBe('app-metrics');
+      expect(log.attributes!.retries).toBe(2);
+      expect(log.attributes!.enabled).toBe(true);
+    });
+
+    it('defaults severity to "info" when none is provided', async () => {
+      const name = uniqueLabel('log-default-severity');
+      AppMetrics.logEvent(name);
+
+      const log = await readBackLog(name);
+      expect(log.severity).toBe('info');
+    });
+  });
+
+  describe('setGlobalAttributes', () => {
+    // Globals are process-wide; clear them after each case so one test can't leak into the next.
+    afterEach(() => {
+      AppMetrics.setGlobalAttributes(null);
+    });
+
+    async function readBackLog(name: string): Promise<LogRecord> {
+      const session = AppMetrics.getMainSession();
+      const logs = await pollUntil(
+        () => session.getLogs(),
+        (all) => all.some((log) => log.name === name),
+        `log "${name}" to appear in getLogs()`
+      );
+      return logs.find((log) => log.name === name) as LogRecord;
+    }
+
+    it('merges global attributes into a subsequently logged event', async () => {
+      AppMetrics.setGlobalAttributes({ subscription_tier: 'pro', experiment_variant: 'B' });
+      const name = uniqueLabel('log-globals');
+      AppMetrics.logEvent(name, { attributes: { local_key: 'local_value' } });
+
+      const log = await readBackLog(name);
+      expect(log.attributes).toBeDefined();
+      expect(log.attributes!.subscription_tier).toBe('pro');
+      expect(log.attributes!.experiment_variant).toBe('B');
+      // Per-record attributes coexist with the globals.
+      expect(log.attributes!.local_key).toBe('local_value');
+    });
+
+    it('lets a per-record attribute win over a global with the same key', async () => {
+      AppMetrics.setGlobalAttributes({ source: 'global' });
+      const name = uniqueLabel('log-globals-collision');
+      AppMetrics.logEvent(name, { attributes: { source: 'local' } });
+
+      const log = await readBackLog(name);
+      expect(log.attributes!.source).toBe('local');
+    });
+
+    it('stops applying globals after they are cleared', async () => {
+      AppMetrics.setGlobalAttributes({ cleared_key: 'present' });
+      AppMetrics.setGlobalAttributes(null);
+
+      const name = uniqueLabel('log-globals-cleared');
+      AppMetrics.logEvent(name);
+
+      const log = await readBackLog(name);
+      expect(log.attributes?.cleared_key).toBeUndefined();
+    });
+  });
+
   describe('NetworkRequestObserver', () => {
     it('emits requestStarted with the documented field shape', async () => {
       const url = `${TEST_HOST}/get?case=started-shape`;


### PR DESCRIPTION
# Why

The `AppMetrics` test in test-suite only exercised `NetworkRequestObserver`. The rest of the public API (`getMainSession`, `Session.addMetric`/`getMetrics`, `logEvent`/`getLogs`, `setGlobalAttributes`) had no JS-level integration coverage.

# How

Adds four suites to `apps/test-suite/tests/AppMetrics.ts`, before the existing `NetworkRequestObserver` block:

- **`getMainSession`**: shape, stable reference across calls, active with no end date.
- **`addMetric`**: round-trips through `getMetrics` with `sessionId` filled in by the receiver, and preserves custom `params`.
- **`logEvent`**: round-trips through `getLogs`, severity defaults to `"info"`.
- **`setGlobalAttributes`**: globals merge into a later log, per-record key wins on collision, clearing stops applying them.

`addMetric` is awaitable so its read-backs are a plain `await`; `logEvent` is fire-and-forget, so those poll until the async store reflects the write. The store isn't cleared between tests (`clearStoredEntries` is a no-op on iOS), so assertions are scoped to a per-run unique label.

# Test Plan

Ran the `AppMetrics` suite in test-suite on both Android and iOS, all passing.
