### PR TITLE
[ios][video] Fix NSHashTable thread-safety crash in player registries

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
+- [iOS] Fixed a thread-safety crash caused by mutating the internal player registries while they were being iterated on another thread (e.g. during audio session and now playing updates). ([#46930](https://github.com/expo/expo/pull/46930) by [@jiunshinn](https://github.com/jiunshinn))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/Cache/SynchronizedHashTable.swift
+++ b/packages/expo-video/ios/Cache/SynchronizedHashTable.swift
@@ -4,12 +4,6 @@ internal class SynchronizedHashTable<T: AnyObject> {
   private let lock = NSLock()
   private let hashTable: NSHashTable<T>
 
-  /**
-   * - Parameter weakObjects: When `true`, the backing `NSHashTable` holds weak references to its
-   *   objects (entries are zeroed by the runtime when an object deallocates). When `false` (default),
-   *   it holds strong references. Either way, the lock serializes `add`/`remove`/`allObjects`, so the
-   *   table is never mutated while it is being iterated.
-   */
   init(weakObjects: Bool = false) {
     hashTable = weakObjects ? NSHashTable<T>.weakObjects() : NSHashTable<T>()
   }

--- a/packages/expo-video/ios/Cache/SynchronizedHashTable.swift
+++ b/packages/expo-video/ios/Cache/SynchronizedHashTable.swift
@@ -2,7 +2,18 @@
 
 internal class SynchronizedHashTable<T: AnyObject> {
   private let lock = NSLock()
-  private var hashTable: NSHashTable<T> = NSHashTable()
+  private let hashTable: NSHashTable<T>
+
+  /**
+   * - Parameter weakObjects: When `true`, the backing `NSHashTable` holds weak references to its
+   *   objects (entries are zeroed by the runtime when an object deallocates). When `false` (default),
+   *   it holds strong references. Either way, the lock serializes `add`/`remove`/`allObjects`, so the
+   *   table is never mutated while it is being iterated.
+   */
+  init(weakObjects: Bool = false) {
+    hashTable = weakObjects ? NSHashTable<T>.weakObjects() : NSHashTable<T>()
+  }
+
   var allObjects: [T] {
     lock.lock()
     defer { lock.unlock() }

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -15,9 +15,6 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   private let skipTimeInterval = 10.0
   private var timeObserver: Any?
   private weak var mostRecentInteractionPlayer: AVPlayer?
-  // Mutated off the main thread (from `VideoPlayer.showNowPlayingNotification`'s setter and `deinit`)
-  // and iterated on the main thread (e.g. the `pauseCommand` target). `NSHashTable` is not
-  // thread-safe, so guard it with `SynchronizedHashTable` to avoid mutate-during-iterate crashes.
   private let players = SynchronizedHashTable<VideoPlayer>(weakObjects: true)
   private var artworkDataTask: URLSessionDataTask?
 

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -15,7 +15,10 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   private let skipTimeInterval = 10.0
   private var timeObserver: Any?
   private weak var mostRecentInteractionPlayer: AVPlayer?
-  private var players = NSHashTable<VideoPlayer>.weakObjects()
+  // Mutated off the main thread (from `VideoPlayer.showNowPlayingNotification`'s setter and `deinit`)
+  // and iterated on the main thread (e.g. the `pauseCommand` target). `NSHashTable` is not
+  // thread-safe, so guard it with `SynchronizedHashTable` to avoid mutate-during-iterate crashes.
+  private let players = SynchronizedHashTable<VideoPlayer>(weakObjects: true)
   private var artworkDataTask: URLSessionDataTask?
 
   private var playTarget: Any?

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -13,10 +13,6 @@ class VideoManager {
   private static var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
   private var mediaServicesResetObserver: NSObjectProtocol?
   private var videoViews = NSHashTable<VideoView>.weakObjects()
-  // `videoPlayers` is accessed concurrently: registered/unregistered from `VideoPlayer.init`/`deinit`
-  // (any thread), iterated in `setAudioSession()` on `managerQueue`, and read by `hasRegisteredPlayers`
-  // on the caller's thread. `NSHashTable` is not thread-safe, so we guard it with the package's
-  // `SynchronizedHashTable` (NSLock-backed) to avoid mutate-during-iterate crashes.
   private let videoPlayers = SynchronizedHashTable<VideoPlayer>(weakObjects: true)
 
   var hasRegisteredPlayers: Bool {

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -13,7 +13,11 @@ class VideoManager {
   private static var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
   private var mediaServicesResetObserver: NSObjectProtocol?
   private var videoViews = NSHashTable<VideoView>.weakObjects()
-  private var videoPlayers = NSHashTable<VideoPlayer>.weakObjects()
+  // `videoPlayers` is accessed concurrently: registered/unregistered from `VideoPlayer.init`/`deinit`
+  // (any thread), iterated in `setAudioSession()` on `managerQueue`, and read by `hasRegisteredPlayers`
+  // on the caller's thread. `NSHashTable` is not thread-safe, so we guard it with the package's
+  // `SynchronizedHashTable` (NSLock-backed) to avoid mutate-during-iterate crashes.
+  private let videoPlayers = SynchronizedHashTable<VideoPlayer>(weakObjects: true)
 
   var hasRegisteredPlayers: Bool {
     return !videoPlayers.allObjects.isEmpty
@@ -39,21 +43,11 @@ class VideoManager {
   }
 
   func register(videoPlayer: VideoPlayer) {
-    Self.managerQueue.async { [weak self, weak videoPlayer] in
-      guard let self = self, let videoPlayer = videoPlayer else {
-        return
-      }
-      self.videoPlayers.add(videoPlayer)
-    }
+    videoPlayers.add(videoPlayer)
   }
 
   func unregister(videoPlayer: VideoPlayer) {
-    Self.managerQueue.async { [weak self, weak videoPlayer] in
-      guard let self = self, let videoPlayer = videoPlayer else {
-        return
-      }
-      self.videoPlayers.remove(videoPlayer)
-    }
+    videoPlayers.remove(videoPlayer)
   }
 
   func register(videoView: VideoView) {


### PR DESCRIPTION
# Why

Fixes #43102.

`VideoManager` and `NowPlayingManager` each track `VideoPlayer`s in a plain `NSHashTable`, which is not thread-safe, yet both registries are mutated and iterated from different threads:

- `VideoManager.videoPlayers` is added/removed from `VideoPlayer.init`/`deinit` (any thread) and iterated in `setAudioSession()` on a background queue (`managerQueue`), while weak entries are also zeroed by the runtime when a player deallocates on the main thread during a Core Animation commit. This mutate-while-iterating is the data race behind the reported `EXC_CRASH (SIGABRT)` — Thread 16 in the report shows `setAudioSession()` running on `managerQueue` at the time of the crash.
- `NowPlayingManager.players` has the same shape: added/removed off the main thread (from the `showNowPlayingNotification` setter and `deinit`) and iterated on the main thread from the `MPRemoteCommandCenter` command targets and now-playing updates.

# How

Guard both registries with the package's existing `SynchronizedHashTable` (NSLock-backed), already used by the cache's `ResourceLoaderDelegate`. Its `allObjects` takes the lock and returns a copy, so callers always iterate a snapshot and the table is never mutated mid-iteration; `add`/`remove` take the same lock.

`SynchronizedHashTable` gains an opt-in `weakObjects:` initializer (default `false`, so the existing strong-reference usage is unchanged) to preserve the weak semantics the player registries rely on.

Because the lock now provides mutual exclusion, `VideoManager.register`/`unregister` no longer hop onto `managerQueue`; they mutate the table directly. This also makes `unregister` from `deinit` deterministic — the previous `managerQueue.async { [weak videoPlayer] … }` typically ran after the player had already deallocated and relied on weak-zeroing to clean up.

`setAudioSession()` stays on `managerQueue`, so the ~70 ms worst-case cost documented in #33127 is unchanged; this PR only makes the shared registries safe to touch across threads.

Scope note: `setAudioSession()` still reads a few scalar player properties (`isPlaying`, `isMuted`, …) from the snapshot across queues. Those are word-sized atomic reads and every state change re-triggers a re-evaluation, so a stale read self-corrects on the next hop and cannot cause the reported crash. Eliminating that residual read race would mean moving player audio state into a manager-owned snapshot updated on `managerQueue`, which is a larger change tied to the #33127 trade-off — happy to follow up separately if preferred.

# Test Plan

The crash is a non-deterministic data race on the players' weak `NSHashTable` (the reporter hit it after ~18 h of pooled-player churn), so I verified the fix with a standalone Swift concurrency probe under Thread Sanitizer rather than a timed repro. The probe reproduces the failure mode at the `NSHashTable` level (the bug is in the table, not in `VideoPlayer`): one thread iterates `allObjects` (like `setAudioSession()` on `managerQueue`) while many threads concurrently `add` / `remove` and let objects deallocate (like `register` / `unregister` / `deinit`).

Built and run with `swiftc -sanitize=thread -o probe probe.swift`:

- Raw `NSHashTable` (pre-fix): aborts within ~3 s — `Weak reference loaded … not in the weak references table`, TSan `SEGV`, and `NSHashTable … count underflow` (`SIGABRT`, exit 134).
- `NSLock`-guarded snapshot table (this PR's `SynchronizedHashTable`): completes (`survived`) with zero TSan warnings.

The same `SynchronizedHashTable` is applied to both `VideoManager.videoPlayers` and `NowPlayingManager.players`; the iOS build is exercised by CI on this PR.

<details><summary>Probe source</summary>

```swift
import Foundation

protocol PlayerRegistry: AnyObject {
  func add(_ o: NSObject)
  func remove(_ o: NSObject)
  var allObjects: [NSObject] { get }
}

// "before": raw NSHashTable, as in VideoManager.videoPlayers / NowPlayingManager.players prior to the fix
final class UnsafeRegistry: PlayerRegistry {
  private let table = NSHashTable<NSObject>.weakObjects()
  func add(_ o: NSObject) { table.add(o) }
  func remove(_ o: NSObject) { table.remove(o) }
  var allObjects: [NSObject] { table.allObjects }
}

// "after": mirrors SynchronizedHashTable(weakObjects: true)
final class SafeRegistry: PlayerRegistry {
  private let lock = NSLock()
  private let table = NSHashTable<NSObject>.weakObjects()
  func add(_ o: NSObject) { lock.lock(); defer { lock.unlock() }; table.add(o) }
  func remove(_ o: NSObject) { lock.lock(); defer { lock.unlock() }; table.remove(o) }
  var allObjects: [NSObject] { lock.lock(); defer { lock.unlock() }; return Array(table.allObjects) }
}

func stress(_ reg: PlayerRegistry) {
  let group = DispatchGroup()

  // Thread B — iterate, like VideoManager.setAudioSession() reading allObjects on managerQueue
  group.enter()
  DispatchQueue.global().async {
    for _ in 0..<200_000 { _ = reg.allObjects }
    group.leave()
  }

  // Threads A — register / unregister / deinit (weak-zeroing) from many threads
  group.enter()
  DispatchQueue.global().async {
    DispatchQueue.concurrentPerform(iterations: 200_000) { i in
      let player = NSObject()
      reg.add(player)                          // register
      if i % 2 == 0 { reg.remove(player) }     // unregister
      // `player` deallocates here -> its weak entry is zeroed concurrently (deinit path)
    }
    group.leave()
  }

  group.wait()
  print("survived")
}

let useSafe = CommandLine.arguments.contains("safe")
print(useSafe ? "[safe] SynchronizedHashTable-style (NSLock + snapshot)" : "[unsafe] raw NSHashTable")
stress(useSafe ? SafeRegistry() : UnsafeRegistry())
```

</details>

# Checklist

- [x] Added a `CHANGELOG.md` entry. (No TypeScript sources changed, so there is nothing to rebuild.)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — n/a, this is a runtime-only native change with no config-plugin/prebuild impact.
- [ ] Conforms with the Documentation Writing Style Guide — n/a, no docs changes.
