### PR TITLE
[ios][core] Update to expo-modules-macros-plugin 0.3.0

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### 🎉 New features
 
 - [iOS] Added the `@Record` macro that synthesizes a record from a type's stored properties, with no `@Field` wrappers needed. ([#46547](https://github.com/expo/expo/pull/46547) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added the `@Event` macro that turns a function-typed `var` on a module or shared object into a typed JavaScript event. ([#46938](https://github.com/expo/expo/pull/46938) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `@ExpoModule` now synthesizes the module's JavaScript name from the class name or its `@ExpoModule("CustomName")` argument, so a `Name(…)` definition entry is no longer required. ([#46938](https://github.com/expo/expo/pull/46938) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `Module.emit` that sends an event directly to the module's own JavaScript object, mirroring `SharedObject.emit`. Both now share an `EventEmitter` protocol. ([#46555](https://github.com/expo/expo/pull/46555) by [@tsapeta](https://github.com/tsapeta))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
 

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -47,6 +47,25 @@ public macro OptimizedFunction() =
 public macro JS(_ jsName: String? = nil) =
   #externalMacro(module: "ExpoModulesMacros", type: "JSMacro")
 
+/// Turns a function-typed `var` on a module or shared object into a typed JavaScript event.
+/// Calling the property emits the event to JavaScript, with the closure's parameter as the payload.
+///
+/// The JS event name defaults to the property name with a leading `on` stripped (`onProgress` emits
+/// `progress`); pass `@Event("customName")` to set it explicitly. The payload type must be
+/// convertible to JavaScript, and a `() -> Void` property is a no-payload event.
+///
+/// Usage:
+///
+///     @Event
+///     var onProgress: (ProgressEvent) -> Void
+///
+///     // Emit it from anywhere:
+///     onProgress(ProgressEvent(percent: 50))
+@attached(accessor)
+@attached(peer, names: arbitrary)
+public macro Event(_ name: String? = nil, sync: Bool = false) =
+  #externalMacro(module: "ExpoModulesMacros", type: "EventMacro")
+
 /// Member macro applied to a `Module` subclass. Scans the class body for declarations
 /// marked with `@JS` and synthesizes a framework-internal `_synthesizedDefinition()` method.
 /// `expo-modules-core` calls it automatically and merges the result into the module's
@@ -54,20 +73,24 @@ public macro JS(_ jsName: String? = nil) =
 /// additionally bound directly into the module's JS object by a synthesized
 /// `_decorateModule(object:in:appContext:)`.
 ///
+/// The module's JavaScript name is synthesized into a `_jsName` static and read by core, so there
+/// is no `Name(…)` DSL entry. It defaults to the class name; pass `@ExpoModule("CustomName")` to
+/// override it.
+///
 /// Usage:
 ///
 ///     @ExpoModule
 ///     public final class MyModule: Module {
-///       public func definition() -> ModuleDefinition {
-///         Name("MyModule")
-///       }
-///
 ///       @JS
 ///       func greet(name: String) -> String { "Hi, \(name)" }
 ///     }
 @attached(
   member,
-  names: named(_synthesizedDefinition), named(appContext), named(init), named(_decorateModule))
+  names:
+    named(_jsName), named(_synthesizedDefinition), named(appContext), named(init),
+    named(_decorateModule))
+@attached(memberAttribute)
+@attached(extension, conformances: AnyModule)
 public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
   #externalMacro(module: "ExpoModulesMacros", type: "ExpoModuleMacro")
 
@@ -91,6 +114,7 @@ public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
 ///       var size: Int { 42 }
 ///     }
 @attached(member, names: named(_synthesizedClassDefinition))
+@attached(memberAttribute)
 public macro SharedObject(_ name: String? = nil) =
   #externalMacro(module: "ExpoModulesMacros", type: "SharedObjectMacro")
 

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -31,10 +31,18 @@ public final class ModuleHolder {
   let definition: ModuleDefinition
 
   /**
-   Returns `definition.name` if not empty, otherwise falls back to the module type name.
+   The module's name. Prefers the name passed at registration, then a non-empty `Name(…)` from the
+   definition, and finally `_jsName` — the `@ExpoModule` macro's synthesized name, defaulting to the
+   module type name.
    */
   var name: String {
-    return _name ?? (definition.name.isEmpty ? String(describing: type(of: module)) : definition.name)
+    if let _name {
+      return _name
+    }
+    if !definition.name.isEmpty {
+      return definition.name
+    }
+    return type(of: module)._jsName
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -70,10 +70,18 @@ public final class ModuleHolder {
   private static func buildDefinition(for module: AnyModule) -> ModuleDefinition {
     let userDefinition = module.definition()
     let synthesized = module._synthesizedDefinition()
-    if synthesized.isEmpty {
-      return userDefinition
+    let definition = synthesized.isEmpty
+      ? userDefinition
+      : ModuleDefinition(definitions: synthesized + userDefinition.rawDefinitions)
+
+    // A macro module describes its name through the synthesized `_jsName` rather than a `Name(…)`
+    // entry, so fill it in here. The definition's name backs `__expo_module_name__` and the view
+    // prototype keys, which legacy event-emitter and view-manager compatibility paths look up by
+    // the registered module name — they'd otherwise key off an empty string.
+    if definition.name.isEmpty {
+      definition.name = type(of: module)._jsName
     }
-    return ModuleDefinition(definitions: synthesized + userDefinition.rawDefinitions)
+    return definition
   }
 
   // MARK: Constants

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
@@ -17,6 +17,12 @@ public protocol AnyModule: AnyObject, AnyArgument {
   @ModuleDefinitionBuilder
   func definition() -> ModuleDefinition
 
+  /// The module's JavaScript name, emitted as a static constant by the `@ExpoModule` macro from the
+  /// class name or the `@ExpoModule("CustomName")` argument. Core reads it as the last resort when
+  /// naming the module, after the `Name(…)` DSL entry. Framework-internal (leading underscore).
+  /// Modules that don't use the macro fall back to the default, which is the class name.
+  static var _jsName: String { get }
+
   /// Returns definitions synthesized from `@JS`-annotated members by the `@ExpoModule` macro.
   /// Framework-internal: the leading underscore signals this is not part of the public API and
   /// should only be called by `expo-modules-core` itself. Modules that don't use the macro fall
@@ -32,6 +38,16 @@ public protocol AnyModule: AnyObject, AnyArgument {
 }
 
 public extension AnyModule {
+  static var _jsName: String {
+    return String(describing: self)
+  }
+
+  /// An empty definition by default, so `@ExpoModule`-macro modules that describe their whole surface
+  /// through `@JS` members don't have to write an empty `definition()` of their own. Modules that use
+  /// the DSL provide their own.
+  @ModuleDefinitionBuilder
+  func definition() -> ModuleDefinition {}
+
   func _synthesizedDefinition() -> [AnyDefinition] {
     return []
   }

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+
+// MARK: - Test module
+
+@Record
+private struct ProgressEvent {
+  var percent: Int = 0
+}
+
+@ExpoModule
+private final class MacroEmitter: Module {
+  @Event
+  var onProgress: (ProgressEvent) -> Void
+
+  @Event
+  var onDone: () -> Void
+}
+
+@Suite("Macro event")
+@JavaScriptActor
+private struct MacroEventTests {
+  let appContext: AppContext
+  let module: MacroEmitter
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  init() {
+    appContext = AppContext.create()
+    module = MacroEmitter(appContext: appContext)
+    appContext.moduleRegistry.register(module: module, name: nil)
+  }
+
+  @Test
+  func `emits an event with a payload to a JS listener`() async throws {
+    try runtime.eval([
+      "globalThis.result = null",
+      "expo.modules.MacroEmitter.addListener('progress', payload => { globalThis.result = payload.percent })"
+    ].joined(separator: "\n"))
+
+    module.onProgress(ProgressEvent(percent: 75))
+
+    try await expectResult(equals: 75)
+  }
+
+  @Test
+  func `emits a no-payload event to a JS listener`() async throws {
+    try runtime.eval([
+      "globalThis.result = 0",
+      "expo.modules.MacroEmitter.addListener('done', () => { globalThis.result = 1 })"
+    ].joined(separator: "\n"))
+
+    module.onDone()
+
+    try await expectResult(equals: 1)
+  }
+
+  nonisolated private func expectResult(equals expected: Int) async throws {
+    try await expectEventually {
+      guard let resultValue = try? await self.runtime.eval("globalThis.result") else {
+        return false
+      }
+      guard resultValue.isNumber() else {
+        return false
+      }
+      return try await resultValue.asInt() == expected
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
@@ -39,10 +39,10 @@ private struct MacroEventTests {
 
   @Test
   func `emits an event with a payload to a JS listener`() async throws {
-    try runtime.eval([
-      "globalThis.result = null",
-      "expo.modules.MacroEmitter.addListener('progress', payload => { globalThis.result = payload.percent })"
-    ].joined(separator: "\n"))
+    try runtime.eval("""
+      globalThis.result = null
+      expo.modules.MacroEmitter.addListener('progress', payload => { globalThis.result = payload.percent })
+      """)
 
     module.onProgress(ProgressEvent(percent: 75))
 
@@ -51,10 +51,10 @@ private struct MacroEventTests {
 
   @Test
   func `emits a no-payload event to a JS listener`() async throws {
-    try runtime.eval([
-      "globalThis.result = 0",
-      "expo.modules.MacroEmitter.addListener('done', () => { globalThis.result = 1 })"
-    ].joined(separator: "\n"))
+    try runtime.eval("""
+      globalThis.result = 0
+      expo.modules.MacroEmitter.addListener('done', () => { globalThis.result = 1 })
+      """)
 
     module.onDone()
 

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
@@ -67,6 +67,14 @@ private struct MacroModuleTests {
     #expect(try runtime.eval("expo.modules.RenamedMacroModule.ping()").asString() == "pong")
   }
 
+  @Test
+  func `synthesized name backs the module's __expo_module_name__`() throws {
+    register(MacroRenamed(appContext: appContext))
+    // `__expo_module_name__` comes from the definition's name, which legacy event-emitter and
+    // view-manager compatibility paths look up by; it must match the registered module name.
+    #expect(try runtime.eval("expo.modules.RenamedMacroModule.__expo_module_name__").asString() == "RenamedMacroModule")
+  }
+
   // MARK: - @JS functions
 
   @Test

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
@@ -1,0 +1,93 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+
+// MARK: - Test modules
+
+@ExpoModule
+private final class MacroGreeter: Module {
+  @JS
+  func greet(name: String) -> String {
+    return "Hi, \(name)"
+  }
+
+  @JS("sum")
+  func add(a: Double, b: Double) -> Double {
+    return a + b
+  }
+
+  @JS
+  var status: String {
+    return "ok"
+  }
+}
+
+@ExpoModule("RenamedMacroModule")
+private final class MacroRenamed: Module {
+  @JS
+  func ping() -> String {
+    return "pong"
+  }
+}
+
+@Suite("Macro module")
+@JavaScriptActor
+private struct MacroModuleTests {
+  let appContext: AppContext
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  init() {
+    appContext = AppContext.create()
+  }
+
+  private func register(_ module: AnyModule) {
+    // `name: nil` so module naming falls through to the macro-synthesized `_jsName`.
+    appContext.moduleRegistry.register(module: module, name: nil)
+  }
+
+  // MARK: - Naming
+
+  @Test
+  func `module name defaults to the class name`() throws {
+    register(MacroGreeter(appContext: appContext))
+    #expect(MacroGreeter._jsName == "MacroGreeter")
+    #expect(try runtime.eval("typeof expo.modules.MacroGreeter").asString() == "object")
+  }
+
+  @Test
+  func `module name honors the @ExpoModule argument`() throws {
+    register(MacroRenamed(appContext: appContext))
+    #expect(MacroRenamed._jsName == "RenamedMacroModule")
+    #expect(try runtime.eval("expo.modules.RenamedMacroModule.ping()").asString() == "pong")
+  }
+
+  // MARK: - @JS functions
+
+  @Test
+  func `binds a @JS function`() throws {
+    register(MacroGreeter(appContext: appContext))
+    #expect(try runtime.eval("typeof expo.modules.MacroGreeter.greet").asString() == "function")
+    #expect(try runtime.eval("expo.modules.MacroGreeter.greet('Expo')").asString() == "Hi, Expo")
+  }
+
+  @Test
+  func `honors the @JS name override`() throws {
+    register(MacroGreeter(appContext: appContext))
+    #expect(try runtime.eval("expo.modules.MacroGreeter.sum(2, 3)").asDouble() == 5)
+    #expect(try runtime.eval("'add' in expo.modules.MacroGreeter").asBool() == false)
+  }
+
+  // MARK: - @JS properties
+
+  @Test
+  func `binds a @JS property`() throws {
+    register(MacroGreeter(appContext: appContext))
+    #expect(try runtime.eval("expo.modules.MacroGreeter.status").asString() == "ok")
+  }
+}

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -55,7 +55,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "0.2.2",
+    "@expo/expo-modules-macros-plugin": "0.3.0",
     "expo-modules-jsi": "workspace:~56.0.7",
     "invariant": "^2.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4930,8 +4930,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.3.0
+        version: 0.3.0
       expo-modules-jsi:
         specifier: workspace:~56.0.7
         version: link:../expo-modules-jsi
@@ -7580,8 +7580,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.2.2':
-    resolution: {integrity: sha512-4IMzPDIo/VOXREQjsJtliSfqYVZvfzU2SLFS/9sKMWF848S8CHx+e/E+Vf0TcMvpWCCKX5umyqxb13KJJ+YUzg==}
+  '@expo/expo-modules-macros-plugin@0.3.0':
+    resolution: {integrity: sha512-2tRq8kiIZTVZcI5uggh86HefQ7s++Zk5WkFFomNp4aUqyN5ownHHvj1jPEP9jWXaXjPDmWuf5SUZTGD5G6AKkg==}
 
   '@expo/material-symbols@0.1.1':
     resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
@@ -7970,72 +7970,85 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -8381,36 +8394,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -9025,24 +9044,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -9663,41 +9686,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -12859,24 +12890,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -17343,7 +17378,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/expo-modules-macros-plugin@0.2.2': {}
+  '@expo/expo-modules-macros-plugin@0.3.0': {}
 
   '@expo/material-symbols@0.1.1': {}
 


### PR DESCRIPTION
# Why

`@expo/expo-modules-macros-plugin` 0.3.0 is out. It adds the `@Event` macro, synthesizes the module's JavaScript name into a `_jsName` static (retiring the `Name(…)` DSL entry for macro modules), and emits a range-based arity check. This bumps the plugin and syncs the `expo-modules-core` side so those features compile and are exercised by tests.

# How

- **Bump** the plugin to `0.3.0`.
- **Macro declarations** in `ExpoModulesMacros.swift`: declare the new `@Event` macro, and add the roles each macro actually implements that were missing from the `#externalMacro` declarations — `@attached(memberAttribute)` + `@attached(extension, conformances: AnyModule)` on `@ExpoModule`, and `@attached(memberAttribute)` on `@SharedObject`. Without the full role set the member expansion is dropped and the class fails `AnyModule` conformance.
- **Module naming**: `AnyModule` gains a `static var _jsName` (defaulting to the class name); `ModuleHolder` reads it as the last resort after a `Name(…)` definition entry, so `@ExpoModule` modules no longer need `Name(…)`.
- **Default `definition()`**: `AnyModule` gets a default empty `definition()` so macro-only modules that describe their whole surface through `@JS` members don't have to write one.
- **Tests**: new `ios/Tests/Macros/` covering `@ExpoModule` naming (class name and `@ExpoModule("…")` argument), `@JS` function/property binding, and async `@Event` dispatch.

`@SharedObject` support needs a further core change (the macro's `nonisolated` synthesized class definition references `@JavaScriptActor`-isolated `@JS` members), so its test is deferred to a follow-up.

# Test Plan

`et check-packages expo-modules-core` passes. iOS native unit tests pass (61/61, 0 failures) including the new `Macro module` and `Macro event` suites:

```
et native-unit-tests -p ios --packages expo-modules-core
…
Executed 61 tests, with 0 failures (0 unexpected)
```
