### PR TITLE
[expo-go][updates] Compare Expo Go SDK compatibility by major version

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ABIVersion.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ABIVersion.kt
@@ -2,6 +2,8 @@
 package host.exp.exponent
 
 object ABIVersion {
+  private const val EXPO_SDK_RUNTIME_VERSION_PREFIX = "exposdk:"
+
   // Returns (5 * 100 * 100 + 6 * 100 + 7) for "5.6.7" or "5_6_7".
   // Assumes all version numbers are < 100
   @JvmStatic fun toNumber(abiVersion: String): Int {
@@ -21,5 +23,34 @@ object ABIVersion {
       currentBasePower *= base
     }
     return value
+  }
+
+  // The major component of an SDK version, e.g. "56" for "56.0.0". Accepts an optional
+  // "exposdk:" runtime-version prefix (so "exposdk:56.0.0" also yields "56"). Returns null
+  // when there is no version or no numeric major to read.
+  @JvmStatic fun majorVersion(sdkVersion: String?): String? {
+    val stripped = sdkVersion?.removePrefix(EXPO_SDK_RUNTIME_VERSION_PREFIX) ?: return null
+    return stripped.split(".").firstOrNull()?.takeIf { it.isNotEmpty() }
+  }
+
+  // Whether a project's [sdkVersion] is compatible with the SDK version this Expo Go client
+  // supports ([supportedSdkVersion]). Two versions are compatible when they share a major
+  // version; UNVERSIONED is compatible with anything.
+  //
+  // Expo Go ships supporting a single SDK major and projects always publish X.0.0, so the
+  // major version is what determines compatibility. The client's own version string is not
+  // guaranteed to equal the supported SDK version — a client patch release (e.g. 56.0.1
+  // serving SDK 56.0.0) bumps the former but not the latter — so comparing the full version
+  // string would reject every otherwise-loadable project. Both arguments accept an optional
+  // "exposdk:" prefix so runtime versions can be passed directly.
+  @JvmStatic fun isCompatibleSdkVersion(supportedSdkVersion: String?, sdkVersion: String?): Boolean {
+    val supported = supportedSdkVersion?.removePrefix(EXPO_SDK_RUNTIME_VERSION_PREFIX) ?: return false
+    val candidate = sdkVersion?.removePrefix(EXPO_SDK_RUNTIME_VERSION_PREFIX) ?: return false
+    if (supported == RNObject.UNVERSIONED || candidate == RNObject.UNVERSIONED) {
+      return true
+    }
+    val supportedMajor = majorVersion(supported) ?: return false
+    val candidateMajor = majorVersion(candidate) ?: return false
+    return supportedMajor == candidateMajor
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
@@ -9,8 +9,12 @@ import org.json.JSONObject
 /**
  * LauncherSelectionPolicy similar to LauncherSelectionPolicyFilterAware but specifically for
  * Expo Go which uses a Expo-Go-specific field to determine compatibility.
+ *
+ * Compatibility is determined by SDK major version (see [ABIVersion.isCompatibleSdkVersion]) so
+ * that a client patch release whose version differs in its patch from the supported SDK version
+ * (e.g. a 56.0.1 client serving SDK 56.0.0 updates) can still launch matching updates.
  */
-class ExpoGoLauncherSelectionPolicyFilterAware(private val sdkVersions: List<String>) :
+class ExpoGoLauncherSelectionPolicyFilterAware(private val supportedSdkVersion: String) :
   LauncherSelectionPolicy {
   override fun selectUpdateToLaunch(
     updates: List<UpdateEntity>,
@@ -19,10 +23,8 @@ class ExpoGoLauncherSelectionPolicyFilterAware(private val sdkVersions: List<Str
     var updateToLaunch: UpdateEntity? = null
     for (update in updates) {
       val manifest = Manifest.fromManifestJson(update.manifest)
-      if (!sdkVersions.contains(manifest.getExpoGoSDKVersion()) || !SelectionPolicies.matchesFilters(
-          update,
-          filters
-        )
+      if (!ABIVersion.isCompatibleSdkVersion(supportedSdkVersion, manifest.getExpoGoSDKVersion()) ||
+        !SelectionPolicies.matchesFilters(update, filters)
       ) {
         continue
       }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -152,11 +152,8 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }.toMap()
 
     val configuration = UpdatesConfiguration(null, configMap)
-    val sdkVersionsList = listOf(Constants.SDK_VERSION, RNObject.UNVERSIONED).flatMap {
-      listOf(it, "exposdk:$it")
-    }
     val selectionPolicy = SelectionPolicy(
-      ExpoGoLauncherSelectionPolicyFilterAware(sdkVersionsList),
+      ExpoGoLauncherSelectionPolicyFilterAware(Constants.SDK_VERSION),
       LoaderSelectionPolicyFilterAware(configuration),
       ReaperSelectionPolicyDevelopmentClient()
     )
@@ -366,16 +363,10 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }
 
   private fun isValidSdkVersion(sdkVersion: String?): Boolean {
-    if (sdkVersion == null) {
-      return false
-    }
-    if (RNObject.UNVERSIONED == sdkVersion) {
-      return true
-    }
-    if (Constants.SDK_VERSION == sdkVersion) {
-      return true
-    }
-    return false
+    // Compare by SDK major version rather than the full version string: Expo Go supports a
+    // single SDK major and projects always publish X.0.0, while the client's own version
+    // (Constants.SDK_VERSION) may differ in its patch (e.g. a 56.0.1 client serving SDK 56.0.0).
+    return ABIVersion.isCompatibleSdkVersion(Constants.SDK_VERSION, sdkVersion)
   }
 
   private fun formatExceptionForIncompatibleSdk(sdkVersion: String?): ManifestException {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -34,6 +34,7 @@ import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.compose.DevMenuState
 import expo.modules.kotlin.weak
 import expo.modules.manifests.core.Manifest
+import host.exp.exponent.ABIVersion
 import host.exp.exponent.Constants
 import host.exp.exponent.ExpoUpdatesAppLoader
 import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderCallback
@@ -501,19 +502,16 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     sdkVersion = manifest.getExpoGoSDKVersion()
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_SDK_VERSION
-    // to point to the unversioned code in ReactAndroid.
-    if (Constants.SDK_VERSION == sdkVersion) {
+    // to point to the unversioned code in ReactAndroid. Compatibility is by SDK major version, so a
+    // client whose patch differs from the supported SDK version (e.g. 56.0.1 serving SDK 56.0.0)
+    // still maps a matching project to the unversioned code.
+    if (ABIVersion.isCompatibleSdkVersion(Constants.SDK_VERSION, sdkVersion)) {
       sdkVersion = RNObject.UNVERSIONED
-    }
-
-    if (RNObject.UNVERSIONED != sdkVersion) {
-      val isValidVersion = sdkVersion == Constants.SDK_VERSION
-      if (!isValidVersion) {
-        KernelProvider.instance.handleError(
-          sdkVersion + " is not a valid SDK version. Only ${Constants.SDK_VERSION} is supported."
-        )
-        return
-      }
+    } else {
+      KernelProvider.instance.handleError(
+        sdkVersion + " is not a valid SDK version. Only ${Constants.SDK_VERSION} is supported."
+      )
+      return
     }
 
     soLoaderInit()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -14,6 +14,7 @@ import expo.modules.apploader.AppLoaderProvider
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
 import expo.modules.manifests.core.Manifest
+import host.exp.exponent.ABIVersion
 import host.exp.exponent.Constants
 import host.exp.exponent.ExpoUpdatesAppLoader
 import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderCallback
@@ -118,20 +119,17 @@ class InternalHeadlessAppLoader(private val context: Context) :
     ExponentDB.saveExperience(ExponentDBObject(this.manifestUrl!!, manifest, bundleUrl!!))
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_SDK_VERSION
-    // to point to the unversioned code in ReactAndroid.
-    if (Constants.SDK_VERSION == sdkVersion) {
+    // to point to the unversioned code in ReactAndroid. Compatibility is by SDK major version, so a
+    // client whose patch differs from the supported SDK version (e.g. 56.0.1 serving SDK 56.0.0)
+    // still maps a matching project to the unversioned code.
+    if (ABIVersion.isCompatibleSdkVersion(Constants.SDK_VERSION, sdkVersion)) {
       sdkVersion = RNObject.UNVERSIONED
+    } else {
+      callback!!.onComplete(false, Exception("$sdkVersion is not a valid SDK version."))
+      return
     }
 
     detachSdkVersion = sdkVersion
-
-    if (RNObject.UNVERSIONED != sdkVersion) {
-      val isValidVersion = sdkVersion == Constants.SDK_VERSION
-      if (!isValidVersion) {
-        callback!!.onComplete(false, Exception("$sdkVersion is not a valid SDK version."))
-        return
-      }
-    }
 
     soLoaderInit()
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
@@ -11,15 +11,20 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import host.exp.exponent.ABIVersion
 import host.exp.exponent.generated.ExponentBuildConstants
 import host.exp.exponent.graphql.BranchDetailsQuery
 import host.exp.exponent.graphql.BranchesForProjectQuery
 
-private fun isUpdateCompatible(sdkVersion: String?): Boolean {
-  if (sdkVersion == null) return false
-  val expoGoMajorVersion = ExponentBuildConstants.TEMPORARY_SDK_VERSION.split(".").firstOrNull()
-  val updateMajorVersion = sdkVersion.split(".").firstOrNull()
-  return expoGoMajorVersion != null && expoGoMajorVersion == updateMajorVersion
+// [runtimeVersion] is an update's runtime version, which for Expo Go updates is prefixed, e.g.
+// "exposdk:56.0.0". [ABIVersion.isCompatibleSdkVersion] strips that prefix and compares by SDK
+// major version, so an update for the supported SDK is recognized as compatible regardless of the
+// prefix or the client's patch version.
+private fun isUpdateCompatible(runtimeVersion: String?): Boolean {
+  return ABIVersion.isCompatibleSdkVersion(
+    ExponentBuildConstants.TEMPORARY_SDK_VERSION,
+    runtimeVersion
+  )
 }
 
 private fun toExp(httpUrl: String): String {

--- a/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/ABIVersionTest.kt
+++ b/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/ABIVersionTest.kt
@@ -1,6 +1,12 @@
 package host.exp.exponent
 
+import host.exp.exponent.ABIVersion.isCompatibleSdkVersion
+import host.exp.exponent.ABIVersion.majorVersion
 import host.exp.exponent.ABIVersion.toNumber
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ABIVersionTest {
@@ -32,5 +38,55 @@ class ABIVersionTest {
   @Test
   fun minorUpdateIsBiggerThanPatchUpdate() {
     assert(toNumber("32.1.0") > toNumber("32.0.1"))
+  }
+
+  @Test
+  fun majorVersionReadsTheMajorComponent() {
+    assertEquals("56", majorVersion("56.0.0"))
+  }
+
+  @Test
+  fun majorVersionStripsTheExpoSdkRuntimePrefix() {
+    assertEquals("56", majorVersion("exposdk:56.0.0"))
+  }
+
+  @Test
+  fun majorVersionOfNullIsNull() {
+    assertNull(majorVersion(null))
+  }
+
+  // Regression test for the Expo Go 56.0.1 (client) vs SDK 56.0.0 (manifest) incompatibility:
+  // a client patch release must still accept projects published for the same SDK major.
+  @Test
+  fun clientPatchReleaseIsCompatibleWithSameSdkMajor() {
+    assertTrue(isCompatibleSdkVersion("56.0.1", "56.0.0"))
+  }
+
+  @Test
+  fun sameVersionsAreCompatible() {
+    assertTrue(isCompatibleSdkVersion("56.0.0", "56.0.0"))
+  }
+
+  @Test
+  fun differentMajorsAreNotCompatible() {
+    assertFalse(isCompatibleSdkVersion("56.0.0", "55.0.0"))
+  }
+
+  @Test
+  fun expoSdkRuntimePrefixIsHandledOnEitherSide() {
+    assertTrue(isCompatibleSdkVersion("56.0.1", "exposdk:56.0.0"))
+    assertTrue(isCompatibleSdkVersion("exposdk:56.0.0", "56.0.0"))
+  }
+
+  @Test
+  fun unversionedIsCompatibleWithAnything() {
+    assertTrue(isCompatibleSdkVersion("56.0.0", "UNVERSIONED"))
+    assertTrue(isCompatibleSdkVersion("UNVERSIONED", "56.0.0"))
+  }
+
+  @Test
+  fun nullVersionsAreNotCompatible() {
+    assertFalse(isCompatibleSdkVersion("56.0.0", null))
+    assertFalse(isCompatibleSdkVersion(null, "56.0.0"))
   }
 }

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -607,14 +607,8 @@ static BOOL isEASUpdateHost(NSString * _Nullable host)
 
   EXUpdatesDatabaseManager *updatesDatabaseManager = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
 
-  NSArray *sdkVersions = @[
-    [EXVersions sharedInstance].sdkVersion,
-    [NSString stringWithFormat:@"exposdk:%@", [EXVersions sharedInstance].sdkVersion],
-    @"UNVERSIONED",
-    @"exposdk:UNVERSIONED"
-  ];
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
-                      initWithLauncherSelectionPolicy:[[EXExpoGoLauncherSelectionPolicyFilterAware alloc] initWithSdkVersions:sdkVersions]
+                      initWithLauncherSelectionPolicy:[[EXExpoGoLauncherSelectionPolicyFilterAware alloc] initWithSupportedSdkVersion:[EXVersions sharedInstance].sdkVersion]
                       loaderSelectionPolicy:[[EXUpdatesLoaderSelectionPolicyFilterAware alloc] initWithConfig:_config]
                       reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]];
 

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
@@ -9,13 +9,17 @@ import EXManifests
 /**
  LauncherSelectionPolicy similar to LauncherSelectionPolicyFilterAware but specifically for
  Expo Go which uses a Expo-Go-specific field to determine compatibility.
+
+ Compatibility is determined by SDK major version (see `Versions.areCompatible`) so that a client
+ patch release whose version differs in its patch from the supported SDK version (e.g. a 56.0.1
+ client serving SDK 56.0.0 updates) can still launch matching updates.
  */
 @objcMembers
 public final class EXExpoGoLauncherSelectionPolicyFilterAware: NSObject, LauncherSelectionPolicy {
-  let sdkVersions: [String]
+  let supportedSdkVersion: String
 
-  public init(sdkVersions: [String]) {
-    self.sdkVersions = sdkVersions
+  public init(supportedSdkVersion: String) {
+    self.supportedSdkVersion = supportedSdkVersion
   }
 
   public func launchableUpdate(fromUpdates updates: [Update], filters: [String: Any]?) -> Update? {
@@ -25,7 +29,8 @@ public final class EXExpoGoLauncherSelectionPolicyFilterAware: NSObject, Launche
         continue
       }
 
-      if !sdkVersions.contains(updateSDKVersion) || !SelectionPolicies.doesUpdate(update, matchFilters: filters) {
+      if !Versions.areCompatible(supportedSdkVersion: supportedSdkVersion, sdkVersion: updateSDKVersion) ||
+          !SelectionPolicies.doesUpdate(update, matchFilters: filters) {
         continue
       }
 

--- a/apps/expo-go/ios/Exponent/Kernel/Environment/Versions.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/Environment/Versions.swift
@@ -16,6 +16,9 @@ public final class Versions: NSObject {
     super.init()
   }
 
+  private static let unversioned = "UNVERSIONED"
+  private static let expoSDKRuntimeVersionPrefix = "exposdk:"
+
   @objc(availableSdkVersionForManifest:)
   public func availableSdkVersion(for manifest: Manifest?) -> String {
     guard let manifest = manifest,
@@ -23,7 +26,7 @@ public final class Versions: NSObject {
       return ""
     }
 
-    if manifestSdkVersion == sdkVersion {
+    if supportsVersion(manifestSdkVersion) {
       return sdkVersion
     }
 
@@ -31,7 +34,7 @@ public final class Versions: NSObject {
   }
 
   public func supportsVersion(_ sdkVersion: String) -> Bool {
-    return self.sdkVersion == sdkVersion
+    return isCompatible(sdkVersion: sdkVersion)
   }
 
   @objc public var majorVersion: String {
@@ -39,11 +42,40 @@ public final class Versions: NSObject {
   }
 
   public static func majorVersion(from sdkVersion: String) -> String {
-    return sdkVersion.components(separatedBy: ".").first ?? sdkVersion
+    let stripped = stripRuntimeVersionPrefix(sdkVersion)
+    return stripped.components(separatedBy: ".").first ?? stripped
   }
 
   public func isCompatible(sdkVersion: String?) -> Bool {
-    guard let sdkVersion else { return false }
-    return Self.majorVersion(from: sdkVersion) == majorVersion
+    return Self.areCompatible(supportedSdkVersion: self.sdkVersion, sdkVersion: sdkVersion)
+  }
+
+  /// Whether a project's `sdkVersion` is compatible with the SDK version an Expo Go client
+  /// supports (`supportedSdkVersion`). Two versions are compatible when they share a major
+  /// version; `UNVERSIONED` is compatible with anything. Both arguments accept an optional
+  /// `exposdk:` runtime-version prefix.
+  ///
+  /// Expo Go supports a single SDK major and projects always publish `X.0.0`, so the major
+  /// version determines compatibility. The client's own version string is not guaranteed to
+  /// equal the supported SDK version — a client patch release (e.g. `56.0.1` serving SDK
+  /// `56.0.0`) bumps the former but not the latter — so comparing the full version string would
+  /// reject every otherwise-loadable project.
+  public static func areCompatible(supportedSdkVersion: String?, sdkVersion: String?) -> Bool {
+    guard let supportedSdkVersion, let sdkVersion else {
+      return false
+    }
+    let supported = stripRuntimeVersionPrefix(supportedSdkVersion)
+    let candidate = stripRuntimeVersionPrefix(sdkVersion)
+    if supported == unversioned || candidate == unversioned {
+      return true
+    }
+    return majorVersion(from: supported) == majorVersion(from: candidate)
+  }
+
+  private static func stripRuntimeVersionPrefix(_ version: String) -> String {
+    guard version.hasPrefix(expoSDKRuntimeVersionPrefix) else {
+      return version
+    }
+    return String(version.dropFirst(expoSDKRuntimeVersionPrefix.count))
   }
 }


### PR DESCRIPTION
# Why

Fixes [#46846](https://github.com/expo/expo/issues/46846).

Expo Go **56.0.1** for Android rejects every SDK 56 project (including an untouched `npx create-expo-app@latest` template) with:

> Project is incompatible with this version of Expo Go.
> This project requires a newer version of Expo Go.

This happens both when scanning the dev-server QR and when opening an EAS Update (`exp://u.expo.dev/...`) — the update downloads fully, then fails at launch (`DatabaseLauncher.launch`). Installing the previous **56.0.0** client on the same device loads the same project and update flawlessly.

**Root cause.** Expo Go decided compatibility by comparing the *full* SDK version string from the manifest (`"56.0.0"`) against the client's own baked version (`Constants.SDK_VERSION` / `TEMPORARY_SDK_VERSION`, which the 56.0.1 release baked as `"56.0.1"`). Those are only equal when the client's patch matches the SDK version, so a client patch release rejects every otherwise-loadable project. This was verified by proxying the dev server and rewriting only `"sdkVersion":"56.0.0"` → `"56.0.1"`: with `56.0.0` the project is rejected, with `56.0.1` it loads.

The exact-string gate existed in several places:

- `ExpoUpdatesAppLoader.isValidSdkVersion` (dev-server manifest check)
- `ExpoGoLauncherSelectionPolicyFilterAware` — exact `contains` over a fixed list; this is the EAS Update `DatabaseLauncher.launch` failure path, and it exists on **both** Android and iOS
- `ExperienceActivity` / `InternalHeadlessAppLoader` (mapping a matching SDK to the unversioned native code)
- iOS `Versions.supportsVersion` / `availableSdkVersion`

There is also a separate, smaller bug: `home/UpdateRow.isUpdateCompatible` was passed an update's runtime version (`exposdk:56.0.0`) and derived the major via `split(".").firstOrNull()`, yielding `"exposdk:56"`, which never equals `"56"`. Every branch update therefore showed a "Not compatible with this version of Expo Go" tag and was un-tappable.

# How

Compare by **SDK major version** instead of the full version string. Expo Go ships supporting a single SDK major and projects always publish `X.0.0`, so the major version is what determines compatibility; the client's own version string is an independent concern that should not gate loading.

The comparison lives in one place per platform and is reused by every gate:

- **Android** — `ABIVersion.isCompatibleSdkVersion(supported, candidate)` (+ `majorVersion`), wired into `isValidSdkVersion`, `ExpoGoLauncherSelectionPolicyFilterAware`, `ExperienceActivity`, `InternalHeadlessAppLoader`, and `home/UpdateRow`.
- **iOS** — `Versions.areCompatible(supportedSdkVersion:sdkVersion:)` now backs `supportsVersion` / `availableSdkVersion` / `isCompatible`, and is used by `EXExpoGoLauncherSelectionPolicyFilterAware`. (The Home UI already used the major-based `isCompatible`.)

Both helpers also strip the `exposdk:` runtime-version prefix, which fixes the `UpdateRow` parsing bug. Prior semantics are preserved: a `null`/missing version is still rejected, an explicit `UNVERSIONED` is still accepted, and a mismatched major is still rejected — only the client/SDK patch mismatch is now tolerated.

Note: the immediate unblock for the community also requires re-releasing the Android client so its baked version reports SDK `56.0.0`. This change prevents the class of bug from recurring on future client patch releases.

# Test Plan

Added unit tests in `ABIVersionTest.kt` covering the regression and surrounding cases:

- `56.0.1` (client) vs `56.0.0` (manifest) → compatible (the reported regression)
- identical versions → compatible
- different majors (`56` vs `55`) → not compatible
- `exposdk:` prefix on either side → handled
- `UNVERSIONED` on either side → compatible
- `null` on either side → not compatible
- `majorVersion` reads the major and strips the `exposdk:` prefix

These run in the Expo Go Android project (`expoview`), which builds against ReactAndroid from source, so they run through the app's Gradle project (`:android:expoview:testDebugUnitTest`) rather than `et native-unit-tests` (which targets standalone packages). The comparison logic is identical across Android and iOS.

Manual reproduction (matches the issue): install Expo Go 56.0.1 on Android, create an SDK 56 app, `npx expo start`, and open it — before this change it shows the incompatibility screen; after, it loads. Same for opening a published EAS Update for runtime `exposdk:56.0.0`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - These changes are entirely native code inside the `apps/expo-go` app (no JS/TS), so there are no package `build/` sources to rebuild, and the Expo Go app has no `CHANGELOG.md`. Happy to add a note to `expo-updates` if maintainers prefer, though that package's source is unchanged.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build — not applicable; no module plugin is touched.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
