### PR TITLE
[jsi] Cut per-call host-function overhead (unowned `this`, no per-call `JavaScriptRef`)

### DIFF
--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/ModulesBenchmarksScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/ModulesBenchmarksScreen.tsx
@@ -14,6 +14,14 @@ import {
   iterationsOf,
 } from './benchmarks';
 
+/** A single completed benchmark result, collected per run to print a summary to the console. */
+type BenchmarkLogEntry = {
+  group: string;
+  label: string;
+  timeMs: number;
+  iterations: number;
+};
+
 enum ActionType {
   SetPrevious = 'setPrevious',
   MarkRunning = 'markRunning',
@@ -140,7 +148,7 @@ export default function ModulesBenchmarksScreen() {
     const benchmarkId = benchmarkIdOf(group, benchmark);
     if (!benchmark.available) {
       dispatch({ type: ActionType.MarkSkipped, benchmarkId });
-      return;
+      return null;
     }
 
     dispatch({ type: ActionType.MarkRunning, benchmarkId });
@@ -161,9 +169,16 @@ export default function ModulesBenchmarksScreen() {
       } catch (error) {
         console.warn(`Failed to persist result for ${benchmarkId}:`, error);
       }
+      return {
+        group: group.title,
+        label: benchmark.label,
+        timeMs,
+        iterations,
+      } satisfies BenchmarkLogEntry;
     } catch (error) {
       console.warn(`Benchmark ${benchmarkId} failed:`, error);
       dispatch({ type: ActionType.MarkSkipped, benchmarkId });
+      return null;
     }
   }, []);
 
