### PR TITLE
[launcher][Android] Support loading embedded bundles via `loadApp`

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.modules.devlauncher.helpers.DevLauncherMetadataHelper
-import expo.modules.devlauncher.helpers.DevLauncherUrl
 import expo.modules.devlauncher.helpers.getFieldInClassHierarchy
 import expo.modules.devlauncher.helpers.hasUrlQueryParam
 import expo.modules.devlauncher.helpers.isDevLauncherUrl
@@ -35,16 +34,16 @@ import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
 import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
 import expo.modules.devlauncher.launcher.errors.DevLauncherUncaughtExceptionHandler
-import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactory
+import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoader
 import expo.modules.devlauncher.launcher.loaders.DevLauncherEmbeddedAppLoader
-import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
+import expo.modules.devlauncher.launcher.loaders.createAppLoader
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityNOPDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityRedirectDelegate
 import expo.modules.devlauncher.services.DependencyInjection
 import expo.modules.kotlin.weak
 import expo.modules.manifests.core.Manifest
-import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesDevLauncherInterface
+import expo.modules.updatesinterface.UpdatesInterface
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -108,10 +107,6 @@ class DevLauncherController private constructor(
   private var networkInterceptor: DevLauncherNetworkInterceptor? = null
   private var pendingIntentExtras: Bundle? = null
 
-  private fun isEASUpdateURL(url: Uri): Boolean {
-    return url.host.equals("u.expo.dev") || url.host.equals("staging-u.expo.dev")
-  }
-
   override fun onRequestRelaunch() {
     val latestLoadedApp = latestLoadedApp ?: return
     coroutineScope.launch {
@@ -133,50 +128,23 @@ class DevLauncherController private constructor(
 
     try {
       ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
-      val devLauncherUrl = DevLauncherUrl(url)
-      val parsedUrl = devLauncherUrl.url
-      var parsedProjectUrl = projectUrl ?: url
-
-      val isEASUpdate = isEASUpdateURL(url)
-
-      // default to the EXPO_UPDATE_URL value configured in AndroidManifest.xml when project url is unspecified for an EAS update
-      if (isEASUpdate && projectUrl == null) {
-        val projectUrlString = getMetadataValue(context, "expo.modules.updates.EXPO_UPDATE_URL")
-        parsedProjectUrl = projectUrlString.toUri()
-      }
-
-      val manifestParser = DevLauncherManifestParser(httpClient, parsedUrl, installationIDHelper.getOrCreateInstallationID(context))
-      val appIntent = createAppIntent()
-
       (updatesInterface as UpdatesDevLauncherInterface?)?.reset()
 
-      val appLoaderFactory = DevLauncherAppLoaderFactory(
-        context,
-        appHost,
-        updatesInterface,
-        this,
-        installationIDHelper
-      )
-      val appLoader = appLoaderFactory.createAppLoader(parsedUrl, parsedProjectUrl, manifestParser)
-      useDeveloperSupport = appLoaderFactory.shouldUseDeveloperSupport()
-      manifest = appLoaderFactory.getManifest()
-      manifestURL = parsedUrl
+      val result = createAppLoader(url, projectUrl, context, appHost, updatesInterface, this, installationIDHelper)
+
+      useDeveloperSupport = result.useDeveloperSupport
+      manifest = result.manifest
+      manifestURL = result.manifestURL
 
       if (url.toString().contains("disableOnboarding=1") || manifestURL?.toString()?.contains("disableOnboarding=1") == true) {
         DependencyInjection.devMenuPreferences?.isOnboardingFinished = true
       }
 
-      val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
-      lifecycle.addListener(appLoaderListener)
-      mode = Mode.APP
-
-      _isLoadingToBundler.value = false
-      // Note that `launch` method is a suspend one. So the execution will be stopped here until the method doesn't finish.
-      if (appLoader.launch(appIntent)) {
-        recentlyOpedAppsRegistry.appWasOpened(parsedUrl.toString(), devLauncherUrl.queryParams, manifest)
-        latestLoadedApp = parsedUrl
-        // Here the app will be loaded - we can remove listener here.
-        lifecycle.removeListener(appLoaderListener)
+      if (launchAppLoader(result.appLoader)) {
+        latestLoadedApp = result.resolvedUrl
+        result.devLauncherUrl?.let { devLauncherUrl ->
+          recentlyOpedAppsRegistry.appWasOpened(devLauncherUrl.url.toString(), devLauncherUrl.queryParams, manifest)
+        }
       } else {
         // The app couldn't be loaded. For now, we just return to the launcher.
         mode = Mode.LAUNCHER
@@ -190,6 +158,19 @@ class DevLauncherController private constructor(
       }
       throw e
     }
+  }
+
+  private suspend fun launchAppLoader(appLoader: DevLauncherAppLoader): Boolean {
+    val listener = appLoader.createOnDelegateWillBeCreatedListener()
+    lifecycle.addListener(listener)
+    mode = Mode.APP
+    _isLoadingToBundler.value = false
+
+    val launched = appLoader.launch(createAppIntent())
+    if (launched) {
+      lifecycle.removeListener(listener)
+    }
+    return launched
   }
 
   override suspend fun loadApp(url: Uri, mainActivity: ReactActivity?) {
@@ -309,9 +290,8 @@ class DevLauncherController private constructor(
         }
 
         if (!hasUrlQueryParam(uri)) {
-          // edge case: this is a dev launcher url but it does not specify what url to open
+          // edge case: this is a dev launcher url, but it does not specify what url to open
           // fallback to navigating to the launcher home screen
-
           if (useDefaultLaunchUrlFallback) {
             launchDefaultUrlOrNavigateToLauncher(coroutineScope, defaultLaunchUrl, activityToBeInvalidated)
             return true

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -31,6 +31,7 @@ fun injectReactInterceptor(
 ): Boolean {
   val (debugServerHost, appBundleName) = parseUrl(url)
 
+  setPackagerServerAccess(reactHost, true)
   injectDevSupportManager(reactHost)
 
   val result = injectDebugServerHost(
@@ -41,6 +42,18 @@ fun injectReactInterceptor(
   )
   (reactHost.devSupportManager as? DevLauncherBridgelessDevSupportManager)?.startInspectorWhenDevLauncherReady()
   return result
+}
+
+@OptIn(UnstableReactNativeAPI::class)
+private fun setPackagerServerAccess(reactHost: ReactHost, enabled: Boolean) {
+  try {
+    check(reactHost is ReactHostImpl)
+    val field = ReactHostImpl::class.java.getDeclaredField("allowPackagerServerAccess")
+    field.isAccessible = true
+    field[reactHost] = enabled
+  } catch (e: Exception) {
+    Log.e("DevLauncher", "Unable to set packager server access to $enabled", e)
+  }
 }
 
 private fun injectDevSupportManager(reactHost: ReactHost) {
@@ -97,17 +110,12 @@ fun injectBundleLoader(
   reactHost: ReactHost,
   jsBundleLoader: JSBundleLoader
 ): Boolean {
+  setPackagerServerAccess(reactHost, false)
+
   return try {
     check(reactHost is ReactHostImpl)
 
-    // [0] Disable `mAllowPackagerServerAccess`
-    // so that ReactHost could use jsBundlerLoader from ReactHostDelegate
     val reactHostClass = ReactHostImpl::class.java
-    val mAllowPackagerServerAccessField = reactHostClass.getDeclaredField("allowPackagerServerAccess")
-    mAllowPackagerServerAccessField.isAccessible = true
-    mAllowPackagerServerAccessField[reactHost] = false
-
-    // [1] Replace the ReactHostDelegate.jsBundlerLoader with our new loader
     val mReactHostDelegateField = reactHostClass.getDeclaredField("reactHostDelegate")
     mReactHostDelegateField.isAccessible = true
     val reactHostDelegate = mReactHostDelegateField[reactHost] as ReactHostDelegate

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -10,10 +10,10 @@ import com.facebook.react.ReactInstanceEventListener
 import com.facebook.react.bridge.ReactContext
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * An abstract class of app loader. An object of this class will launch provided `Intent` with all the needed setup.
@@ -71,11 +71,11 @@ abstract class DevLauncherAppLoader(
   }
 
   open suspend fun launch(intent: Intent): Boolean = withContext(Dispatchers.Main) {
-    suspendCoroutine { callback ->
+    suspendCancellableCoroutine { callback ->
       if (injectBundleLoader()) {
         continuation = callback
         launchIntent(intent)
-        return@suspendCoroutine
+        return@suspendCancellableCoroutine
       }
       callback.resume(false)
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -2,9 +2,11 @@ package expo.modules.devlauncher.launcher.loaders
 
 import android.content.Context
 import android.net.Uri
+import androidx.core.net.toUri
 import com.facebook.react.ReactHost
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
+import expo.modules.devlauncher.helpers.DevLauncherUrl
 import expo.modules.devlauncher.helpers.createUpdatesConfigurationWithUrl
 import expo.modules.devlauncher.helpers.loadUpdate
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
@@ -12,69 +14,113 @@ import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesDevLauncherInterface
 import expo.modules.updatesinterface.UpdatesInterface
 
-class DevLauncherAppLoaderFactory(
-  val context: Context,
-  val appHost: ReactHost,
-  val updatesInterface: UpdatesInterface?,
-  val controller: DevLauncherController,
-  val installationIDHelper: DevLauncherInstallationIDHelper
-) {
-  private var instanceWasCreated = false
-  private var manifest: Manifest? = null
-  private var useDeveloperSupport = true
+data class AppLoaderResult(
+  val appLoader: DevLauncherAppLoader,
+  val manifest: Manifest?,
+  val manifestURL: Uri?,
+  val resolvedUrl: Uri,
+  val devLauncherUrl: DevLauncherUrl?,
+  val useDeveloperSupport: Boolean
+)
 
-  suspend fun createAppLoader(url: Uri, projectUrl: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader {
-    instanceWasCreated = true
+suspend fun createAppLoader(
+  url: Uri,
+  projectUrl: Uri?,
+  context: Context,
+  appHost: ReactHost,
+  updatesInterface: UpdatesInterface?,
+  controller: DevLauncherController,
+  installationIDHelper: DevLauncherInstallationIDHelper
+): AppLoaderResult {
+  if (isAssetUrl(url)) {
+    (updatesInterface as? UpdatesDevLauncherInterface)?.setIsUsingEmbeddedAssets(true)
+    return AppLoaderResult(
+      appLoader = DevLauncherEmbeddedAppLoader(appHost, context, controller, url.toString()),
+      manifest = null,
+      manifestURL = null,
+      resolvedUrl = url,
+      devLauncherUrl = null,
+      useDeveloperSupport = false
+    )
+  }
 
-    if (!manifestParser.isManifestUrl()) {
-      // It's (maybe) a raw React Native bundle
-      return DevLauncherReactNativeAppLoader(url, appHost, context, controller)
-    }
+  val devLauncherUrl = DevLauncherUrl(url)
+  val parsedUrl = devLauncherUrl.url
+  var parsedProjectUrl = projectUrl ?: url
 
-    val validConfiguration = updatesInterface?.let {
-      val runtimeVersion = it.runtimeVersion
-      if (runtimeVersion == null) {
-        null
-      } else {
-        val configurationCandidate = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
-        if ((it as UpdatesDevLauncherInterface).isValidUpdatesConfiguration(configurationCandidate)) {
-          configurationCandidate
-        } else {
-          null
-        }
-      }
-    }
+  if (isEASUpdateURL(url) && projectUrl == null) {
+    parsedProjectUrl = DevLauncherController.getMetadataValue(context, "expo.modules.updates.EXPO_UPDATE_URL").toUri()
+  }
 
-    return if (validConfiguration == null) {
-      manifest = manifestParser.parseManifest()
-      if (!manifest!!.isUsingDeveloperTool()) {
-        throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
-      }
-      DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
+  val manifestParser = DevLauncherManifestParser(controller.httpClient, parsedUrl, installationIDHelper.getOrCreateInstallationID(context))
+
+  if (!manifestParser.isManifestUrl()) {
+    return AppLoaderResult(
+      appLoader = DevLauncherReactNativeAppLoader(parsedUrl, appHost, context, controller),
+      manifest = null,
+      manifestURL = null,
+      resolvedUrl = parsedUrl,
+      devLauncherUrl = devLauncherUrl,
+      useDeveloperSupport = true
+    )
+  }
+
+  val validConfiguration = updatesInterface?.let {
+    val runtimeVersion = it.runtimeVersion ?: return@let null
+    val configurationCandidate = createUpdatesConfigurationWithUrl(parsedUrl, parsedProjectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
+    if ((it as UpdatesDevLauncherInterface).isValidUpdatesConfiguration(configurationCandidate)) {
+      configurationCandidate
     } else {
-      val update = (updatesInterface as UpdatesDevLauncherInterface?)!!.loadUpdate(validConfiguration, context) {
-        manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
-        return@loadUpdate !manifest!!.isUsingDeveloperTool()
-      }
-      if (manifest!!.isUsingDeveloperTool()) {
-        DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
-      } else {
-        useDeveloperSupport = false
-        val localBundlePath = update.launchAssetPath
-        DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context, controller)
-      }
+      null
     }
   }
 
-  fun getManifest(): Manifest? = checkIfInstanceWasCreated { manifest }
-
-  fun shouldUseDeveloperSupport(): Boolean = checkIfInstanceWasCreated { useDeveloperSupport }
-
-  private inline fun <T> checkIfInstanceWasCreated(block: () -> T): T {
-    if (!instanceWasCreated) {
-      throw IllegalStateException("You need to create the AppLoader first.")
+  if (validConfiguration == null) {
+    val manifest = manifestParser.parseManifest()
+    if (!manifest.isUsingDeveloperTool()) {
+      throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
     }
-
-    return block()
+    return AppLoaderResult(
+      appLoader = DevLauncherLocalAppLoader(manifest, appHost, context, controller),
+      manifest = manifest,
+      manifestURL = parsedUrl,
+      resolvedUrl = parsedUrl,
+      devLauncherUrl = devLauncherUrl,
+      useDeveloperSupport = true
+    )
   }
+
+  var manifest: Manifest? = null
+  val update = (updatesInterface as UpdatesDevLauncherInterface).loadUpdate(validConfiguration, context) {
+    manifest = Manifest.fromManifestJson(it)
+    return@loadUpdate !manifest.isUsingDeveloperTool()
+  }
+
+  return if (manifest!!.isUsingDeveloperTool()) {
+    AppLoaderResult(
+      appLoader = DevLauncherLocalAppLoader(manifest, appHost, context, controller),
+      manifest = manifest,
+      manifestURL = parsedUrl,
+      resolvedUrl = parsedUrl,
+      devLauncherUrl = devLauncherUrl,
+      useDeveloperSupport = true
+    )
+  } else {
+    AppLoaderResult(
+      appLoader = DevLauncherPublishedAppLoader(manifest, update.launchAssetPath, appHost, context, controller),
+      manifest = manifest,
+      manifestURL = parsedUrl,
+      resolvedUrl = parsedUrl,
+      devLauncherUrl = devLauncherUrl,
+      useDeveloperSupport = false
+    )
+  }
+}
+
+private fun isAssetUrl(url: Uri): Boolean {
+  return url.toString().startsWith("assets://")
+}
+
+private fun isEASUpdateURL(url: Uri): Boolean {
+  return url.host.equals("u.expo.dev") || url.host.equals("staging-u.expo.dev")
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherEmbeddedAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherEmbeddedAppLoader.kt
@@ -13,10 +13,11 @@ import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 class DevLauncherEmbeddedAppLoader(
   private val appHost: ReactHost,
   private val context: Context,
-  controller: DevLauncherControllerInterface
+  controller: DevLauncherControllerInterface,
+  private val assetBundlePath: String = "assets://index.android.bundle"
 ) : DevLauncherAppLoader(appHost, context, controller) {
   override fun injectBundleLoader(): Boolean {
-    val loader = JSBundleLoader.createAssetLoader(context, "assets://index.android.bundle", true)
+    val loader = JSBundleLoader.createAssetLoader(context, assetBundlePath, true)
     return injectBundleLoader(appHost, loader)
   }
 }

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -11,15 +11,18 @@ import expo.modules.devlauncher.helpers.loadUpdate
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesDevLauncherInterface
-import expo.modules.updatesinterface.UpdatesInterface
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -33,54 +36,60 @@ internal class DevLauncherAppLoaderFactoryTest {
   private val publishedManifestJSONString = "{\"metadata\":{},\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"},\"extra\":{\"scopeKey\":\"@test/app\",\"eas\":{\"projectId\":\"285dc9ca-a25d-4f60-93be-36dc312266d7\"}}}"
 
   private val context: Context = ApplicationProvider.getApplicationContext()
+  private val appHost = mockk<ReactHost>(relaxed = true)
+  private val controller = mockk<DevLauncherController>(relaxed = true)
+  private val installationIDHelper = mockk<DevLauncherInstallationIDHelper>(relaxed = true)
 
-  private fun createAppLoaderFactory(updatesInterface: UpdatesInterface? = null): DevLauncherAppLoaderFactory {
-    return DevLauncherAppLoaderFactory(
-      context = context,
-      appHost = mockk<ReactHost>(relaxed = true),
-      updatesInterface = updatesInterface,
-      controller = mockk<DevLauncherController>(relaxed = true),
-      installationIDHelper = mockk<DevLauncherInstallationIDHelper>(relaxed = true)
-    )
+  @Before
+  fun setUp() {
+    mockkConstructor(DevLauncherManifestParser::class)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkConstructor(DevLauncherManifestParser::class)
+  }
+
+  @Test
+  fun `loads embedded bundle if url is an asset url`() = runBlocking<Unit> {
+    val assetUrl = Uri.parse("assets://index.android.bundle")
+
+    val result = createAppLoader(assetUrl, assetUrl, context, appHost, null, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherEmbeddedAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isFalse()
+    Truth.assertThat(result.manifest).isNull()
+    Truth.assertThat(result.manifestURL).isNull()
+    Truth.assertThat(result.devLauncherUrl).isNull()
   }
 
   @Test
   fun `loads app as React Native bundle if url is not a manifest url`() = runBlocking<Unit> {
-    val appLoaderFactory = createAppLoaderFactory()
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns false
 
-    val manifestParser = mockk<DevLauncherManifestParser>()
-    coEvery { manifestParser.isManifestUrl() } returns false
-
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
-    Truth.assertThat(appLoader).isInstanceOf(DevLauncherReactNativeAppLoader::class.java)
-    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+    val result = createAppLoader(developmentManifestURL, developmentManifestURL, context, appHost, null, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherReactNativeAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isTrue()
   }
 
   @Test
   fun `loads app locally if manifest indicates developer tool and no updatesInterface exists`() = runBlocking<Unit> {
-    val appLoaderFactory = createAppLoaderFactory()
-
-    val manifestParser = mockk<DevLauncherManifestParser>()
     val manifest = Manifest.fromManifestJson(JSONObject(developmentManifestJSONString))
-    coEvery { manifestParser.isManifestUrl() } returns true
-    coEvery { manifestParser.parseManifest() } returns manifest
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns true
+    coEvery { anyConstructed<DevLauncherManifestParser>().parseManifest() } returns manifest
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
-    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
-    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+    val result = createAppLoader(developmentManifestURL, developmentManifestURL, context, appHost, null, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isTrue()
   }
 
   @Test
   fun `throws if manifest is published and no updatesInterface exists`() {
-    val appLoaderFactory = createAppLoaderFactory()
-
-    val manifestParser = mockk<DevLauncherManifestParser>()
     val manifest = Manifest.fromManifestJson(JSONObject(publishedManifestJSONString))
-    coEvery { manifestParser.isManifestUrl() } returns true
-    coEvery { manifestParser.parseManifest() } returns manifest
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns true
+    coEvery { anyConstructed<DevLauncherManifestParser>().parseManifest() } returns manifest
 
     Assert.assertThrows(Exception::class.java) {
-      runBlocking { appLoaderFactory.createAppLoader(publishedManifestURL, developmentManifestURL, manifestParser) }
+      runBlocking { createAppLoader(publishedManifestURL, developmentManifestURL, context, appHost, null, controller, installationIDHelper) }
     }
   }
 
@@ -90,14 +99,12 @@ internal class DevLauncherAppLoaderFactoryTest {
       Truth.assertThat(it).isFalse()
     }
     every { updatesInterface.isValidUpdatesConfiguration(any()) } returns true
-    val appLoaderFactory = createAppLoaderFactory(updatesInterface)
 
-    val manifestParser = mockk<DevLauncherManifestParser>()
-    coEvery { manifestParser.isManifestUrl() } returns true
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns true
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
-    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
-    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+    val result = createAppLoader(developmentManifestURL, developmentManifestURL, context, appHost, updatesInterface, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isTrue()
   }
 
   @Test
@@ -106,14 +113,12 @@ internal class DevLauncherAppLoaderFactoryTest {
       Truth.assertThat(it).isTrue()
     }
     every { updatesInterface.isValidUpdatesConfiguration(any()) } returns true
-    val appLoaderFactory = createAppLoaderFactory(updatesInterface)
 
-    val manifestParser = mockk<DevLauncherManifestParser>()
-    coEvery { manifestParser.isManifestUrl() } returns true
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns true
 
-    val appLoader = appLoaderFactory.createAppLoader(publishedManifestURL, developmentManifestURL, manifestParser)
-    Truth.assertThat(appLoader).isInstanceOf(DevLauncherPublishedAppLoader::class.java)
-    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isFalse()
+    val result = createAppLoader(publishedManifestURL, developmentManifestURL, context, appHost, updatesInterface, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherPublishedAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isFalse()
   }
 
   @Test
@@ -122,16 +127,14 @@ internal class DevLauncherAppLoaderFactoryTest {
       Truth.assertThat(it).isTrue()
     }
     every { updatesInterface.isValidUpdatesConfiguration(any()) } returns false
-    val appLoaderFactory = createAppLoaderFactory(updatesInterface)
 
-    val manifestParser = mockk<DevLauncherManifestParser>()
     val manifest = Manifest.fromManifestJson(JSONObject(developmentManifestJSONString))
-    coEvery { manifestParser.isManifestUrl() } returns true
-    coEvery { manifestParser.parseManifest() } returns manifest
+    coEvery { anyConstructed<DevLauncherManifestParser>().isManifestUrl() } returns true
+    coEvery { anyConstructed<DevLauncherManifestParser>().parseManifest() } returns manifest
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
-    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
-    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+    val result = createAppLoader(developmentManifestURL, developmentManifestURL, context, appHost, updatesInterface, controller, installationIDHelper)
+    Truth.assertThat(result.appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(result.useDeveloperSupport).isTrue()
   }
 
   private fun mockUpdatesInterface(manifestJSONString: String, verifyShouldContinue: (Boolean) -> Unit): UpdatesDevLauncherInterface {

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -63,6 +63,7 @@ interface UpdatesDevLauncherInterface : UpdatesInterface {
   var updatesInterfaceCallbacks: WeakReference<UpdatesInterfaceCallbacks>?
 
   fun reset()
+  fun setIsUsingEmbeddedAssets(isUsingEmbeddedAssets: Boolean) {}
   fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, callback: UpdateCallback)
   fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>): Boolean
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -131,11 +131,18 @@ class UpdatesDevLauncherController(
   private val localAssetFiles: Map<AssetEntity, String>?
     get() = launcher?.localAssetFiles
 
+  private var _isUsingEmbeddedAssetsOverride: Boolean? = null
+
   private val isUsingEmbeddedAssets: Boolean
-    get() = launcher?.isUsingEmbeddedAssets ?: false
+    get() = _isUsingEmbeddedAssetsOverride ?: launcher?.isUsingEmbeddedAssets ?: false
 
   override fun reset() {
     launcher = null
+    _isUsingEmbeddedAssetsOverride = null
+  }
+
+  override fun setIsUsingEmbeddedAssets(isUsingEmbeddedAssets: Boolean) {
+    _isUsingEmbeddedAssetsOverride = isUsingEmbeddedAssets
   }
 
   override val runtimeVersion: String?
@@ -396,9 +403,5 @@ class UpdatesDevLauncherController(
 
   override fun shutdown() {
     controllerScope.cancel()
-  }
-
-  companion object {
-    private val TAG = UpdatesDevLauncherController::class.java.simpleName
   }
 }


### PR DESCRIPTION
# Why

When using `expo export:embed` to create a local bundle and loading it through dev-launcher, there was no way to load an `assets://` bundle via the standard `loadApp` flow. This required using the separate `loadEmbeddedBundle` method, which doesn't go through the same code path.

Additionally, switching from an embedded bundle back to a metro bundler session broke asset resolution because:
1. `allowPackagerServerAccess` on `ReactHostImpl` was set to `false` by the embedded loader and never restored.
2. `isUsingEmbeddedAssets` in `expo-updates` was not set for embedded loads, causing incorrect asset resolution on the JS side.

# How

- `DevLauncherAppLoaderFactory` - Replaced the stateful class with a pure `suspend fun createAppLoader()` 
- `DevLauncherEmbeddedAppLoader` - Added a configurable `assetBundlePath` parameter (defaults to `assets://index.android.bundle`) so it can load from any asset path
- `DevLauncherController.loadApp` - Simplified to a single linear flow that delegates to `createAppLoader()` and reads back results.
- `DevLauncherReactUtils` - Extracted `setPackagerServerAccess(reactHost, enabled)` used by both `injectBundleLoader` and `injectReactInterceptor`.
- `UpdatesDevLauncherInterface` - Added `setIsUsingEmbeddedAssets(Boolean)` so dev-launcher can signal embedded asset mode to `expo-updates`.
- `UpdatesDevLauncherController` - Implemented the override flag that takes precedence over the launcher's value, cleared on `reset()`.

# Test Plan

 The embedded bundle is created with:
 ```
 npx expo export:embed \
   --platform android \
   --dev false \
   --bundle-output android/app/src/main/assets/index.android.bundle \
   --assets-dest android/app/src/main/res
 ```

[Screen_recording_20260615_195646.webm](https://github.com/user-attachments/assets/f06f3406-4d50-4a23-872c-dab74824485a)
