### PR TITLE
[docs] Add missing tabs in documentation markdown files and improve Collapsible and Prerequisites

### DIFF
--- a/docs/pages/internal/test-markdown-pipeline.mdx
+++ b/docs/pages/internal/test-markdown-pipeline.mdx
@@ -6,6 +6,7 @@ hideFromSearch: true
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
@@ -39,9 +40,17 @@ yarn add md-test-tab-two-pkg
 
 ## Collapsible Section
 
-<Collapsible summary="Expand for details">
+<Collapsible summary="md-test-collapsible-summary">
   This is md-test-collapsible-content that should survive conversion.
 </Collapsible>
+
+## Prerequisites Section
+
+<Prerequisites>
+  <Requirement title="md-test-requirement-title">
+    This is md-test-requirement-body that should survive conversion.
+  </Requirement>
+</Prerequisites>
 
 ## Step-by-Step Guide
 

--- a/docs/pages/internal/test-markdown-pipeline.mdx
+++ b/docs/pages/internal/test-markdown-pipeline.mdx
@@ -21,17 +21,17 @@ This page exists to validate the HTML-to-Markdown conversion pipeline.
 ## Tab Panels
 
 <Tabs>
-<Tab label="npm">
+<Tab label="md-test-tab-one-label">
 
 ```sh
-npm install md-test-npm-pkg
+npm install md-test-tab-one-pkg
 ```
 
 </Tab>
-<Tab label="yarn">
+<Tab label="md-test-tab-two-label">
 
 ```sh
-yarn add md-test-yarn-pkg
+yarn add md-test-tab-two-pkg
 ```
 
 </Tab>