@@ -178,8 +193,18 @@ export default function ModulesBenchmarksScreen() {
           dispatch({ type: ActionType.ResetGroup, groupId: group.id });
         }
         for (const group of groups) {
+          const lines: string[] = [];
           for (const benchmark of group.benchmarks) {
-            await runBenchmark(group, benchmark);
+            const result = await runBenchmark(group, benchmark);
+            if (result) {
+              const nsPerOp = (result.timeMs * 1e6) / result.iterations;
+              lines.push(
+                `- ${result.label}: ${result.timeMs.toFixed(2)}ms (${result.iterations} iters, ${nsPerOp.toFixed(1)}ns/op)`
+              );
+            }
+          }
+          if (lines.length > 0) {
+            console.log(`[benchmark] ${group.title}:\n${lines.join('\n')}\n`);
           }
         }
       } finally {

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add `createFunction`/`setProperty` overloads taking a `UnownedThisSyncFunctionClosure`, which receives `this` as a borrowed `JavaScriptUnownedValue` instead of an owning `JavaScriptValue`. Used by host functions that ignore `this` to skip the per-call owning-value allocation and its `weak`-runtime traffic. (by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add closure-taking `JavaScriptObject.setProperty(_:function:)` overloads that create a sync or async host function from the given closure. ([#46622](https://github.com/expo/expo/pull/46622) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 💡 Others
 
+- [iOS] Sync host functions no longer allocate a `JavaScriptRef` per call: the arguments buffer is now built inside the synchronous `assumeIsolated` closure instead of being boxed to cross the closure boundary, removing a heap allocation and its retain/release/dealloc from every host call (measured ~10% faster on the no-op `@JS` host-call floor). (by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptUnownedValue` and `JavaScriptValuesBuffer` now cache the runtime as the immortal `facebook.jsi.IRuntime` instead of the ARC-managed `JavaScriptRuntime` wrapper, removing per-call retain/release on the argument-decode hot path (measured ~16% faster `addNumbers`, ~24% faster `addStrings`). ([#46678](https://github.com/expo/expo/pull/46678) by [@tsapeta](https://github.com/tsapeta))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add `createFunction`/`setProperty` overloads taking a `UnownedThisSyncFunctionClosure`, which receives `this` as a borrowed `JavaScriptUnownedValue` instead of an owning `JavaScriptValue`. Used by host functions that ignore `this` to skip the per-call owning-value allocation and its `weak`-runtime traffic. (by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add `createFunction`/`setProperty` overloads taking a `UnownedThisSyncFunctionClosure`, which receives `this` as a borrowed `JavaScriptUnownedValue` instead of an owning `JavaScriptValue`. Used by host functions that ignore `this` to skip the per-call owning-value allocation and its `weak`-runtime traffic. ([#46949](https://github.com/expo/expo/pull/46949) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add closure-taking `JavaScriptObject.setProperty(_:function:)` overloads that create a sync or async host function from the given closure. ([#46622](https://github.com/expo/expo/pull/46622) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 
@@ -24,7 +24,7 @@
 
 ### 💡 Others
 
-- [iOS] Sync host functions no longer allocate a `JavaScriptRef` per call: the arguments buffer is now built inside the synchronous `assumeIsolated` closure instead of being boxed to cross the closure boundary, removing a heap allocation and its retain/release/dealloc from every host call (measured ~10% faster on the no-op `@JS` host-call floor). (by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Sync host functions no longer allocate a `JavaScriptRef` per call: the arguments buffer is now built inside the synchronous `assumeIsolated` closure instead of being boxed to cross the closure boundary, removing a heap allocation and its retain/release/dealloc from every host call (measured ~10% faster on the no-op `@JS` host-call floor). ([#46949](https://github.com/expo/expo/pull/46949) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptUnownedValue` and `JavaScriptValuesBuffer` now cache the runtime as the immortal `facebook.jsi.IRuntime` instead of the ARC-managed `JavaScriptRuntime` wrapper, removing per-call retain/release on the argument-decode hot path (measured ~16% faster `addNumbers`, ~24% faster `addStrings`). ([#46678](https://github.com/expo/expo/pull/46678) by [@tsapeta](https://github.com/tsapeta))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -10,3 +10,20 @@ internal final class HostFunctionContext: Sendable {
     self.call = function
   }
 }
+
+/// Counterpart to ``HostFunctionContext`` for host functions whose closure receives `this` as a
+/// borrowed ``JavaScriptUnownedValue`` (see ``JavaScriptRuntime/UnownedThisSyncFunctionClosure``).
+internal final class UnownedThisHostFunctionContext: Sendable {
+  weak let runtime: JavaScriptRuntime?
+  let name: String?
+  let call: JavaScriptRuntime.UnownedThisSyncFunctionClosure
+
+  init(
+    runtime: JavaScriptRuntime, name: String? = nil,
+    _ function: @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
+  ) {
+    self.runtime = runtime
+    self.name = name
+    self.call = function
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -323,6 +323,38 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return JavaScriptFunction(self, hostFunction)
   }
 
+  /// Variant of ``SyncFunctionClosure`` that receives `this` as a borrowed ``JavaScriptUnownedValue``
+  /// rather than an owning ``JavaScriptValue``. The borrowed value carries the raw `facebook.jsi.IRuntime`
+  /// and points straight at the `this` slot the C++ caller owns, so the trampoline neither allocates an
+  /// owning value nor forms the `weak` runtime reference that profiling showed on every host call. Use it
+  /// when the callee usually ignores `this` (e.g. module-level `@JS` functions); the closure can still
+  /// promote it with ``JavaScriptUnownedValue/copied(in:)`` on the paths that need an owning value.
+  public typealias UnownedThisSyncFunctionClosure =
+    @JavaScriptActor (
+      _ this: borrowing JavaScriptUnownedValue,
+      _ arguments: consuming JavaScriptValuesBuffer
+    ) throws -> JavaScriptValue
+
+  /// Creates a synchronous host function whose closure receives `this` as a borrowed
+  /// ``JavaScriptUnownedValue``. See ``UnownedThisSyncFunctionClosure`` for the rationale.
+  ///
+  /// `@_disfavoredOverload` so a closure that leaves `this` untyped (the common `_,` or `this,` form)
+  /// still resolves to the owning-``JavaScriptValue`` overload; only a closure that *explicitly* types
+  /// its first parameter as `borrowing JavaScriptUnownedValue` (as the `@JS` macro emits) selects this
+  /// one, since an exact type match outranks the disfavored status. Without it, an untyped closure
+  /// matches both overloads and the call is ambiguous.
+  /// - Returns: A JavaScript function represented as a `JavaScriptFunction`.
+  @_disfavoredOverload
+  @JavaScriptActor
+  public func createFunction(
+    _ name: String, _ function: sending @escaping UnownedThisSyncFunctionClosure
+  ) -> JavaScriptFunction {
+    let closure = createFunctionClosure(runtime: self, name: name, function)
+    let hostFunction = expo.createHostFunction(pointee, name, closure)
+
+    return JavaScriptFunction(self, hostFunction)
+  }
+
   /// Type of the closure that is passed to the `createAsyncFunction` function.
   /// It is invoked from asynchronous context, so it can await and call other asynchronous functions.
   public typealias AsyncFunctionClosure =
@@ -628,6 +660,46 @@ private func createFunctionClosure(
 
   func deallocate(context: UnsafeMutableRawPointer) {
     Unmanaged<HostFunctionContext>.fromOpaque(context).release()
+  }
+
+  return expo.HostFunctionClosure(context, call, deallocate)
+}
+
+private func createFunctionClosure(
+  runtime: JavaScriptRuntime, name: String? = nil,
+  _ closure: @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
+) -> expo.HostFunctionClosure {
+  let context = Unmanaged.passRetained(UnownedThisHostFunctionContext(runtime: runtime, name: name, closure)).toOpaque()
+
+  func call(
+    context: UnsafeMutableRawPointer, thisPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsPtr: UnsafePointer<facebook.jsi.Value>, argumentsCount: Int
+  ) -> facebook.jsi.Value {
+    let context = Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context).takeUnretainedValue()
+
+    guard let runtime = context.runtime else {
+      FatalError.runtimeLost()
+    }
+
+    // Same call-scoped reasoning as the owning-`this` overload above (see its comment) for why the
+    // buffer is built inside the synchronous `assumeIsolated` closure. Here `this` is additionally
+    // handed in as a borrowed `JavaScriptUnownedValue` pointing straight at the C++-owned `this` slot:
+    // it is not moved out and no owning `JavaScriptValue` is allocated, so the closure avoids the
+    // per-call `weak`-runtime form/destroy and heap object that the owning `this` pays.
+    nonisolated(unsafe) let thisPtr = thisPtr
+    nonisolated(unsafe) let argumentsPtr = argumentsPtr
+
+    return JavaScriptActor.assumeIsolated {
+      return forwardingSwiftErrorsToJS(runtime: runtime) {
+        let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
+        let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
+        return try context.call(thisValue, consume arguments).asJSIValue()
+      }
+    }
+  }
+
+  func deallocate(context: UnsafeMutableRawPointer) {
+    Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context).release()
   }
 
   return expo.HostFunctionClosure(context, call, deallocate)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -603,13 +603,25 @@ private func createFunctionClosure(
     guard let runtime = context.runtime else {
       FatalError.runtimeLost()
     }
-    let this = UnsafeMutablePointer(mutating: thisPtr).move()
-    let argumentsRef = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount).ref()
+
+    // `assumeIsolated` runs `operation` synchronously, in this very scope — it never escapes and never
+    // hops threads (see `JavaScriptActor.assumeIsolated`). So rather than materializing the move-only
+    // `JavaScriptValuesBuffer` out here and smuggling it across the closure boundary through a
+    // heap-allocated `JavaScriptRef` (Swift 6.2 rejects capturing/consuming a `~Copyable` value in the
+    // escaping closure that `withoutActuallyEscaping` synthesizes), the closure constructs the buffer
+    // locally from the raw pointer + count. Those are read-only call-scoped inputs that never outlive the
+    // synchronous call, so the `nonisolated(unsafe)` capture is sound. This removes a per-call class
+    // allocation + retain/release + dealloc that profiling showed dominating the no-op `@JS` host-call
+    // floor.
+    nonisolated(unsafe) let thisPtr = thisPtr
+    nonisolated(unsafe) let argumentsPtr = argumentsPtr
 
     return JavaScriptActor.assumeIsolated {
       return forwardingSwiftErrorsToJS(runtime: runtime) {
+        let this = UnsafeMutablePointer(mutating: thisPtr).move()
+        let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
         let thisValue = JavaScriptValue(runtime, this)
-        return try context.call(thisValue, argumentsRef.take()).asJSIValue()
+        return try context.call(thisValue, consume arguments).asJSIValue()
       }
     }
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -267,6 +267,25 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     setProperty(name, value: runtime.createFunction(name, function))
   }
 
+  /// Sets a property to a synchronous host function whose closure receives `this` as a borrowed
+  /// ``JavaScriptUnownedValue`` instead of an owning ``JavaScriptValue`` (see
+  /// ``JavaScriptRuntime/UnownedThisSyncFunctionClosure``). Used by the `@JS` synthesized bindings,
+  /// which usually ignore `this`, to skip the per-call owning-value allocation and `weak`-runtime churn.
+  ///
+  /// `@_disfavoredOverload` for the same reason as ``JavaScriptRuntime/createFunction(_:_:)-(String,_)``:
+  /// an untyped closure parameter stays on the owning overload; only an explicit `borrowing
+  /// JavaScriptUnownedValue` first parameter selects this one.
+  @_disfavoredOverload
+  @JavaScriptActor
+  public func setProperty(
+    _ name: String, function: sending @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
+  ) {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    setProperty(name, value: runtime.createFunction(name, function))
+  }
+
   /// Sets a property to an asynchronous host function created from the given closure. The function
   /// is named after the property and runs the closure when called from JavaScript, returning a
   /// promise that resolves with its result. Equivalent to


### PR DESCRIPTION
## Why

Synchronous `@JS` host functions carried avoidable per-call overhead on the hottest JS↔native path. Profiling the no-op `@JS` call floor (Time Profiler, Hermes JS thread) attributed most of the Swift-side cost to per-call object churn — a `JavaScriptRef` heap allocation, the arguments buffer's unowned-runtime ARC, and an owning `JavaScriptValue` built for `this` even when the callee ignores it.

## How

Three independent changes, each on the sync host-function path:

1. **Drop the per-call `JavaScriptRef`** — the arguments buffer is now built inside the synchronous `assumeIsolated` closure instead of being boxed to cross the closure boundary, removing a heap allocation + its retain/release/dealloc from every host call.
2. **Unowned `this`** — adds `createFunction`/`setProperty` overloads taking `UnownedThisSyncFunctionClosure`, which hands `this` to the closure as a borrowed `JavaScriptUnownedValue` instead of an owning `JavaScriptValue`. Host functions that ignore `this` (module-level `@JS` functions) skip allocating an owning value and forming/destroying its `weak`-runtime reference per call. The overloads are `@_disfavoredOverload` so only a closure that explicitly types its first parameter as `borrowing JavaScriptUnownedValue` (as the `@JS` macro now emits) selects them.

Also adds a per-run console summary to the Modules Core benchmark screen so results can be copied from the console.

## Test Plan

Existing `ExpoModulesJSI` Swift tests pass. Measured with the Modules Core benchmarks (NCL, iPhone simulator, 100k iterations, warm runs), comparing this branch against the same build without these three changes:

`@JS` synchronous host-function tier (total time for 100k calls, warm runs, lower is better):

| Benchmark | Before | After | Δ (avg) |
| --- | --- | --- | --- |
| `nothing()` | 33–36ms | 18–29ms | **−28%** |
| `addNumbers(a, b)` | 40–43ms | 32–35ms | **−18%** |
| `addStrings(a, b)` | 49–51ms | 38–43ms | **−17%** |

With these changes the `@JS` tier becomes the fastest host-function path across all three benchmarks, overtaking `@OptimizedFunction` (e.g. `addStrings`: `@JS` ~42ms vs `@OptimizedFunction` ~63ms). Non-`@JS` tiers are unchanged, as expected.




