### PR TITLE
[android][audio] Improve audio focus handling

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Deactivate the audio session off the main thread to avoid app hangs. ([#47066](https://github.com/expo/expo/pull/47066) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -140,9 +140,14 @@ class AudioModule : Module() {
     return playsInSilentMode || audioManager.ringerMode == AudioManager.RINGER_MODE_NORMAL
   }
 
-  private fun requestAudioFocus() {
-    if (focusAcquired || !audioEnabled || interruptionMode == InterruptionMode.MIX_WITH_OTHERS) {
-      return
+  private enum class AudioFocusResult { GRANTED, DELAYED, FAILED, NOT_REQUESTED }
+
+  private fun requestAudioFocus(): AudioFocusResult {
+    if (focusAcquired) {
+      return AudioFocusResult.GRANTED
+    }
+    if (!audioEnabled || interruptionMode == InterruptionMode.MIX_WITH_OTHERS) {
+      return AudioFocusResult.NOT_REQUESTED
     }
 
     val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -165,7 +170,7 @@ class AudioModule : Module() {
       }
       audioFocusRequest?.let {
         audioManager.requestAudioFocus(it)
-      }
+      } ?: AudioManager.AUDIOFOCUS_REQUEST_FAILED
     } else {
       @Suppress("DEPRECATION")
       val requestType = if (interruptionMode == InterruptionMode.DO_NOT_MIX) {
@@ -176,10 +181,21 @@ class AudioModule : Module() {
       audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC, requestType)
     }
 
-    if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-      focusAcquired = true
-    } else {
-      Log.e(TAG, "Audio focus request failed with: $result")
+    return when (result) {
+      AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+        focusAcquired = true
+        AudioFocusResult.GRANTED
+      }
+      // The system can grant focus later through the listener, so this is not a failure.
+      AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> AudioFocusResult.DELAYED
+      else -> {
+        appContext.jsLogger?.warn(
+          "expo-audio couldn't acquire audio focus, so playback won't start. On Android an app can't " +
+            "play in the background without an active media playback foreground service. Call " +
+            "setActiveForLockScreen(true) on the player to keep playback alive in the background."
+        )
+        AudioFocusResult.FAILED
+      }
     }
   }
 
@@ -473,8 +489,8 @@ class AudioModule : Module() {
           return@Function
         }
         runOnMain {
-          if (!focusAcquired) {
-            requestAudioFocus()
+          if (!focusAcquired && requestAudioFocus() == AudioFocusResult.FAILED) {
+            return@runOnMain
           }
           player.ref.play()
         }
@@ -497,8 +513,8 @@ class AudioModule : Module() {
                 if (!shouldPlayInSilentMode()) {
                   return@runOnMain
                 }
-                if (!focusAcquired) {
-                  requestAudioFocus()
+                if (!focusAcquired && requestAudioFocus() == AudioFocusResult.FAILED) {
+                  return@runOnMain
                 }
                 player.ref.play()
               }
@@ -793,8 +809,8 @@ class AudioModule : Module() {
           return@Function
         }
         runOnMain {
-          if (!focusAcquired) {
-            requestAudioFocus()
+          if (!focusAcquired && requestAudioFocus() == AudioFocusResult.FAILED) {
+            return@runOnMain
           }
           playlist.ref.play()
         }


### PR DESCRIPTION
## Why

On Android 17, `AudioManager.requestAudioFocus()` returns `AUDIOFOCUS_REQUEST_FAILED` when the app has no visible activity and no qualifying foreground service. expo-audio requested focus directly from `play()` and then started playback even when the request was denied, so audio would not actually play and the failure surfaced only as a log line. The code also treated `AUDIOFOCUS_REQUEST_DELAYED` as a failure, even though the system can still grant focus later through the listener.

## How

`requestAudioFocus()` now returns a typed result. Playback is skipped when the request is denied rather than starting audio the system has refused. A denied request logs an actionable warning that explains background playback needs an active media playback foreground service and points at `setActiveForLockScreen(true)`. `AUDIOFOCUS_REQUEST_DELAYED `is treated as a deferred grant rather than a failure, so the existing delayed focus path keeps working.

## Test Plan

Bare expo