### PR TITLE
[android][image-picker] Add flags for android 17

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
+- [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -33,6 +33,8 @@ internal class CameraContract(
     Intent(input.options.nativeMediaTypes.toCameraIntentAction())
       .putExtra(MediaStore.EXTRA_OUTPUT, input.uri.toUri())
       .apply {
+        // Android no longer grants it implicitly in android 17.
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
         if (input.options.nativeMediaTypes.toCameraIntentAction() == MediaStore.ACTION_VIDEO_CAPTURE) {
           putExtra(MediaStore.EXTRA_DURATION_LIMIT, input.options.videoMaxDuration)
         }


### PR DESCRIPTION
## Why

`launchCameraAsync` builds an `ACTION_IMAGE_CAPTURE` / `ACTION_VIDEO_CAPTURE` intent and passes a content URI through `EXTRA_OUTPUT` for the camera app to write into. The system grants that write access implicitly, but Android is removing the implicit grant for `ACTION_IMAGE_CAPTURE`. It is already detectable through `StrictMode.detectImplicitUriPermissionGrant()` and becomes enforced in Android 18. Once the implicit grant is gone, the camera app cannot write to the output URI and capture silently fails to save.

## How

Add `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_WRITE_URI_PERMISSION` to the capture intent in `CameraContract`.

## Test Plan

Bare expo