### PR TITLE
[core][Android] Fix composeProps naming

### DIFF
--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
@@ -15,7 +15,7 @@ inline fun <reified Props : ComposeProps> createComposeProps(
   appContext: AppContext? = null
 ): Props {
   val propsParsingStrategy = toPropsParsingStrategy<Props>()
-  val propsInstance = propsParsingStrategy.createNewInstance()
+  var propsInstance = propsParsingStrategy.createNewInstance()
 
   if (propsMap == null) {
     return propsInstance
@@ -29,12 +29,11 @@ inline fun <reified Props : ComposeProps> createComposeProps(
     val prop = props[name] ?: continue
 
     propsMap.getDynamic(name).recycle {
-      @Suppress("UNCHECKED_CAST")
-      prop.setPropDirectly(
+      propsInstance = (prop.copyPropsWithNewValue(
         prop = this,
         currentProps = propsInstance,
         appContext = appContext
-      ) as Props
+      ) ?: propsInstance) as Props
     }
   }
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
@@ -29,11 +29,13 @@ inline fun <reified Props : ComposeProps> createComposeProps(
     val prop = props[name] ?: continue
 
     propsMap.getDynamic(name).recycle {
-      propsInstance = (prop.copyPropsWithNewValue(
-        prop = this,
-        currentProps = propsInstance,
-        appContext = appContext
-      ) ?: propsInstance) as Props
+      propsInstance = (
+        prop.copyPropsWithNewValue(
+          prop = this,
+          currentProps = propsInstance,
+          appContext = appContext
+        ) ?: propsInstance
+        ) as Props
     }
   }
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -18,22 +18,12 @@ class ComposeViewProp(
 ) : AnyViewProp(name, anyType) {
   private var _isStateProp = false
 
-  @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop = prop, onView = onView, appContext = appContext)
-  }
-
-  override fun set(prop: Any?, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop = prop, onView = onView, appContext = appContext)
-  }
-
-  @PublishedApi
-  internal fun setPropDirectly(prop: Dynamic, currentProps: Any, appContext: AppContext?): Any {
-    return copyPropsWithNewValue(prop, currentProps, appContext) ?: currentProps
+    set(prop = prop as Any, onView = onView, appContext = appContext)
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun setPropDirectly(prop: Any?, onView: View, appContext: AppContext?) {
+  override fun set(prop: Any?, onView: View, appContext: AppContext?) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
@@ -57,7 +47,8 @@ class ComposeViewProp(
     }
   }
 
-  private fun copyPropsWithNewValue(prop: Any?, currentProps: Any, appContext: AppContext?): Any? {
+  @PublishedApi
+  internal fun copyPropsWithNewValue(prop: Any?, currentProps: Any, appContext: AppContext?): Any? {
     // TODO(@lukmccall): We should remove the copy call
     val copy = currentProps::class.memberFunctions.firstOrNull { it.name == "copy" }
     if (copy == null) {


### PR DESCRIPTION
# Why

Too much confusing names, set, set, setDirectly etc.

# How

Remove duplicated functions and use better naming.

# Test Plan

* CI should be green
* Manually tested in bare expo `@expo/ui` examples

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
