### PR TITLE
[docs] Document developmentClient build profile requirement on dev-client page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -23,6 +23,23 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
+When you create a build with EAS Build, set `developmentClient` to `true` on a build profile in your **eas.json**. Without it, EAS Build produces a standalone build with no development tools. For example:
+
+```json eas.json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+      /* @hide ... */ /* @end */
+    }
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+For more information, see the [`developmentClient` property in the eas.json reference](/eas/json/#developmentclient).
+
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app config
@@ -101,9 +118,8 @@ You can configure development client launcher using its built-in [config plugin]
 
 ## TV support
 
-- This library is only supported for TV in SDK 54 and later.
-  - **Android TV**: All operations are supported, similar to an Android phone.
-  - **Apple TV**: Basic operations with a local or tunneled packager are supported. Authentication to EAS and listing of EAS builds and updates is not yet supported.
+- **Android TV**: All operations are supported, similar to an Android phone.
+- **Apple TV**: Basic operations with a local or tunneled packager are supported. Authentication to EAS and listing of EAS builds and updates is not yet supported.
 
 ## API
 

--- a/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
@@ -23,6 +23,23 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
+When you create a build with EAS Build, set `developmentClient` to `true` on a build profile in your **eas.json**. Without it, EAS Build produces a standalone build with no development tools. For example:
+
+```json eas.json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+      /* @hide ... */ /* @end */
+    }
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+For more information, see the [`developmentClient` property in the eas.json reference](/eas/json/#developmentclient).
+
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app config
@@ -101,9 +118,8 @@ You can configure development client launcher using its built-in [config plugin]
 
 ## TV support
 
-- This library is only supported for TV in SDK 54 and later.
-  - **Android TV**: All operations are supported, similar to an Android phone.
-  - **Apple TV**: Basic operations with a local or tunneled packager are supported. Authentication to EAS and listing of EAS builds and updates is not yet supported.
+- **Android TV**: All operations are supported, similar to an Android phone.
+- **Apple TV**: Basic operations with a local or tunneled packager are supported. Authentication to EAS and listing of EAS builds and updates is not yet supported.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21884

# How

On the `expo-dev-client` SDK reference page (current `v56.0.0` and `unversioned`), the Installation section now documents that EAS Build requires `developmentClient: true` per build profile in `eas.json`, with a minimal snippet and a link to the `eas.json` reference. 

The TV support section also drops the stale "supported for TV in SDK 54 and later" line, since both pages are already in that range.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2420" height="1276" alt="CleanShot 2026-06-15 at 00 36 48@2x" src="https://github.com/user-attachments/assets/18f14ce0-07c3-4c55-8d61-489a51af4ade" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
