### PR TITLE
[ios][cli] Fix `expo run:ios --device` hanging after install on wireless devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo run:ios --device` hanging instead of exiting after installing and launching the app on a device connected over Wi-Fi. ([#46936](https://github.com/expo/expo/pull/46936) by [@helios1138](https://github.com/helios1138))
 - Focus the booted device in Device Hub using its `devices://` deep link instead of only bringing the app forward. ([#46809](https://github.com/expo/expo/pull/46809) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Disable sextant QR code rendering for Windows Terminal ([#46455](https://github.com/expo/expo/pull/46455) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
@@ -31,12 +31,25 @@ export class ClientManager {
 
   static async create(udid?: string) {
     const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
-    const device = await usbmuxClient.getDevice(udid);
-    const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
-    const lockdownSocket = await usbmuxClient.connect(device, 62078);
-    const lockdownClient = new LockdowndClient(lockdownSocket);
-    await lockdownClient.doHandshake(pairRecord);
-    return new ClientManager(pairRecord, device, lockdownClient);
+    try {
+      const device = await usbmuxClient.getDevice(udid);
+      const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
+      const lockdownSocket = await usbmuxClient.connect(device, 62078);
+      const lockdownClient = new LockdowndClient(lockdownSocket);
+      await lockdownClient.doHandshake(pairRecord);
+      return new ClientManager(pairRecord, device, lockdownClient);
+    } catch (error) {
+      // `getDevice()` throws `APPLE_DEVICE_USBMUXD` when the device isn't in usbmuxd's USB
+      // device list (e.g. a wireless device). The socket opened above isn't tracked by a
+      // `ClientManager` instance yet — `create()` threw before constructing one, so
+      // `ClientManager.end()` will never close it. Close it here; otherwise the orphaned
+      // socket keeps the Node event loop alive and `expo run:ios --device` never exits after
+      // the slower `devicectl` fallback installs and launches the app.
+      try {
+        usbmuxClient.socket.end();
+      } catch {}
+      throw error;
+    }
   }
 
   async getUsbmuxdClient() {

--- a/packages/@expo/cli/src/run/ios/appleDevice/__tests__/ClientManager-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/__tests__/ClientManager-test.ts
@@ -1,0 +1,30 @@
+import { CommandError } from '../../../../utils/errors';
+import { ClientManager } from '../ClientManager';
+
+const mockSocketEnd = jest.fn();
+const mockGetDevice = jest.fn();
+
+jest.mock('../client/UsbmuxdClient', () => ({
+  UsbmuxdClient: class {
+    socket = { end: mockSocketEnd };
+    getDevice = mockGetDevice;
+    readPairRecord = jest.fn();
+    connect = jest.fn();
+    static connectUsbmuxdSocket = jest.fn(() => ({ end: mockSocketEnd }));
+  },
+}));
+
+describe('create', () => {
+  it(`closes the usbmuxd socket and rethrows when the device is not reachable over usbmuxd (e.g. wireless)`, async () => {
+    // `getDevice()` rejects with `APPLE_DEVICE_USBMUXD` when usbmuxd has no USB device list,
+    // which is the case for a Wi-Fi-only device that falls back to the `devicectl` install path.
+    const error = new CommandError('APPLE_DEVICE_USBMUXD', 'No devices found');
+    mockGetDevice.mockRejectedValueOnce(error);
+
+    await expect(ClientManager.create('00008101-001964A22629003A')).rejects.toThrow(error);
+
+    // The socket opened before the throw must be closed, otherwise it keeps the event loop alive
+    // and `expo run:ios --device` hangs after the app installs and launches.
+    expect(mockSocketEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/devicectl.test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/devicectl.test.ts
@@ -1,7 +1,34 @@
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
 import { xcrunAsync } from '../../../../start/platforms/ios/xcrun';
-import { launchAppWithDeviceCtl } from '../devicectl';
+import { installAndLaunchAppAsync, launchAppWithDeviceCtl } from '../devicectl';
 
 jest.mock('../../../../start/platforms/ios/xcrun');
+
+// A controllable spinner so we can assert on its final state. `devicectl` imports the local
+// `ora` wrapper, which is what we mock here (the `ora` npm module is already globally mocked in
+// jest.setup.ts).
+const mockSpinner: any = {
+  text: '',
+  succeed: jest.fn(),
+  fail: jest.fn(),
+  stop: jest.fn(),
+  clear: jest.fn(),
+};
+mockSpinner.start = jest.fn(() => mockSpinner);
+
+jest.mock('../../../../utils/ora', () => ({
+  ora: jest.fn(() => mockSpinner),
+  logNewSection: jest.fn(() => mockSpinner),
+  getAllSpinners: jest.fn(() => []),
+}));
+
+// Don't register real process exit listeners while the install promise is pending.
+jest.mock('../../../../utils/exit', () => ({
+  ...jest.requireActual('../../../../utils/exit'),
+  installExitHooks: jest.fn(() => jest.fn()),
+}));
 
 describe(launchAppWithDeviceCtl, () => {
   it('throws generic error when `xcrun` fails without error logs', async () => {
@@ -29,25 +56,90 @@ describe(launchAppWithDeviceCtl, () => {
   });
 });
 
-// const INSTALL_FIXTURE = [
-//   '15:06:52  Acquired tunnel connection to device.\n',
-//   '15:06:52  Enabling developer disk image services.\n',
-//   '15:06:52  Acquired usage assertion.\n',
-//   '57%... ',
-//   '60%... ',
-//   '62%... ',
-//   '66%... ',
-//   '68%... ',
-//   '72%... ',
-//   '74%... ',
-//   '76%... ',
-//   '80%... 84%... 88%... 92%... ',
-//   '96%... ',
-//   'Complete!\nApp installed:\n',
-//   '• bundleID: com.bacon.apr22\n' +
-//     '• installationURL: file:///private/var/containers/Bundle/Application/54B96933-4472-4D98-9D67-A1F8AFC14FDE/apr22.app/\n' +
-//     '• launchServicesIdentifier: unknown\n' +
-//     '• databaseUUID: 9D988F8D-8E2F-4C4A-B57A-69B11F70A7AD\n' +
-//     '• databaseSequenceNumber: 5892\n' +
-//     '• options: \n',
-// ];
+// The exact stdout chunks `xcrun devicectl device install app` emits for a wired device.
+const INSTALL_FIXTURE = [
+  '15:06:52  Acquired tunnel connection to device.\n',
+  '15:06:52  Enabling developer disk image services.\n',
+  '15:06:52  Acquired usage assertion.\n',
+  '57%... ',
+  '60%... ',
+  '62%... ',
+  '66%... ',
+  '68%... ',
+  '72%... ',
+  '74%... ',
+  '76%... ',
+  '80%... 84%... 88%... 92%... ',
+  '96%... ',
+  'Complete!\nApp installed:\n',
+  '• bundleID: com.bacon.apr22\n' +
+    '• installationURL: file:///private/var/containers/Bundle/Application/54B96933-4472-4D98-9D67-A1F8AFC14FDE/apr22.app/\n' +
+    '• launchServicesIdentifier: unknown\n' +
+    '• databaseUUID: 9D988F8D-8E2F-4C4A-B57A-69B11F70A7AD\n' +
+    '• databaseSequenceNumber: 5892\n' +
+    '• options: \n',
+];
+
+const INSTALL_PROPS = {
+  bundle: '/path/to/App.app',
+  bundleIdentifier: 'com.test.app',
+  udid: '00008101-001964A22629003A',
+  deviceName: 'Test iPhone',
+};
+
+function createFakeChildProcess() {
+  const childProcess: any = new EventEmitter();
+  childProcess.stdout = new EventEmitter();
+  childProcess.stderr = new EventEmitter();
+  childProcess.kill = jest.fn();
+  return childProcess;
+}
+
+// Flush the queue so the install promise wires up its child-process `data`/`close` listeners.
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe(installAndLaunchAppAsync, () => {
+  beforeEach(() => {
+    mockSpinner.text = '';
+    // The `xcrun devicectl ... process launch` call that runs after a successful install.
+    jest.mocked(xcrunAsync).mockResolvedValue({ stdout: '', stderr: '' } as any);
+  });
+
+  it(`finishes at Complete 100% and resolves when the install prints no progress lines (wireless OTA)`, async () => {
+    const childProcess = createFakeChildProcess();
+    jest.mocked(spawn).mockReturnValue(childProcess);
+
+    const promise = installAndLaunchAppAsync(INSTALL_PROPS);
+    await flushAsync();
+
+    // The OTA install path is silent — it exits 0 without ever emitting an `NN%...` line.
+    childProcess.emit('close', 0);
+
+    await expect(promise).resolves.toBeUndefined();
+
+    // Without the terminal `updateProgress(100)` in the close handler the completion event never
+    // fires, the spinner never stops, and `expo run:ios --device` hangs. Assert it completed.
+    expect(mockSpinner.succeed).toHaveBeenCalledTimes(1);
+    expect(mockSpinner.text).toContain('Complete');
+    expect(mockSpinner.text).toContain('100%');
+  });
+
+  it(`completes exactly once when the install prints progress then a Complete line (wired)`, async () => {
+    const childProcess = createFakeChildProcess();
+    jest.mocked(spawn).mockReturnValue(childProcess);
+
+    const promise = installAndLaunchAppAsync(INSTALL_PROPS);
+    await flushAsync();
+
+    INSTALL_FIXTURE.forEach((chunk) => childProcess.stdout.emit('data', Buffer.from(chunk)));
+    childProcess.emit('close', 0);
+
+    await expect(promise).resolves.toBeUndefined();
+
+    // stdout already reported 100%, so the close handler's `updateProgress(100)` is a no-op and
+    // must not complete the spinner a second time.
+    expect(mockSpinner.succeed).toHaveBeenCalledTimes(1);
+    expect(mockSpinner.text).toContain('Complete');
+    expect(mockSpinner.text).toContain('100%');
+  });
+});

--- a/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
@@ -268,10 +268,17 @@ async function installAppWithDeviceCtlInternalAsync(
         return;
       }
       currentProgress = progress;
-      const statusPrefix = attempt > 1 ? `Installing (attempt ${attempt})` : 'Installing';
+      const isComplete = progress === 100;
+      // Match the usbmux install path, which reports a `Complete` status at 100%
+      // (`✔ Complete 100%`) via `InstallationProxyClient`.
+      const statusPrefix = isComplete
+        ? 'Complete'
+        : attempt > 1
+          ? `Installing (attempt ${attempt})`
+          : 'Installing';
       onProgress({
         progress,
-        isComplete: progress === 100,
+        isComplete,
         status: statusPrefix,
       });
     }
@@ -309,6 +316,12 @@ async function installAppWithDeviceCtlInternalAsync(
     childProcess.on('close', (code) => {
       debug('[close]: ' + code);
       if (code === 0) {
+        // `devicectl` OTA installs (e.g. to a wireless device) can exit 0 without ever
+        // printing an `NN%...` progress line, so `updateProgress()` may never have fired and
+        // consumers would never receive the completion event that stops their progress
+        // spinner — leaving `expo run:ios --device` hanging after a successful install.
+        // Emit a terminal 100% here; it's a no-op when stdout already reported 100%.
+        updateProgress(100);
         resolve();
       } else {
         const err = new Error(stderrBuffer || `Command failed with exit code ${code}`);


### PR DESCRIPTION
# Why

`expo run:ios --device` hangs and never exits after the app installs and launches when the target device is connected over Wi-Fi (it works fine when the device is wired). The process stays alive on `⠦ Connecting to: …` even though the app is already installed and running.

When the device isn't reachable over usbmux (the Wi-Fi case), `installOnDeviceAsync` catches `APPLE_DEVICE_USBMUXD` and falls back to the slower `devicectl` OTA install path. After that path installs and launches the app, the command never returns.

# How

Two leaked ref'd handles keep the Node event loop alive on the fallback path; this fixes both root causes:

- **Leaked usbmuxd socket.** `ClientManager.create()` opens a usbmuxd socket and then calls `getDevice()`, which throws `APPLE_DEVICE_USBMUXD` for a Wi-Fi-only device. Because the throw happens before a `ClientManager` is constructed, `ClientManager.end()` never runs and the socket is never closed. `create()` now closes the socket on the throw path (mirroring the existing guarded `socket.end()` in `end()`).

- **Missing completion event → spinner never stops.** A `devicectl` install can exit 0 without ever printing an `NN%...` progress line, so `updateProgress()` never fires the completion event that stops the consumer's `ora` spinner (its interval keeps the loop alive). `installAppWithDeviceCtlInternalAsync` now calls `updateProgress(100)` immediately before `resolve()` on a successful close — a no-op when stdout already reported 100%. `updateProgress` also reports a `Complete` status at 100%, so the `devicectl` path finishes at `✔ Complete 100%`, matching the usbmux path (`InstallationProxyClient` emits `{ isComplete: true, status: 'Complete' }`).

# Test Plan

Automated tests added in this PR — both verified to fail without their respective fix:

- `ClientManager-test.ts` — `create()` closes `socket.end()` and rethrows when `getDevice()` rejects `APPLE_DEVICE_USBMUXD`.
- `devicectl.test.ts` — `installAndLaunchAppAsync`, driven through a faked `spawn` child process: a silent (wireless OTA) install that only exits 0 completes once at `Complete 100%`; a progress-printing (wired) install completes *exactly once* (no double-complete).

```
$ pnpm test devicectl ClientManager   # 2 suites, 5 tests pass
$ pnpm test                            # 231 suites, 1804 tests pass, 7 skipped
$ pnpm lint && pnpm typecheck && pnpm build   # all clean
```

Verified manually on a physical iPhone connected over Wi-Fi: `expo run:ios --device` now installs, launches, prints `✔ Complete 100%`, and exits cleanly (previously it hung on `⠦ Connecting to: …`). Still exits cleanly when the device is wired.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
