### PR TITLE
[docs] Fix MCP sync script and sync MCP tools data

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "react-navigation-docs-sync": "node ./scripts/fetch-react-navigation-options.js",
     "eas-cli-sync": "node ./ui/components/EASCLIReference/eas-cli-rerference.js",
     "expo-skills-sync": "node --experimental-strip-types ./ui/components/ExpoSkillsTable/sync-expo-skills.js",
-    "expo-mcp-sync": "node --experimental-strip-types --env-file=.env ./ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js",
+    "expo-mcp-sync": "node --experimental-strip-types ./ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js",
     "install-vale": "node --experimental-strip-types scripts/install-vale.ts",
     "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale"
   },

--- a/docs/ui/components/ExpoMCPToolsTable/data/expo-mcp-tools.json
+++ b/docs/ui/components/ExpoMCPToolsTable/data/expo-mcp-tools.json
@@ -2,7 +2,7 @@
   "source": {
     "server": "https://mcp.expo.dev/mcp",
     "localRepo": "expo/expo-mcp",
-    "fetchedAt": "2026-03-18T10:06:19.629Z"
+    "fetchedAt": "2026-06-15T15:49:08.099Z"
   },
   "totalTools": 25,
   "totalPrompts": 1,
@@ -14,17 +14,17 @@
       "availability": "Server"
     },
     {
+      "name": "read_documentation",
+      "description": "Fetch a single Expo documentation page and return its content as markdown. Returns up to ~5000 tokens per call. Use offset to paginate through long pages.",
+      "examplePrompt": "read the Expo Router docs page",
+      "availability": "Server"
+    },
+    {
       "name": "search_documentation",
       "description": "Search the official Expo documentation and return page URLs ranked by relevance for a user query. Use read_documentation to fetch the full content of specific pages, starting from the top.",
       "examplePrompt": "search documentation for CNG",
       "availability": "Server",
       "requirements": "requires an EAS paid plan"
-    },
-    {
-      "name": "read_documentation",
-      "description": "Fetch a single Expo documentation page and return its content as markdown. Returns up to ~5000 tokens per call. Use offset to paginate through long pages.",
-      "examplePrompt": "read the Expo Router docs page",
-      "availability": "Server"
     },
     {
       "name": "learn",

--- a/docs/ui/components/ExpoMCPToolsTable/expo-mcp-oauth.js
+++ b/docs/ui/components/ExpoMCPToolsTable/expo-mcp-oauth.js
@@ -1,0 +1,195 @@
+import {
+  discoverAuthorizationServerMetadata,
+  registerClient,
+  startAuthorization,
+  exchangeAuthorization,
+  refreshAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * mcp.expo.dev is an OAuth 2.0 protected resource.
+ * This module implements the authorization code + PKCE
+ * flow to obtain access tokens for it.
+ */
+export const EXPO_MCP_URL = 'https://mcp.expo.dev/mcp';
+
+const AUTHORIZATION_SERVER = 'https://mcp.expo.dev';
+const RESOURCE = new URL(EXPO_MCP_URL);
+const SCOPE = 'mcp:access';
+
+const AUTH_DIR = path.join(os.homedir(), '.expo-mcp-docs-sync');
+const AUTH_FILE = path.join(AUTH_DIR, 'auth.json');
+
+const REDIRECT_TIMEOUT_MS = 5 * 60 * 1000;
+
+function loadCache() {
+  try {
+    return JSON.parse(fs.readFileSync(AUTH_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveCache(cache) {
+  fs.mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(AUTH_FILE, JSON.stringify(cache, null, 2) + '\n', { mode: 0o600 });
+  fs.chmodSync(AUTH_FILE, 0o600);
+}
+
+function openBrowser(url) {
+  const [cmd, args, extraOptions] =
+    process.platform === 'darwin'
+      ? ['open', [url], {}]
+      : process.platform === 'win32'
+        ? [
+            'cmd',
+            ['/c', 'start', '""', '/b', url.replace(/&/g, '^&')],
+            { windowsVerbatimArguments: true },
+          ]
+        : ['xdg-open', [url], {}];
+  try {
+    spawn(cmd, args, { stdio: 'ignore', detached: true, ...extraOptions }).unref();
+  } catch {
+  }
+}
+
+function waitForRedirect(expectedState) {
+  let resolveCode;
+  let rejectCode;
+  const code = new Promise((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    if (url.pathname !== '/oauth/callback') {
+      res.writeHead(404).end();
+      return;
+    }
+    const error = url.searchParams.get('error');
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    if (error) {
+      res.end('<p>Authorization failed. You can close this tab.</p>');
+      rejectCode(new Error(`Authorization failed: ${error}`));
+    } else if (url.searchParams.get('state') !== expectedState) {
+      res.end('<p>State mismatch. You can close this tab.</p>');
+      rejectCode(new Error('OAuth state mismatch (possible CSRF). Aborting.'));
+    } else {
+      const authCode = url.searchParams.get('code');
+      if (!authCode) {
+        res.end('<p>No authorization code received. You can close this tab.</p>');
+        rejectCode(new Error('Authorization response did not include a code.'));
+      } else {
+        res.end(
+          '<p>Authentication complete. You can close this tab and return to the terminal.</p>'
+        );
+        resolveCode(authCode);
+      }
+    }
+  });
+
+  const ready = new Promise((resolve, reject) => {
+    server.once('error', error => {
+      reject(error);
+      rejectCode(error);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      resolve(`http://127.0.0.1:${server.address().port}/oauth/callback`);
+    });
+  });
+
+  const timeout = setTimeout(
+    () => rejectCode(new Error('Timed out waiting for browser authorization (5 min).')),
+    REDIRECT_TIMEOUT_MS
+  );
+  code
+    .finally(() => {
+      clearTimeout(timeout);
+      server.close();
+    })
+    .catch(() => {});
+
+  return { ready, code };
+}
+
+async function fullLogin(metadata) {
+  const state = crypto.randomUUID();
+  const { ready, code } = waitForRedirect(state);
+  const redirectUrl = await ready;
+
+  console.log('  Registering OAuth client with mcp.expo.dev...');
+  const clientInformation = await registerClient(AUTHORIZATION_SERVER, {
+    metadata,
+    clientMetadata: {
+      client_name: 'expo-docs-mcp-sync',
+      redirect_uris: [redirectUrl],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: SCOPE,
+    },
+  });
+
+  const { authorizationUrl, codeVerifier } = await startAuthorization(AUTHORIZATION_SERVER, {
+    metadata,
+    clientInformation,
+    redirectUrl,
+    scope: SCOPE,
+    state,
+    resource: RESOURCE,
+  });
+
+  console.log(
+    `\n  Opening your browser to authorize. If it does not open, visit:\n  ${authorizationUrl.href}\n`
+  );
+  openBrowser(authorizationUrl.href);
+
+  const authorizationCode = await code;
+  const tokens = await exchangeAuthorization(AUTHORIZATION_SERVER, {
+    metadata,
+    clientInformation,
+    authorizationCode,
+    codeVerifier,
+    redirectUri: redirectUrl,
+    resource: RESOURCE,
+  });
+
+  saveCache({ clientInformation, tokens });
+  console.log(`  Authenticated. Tokens cached at ${AUTH_FILE}`);
+  return tokens.access_token;
+}
+
+export async function getExpoMcpAccessToken() {
+  const metadata = await discoverAuthorizationServerMetadata(AUTHORIZATION_SERVER);
+  if (!metadata) {
+    throw new Error(`Could not discover OAuth metadata for ${AUTHORIZATION_SERVER}.`);
+  }
+
+  const cache = loadCache();
+  if (cache.tokens?.refresh_token && cache.clientInformation) {
+    try {
+      const tokens = await refreshAuthorization(AUTHORIZATION_SERVER, {
+        metadata,
+        clientInformation: cache.clientInformation,
+        refreshToken: cache.tokens.refresh_token,
+        resource: RESOURCE,
+      });
+      tokens.refresh_token ??= cache.tokens.refresh_token;
+      saveCache({ clientInformation: cache.clientInformation, tokens });
+      return tokens.access_token;
+    } catch (error) {
+      console.log(
+        `  Cached token could not be refreshed (${error.message}); starting a new login.`
+      );
+    }
+  }
+
+  return fullLogin(metadata);
+}

--- a/docs/ui/components/ExpoMCPToolsTable/expo-mcp-oauth.js
+++ b/docs/ui/components/ExpoMCPToolsTable/expo-mcp-oauth.js
@@ -55,8 +55,7 @@ function openBrowser(url) {
         : ['xdg-open', [url], {}];
   try {
     spawn(cmd, args, { stdio: 'ignore', detached: true, ...extraOptions }).unref();
-  } catch {
-  }
+  } catch {}
 }
 
 function waitForRedirect(expectedState) {

--- a/docs/ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js
+++ b/docs/ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js
@@ -5,11 +5,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ensureTrailingPeriod } from '../utils/syncUtils.ts';
+import { getExpoMcpAccessToken, EXPO_MCP_URL } from './expo-mcp-oauth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_FILE = path.join(__dirname, 'data/expo-mcp-tools.json');
-
-const EXPO_MCP_URL = 'https://mcp.expo.dev/mcp';
 
 const GITHUB_RAW_BASE =
   'https://raw.githubusercontent.com/expo/expo-mcp/main/packages/expo-mcp/src/mcp';
@@ -94,17 +93,13 @@ async function fetchText(url) {
 
 /**
  * Fetches server tools from the Expo MCP server using the MCP client SDK.
- * Requires EXPO_TOKEN environment variable.
+ *
+ * mcp.expo.dev is an OAuth 2.0 protected resource (it no longer accepts Expo
+ * personal access tokens), so this runs the authorization-code + PKCE flow via
+ * getExpoMcpAccessToken() and sends the resulting access token as a bearer.
  */
 async function fetchServerTools() {
-  const token = process.env.EXPO_TOKEN;
-  if (!token) {
-    throw new Error(
-      'EXPO_TOKEN environment variable is required to fetch server tools.\n' +
-        'Create a personal access token at https://expo.dev/settings/access-tokens\n' +
-        'and add it to docs/.env as EXPO_TOKEN=<your-token>'
-    );
-  }
+  const token = await getExpoMcpAccessToken();
 
   const client = new Client({ name: 'expo-docs-sync', version: '1.0.0' });
 


### PR DESCRIPTION
# Why

`mcp.expo.dev` moved to OAuth at GA and now rejects Expo personal access tokens, so `pnpm expo-mcp-sync` fails with a `401 invalid_token` ("Invalid or tampered token") error.

# How

Replaces the personal-access-token bearer in `sync-expo-mcp-tools.js` with `getExpoMcpAccessToken()`, a new `expo-mcp-oauth.js` helper that runs the OAuth authorization-code + PKCE flow on the MCP client SDK and caches refreshable tokens under `~/.expo-mcp-docs-sync` (outside the repo, so no secrets are committed). Also drops the now-unused `--env-file` flag from the `expo-mcp-sync` package script and regenerates `expo-mcp-tools.json`.

# Test Plan

Run `pnpm expo-mcp-sync`, authorize once in the browser when prompted, and confirm it rewrites `expo-mcp-tools.json`; a second run should refresh silently with no browser prompt.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).