### PR TITLE
[core] Add JavaScriptCodable static conversion protocols and conformances

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 💡 Others
 
 - [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9. ([#46769](https://github.com/expo/expo/pull/46769) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Added `JavaScriptDecodable` / `JavaScriptEncodable` (composed as `JavaScriptCodable`), a statically-dispatched, non-erasing conversion path between JavaScript and native values for Expo Modules v2, with conformances for primitives, containers, records, enumerables and `Data`. ([#46893](https://github.com/expo/expo/pull/46893) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `@ExpoModule` now synthesizes a `_decorateModule` that binds the module's `@JS` functions directly onto the JS object, letting the module holder skip the dynamic definition path for synthesized modules. ([#46612](https://github.com/expo/expo/pull/46612) by [@tsapeta](https://github.com/tsapeta))
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-core/ios/Core/Arguments/Enumerable.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Enumerable.swift
@@ -3,7 +3,7 @@
 /**
  A protocol that allows converting raw values to enum cases.
  */
-public protocol Enumerable: AnyArgument, CaseIterable {
+public protocol Enumerable: AnyArgument, CaseIterable, JavaScriptDecodable, JavaScriptEncodable {
   /**
    Tries to create an enum case using given raw value.
    May throw errors, e.g. when the raw value doesn't match any case.

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Builtins.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Builtins.swift
@@ -1,0 +1,26 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `JavaScriptCodable` conformance for the JS value passthrough.
+//
+// `Void` is intentionally not here: it is the empty tuple `()`, which cannot be extended to conform
+// to a protocol (the same reason it is not `AnyArgument`). A `() -> Void` function's `undefined`
+// return is emitted directly by the macro, which knows the return type statically.
+
+// MARK: - JavaScriptValue (identity)
+
+// A `JavaScriptValue` argument or return value is passed through unchanged — no conversion.
+extension JavaScriptValue: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return value
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return value
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Containers.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Containers.swift
@@ -1,0 +1,105 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `JavaScriptCodable` conformances for the standard container and wrapper types — `Array`,
+// `Optional`, and `Dictionary` — each conditional on its element/wrapped type conforming, and
+// each recursing statically into that element's conversion.
+//
+// `JavaScriptCodable` is a composition type alias, so a conformance clause spells out both halves:
+// `extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScriptCodable`.
+
+// MARK: - Array
+
+extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> [Element] {
+    // A non-array value is "arrayized" into a single-element array, so a caller that passes a
+    // scalar where an array is expected still works.
+    guard value.isArray() else {
+      return [try Element.decode(value, appContext: appContext, runtime: runtime)]
+    }
+    // `map` reads the length once and uses the unchecked element accessor, avoiding a
+    // per-element weak-runtime load and bounds check on this hot path.
+    return try value.getArray().map { element in
+      return try Element.decode(element, appContext: appContext, runtime: runtime)
+    }
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: [Element], appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    let jsArray = runtime.createArray(length: value.count)
+    for (index, element) in value.enumerated() {
+      try jsArray.set(value: Element.encode(element, appContext: appContext, runtime: runtime), at: index)
+    }
+    return jsArray.asValue()
+  }
+}
+
+// MARK: - Optional
+
+extension Optional: JavaScriptDecodable, JavaScriptEncodable where Wrapped: JavaScriptCodable {
+  // Optional copies nothing itself, so it overrides the zero-copy overload too and forwards the
+  // borrowed value straight through — a wrapped primitive argument stays fully zero-copy.
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Wrapped? {
+    if value.isNull() || value.isUndefined() {
+      return .none
+    }
+    return try Wrapped.decode(value, appContext: appContext, runtime: runtime)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Wrapped? {
+    if value.isNull() || value.isUndefined() {
+      return .none
+    }
+    return try Wrapped.decode(value, appContext: appContext, runtime: runtime)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Wrapped?, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    guard let value else {
+      // `nil` maps to `null`; mapping to `undefined` is the job of `ValueOrUndefined`.
+      return .null
+    }
+    return try Wrapped.encode(value, appContext: appContext, runtime: runtime)
+  }
+}
+
+// MARK: - Dictionary
+
+extension Dictionary: JavaScriptDecodable, JavaScriptEncodable where Key == String, Value: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> [String: Value] {
+    let object = try value.asObject()
+    let keys = object.getPropertyNames()
+    var result = [String: Value](minimumCapacity: keys.count)
+    for key in keys {
+      let property = object.getProperty(key)
+      // Treat an `undefined`-valued property as an absent entry. Without this a non-optional
+      // `Value` would reject an object that simply omits the property as `undefined`.
+      if property.isUndefined() {
+        continue
+      }
+      result[key] = try Value.decode(property, appContext: appContext, runtime: runtime)
+    }
+    return result
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: [String: Value], appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    let object = runtime.createObject()
+    for (key, element) in value {
+      object.setProperty(key, value: try Value.encode(element, appContext: appContext, runtime: runtime))
+    }
+    return object.asValue()
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Data.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Data.swift
@@ -1,0 +1,52 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `Data` converts to and from a JavaScript `Uint8Array`. Decoding copies the typed array's bytes
+// into `Data`; encoding copies the bytes into a new `ArrayBuffer` wrapped in a `Uint8Array`.
+//
+// `Data` is not in `+Primitives` because it is not a scalar. It maps to a typed array, with its own
+// read/write rather than a single accessor.
+
+extension Data: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Data {
+    guard value.isTypedArray() else {
+      throw DataNotUint8ArrayException()
+    }
+    let typedArray = value.getTypedArray()
+    guard typedArray.kind == .Uint8Array else {
+      throw DataNotUint8ArrayException()
+    }
+    return typedArray.withUnsafeBytes { bytes in
+      guard typedArray.byteLength > 0, let baseAddress = bytes.baseAddress else {
+        return Data()
+      }
+      return Data(bytes: baseAddress, count: typedArray.byteLength)
+    }
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Data, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    let arrayBuffer = runtime.createArrayBuffer(size: value.count)
+    value.withUnsafeBytes { rawBuffer in
+      if let baseAddress = rawBuffer.baseAddress, value.count > 0 {
+        memcpy(arrayBuffer.data(), baseAddress, value.count)
+      }
+    }
+    let uint8ArrayConstructor = try runtime.global().getPropertyAsFunction("Uint8Array")
+    return try uint8ArrayConstructor.callAsConstructor(arrayBuffer.asValue())
+  }
+}
+
+/// Thrown when decoding `Data` from a JavaScript value that is not a `Uint8Array`.
+public final class DataNotUint8ArrayException: Exception, @unchecked Sendable {
+  override public var code: String {
+    "ERR_DATA_NOT_UINT8ARRAY"
+  }
+  override public var reason: String {
+    "Cannot convert a JavaScript value to Data because it is not a Uint8Array"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Enumerable.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Enumerable.swift
@@ -1,0 +1,22 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// Every `Enumerable` is `JavaScriptCodable`: an enum converts as its raw value. The witnesses are
+// provided for `RawRepresentable` enums whose `RawValue` is itself `JavaScriptCodable` (in practice
+// `String` or an integer type), delegating the actual conversion to that raw value's conformance.
+
+extension Enumerable where Self: RawRepresentable, RawValue: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Self {
+    let rawValue = try RawValue.decode(value, appContext: appContext, runtime: runtime)
+    return try create(fromRawValue: rawValue)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Self, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return try RawValue.encode(value.rawValue, appContext: appContext, runtime: runtime)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Primitives.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Primitives.swift
@@ -1,0 +1,363 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import CoreGraphics
+import ExpoModulesJSI
+
+// `JavaScriptCodable` conformances for leaf primitive types — `Bool`, `String`, and the integer
+// and floating-point families. Each reads a JavaScript value directly via the corresponding
+// accessor with no recursion and no element conversion.
+//
+// `Data` is intentionally not here: it maps to a JS `Uint8Array`, not a scalar, and belongs with
+// the typed-array conversions rather than these scalar primitives.
+//
+// Each conformance overrides the zero-copy `JavaScriptUnownedValue` decode overload so an
+// argument is read straight from the borrowed value, never materializing a `JavaScriptValue`.
+
+// MARK: - Bool
+
+extension Bool: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Bool {
+    return try value.asBool()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Bool {
+    return try value.asBool()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Bool, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return value ? .true() : .false()
+  }
+}
+
+// MARK: - String
+
+extension String: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> String {
+    return try value.asString()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> String {
+    return try value.asString()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: String, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    // The `JavaScriptValue(_:_:)` initializer takes the runtime by owned convention (it stores it),
+    // so an owned copy is needed from the borrowed parameter.
+    return JavaScriptValue(copy runtime, value)
+  }
+}
+
+// MARK: - Floating-point types
+
+// Both overloads use the throwing `as*` accessors, never the non-throwing `get*`. Even though the
+// Swift signature names a concrete type, the JavaScript caller is untyped and may pass anything, so
+// the value's actual JS type is unknown until checked. `as*` turns a type mismatch into a thrown
+// `TypeError`; `get*` only asserts (compiled out in release), so on a wrong-typed value it would be
+// undefined behavior — a native crash, not a catchable error.
+
+extension Double: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Double {
+    return try value.asDouble()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Double {
+    return try value.asDouble()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Double, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(value)
+  }
+}
+
+extension Float: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Float {
+    return try Float(value.asDouble())
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Float {
+    return try Float(value.asDouble())
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Float, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension CGFloat: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> CGFloat {
+    return try CGFloat(value.asDouble())
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> CGFloat {
+    return try CGFloat(value.asDouble())
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: CGFloat, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+// MARK: - Integer types
+//
+// JavaScript numbers are doubles. Each integer `decode` reads the value as a `Double` (throwing on a
+// non-number) and narrows it through `decodeInteger`, which rounds to the nearest integer before
+// converting (e.g. `1.6` decodes to `2`) and throws rather than traps on a non-finite or out-of-range
+// value. Encoding widens back to `Double` for `.number`.
+//
+// TODO (encode side): widening to `Double` for `.number` silently loses precision for `Int64`/`UInt64`
+// (and `Int`/`UInt` on 64-bit) magnitudes above 2^53, JavaScript's safe-integer ceiling. Routing wide
+// integers through `BigInt` (which the JSI layer already models) would be lossless; left as a follow-up.
+
+extension Int: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int {
+    return try decodeInteger(value.asDouble(), as: Int.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int {
+    return try decodeInteger(value.asDouble(), as: Int.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Int, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension Int8: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int8 {
+    return try decodeInteger(value.asDouble(), as: Int8.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int8 {
+    return try decodeInteger(value.asDouble(), as: Int8.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Int8, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension Int16: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int16 {
+    return try decodeInteger(value.asDouble(), as: Int16.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int16 {
+    return try decodeInteger(value.asDouble(), as: Int16.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Int16, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension Int32: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int32 {
+    return try decodeInteger(value.asDouble(), as: Int32.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int32 {
+    return try decodeInteger(value.asDouble(), as: Int32.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Int32, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension Int64: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int64 {
+    return try decodeInteger(value.asDouble(), as: Int64.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Int64 {
+    return try decodeInteger(value.asDouble(), as: Int64.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Int64, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension UInt: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt {
+    return try decodeInteger(value.asDouble(), as: UInt.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt {
+    return try decodeInteger(value.asDouble(), as: UInt.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: UInt, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension UInt8: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt8 {
+    return try decodeInteger(value.asDouble(), as: UInt8.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt8 {
+    return try decodeInteger(value.asDouble(), as: UInt8.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: UInt8, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension UInt16: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt16 {
+    return try decodeInteger(value.asDouble(), as: UInt16.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt16 {
+    return try decodeInteger(value.asDouble(), as: UInt16.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: UInt16, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension UInt32: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt32 {
+    return try decodeInteger(value.asDouble(), as: UInt32.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt32 {
+    return try decodeInteger(value.asDouble(), as: UInt32.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: UInt32, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+extension UInt64: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt64 {
+    return try decodeInteger(value.asDouble(), as: UInt64.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> UInt64 {
+    return try decodeInteger(value.asDouble(), as: UInt64.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: UInt64, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return .number(Double(value))
+  }
+}
+
+/// Rounds a JavaScript number to the nearest integer and narrows it to `T`, throwing instead of
+/// trapping when the value is non-finite or outside `T`'s representable range. `T(exactly:)` on the
+/// already-rounded value is nil only when out of range, sidestepping the lossy `Double(T.max)`
+/// boundary comparison for 64-bit widths.
+@usableFromInline
+@JavaScriptActor
+func decodeInteger<T: FixedWidthInteger>(_ number: Double, as type: T.Type) throws -> T {
+  guard number.isFinite, let result = T(exactly: number.rounded()) else {
+    throw IntegerOutOfRangeException((value: number, type: "\(T.self)"))
+  }
+  return result
+}
+
+/// Thrown when a JavaScript number cannot be represented as the target integer type because it is
+/// non-finite or outside the type's range.
+public final class IntegerOutOfRangeException: GenericException<(value: Double, type: String)>, @unchecked Sendable {
+  override public var code: String {
+    "ERR_INTEGER_OUT_OF_RANGE"
+  }
+  override public var reason: String {
+    "JavaScript number '\(param.value)' cannot be represented as \(param.type)"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Record.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Record.swift
@@ -1,0 +1,26 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// Every `Record` is `JavaScriptCodable`. The conversion is a thin wrapper over the record's own
+// `from(object:)` / `toObject(appContext:)` surface — which the `@Record` macro synthesizes as flat,
+// reflection-free, per-property reads and writes. So a record decode is N concrete property
+// conversions with no `Mirror` and no per-value `Any` box.
+//
+// Records only implement the owning `decode` overload (the requirement). They walk an object's
+// properties regardless, so the zero-copy `JavaScriptUnownedValue` fast path offers nothing here;
+// the defaulted overload materializes an owning value and forwards.
+
+extension Record {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Self {
+    return try from(object: value.asObject(), appContext: appContext)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Self, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    return try value.toObject(appContext: appContext).asValue()
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable.swift
@@ -1,0 +1,9 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/// A composition of `JavaScriptDecodable` and `JavaScriptEncodable` for types that convert in
+/// both directions between JavaScript and native.
+///
+/// This is a type alias rather than an inheriting protocol so that satisfying both halves is
+/// enough to satisfy it — no extra conformance declaration — and so that decode-only or
+/// encode-only types are never required to implement the other side.
+public typealias JavaScriptCodable = JavaScriptDecodable & JavaScriptEncodable

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptDecodable.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptDecodable.swift
@@ -1,0 +1,47 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+/// A protocol for types that can be created from a JavaScript value without type erasure.
+///
+/// `decode` returns the concrete `Self` directly, so the macro-synthesized bindings that call it
+/// never box the value as `Any` or cast it back with `as!`. It is the JS → native half of
+/// `JavaScriptCodable`.
+///
+/// The conversion runs on the JavaScript thread; conformers are called under `@JavaScriptActor`.
+/// The `appContext` and `runtime` are both `borrowing` because the conversions only read them.
+/// A conversion that needs to store or escape the context (e.g. a shared object retaining it)
+/// makes an owned copy with `copy appContext`.
+public protocol JavaScriptDecodable {
+  /// Decodes an owning `JavaScriptValue` into `Self`.
+  ///
+  /// This overload is the protocol requirement: every conformer provides it. It is also the
+  /// correct entry point for any value that must outlive the call (stored, captured, handed to a
+  /// `Promise`).
+  @JavaScriptActor
+  static func decode(_ value: JavaScriptValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Self
+
+  /// Decodes a non-owning `JavaScriptUnownedValue` into `Self` without copying the underlying
+  /// `jsi::Value`.
+  ///
+  /// This is the argument-decode fast path: the value borrows the argument the
+  /// `JavaScriptValuesBuffer` already owns for the duration of the call. It is defaulted (see the
+  /// extension below), so conformers get it for free by materializing an owning value; types that
+  /// can read straight from the borrowed value override it to stay zero-copy.
+  @JavaScriptActor
+  static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Self
+}
+
+extension JavaScriptDecodable {
+  /// Default fast-path implementation: materialize an owning value and forward to the requirement.
+  /// This is the "explicitly copy" behavior for types that cannot (or need not) read directly from
+  /// the borrowed value.
+  ///
+  /// `@inlinable` so the default specializes into the user module across the resilient
+  /// (library-evolution) boundary instead of dispatching through the prebuilt binary.
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> Self {
+    return try decode(value.copied(in: runtime), appContext: appContext, runtime: runtime)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptEncodable.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptEncodable.swift
@@ -1,0 +1,17 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+/// A protocol for types that can be converted to a JavaScript value without type erasure.
+///
+/// `encode` is static and takes the value explicitly so the macro emits one uniform call shape
+/// — `T.encode(result, …)` — regardless of the type, and so types that represent absence
+/// (e.g. `Optional`) can produce a JavaScript value without first having a non-nil `self`.
+/// It is the native → JS half of `JavaScriptCodable`.
+///
+/// The conversion runs on the JavaScript thread; conformers are called under `@JavaScriptActor`.
+/// See `JavaScriptDecodable` for why `appContext` and `runtime` are both `borrowing`.
+public protocol JavaScriptEncodable {
+  @JavaScriptActor
+  static func encode(_ value: Self, appContext: borrowing AppContext, runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue
+}

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -4,7 +4,7 @@ import ExpoModulesJSI
  A protocol that allows initializing the object with a dictionary.
  For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
  */
-public protocol Record: Convertible {
+public protocol Record: Convertible, JavaScriptDecodable, JavaScriptEncodable {
   /**
    The dictionary type that the record can be created from or converted back.
    */

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableBuiltinsTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableBuiltinsTests.swift
@@ -1,0 +1,30 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+Builtins")
+@JavaScriptActor
+struct JavaScriptCodableBuiltinsTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - JavaScriptValue passthrough
+
+  @Test
+  func `passes a JavaScriptValue through`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("123")
+    let decoded = try JavaScriptValue.decode(value, appContext: appContext, runtime: runtime)
+    #expect(decoded.getInt() == 123)
+    let encoded = try JavaScriptValue.encode(decoded, appContext: appContext, runtime: runtime)
+    #expect(encoded.getInt() == 123)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableContainersTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableContainersTests.swift
@@ -1,0 +1,128 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+Containers")
+@JavaScriptActor
+struct JavaScriptCodableContainersTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - Array
+
+  @Test
+  func `decodes an array of ints`() throws {
+    let runtime = try runtime
+    let decoded = try [Int].decode(runtime.eval("[1, 2, 3]"), appContext: appContext, runtime: runtime)
+    #expect(decoded == [1, 2, 3])
+  }
+
+  @Test
+  func `encodes an array of strings`() throws {
+    let runtime = try runtime
+    let encoded = try [String].encode(["a", "b"], appContext: appContext, runtime: runtime)
+    let array = encoded.getArray()
+    #expect(array.length == 2)
+    #expect(try array.getValue(at: 0).getString() == "a")
+    #expect(try array.getValue(at: 1).getString() == "b")
+  }
+
+  @Test
+  func `round-trips a nested array`() throws {
+    let runtime = try runtime
+    let decoded = try [[Double]].decode(runtime.eval("[[1.5], [2.5, 3.5]]"), appContext: appContext, runtime: runtime)
+    #expect(decoded == [[1.5], [2.5, 3.5]])
+  }
+
+  @Test
+  func `round-trips an empty array`() throws {
+    let runtime = try runtime
+    #expect(try [Int].decode(runtime.eval("[]"), appContext: appContext, runtime: runtime) == [])
+    #expect(try [Int].encode([], appContext: appContext, runtime: runtime).getArray().length == 0)
+  }
+
+  @Test
+  func `arrayizes a non-array scalar, matching v1`() throws {
+    // v1 `DynamicArrayType` wraps a non-array value into a single-element array.
+    let runtime = try runtime
+    #expect(try [Int].decode(runtime.eval("42"), appContext: appContext, runtime: runtime) == [42])
+  }
+
+  // MARK: - Optional
+
+  @Test
+  func `decodes a present and absent optional`() throws {
+    let runtime = try runtime
+    #expect(try Int?.decode(runtime.eval("42"), appContext: appContext, runtime: runtime) == 42)
+    #expect(try Int?.decode(runtime.eval("null"), appContext: appContext, runtime: runtime) == nil)
+    #expect(try Int?.decode(runtime.eval("undefined"), appContext: appContext, runtime: runtime) == nil)
+  }
+
+  @Test
+  func `encodes a present optional and nil as null`() throws {
+    let runtime = try runtime
+    #expect(try Int?.encode(7, appContext: appContext, runtime: runtime).getInt() == 7)
+    #expect(try Int?.encode(nil, appContext: appContext, runtime: runtime).isNull() == true)
+  }
+
+  @Test
+  func `decodes an array of optionals`() throws {
+    let runtime = try runtime
+    let decoded = try [Int?].decode(runtime.eval("[1, null, 3]"), appContext: appContext, runtime: runtime)
+    #expect(decoded == [1, nil, 3])
+  }
+
+  // MARK: - Dictionary
+
+  @Test
+  func `decodes a string-keyed dictionary`() throws {
+    let runtime = try runtime
+    let decoded = try [String: Int].decode(runtime.eval("({ a: 1, b: 2 })"), appContext: appContext, runtime: runtime)
+    #expect(decoded == ["a": 1, "b": 2])
+  }
+
+  @Test
+  func `encodes a string-keyed dictionary`() throws {
+    let runtime = try runtime
+    let encoded = try [String: Int].encode(["x": 9], appContext: appContext, runtime: runtime)
+    #expect(encoded.getObject().getProperty("x").getInt() == 9)
+  }
+
+  @Test
+  func `round-trips an empty dictionary`() throws {
+    let runtime = try runtime
+    #expect(try [String: Int].decode(runtime.eval("({})"), appContext: appContext, runtime: runtime) == [:])
+    let encoded = try [String: Int].encode([:], appContext: appContext, runtime: runtime)
+    #expect(encoded.getObject().getPropertyNames().isEmpty)
+  }
+
+  @Test
+  func `decode skips undefined-valued properties, matching v1`() throws {
+    // An `undefined`-valued property is treated as absent rather than decoded (which would throw
+    // for a non-optional value), matching the v1 dictionary converter.
+    let runtime = try runtime
+    let decoded = try [String: Int].decode(
+      runtime.eval("({ a: 1, b: undefined })"), appContext: appContext, runtime: runtime)
+    #expect(decoded == ["a": 1])
+  }
+
+  // MARK: - Zero-copy borrowed-value overload
+
+  @Test
+  func `decodes an optional from a borrowed value, present and absent`() throws {
+    let runtime = try runtime
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: 7, JavaScriptValue.null, JavaScriptValue.undefined)
+    #expect(try Int?.decode(buffer.unownedValue(at: 0), appContext: appContext, runtime: runtime) == 7)
+    #expect(try Int?.decode(buffer.unownedValue(at: 1), appContext: appContext, runtime: runtime) == nil)
+    #expect(try Int?.decode(buffer.unownedValue(at: 2), appContext: appContext, runtime: runtime) == nil)
+  }
+
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableDataTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableDataTests.swift
@@ -1,0 +1,70 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+Data")
+@JavaScriptActor
+struct JavaScriptCodableDataTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  @Test
+  func `decodes Data from a Uint8Array`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("new Uint8Array([0, 255, 16])")
+    let decoded = try Data.decode(value, appContext: appContext, runtime: runtime)
+    #expect(Array(decoded) == [0, 255, 16])
+  }
+
+  @Test
+  func `encodes Data to a Uint8Array`() throws {
+    let runtime = try runtime
+    let encoded = try Data.encode(Data([1, 2, 3]), appContext: appContext, runtime: runtime)
+    #expect(encoded.isTypedArray() == true)
+    let roundTripped = try Data.decode(encoded, appContext: appContext, runtime: runtime)
+    #expect(Array(roundTripped) == [1, 2, 3])
+  }
+
+  @Test
+  func `round-trips empty Data`() throws {
+    let runtime = try runtime
+    // Exercises the `byteLength == 0` decode guard and the `count > 0` encode guard.
+    let decoded = try Data.decode(runtime.eval("new Uint8Array([])"), appContext: appContext, runtime: runtime)
+    #expect(decoded.isEmpty)
+    let encoded = try Data.encode(Data(), appContext: appContext, runtime: runtime)
+    #expect(encoded.isTypedArray() == true)
+    #expect(try Data.decode(encoded, appContext: appContext, runtime: runtime).isEmpty)
+  }
+
+  @Test
+  func `decodes Data through the borrowed-value overload`() throws {
+    // `Data` does not override the zero-copy overload, so this goes through the default that copies
+    // the borrowed value into an owning one and forwards. It should still decode correctly.
+    let runtime = try runtime
+    let value = try runtime.eval("new Uint8Array([1, 2, 3])")
+    let buffer = JavaScriptValuesBuffer.copying(in: runtime, values: [value])
+    let decoded = try Data.decode(buffer.unownedValue(at: 0), appContext: appContext, runtime: runtime)
+    #expect(Array(decoded) == [1, 2, 3])
+  }
+
+  // MARK: - Error paths
+
+  @Test
+  func `Data decode throws on a non-Uint8Array`() throws {
+    let runtime = try runtime
+    #expect(throws: DataNotUint8ArrayException.self) {
+      _ = try Data.decode(runtime.eval("[1, 2, 3]"), appContext: appContext, runtime: runtime)
+    }
+    #expect(throws: DataNotUint8ArrayException.self) {
+      _ = try Data.decode(runtime.eval("new Float64Array([1, 2])"), appContext: appContext, runtime: runtime)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableEnumerableTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableEnumerableTests.swift
@@ -1,0 +1,60 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+enum CodableColor: String, Enumerable {
+  case red
+  case green
+}
+
+enum CodablePriority: Int, Enumerable {
+  case low = 1
+  case high = 2
+}
+
+@Suite("JavaScriptCodable+Enumerable")
+@JavaScriptActor
+struct JavaScriptCodableEnumerableTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - String-backed enum
+
+  @Test
+  func `decodes and encodes a string enum`() throws {
+    let runtime = try runtime
+    let decoded = try CodableColor.decode(runtime.eval("'green'"), appContext: appContext, runtime: runtime)
+    #expect(decoded == .green)
+    let encoded = try CodableColor.encode(.red, appContext: appContext, runtime: runtime)
+    #expect(encoded.getString() == "red")
+  }
+
+  // MARK: - Int-backed enum
+
+  @Test
+  func `decodes and encodes an int enum`() throws {
+    let runtime = try runtime
+    let decoded = try CodablePriority.decode(runtime.eval("2"), appContext: appContext, runtime: runtime)
+    #expect(decoded == .high)
+    let encoded = try CodablePriority.encode(.low, appContext: appContext, runtime: runtime)
+    #expect(encoded.getInt() == 1)
+  }
+
+  // MARK: - Error paths
+
+  @Test
+  func `enum decode throws on an unknown raw value`() throws {
+    let runtime = try runtime
+    #expect(throws: (any Error).self) {
+      _ = try CodableColor.decode(runtime.eval("'purple'"), appContext: appContext, runtime: runtime)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodablePrimitivesTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodablePrimitivesTests.swift
@@ -1,0 +1,146 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+Primitives")
+@JavaScriptActor
+struct JavaScriptCodablePrimitivesTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - Double
+
+  @Test
+  func `decodes a double from a JS number`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("3.5")
+    let decoded = try Double.decode(value, appContext: appContext, runtime: runtime)
+    #expect(decoded == 3.5)
+  }
+
+  @Test
+  func `encodes a double to a JS number`() throws {
+    let runtime = try runtime
+    let encoded = try Double.encode(2.5, appContext: appContext, runtime: runtime)
+    #expect(encoded.getDouble() == 2.5)
+  }
+
+  @Test
+  func `round-trips a double`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("42.25")
+    let decoded = try Double.decode(value, appContext: appContext, runtime: runtime)
+    let reencoded = try Double.encode(decoded, appContext: appContext, runtime: runtime)
+    #expect(reencoded.getDouble() == 42.25)
+  }
+
+  // MARK: - Int
+
+  @Test
+  func `decodes and encodes an int`() throws {
+    let runtime = try runtime
+    let decoded = try Int.decode(runtime.eval("42"), appContext: appContext, runtime: runtime)
+    #expect(decoded == 42)
+    let encoded = try Int.encode(-7, appContext: appContext, runtime: runtime)
+    #expect(encoded.getInt() == -7)
+  }
+
+  // MARK: - Integer family (representative widths)
+
+  @Test
+  func `decodes and encodes narrow and unsigned integers`() throws {
+    let runtime = try runtime
+    #expect(try Int8.decode(runtime.eval("127"), appContext: appContext, runtime: runtime) == 127)
+    #expect(try UInt8.decode(runtime.eval("255"), appContext: appContext, runtime: runtime) == 255)
+    #expect(try Int64.decode(runtime.eval("1024"), appContext: appContext, runtime: runtime) == 1024)
+    #expect(try UInt32.encode(300, appContext: appContext, runtime: runtime).getInt() == 300)
+  }
+
+  @Test
+  func `rounds a fractional number when decoding an integer, matching v1`() throws {
+    // v1 `DynamicNumberType` rounds before narrowing, so 1.6 -> 2 (not truncated to 1).
+    let runtime = try runtime
+    #expect(try Int.decode(runtime.eval("1.6"), appContext: appContext, runtime: runtime) == 2)
+    #expect(try Int.decode(runtime.eval("1.4"), appContext: appContext, runtime: runtime) == 1)
+    #expect(try Int.decode(runtime.eval("-1.6"), appContext: appContext, runtime: runtime) == -2)
+  }
+
+  @Test
+  func `integer decode throws instead of trapping on out-of-range or non-finite numbers`() throws {
+    let runtime = try runtime
+    #expect(throws: IntegerOutOfRangeException.self) {
+      _ = try Int8.decode(runtime.eval("200"), appContext: appContext, runtime: runtime)
+    }
+    #expect(throws: IntegerOutOfRangeException.self) {
+      _ = try Int.decode(runtime.eval("1e308"), appContext: appContext, runtime: runtime)
+    }
+    #expect(throws: IntegerOutOfRangeException.self) {
+      _ = try Int.decode(runtime.eval("NaN"), appContext: appContext, runtime: runtime)
+    }
+  }
+
+  // MARK: - Float / CGFloat
+
+  @Test
+  func `decodes and encodes float and cgfloat`() throws {
+    let runtime = try runtime
+    #expect(try Float.decode(runtime.eval("1.5"), appContext: appContext, runtime: runtime) == 1.5)
+    #expect(try CGFloat.encode(2.5, appContext: appContext, runtime: runtime).getDouble() == 2.5)
+  }
+
+  // MARK: - Bool
+
+  @Test
+  func `decodes and encodes a bool`() throws {
+    let runtime = try runtime
+    #expect(try Bool.decode(runtime.eval("true"), appContext: appContext, runtime: runtime) == true)
+    #expect(try Bool.encode(false, appContext: appContext, runtime: runtime).getBool() == false)
+  }
+
+  // MARK: - String
+
+  @Test
+  func `decodes and encodes a string`() throws {
+    let runtime = try runtime
+    #expect(try String.decode(runtime.eval("'expo'"), appContext: appContext, runtime: runtime) == "expo")
+    #expect(try String.encode("modules", appContext: appContext, runtime: runtime).getString() == "modules")
+  }
+
+  // MARK: - Zero-copy borrowed-value overload
+
+  @Test
+  func `decodes primitives from a borrowed argument buffer`() throws {
+    // Each `decode` resolves to the borrowing `JavaScriptUnownedValue` overload (the fast path the
+    // macro emits for arguments), exercising the per-type overrides rather than the owning form.
+    let runtime = try runtime
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: 42, 3.5, "expo", true)
+    #expect(try Int.decode(buffer.unownedValue(at: 0), appContext: appContext, runtime: runtime) == 42)
+    #expect(try Double.decode(buffer.unownedValue(at: 1), appContext: appContext, runtime: runtime) == 3.5)
+    #expect(try String.decode(buffer.unownedValue(at: 2), appContext: appContext, runtime: runtime) == "expo")
+    #expect(try Bool.decode(buffer.unownedValue(at: 3), appContext: appContext, runtime: runtime) == true)
+  }
+
+  // MARK: - Error paths
+
+  @Test
+  func `decode throws on a wrong-typed primitive instead of crashing`() throws {
+    let runtime = try runtime
+    #expect(throws: JavaScriptValue.TypeError.self) {
+      _ = try String.decode(runtime.eval("42"), appContext: appContext, runtime: runtime)
+    }
+    #expect(throws: JavaScriptValue.TypeError.self) {
+      _ = try Double.decode(runtime.eval("'not a number'"), appContext: appContext, runtime: runtime)
+    }
+    #expect(throws: JavaScriptValue.TypeError.self) {
+      _ = try Bool.decode(runtime.eval("'true'"), appContext: appContext, runtime: runtime)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableRecordTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableRecordTests.swift
@@ -1,0 +1,62 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+// A record synthesized by the `@Record` macro, declared at file scope so the macro emits its
+// `extension … : Record {}` in a top-level context.
+@Record
+struct CodablePoint: Equatable {
+  var x: Double = 0
+  var y: Double = 0
+}
+
+@Suite("JavaScriptCodable+Record")
+@JavaScriptActor
+struct JavaScriptCodableRecordTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  @Test
+  func `decodes a record from a JS object`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 1.5, y: 2.5 })")
+    let decoded = try CodablePoint.decode(value, appContext: appContext, runtime: runtime)
+    #expect(decoded == CodablePoint(x: 1.5, y: 2.5))
+  }
+
+  @Test
+  func `encodes a record to a JS object`() throws {
+    let runtime = try runtime
+    let encoded = try CodablePoint.encode(CodablePoint(x: 3, y: 4), appContext: appContext, runtime: runtime)
+    let object = encoded.getObject()
+    #expect(object.getProperty("x").getDouble() == 3)
+    #expect(object.getProperty("y").getDouble() == 4)
+  }
+
+  @Test
+  func `round-trips a record`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 10, y: 20 })")
+    let decoded = try CodablePoint.decode(value, appContext: appContext, runtime: runtime)
+    let reencoded = try CodablePoint.encode(decoded, appContext: appContext, runtime: runtime)
+    let object = reencoded.getObject()
+    #expect(object.getProperty("x").getDouble() == 10)
+    #expect(object.getProperty("y").getDouble() == 20)
+  }
+
+  @Test
+  func `decodes a record nested in an array`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("[{ x: 1, y: 1 }, { x: 2, y: 2 }]")
+    let decoded = try [CodablePoint].decode(value, appContext: appContext, runtime: runtime)
+    #expect(decoded == [CodablePoint(x: 1, y: 1), CodablePoint(x: 2, y: 2)])
+  }
+}


