### PR TITLE
[core][Android] Remove deprecated `AppContext` fields and fix warnings

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 🛠 Breaking changes
 
+- [Android] Removed the deprecated `AppContext.hostingRuntimeContext` property. Use `AppContext.runtime` instead. ([#46964](https://github.com/expo/expo/pull/46964) by [@wenszel](https://github.com/wenszel))
+- [Android] Removed the deprecated `AppContext.errorManager` property. Use `AppContext.jsLogger` instead. ([#46964](https://github.com/expo/expo/pull/46964) by [@wenszel](https://github.com/wenszel))
+
 ### 🎉 New features
 
 - [iOS] Added the `@Record` macro that synthesizes a record from a type's stored properties, with no `@Field` wrappers needed. ([#46547](https://github.com/expo/expo/pull/46547) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -3,11 +3,8 @@
 package expo.modules.kotlin.jni
 
 import android.view.View
-import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.annotations.FrameworkAPI
-import com.facebook.react.uimanager.UIBlock
-import com.facebook.react.uimanager.UIManagerModule
 import com.google.common.truth.Truth
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
@@ -26,7 +23,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 
 private fun defaultAppContextMock(): Pair<AppContext, MainRuntime> {
@@ -37,7 +33,6 @@ private fun defaultAppContextMock(): Pair<AppContext, MainRuntime> {
   every { runtimeContext.classRegistry } answers { classRegistry }
   every { runtimeContext.appContext } answers { appContextMock }
   every { appContextMock.findView<View>(capture(slot())) } answers { mockk() }
-  every { appContextMock.hostingRuntimeContext } answers { runtimeContext }
   every { appContextMock.runtime } answers { runtimeContext }
 
   return appContextMock to runtimeContext
@@ -55,22 +50,10 @@ internal inline fun withJSIInterop(
   val (appContextMock, runtimeContext) = defaultAppContextMock()
   val methodQueue = TestScope()
 
-  val uiManagerModuleMock = mockk<UIManagerModule>()
-  val slot = slot<UIBlock>()
-  every { uiManagerModuleMock.addUIBlock(capture(slot)) } answers {
-    methodQueue.launch {
-      slot.captured.execute(mockk())
-    }
-  }
-
-  val catalystInstanceMock = mockk<CatalystInstance>()
-  every { catalystInstanceMock.getNativeModule(UIManagerModule::class.java) } answers { uiManagerModuleMock }
-
   val reactContextMock = mockk<ReactContext>()
   every { reactContextMock.isBridgeless } answers { false }
   every { reactContextMock.hasCatalystInstance() } answers { true }
   every { reactContextMock.hasActiveReactInstance() } answers { true }
-  every { reactContextMock.catalystInstance } answers { catalystInstanceMock }
 
   every { appContextMock.modulesQueue } answers { methodQueue }
   every { appContextMock.mainQueue } answers { methodQueue }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -78,11 +78,6 @@ internal inline fun withJSIInterop(
   every { appContextMock.reactContext } answers { reactContextMock }
   every { appContextMock.assertMainThread() } answers { }
 
-  val functionSlot = slot<() -> Unit>()
-  every { appContextMock.dispatchOnMainUsingUIManager(capture(functionSlot)) } answers {
-    functionSlot.captured.invoke()
-  }
-
   val jniDeallocator = JNIDeallocator(shouldCreateDestructorThread = false)
   repeat(numberOfReloads) {
     val coreModule = run {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/apploader/AppLoaderProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/apploader/AppLoaderProvider.kt
@@ -31,6 +31,7 @@ object AppLoaderProvider {
         "org.unimodules.core.AppLoader#$name"
       ) ?: throw IllegalStateException("Unable to instantiate AppLoader!")
 
+      @Suppress("UNCHECKED_CAST")
       loaderClass = Class.forName(loaderClassName) as Class<out HeadlessAppLoader>
       loaders[name] = loaderClass
         .getDeclaredConstructor()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -51,11 +51,7 @@ class AppContext(
 ) : CurrentActivityProvider {
   // The main context used in the app.
   // Modules attached to this context will be available on the main js context.
-  @Deprecated("Use AppContext.runtimeContext instead", ReplaceWith("runtime"))
-  val hostingRuntimeContext = MainRuntime(this, reactContextHolder)
-
-  val runtime: MainRuntime
-    get() = hostingRuntimeContext
+  val runtime = MainRuntime(this, reactContextHolder)
 
   private val uiRuntimeHolder = lazy { WorkletRuntime(this, reactContextHolder) }
   val uiRuntime

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -11,8 +11,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.react.uimanager.UIManagerHelper
-import com.facebook.react.uimanager.UIManagerModule
-import com.facebook.react.uimanager.common.UIManagerType
 import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
@@ -371,18 +369,6 @@ class AppContext(
     return UIManagerHelper
       .getUIManagerForReactTag(reactContext, viewTag)
       ?.resolveView(viewTag) as? T
-  }
-
-  internal fun dispatchOnMainUsingUIManager(block: () -> Unit) {
-    val reactContext = runtime.reactContext ?: throw Exceptions.ReactContextLost()
-    val uiManager = UIManagerHelper.getUIManagerForReactTag(
-      reactContext,
-      UIManagerType.DEFAULT
-    ) as UIManagerModule
-
-    uiManager.addUIBlock {
-      block()
-    }
   }
 
   internal fun assertMainThread() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -17,7 +17,6 @@ import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.activityresult.ActivityResultsManager
 import expo.modules.kotlin.activityresult.DefaultAppContextActivityResultCaller
-import expo.modules.kotlin.defaultmodules.ErrorManagerModule
 import expo.modules.kotlin.defaultmodules.JSLoggerModule
 import expo.modules.kotlin.defaultmodules.NativeModulesProxyModule
 import expo.modules.kotlin.events.EventEmitter
@@ -264,11 +263,6 @@ class AppContext(
         ?: return null
       return KEventEmitterWrapper(legacyEventEmitter, runtime.reactContextHolder)
     }
-
-  @Deprecated("Use AppContext.jsLogger instead")
-  val errorManager: ErrorManagerModule? by lazy {
-    registry.getModule()
-  }
 
   val jsLogger by lazy {
     registry.getModule<JSLoggerModule>()?.logger

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
@@ -13,8 +13,10 @@ class NativeModulesProxyModule : Module() {
   override fun definition() = ModuleDefinition {
     Name(NativeModulesProxyModuleName)
 
-    Constants {
-      appContext.legacyModulesProxyHolder?.get()?.constants ?: emptyMap()
+    appContext.legacyModulesProxyHolder?.get()?.constants?.forEach {
+      Constant(it.key) {
+        it.value
+      }
     }
 
     AsyncFunction("callMethod") { moduleName: String, methodName: String, arguments: ReadableArray, promise: Promise ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -96,7 +96,7 @@ open class KEventEmitterWrapper(
   override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {
     val context = reactContextHolder.get() ?: return
     val uiEvent = UIEvent(surfaceId = -1, viewId, eventName, eventBody, coalescingKey)
-    UIManagerHelper.getEventDispatcherForReactTag(context, viewId)
+    UIManagerHelper.getEventDispatcher(context)
       ?.dispatchEvent(uiEvent)
   }
 
@@ -105,7 +105,7 @@ open class KEventEmitterWrapper(
     val surfaceId = UIManagerHelper.getSurfaceId(view)
     val viewId = view.id
     val uiEvent = UIEvent(surfaceId, viewId, eventName, eventBody, coalescingKey)
-    UIManagerHelper.getEventDispatcherForReactTag(context, view.id)
+    UIManagerHelper.getEventDispatcher(context)
       ?.dispatchEvent(uiEvent)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -67,17 +67,6 @@ abstract class AsyncFunctionComponent(
       }
 
       Queues.MAIN -> {
-        if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && desiredArgsTypes.any { it.inheritFrom<View>() }) {
-          // On certain occasions, invoking a function on a view could lead to an error
-          // because of the asynchronous communication between the JavaScript and native components.
-          // In such cases, the native view may not have been mounted yet,
-          // but the JavaScript code has already received the future tag of the view.
-          // To avoid this issue, we have decided to temporarily utilize
-          // the UIManagerModule for dispatching functions on the main thread.
-          appContext.dispatchOnMainUsingUIManager(block)
-          return
-        }
-
         appContext.mainQueue.launch {
           block()
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.functions
 
-import android.view.View
 import expo.modules.BuildConfig
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
@@ -9,7 +8,6 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.inheritFrom
 import expo.modules.kotlin.weak
 import kotlinx.coroutines.launch
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -467,8 +467,9 @@ class ViewDefinitionBuilder<T : View>(
   private fun handleFailureDuringViewCreation(context: Context, appContext: AppContext, error: Throwable): View {
     Log.e("ExpoModulesCore", "Couldn't create view of type $viewClass", error)
 
-    appContext.errorManager?.reportExceptionToLogBox(
-      error as? CodedException ?: UnexpectedException(error)
+    appContext.jsLogger?.error(
+      message = error.message.toString(),
+      cause = error
     )
 
     return if (ViewGroup::class.java.isAssignableFrom(viewClass.java)) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -11,8 +11,6 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
-import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
 import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -37,7 +37,9 @@ class ViewManagerDefinition(
     val reactContext = (view.context as? ReactContext) ?: return
     val nativeModulesProxy = reactContext.getUnimoduleProxy() ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
-
-    appContext.errorManager?.reportExceptionToLogBox(exception)
+    appContext.jsLogger?.error(
+      message = exception.message.toString(),
+      cause = exception
+    )
   }
 }


### PR DESCRIPTION
# Why

Fixes warnings that appear during `expo-modules-core` compilation: deprecated API usages and an unchecked cast. Each commit fixes exactly one warning.

# How

- Suppressed an unchecked cast warning in `AppLoaderProvider`
- Removed `ErrorManagerModule`, deprecated since SDK 55
- Removed `hostingRuntimeContext`, deprecated since SDK 54
- Replaced `errorManager.reportExceptionToLogBox` with `appContext.jsLogger.error()`
- Replaced `Constants` with a loop that declares `Constant` values
- Replaced `getEventDispatcherForReactTag` with `getEventDispatcher`
- Removed `dispatchOnMainUsingUIManager`

# Test Plan

Native Unit Tests ✅