### PR TITLE
[ios][core] Add public ArgumentsRangeMismatch exception

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9. ([#46769](https://github.com/expo/expo/pull/46769) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] `@ExpoModule` now synthesizes a `_decorateModule` that binds the module's `@JS` functions directly onto the JS object, letting the module holder skip the dynamic definition path for synthesized modules. ([#46612](https://github.com/expo/expo/pull/46612) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added the public `Exceptions.ArgumentsRangeMismatch` exception, thrown by synthesized `@JS` function bindings when a JavaScript caller passes a number of arguments outside the accepted range. ([#46901](https://github.com/expo/expo/pull/46901) by [@tsapeta](https://github.com/tsapeta))
 - Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `SharedObject::NativeState` now derives from `expo::NativeState` so the Swift wrapper can be recovered from the JS side via `getNativeState`, laying the groundwork for native-state-based shared object lookup. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
@@ -55,6 +55,21 @@ public struct Exceptions {
   }
 
   /**
+   An exception to throw when a JavaScript caller passes a number of arguments outside the range the
+   native function accepts. The accepted range spans the required count (total minus the trailing run
+   of parameters that have a default value or an optional type) through the maximum (total parameters).
+   Thrown by the bindings the Expo Modules macros synthesize for `@JS` functions.
+   */
+  public final class ArgumentsRangeMismatch: GenericException<(functionName: String, received: Int, required: Int, maximum: Int)> {
+    override public var reason: String {
+      if param.required == param.maximum {
+        return "'\(param.functionName)' takes \(param.maximum) argument(s), but received \(param.received)"
+      }
+      return "'\(param.functionName)' takes from \(param.required) to \(param.maximum) arguments, but received \(param.received)"
+    }
+  }
+
+  /**
    An exception to throw when there is no module implementing the `EXFileSystemInterface` interface.
    */
   public final class FileSystemModuleNotFound: Exception {


### PR DESCRIPTION
## Why

The Expo Modules macros synthesize a `_decorateModule` that binds each `@JS` function directly onto the module's JS object. Those synthesized bindings need to validate the argument count a JavaScript caller passes. The generated code currently throws an ad-hoc `Exception(name: "InvalidArgumentCount", ...)`, which doesn't express the accepted *range* (a function with trailing defaulted or optional parameters accepts a span of arities, not one exact count) and isn't a typed exception modules can match on.

This adds a dedicated, public exception purpose-built for that validation, so the synthesized bindings throw a consistent typed error and the message can describe the full accepted range.

## How

Added `Exceptions.ArgumentsRangeMismatch`, a public `GenericException<(functionName: String, received: Int, range: ClosedRange<Int>)>` in the `Exceptions` namespace (alongside `AppContextLost`, etc., which the generated code already references). It carries the function name and the accepted arity range, and renders two message forms:

- exact arity: `'add' takes 2 argument(s), but received 1`
- range: `'resize' takes from 1 to 2 arguments, but received 3`

The paired macro change that emits the range-based arity guard throwing this exception is in expo/expo-modules-macros-plugin#19. This PR is the core half; it must land together with that plugin change, which references this exception.

## Test Plan

`Exceptions.ArgumentsRangeMismatch` is a small, self-contained exception subclass. Its `reason` text and the `ClosedRange<Int>` parameter were verified with a standalone Swift check:

```
'add' takes 2 argument(s), but received 1
'resize' takes from 1 to 2 arguments, but received 3
'opt' takes from 0 to 1 arguments, but received 5
```

The macro side that emits the throw is covered by expansion tests in the plugin repo (`swift test`, 86 passing), including new cases for a trailing defaulted parameter, a trailing optional parameter, and an all-omittable signature (`required == 0`).
