### PR TITLE
[ios][core] Remove keyWindow usage from currentViewController

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Internal] Remove `EventEmitter` re-export global type indirection ([#46719](https://github.com/expo/expo/pull/46719) by [@kitten](https://github.com/kitten))
 - [Android] Fixed Expo UI re-compose when switching screens in react-native-screens. ([#46650](https://github.com/expo/expo/pull/46650) by [@kudo](https://github.com/kudo))
 - [iOS] Fix Expo DevTools Network response bodies for JSON content types with parameters. ([#46336](https://github.com/expo/expo/pull/46336) by [@SJvaca30](https://github.com/SJvaca30))
+- [iOS] Resolve the key window across connected scenes in `currentViewController()` so it keeps working with multiple scenes, and expose `Utilities.keyWindow()` for modules to reuse. ([#46956](https://github.com/expo/expo/pull/46956) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Utilities/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities/Utilities.swift
@@ -138,10 +138,26 @@ public struct Utilities {
     return convertToUrl(string: string)
   }
 
+  /**
+   Returns the app's key window. On iOS and tvOS it is resolved across all connected scenes,
+   which is more reliable than the deprecated `UIApplication.keyWindow` once the app has multiple scenes.
+   */
+  @MainActor
+  public static func keyWindow() -> UIWindow? {
+#if os(iOS) || os(tvOS)
+    return UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }
+#elseif os(macOS)
+    return NSApplication.shared.keyWindow
+#endif
+  }
+
   nonisolated public func currentViewController() -> UIViewController? {
     return MainActor.assumeIsolated {
 #if os(iOS) || os(tvOS)
-      var controller = UIApplication.shared.keyWindow?.rootViewController
+      var controller = Utilities.keyWindow()?.rootViewController
 
       while let presentedController = controller?.presentedViewController, !presentedController.isBeingDismissed {
         controller = presentedController
@@ -149,7 +165,7 @@ public struct Utilities {
       return controller
 #elseif os(macOS)
       // Even though the function's return type is `UIViewController`, react-native-macos will alias `NSViewController` to `UIViewController`.
-      return NSApplication.shared.keyWindow?.contentViewController
+      return Utilities.keyWindow()?.contentViewController
 #endif
     }
   }


### PR DESCRIPTION
## Why

`Utilities.currentViewController()` resolved the root view controller through`UIApplication.shared.keyWindow`. That property is unreliable with scenes,  many modules rely on`currentViewController()` to present their UI.

## How

Add `Utilities.keyWindow()` that resolves the key window across `connectedScenes`, and use it in the iOS branch of `currentViewController(`

## Test Plan

Bare expo. Works as normal.