### PR TITLE
[core][Android] Do not strip `RNHeadlessAppLoader`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -12,6 +12,7 @@ import expo.modules.core.interfaces.DoNotStrip
 
 private val appRecords: MutableMap<String, ReactContext> = mutableMapOf()
 
+@DoNotStrip
 class RNHeadlessAppLoader @DoNotStrip constructor() : HeadlessAppLoader {
 
   //region HeadlessAppLoader


### PR DESCRIPTION
# Why

Do not strip `RNHeadlessAppLoader` as it's created by the reflection. The current version might not work with an Android-optimized proguard preset. 

# Test Plan

- bare-expo ✅ 