### PR TITLE
[ios][router] Keep Link.Preview triggers accessible

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Keep `Link.Preview` triggers visible to the accessibility tree. ([#46875](https://github.com/expo/expo/issues/46875) by [@vivekjm](https://github.com/vivekjm))
 - [android] Disable safe area insets in Native Tabs on Android when tab bar is hidden. ([#47611](https://github.com/expo/expo/pull/47611) by [@debitan](https://github.com/debitan))
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -6,6 +6,9 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
   private var preview: NativeLinkPreviewContentView?
   private var interaction: UIContextMenuInteraction?
   var directChild: UIView?
+  private var accessibilityTriggerView: UIView? {
+    return (directChild as? LinkPreviewIndirectTriggerProtocol)?.indirectTrigger ?? directChild
+  }
   var nextScreenId: String? {
     didSet {
       performUpdateOfPreloadedView()
@@ -28,6 +31,35 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
   let onDidPreviewOpen = EventDispatcher()
   let onPreviewWillClose = EventDispatcher()
   let onPreviewDidClose = EventDispatcher()
+
+  override var isAccessibilityElement: Bool {
+    get {
+      return false
+    }
+    set {}
+  }
+
+  override var accessibilityElements: [Any]? {
+    get {
+      guard let accessibilityTriggerView else {
+        return super.accessibilityElements
+      }
+      return [accessibilityTriggerView]
+    }
+    set {}
+  }
+
+  override var accessibilityFrame: CGRect {
+    get {
+      guard let accessibilityTriggerView else {
+        return super.accessibilityFrame
+      }
+      return accessibilityTriggerView.convert(accessibilityTriggerView.bounds, to: nil)
+    }
+    set {
+      super.accessibilityFrame = newValue
+    }
+  }
 
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)

--- a/packages/expo-router/ios/Tests/LinkPreviewNativeViewTests.swift
+++ b/packages/expo-router/ios/Tests/LinkPreviewNativeViewTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import UIKit
+
+@testable import ExpoRouter
+
+@Suite("NativeLinkPreviewView accessibility")
+@MainActor
+struct NativeLinkPreviewViewAccessibilityTests {
+  @Test
+  func `forwards accessibility elements to trigger view`() throws {
+    let linkPreviewView = NativeLinkPreviewView()
+    let triggerView = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 44))
+
+    linkPreviewView.directChild = triggerView
+
+    #expect(!linkPreviewView.isAccessibilityElement)
+    let elements = try #require(linkPreviewView.accessibilityElements as? [UIView])
+    #expect(elements == [triggerView])
+  }
+
+  @Test
+  func `reports trigger frame for accessibility`() {
+    let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+    let linkPreviewView = NativeLinkPreviewView()
+    let triggerView = UIView(frame: CGRect(x: 12, y: 34, width: 56, height: 78))
+
+    containerView.addSubview(linkPreviewView)
+    linkPreviewView.addSubview(triggerView)
+    linkPreviewView.directChild = triggerView
+
+    #expect(linkPreviewView.accessibilityFrame == triggerView.convert(triggerView.bounds, to: nil))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #46875.

This keeps the native `Link.Preview` wrapper out of the iOS accessibility tree by passing `accessible={false}` to `NativeLinkPreview`. The trigger subtree remains the accessible content, so VoiceOver and XCUITest-based tooling can continue to find rows wrapped with `Link.Trigger` and `Link.Preview`.

I also added a focused regression assertion that `Link.Preview` renders the native wrapper with `accessible: false`, and updated the committed build output and changelog.

## Test Plan

- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('packages/expo-router/build/link/LinkWithPreview.js.map','utf8')); console.log('map ok')"`
- Attempted `yarn workspace expo-router test -- Link.test.ios.tsx`, but it could not run in this sparse checkout because dependencies are not installed and `expo-module` is unavailable locally (`/bin/sh: expo-module: command not found`).
