### PR TITLE
[tools] Only build default package set

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7970,85 +7970,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -8394,42 +8381,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -9044,28 +9025,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -9686,49 +9663,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -12890,28 +12859,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -32,7 +32,7 @@ export default (program: Command) => {
   program
     .command('prebuild-packages [packageNames...]')
     .description(
-      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, discovers all packages with spm.config.json.'
+      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.'
     )
     .alias('prebuild')
     .option(
@@ -92,6 +92,11 @@ export default (program: Command) => {
     .option(
       '--external-only',
       'Build only external (third-party) packages. Implies --include-external.',
+      false
+    )
+    .option(
+      '--all-packages',
+      'When no package names are given, build every Expo package with an spm.config.json instead of only the default distributed set.',
       false
     )
     .option(

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -6,7 +6,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { before, describe, it, afterEach } from 'node:test';
 
-import { getVersionsInfoAsync, isNonInteractive, setForceNonInteractive } from './Utils';
+import {
+  getVersionsInfoAsync,
+  isNonInteractive,
+  selectDistributedPackages,
+  setForceNonInteractive,
+  IOS_PREBUILD_PACKAGES,
+} from './Utils';
 import { resolvePackagePath } from './resolvePackage';
 
 // ---------------------------------------------------------------------------
@@ -63,6 +69,34 @@ describe('isNonInteractive', () => {
     process.env.CI = '';
     setForceNonInteractive(false);
     assert.equal(isNonInteractive(), true);
+  });
+});
+
+describe('selectDistributedPackages', () => {
+  const fakePackages = [
+    { packageName: 'expo-modules-core' },
+    { packageName: 'expo-video' },
+    { packageName: 'expo-age-range' },
+    { packageName: 'expo-blur' },
+  ] as any[];
+
+  it('keeps only the distributed set when allPackages is false', () => {
+    const result = selectDistributedPackages(fakePackages, false);
+    assert.deepEqual(
+      result.map((p) => p.packageName),
+      ['expo-modules-core', 'expo-video']
+    );
+  });
+
+  it('returns every package unchanged when allPackages is true', () => {
+    const result = selectDistributedPackages(fakePackages, true);
+    assert.equal(result, fakePackages);
+  });
+
+  it('IOS_PREBUILD_PACKAGES lists the 15 distributed packages', () => {
+    assert.equal(IOS_PREBUILD_PACKAGES.length, 15);
+    assert.ok(IOS_PREBUILD_PACKAGES.includes('expo-modules-core'));
+    assert.ok(!IOS_PREBUILD_PACKAGES.includes('expo-age-range'));
   });
 });
 

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -146,6 +146,39 @@ export const discoverAllSPMPackagesAsync = async (): Promise<SPMPackageSource[]>
 };
 
 /**
+ * Packages whose iOS prebuilt xcframeworks are distributed by default: built by
+ * `et prebuild-packages` with no arguments and bundled into the published npm tarballs.
+ * Many more packages have an `spm.config.json`; pass `--all-packages` to build those too.
+ */
+export const IOS_PREBUILD_PACKAGES = [
+  'expo-brownfield',
+  'expo-camera',
+  'expo-contacts',
+  'expo-file-system',
+  'expo-font',
+  'expo-image',
+  'expo-image-manipulator',
+  'expo-live-photo',
+  'expo-location',
+  'expo-maps',
+  'expo-media-library',
+  'expo-modules-core',
+  'expo-print',
+  'expo-ui',
+  'expo-video',
+];
+
+export const selectDistributedPackages = <T extends { packageName: string }>(
+  expoPackages: T[],
+  allPackages: boolean
+): T[] => {
+  if (allPackages) {
+    return expoPackages;
+  }
+  return expoPackages.filter((pkg) => IOS_PREBUILD_PACKAGES.includes(pkg.packageName));
+};
+
+/**
  * Builds a map from CocoaPods pod name to SPM dependency string
  * (e.g., "UMAppLoader" -> "unimodules-app-loader/UMAppLoader").
  *
@@ -294,22 +327,30 @@ export const validateAllPodNamesAsync = async (
  * @param packageNames Names of packages to verify (if empty, discovers all SPM packages)
  * @param includeExternal Whether to include external packages in discovery (default: true)
  * @param externalOnly Whether to only include external packages (default: false)
+ * @param allPackages When discovering, build every Expo package with an spm.config.json
+ *   instead of only the default distributed set (default: false)
  * @returns Parsed SPMPackageSources that were verified
  */
 export const verifyAllPackagesAsync = async (
   packageNames: string[],
   includeExternal: boolean = true,
-  externalOnly: boolean = false
+  externalOnly: boolean = false,
+  allPackages: boolean = false
 ): Promise<SPMPackageSource[]> => {
-  // If no package names provided, discover all packages with spm.config.json
+  // If no package names provided, discover packages with spm.config.json. By default
+  // only the distributed set is built; --all-packages widens this to every Expo package.
   if (packageNames.length === 0) {
     let packages: SPMPackageSource[];
     if (externalOnly) {
       packages = await discoverExternalPackagesAsync();
     } else if (includeExternal) {
-      packages = await discoverAllSPMPackagesAsync();
+      const [expoPackages, externalPackages] = await Promise.all([
+        discoverPackagesWithSPMConfigAsync(),
+        discoverExternalPackagesAsync(),
+      ]);
+      packages = [...selectDistributedPackages(expoPackages, allPackages), ...externalPackages];
     } else {
-      packages = await discoverPackagesWithSPMConfigAsync();
+      packages = selectDistributedPackages(await discoverPackagesWithSPMConfigAsync(), allPackages);
     }
 
     if (packages.length === 0) {

--- a/tools/src/prebuilds/index.ts
+++ b/tools/src/prebuilds/index.ts
@@ -10,6 +10,8 @@ export {
   discoverAllSPMPackagesAsync,
   discoverPackagesWithSPMConfigAsync,
   getVersionsInfoAsync,
+  IOS_PREBUILD_PACKAGES,
+  selectDistributedPackages,
   validateAllPodNamesAsync,
   validatePodNamesAsync,
   verifyAllPackagesAsync,

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -36,6 +36,7 @@ export type PrebuildCliOptions = {
   platform?: BuildPlatform;
   includeExternal?: boolean;
   externalOnly?: boolean;
+  allPackages?: boolean;
   sign?: string;
   noTimestamp?: boolean;
   verbose: boolean;
@@ -61,6 +62,7 @@ export interface PrebuildRequest {
   readonly platformFilter?: BuildPlatform;
   readonly includeExternal: boolean;
   readonly externalOnly: boolean;
+  readonly allPackages: boolean;
   readonly signing?: SigningOptions;
   readonly verbose: boolean;
   readonly bundleSharedDeps: boolean;
@@ -142,6 +144,7 @@ export function createRequest(
     platformFilter: options.platform,
     includeExternal: !!(options.includeExternal || options.externalOnly),
     externalOnly: options.externalOnly ?? false,
+    allPackages: options.allPackages ?? false,
     signing,
     verbose: options.verbose,
     localTarballTemplates: {

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -498,15 +498,17 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     } else if (request.externalOnly) {
       logger.info(`📦 Discovering external packages with spm.config.json...`);
     } else {
+      const scope = request.allPackages ? 'all' : 'the default distributed set of';
       const externalNote = request.includeExternal ? ' (including external packages)' : '';
-      logger.info(`📦 Discovering packages with spm.config.json${externalNote}...`);
+      logger.info(`📦 Discovering ${scope} packages with spm.config.json${externalNote}...`);
     }
 
-    // 1. Verify packages exist and have spm.config.json (or discover all)
+    // 1. Verify packages exist and have spm.config.json (or discover the default set)
     const requestedPackages = await verifyAllPackagesAsync(
       request.packageNames,
       request.includeExternal,
-      request.externalOnly
+      request.externalOnly,
+      request.allPackages
     );
 
     // 2. Auto-add unbuilt dependencies to the build set

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -7,6 +7,7 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner, spawnAsync } from '../../Utils';
 import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
+import { IOS_PREBUILD_PACKAGES } from '../../prebuilds/Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 /**
@@ -93,27 +94,6 @@ export async function ensureSupportedToolchainAsync(
       `Install Xcode ${SUPPORTED_XCODE_VERSION} from https://developer.apple.com/download/all/ (it can coexist with other Xcodes), or rerun with \`--skip-ios-prebuilds\` if you don't need fresh artifacts.`
   );
 }
-
-/**
- * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
- */
-const IOS_PREBUILD_PACKAGES = [
-  'expo-brownfield',
-  'expo-camera',
-  'expo-contacts',
-  'expo-file-system',
-  'expo-font',
-  'expo-image',
-  'expo-image-manipulator',
-  'expo-live-photo',
-  'expo-location',
-  'expo-maps',
-  'expo-media-library',
-  'expo-modules-core',
-  'expo-print',
-  'expo-ui',
-  'expo-video',
-];
 
 const PRECOMPILE_BUILD_DIR = path.join(PACKAGES_DIR, 'precompile', '.build');
 const FLAVORS = ['debug', 'release'] as const;


### PR DESCRIPTION
# Why
When using `et prebuild-packages` we currently build everything in the monorepo but we only distribute a small set of these. To make the command quicker, we should only build the packages we care about. 

# How
Only build the packages in the `IOS_PREBUILD_PACKAGES` list. I've added the `--all-packages` flag if you want the current behaviour. 

# Test Plan
A full run with `--clean` goes from 21 minutes on my machine to 9
