### PR TITLE
[docs] Add Using PostHog guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -370,6 +370,7 @@ export const general = [
       makePage('guides/using-bugsnag.mdx'),
       makePage('guides/using-logrocket.mdx'),
       makePage('guides/using-vexo.mdx'),
+      makePage('guides/using-posthog.mdx'),
     ]),
     makeGroup('Authentication', [
       makePage('guides/using-authentication.mdx'),

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
     "@expo/styleguide": "^14.1.5",
     "@expo/styleguide-base": "^3.1.2",
     "@expo/styleguide-cookie-consent": "^2.1.2",
-    "@expo/styleguide-icons": "^4.2.4",
+    "@expo/styleguide-icons": "^4.2.5",
     "@expo/styleguide-search-ui": "^9.1.7",
     "@formatjs/intl-localematcher": "^0.8.5",
     "@kapaai/react-sdk": "^0.9.6",

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -11,7 +11,7 @@ import { Step } from '~/ui/components/Step';
 
 [PostHog](https://posthog.com/) is a product analytics platform with session replay, feature flags, and error tracking.
 
-The EAS CLI integration automates the standard PostHog React Native setup — installing the SDK, creating a PostHog organization and project, and configuring your environment variables. You can also [set it up manually](#manual-setup) and use the rest of this guide unchanged.
+The EAS CLI integration automates the standard PostHog React Native setup: installing the SDK, creating a PostHog organization and project, and configuring your environment variables. You can also [set it up manually](#manual-setup) and use the rest of this guide unchanged.
 
 <Prerequisites>
   <Requirement title="Expo account">
@@ -46,12 +46,12 @@ Run the following command in your project directory:
 This command:
 
 - Prompts for a PostHog **region** (US or EU). The region sets your data residency and can't be changed after connecting.
-- Creates a PostHog organization and project for you, or reuses the existing one if you've already connected. (New PostHog accounts only — see [Troubleshooting](#troubleshooting).)
-- Asks which features to set up — a multiselect of **Analytics**, **Session replay**, and **Error tracking**, all enabled by default.
-- If you enable **error tracking**, prompts you to paste a PostHog **personal API key** — create one in PostHog under **Settings → Personal API keys** with the "Source map upload" preset. (Non-interactively, pass it with `--posthog-cli-api-key`.)
+- Creates a PostHog organization and project for you, or reuses the existing one if you've already connected. (New PostHog accounts only; see [Troubleshooting](#troubleshooting).)
+- Asks which features to set up: a multiselect of **Analytics**, **Session replay**, and **Error tracking**, all enabled by default.
+- If you enable **error tracking**, prompts you to paste a PostHog **personal API key**. Create one in PostHog under **Settings → Personal API keys** with the "Source map upload" preset. (Non-interactively, pass it with `--posthog-cli-api-key`.)
 - Installs the PostHog SDK and required Expo modules (plus the session-replay package if you keep that feature).
-- Adds the `posthog-react-native/expo` config plugin to your app config — it wires up the native modules the SDK, session replay, and error symbolication rely on. It edits a static **app.json** for you; with a dynamic **app.config.js** it can't edit the file, so it prints the plugin entry for you to add.
-- Writes `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` to **.env.local** and to your EAS environment variables across Production, Preview, and Development. With error tracking enabled it also stores the personal API key as `POSTHOG_CLI_API_KEY` (with [sensitive visibility](/eas/environment-variables/#visibility-settings-for-environment-variables)) plus the public `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`.
+- Adds the `posthog-react-native/expo` config plugin to your app config. The plugin wires up the native modules that PostHog's SDK, session replay, and error symbolication rely on. It edits a static [app config](/workflow/configuration/) file for you, but it can't edit a [dynamic app config](/workflow/configuration/#dynamic-configuration), so it prints the plugin entry for you to add.
+- Writes `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` to **.env.local** and to your EAS environment variables across Production, Preview, and Development environments. With error tracking enabled it also stores the personal API key as `POSTHOG_CLI_API_KEY` (with [sensitive visibility](/eas/environment-variables/#visibility-settings-for-environment-variables)) and the public `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`.
 
 Re-running `connect` is safe: it reuses your existing organization and project and prompts before overwriting environment variables.
 
@@ -94,9 +94,9 @@ export default function RootLayout() {
 
 ### Create a development build
 
-Session replay and native error symbolication require a [development build](/develop/development-builds/introduction/) — they don't work in Expo Go. Product analytics works in Expo Go.
+Session replay and native error symbolication require a [development build](/develop/development-builds/introduction/) since they don't work in Expo Go. Product analytics works in Expo Go.
 
-<Terminal cmd={['$ npx expo prebuild', '$ eas build --profile development']} />
+<Terminal cmd={['$ eas build --profile development']} />
 
 </Step>
 
@@ -122,21 +122,21 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 ## Manual setup
 
-`connect` is a shortcut for the standard PostHog React Native setup. To do it by hand, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps — see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native)). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog).
+`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog). For source maps, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
 
 ## Usage with EAS Build
 
-The `posthog-react-native/expo` config plugin, together with the `POSTHOG_CLI_*` environment variables, handles source-map upload during `eas build` — there's no extra command to run. For configuration details and options, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). If your build needs to adjust iOS script sandboxing for source-map upload, the plugin's options are documented there as well.
+The `posthog-react-native/expo` config plugin, together with the `POSTHOG_CLI_*` environment variables, handles source-map upload during `eas build`, so there's no extra command to run. For configuration details and options, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). If your build needs to adjust iOS script sandboxing for source-map upload, the plugin's options are documented there as well.
 
 ## Usage with EAS Update
 
-Over-the-air bundles aren't part of `eas build`, so you upload their source maps separately after each `eas update`. Follow [PostHog's React Native source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native) — PostHog's CLI reads the `POSTHOG_CLI_*` environment variables that `connect` configured.
+Over-the-air bundles aren't part of `eas build`, so you upload their source maps separately after each `eas update`. Follow [PostHog's React Native source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). PostHog's CLI reads the `POSTHOG_CLI_*` environment variables that `connect` configured.
 
-For EAS Workflows and other CI, those variables are already set in your EAS environment variables. For external CI, add them with `eas secret:create` and reference them in your workflow.
+For EAS Workflows and other CI, those variables are already set in your EAS environment variables. For external CI, add them with `eas env:create` and reference them in your workflow.
 
 ## Release tagging
 
-Map each captured event back to a specific over-the-air update by registering super properties from [`expo-updates`](/versions/latest/sdk/updates/):
+Map each captured event back to a specific over-the-air update by registering [super properties](https://posthog.com/docs/libraries/react-native#super-properties) from [`expo-updates`](/versions/latest/sdk/updates/):
 
 ```tsx
 import { useEffect } from 'react';
@@ -158,19 +158,21 @@ function ReleaseTagger() {
 }
 ```
 
-Render `<ReleaseTagger />` inside `<PostHogProvider>`. Every subsequent `capture()` carries these properties, so you can filter or group events by `expo_update_id` in PostHog. See [PostHog's super properties docs](https://posthog.com/docs/libraries/react-native#super-properties).
+Render `<ReleaseTagger />` inside `<PostHogProvider>`. Every subsequent `capture()` carries these properties, so you can filter or group events by `expo_update_id` in PostHog.
 
 ## Feature flags
 
-Once the provider is set up, feature flags work with no extra configuration. See [PostHog's feature flags for React Native](https://posthog.com/docs/feature-flags/installation/react-native), and [bootstrapping](https://posthog.com/docs/feature-flags/bootstrapping) to avoid a network round-trip on app start.
+Once the provider is set up, feature flags work with no extra configuration. See [PostHog's feature flags for React Native](https://posthog.com/docs/feature-flags/installation/react-native) and [bootstrapping](https://posthog.com/docs/feature-flags/bootstrapping) to avoid a network round-trip on app start.
 
 ## Manage the integration
 
 Use these commands to manage the integration later:
 
-<Terminal cmd={['$ eas integrations:posthog:dashboard', '$ eas integrations:posthog:disconnect']} />
+<Terminal
+  cmd={['$ eas integrations:posthog:dashboard', '', '$ eas integrations:posthog:disconnect']}
+/>
 
-`dashboard` opens your linked PostHog project. `disconnect` removes the Expo-side link only — your PostHog organization, project, and data are left intact.
+`dashboard` opens your linked PostHog project. `disconnect` removes the Expo-side link only. Your PostHog organization, project, and data are left intact.
 
 ## Troubleshooting
 
@@ -182,7 +184,7 @@ Confirm `disabled: __DEV__` isn't masking events in your production build, and t
 
 <Collapsible summary="Session replay isn't working">
 
-Session replay requires a development build — it doesn't work in Expo Go. Create one with `npx expo prebuild` and `eas build --profile development`.
+Session replay requires a development build since it doesn't work with Expo Go. If your project uses [Continuous Native Generation](/workflow/continuous-native-generation/), create one with `npx expo run:android` or `npx expo run:ios` locally, or with `eas build --profile development`.
 
 </Collapsible>
 
@@ -194,7 +196,7 @@ Confirm the `POSTHOG_CLI_*` environment variables are set (connect adds them whe
 
 <Collapsible summary="'You already have a PostHog account'">
 
-The integration connects new PostHog accounts. If your email already has a PostHog account, set it up using the [manual steps](#manual-setup) instead — create a project in PostHog and configure the SDK, config plugin, and environment variables yourself.
+The integration connects new PostHog accounts. If your email already has a PostHog account, set it up using the [manual steps](#manual-setup) instead.
 
 </Collapsible>
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -122,10 +122,6 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 </Step>
 
-## Manual setup
-
-`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#wrap-your-app-in-posthogprovider). For source maps, see [Source maps](#source-maps).
-
 ## Error tracking
 
 If you enabled error tracking, PostHog symbolicates two separate things, and you set them up independently:
@@ -244,6 +240,10 @@ Use these commands to manage the integration later:
 />
 
 `dashboard` opens your linked PostHog project. `disconnect` removes the Expo-side link only. Your PostHog organization, project, and data are left intact.
+
+## Manual setup
+
+`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#wrap-your-app-in-posthogprovider). For source maps, see [Source maps](#source-maps).
 
 ## Troubleshooting
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -28,7 +28,7 @@ The EAS CLI integration automates the standard PostHog React Native setup: insta
 This guide covers integrating PostHog with your Expo project:
 
 - [Install and configure PostHog](#install-and-configure-posthog) in your React Native app
-- [Source maps](#source-maps) for error symbolication on EAS Build and EAS Update
+- [Error tracking](#error-tracking) with source maps and native crash symbolication
 - [Release tagging](#release-tagging), [feature flags](#feature-flags), and [troubleshooting](#troubleshooting)
 
 ## Install and configure PostHog
@@ -122,16 +122,18 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 `connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog). For source maps, see [Source maps](#source-maps).
 
-## Source maps
+## Error tracking
 
 If you enabled error tracking, PostHog symbolicates two separate things, and you set them up independently:
 
-- **JavaScript source maps** for JS/TS exceptions, including Hermes bytecode. Covered by the steps below.
-- **Native debug symbols** for native Android and iOS crashes (ProGuard/R8 mappings and dSYMs). Optional, and covered in [Native crash symbolication](#native-crash-symbolication).
+- **JavaScript source maps** for JS/TS exceptions, including Hermes bytecode. See [Source maps](#source-maps).
+- **Native debug symbols** for native Android and iOS crashes (ProGuard/R8 mappings and dSYMs). Optional. See [Native crash symbolication](#native-crash-symbolication).
 
-### Set up source map injection
+### Source maps
 
-Wrap your Metro config with PostHog's helper so each bundle is tagged for upload. Add this to **metro.config.js** in your project root (create the file if it doesn't exist):
+Source maps make JavaScript stack traces (including Hermes bytecode) point to your original source instead of minified output.
+
+First, set up injection so each bundle is tagged for upload. Add this to **metro.config.js** in your project root (create the file if it doesn't exist):
 
 ```js metro.config.js
 const { getPostHogExpoConfig } = require('posthog-react-native/metro');
@@ -145,13 +147,9 @@ If you already customize your Metro config (for example, with NativeWind or in a
 
 PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that `connect` set. To upload from your own machine, run `posthog-cli login` instead.
 
-### EAS Build
+**On EAS Build**, the `posthog-react-native/expo` config plugin uploads source maps automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run.
 
-The `posthog-react-native/expo` config plugin configures upload for you. JavaScript source maps upload automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run on `eas build`. Native debug-symbol upload is also built into the plugin, but it's off by default; turn it on with the `uploadNativeSymbols` option (see [Native crash symbolication](#native-crash-symbolication)).
-
-### EAS Update
-
-Over-the-air updates ship only JavaScript, so you upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
+**On EAS Update**, over-the-air updates ship only JavaScript, so upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
 
 <Terminal cmd={['$ eas update', '', '$ posthog-cli hermes upload --directory dist']} />
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -35,7 +35,7 @@ This guide covers integrating PostHog with your Expo project:
 
 <Step label="1">
 
-### Run the connect command
+### Run the `connect` command
 
 Run the following command in your project directory:
 
@@ -261,7 +261,7 @@ Session replay requires a development build since it doesn't work with Expo Go. 
 
 <Collapsible summary="Source maps aren't symbolicating">
 
-Confirm your **metro.config.js** is wrapped with `getPostHogExpoConfig` (see [Source maps](#source-maps)) and that the `POSTHOG_CLI_*` environment variables are set (connect adds them when error tracking is enabled). For over-the-air updates, make sure you ran `posthog-cli hermes upload --directory dist` after `eas update`.
+Confirm your **metro.config.js** is wrapped with `getPostHogExpoConfig` (see [Source maps](#source-maps)) and that the `POSTHOG_CLI_*` environment variables are set (`connect` adds them when error tracking is enabled). For over-the-air updates, make sure you ran `posthog-cli hermes upload --directory dist` after `eas update`.
 
 </Collapsible>
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -77,8 +77,8 @@ export default function RootLayout() {
       apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY}
       options={{
         host: process.env.EXPO_PUBLIC_POSTHOG_HOST,
-        enableSessionReplay: true, // set to true only if you set up session replay
-        disabled: __DEV__, // gate out development traffic
+        enableSessionReplay: false, // set to true if you enabled session replay
+        // disabled: __DEV__, // uncomment to stop sending events from development builds
       }}>
       <Slot />
     </PostHogProvider>
@@ -120,7 +120,7 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 ## Manual setup
 
-`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog). For source maps, see [Source maps](#source-maps).
+`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#wrap-your-app-in-posthogprovider). For source maps, see [Source maps](#source-maps).
 
 ## Error tracking
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -1,0 +1,208 @@
+---
+title: Using PostHog
+description: A guide on installing and configuring PostHog for product analytics, session replay, and error tracking.
+platforms: ['android', 'ios']
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+[PostHog](https://posthog.com/) is a product analytics platform with session replay, feature flags, and error tracking.
+
+The EAS CLI integration automates the standard PostHog React Native setup — installing the SDK, creating a PostHog organization and project, and configuring your environment variables. You can also [set it up manually](#manual-setup) and use the rest of this guide unchanged.
+
+<Prerequisites>
+  <Requirement title="Expo account">
+    Sign up for an [Expo account](https://expo.dev/signup).
+  </Requirement>
+  <Requirement title="EAS CLI">Install EAS CLI globally with `npm install -g eas-cli`.</Requirement>
+  <Requirement title="Expo project linked to EAS">
+    Create an Expo project and link it to EAS with `eas init`.
+  </Requirement>
+</Prerequisites>
+
+## What you'll learn
+
+This guide covers integrating PostHog with your Expo project:
+
+- [Install and configure PostHog](#install-and-configure-posthog) in your React Native app
+- Using PostHog with EAS:
+  - [EAS Build](#usage-with-eas-build) for building your app
+  - [EAS Update](#usage-with-eas-update) for over-the-air updates
+- [Release tagging](#release-tagging), [feature flags](#feature-flags), and [troubleshooting](#troubleshooting)
+
+## Install and configure PostHog
+
+<Step label="1">
+
+### Run the connect command
+
+Run the following command in your project directory:
+
+<Terminal cmd={['$ eas integrations:posthog:connect']} />
+
+This command:
+
+- Prompts for a PostHog **region** (US or EU). The region sets your data residency and can't be changed after connecting.
+- Creates a PostHog organization and project for you, or reuses the existing one if you've already connected. (New PostHog accounts only — see [Troubleshooting](#troubleshooting).)
+- Asks which features to set up — a multiselect of **Analytics**, **Session replay**, and **Error tracking**, all enabled by default.
+- If you enable **error tracking**, prompts you to paste a PostHog **personal API key** — create one in PostHog under **Settings → Personal API keys** with the "Source map upload" preset. (Non-interactively, pass it with `--posthog-cli-api-key`.)
+- Installs the PostHog SDK and required Expo modules (plus the session-replay package if you keep that feature).
+- Adds the `posthog-react-native/expo` config plugin to your app config — it wires up the native modules the SDK, session replay, and error symbolication rely on. It edits a static **app.json** for you; with a dynamic **app.config.js** it can't edit the file, so it prints the plugin entry for you to add.
+- Writes `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` to **.env.local** and to your EAS environment variables across Production, Preview, and Development. With error tracking enabled it also stores the personal API key as `POSTHOG_CLI_API_KEY` (with [sensitive visibility](/eas/environment-variables/#visibility-settings-for-environment-variables)) plus the public `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`.
+
+Re-running `connect` is safe: it reuses your existing organization and project and prompts before overwriting environment variables.
+
+<Collapsible summary="Running in CI or non-interactively">
+
+Pass `--non-interactive` with `--region US` or `--region EU` (required, since there's no safe default for data residency). Control features with `--session-replay` / `--no-session-replay` and `--error-tracking` / `--no-error-tracking`; error tracking also needs `--posthog-cli-api-key`. Use `--overwrite` to replace existing environment variables without prompting.
+
+</Collapsible>
+
+</Step>
+
+<Step label="2">
+
+### Wrap your app in `<PostHogProvider>`
+
+In your root layout file (**src/app/\_layout.tsx** with Expo Router), wrap your app in `<PostHogProvider>`, reading the keys from the environment variables the command wrote. See the [PostHog React Native docs](https://posthog.com/docs/libraries/react-native) for all options, including [error-tracking autocapture](https://posthog.com/docs/error-tracking/installation/react-native).
+
+```tsx src/app/_layout.tsx
+import { PostHogProvider } from 'posthog-react-native';
+import { Slot } from 'expo-router';
+
+export default function RootLayout() {
+  return (
+    <PostHogProvider
+      apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY}
+      options={{
+        host: process.env.EXPO_PUBLIC_POSTHOG_HOST,
+        enableSessionReplay: true, // set to true only if you set up session replay
+        disabled: __DEV__, // gate out development traffic
+      }}>
+      <Slot />
+    </PostHogProvider>
+  );
+}
+```
+
+</Step>
+
+<Step label="3">
+
+### Create a development build
+
+Session replay and native error symbolication require a [development build](/develop/development-builds/introduction/) — they don't work in Expo Go. Product analytics works in Expo Go.
+
+<Terminal cmd={['$ npx expo prebuild', '$ eas build --profile development']} />
+
+</Step>
+
+<Step label="4">
+
+### Verify the configuration
+
+Add a temporary button to capture a test event, run your development build, and tap it:
+
+{/* prettier-ignore */}
+```tsx
+import { Button } from 'react-native';
+import { usePostHog } from 'posthog-react-native';
+
+// Inside a component
+const posthog = usePostHog();
+<Button title="Send test event" onPress={() => posthog?.capture('test_event')} />
+```
+
+Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.com`, depending on your region) and confirm the event arrives.
+
+</Step>
+
+## Manual setup
+
+`connect` is a shortcut for the standard PostHog React Native setup. To do it by hand, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps — see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native)). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog).
+
+## Usage with EAS Build
+
+The `posthog-react-native/expo` config plugin, together with the `POSTHOG_CLI_*` environment variables, handles source-map upload during `eas build` — there's no extra command to run. For configuration details and options, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). If your build needs to adjust iOS script sandboxing for source-map upload, the plugin's options are documented there as well.
+
+## Usage with EAS Update
+
+Over-the-air bundles aren't part of `eas build`, so you upload their source maps separately after each `eas update`. Follow [PostHog's React Native source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native) — PostHog's CLI reads the `POSTHOG_CLI_*` environment variables that `connect` configured.
+
+For EAS Workflows and other CI, those variables are already set in your EAS environment variables. For external CI, add them with `eas secret:create` and reference them in your workflow.
+
+## Release tagging
+
+Map each captured event back to a specific over-the-air update by registering super properties from [`expo-updates`](/versions/latest/sdk/updates/):
+
+```tsx
+import { useEffect } from 'react';
+import * as Updates from 'expo-updates';
+import { usePostHog } from 'posthog-react-native';
+
+function ReleaseTagger() {
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    posthog?.register({
+      expo_update_id: Updates.updateId,
+      expo_channel: Updates.channel,
+      expo_runtime_version: Updates.runtimeVersion,
+    });
+  }, [posthog]);
+
+  return null;
+}
+```
+
+Render `<ReleaseTagger />` inside `<PostHogProvider>`. Every subsequent `capture()` carries these properties, so you can filter or group events by `expo_update_id` in PostHog. See [PostHog's super properties docs](https://posthog.com/docs/libraries/react-native#super-properties).
+
+## Feature flags
+
+Once the provider is set up, feature flags work with no extra configuration. See [PostHog's feature flags for React Native](https://posthog.com/docs/feature-flags/installation/react-native), and [bootstrapping](https://posthog.com/docs/feature-flags/bootstrapping) to avoid a network round-trip on app start.
+
+## Manage the integration
+
+Use these commands to manage the integration later:
+
+<Terminal cmd={['$ eas integrations:posthog:dashboard', '$ eas integrations:posthog:disconnect']} />
+
+`dashboard` opens your linked PostHog project. `disconnect` removes the Expo-side link only — your PostHog organization, project, and data are left intact.
+
+## Troubleshooting
+
+<Collapsible summary="No events arriving">
+
+Confirm `disabled: __DEV__` isn't masking events in your production build, and that `EXPO_PUBLIC_POSTHOG_API_KEY` is set in the environment profile your build uses.
+
+</Collapsible>
+
+<Collapsible summary="Session replay isn't working">
+
+Session replay requires a development build — it doesn't work in Expo Go. Create one with `npx expo prebuild` and `eas build --profile development`.
+
+</Collapsible>
+
+<Collapsible summary="Source maps aren't symbolicating">
+
+Confirm the `POSTHOG_CLI_*` environment variables are set (connect adds them when error tracking is enabled). For over-the-air updates, make sure you uploaded source maps after `eas update`, following [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+
+</Collapsible>
+
+<Collapsible summary="'You already have a PostHog account'">
+
+The integration connects new PostHog accounts. If your email already has a PostHog account, set it up using the [manual steps](#manual-setup) instead — create a project in PostHog and configure the SDK, config plugin, and environment variables yourself.
+
+</Collapsible>
+
+## Learn more
+
+- [PostHog React Native library](https://posthog.com/docs/libraries/react-native)
+- [Product analytics for React Native](https://posthog.com/docs/product-analytics/installation/react-native)
+- [Error tracking for React Native](https://posthog.com/docs/error-tracking/installation/react-native)
+- [Session replay for React Native](https://posthog.com/docs/session-replay/installation/react-native)
+- [Upload source maps for React Native](https://posthog.com/docs/error-tracking/upload-source-maps/react-native)
+- [Feature flags for React Native](https://posthog.com/docs/feature-flags/installation/react-native)

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -78,6 +78,10 @@ export default function RootLayout() {
       options={{
         host: process.env.EXPO_PUBLIC_POSTHOG_HOST,
         enableSessionReplay: false, // set to true if you enabled session replay
+        // Capture JS exceptions (remove if you didn't enable error tracking):
+        errorTracking: {
+          autocapture: { uncaughtExceptions: true, unhandledRejections: true },
+        },
         // disabled: __DEV__, // uncomment to stop sending events from development builds
       }}>
       <Slot />
@@ -245,7 +249,7 @@ Use these commands to manage the integration later:
 
 <Collapsible summary="No events arriving">
 
-Confirm `disabled: __DEV__` isn't masking events in your production build, and that `EXPO_PUBLIC_POSTHOG_API_KEY` is set in the environment profile your build uses.
+Confirm `disabled: __DEV__` isn't masking events in your production build, and that `EXPO_PUBLIC_POSTHOG_API_KEY` is set in the environment profile your build uses. If a dev server was already running when `connect` wrote your environment variables, do a full reload (not Fast Refresh) so the app picks up the new `EXPO_PUBLIC_*` values.
 
 </Collapsible>
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -124,7 +124,10 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 ## Source maps
 
-If you enabled error tracking, source maps let PostHog symbolicate JavaScript stack traces (including Hermes bytecode), so errors point to your original source instead of minified output. Set up injection once, then source maps upload automatically for native builds and manually for over-the-air updates.
+If you enabled error tracking, PostHog symbolicates two separate things, and you set them up independently:
+
+- **JavaScript source maps** for JS/TS exceptions, including Hermes bytecode. Covered by the steps below.
+- **Native debug symbols** for native Android and iOS crashes (ProGuard/R8 mappings and dSYMs). Optional, and covered in [Native crash symbolication](#native-crash-symbolication).
 
 ### Set up source map injection
 
@@ -144,15 +147,61 @@ PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that 
 
 ### EAS Build
 
-The `posthog-react-native/expo` config plugin uploads source maps automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run on `eas build`. To adjust iOS script sandboxing, see the plugin's options in [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+The `posthog-react-native/expo` config plugin configures upload for you. JavaScript source maps upload automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run on `eas build`. Native debug-symbol upload is also built into the plugin, but it's off by default; turn it on with the `uploadNativeSymbols` option (see [Native crash symbolication](#native-crash-symbolication)).
 
 ### EAS Update
 
-Over-the-air bundles aren't part of `eas build`, so upload their source maps manually after each update. [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
+Over-the-air updates ship only JavaScript, so you upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
 
 <Terminal cmd={['$ eas update', '', '$ posthog-cli hermes upload --directory dist']} />
 
-`dist` is the default EAS Update output directory. For EAS Workflows and other CI, the `POSTHOG_CLI_*` variables are already set in your EAS environment variables. For external CI, add them with `eas env:create` and reference them in your workflow.
+`dist` is the default EAS Update output directory.
+
+<Collapsible summary="Automate uploads with EAS Workflows">
+
+EAS Build uploads source maps as part of the native build, so a build workflow needs nothing extra. For updates, add a job that re-exports and uploads after publishing:
+
+```yaml .eas/workflows/publish-update.yml
+name: Publish update
+on:
+  push:
+    branches: ['main']
+jobs:
+  publish_update:
+    name: Publish update
+    type: update
+    params:
+      channel: production
+  upload_update_sourcemaps:
+    name: Upload OTA source maps to PostHog
+    needs: [publish_update]
+    environment: production
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - name: Export JS bundle and source maps
+        run: npx expo export --dump-sourcemap --output-dir dist
+      - name: Upload source maps to PostHog
+        run: npx --yes @posthog/cli@latest hermes upload --directory dist
+```
+
+`environment: production` gives the job the `POSTHOG_CLI_*` variables that `connect` stored. The chunk IDs injected by `getPostHogExpoConfig` let the re-exported source maps match the bundle the update published. For external CI, set the `POSTHOG_CLI_*` variables yourself.
+
+</Collapsible>
+
+### Native crash symbolication
+
+Optional. Native crashes (as opposed to JavaScript exceptions) need native debug symbols uploaded at build time. The `posthog-react-native/expo` plugin can do this during EAS Build once you opt in:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [["posthog-react-native/expo", { "uploadNativeSymbols": true }]]
+  }
+}
+```
+
+This is one of three pieces required end to end: build-time symbol upload (above), native crash autocapture in your provider, and the exception-autocapture setting in your PostHog project. See [PostHog's native crash autocapture](https://posthog.com/docs/libraries/react-native#native-crash-autocapture) for the full setup.
 
 ## Release tagging
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -96,7 +96,7 @@ export default function RootLayout() {
 
 ### Create a development build
 
-Session replay and native error symbolication require a [development build](/develop/development-builds/introduction/) since they don't work in Expo Go. Product analytics works in Expo Go.
+Session replay and native crash symbolication require a [development build](/develop/development-builds/introduction/) since they don't work in Expo Go. Product analytics works in Expo Go.
 
 <Terminal cmd={['$ eas build --profile development']} />
 
@@ -249,7 +249,7 @@ Use these commands to manage the integration later:
 
 <Collapsible summary="No events arriving">
 
-Confirm `disabled: __DEV__` isn't masking events in your production build, and that `EXPO_PUBLIC_POSTHOG_API_KEY` is set in the environment profile your build uses. If a dev server was already running when `connect` wrote your environment variables, do a full reload (not Fast Refresh) so the app picks up the new `EXPO_PUBLIC_*` values.
+Confirm `EXPO_PUBLIC_POSTHOG_API_KEY` is set in the environment profile your build uses. Note that `disabled: __DEV__` stops events from development builds, so test in a preview or production build (or remove it temporarily). If a dev server was already running when `connect` wrote your environment variables, do a full reload (not Fast Refresh) so the app picks up the new `EXPO_PUBLIC_*` values.
 
 </Collapsible>
 

--- a/docs/pages/guides/using-posthog.mdx
+++ b/docs/pages/guides/using-posthog.mdx
@@ -28,9 +28,7 @@ The EAS CLI integration automates the standard PostHog React Native setup: insta
 This guide covers integrating PostHog with your Expo project:
 
 - [Install and configure PostHog](#install-and-configure-posthog) in your React Native app
-- Using PostHog with EAS:
-  - [EAS Build](#usage-with-eas-build) for building your app
-  - [EAS Update](#usage-with-eas-update) for over-the-air updates
+- [Source maps](#source-maps) for error symbolication on EAS Build and EAS Update
 - [Release tagging](#release-tagging), [feature flags](#feature-flags), and [troubleshooting](#troubleshooting)
 
 ## Install and configure PostHog
@@ -122,17 +120,39 @@ Open your PostHog project (at `https://us.posthog.com` or `https://eu.posthog.co
 
 ## Manual setup
 
-`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog). For source maps, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+`connect` is a shortcut for the standard PostHog React Native setup. To do it manually, follow [PostHog's React Native installation guide](https://posthog.com/docs/libraries/react-native), then set `EXPO_PUBLIC_POSTHOG_API_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (plus the `POSTHOG_CLI_*` variables for source maps). Wrap your app in `<PostHogProvider>` as shown in [Step 2](#install-and-configure-posthog). For source maps, see [Source maps](#source-maps).
 
-## Usage with EAS Build
+## Source maps
 
-The `posthog-react-native/expo` config plugin, together with the `POSTHOG_CLI_*` environment variables, handles source-map upload during `eas build`, so there's no extra command to run. For configuration details and options, see [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). If your build needs to adjust iOS script sandboxing for source-map upload, the plugin's options are documented there as well.
+If you enabled error tracking, source maps let PostHog symbolicate JavaScript stack traces (including Hermes bytecode), so errors point to your original source instead of minified output. Set up injection once, then source maps upload automatically for native builds and manually for over-the-air updates.
 
-## Usage with EAS Update
+### Set up source map injection
 
-Over-the-air bundles aren't part of `eas build`, so you upload their source maps separately after each `eas update`. Follow [PostHog's React Native source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native). PostHog's CLI reads the `POSTHOG_CLI_*` environment variables that `connect` configured.
+Wrap your Metro config with PostHog's helper so each bundle is tagged for upload. Add this to **metro.config.js** in your project root (create the file if it doesn't exist):
 
-For EAS Workflows and other CI, those variables are already set in your EAS environment variables. For external CI, add them with `eas env:create` and reference them in your workflow.
+```js metro.config.js
+const { getPostHogExpoConfig } = require('posthog-react-native/metro');
+
+const config = getPostHogExpoConfig(__dirname);
+
+module.exports = config;
+```
+
+If you already customize your Metro config (for example, with NativeWind or in a monorepo), apply your changes to the `config` object that `getPostHogExpoConfig` returns instead of calling `getDefaultConfig` yourself.
+
+PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that `connect` set. To upload from your own machine, run `posthog-cli login` instead.
+
+### EAS Build
+
+The `posthog-react-native/expo` config plugin uploads source maps automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run on `eas build`. To adjust iOS script sandboxing, see the plugin's options in [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+
+### EAS Update
+
+Over-the-air bundles aren't part of `eas build`, so upload their source maps manually after each update. [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
+
+<Terminal cmd={['$ eas update', '', '$ posthog-cli hermes upload --directory dist']} />
+
+`dist` is the default EAS Update output directory. For EAS Workflows and other CI, the `POSTHOG_CLI_*` variables are already set in your EAS environment variables. For external CI, add them with `eas env:create` and reference them in your workflow.
 
 ## Release tagging
 
@@ -190,7 +210,7 @@ Session replay requires a development build since it doesn't work with Expo Go. 
 
 <Collapsible summary="Source maps aren't symbolicating">
 
-Confirm the `POSTHOG_CLI_*` environment variables are set (connect adds them when error tracking is enabled). For over-the-air updates, make sure you uploaded source maps after `eas update`, following [PostHog's source maps guide](https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+Confirm your **metro.config.js** is wrapped with `getPostHogExpoConfig` (see [Source maps](#source-maps)) and that the `POSTHOG_CLI_*` environment variables are set (connect adds them when error tracking is enabled). For over-the-air updates, make sure you ran `posthog-cli hermes upload --directory dist` after `eas update`.
 
 </Collapsible>
 

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -4,6 +4,7 @@ description: Learn how to monitor the usage of your Expo and React Native app af
 ---
 
 import { LogrocketIcon } from '@expo/styleguide-icons/custom/LogrocketIcon';
+import { PosthogIcon } from '@expo/styleguide-icons/custom/PosthogIcon';
 import { SentryIcon } from '@expo/styleguide-icons/custom/SentryIcon';
 import { ActivityIcon } from '@expo/styleguide-icons/outline/ActivityIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -118,4 +119,17 @@ Get started with the following guide:
   description="Learn how to use BugSnag to monitor your app."
   href="/guides/using-bugsnag/"
   Icon={BookOpen02Icon}
+/>
+
+## PostHog
+
+[PostHog](https://posthog.com/) is a product analytics platform with session replay, feature flags, and error tracking. The EAS CLI integration provisions a PostHog project, wires up the SDK, and lets you tag events by EAS Update through release tagging, so you can filter analytics and errors by release.
+
+Get started with the following guide:
+
+<BoxLink
+  title="Using PostHog"
+  description="Learn how to use PostHog to monitor your app."
+  href="/guides/using-posthog/"
+  Icon={PosthogIcon}
 />

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       '@expo/styleguide-icons':
-        specifier: ^4.2.4
-        version: 4.2.4(react@19.2.6)(tailwindcss@4.2.4)
+        specifier: ^4.2.5
+        version: 4.2.6(react@19.2.6)(tailwindcss@4.2.4)
       '@expo/styleguide-search-ui':
         specifier: ^9.1.7
         version: 9.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(next@16.2.6(patch_hash=423eaa79c801dbfda09aef892b3236e0194d49baf618fb3c7a89ec95d486eaeb)(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)
@@ -765,13 +765,18 @@ packages:
     peerDependencies:
       react: '>= 19'
 
+  '@expo/styleguide-base@3.1.4':
+    resolution: {integrity: sha512-nYr0MYFDKjTqkJVMEfkhfCejCiGOfyuSnzsRkM2Ux49BwpygONF2fCzJcWMSGE8KoEYaYjRydRiSwqKT2VJY8g==}
+    peerDependencies:
+      react: '>= 19'
+
   '@expo/styleguide-cookie-consent@2.1.2':
     resolution: {integrity: sha512-97X0ZCcV2Q1hNoDk70gfnqFuXdh3RvaHVfCjhktz1RIXWLJRM9CvsqgZWIl6DgCyb9xCnYL0RCZOpNPp2L614w==}
     peerDependencies:
       react: '>= 19'
 
-  '@expo/styleguide-icons@4.2.4':
-    resolution: {integrity: sha512-ibh6sVj+IsGkhdeyMfj28l7vb0JBUSSbrOeW2L2OJQ+hn29TonK9vg/HW1AaUEp9rEZAEUmLEEV4kjejvkOXIA==}
+  '@expo/styleguide-icons@4.2.6':
+    resolution: {integrity: sha512-IBjcInVTDg3zPJaskppMy/FQzhYK1HewtL3OWVpwinL45L+IzqluWV+K6oDPuis0VFDzFkIcnbEXAuR0DkecVQ==}
     peerDependencies:
       react: '>= 19'
       tailwindcss: ^4.2.2
@@ -7550,6 +7555,12 @@ snapshots:
       react: 19.2.6
       tailwind-merge: 3.5.0
 
+  '@expo/styleguide-base@3.1.4(react@19.2.6)':
+    dependencies:
+      '@radix-ui/colors': 3.0.0
+      react: 19.2.6
+      tailwind-merge: 3.5.0
+
   '@expo/styleguide-cookie-consent@2.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -7565,16 +7576,16 @@ snapshots:
       - react-dom
       - use-sync-external-store
 
-  '@expo/styleguide-icons@4.2.4(react@19.2.6)(tailwindcss@4.2.4)':
+  '@expo/styleguide-icons@4.2.6(react@19.2.6)(tailwindcss@4.2.4)':
     dependencies:
-      '@expo/styleguide-base': 3.1.2(react@19.2.6)
+      '@expo/styleguide-base': 3.1.4(react@19.2.6)
       react: 19.2.6
       tailwindcss: 4.2.4
 
   '@expo/styleguide-search-ui@9.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(next@16.2.6(patch_hash=423eaa79c801dbfda09aef892b3236e0194d49baf618fb3c7a89ec95d486eaeb)(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)':
     dependencies:
       '@expo/styleguide': 14.1.5(next@16.2.6(patch_hash=423eaa79c801dbfda09aef892b3236e0194d49baf618fb3c7a89ec95d486eaeb)(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)
-      '@expo/styleguide-icons': 4.2.4(react@19.2.6)(tailwindcss@4.2.4)
+      '@expo/styleguide-icons': 4.2.6(react@19.2.6)(tailwindcss@4.2.4)
       '@kapaai/react-sdk': 0.9.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@sanity/client': 7.21.0
       '@sanity/image-url': 2.1.1


### PR DESCRIPTION
# Why

We're shipping an EAS CLI integration (`eas integrations:posthog:connect`) that automates PostHog setup for React Native apps. This adds the guide it points people to.

# How

New guide at `docs/pages/guides/using-posthog.mdx` plus a sidebar entry. It walks through the `connect` command (region, feature multiselect, SDK install, config plugin, personal API key for source maps, env vars), wrapping the app in `<PostHogProvider>`, making a development build, and verifying events. It also covers manual setup, source maps on EAS Build and EAS Update, release tagging, feature flags, managing and disconnecting, and troubleshooting. It follows the same shape as the other "Using X" integration guides.

# Test Plan

- `vale` prose linter — 0 errors / 0 warnings / 0 suggestions
- `oxfmt --check` — clean
- Cross-checked every step against the `integrations:posthog:connect` / `dashboard` / `disconnect` implementation in eas-cli
- Preview link once the branch is up

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