### PR DESCRIPTION
## Why

The current JS↔native conversion path (`AnyDynamicType`) is type-erased: function arguments are collected into a `[Any]` array, resolved through a runtime dynamic-type lookup, and reassembled into a tuple via `toTuple`. That boxing and dynamic dispatch is the biggest per-call cost on the conversion path.

This introduces a statically-dispatched, non-erasing alternative for Expo Modules v2, where the macro-synthesized bindings know each argument's concrete type at expansion time. It coexists with `AnyDynamicType` (v1 modules are unchanged); v2 macro output will target this path.

## How

A direction-split protocol pair, composed as a type alias:

- `JavaScriptDecodable`: `static func decode(_:appContext:runtime:) -> Self` (returns concrete `Self`, no `Any`/`as!`).
- `JavaScriptEncodable`: `static func encode(_:appContext:runtime:) -> JavaScriptValue`.
- `JavaScriptCodable = JavaScriptDecodable & JavaScriptEncodable` for types that go both ways.

The two directions are separate protocols (rather than one combined protocol) because some types convert only one way. For example `CMTime` and `Date` are parsed from JS arguments but have no native-to-JS form today (decode-only), and the planned `Either` / `ValueOrUndefined` input wrappers are similarly argument-only; conversely a native-only result type can be return-only (encode-only). Splitting lets each type conform to exactly the half it uses instead of being forced to implement (or stub) the other direction. `JavaScriptCodable` is a type alias rather than a third protocol so that satisfying both halves is automatically enough, with no extra conformance to declare. It also mirrors the standard library's `Decodable` / `Encodable` / `Codable`.