--- a/docs/scripts/check-markdown-pages.ts
+++ b/docs/scripts/check-markdown-pages.ts
@@ -187,6 +187,9 @@ if (integrationMd === null) {
     ['first tab content', 'md-test-tab-one-pkg'],
     ['second tab label', 'md-test-tab-two-label'],
     ['second tab content', 'md-test-tab-two-pkg'],
+    ['collapsible summary heading', '#### md-test-collapsible-summary'],
+    ['requirement title heading', '##### md-test-requirement-title'],
+    ['requirement body', 'md-test-requirement-body'],
   ];
   for (const [label, text] of mustContain) {
     if (!integrationMd.includes(text)) {

--- a/docs/scripts/check-markdown-pages.ts
+++ b/docs/scripts/check-markdown-pages.ts
@@ -38,11 +38,6 @@ const PAGES_DIR = path.join(process.cwd(), 'pages');
 
 let failCount = 0;
 
-/**
- * Every <Tab label="..."> in the source MDX must survive into the generated
- * markdown as a heading. Guards against silent content loss when a multi-panel
- * component is stripped during HTML→Markdown conversion (ENG-21907).
- */
 function findMissingTabLabels(markdown: string, mdxPath: string): string[] {
   const mdx = fs.readFileSync(mdxPath, 'utf-8');
   const labelRegex = /<Tab\s+label=(?:"([^"]*)"|'([^']*)')/g;
@@ -57,14 +52,6 @@ function findMissingTabLabels(markdown: string, mdxPath: string): string[] {
   return missing;
 }
 
-/**
- * Structural backstop for tab content loss, independent of how labels are
- * declared. The conversion prefixes every rendered tab panel with its label as
- * an h4, so the markdown must hold at least as many h4 headings as the built
- * HTML has tab panels. A shortfall means panels were dropped. Covers the
- * <Tabs tabs={[...]}> prop style and dynamic labels, which the source-MDX check
- * above cannot see (ENG-21907). Returns the number of missing headings.
- */
 function tabPanelHeadingDeficit(markdown: string, htmlPath: string): number {
   if (!fs.existsSync(htmlPath)) {
     return 0;
@@ -77,7 +64,7 @@ function tabPanelHeadingDeficit(markdown: string, htmlPath: string): number {
   if (panels === 0) {
     return 0;
   }
-  const headings = (markdown.match(/^#### /gm) ?? []).length;
+  const headings = (markdown.match(/^#{4} /gm) ?? []).length;
   return Math.max(0, panels - headings);
 }
 

--- a/docs/scripts/check-markdown-pages.ts
+++ b/docs/scripts/check-markdown-pages.ts
@@ -20,6 +20,7 @@
  * - Validates that key content survived conversion and no artifacts leaked through.
  */
 
+import * as cheerio from 'cheerio';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -29,11 +30,56 @@ import {
   extractFrontmatter,
   findHtmlPages,
   findMarkdownPages,
+  findMdxSource,
 } from './generate-markdown-pages-utils.ts';
 
 const OUT_DIR = path.join(process.cwd(), 'out');
+const PAGES_DIR = path.join(process.cwd(), 'pages');
 
 let failCount = 0;
+
+/**
+ * Every <Tab label="..."> in the source MDX must survive into the generated
+ * markdown as a heading. Guards against silent content loss when a multi-panel
+ * component is stripped during HTML→Markdown conversion (ENG-21907).
+ */
+function findMissingTabLabels(markdown: string, mdxPath: string): string[] {
+  const mdx = fs.readFileSync(mdxPath, 'utf-8');
+  const labelRegex = /<Tab\s+label=(?:"([^"]*)"|'([^']*)')/g;
+  const missing: string[] = [];
+  let match: RegExpExecArray | null = null;
+  while ((match = labelRegex.exec(mdx)) !== null) {
+    const label = (match[1] ?? match[2] ?? '').trim();
+    if (label && !markdown.includes(label)) {
+      missing.push(label);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Structural backstop for tab content loss, independent of how labels are
+ * declared. The conversion prefixes every rendered tab panel with its label as
+ * an h4, so the markdown must hold at least as many h4 headings as the built
+ * HTML has tab panels. A shortfall means panels were dropped. Covers the
+ * <Tabs tabs={[...]}> prop style and dynamic labels, which the source-MDX check
+ * above cannot see (ENG-21907). Returns the number of missing headings.
+ */
+function tabPanelHeadingDeficit(markdown: string, htmlPath: string): number {
+  if (!fs.existsSync(htmlPath)) {
+    return 0;
+  }
+  const html = fs.readFileSync(htmlPath, 'utf-8');
+  if (!html.includes('data-reach-tab')) {
+    return 0;
+  }
+  const panels = cheerio.load(html)('[data-reach-tab-panel]').length;
+  if (panels === 0) {
+    return 0;
+  }
+  const headings = (markdown.match(/^#### /gm) ?? []).length;
+  return Math.max(0, panels - headings);
+}
 
 // --- Bulk quality gate (requires out/ from a full build) ---
 
@@ -58,6 +104,21 @@ if (fs.existsSync(OUT_DIR)) {
     const rel = path.relative(OUT_DIR, mdPath);
     const htmlRel = rel.replace(/\.md$/, '.html');
     const errors = checkPage(markdown, htmlRel);
+
+    const mdxPath = findMdxSource(mdPath, OUT_DIR, PAGES_DIR);
+    if (mdxPath) {
+      const missingLabels = findMissingTabLabels(markdown, mdxPath);
+      for (const label of missingLabels) {
+        errors.push(`Tab "${label}" from source MDX is missing (content dropped)`);
+      }
+    }
+
+    const htmlPath = path.join(OUT_DIR, htmlRel);
+    const deficit = tabPanelHeadingDeficit(markdown, htmlPath);
+    if (deficit > 0) {
+      errors.push(`${deficit} tab panel(s) dropped: fewer h4 headings than rendered tab panels`);
+    }
+
     if (errors.length > 0) {
       for (const error of errors) {
         console.error(`  \x1b[31m✗\x1b[0m ${rel}: ${error}`);
@@ -135,7 +196,10 @@ if (integrationMd === null) {
     ['bold text', 'md-test-bold-text'],
     ['unordered list', 'md-test-unordered-item'],
     ['ordered list', 'md-test-ordered-item'],
-    ['npm tab content', 'md-test-npm-pkg'],
+    ['first tab label', 'md-test-tab-one-label'],
+    ['first tab content', 'md-test-tab-one-pkg'],
+    ['second tab label', 'md-test-tab-two-label'],
+    ['second tab content', 'md-test-tab-two-pkg'],
   ];
   for (const [label, text] of mustContain) {
     if (!integrationMd.includes(text)) {
@@ -144,9 +208,6 @@ if (integrationMd === null) {
   }
 
   // Negative: artifacts must not leak
-  if (integrationMd.includes('md-test-yarn-pkg')) {
-    errors.push('Non-default tab panel content leaked (yarn tab should be stripped)');
-  }
   if (/^Terminal$/m.test(integrationMd)) {
     errors.push('Snippet header "Terminal" label leaked as standalone text');
   }

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -219,10 +219,14 @@ describe('cleanHtml', () => {
     expect($('main').text()).toContain('content');
   });
 
-  it('keeps only first tab panel in @reach/tabs groups', () => {
+  it('keeps every tab panel, labeled by its tab button', () => {
     const html = [
       '<main>',
       '<div data-reach-tabs="">',
+      '<div data-reach-tab-list="" role="tablist">',
+      '<div class="relative"><button data-reach-tab="" role="tab"><div><p>Alpha</p></div></button></div>',
+      '<div class="relative"><button data-reach-tab="" role="tab"><div><p>Beta</p></div></button></div>',
+      '</div>',
       '<div data-reach-tab-panels="">',
       '<div data-reach-tab-panel="" role="tabpanel">',
       '<pre><code class="language-sh">npm install expo</code></pre>',
@@ -236,8 +240,15 @@ describe('cleanHtml', () => {
     ].join('');
     const $ = cheerio.load(html);
     cleanHtml($, $('main'));
-    expect($('main').text()).toContain('npm install expo');
-    expect($('main').text()).not.toContain('yarn add expo');
+    const text = $('main').text();
+    expect(text).toContain('npm install expo');
+    expect(text).toContain('yarn add expo');
+    expect(
+      $('main')
+        .find('h4')
+        .map((_, el) => $(el).text())
+        .get()
+    ).toEqual(['Alpha', 'Beta']);
   });
 
   it('unwraps non-empty div/span inside headings', () => {
@@ -600,12 +611,17 @@ describe('platform indicators in table cells', () => {
   });
 });
 
-describe('tab panel deduplication', () => {
-  it('only includes first tab panel content in output', () => {
+describe('tab panels', () => {
+  it('preserves content from every tab panel in output', () => {
     const html = [
       '<main>',
       '<h1>Installation</h1>',
       '<div data-reach-tabs="">',
+      '<div data-reach-tab-list="" role="tablist">',
+      '<div class="relative"><button data-reach-tab="" role="tab"><div><p>npm</p></div></button></div>',
+      '<div class="relative"><button data-reach-tab="" role="tab"><div><p>yarn</p></div></button></div>',
+      '<div class="relative"><button data-reach-tab="" role="tab"><div><p>bun</p></div></button></div>',
+      '</div>',
       '<div data-reach-tab-panels="">',
       '<div data-reach-tab-panel="" role="tabpanel">',
       '<pre><code class="language-sh">npx expo install expo-camera</code></pre>',
@@ -622,8 +638,11 @@ describe('tab panel deduplication', () => {
     ].join('');
     const md = convertHtmlToMarkdown(html);
     expect(md).toContain('npx expo install expo-camera');
-    expect(md).not.toContain('yarn add expo-camera');
-    expect(md).not.toContain('bun add expo-camera');
+    expect(md).toContain('yarn add expo-camera');
+    expect(md).toContain('bun add expo-camera');
+    expect(md).toContain('#### npm');
+    expect(md).toContain('#### yarn');
+    expect(md).toContain('#### bun');
   });
 });
 
@@ -944,6 +963,7 @@ describe('tabs', () => {
     </main>`;
     const md = convertHtmlToMarkdown(html);
     expect(md).toContain('# Installation');
+    expect(md).toContain('#### npm');
     expect(md).toContain('npm install expo');
   });
 });

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -917,12 +917,15 @@ describe('checkPage (check-markdown-pages)', () => {
 });
 
 describe('collapsible/details', () => {
-  it('converts collapsible with data-md="collapsible"', () => {
+  it('promotes the collapsible summary to an h4 heading and keeps the body', () => {
     const html = `<main>
       <h1>Guide</h1>
       <details data-md="collapsible">
         <summary>
+          <div><svg class="icon-sm"></svg></div>
           <span class="font-medium" data-text="true">How to configure</span>
+          <a href="#how-to-configure" aria-label="Permalink"><svg></svg></a>
+          <div></div>
         </summary>
         <div class="overflow-hidden">
           <div class="px-5 py-4">
@@ -932,8 +935,51 @@ describe('collapsible/details', () => {
       </details>
     </main>`;
     const md = convertHtmlToMarkdown(html);
-    expect(md).toContain('How to configure');
+    expect(md).toContain('#### How to configure');
     expect(md).toContain('Configuration details here.');
+  });
+});
+
+describe('prerequisites', () => {
+  it('emits a heading and a per-requirement h5, dropping the requirement counter', () => {
+    const html = `<main>
+      <h1>Install</h1>
+      <details data-md="prerequisites" id="prerequisites">
+        <summary>
+          <div class="flex items-center">
+            <div><svg></svg></div>
+            <div class="flex items-center gap-2"><svg></svg><p>Prerequisites</p></div>
+            <a aria-label="Permalink"><svg></svg></a>
+          </div>
+          <div><p class="text-sm text-secondary" data-md="skip">2 requirements</p></div>
+        </summary>
+        <div class="overflow-hidden">
+          <div>
+            <div class="flex p-5">
+              <p class="font-medium" data-md="skip">1.</p>
+              <div class="flex-1">
+                <div class="font-medium" data-md="requirement-title">Install dependencies</div>
+                <div><p>Run the install command.</p></div>
+              </div>
+            </div>
+            <div class="flex p-5">
+              <p class="font-medium" data-md="skip">2.</p>
+              <div class="flex-1">
+                <div class="font-medium" data-md="requirement-title">Set up environment</div>
+                <div><p>Configure your machine.</p></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </details>
+    </main>`;
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('#### Prerequisites');
+    expect(md).toContain('##### Install dependencies');
+    expect(md).toContain('##### Set up environment');
+    expect(md).toContain('Run the install command.');
+    expect(md).toContain('Configure your machine.');
+    expect(md).not.toContain('2 requirements');
   });
 });
 

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -303,22 +303,29 @@ export function convertMdxInstructionToMarkdown(
  * normalize terminal blocks, and strip decorative artifacts.
  */
 export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
-  // Remove interactive/decorative elements
-  main.find('button').remove();
-  main.find('style').remove();
-
-  // Keep only the first tab panel in each tab group (typically the npm variant).
-  // @reach/tabs renders all panels in SSR HTML; we want only the first (default) one
-  // to avoid duplicating install commands for npm/yarn/bun.
-  main.find('[data-reach-tab-panels]').each((_, el) => {
-    $(el)
+  // Keep every tab panel, each prefixed with its label as an h4 (ENG-21907).
+  // Must run before the button removal below, since labels live in the buttons.
+  main.find('[data-reach-tabs]').each((_, tabsEl) => {
+    const $tabs = $(tabsEl);
+    const ownLabels = $tabs
+      .find('[data-reach-tab]')
+      .filter((_, btn) => $(btn).closest('[data-reach-tabs]').is($tabs))
+      .map((_, btn) => $(btn).text().replace(/\s+/g, ' ').trim())
+      .get();
+    $tabs
       .find('[data-reach-tab-panel]')
+      .filter((_, panel) => $(panel).closest('[data-reach-tabs]').is($tabs))
       .each((i, panel) => {
-        if (i > 0) {
-          $(panel).remove();
+        const label = ownLabels[i];
+        if (label) {
+          $(panel).prepend(`<h4>${label}</h4>`);
         }
       });
   });
+
+  // Remove interactive/decorative elements
+  main.find('button').remove();
+  main.find('style').remove();
 
   // Preserve semantic SVG icons as text before blanket SVG removal.
   // YesIcon (text-icon-success) → ✓, NoIcon (text-icon-danger) → ✗

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -323,6 +323,39 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
       });
   });
 
+  main.find('[data-md="collapsible"]').each((_, el) => {
+    const $details = $(el);
+    const $summary = $details.children('summary').first();
+    const $label = $summary.find('[data-text="true"]').first();
+    const summaryText = ($label.length ? $label : $summary).text().replace(/\s+/g, ' ').trim();
+    if (summaryText) {
+      $summary.replaceWith(`<h4>${summaryText}</h4>`);
+    } else {
+      $summary.remove();
+    }
+    $details.replaceWith($details.contents());
+  });
+
+  main.find('[data-md="prerequisites"]').each((_, el) => {
+    const $details = $(el);
+    const $summary = $details.children('summary').first();
+    $summary.find('[data-md="skip"]').remove();
+    const headingText = $summary.text().replace(/\s+/g, ' ').trim();
+    if (headingText) {
+      $summary.replaceWith(`<h4>${headingText}</h4>`);
+    } else {
+      $summary.remove();
+    }
+    $details.find('[data-md="requirement-title"]').each((_, title) => {
+      const $title = $(title);
+      const titleText = $title.text().replace(/\s+/g, ' ').trim();
+      if (titleText) {
+        $title.replaceWith(`<h5>${titleText}</h5>`);
+      }
+    });
+    $details.replaceWith($details.contents());
+  });
+
   // Remove interactive/decorative elements
   main.find('button').remove();
   main.find('style').remove();

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -8,7 +8,9 @@ export type RequirementProps = PropsWithChildren<{
 export function Requirement({ title, children }: RequirementProps) {
   return (
     <div className="flex-1 overflow-hidden">
-      <div className="mb-2 flex items-baseline gap-2 font-medium">{title}</div>
+      <div className="mb-2 flex items-baseline gap-2 font-medium" data-md="requirement-title">
+        {title}
+      </div>
       <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
         {children}
       </div>

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -78,7 +78,8 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
         open={isOpen}
         onToggle={event => {
           setIsOpen(event.currentTarget.open);
-        }}>
+        }}
+        data-md="prerequisites">
         <summary
           className={mergeClasses(
             'group m-0 flex cursor-pointer items-center justify-between rounded-md p-1.5 py-3 pr-4',
@@ -117,7 +118,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
             </LinkBase>
           </div>
           <div>
-            <p className="text-sm text-secondary">
+            <p className="text-sm text-secondary" data-md="skip">
               {numberOfRequirements}{' '}
               {intl.formatMessage({
                 id:
@@ -141,7 +142,9 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
                 key={index}
                 className={mergeClasses('flex items-baseline gap-1.5 border-t border-default p-5')}>
                 {numberOfRequirements > 1 && (
-                  <p className="mb-2 text-right font-medium">{index + 1}.</p>
+                  <p className="mb-2 text-right font-medium" data-md="skip">
+                    {index + 1}.
+                  </p>
                 )}
                 {child}
               </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21907 ENG-21927

# How

<!--
How did you build this feature or fix this bug and why?
-->


- `cleanHtml` in `generate-markdown-pages-utils.ts` now keeps every rendered tab panel and prefixes each with its label as an `h4`, instead of removing panels after the first (which wrongly assumed tabs only wrap redundant package-manager commands).
- Adds two regression guards in `check-markdown-pages.ts`, so every `<Tab label>` in the source MDX must survive into the `.md`.
- **Collapsible / FAQ:** wires up the existing `data-md="collapsible"` marker so each summary renders as an `h4` heading with its body kept, instead of an unmarked paragraph indistinguishable from the answer.
- **Prerequisites:** adds `data-md` markers in the component plus a handler that emits an `h4` heading and an `h5` per requirement, dropping the "N requirements" counter and ordinal numbering.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="3098" height="1016" alt="CleanShot 2026-06-16 at 15 50 23@2x" src="https://github.com/user-attachments/assets/fe0ae252-9bae-4964-a0cb-326bb0c32894" />

<img width="4112" height="1536" alt="CleanShot 2026-06-16 at 16 47 51@2x" src="https://github.com/user-attachments/assets/8e47bec4-410a-49d1-b180-bef4f5cd8e02" />

<img width="4062" height="874" alt="CleanShot 2026-06-16 at 16 48 13@2x" src="https://github.com/user-attachments/assets/77cd2d2a-9452-462d-b14e-7e3fdc30ab7a" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
