### PR TITLE
[ui][Android] Mark `InnerTextFieldProps` and `PlaceholderProps` as optimized

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/textfield/BasicTextField.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/textfield/BasicTextField.kt
@@ -38,6 +38,7 @@ import expo.modules.ui.state.WorkletCallback
  */
 val LocalInnerTextField = compositionLocalOf<(@Composable () -> Unit)?> { null }
 
+@OptimizedComposeProps
 class InnerTextFieldProps : ComposeProps
 
 /**
@@ -63,6 +64,7 @@ class InnerTextFieldView(context: Context, appContext: AppContext) :
  */
 val LocalTextFieldIsEmpty = compositionLocalOf { true }
 
+@OptimizedComposeProps
 class PlaceholderProps : ComposeProps
 
 /**


### PR DESCRIPTION
# Why

Marks `InnerTextFieldProps` and `PlaceholderProps` as optimized. 
It's worth it even for classes without data. 

# Test Plan

- bare-expo ✅ 