### PR TITLE
[ios][app-metrics] Emit `expo.session.crashed` event on crash attribution

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix an infinite recursion crash when reading sessions with a crash report by representing `CrashReport` timestamps as ISO 8601 strings instead of `Date`, matching the rest of the public session shape. ([#46889](https://github.com/expo/expo/pull/46889) by [@tsapeta](https://github.com/tsapeta))
 - fix race condition between db inserts ([#46702](https://github.com/expo/expo/pull/46702) by [@Ubax](https://github.com/Ubax))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Observe HTTP requests on iOS and Android and expose them to JS via the `NetworkRequestObserver` class and `useNetworkRequestObserver` hook. The TTI metric also carries an `expo.network.requests.*` summary for requests that completed in the launch window. ([#46475](https://github.com/expo/expo/pull/46475) by [@tsapeta](https://github.com/tsapeta))
 - Add native-side filtering to `NetworkRequestObserver` by host and method, configurable at construction or at runtime via `setFilter`, so non-matching requests never cross into JS. ([#46775](https://github.com/expo/expo/pull/46775) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Emit an `expo.session.crashed` log event when a crash report is attributed to a past session, carrying the exception type, signal, and termination reason as `expo.crash.*` attributes. ([#46889](https://github.com/expo/expo/pull/46889) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -26,17 +26,17 @@ public struct CrashReport: Codable, Sendable {
   /// App version at the time of the crash.
   public let appVersion: String
 
-  /// Timestamp range start of the diagnostic payload.
-  public let timestampBegin: Date
+  /// Timestamp range start of the diagnostic payload, as an ISO 8601 string.
+  public let timestampBegin: String
 
-  /// Timestamp range end of the diagnostic payload.
-  public let timestampEnd: Date
+  /// Timestamp range end of the diagnostic payload, as an ISO 8601 string.
+  public let timestampEnd: String
 
-  /// Timestamp at which this device received the diagnostic and constructed the report.
-  /// Distinct from `timestampEnd` because MetricKit can deliver historical or backlogged
-  /// diagnostics — `ingestedAt` reflects when *we* learned about the crash, not when it
-  /// happened.
-  public let ingestedAt: Date
+  /// Timestamp at which this device received the diagnostic and constructed the report,
+  /// as an ISO 8601 string. Distinct from `timestampEnd` because MetricKit can deliver
+  /// historical or backlogged diagnostics — `ingestedAt` reflects when *we* learned about
+  /// the crash, not when it happened.
+  public let ingestedAt: String
 
   /// Picks the most likely main session that this crash report belongs to.
   ///
@@ -56,8 +56,8 @@ public struct CrashReport: Codable, Sendable {
   /// is genuinely unattributable, and silently misattributing it to the current
   /// session would hide that.
   func findMatchingSession(in mainSessions: [SessionRow]) -> SessionRow? {
-    let payloadBegin = timestampBegin.ISO8601Format()
-    let payloadEnd = timestampEnd.ISO8601Format()
+    let payloadBegin = timestampBegin
+    let payloadEnd = timestampEnd
     let intersecting = mainSessions.filter { session in
       guard session.startTimestamp <= payloadEnd else {
         return false
@@ -174,9 +174,9 @@ extension CrashReport {
     let decodedTree = try? JSONDecoder().decode(CallStackTree.self, from: diagnostic.callStackTree.jsonRepresentation())
     self.callStackTree = decodedTree.map(CrashReportSymbolicator.symbolicate)
     self.appVersion = diagnostic.applicationVersion
-    self.timestampBegin = payload.timeStampBegin
-    self.timestampEnd = payload.timeStampEnd
-    self.ingestedAt = Date.now
+    self.timestampBegin = payload.timeStampBegin.ISO8601Format()
+    self.timestampEnd = payload.timeStampEnd.ISO8601Format()
+    self.ingestedAt = Date.now.ISO8601Format()
 
     if #available(iOS 17.0, *), let reason = diagnostic.exceptionReason {
       self.exceptionReason = ExceptionReason(
@@ -218,8 +218,7 @@ extension CrashReport: CustomStringConvertible {
       lines.append("    \(exceptionReason.composedMessage)")
     }
 
-    let formatter = ISO8601DateFormatter()
-    lines.append("  Time window: \(formatter.string(from: timestampBegin)) – \(formatter.string(from: timestampEnd))")
+    lines.append("  Time window: \(timestampBegin) – \(timestampEnd)")
 
     return lines.joined(separator: "\n")
   }

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -83,6 +83,36 @@ public struct CrashReport: Codable, Sendable {
     return candidates.max(by: { $0.startTimestamp < $1.startTimestamp })
   }
 
+  /// Compact, high-signal attributes describing the crash, attached to the `expo.session.crashed`
+  /// event. Deliberately omits the call stack and VM-region blob — those are large and already
+  /// persisted in full on the crash report row; the event is just a marker that the session ended
+  /// in a crash. Opaque numeric codes are surfaced as both their raw value and a human-readable
+  /// name so consumers don't have to maintain their own lookup tables. All keys live under the
+  /// SDK-owned `expo.*` namespace.
+  var eventAttributes: [String: Any] {
+    var attributes: [String: Any] = ["expo.app.version": appVersion]
+
+    if let exceptionType {
+      attributes["expo.crash.exception_type"] = exceptionName(for: exceptionType)
+      attributes["expo.crash.exception_type_code"] = exceptionType
+    }
+    if let exceptionCode {
+      attributes["expo.crash.exception_code"] = exceptionCode
+    }
+    if let signal {
+      attributes["expo.crash.signal"] = signalName(for: signal)
+      attributes["expo.crash.signal_code"] = signal
+    }
+    if let terminationReason {
+      attributes["expo.crash.termination_reason"] = terminationReason
+    }
+    if let exceptionReason {
+      attributes["expo.crash.objc_exception_type"] = exceptionReason.exceptionType
+      attributes["expo.crash.objc_exception_message"] = exceptionReason.composedMessage
+    }
+    return attributes
+  }
+
   /// Mirrors the shape of `MXCallStackTree.JSONRepresentation()`. Every field is optional so that
   /// silently-renamed or removed Apple fields don't break decoding for the rest of the report.
   public struct CallStackTree: Codable, Sendable {

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReportSimulation.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReportSimulation.swift
@@ -24,9 +24,9 @@ func simulateCrashReport() {
     exceptionReason: simulateExceptionReason(),
     callStackTree: simulateCallStackTree(),
     appVersion: AppInfo.current.appVersion ?? "unknown",
-    timestampBegin: Date.now.addingTimeInterval(-hoursAgo - 3600),
-    timestampEnd: Date.now.addingTimeInterval(-hoursAgo),
-    ingestedAt: Date.now
+    timestampBegin: Date.now.addingTimeInterval(-hoursAgo - 3600).ISO8601Format(),
+    timestampEnd: Date.now.addingTimeInterval(-hoursAgo).ISO8601Format(),
+    ingestedAt: Date.now.ISO8601Format()
   )
   AppMetricsActor.isolated {
     AppMetrics.mainSession.storeCrashReport(report)

--- a/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
+++ b/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
@@ -74,7 +74,7 @@ private func logCrashEvent(_ crashReport: CrashReport, sessionId: String) {
     name: "expo.session.crashed",
     attributes: crashReport.eventAttributes,
     severity: .fatal,
-    timestamp: crashReport.ingestedAt.ISO8601Format()
+    timestamp: crashReport.ingestedAt
   )
   do {
     try AppMetrics.database?.insert(log: LogRow.from(log: record, sessionId: sessionId))

--- a/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
+++ b/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
@@ -43,6 +43,7 @@ final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber, Sendable {
       for crashReport in crashReports {
         if let session = crashReport.findMatchingSession(in: mainSessions) {
           persistCrashReport(crashReport, sessionId: session.id)
+          logCrashEvent(crashReport, sessionId: session.id)
         } else {
           logger.warn("[AppMetrics] Received crash report with no matching session:\n\(crashReport)")
         }
@@ -60,6 +61,25 @@ private func persistCrashReport(_ crashReport: CrashReport, sessionId: String) {
     try AppMetrics.database?.setCrashReport(sessionId: sessionId, payload: payload)
   } catch {
     logger.warn("[AppMetrics] Failed to persist crash report for session \(sessionId): \(error.localizedDescription)")
+  }
+}
+
+/// Records an `expo.session.crashed` log event on the session the crash was attributed to, marking
+/// that the session ended in a crash. This is an SDK-internal event, so it's built directly rather
+/// than going through the JS-facing `logEvent` path — that path rejects the reserved `expo.` name
+/// prefix and strips `expo.*` attributes, both of which the SDK owns here.
+@AppMetricsActor
+private func logCrashEvent(_ crashReport: CrashReport, sessionId: String) {
+  let record = LogRecord(
+    name: "expo.session.crashed",
+    attributes: crashReport.eventAttributes,
+    severity: .fatal,
+    timestamp: crashReport.ingestedAt.ISO8601Format()
+  )
+  do {
+    try AppMetrics.database?.insert(log: LogRow.from(log: record, sessionId: sessionId))
+  } catch {
+    logger.warn("[AppMetrics] Failed to log crash event for session \(sessionId): \(error.localizedDescription)")
   }
 }
 

--- a/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
@@ -163,6 +163,71 @@ struct CrashReportTests {
       #expect(report.findMatchingSession(in: []) == nil)
     }
   }
+
+  @AppMetricsActor
+  @Suite("eventAttributes")
+  struct EventAttributesTests {
+    @Test
+    func `surfaces exception and signal codes as both raw value and name`() {
+      let report = makeCrashReport(
+        timestampBegin: Date.now,
+        timestampEnd: Date.now,
+        exceptionType: 1,
+        exceptionCode: 2,
+        signal: 11
+      )
+      let attributes = report.eventAttributes
+
+      #expect(attributes["expo.crash.exception_type"] as? String == "EXC_BAD_ACCESS")
+      #expect(attributes["expo.crash.exception_type_code"] as? Int == 1)
+      #expect(attributes["expo.crash.exception_code"] as? Int == 2)
+      #expect(attributes["expo.crash.signal"] as? String == "SIGSEGV")
+      #expect(attributes["expo.crash.signal_code"] as? Int == 11)
+      #expect(attributes["expo.app.version"] as? String == "1.0.0")
+    }
+
+    @Test
+    func `omits absent optional fields`() {
+      let report = makeCrashReport(
+        timestampBegin: Date.now,
+        timestampEnd: Date.now,
+        exceptionType: nil,
+        exceptionCode: nil,
+        signal: nil
+      )
+      let attributes = report.eventAttributes
+
+      #expect(attributes["expo.crash.exception_type"] == nil)
+      #expect(attributes["expo.crash.exception_code"] == nil)
+      #expect(attributes["expo.crash.signal"] == nil)
+      #expect(attributes["expo.crash.termination_reason"] == nil)
+      #expect(attributes["expo.crash.objc_exception_type"] == nil)
+      // App version is always present.
+      #expect(attributes["expo.app.version"] as? String == "1.0.0")
+    }
+
+    @Test
+    func `includes termination reason and ObjC exception details when present`() {
+      let report = makeCrashReport(
+        timestampBegin: Date.now,
+        timestampEnd: Date.now,
+        terminationReason: "Namespace SIGNAL, Code 11",
+        exceptionReason: CrashReport.ExceptionReason(
+          composedMessage: "-[NSNull length]: unrecognized selector",
+          formatString: "%@: unrecognized selector",
+          arguments: ["-[NSNull length]"],
+          exceptionType: "NSInvalidArgumentException",
+          className: "NSException",
+          exceptionName: "NSInvalidArgumentException"
+        )
+      )
+      let attributes = report.eventAttributes
+
+      #expect(attributes["expo.crash.termination_reason"] as? String == "Namespace SIGNAL, Code 11")
+      #expect(attributes["expo.crash.objc_exception_type"] as? String == "NSInvalidArgumentException")
+      #expect(attributes["expo.crash.objc_exception_message"] as? String == "-[NSNull length]: unrecognized selector")
+    }
+  }
 }
 
 private func makeMainSessionRow(id: String, startDate: Date, endDate: Date?) -> SessionRow {
@@ -175,14 +240,22 @@ private func makeMainSessionRow(id: String, startDate: Date, endDate: Date?) -> 
   )
 }
 
-private func makeCrashReport(timestampBegin: Date, timestampEnd: Date) -> CrashReport {
+private func makeCrashReport(
+  timestampBegin: Date,
+  timestampEnd: Date,
+  exceptionType: Int? = 1,
+  exceptionCode: Int? = 1,
+  signal: Int? = 11,
+  terminationReason: String? = nil,
+  exceptionReason: CrashReport.ExceptionReason? = nil
+) -> CrashReport {
   return CrashReport(
-    exceptionType: 1,
-    exceptionCode: 1,
-    signal: 11,
-    terminationReason: nil,
+    exceptionType: exceptionType,
+    exceptionCode: exceptionCode,
+    signal: signal,
+    terminationReason: terminationReason,
     virtualMemoryRegionInfo: nil,
-    exceptionReason: nil,
+    exceptionReason: exceptionReason,
     callStackTree: nil,
     appVersion: "1.0.0",
     timestampBegin: timestampBegin,

--- a/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
@@ -258,8 +258,8 @@ private func makeCrashReport(
     exceptionReason: exceptionReason,
     callStackTree: nil,
     appVersion: "1.0.0",
-    timestampBegin: timestampBegin,
-    timestampEnd: timestampEnd,
-    ingestedAt: Date.now
+    timestampBegin: timestampBegin.ISO8601Format(),
+    timestampEnd: timestampEnd.ISO8601Format(),
+    ingestedAt: Date.now.ISO8601Format()
   )
 }


### PR DESCRIPTION
## Why

`expo-app-metrics` already collects crash reports on iOS (via MetricKit) and attributes each one to the past session it most likely belongs to. Until now that attribution only persisted the full crash report blob on the session row. Consumers (e.g. `expo-observe`) had no compact, queryable signal that a given session ended in a crash. This adds one.

## How

When `MetricKitSubscriber` attributes a crash report to a session, it now also records an `expo.session.crashed` log event on that session, right after `persistCrashReport` succeeds.

- The event is built as a `LogRecord` directly rather than through the JS-facing `logEvent` path. That path is for app developers and deliberately rejects the reserved `expo.` name prefix and strips `expo.*` attributes, both of which the SDK owns here.
- It is inserted via the existing `LogRow.from(log:sessionId:)` + `database.insert(log:)` path, the same direct-DB write `persistCrashReport` uses, so it lands on the matched *past* session rather than the current one.
- Severity is `fatal` and the timestamp is the report's `ingestedAt`.

Crash details are surfaced under the SDK-owned `expo.crash.*` namespace via a new `CrashReport.eventAttributes` property:

- `expo.app.version`
- `expo.crash.exception_type` (human-readable, e.g. `EXC_BAD_ACCESS`) + `expo.crash.exception_type_code`
- `expo.crash.exception_code`
- `expo.crash.signal` (e.g. `SIGSEGV`) + `expo.crash.signal_code`
- `expo.crash.termination_reason`
- `expo.crash.objc_exception_type` / `expo.crash.objc_exception_message` (when an `NSException` was involved)

Opaque numeric codes are carried as both their raw value and a human-readable name so consumers don't need their own lookup tables. The call stack and VM-region blob are omitted from the event since they're large and already persisted in full on the crash report row.

This is iOS-only: crash reporting is a MetricKit feature with no Android counterpart yet.

### A note on attribute naming

I kept everything under `expo.crash.*` rather than reusing the OpenTelemetry `exception.type` / `exception.message` semantic conventions. Those conventions describe a caught *language-level* exception on an event named `exception`, which would mislabel a Mach-exception/signal process crash and couple us to backend rendering keyed on that event name. Only the `NSException` subset genuinely matches that convention, and mixing two namespaces in one event isn't worth it. The `expo.*` namespace is also already documented as SDK-owned in `AttributeValidation`.

## Test Plan

`et native-unit-tests -p ios --packages expo-app-metrics` passes, including a new `eventAttributes` test suite covering raw+named code surfacing, omission of absent optional fields, and termination/ObjC exception details. `et check-packages expo-app-metrics` is green.
