### PR TITLE
[widgets][Android] Basic Android components

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
@@ -88,12 +88,12 @@ typealias ModifierFactory = @Composable (ModifierType, ComposableScope?, AppCont
 // region Modifier Params
 
 @OptimizedRecord
-internal data class PaddingAllParams(
+data class PaddingAllParams(
   @Field val all: Int = 0
 ) : Record
 
 @OptimizedRecord
-internal data class PaddingParams(
+data class PaddingParams(
   @Field val start: Int = 0,
   @Field val top: Int = 0,
   @Field val end: Int = 0,
@@ -101,48 +101,48 @@ internal data class PaddingParams(
 ) : Record
 
 @OptimizedRecord
-internal data class SizeParams(
+data class SizeParams(
   @Field val width: Int = 0,
   @Field val height: Int = 0
 ) : Record
 
 @OptimizedRecord
-internal data class FillMaxSizeParams(
+data class FillMaxSizeParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
 @OptimizedRecord
-internal data class FillMaxWidthParams(
+data class FillMaxWidthParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
 @OptimizedRecord
-internal data class FillMaxHeightParams(
+data class FillMaxHeightParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
 @OptimizedRecord
-internal data class WidthParams(
+data class WidthParams(
   @Field val width: Int = 0
 ) : Record
 
 @OptimizedRecord
-internal data class HeightParams(
+data class HeightParams(
   @Field val height: Int = 0
 ) : Record
 
 @OptimizedRecord
-internal data class WrapContentWidthParams(
+data class WrapContentWidthParams(
   @Field val alignment: AlignmentType? = null
 ) : Record
 
 @OptimizedRecord
-internal data class WrapContentHeightParams(
+data class WrapContentHeightParams(
   @Field val alignment: AlignmentType? = null
 ) : Record
 
 @OptimizedRecord
-internal data class DefaultMinSizeParams(
+data class DefaultMinSizeParams(
   @Field val minWidth: Float? = null,
   @Field val minHeight: Float? = null
 ) : Record
@@ -154,7 +154,7 @@ internal data class OffsetParams(
 ) : Record
 
 @OptimizedRecord
-internal data class BackgroundParams(
+data class BackgroundParams(
   @Field val color: Color? = null
 ) : Record
 
@@ -235,7 +235,7 @@ internal data class AlignParams(
 ) : Record
 
 @OptimizedRecord
-internal data class TestIDParams(
+data class TestIDParams(
   @Field val testID: String? = null
 ) : Record
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add a initial layout registry for widgets. ([#46501](https://github.com/expo/expo/pull/46501) by [@jakex7](https://github.com/jakex7))
 - Add `initialProps` to widgets layout registry. ([#46527](https://github.com/expo/expo/pull/46527) by [@jakex7](https://github.com/jakex7))
 - [Android] Add Hermes runtime. ([#46684](https://github.com/expo/expo/pull/46684) by [@jakex7](https://github.com/jakex7))
+- [Android] Basic Android components. ([#46951](https://github.com/expo/expo/pull/46951) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -105,6 +105,9 @@ androidComponents {
 dependencies {
   implementation 'com.facebook.react:react-android'
   implementation 'com.facebook.react:hermes-android'
+  implementation expoModule.getExpoDependency("expo-ui")
+  implementation 'androidx.compose.foundation:foundation-android:1.10.6'
+  implementation 'androidx.compose.ui:ui-android:1.10.6'
   api 'androidx.glance:glance:1.2.0-rc01'
   api 'androidx.glance:glance-appwidget:1.2.0-rc01'
 }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
@@ -1,0 +1,101 @@
+package expo.modules.widgets
+
+import androidx.compose.runtime.Composable
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.createComposeProps
+import expo.modules.ui.CheckboxProps
+import expo.modules.ui.CircularProgressIndicatorProps
+import expo.modules.ui.LayoutProps
+import expo.modules.ui.LinearProgressIndicatorProps
+import expo.modules.ui.LoadingIndicatorProps
+import expo.modules.ui.RadioButtonProps
+import expo.modules.ui.SpacerProps
+import expo.modules.ui.SwitchProps
+import expo.modules.ui.TextProps
+import expo.modules.ui.button.ButtonProps
+import expo.modules.widgets.ui.ButtonView
+import expo.modules.widgets.ui.ElevatedButtonView
+import expo.modules.widgets.ui.FilledTonalButtonView
+import expo.modules.widgets.ui.OutlinedButtonView
+import expo.modules.widgets.ui.BoxView
+import expo.modules.widgets.ui.CheckboxView
+import expo.modules.widgets.ui.CircularProgressIndicatorView
+import expo.modules.widgets.ui.ColumnView
+import expo.modules.widgets.ui.LinearProgressIndicatorView
+import expo.modules.widgets.ui.LoadingIndicatorView
+import expo.modules.widgets.ui.RadioButtonView
+import expo.modules.widgets.ui.RowView
+import expo.modules.widgets.ui.SpacerView
+import expo.modules.widgets.ui.SwitchView
+import expo.modules.widgets.ui.TextButtonView
+import expo.modules.widgets.ui.TextView
+
+@Composable
+internal fun DynamicView(node: ReadableMap) {
+  when (if (node.hasKey("type")) node.getString("type") else null) {
+    "Button" -> ButtonView(node.props<ButtonProps>(), node.children())
+    "FilledTonalButton" -> FilledTonalButtonView(node.props<ButtonProps>(), node.children())
+    "OutlinedButton" -> OutlinedButtonView(node.props<ButtonProps>(), node.children())
+    "ElevatedButton" -> ElevatedButtonView(node.props<ButtonProps>(), node.children())
+    "TextButton" -> TextButtonView(node.props<ButtonProps>(), node.children())
+    "BoxView" -> BoxView(node.props<LayoutProps>()) {
+      node.children().forEach { DynamicView(it) }
+    }
+    "CheckboxView" -> CheckboxView(node.props<CheckboxProps>())
+    "CircularProgressIndicatorView" -> CircularProgressIndicatorView(node.props<CircularProgressIndicatorProps>())
+    "ColumnView" -> ColumnView(node.props<LayoutProps>()) {
+      node.children().forEach { DynamicView(it) }
+    }
+    "LinearProgressIndicatorView" -> LinearProgressIndicatorView(node.props<LinearProgressIndicatorProps>())
+    "LoadingIndicatorView" -> LoadingIndicatorView(node.props<LoadingIndicatorProps>())
+    "RadioButtonView" -> RadioButtonView(node.props<RadioButtonProps>())
+    "react.fragment" -> node.children().forEach { DynamicView(it) }
+    "RowView" -> RowView(node.props<LayoutProps>()) {
+      node.children().forEach { DynamicView(it) }
+    }
+    "SpacerView" -> SpacerView(node.props<SpacerProps>())
+    "SwitchView" -> SwitchView(node.props<SwitchProps>())
+    "TextView" -> TextView(node.props<TextProps>())
+    else -> TextView(TextProps("View not found"))
+  }
+}
+
+private inline fun <reified Props : ComposeProps> ReadableMap.props(): Props {
+  return createComposeProps(
+    propsMap()
+  )
+}
+
+private fun ReadableMap.propsMap(): ReadableMap? {
+  return if (hasKey("props") && !isNull("props")) {
+    getMap("props")
+  } else {
+    null
+  }
+}
+
+private fun ReadableMap.children(): List<ReadableMap> {
+  val props = propsMap() ?: return emptyList()
+  if (!props.hasKey("children") || props.isNull("children")) {
+    return emptyList()
+  }
+
+  return when (props.getType("children")) {
+    ReadableType.Map -> listOfNotNull(props.getMap("children"))
+    ReadableType.Array -> props.getArray("children")?.children() ?: emptyList()
+    else -> emptyList()
+  }
+}
+
+private fun ReadableArray.children(): List<ReadableMap> {
+  return buildList {
+    for (index in 0 until size()) {
+      if (!isNull(index) && getType(index) == ReadableType.Map) {
+        getMap(index)?.let(::add)
+      }
+    }
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
@@ -35,7 +35,8 @@ import expo.modules.widgets.ui.TextView
 
 @Composable
 internal fun DynamicView(node: ReadableMap) {
-  when (if (node.hasKey("type")) node.getString("type") else null) {
+  val type = if (node.hasKey("type")) node.getString("type") else null
+  when (type) {
     "Button" -> ButtonView(node.props<ButtonProps>(), node.children())
     "FilledTonalButton" -> FilledTonalButtonView(node.props<ButtonProps>(), node.children())
     "OutlinedButton" -> OutlinedButtonView(node.props<ButtonProps>(), node.children())
@@ -93,7 +94,7 @@ private fun ReadableMap.children(): List<ReadableMap> {
 private fun ReadableArray.children(): List<ReadableMap> {
   return buildList {
     for (index in 0 until size()) {
-      if (!isNull(index) && getType(index) == ReadableType.Map) {
+      if (getType(index) == ReadableType.Map) {
         getMap(index)?.let(::add)
       }
     }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/BoxView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/BoxView.kt
@@ -1,0 +1,34 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import expo.modules.ui.LayoutProps
+import expo.modules.ui.convertibles.ContentAlignment
+
+@Composable
+fun BoxView(
+  props: LayoutProps,
+  content: @Composable () -> Unit = {}
+) {
+  Box(
+    modifier = props.modifiers.toGlanceModifier(),
+    contentAlignment = props.contentAlignment?.toGlanceAlignment() ?: Alignment.TopStart,
+  ) {
+    content()
+  }
+}
+
+private fun ContentAlignment.toGlanceAlignment(): Alignment {
+  return when (this) {
+    ContentAlignment.TOP_START -> Alignment.TopStart
+    ContentAlignment.TOP_CENTER -> Alignment.TopCenter
+    ContentAlignment.TOP_END -> Alignment.TopEnd
+    ContentAlignment.CENTER_START -> Alignment.CenterStart
+    ContentAlignment.CENTER -> Alignment.Center
+    ContentAlignment.CENTER_END -> Alignment.CenterEnd
+    ContentAlignment.BOTTOM_START -> Alignment.BottomStart
+    ContentAlignment.BOTTOM_CENTER -> Alignment.BottomCenter
+    ContentAlignment.BOTTOM_END -> Alignment.BottomEnd
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
@@ -1,0 +1,219 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.glance.Button
+import androidx.glance.ButtonDefaults
+import androidx.glance.GlanceTheme
+import androidx.glance.unit.ColorProvider
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import expo.modules.ui.button.ButtonProps
+import expo.modules.ui.colorToComposeColorOrNull
+import androidx.glance.ButtonColors
+import androidx.glance.appwidget.components.FilledButton
+import androidx.glance.appwidget.components.OutlineButton
+
+@Composable
+internal fun ButtonView(
+  props: ButtonProps,
+  children: List<ReadableMap> = emptyList()
+) {
+  FilledButton(
+    text = props.textContent(children),
+    onClick = {},
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.enabled,
+    colors = props.toGlanceButtonColors(
+      defaultBackgroundColor = GlanceTheme.colors.primary,
+      defaultContentColor = GlanceTheme.colors.onPrimary
+    )
+  )
+}
+
+@Composable
+internal fun FilledTonalButtonView(
+  props: ButtonProps,
+  children: List<ReadableMap> = emptyList()
+) {
+  FilledButton(
+    text = props.textContent(children),
+    onClick = {},
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.enabled,
+    colors = props.toGlanceButtonColors(
+      defaultBackgroundColor = GlanceTheme.colors.secondaryContainer,
+      defaultContentColor = GlanceTheme.colors.onSecondaryContainer
+    )
+  )
+}
+
+@Composable
+internal fun OutlinedButtonView(
+  props: ButtonProps,
+  children: List<ReadableMap> = emptyList()
+) {
+  OutlineButton(
+    text = props.textContent(children),
+    contentColor = props.toGlanceContentColor(GlanceTheme.colors.primary),
+    onClick = {},
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.enabled
+  )
+}
+
+@Composable
+internal fun ElevatedButtonView(
+  props: ButtonProps,
+  children: List<ReadableMap> = emptyList()
+) {
+  FilledButton(
+    text = props.textContent(children),
+    onClick = {},
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.enabled,
+    colors = props.toGlanceButtonColors(
+      defaultBackgroundColor = GlanceTheme.colors.surface,
+      defaultContentColor = GlanceTheme.colors.primary
+    )
+  )
+}
+
+@Composable
+internal fun TextButtonView(
+  props: ButtonProps,
+  children: List<ReadableMap> = emptyList()
+) {
+  Button(
+    text = props.textContent(children),
+    onClick = {},
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.enabled,
+    colors = props.toGlanceButtonColors(
+      defaultBackgroundColor = Color.Transparent.toGlanceColorProvider(),
+      defaultContentColor = GlanceTheme.colors.primary
+    )
+  )
+}
+
+// TODO(@jakex7): Find a better way to get text
+private fun ButtonProps.textContent(children: List<ReadableMap>): String {
+  return children.textContent() ?: ""
+}
+
+private fun List<ReadableMap>.textContent(): String? {
+  return mapNotNull { it.textFromTextNode() }
+    .joinToString(separator = "")
+    .takeIf { it.isNotEmpty() }
+}
+
+@Composable
+private fun ButtonProps.toGlanceButtonColors(
+  defaultBackgroundColor: ColorProvider,
+  defaultContentColor: ColorProvider
+): ButtonColors {
+  return ButtonDefaults.buttonColors(
+    backgroundColor = toGlanceContainerColor(defaultBackgroundColor),
+    contentColor = toGlanceContentColor(defaultContentColor)
+  )
+}
+
+private fun ButtonProps.toGlanceContainerColor(defaultColor: ColorProvider): ColorProvider {
+  return colorToComposeColorOrNull(
+    if (enabled) {
+      colors.containerColor
+    } else {
+      colors.disabledContainerColor ?: colors.containerColor
+    }
+  )?.toGlanceColorProvider() ?: defaultColor
+}
+
+private fun ButtonProps.toGlanceContentColor(defaultColor: ColorProvider): ColorProvider {
+  return colorToComposeColorOrNull(
+    if (enabled) {
+      colors.contentColor
+    } else {
+      colors.disabledContentColor ?: colors.contentColor
+    }
+  )?.toGlanceColorProvider() ?: defaultColor
+}
+
+private fun ReadableMap.textFromTextNode(): String? {
+  return when (if (hasKey("type")) getString("type") else null) {
+    "TextView" -> propsMap()?.textContent()
+    "react.fragment" -> children().textContent()
+    else -> null
+  }
+}
+
+private fun ReadableMap.textContent(): String? {
+  return spansText()
+    ?: stringValue("text")?.takeIf { it.isNotEmpty() }
+}
+
+private fun ReadableMap.spansText(): String? {
+  if (!hasKey("spans") || isNull("spans") || getType("spans") != ReadableType.Array) {
+    return null
+  }
+
+  return getArray("spans")
+    ?.spansText()
+    ?.takeIf { it.isNotEmpty() }
+}
+
+private fun ReadableArray.spansText(): String {
+  return buildString {
+    for (index in 0 until size()) {
+      if (!isNull(index) && getType(index) == ReadableType.Map) {
+        getMap(index)?.let { span ->
+          append(span.spansText() ?: span.stringValue("text").orEmpty())
+        }
+      }
+    }
+  }
+}
+
+private fun ReadableMap.stringValue(key: String): String? {
+  if (!hasKey(key) || isNull(key)) {
+    return null
+  }
+
+  return when (getType(key)) {
+    ReadableType.Boolean -> getBoolean(key).toString()
+    ReadableType.Number -> getDouble(key).toString()
+    ReadableType.String -> getString(key)
+    else -> null
+  }
+}
+
+private fun ReadableMap.children(): List<ReadableMap> {
+  val props = propsMap() ?: return emptyList()
+  if (!props.hasKey("children") || props.isNull("children")) {
+    return emptyList()
+  }
+
+  return when (props.getType("children")) {
+    ReadableType.Map -> listOfNotNull(props.getMap("children"))
+    ReadableType.Array -> props.getArray("children")?.children() ?: emptyList()
+    else -> emptyList()
+  }
+}
+
+private fun ReadableArray.children(): List<ReadableMap> {
+  return buildList {
+    for (index in 0 until size()) {
+      if (!isNull(index) && getType(index) == ReadableType.Map) {
+        getMap(index)?.let(::add)
+      }
+    }
+  }
+}
+
+private fun ReadableMap.propsMap(): ReadableMap? {
+  return if (hasKey("props") && !isNull("props")) {
+    getMap("props")
+  } else {
+    null
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
@@ -140,7 +140,8 @@ private fun ButtonProps.toGlanceContentColor(defaultColor: ColorProvider): Color
 }
 
 private fun ReadableMap.textFromTextNode(): String? {
-  return when (if (hasKey("type")) getString("type") else null) {
+  val type = if (hasKey("type")) getString("type") else null
+  return when (type) {
     "TextView" -> propsMap()?.textContent()
     "react.fragment" -> children().textContent()
     else -> null
@@ -153,7 +154,7 @@ private fun ReadableMap.textContent(): String? {
 }
 
 private fun ReadableMap.spansText(): String? {
-  if (!hasKey("spans") || isNull("spans") || getType("spans") != ReadableType.Array) {
+  if (!hasKey("spans") || getType("spans") != ReadableType.Array) {
     return null
   }
 
@@ -165,7 +166,7 @@ private fun ReadableMap.spansText(): String? {
 private fun ReadableArray.spansText(): String {
   return buildString {
     for (index in 0 until size()) {
-      if (!isNull(index) && getType(index) == ReadableType.Map) {
+      if (getType(index) == ReadableType.Map) {
         getMap(index)?.let { span ->
           append(span.spansText() ?: span.stringValue("text").orEmpty())
         }
@@ -189,7 +190,7 @@ private fun ReadableMap.stringValue(key: String): String? {
 
 private fun ReadableMap.children(): List<ReadableMap> {
   val props = propsMap() ?: return emptyList()
-  if (!props.hasKey("children") || props.isNull("children")) {
+  if (!props.hasKey("children")) {
     return emptyList()
   }
 
@@ -203,7 +204,7 @@ private fun ReadableMap.children(): List<ReadableMap> {
 private fun ReadableArray.children(): List<ReadableMap> {
   return buildList {
     for (index in 0 until size()) {
-      if (!isNull(index) && getType(index) == ReadableType.Map) {
+      if (getType(index) == ReadableType.Map) {
         getMap(index)?.let(::add)
       }
     }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/CheckboxView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/CheckboxView.kt
@@ -1,0 +1,33 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.appwidget.CheckBox
+import androidx.glance.appwidget.CheckboxDefaults
+import androidx.glance.appwidget.CheckBoxColors
+import expo.modules.ui.CheckboxProps
+import expo.modules.ui.colorToComposeColorOrNull
+
+@Composable
+fun CheckboxView(props: CheckboxProps) {
+  CheckBox(
+    checked = props.value,
+    onCheckedChange = null,
+    modifier = props.modifiers.toGlanceModifier(),
+    colors = props.toGlanceCheckboxColors()
+  )
+}
+
+@Composable
+private fun CheckboxProps.toGlanceCheckboxColors(): CheckBoxColors {
+  val checkedColor = colorToComposeColorOrNull(colors.checkedColor)
+  val uncheckedColor = colorToComposeColorOrNull(colors.uncheckedColor)
+
+  return if (checkedColor != null && uncheckedColor != null) {
+    CheckboxDefaults.colors(
+      checkedColor = checkedColor.toGlanceColorProvider(),
+      uncheckedColor = uncheckedColor.toGlanceColorProvider()
+    )
+  } else {
+    CheckboxDefaults.colors()
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ColumnView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ColumnView.kt
@@ -1,0 +1,76 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import expo.modules.ui.LayoutProps
+import expo.modules.ui.convertibles.HorizontalAlignment
+import expo.modules.ui.convertibles.HorizontalArrangementDefault
+import expo.modules.ui.convertibles.VerticalAlignment
+import expo.modules.ui.convertibles.VerticalArrangementDefault
+
+@Composable
+fun ColumnView(
+  props: LayoutProps,
+  content: @Composable () -> Unit = {}
+) {
+  Column(
+    modifier = props.modifiers.toGlanceModifier(),
+    verticalAlignment = props.toGlanceVerticalAlignment(),
+    horizontalAlignment = props.toGlanceHorizontalAlignment()
+  ) {
+    content()
+  }
+}
+
+private fun LayoutProps.toGlanceHorizontalAlignment(): Alignment.Horizontal {
+  horizontalAlignment?.let {
+    return it.toGlanceHorizontalAlignment()
+  }
+
+  val arrangement = horizontalArrangement
+  return if (arrangement?.`is`(HorizontalArrangementDefault::class) == true) {
+    when (arrangement.first()) {
+      HorizontalArrangementDefault.START -> Alignment.Start
+      HorizontalArrangementDefault.CENTER -> Alignment.CenterHorizontally
+      HorizontalArrangementDefault.END -> Alignment.End
+      else -> Alignment.Start
+    }
+  } else {
+    Alignment.Start
+  }
+}
+
+private fun LayoutProps.toGlanceVerticalAlignment(): Alignment.Vertical {
+  verticalAlignment?.let {
+    return it.toGlanceVerticalAlignment()
+  }
+
+  val arrangement = verticalArrangement
+  return if (arrangement?.`is`(VerticalArrangementDefault::class) == true) {
+    when (arrangement.first()) {
+      VerticalArrangementDefault.TOP -> Alignment.Top
+      VerticalArrangementDefault.CENTER -> Alignment.CenterVertically
+      VerticalArrangementDefault.BOTTOM -> Alignment.Bottom
+      else -> Alignment.Top
+    }
+  } else {
+    Alignment.Top
+  }
+}
+
+private fun HorizontalAlignment.toGlanceHorizontalAlignment(): Alignment.Horizontal {
+  return when (this) {
+    HorizontalAlignment.START -> Alignment.Start
+    HorizontalAlignment.CENTER -> Alignment.CenterHorizontally
+    HorizontalAlignment.END -> Alignment.End
+  }
+}
+
+private fun VerticalAlignment.toGlanceVerticalAlignment(): Alignment.Vertical {
+  return when (this) {
+    VerticalAlignment.TOP -> Alignment.Top
+    VerticalAlignment.CENTER -> Alignment.CenterVertically
+    VerticalAlignment.BOTTOM -> Alignment.Bottom
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ProgressView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ProgressView.kt
@@ -1,0 +1,57 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.appwidget.CircularProgressIndicator
+import androidx.glance.appwidget.LinearProgressIndicator
+import androidx.glance.appwidget.ProgressIndicatorDefaults
+import expo.modules.ui.CircularProgressIndicatorProps
+import expo.modules.ui.LinearProgressIndicatorProps
+import expo.modules.ui.LoadingIndicatorProps
+import expo.modules.ui.colorToComposeColorOrNull
+
+@Composable
+fun LinearProgressIndicatorView(props: LinearProgressIndicatorProps) {
+  val modifier = props.modifiers.toGlanceModifier()
+  val color = colorToComposeColorOrNull(props.color)
+    ?.toGlanceColorProvider()
+    ?: ProgressIndicatorDefaults.IndicatorColorProvider
+  val trackColor = colorToComposeColorOrNull(props.trackColor)
+    ?.toGlanceColorProvider()
+    ?: ProgressIndicatorDefaults.BackgroundColorProvider
+
+  val progress = props.progress
+  if (progress != null) {
+    LinearProgressIndicator(
+      progress = progress,
+      modifier = modifier,
+      color = color,
+      backgroundColor = trackColor
+    )
+  } else {
+    LinearProgressIndicator(
+      modifier = modifier,
+      color = color,
+      backgroundColor = trackColor
+    )
+  }
+}
+
+@Composable
+fun CircularProgressIndicatorView(props: CircularProgressIndicatorProps) {
+  CircularProgressIndicator(
+    modifier = props.modifiers.toGlanceModifier(),
+    color = colorToComposeColorOrNull(props.color)
+      ?.toGlanceColorProvider()
+      ?: ProgressIndicatorDefaults.IndicatorColorProvider
+  )
+}
+
+@Composable
+fun LoadingIndicatorView(props: LoadingIndicatorProps) {
+  CircularProgressIndicator(
+    modifier = props.modifiers.toGlanceModifier(),
+    color = colorToComposeColorOrNull(props.color)
+      ?.toGlanceColorProvider()
+      ?: ProgressIndicatorDefaults.IndicatorColorProvider
+  )
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/RadioButtonView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/RadioButtonView.kt
@@ -1,0 +1,15 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.appwidget.RadioButton
+import expo.modules.ui.RadioButtonProps
+
+@Composable
+fun RadioButtonView(props: RadioButtonProps) {
+  RadioButton(
+    checked = props.selected,
+    onClick = null,
+    modifier = props.modifiers.toGlanceModifier(),
+    enabled = props.clickable
+  )
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/RowView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/RowView.kt
@@ -1,0 +1,76 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Row
+import expo.modules.ui.LayoutProps
+import expo.modules.ui.convertibles.HorizontalAlignment
+import expo.modules.ui.convertibles.HorizontalArrangementDefault
+import expo.modules.ui.convertibles.VerticalAlignment
+import expo.modules.ui.convertibles.VerticalArrangementDefault
+
+@Composable
+fun RowView(
+  props: LayoutProps,
+  content: @Composable () -> Unit = {}
+) {
+  Row(
+    modifier = props.modifiers.toGlanceModifier(),
+    horizontalAlignment = props.toGlanceHorizontalAlignment(),
+    verticalAlignment = props.toGlanceVerticalAlignment()
+  ) {
+    content()
+  }
+}
+
+private fun LayoutProps.toGlanceHorizontalAlignment(): Alignment.Horizontal {
+  horizontalAlignment?.let {
+    return it.toGlanceHorizontalAlignment()
+  }
+
+  val arrangement = horizontalArrangement
+  return if (arrangement?.`is`(HorizontalArrangementDefault::class) == true) {
+    when (arrangement.first()) {
+      HorizontalArrangementDefault.START -> Alignment.Start
+      HorizontalArrangementDefault.CENTER -> Alignment.CenterHorizontally
+      HorizontalArrangementDefault.END -> Alignment.End
+      else -> Alignment.Start
+    }
+  } else {
+    Alignment.Start
+  }
+}
+
+private fun LayoutProps.toGlanceVerticalAlignment(): Alignment.Vertical {
+  verticalAlignment?.let {
+    return it.toGlanceVerticalAlignment()
+  }
+
+  val arrangement = verticalArrangement
+  return if (arrangement?.`is`(VerticalArrangementDefault::class) == true) {
+    when (arrangement.first()) {
+      VerticalArrangementDefault.TOP -> Alignment.Top
+      VerticalArrangementDefault.CENTER -> Alignment.CenterVertically
+      VerticalArrangementDefault.BOTTOM -> Alignment.Bottom
+      else -> Alignment.Top
+    }
+  } else {
+    Alignment.Top
+  }
+}
+
+private fun HorizontalAlignment.toGlanceHorizontalAlignment(): Alignment.Horizontal {
+  return when (this) {
+    HorizontalAlignment.START -> Alignment.Start
+    HorizontalAlignment.CENTER -> Alignment.CenterHorizontally
+    HorizontalAlignment.END -> Alignment.End
+  }
+}
+
+private fun VerticalAlignment.toGlanceVerticalAlignment(): Alignment.Vertical {
+  return when (this) {
+    VerticalAlignment.TOP -> Alignment.Top
+    VerticalAlignment.CENTER -> Alignment.CenterVertically
+    VerticalAlignment.BOTTOM -> Alignment.Bottom
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SpacerView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SpacerView.kt
@@ -1,0 +1,10 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.layout.Spacer
+import expo.modules.ui.SpacerProps
+
+@Composable
+fun SpacerView(props: SpacerProps) {
+  Spacer(modifier = props.modifiers.toGlanceModifier())
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SwitchView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SwitchView.kt
@@ -1,11 +1,12 @@
 package expo.modules.widgets.ui
 
 import androidx.compose.runtime.Composable
+import androidx.glance.GlanceTheme
 import androidx.glance.appwidget.Switch
+import androidx.glance.appwidget.SwitchColors
 import androidx.glance.appwidget.SwitchDefaults
 import expo.modules.ui.SwitchProps
 import expo.modules.ui.colorToComposeColorOrNull
-import androidx.glance.appwidget.SwitchColors
 
 @Composable
 fun SwitchView(props: SwitchProps) {
@@ -19,24 +20,19 @@ fun SwitchView(props: SwitchProps) {
 
 @Composable
 private fun SwitchProps.toGlanceSwitchColors(): SwitchColors {
-  val checkedThumbColor = colorToComposeColorOrNull(colors.checkedThumbColor)
-  val uncheckedThumbColor = colorToComposeColorOrNull(colors.uncheckedThumbColor)
-  val checkedTrackColor = colorToComposeColorOrNull(colors.checkedTrackColor)
-  val uncheckedTrackColor = colorToComposeColorOrNull(colors.uncheckedTrackColor)
+  val checkedThumbColor =
+    colorToComposeColorOrNull(colors.checkedThumbColor)?.toGlanceColorProvider()
+  val uncheckedThumbColor =
+    colorToComposeColorOrNull(colors.uncheckedThumbColor)?.toGlanceColorProvider()
+  val checkedTrackColor =
+    colorToComposeColorOrNull(colors.checkedTrackColor)?.toGlanceColorProvider()
+  val uncheckedTrackColor =
+    colorToComposeColorOrNull(colors.uncheckedTrackColor)?.toGlanceColorProvider()
 
-  return if (
-    checkedThumbColor != null &&
-    uncheckedThumbColor != null &&
-    checkedTrackColor != null &&
-    uncheckedTrackColor != null
-  ) {
-    SwitchDefaults.colors(
-      checkedThumbColor = checkedThumbColor.toGlanceColorProvider(),
-      uncheckedThumbColor = uncheckedThumbColor.toGlanceColorProvider(),
-      checkedTrackColor = checkedTrackColor.toGlanceColorProvider(),
-      uncheckedTrackColor = uncheckedTrackColor.toGlanceColorProvider()
-    )
-  } else {
-    SwitchDefaults.colors()
-  }
+  return SwitchDefaults.colors(
+    checkedThumbColor = checkedThumbColor ?: GlanceTheme.colors.onPrimary,
+    uncheckedThumbColor = uncheckedThumbColor ?: GlanceTheme.colors.outline,
+    checkedTrackColor = checkedTrackColor ?: GlanceTheme.colors.primary,
+    uncheckedTrackColor = uncheckedTrackColor ?: GlanceTheme.colors.surfaceVariant
+  )
 }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SwitchView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/SwitchView.kt
@@ -1,0 +1,42 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.appwidget.Switch
+import androidx.glance.appwidget.SwitchDefaults
+import expo.modules.ui.SwitchProps
+import expo.modules.ui.colorToComposeColorOrNull
+import androidx.glance.appwidget.SwitchColors
+
+@Composable
+fun SwitchView(props: SwitchProps) {
+  Switch(
+    checked = props.value,
+    onCheckedChange = null,
+    modifier = props.modifiers.toGlanceModifier(),
+    colors = props.toGlanceSwitchColors()
+  )
+}
+
+@Composable
+private fun SwitchProps.toGlanceSwitchColors(): SwitchColors {
+  val checkedThumbColor = colorToComposeColorOrNull(colors.checkedThumbColor)
+  val uncheckedThumbColor = colorToComposeColorOrNull(colors.uncheckedThumbColor)
+  val checkedTrackColor = colorToComposeColorOrNull(colors.checkedTrackColor)
+  val uncheckedTrackColor = colorToComposeColorOrNull(colors.uncheckedTrackColor)
+
+  return if (
+    checkedThumbColor != null &&
+    uncheckedThumbColor != null &&
+    checkedTrackColor != null &&
+    uncheckedTrackColor != null
+  ) {
+    SwitchDefaults.colors(
+      checkedThumbColor = checkedThumbColor.toGlanceColorProvider(),
+      uncheckedThumbColor = uncheckedThumbColor.toGlanceColorProvider(),
+      checkedTrackColor = checkedTrackColor.toGlanceColorProvider(),
+      uncheckedTrackColor = uncheckedTrackColor.toGlanceColorProvider()
+    )
+  } else {
+    SwitchDefaults.colors()
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/TextView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/TextView.kt
@@ -1,0 +1,142 @@
+package expo.modules.widgets.ui
+
+import android.annotation.SuppressLint
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceModifier
+import androidx.glance.background
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontStyle
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextDecoration
+import androidx.glance.text.TextDefaults
+import androidx.glance.text.TextStyle
+import expo.modules.ui.TextAlignType
+import expo.modules.ui.TextDecorationType
+import expo.modules.ui.TextFontStyle
+import expo.modules.ui.TextFontWeight
+import expo.modules.ui.TextProps
+import expo.modules.ui.TextSpanRecord
+import expo.modules.ui.TypographyStyle
+import expo.modules.ui.colorToComposeColorOrNull
+
+@Composable
+fun TextView(props: TextProps) {
+  Text(
+    text = props.textContent(),
+    modifier = props.glanceModifier(),
+    style = props.glanceTextStyle(),
+    maxLines = props.maxLines ?: Int.MAX_VALUE
+  )
+}
+
+private fun TextProps.textContent(): String {
+  return spans?.joinToString(separator = "") { it.textContent() } ?: text
+}
+
+private fun TextSpanRecord.textContent(): String {
+  return children?.joinToString(separator = "") { it.textContent() } ?: text
+}
+
+private fun TextProps.glanceModifier(): GlanceModifier {
+  val backgroundColor = colorToComposeColorOrNull(background)
+  val modifier = modifiers.toGlanceModifier()
+  return if (backgroundColor != null) {
+    modifier.background(backgroundColor)
+  } else {
+    modifier
+  }
+}
+
+@SuppressLint("RestrictedApi")
+private fun TextProps.glanceTextStyle(): TextStyle {
+  val typography = typography?.glanceTypographyStyle()
+
+  return TextStyle(
+    color = colorToComposeColorOrNull(color)?.toGlanceColorProvider()
+      ?: typography?.color
+      ?: TextDefaults.defaultTextColor,
+    fontSize = fontSize?.sp ?: typography?.fontSize,
+    fontWeight = fontWeight?.toGlanceFontWeight() ?: typography?.fontWeight,
+    fontStyle = fontStyle?.toGlanceFontStyle() ?: typography?.fontStyle,
+    textAlign = textAlign?.toGlanceTextAlign() ?: typography?.textAlign,
+    textDecoration = textDecoration?.toGlanceTextDecoration() ?: typography?.textDecoration,
+    fontFamily = fontFamily.toGlanceFontFamily() ?: typography?.fontFamily
+  )
+}
+
+private fun TypographyStyle.glanceTypographyStyle(): TextStyle {
+  return when (this) {
+    TypographyStyle.DISPLAY_LARGE -> TextStyle(fontSize = 57.sp)
+    TypographyStyle.DISPLAY_MEDIUM -> TextStyle(fontSize = 45.sp)
+    TypographyStyle.DISPLAY_SMALL -> TextStyle(fontSize = 36.sp)
+    TypographyStyle.HEADLINE_LARGE -> TextStyle(fontSize = 32.sp)
+    TypographyStyle.HEADLINE_MEDIUM -> TextStyle(fontSize = 28.sp)
+    TypographyStyle.HEADLINE_SMALL -> TextStyle(fontSize = 24.sp)
+    TypographyStyle.TITLE_LARGE -> TextStyle(fontSize = 22.sp)
+    TypographyStyle.TITLE_MEDIUM -> TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Medium)
+    TypographyStyle.TITLE_SMALL -> TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium)
+    TypographyStyle.BODY_LARGE -> TextStyle(fontSize = 16.sp)
+    TypographyStyle.BODY_MEDIUM -> TextStyle(fontSize = 14.sp)
+    TypographyStyle.BODY_SMALL -> TextStyle(fontSize = 12.sp)
+    TypographyStyle.LABEL_LARGE -> TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium)
+    TypographyStyle.LABEL_MEDIUM -> TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Medium)
+    TypographyStyle.LABEL_SMALL -> TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium)
+  }
+}
+
+private fun TextFontWeight.toGlanceFontWeight(): FontWeight {
+  return when (this) {
+    TextFontWeight.NORMAL,
+    TextFontWeight.W100,
+    TextFontWeight.W200,
+    TextFontWeight.W300,
+    TextFontWeight.W400 -> FontWeight.Normal
+    TextFontWeight.W500,
+    TextFontWeight.W600 -> FontWeight.Medium
+    TextFontWeight.BOLD,
+    TextFontWeight.W700,
+    TextFontWeight.W800,
+    TextFontWeight.W900 -> FontWeight.Bold
+  }
+}
+
+private fun TextFontStyle.toGlanceFontStyle(): FontStyle {
+  return when (this) {
+    TextFontStyle.NORMAL -> FontStyle.Normal
+    TextFontStyle.ITALIC -> FontStyle.Italic
+  }
+}
+
+private fun TextAlignType.toGlanceTextAlign(): TextAlign {
+  return when (this) {
+    TextAlignType.LEFT -> TextAlign.Left
+    TextAlignType.RIGHT -> TextAlign.Right
+    TextAlignType.CENTER -> TextAlign.Center
+    TextAlignType.JUSTIFY,
+    TextAlignType.START -> TextAlign.Start
+    TextAlignType.END -> TextAlign.End
+  }
+}
+
+private fun TextDecorationType.toGlanceTextDecoration(): TextDecoration {
+  return when (this) {
+    TextDecorationType.NONE -> TextDecoration.None
+    TextDecorationType.UNDERLINE -> TextDecoration.Underline
+    TextDecorationType.LINE_THROUGH -> TextDecoration.LineThrough
+  }
+}
+
+private fun String?.toGlanceFontFamily(): FontFamily? {
+  return when (this) {
+    null,
+    "default" -> null
+    "sansSerif" -> FontFamily.SansSerif
+    "serif" -> FontFamily.Serif
+    "monospace" -> FontFamily.Monospace
+    "cursive" -> FontFamily.Cursive
+    else -> FontFamily(this)
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/WidgetColorProvider.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/WidgetColorProvider.kt
@@ -1,0 +1,11 @@
+package expo.modules.widgets.ui
+
+import android.annotation.SuppressLint
+import androidx.compose.ui.graphics.Color
+import androidx.glance.unit.ColorProvider
+
+// TODO(@jakex7): Inspect restricted API use
+@SuppressLint("RestrictedApi")
+internal fun Color.toGlanceColorProvider(): ColorProvider {
+  return ColorProvider(this)
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/WidgetModifiers.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/WidgetModifiers.kt
@@ -1,0 +1,164 @@
+package expo.modules.widgets.ui
+
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceModifier
+import androidx.glance.background
+import androidx.glance.layout.fillMaxHeight
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.layout.wrapContentHeight
+import androidx.glance.layout.wrapContentWidth
+import androidx.glance.semantics.semantics
+import androidx.glance.semantics.testTag
+import expo.modules.kotlin.records.recordFromMap
+import expo.modules.ui.BackgroundParams
+import expo.modules.ui.DefaultMinSizeParams
+import expo.modules.ui.FillMaxHeightParams
+import expo.modules.ui.FillMaxSizeParams
+import expo.modules.ui.FillMaxWidthParams
+import expo.modules.ui.HeightParams
+import expo.modules.ui.ModifierList
+import expo.modules.ui.ModifierType
+import expo.modules.ui.PaddingAllParams
+import expo.modules.ui.PaddingParams
+import expo.modules.ui.SizeParams
+import expo.modules.ui.TestIDParams
+import expo.modules.ui.WidthParams
+import expo.modules.ui.WrapContentHeightParams
+import expo.modules.ui.WrapContentWidthParams
+import expo.modules.ui.colorToComposeColorOrNull
+
+internal typealias WidgetModifierFactory = (ModifierType) -> GlanceModifier
+
+internal fun ModifierList.toGlanceModifier(): GlanceModifier {
+  return WidgetModifierRegistry.applyModifiers(this)
+}
+
+internal object WidgetModifierRegistry {
+  private val modifierFactories: MutableMap<String, WidgetModifierFactory> = mutableMapOf()
+
+  init {
+    registerBuiltInModifiers()
+  }
+
+  fun register(
+    type: String,
+    factory: WidgetModifierFactory
+  ) {
+    modifierFactories[type] = factory
+  }
+
+  fun unregister(type: String) {
+    modifierFactories.remove(type)
+  }
+
+  fun applyModifiers(modifiers: ModifierList?): GlanceModifier {
+    if (modifiers.isNullOrEmpty()) {
+      return GlanceModifier
+    }
+
+    var result: GlanceModifier = GlanceModifier
+    for (config in modifiers) {
+      val type = config["\$type"] as? String ?: continue
+      val modifier = modifierFactories[type]?.invoke(config) ?: GlanceModifier
+      result = result.then(modifier)
+    }
+    return result
+  }
+
+  fun hasModifier(type: String): Boolean {
+    return modifierFactories[type] != null
+  }
+
+  fun registeredTypes(): List<String> {
+    return modifierFactories.keys.toList()
+  }
+
+  private fun registerBuiltInModifiers() {
+    register("paddingAll") { map ->
+      val params = recordFromMap<PaddingAllParams>(map)
+      GlanceModifier.padding(params.all.dp)
+    }
+
+    register("padding") { map ->
+      val params = recordFromMap<PaddingParams>(map)
+      GlanceModifier.padding(
+        start = params.start.dp,
+        top = params.top.dp,
+        end = params.end.dp,
+        bottom = params.bottom.dp
+      )
+    }
+
+    register("size") { map ->
+      val params = recordFromMap<SizeParams>(map)
+      GlanceModifier.size(params.width.dp, params.height.dp)
+    }
+
+    register("width") { map ->
+      val params = recordFromMap<WidthParams>(map)
+      GlanceModifier.width(params.width.dp)
+    }
+
+    register("height") { map ->
+      val params = recordFromMap<HeightParams>(map)
+      GlanceModifier.height(params.height.dp)
+    }
+
+    register("defaultMinSize") { map ->
+      val params = recordFromMap<DefaultMinSizeParams>(map)
+      val minWidth = params.minWidth
+      val minHeight = params.minHeight
+      when {
+        minWidth != null && minHeight != null -> GlanceModifier.size(minWidth.dp, minHeight.dp)
+        minWidth != null -> GlanceModifier.width(minWidth.dp)
+        minHeight != null -> GlanceModifier.height(minHeight.dp)
+        else -> GlanceModifier
+      }
+    }
+
+    register("wrapContentWidth") { map ->
+      recordFromMap<WrapContentWidthParams>(map)
+      GlanceModifier.wrapContentWidth()
+    }
+
+    register("wrapContentHeight") { map ->
+      recordFromMap<WrapContentHeightParams>(map)
+      GlanceModifier.wrapContentHeight()
+    }
+
+    register("fillMaxSize") { map ->
+      recordFromMap<FillMaxSizeParams>(map)
+      GlanceModifier.fillMaxSize()
+    }
+
+    register("fillMaxWidth") { map ->
+      recordFromMap<FillMaxWidthParams>(map)
+      GlanceModifier.fillMaxWidth()
+    }
+
+    register("fillMaxHeight") { map ->
+      recordFromMap<FillMaxHeightParams>(map)
+      GlanceModifier.fillMaxHeight()
+    }
+
+    register("background") { map ->
+      val params = recordFromMap<BackgroundParams>(map)
+      val color = colorToComposeColorOrNull(params.color) ?: return@register GlanceModifier
+      GlanceModifier.background(color)
+    }
+
+    register("testID") { map ->
+      val params = recordFromMap<TestIDParams>(map)
+      params.testID?.let { testID ->
+        GlanceModifier.semantics {
+          testTag = testID
+        }
+      } ?: GlanceModifier
+    }
+  }
+}

--- a/packages/expo-widgets/bundle/__tests__/decorator.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/decorator.test.ts
@@ -24,6 +24,25 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.children[1].props.target).toBe('__expo_widgets_target_1');
   });
 
+  it('adds targets to material button variants during render', () => {
+    globalThis.__expoWidgetLayout = () =>
+      jsxs('View', {
+        children: [
+          jsx('FilledTonalButton', { label: 'First', onButtonPress: () => ({ id: 'first' }) }),
+          jsx('OutlinedButton', { label: 'Second', onButtonPress: () => ({ id: 'second' }) }),
+          jsx('ElevatedButton', { label: 'Third', onButtonPress: () => ({ id: 'third' }) }),
+          jsx('TextButton', { label: 'Fourth', onButtonPress: () => ({ id: 'fourth' }) }),
+        ],
+      });
+
+    const tree = globalThis.__expoWidgetRender({}, { timestamp: 1 }) as any;
+
+    expect(tree.props.children[0].props.target).toBe('__expo_widgets_target_0');
+    expect(tree.props.children[1].props.target).toBe('__expo_widgets_target_1');
+    expect(tree.props.children[2].props.target).toBe('__expo_widgets_target_2');
+    expect(tree.props.children[3].props.target).toBe('__expo_widgets_target_3');
+  });
+
   it('uses the nearest keyed parent when generating button targets', () => {
     globalThis.__expoWidgetLayout = () =>
       jsx(

--- a/packages/expo-widgets/bundle/decorator.ts
+++ b/packages/expo-widgets/bundle/decorator.ts
@@ -1,12 +1,20 @@
 import { ReactElementNode } from './jsx-runtime-stub';
 
+const interactiveTargetTypes = [
+  'Button',
+  'FilledTonalButton',
+  'OutlinedButton',
+  'ElevatedButton',
+  'TextButton',
+];
+
 export function decorateInteractiveTargets(node: unknown) {
   return decorateNode(node, {
     nearestParentKey: null,
     nextTargetIndex: {
       current: 0,
     },
-    typesToDecorate: ['Button'],
+    typesToDecorate: interactiveTargetTypes,
   });
 }
 


### PR DESCRIPTION
# Why

This PR adds the Android components layer for Expo Widgets, it uses the `@expo/ui/jetpack-compose` js layer with custom native components from Jetpack Glance.

# How

Adds a basic rendering layer that maps widget layout output to Android Glance components, reusing shared Expo UI props and modifier data where possible.

# Test Plan

- Build an Android app using `expo-widgets`.
- Verify basic widget layouts render correctly on Android.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)