### PR TITLE
[docs] Document branch-delete workflow job

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -475,6 +475,7 @@ export const eas = [
       makePage('eas/workflows/examples/introduction.mdx'),
       makePage('eas/workflows/examples/create-development-builds.mdx'),
       makePage('eas/workflows/examples/publish-preview-update.mdx'),
+      makePage('eas/workflows/examples/branch-cleanup.mdx'),
       makePage('eas/workflows/examples/deploy-to-production.mdx'),
       makePage('eas/workflows/examples/e2e-tests.mdx'),
     ]),

--- a/docs/pages/eas/workflows/examples/branch-cleanup.mdx
+++ b/docs/pages/eas/workflows/examples/branch-cleanup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Clean up EAS Update branches with EAS Workflows
 sidebar_title: Clean up update branches
-description: Learn how to delete EAS Update branches when GitHub branches are deleted.
+description: Learn how to delete EAS Update branches when GitHub branches are deleted using EAS Workflows.
 hideTOC: true
 ---
 

--- a/docs/pages/eas/workflows/examples/branch-cleanup.mdx
+++ b/docs/pages/eas/workflows/examples/branch-cleanup.mdx
@@ -46,7 +46,7 @@ jobs:
 ## How it works
 
 1. [`on.ref_delete`](/eas/workflows/syntax/#onref_delete) runs when a GitHub branch matching the patterns is deleted. The example above triggers on all branches except `main`.
-2. The [`branch-delete`](/eas/workflows/pre-packaged-jobs#branch-delete) job deletes the EAS Update branch named `${{ github.ref_name }}` — the same name as the deleted Git branch.
+2. The [`branch-delete`](/eas/workflows/pre-packaged-jobs#branch-delete) job deletes the EAS Update branch named `${{ github.ref_name }}`, the same name as the deleted Git branch.
 3. With the default `fail_on_missing: false`, the job succeeds even if the EAS Update branch was already deleted or never existed.
 
 ## Important notes

--- a/docs/pages/eas/workflows/examples/branch-cleanup.mdx
+++ b/docs/pages/eas/workflows/examples/branch-cleanup.mdx
@@ -2,7 +2,6 @@
 title: Clean up EAS Update branches with EAS Workflows
 sidebar_title: Clean up update branches
 description: Learn how to delete EAS Update branches when GitHub branches are deleted using EAS Workflows.
-hideTOC: true
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';

--- a/docs/pages/eas/workflows/examples/branch-cleanup.mdx
+++ b/docs/pages/eas/workflows/examples/branch-cleanup.mdx
@@ -1,0 +1,56 @@
+---
+title: Clean up EAS Update branches with EAS Workflows
+sidebar_title: Clean up update branches
+description: Learn how to delete EAS Update branches when GitHub branches are deleted.
+hideTOC: true
+---
+
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { Terminal } from '~/ui/components/Snippet';
+
+If you publish updates to EAS Update branches named after GitHub branches, for example with [`eas update --auto`](/eas-update/eas-cli/#create-a-new-update-and-publish-it), the [`update` workflow job](/eas/workflows/pre-packaged-jobs#update) with `branch: ${{ github.ref_name }}`, or [preview updates on every branch](/eas/workflows/examples/publish-preview-update), deleting the GitHub branch leaves the EAS Update branch behind. This workflow cleans up when a Git branch is deleted.
+
+## Get started
+
+<Prerequisites>
+  <Requirement title="Set up EAS Update">
+    Your project needs to have [EAS Update](/eas-update/introduction/) configured. You can set up your project with:
+
+    <Terminal cmd={['$ eas update:configure']} />
+
+  </Requirement>
+  <Requirement title="Connect your GitHub repository">
+    Your EAS project must be linked to a GitHub repository. See [Get started with EAS Workflows](/eas/workflows/get-started/#automate-workflows-with-github-events).
+  </Requirement>
+  <Requirement title="Workflow file on the default branch">
+    Keep this workflow file on your repository's default branch. When a branch is deleted, EAS reads workflow configuration from the default branch HEAD, not from the deleted ref.
+  </Requirement>
+</Prerequisites>
+
+The following workflow deletes the EAS Update branch with the same name as the deleted GitHub branch:
+
+```yaml .eas/workflows/branch-cleanup.yml
+name: Branch cleanup
+
+on:
+  ref_delete:
+    branches: ['*', '!main']
+
+jobs:
+  delete-update-branch:
+    type: branch-delete
+    params:
+      branch_name: ${{ github.ref_name }}
+```
+
+## How it works
+
+1. [`on.ref_delete`](/eas/workflows/syntax/#onref_delete) runs when a GitHub branch matching the patterns is deleted. The example above triggers on all branches except `main`.
+2. The [`branch-delete`](/eas/workflows/pre-packaged-jobs#branch-delete) job deletes the EAS Update branch named `${{ github.ref_name }}` — the same name as the deleted Git branch.
+3. With the default `fail_on_missing: false`, the job succeeds even if the EAS Update branch was already deleted or never existed.
+
+## Important notes
+
+- `github.sha` is the default branch, not the deleted ref's last commit. See the [`github` context reference](/eas/workflows/syntax/#github) for interpolation details on `ref_delete` runs.
+- Channel mappings block deletion: if a channel points to the EAS Update branch, deletion fails with an error about the channel mapping.
+- Protect branches you never want cleaned up using negation patterns like `!main` or `!release/**` in `on.ref_delete.branches`.

--- a/docs/pages/eas/workflows/examples/branch-cleanup.mdx
+++ b/docs/pages/eas/workflows/examples/branch-cleanup.mdx
@@ -8,7 +8,7 @@ hideTOC: true
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
-If you publish updates to EAS Update branches named after GitHub branches, for example with [`eas update --auto`](/eas-update/eas-cli/#create-a-new-update-and-publish-it), the [`update` workflow job](/eas/workflows/pre-packaged-jobs#update) with `branch: ${{ github.ref_name }}`, or [preview updates on every branch](/eas/workflows/examples/publish-preview-update), deleting the GitHub branch leaves the EAS Update branch behind. This workflow cleans up when a Git branch is deleted.
+You might publish updates to EAS Update branches named after GitHub branches, for example with [`eas update --auto`](/eas-update/eas-cli/#create-a-new-update-and-publish-it), the [`update` workflow job](/eas/workflows/pre-packaged-jobs#update) with `branch: ${{ github.ref_name }}`, or [preview updates on every branch](/eas/workflows/examples/publish-preview-update). When you do, deleting the GitHub branch leaves the EAS Update branch behind. This workflow cleans up the orphaned EAS Update branch when a Git branch is deleted.
 
 ## Get started
 

--- a/docs/pages/eas/workflows/examples/introduction.mdx
+++ b/docs/pages/eas/workflows/examples/introduction.mdx
@@ -28,6 +28,13 @@ The following workflows are examples of how you can use EAS Workflows to automat
 />
 
 <BoxLink
+  title="Clean up update branches"
+  description="Learn how to delete EAS Update branches when GitHub branches are deleted."
+  href="/eas/workflows/examples/branch-cleanup"
+  Icon={Dataflow03Icon}
+/>
+
+<BoxLink
   title="Deploy to production"
   description="Learn how to build and submit to the app stores or send an over-the-air update when merging to main."
   href="/eas/workflows/examples/deploy-to-production"

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -902,11 +902,10 @@ You can pass the following parameters into the `params` list:
 
 You can reference the following outputs in subsequent jobs:
 
-| Output                    | Type   | Description                                                                                       |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
-| branch_id                 | string | UUID of the deleted branch, or `null` if the branch was missing and `fail_on_missing` is `false`. |
-| branch_name               | string | The branch name from `params.branch_name`.                                                        |
-| background_job_receipt_id | string | Set once background deletion is dispatched.                                                       |
+| Output      | Type   | Description                                                                                       |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------- |
+| branch_id   | string | UUID of the deleted branch, or `null` if the branch was missing and `fail_on_missing` is `false`. |
+| branch_name | string | The branch name from `params.branch_name`.                                                        |
 
 ### Examples
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -908,7 +908,7 @@ You can reference the following outputs in subsequent jobs:
 | branch_name               | string | The branch name from `params.branch_name`.                                                        |
 | background_job_receipt_id | string | Set once background deletion is dispatched.                                                       |
 
-### Example
+### Examples
 
 See [Clean up update branches example](/eas/workflows/examples/branch-cleanup) for a workflow that uses [`on.ref_delete`](/eas/workflows/syntax/#onref_delete) with the `branch-delete` job.
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -874,6 +874,44 @@ jobs:
 
 </Collapsible>
 
+## Branch delete
+
+Delete an [EAS Update](/eas-update/introduction/) branch in the current project. The same as [`eas branch:delete`](/eas-update/eas-cli/#delete-a-branch). Pass the EAS Update branch name in `branch_name`.
+
+### Syntax
+
+```yaml
+jobs:
+  delete_branch:
+    type: branch-delete
+    params:
+      branch_name: string # required
+      fail_on_missing: boolean # optional, default: false
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter       | Type    | Description                                                                                                                                                    |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| branch_name     | string  | Required. Name of the EAS Update branch to delete.                                                                                                             |
+| fail_on_missing | boolean | If `false`, the job succeeds when the branch does not exist. If `true`, the job fails with a validation error when the branch is missing. Defaults to `false`. |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                    | Type   | Description                                                                                       |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| branch_id                 | string | UUID of the deleted branch, or `null` if the branch was missing and `fail_on_missing` is `false`. |
+| branch_name               | string | The branch name from `params.branch_name`.                                                        |
+| background_job_receipt_id | string | Set once background deletion is dispatched.                                                       |
+
+### Example
+
+See [Clean up update branches example](/eas/workflows/examples/branch-cleanup) for a workflow that uses [`on.ref_delete`](/eas/workflows/syntax/#onref_delete) with the `branch-delete` job.
+
 ## Maestro
 
 Run Maestro tests on an Android Emulator or iOS Simulator build.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1295,8 +1295,7 @@ This job outputs the following properties:
 ```json
 {
   "branch_id": string | null,
-  "branch_name": string,
-  "background_job_receipt_id": string
+  "branch_name": string
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -122,6 +122,7 @@ on:
       - feat/**
       - !main # other branch names and globs
 
+
     tags:
       - v*
       - !v2-preview** # other tag names and globs

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -122,7 +122,6 @@ on:
       - feat/**
       - !main # other branch names and globs
 
-
     tags:
       - v*
       - !v2-preview** # other tag names and globs

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -113,6 +113,8 @@ When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` 
 
 > **info** Workflow files are read from the default branch HEAD at the time of deletion, not from the deleted ref.
 
+Pair this trigger with the [`branch-delete`](/eas/workflows/pre-packaged-jobs#branch-delete) job to remove EAS Update branches when GitHub branches are deleted. See the [Clean up update branches example](/eas/workflows/examples/branch-cleanup) for a complete workflow.
+
 ```yaml
 on:
   # @info #
@@ -1270,6 +1272,31 @@ This job outputs the following properties:
 {
   "first_update_group_id": string, // ID of the first update group. You can use it to e.g. construct the update URL for a development client deep link.
   "updates_json": string // Stringified JSON array of update groups. Output of `eas update --json`.
+}
+```
+
+#### `branch-delete`
+
+Deletes an EAS Update branch and all of its updates. See [Branch delete job documentation](/eas/workflows/pre-packaged-jobs#branch-delete) for detailed information and examples.
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    type: branch-delete
+    # @end #
+    params:
+      branch_name: string # required
+      fail_on_missing: boolean # optional, default: false
+```
+
+This job outputs the following properties:
+
+```json
+{
+  "branch_id": string | null,
+  "branch_name": string,
+  "background_job_receipt_id": string
 }
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added the `branch-delete` workflow job support, now we need to add user-facing docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Document the `branch-delete` pre-packaged job (params, outputs) in syntax and pre-packaged jobs.
- Add a "Clean up update branches" workflow example and link it from the examples index, workflows introduction, and navigation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="801" height="1128" alt="image" src="https://github.com/user-attachments/assets/11ffeaca-6dfb-4a99-a7ce-5c00af6dcd7c" />

<img width="1071" height="1148" alt="image" src="https://github.com/user-attachments/assets/8f8879b7-832f-443c-9d36-7cd2702086e9" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
