### PR TITLE
[ios][dev-launcher] Add keyboard shortcuts for manual URL input

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -23,6 +23,7 @@ private func sanitizeUrlString(_ urlString: String) -> String? {
 }
 
 private let urlInputAnimation = Animation.easeInOut(duration: 0.3)
+private let keyboardShortcuts = ["http://", "https://", "127.0.0.1", ":", "/"]
 
 struct DevServersView: View {
   @EnvironmentObject var viewModel: DevLauncherViewModel
@@ -110,6 +111,17 @@ struct DevServersView: View {
           .autocapitalization(.none)
         #endif
           .disableAutocorrection(true)
+          .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+              ForEach(keyboardShortcuts, id: \.self) { shortcut in
+                Button {
+                  urlText += shortcut
+                } label: {
+                  Text(shortcut)
+                }
+              }
+            }
+          }
           .padding(.horizontal, 16)
           .padding(.vertical, 12)
           .foregroundColor(.primary)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I find the current URL input box inconvenient to use; I have to switch keyboard types multiple times to enter a complete URL.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I added a `toolbar` modifier to the SwiftUI TextField and used `ForEach` to add some shortcut input characters, which concatenate the text when clicked.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
This change can be reproduced directly using Xcode Playground.
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ae36437f-4060-46d1-865f-c7133150cd6e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
