### PR TITLE
[expo-modules-core][android] Resolve worklet UI runtime without react-native-reanimated

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `SharedObject::NativeState` now derives from `expo::NativeState` so the Swift wrapper can be recovered from the JS side via `getNativeState`, laying the groundwork for native-state-based shared object lookup. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Ignore already-settled promises. ([#46770](https://github.com/expo/expo/pull/46770) by [@jakex7](https://github.com/jakex7))
-- [iOS] Resolve the worklet UI runtime through the `react-native-worklets` stable API (`StableApi.h`) from its UI runtime holder; `installOnUIRuntime` now takes the holder from `getUIRuntimeHolder()`. ([#46922](https://github.com/expo/expo/pull/46922) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS][android] Resolve the worklet UI runtime from its `react-native-worklets` holder instead of the reanimated `_WORKLET_RUNTIME` global; `installOnUIRuntime` now takes the holder from `getUIRuntimeHolder()`. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -58,6 +58,12 @@ std::shared_ptr<jsi::Object> JavaScriptObject::get() {
   return jsObject;
 }
 
+jsi::Runtime &JavaScriptObject::getRuntime() {
+  auto runtime = runtimeHolder.lock();
+  assert((runtime != nullptr) && "JS Runtime was used after deallocation");
+  return runtime->get();
+}
+
 bool JavaScriptObject::hasProperty(const std::string &name) {
   auto runtime = runtimeHolder.lock();
   assert((runtime != nullptr) && "JS Runtime was used after deallocation");

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -45,6 +45,11 @@ public:
   std::shared_ptr<jsi::Object> get() override;
 
   /**
+   * @return the `jsi::Runtime` this object is bound to.
+   */
+  jsi::Runtime &getRuntime();
+
+  /**
    * @return a bool whether the object has a property with the given name
    */
   bool hasProperty(const std::string &name);

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
@@ -3,6 +3,7 @@
 #if WORKLETS_ENABLED
 
 #include "../worklets/WorkletJSCallInvoker.h"
+#include <worklets/Compat/StableApi.h>
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #endif
@@ -15,7 +16,8 @@ namespace expo {
 
 void WorkletRuntimeInstaller::registerNatives() {
   javaClassLocal()->registerNatives({
-                                      makeNativeMethod("install", WorkletRuntimeInstaller::install)
+                                      makeNativeMethod("install", WorkletRuntimeInstaller::install),
+                                      makeNativeMethod("resolveUIRuntimePointer", WorkletRuntimeInstaller::resolveUIRuntimePointer)
                                     });
 }
 
@@ -41,6 +43,28 @@ jni::local_ref<JSIContext::javaobject> WorkletRuntimeInstaller::install(
   return jsiContext;
 #else
   return nullptr;
+#endif
+}
+
+jlong WorkletRuntimeInstaller::resolveUIRuntimePointer(
+  jni::alias_ref<jni::JClass>,
+  jni::alias_ref<JavaScriptObject::javaobject> uiRuntimeHolder
+) noexcept {
+#if WORKLETS_ENABLED
+  auto *holder = uiRuntimeHolder->cthis();
+  jsi::Runtime &runtime = holder->getRuntime();
+  std::shared_ptr<jsi::Object> holderObject = holder->get();
+
+  std::shared_ptr<worklets::WorkletRuntime> workletRuntime =
+    worklets::getWorkletRuntimeFromHolder(runtime, *holderObject);
+  if (!workletRuntime) {
+    return 0;
+  }
+
+  jsi::Runtime &uiRuntime = worklets::getJSIRuntimeFromWorkletRuntime(workletRuntime);
+  return reinterpret_cast<jlong>(&uiRuntime);
+#else
+  return 0;
 #endif
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../ExpoHeader.pch"
+#include "../JavaScriptObject.h"
 #include "MainRuntimeInstaller.h"
 
 namespace jni = facebook::jni;
@@ -23,6 +24,14 @@ public:
 
   static void prepareRuntime(
     jni::local_ref<JSIContext::javaobject> jsiContext
+  ) noexcept;
+
+  // Resolves the raw UI `jsi::Runtime *` (as a jlong) from a
+  // `react-native-worklets` UI runtime holder. Returns 0 when worklets isn't
+  // linked or the holder doesn't wrap a worklet runtime.
+  static jlong resolveUIRuntimePointer(
+    jni::alias_ref<jni::JClass> clazz,
+    jni::alias_ref<JavaScriptObject::javaobject> uiRuntimeHolder
   ) noexcept;
 };
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -6,6 +6,8 @@ import com.facebook.react.ReactActivity
 import expo.modules.BuildConfig
 import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.WorkletRuntimeInstaller
 import expo.modules.kotlin.modules.DEFAULT_MODULE_VIEW
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -95,25 +97,14 @@ class CoreModule : Module() {
       reactDelegate.reload()
     }
 
-    Function("installOnUIRuntime") {
-      val uiRuntimePointerHolder = appContext.runtime.jsiContext.global()["_WORKLET_RUNTIME"]
-        ?: throw IllegalStateException("UI Runtime is not available. Make sure you have Reanimated installed and imported in your project.")
-
-      assert(uiRuntimePointerHolder.isObject()) {
-        "Expected _WORKLET_RUNTIME to be an ArrayBuffer, got: ${uiRuntimePointerHolder.kind()}."
+    Function("installOnUIRuntime") { uiRuntimeHolder: JavaScriptObject ->
+      val runtimePointer = WorkletRuntimeInstaller.resolveUIRuntimePointer(uiRuntimeHolder)
+      if (runtimePointer == 0L) {
+        throw IllegalStateException(
+          "Couldn't resolve the worklets UI runtime from the provided holder. " +
+            "Make sure `react-native-worklets` is installed and rebuild the app."
+        )
       }
-
-      val uiRuntimePointerHolderObj = uiRuntimePointerHolder.getObject()
-      assert(uiRuntimePointerHolderObj.isArrayBuffer()) {
-        "Expected _WORKLET_RUNTIME to be an ArrayBuffer, got: ${uiRuntimePointerHolder.kind()}."
-      }
-
-      val arayBuffer = uiRuntimePointerHolderObj.getArrayBuffer()
-      assert(arayBuffer.size() == 8) {
-        "Expected _WORKLET_RUNTIME to be an ArrayBuffer with a size of 8 bytes (a pointer size), got: ${arayBuffer.size()}."
-      }
-
-      val runtimePointer = arayBuffer.read8Byte(0)
 
       runBlocking {
         withContext(Dispatchers.Main) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/WorkletRuntimeInstaller.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/WorkletRuntimeInstaller.kt
@@ -22,4 +22,15 @@ class WorkletRuntimeInstaller(
     jsRuntimePointer: Long,
     jniDeallocator: JNIDeallocator
   ): JSIContext
+
+  companion object {
+    /**
+     * Resolves the raw UI `jsi::Runtime*` (as a Long) from a `react-native-worklets`
+     * UI runtime holder. Returns 0 when worklets isn't installed or the holder
+     * doesn't wrap a worklet runtime.
+     */
+    @JvmStatic
+    @Suppress("KotlinJniMissingFunction")
+    external fun resolveUIRuntimePointer(uiRuntimeHolder: JavaScriptObject): Long
+  }
 }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -54,7 +54,7 @@
 ### 💡 Others
 
 - [universal] Revamp web universal components (`Button`, `Checkbox`, `FieldGroup`, `Picker`, `Slider`,`Switch`,`TextInput`) with shared design tokens, light / dark themes, and keyboard focus styles. ([#46258](https://github.com/expo/expo/pull/46258), [#46541](https://github.com/expo/expo/pull/46541) by [@zoontek](https://github.com/zoontek))
-- [iOS] Removed the `react-native-reanimated` dependency from the worklet integration; worklet features rely on `react-native-worklets` directly. ([#46922](https://github.com/expo/expo/pull/46922) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS][android] Removed the `react-native-reanimated` dependency from the worklet integration; worklet features rely on `react-native-worklets` directly. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ## 56.0.14 — 2026-05-26
 


### PR DESCRIPTION
# Why

Our current worklets integration require reanimated, it uses global property (`_WORKLET_RUNTIME`) set by reanimated to get the ui runtime pointer. We can use the worklets stable API instead, this removes the required dependency on reanimated.

iOS PR - https://github.com/expo/expo/pull/46922

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use `getUIRuntimeHolder` API by worklets to get the runtime holder, it is also used by reanimated internally here https://github.com/software-mansion/react-native-reanimated/blob/32941a8780fd5a4179bfc91367ce129a55732814/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts#L309

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested worklets screens in NCL and Expo UI. 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