Design points:

- **Two `decode` overloads.** The owning `JavaScriptValue` form is the requirement (correct for values that escape). A defaulted `borrowing JavaScriptUnownedValue` fast-path overload reads the argument straight off the buffer with no `jsi::Value` copy. Leaf primitives and `Optional` override it to stay zero-copy; others fall back to materializing.
- **Two trailing parameters, not a context struct:** `appContext` plus `borrowing runtime`. `runtime` is borrowed (read-only, no ARC) and passed explicitly to avoid the throwing `appContext.runtime` getter. `appContext` stays owned because the SharedObject path escapes it.
- **`@inlinable`** on the conformances so they specialize across the resilient prebuilt-xcframework boundary (`BUILD_LIBRARY_FOR_DISTRIBUTION`).
- **Errors stay plain `throws`.** Conformers are expected to throw `JavaScriptThrowable`-conforming errors (documented on the protocols) so they surface to JavaScript. Typed throws is not used: a protocol existential cannot appear in a `throws(...)` clause, and a single concrete error type would not fit the variety of converter failures.

Conformances in this change: primitives (`Bool`, `String`, the integer and floating-point families), containers (`Array`, `Optional`, `Dictionary`), `Record`, `JavaScriptValue` passthrough, `Enumerable`, and `Data` (to and from `Uint8Array`). `Void` is handled by the macro (it is `()` and cannot conform).

