### PR TITLE
fix(expo-crypto): replace @OptimizedFunction macro with closure for Xcode 26 compatibility

### DIFF
--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -15,12 +15,9 @@ public class CryptoModule: Module {
 
     Function("digest", digest)
 
-    Function("randomUUID", randomUUID())
-  }
-
-  @OptimizedFunction
-  private func randomUUID() -> String {
-    return UUID().uuidString.lowercased()
+    Function("randomUUID") {
+      return UUID().uuidString.lowercased()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The `@OptimizedFunction` Swift macro plugin binary shipped with `expo-modules-core` is not compatible with Xcode 26 (Swift 6.2), causing iOS builds to fail with:

```
external macro implementation type 'ExpoModulesMacros.OptimizedFunctionAttachedMacro' could not be found for macro 'OptimizedFunction'; No such file or directory
```

Replacing the macro with an equivalent closure fixes the build without any functional change — `Function("name") { ... }` is the standard non-optimized path that works identically.

## Test plan

- [x] Verified fix with `expo-crypto@56.0.4`, `expo-modules-core@56.0.12`, Xcode 26.2
- [x] `randomUUID()` functionality unchanged — still returns lowercased UUID string

Fixes #46317