### PR TITLE
[docs] Drop react-native-reanimated requirement from Expo UI worklet docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -60,7 +60,7 @@ export default function BasicTextFieldExample() {
 
 Pass a [`useNativeState`](usenativestate) observable as `value` and an `onValueChange` worklet to transform or validate input before writing it back. The example below uppercases the text as it is typed.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx ControlledTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
@@ -310,7 +310,7 @@ export default function ImperativeRefExample() {
 
 When `onValueChange` is marked with the `'worklet'` directive, it runs synchronously on the UI thread, so writes to [`useNativeState`](usenativestate) observables inside the callback take effect before the next frame. There is no flicker between the typed text and the masked text. The example below masks a phone number as the user types and writes both `value` and `selection` from the worklet to keep the cursor at the end of the formatted value.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -19,7 +19,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Usage
 
-> **Note:** Using worklets requires installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without them, but the synchronous UI-thread updates shown below depend on the worklet runtime.
+> **Note:** Using worklets requires installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without it, but the synchronous UI-thread updates shown below depend on the worklet runtime.
 
 The example below masks a phone number as the user types. The formatting and the writes to `maskedPhone.value` (text) and `selection.value` (cursor position) all happen synchronously on the UI thread, so there is no flicker between the typed value and the masked value.
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -50,7 +50,7 @@ export default function BasicTextFieldExample() {
 
 Pass an `onTextChange` worklet to transform or validate input and write the result back to the [`useNativeState`](usenativestate) observable state. The example below uppercases the text as it is typed.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx ControlledTextFieldExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
@@ -212,7 +212,7 @@ export default function ImperativeRefExample() {
 
 When `onTextChange` is marked with the `'worklet'` directive, it runs synchronously on the UI thread, so writes to [`useNativeState`](usenativestate) observables inside the callback take effect before the next frame. There is no flicker between the typed text and the masked text. The example below masks a phone number as the user types and writes both `text` and `selection` from the worklet to keep the cursor at the end of the formatted value.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/). The `selection` prop requires iOS 18.0+ / tvOS 18.0+. On older versions the worklet can still update the text but cursor positioning is unavailable.
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/). The `selection` prop requires iOS 18.0+ / tvOS 18.0+. On older versions the worklet can still update the text but cursor positioning is unavailable.
 
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
@@ -19,7 +19,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Usage
 
-> **Note:** Using worklets requires installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without them, but the synchronous UI-thread updates shown below depend on the worklet runtime.
+> **Note:** Using worklets requires installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without it, but the synchronous UI-thread updates shown below depend on the worklet runtime.
 
 The example below masks a phone number as the user types. The formatting and the writes to `maskedPhone.value` (text) and `selection.value` (cursor position) all happen synchronously on the UI thread, so there is no flicker between the typed value and the masked value.
 

--- a/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
@@ -77,7 +77,7 @@ export default function ControlledTextInputExample() {
 
 Add the `'worklet'` directive to [`onChangeText`](#onchangetext) for synchronously updating the state on the UI thread. Writes to `value` land without the JS-thread round-trip that can cause cursor flicker.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx PhoneMaskExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -60,7 +60,7 @@ export default function BasicTextFieldExample() {
 
 Pass a [`useNativeState`](usenativestate) observable as `value` and an `onValueChange` worklet to transform or validate input before writing it back. The example below uppercases the text as it is typed.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx ControlledTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
@@ -310,7 +310,7 @@ export default function ImperativeRefExample() {
 
 When `onValueChange` is marked with the `'worklet'` directive, it runs synchronously on the UI thread, so writes to [`useNativeState`](usenativestate) observables inside the callback take effect before the next frame. There is no flicker between the typed text and the masked text. The example below masks a phone number as the user types and writes both `value` and `selection` from the worklet to keep the cursor at the end of the formatted value.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -19,7 +19,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Usage
 
-> **Note:** Using worklets requires installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without them, but the synchronous UI-thread updates shown below depend on the worklet runtime.
+> **Note:** Using worklets requires installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without it, but the synchronous UI-thread updates shown below depend on the worklet runtime.
 
 The example below masks a phone number as the user types. The formatting and the writes to `maskedPhone.value` (text) and `selection.value` (cursor position) all happen synchronously on the UI thread, so there is no flicker between the typed value and the masked value.
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -50,7 +50,7 @@ export default function BasicTextFieldExample() {
 
 Pass an `onTextChange` worklet to transform or validate input and write the result back to the [`useNativeState`](usenativestate) observable state. The example below uppercases the text as it is typed.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx ControlledTextFieldExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
@@ -212,7 +212,7 @@ export default function ImperativeRefExample() {
 
 When `onTextChange` is marked with the `'worklet'` directive, it runs synchronously on the UI thread, so writes to [`useNativeState`](usenativestate) observables inside the callback take effect before the next frame. There is no flicker between the typed text and the masked text. The example below masks a phone number as the user types and writes both `text` and `selection` from the worklet to keep the cursor at the end of the formatted value.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/). The `selection` prop requires iOS 18.0+ / tvOS 18.0+. On older versions the worklet can still update the text but cursor positioning is unavailable.
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/). The `selection` prop requires iOS 18.0+ / tvOS 18.0+. On older versions the worklet can still update the text but cursor positioning is unavailable.
 
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
@@ -19,7 +19,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Usage
 
-> **Note:** Using worklets requires installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without them, but the synchronous UI-thread updates shown below depend on the worklet runtime.
+> **Note:** Using worklets requires installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/) in your project. `useNativeState` itself works without it, but the synchronous UI-thread updates shown below depend on the worklet runtime.
 
 The example below masks a phone number as the user types. The formatting and the writes to `maskedPhone.value` (text) and `selection.value` (cursor position) all happen synchronously on the UI thread, so there is no flicker between the typed value and the masked value.
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
@@ -77,7 +77,7 @@ export default function ControlledTextInputExample() {
 
 Add the `'worklet'` directive to [`onChangeText`](#onchangetext) for synchronously updating the state on the UI thread. Writes to `value` land without the JS-thread round-trip that can cause cursor flicker.
 
-> **Note:** Worklets require installing [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) and [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
+> **Note:** Worklets require installing [`react-native-worklets`](https://docs.swmansion.com/react-native-worklets/).
 
 ```tsx PhoneMaskExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';


### PR DESCRIPTION
# Why

Drops reanimated requirement from Expo UI for using worklets. Android PR - https://github.com/expo/expo/pull/46922, iOS PR - https://github.com/expo/expo/pull/46922
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Removed reanimated reference from Expo UI docs
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