## Future direction

This commit is the foundation of the v2 conversion path. It lands the protocol and the common conformances on their own so the surface can be reviewed in isolation, ahead of the pieces that build on it:

- **The v2 macro is the real call site.** The `@ExpoModule` / `@Record` / `@SharedObject` macros will emit bindings that call `T.decode(...)` / `T.encode(...)` with the concrete type known at expansion. That removes the `[Any]` array, the per-argument dynamic-type lookup, and the `toTuple` step entirely. This PR provides the converters those bindings target.
- **Remaining type coverage (follow-ups):** `SharedObject` (its open-class `Self` narrowing and registry pairing need their own change), the CoreGraphics/Foundation `Convertible`s (`URL`, `Date`, `CGPoint`/`CGSize`/`CGRect`/`CGVector`, `CMTime`, `UIColor`, `CGColor`), and `Either`/`ValueOrUndefined`.
- **Performance gate:** the `@inlinable` win depends on the conformances actually specializing across the prebuilt, library-evolution boundary. This is to be confirmed by benchmark before relying on it; if specialization does not fire, the macro can emit the container/record traversal inline instead.
- **Possible v1 convergence:** full replacement of `AnyDynamicType` is not in scope (its runtime argument-buffer call shape has no static element types), but its converters could later delegate to this path to unify the conversion logic, and the variadic-generic DSL factories (`Function<R, each A>`) could adopt the static path directly, giving hand-written modules the same fast path without the macro.

## ABI note

This adds protocol inheritance (`JavaScriptDecodable`, `JavaScriptEncodable`) to the released public protocols `Record` and `Enumerable`, so the PR carries the `breaking: ABI` label. The practical risk is low and it is **not a hazard for already-prebuilt binaries**: the new conformances are additive (new symbols old binaries never reference), and the refinement appends inherited protocols without reordering either protocol's existing requirements, so a consumer prebuilt against the previous core keeps the witness-table offsets it uses and cannot reference the new surface (it did not exist when that consumer was compiled). The only forward exposure is the standard contract that a module prebuilt against the new core must be linked against a matching core, which already governs the prebuilt xcframework distribution.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-core`. The new suites (`JavaScriptCodable+Primitives`, `+Containers`, `+Builtins`, `+Record`) pass, covering decode/encode/round-trip for each type, nested containers, records nested in arrays, string- and int-backed enums, and `Data` to and from `Uint8Array`.

> Note: the pre-existing `ColorConvertiblesTests` HSL failures on this branch are unrelated to this change (no Color code is touched).



