### PR TITLE
[docs] Document `on.ref_delete` workflow trigger

### DIFF
--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -40,7 +40,7 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 - **Pre-packaged for React Native/Expo**: Comes with ready-to-use job types (`build`, `submit`, `update`, `maestro`, `deploy`, and more) that abstract away implementation complexity
 - **No infrastructure to manage**: Runs on EAS with macOS and Linux workers, so you don't need to maintain CI servers or configure Android Studio/Xcode
 - **Unified artifact management**: All build artifacts, updates, and logs appear on EAS dashboard
-- **GitHub integration**: Trigger workflows automatically on push, pull request, or label events with branch and path filtering
+- **GitHub integration**: Trigger workflows automatically on push, pull request, label, or ref deletion events with branch and path filtering
 - **Faster iteration**: Combine Fingerprint, Get Build, and Update jobs to avoid redundant native builds and publish OTA (over-the-air) updates when possible
 - **E2E testing built-in**: Run Maestro tests on Android emulators and iOS simulators directly in workflows
 - **Slack notifications**: Send notifications to Slack channels when workflows run successfully or fail
@@ -51,6 +51,12 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 ### Push workflows
 
 Run when commits are pushed to matching branches or tags. Supports branch, tag, and path filtering with glob patterns.
+
+### Ref delete workflows
+
+Run when GitHub branches or tags are deleted. Supports branch and tag filtering with glob patterns. Useful for cleaning up EAS Update branches that share names with Git branches.
+
+See [`on.ref_delete` syntax reference](/eas/workflows/syntax/#onref_delete).
 
 ### Pull request workflows
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -122,6 +122,7 @@ on:
       - feat/**
       - !main # other branch names and globs
 
+
     tags:
       - v*
       - !v2-preview** # other tag names and globs

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -105,7 +105,7 @@ on:
 
 Runs your workflow when a GitHub branch or tag is deleted. Requires a [linked GitHub repository](/eas/workflows/get-started/#automate-workflows-with-github-events) on your EAS project.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are deleted. For example, if you use `branches: ['main']`, only deletion of the `main` branch triggers the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it). See [`on.push`](#onpush) for details on glob and negation pattern matching.
+With the `branches` list, you can trigger the workflow only when those specified branches are deleted. For example, if you use `branches: ['feat/**']`, only deletion of branches matching `feat/**` triggers the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it). See [`on.push`](#onpush) for details on glob and negation pattern matching.
 
 With the `tags` list, you can trigger the workflow only when those specified tags are deleted. Supports globs and `!` negation with the same rules as branches.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -122,7 +122,6 @@ on:
       - feat/**
       - !main # other branch names and globs
 
-
     tags:
       - v*
       - !v2-preview** # other tag names and globs

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -69,13 +69,13 @@ on:
 
 Runs your workflow when you push a commit to matching branches and/or tags.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only pushes to the `main` branch will trigger the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
+With the `branches` list, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only pushes to the `main` branch trigger the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
 
-With the `tags` list, you can trigger the workflow only when those specified tags are pushed. For example, if you use `tags: ['v1']`, only the `v1` tag being pushed will trigger the workflow. Supports globs. By using the `!` prefix you can specify tags to ignore (you still need to provide at least one tag pattern without it).
+With the `tags` list, you can trigger the workflow only when those specified tags are pushed. For example, if you use `tags: ['v1']`, only the `v1` tag being pushed triggers the workflow. Supports globs. By using the `!` prefix you can specify tags to ignore (you still need to provide at least one tag pattern without it).
 
-With the `paths` list, you can trigger the workflow only when changes are made to files matching the specified paths. For example, if you use `paths: ['apps/mobile/**']`, only changes to files in the `apps/mobile` directory will trigger the workflow. Supports globs. By default, changes to any path will trigger the workflow.
+With the `paths` list, you can trigger the workflow only when changes are made to files matching the specified paths. For example, if you use `paths: ['apps/mobile/**']`, only changes to files in the `apps/mobile` directory trigger the workflow. Supports globs. By default, changes to any path trigger the workflow.
 
-When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow will trigger on push events to all branches and will not trigger on tag pushes. If only one of the two lists is provided the other defaults to `[]`.
+When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow triggers on push events to all branches and does not trigger on tag pushes. If only one of the two lists is provided the other defaults to `[]`.
 
 ```yaml
 on:
@@ -105,11 +105,11 @@ on:
 
 Runs your workflow when a GitHub branch or tag is deleted. Requires a [linked GitHub repository](/eas/workflows/get-started/#automate-workflows-with-github-events) on your EAS project.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are deleted. For example, if you use `branches: ['main']`, only deletion of the `main` branch will trigger the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it). See [`on.push`](#onpush) for details on glob and negation pattern matching.
+With the `branches` list, you can trigger the workflow only when those specified branches are deleted. For example, if you use `branches: ['main']`, only deletion of the `main` branch triggers the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it). See [`on.push`](#onpush) for details on glob and negation pattern matching.
 
 With the `tags` list, you can trigger the workflow only when those specified tags are deleted. Supports globs and `!` negation with the same rules as branches.
 
-When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow will trigger when any branch is deleted and will not trigger on tag deletions. If only one of the two lists is provided the other defaults to `[]`.
+When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow triggers when any branch is deleted and does not trigger on tag deletions. If only one of the two lists is provided the other defaults to `[]`.
 
 > **info** Workflow files are read from the default branch HEAD at the time of deletion, not from the deleted ref.
 
@@ -133,9 +133,9 @@ on:
 
 Runs your workflow when you create or update a pull request that targets one of the matching branches.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to merge into the main branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
+With the `branches` list, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to merge into the main branch trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow triggers on pull request events to all branches. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
 
-With the `types` list, you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']`, only the `pull_request.opened` event (sent when a pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
+With the `types` list, you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']`, only the `pull_request.opened` event (sent when a pull request is first opened) triggers the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
 
 - `opened`
 - `ready_for_review`
@@ -143,7 +143,7 @@ With the `types` list, you can trigger the workflow only on the specified pull r
 - `synchronize`
 - `labeled`
 
-With the `paths` list, you can trigger the workflow only when changes are made to files matching the specified paths. For example, if you use `paths: ['apps/mobile/**']`, only changes to files in the `apps/mobile` directory will trigger the workflow. Supports globs. By default, changes to any path will trigger the workflow.
+With the `paths` list, you can trigger the workflow only when changes are made to files matching the specified paths. For example, if you use `paths: ['apps/mobile/**']`, only changes to files in the `apps/mobile` directory trigger the workflow. Supports globs. By default, changes to any path trigger the workflow.
 
 ```yaml
 on:
@@ -171,7 +171,7 @@ on:
 
 Runs your workflow when a pull request is labeled with a matching label.
 
-With the `labels` list, you can specify which labels, when assigned to your pull request, will trigger the workflow. For example, if you use `labels: ['Test']`, only labeling a pull request with the `Test` label will trigger the workflow. Defaults to `[]` when not provided, which means no labels will trigger the workflow.
+With the `labels` list, you can specify which labels, when assigned to your pull request, trigger the workflow. For example, if you use `labels: ['Test']`, only labeling a pull request with the `Test` label triggers the workflow. Defaults to `[]` when not provided, which means no labels trigger the workflow.
 
 You can also provide a list of matching labels directly to `on.pull_request_labeled` for simpler syntax.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -101,6 +101,34 @@ on:
 
 ```
 
+### `on.ref_delete`
+
+Runs your workflow when a GitHub branch or tag is deleted. Requires a [linked GitHub repository](/eas/workflows/get-started/#automate-workflows-with-github-events) on your EAS project.
+
+With the `branches` list, you can trigger the workflow only when those specified branches are deleted. For example, if you use `branches: ['main']`, only deletion of the `main` branch will trigger the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it). See [`on.push`](#onpush) for details on glob and negation pattern matching.
+
+With the `tags` list, you can trigger the workflow only when those specified tags are deleted. Supports globs and `!` negation with the same rules as branches.
+
+When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow will trigger when any branch is deleted and will not trigger on tag deletions. If only one of the two lists is provided the other defaults to `[]`.
+
+> **info** Workflow files are read from the default branch HEAD at the time of deletion, not from the deleted ref.
+
+```yaml
+on:
+  # @info #
+  ref_delete:
+    # @end #
+    branches:
+      - feat/**
+      - !main # other branch names and globs
+
+
+    tags:
+      - v*
+      - !v2-preview** # other tag names and globs
+
+```
+
 ### `on.pull_request`
 
 Runs your workflow when you create or update a pull request that targets one of the matching branches.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added the `on.ref_delete` EAS workflows trigger, we need to add user-facing documentation.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added the `on.ref_delete` section in the EAS workflows syntax documentation. Updated the workflows introduction doc by referencing this trigger among other GitHub triggers.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders properly:

<img width="800" height="775" alt="image" src="https://github.com/user-attachments/assets/c42e08e8-69df-4c9f-b6a5-78b0166a692d" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
