### PR TITLE
[docs] Document the expo-go CLI for installing Expo Go

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -12,6 +12,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 **Development build** is the term that we use for a "Debug" build of an app that includes the [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. This library augments the built-in React Native development tooling with additional capabilities, such as support for inspecting network requests and a "launcher" UI that lets you switch between different development servers (such as between a server running on your machine or a teammate's machine) and deployments of your app (such as published updates with EAS Update).
@@ -73,6 +74,18 @@ Both [Android App Links](/linking/android-app-links/) and [iOS Universal Links](
 Expo Go can only support one SDK version at a time. When a new SDK version is released, Expo Go is updated to support the newer version, and this will be the only version of Expo Go available to install from the stores.
 
 If you're developing on an Android Device, Android Emulator, or iOS Simulator, a compatible version of Expo Go can be [downloaded and installed](https://expo.dev/go). The only platform where this is impossible is iPhone devices because Apple does not support side-loading older versions of apps.
+
+The [`expo-go` CLI](https://www.npmjs.com/package/expo-go) downloads the binary for a given SDK version without an Expo project:
+
+<Terminal
+  cmd={[
+    '# Use the SDK version your project targets (omit it for the latest)',
+    '$ npx expo-go download android 53',
+    '',
+    '# iOS simulator app',
+    '$ npx expo-go download ios 53',
+  ]}
+/>
 
 </Collapsible>
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -12,7 +12,6 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 **Development build** is the term that we use for a "Debug" build of an app that includes the [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. This library augments the built-in React Native development tooling with additional capabilities, such as support for inspecting network requests and a "launcher" UI that lets you switch between different development servers (such as between a server running on your machine or a teammate's machine) and deployments of your app (such as published updates with EAS Update).
@@ -74,18 +73,6 @@ Both [Android App Links](/linking/android-app-links/) and [iOS Universal Links](
 Expo Go can only support one SDK version at a time. When a new SDK version is released, Expo Go is updated to support the newer version, and this will be the only version of Expo Go available to install from the stores.
 
 If you're developing on an Android Device, Android Emulator, or iOS Simulator, a compatible version of Expo Go can be [downloaded and installed](https://expo.dev/go). The only platform where this is impossible is iPhone devices because Apple does not support side-loading older versions of apps.
-
-The [`expo-go` CLI](https://www.npmjs.com/package/expo-go) downloads the binary for a given SDK version without an Expo project:
-
-<Terminal
-  cmd={[
-    '# Use the SDK version your project targets (omit it for the latest)',
-    '$ npx expo-go download android 53',
-    '',
-    '# iOS simulator app',
-    '$ npx expo-go download ios 53',
-  ]}
-/>
 
 </Collapsible>
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -156,15 +156,58 @@ For more information on how to use it:
 
 > **Note:** Expo Go is limited and not useful for building production-grade projects. Use [development builds](/get-started/set-up-your-environment/?mode=development-build) instead.
 
+#### `expo-go` CLI
+
+The [`expo-go` CLI](https://www.npmjs.com/package/expo-go) is a standalone tool that downloads an Expo Go binary for a platform and specific SDK version, or prints its download URL. Pass an SDK version to pin a specific release, or omit it for the latest release, and specify a platform to download the correct binary.
+
+<Terminal
+  cmd={{
+    npm: [
+      '# Download Expo Go for a platform',
+      '$ npx expo-go download android latest',
+      '',
+      '# Print the download URL instead of downloading',
+      '$ npx expo-go url ios latest',
+    ],
+    yarn: [
+      '# Download Expo Go for a platform',
+      '$ yarn dlx expo-go download android latest',
+      '',
+      '# Print the download URL instead of downloading',
+      '$ yarn dlx expo-go url ios latest',
+    ],
+    pnpm: [
+      '# Download Expo Go for a platform',
+      '$ pnpm dlx expo-go download android latest',
+      '',
+      '# Print the download URL instead of downloading',
+      '$ pnpm dlx expo-go url ios latest',
+    ],
+    bun: [
+      '# Download Expo Go for a platform',
+      '$ bunx expo-go download android latest',
+      '',
+      '# Print the download URL instead of downloading',
+      '$ bunx expo-go url ios latest',
+    ],
+  }}
+/>
+
+This command downloads the Expo Go app to the current directory and caches it under **~/.expo**.
+
+> **warning** The `expo-go` CLI works for Android device, Android Emulator, iOS Simulator. Due to Apple's policies, an iPhone device does not support side-loading older app versions in general and the `expo-go` CLI does not support it.
+
 <Collapsible summary="What if I open a project with an unsupported SDK version?">
 
 When running a project that was created for an unsupported SDK version in Expo Go, you'll see the following error:
 
-```sh
+```text
 "Project is incompatible with this version of Expo Go"
 ```
 
 To fix this, upgrading your project to a [supported SDK version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) is recommended. If you want to learn how to do it, see [Upgrade the project to a new SDK Version](#how-do-i-upgrade-my-project-from).
+
+Alternatively, you can use `expo-go` CLI to download the version of Expo Go that matches your project's SDK version.
 
 </Collapsible>
 

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -48,3 +48,51 @@ Copy `adb` from Android SDK directory to `usr/bin` directory:
 
 <Terminal cmd={['$ sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin']} />
 </Step>
+
+### How do I install a specific version of Expo Go?
+
+You can create a project with the desired SDK version and open it in a simulator to install the matching version of Expo Go.
+
+<Terminal
+  cmd={{
+    npm: [
+      '# Bootstrap an SDK 56 project',
+      '$ npx create-expo-app --template blank@56',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ npx expo start --android',
+    ],
+    yarn: [
+      '# Bootstrap an SDK 56 project',
+      '$ yarn create expo-app --template blank@56',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ yarn expo start --android',
+    ],
+    pnpm: [
+      '# Bootstrap an SDK 56 project',
+      '$ pnpm create expo-app --template blank@56',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ pnpm expo start --android',
+    ],
+    bun: [
+      '# Bootstrap an SDK 56 project',
+      '$ bun create expo --template blank@56',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ bun expo start --android',
+    ],
+  }}
+/>
+
+Alternatively, you can download a specific version of Expo Go with the [`expo-go` CLI](https://www.npmjs.com/package/expo-go) by passing an SDK version, or use `latest` for the latest SDK version. This command downloads the Expo Go app to the current directory and caches it under **~/.expo**.
+
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-go download android latest'],
+    yarn: ['$ yarn dlx expo-go download android latest'],
+    pnpm: ['$ pnpm dlx expo-go download android latest'],
+    bun: ['$ bunx expo-go download android latest'],
+  }}
+/>

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -80,40 +80,51 @@ You can use this menu to open any version of the simulator. You can also open mu
 
 The first time you install the app in the simulator, iOS will ask if you'd like to open the Expo Go app. You may need to interact with the simulator (click around, drag something) for this prompt to show up, then press **OK**.
 
-### How do I force an update to the latest version?
+### How do I install a specific version of Expo Go?
 
-Create a project with the desired SDK version and open it in a simulator to install a particular version of Expo Go.
+You can create a project with the desired SDK version and open it in a simulator to install the matching version of Expo Go.
 
 <Terminal
   cmd={{
     npm: [
-      '# Bootstrap an SDK 53 project',
-      '$ npx create-expo-app --template blank@53',
+      '# Bootstrap an SDK 56 project',
+      '$ npx create-expo-app --template blank@56',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ npx expo start --ios',
     ],
     yarn: [
-      '# Bootstrap an SDK 53 project',
-      '$ yarn create expo-app --template blank@53',
+      '# Bootstrap an SDK 56 project',
+      '$ yarn create expo-app --template blank@56',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ yarn expo start --ios',
     ],
     pnpm: [
-      '# Bootstrap an SDK 53 project',
-      '$ pnpm create expo-app --template blank@53',
+      '# Bootstrap an SDK 56 project',
+      '$ pnpm create expo-app --template blank@56',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ pnpm expo start --ios',
     ],
     bun: [
-      '# Bootstrap an SDK 53 project',
-      '$ bun create expo --template blank@53',
+      '# Bootstrap an SDK 56 project',
+      '$ bun create expo --template blank@56',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ bun expo start --ios',
     ],
+  }}
+/>
+
+Alternatively, you can download a specific version of Expo Go with the [`expo-go` CLI](https://www.npmjs.com/package/expo-go) by passing an SDK version, or use `latest` for the latest SDK version. This command downloads the Expo Go app to the current directory and caches it under **~/.expo**.
+
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-go download ios latest'],
+    yarn: ['$ yarn dlx expo-go download ios latest'],
+    pnpm: ['$ pnpm dlx expo-go download ios latest'],
+    bun: ['$ bunx expo-go download ios latest'],
   }}
 />
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -11,7 +11,7 @@ import { Step } from '~/ui/components/Step';
 
 With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
 
-If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
+If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go) or use [`expo-go` CLI](/develop/tools/#expo-go-cli). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
 
 ## How to upgrade to the latest SDK version
 


### PR DESCRIPTION

# Why

Fix ENG-21532

# How

Document the `expo-go` CLI in the Expo Go sections of `develop/tools.mdx` and `develop/development-builds/introduction.mdx`, and add it as the no-project alternative in the "install a specific version of Expo Go" FAQs on `workflow/ios-simulator.mdx` and `workflow/android-studio-emulator.mdx`, with `npm`/`yarn`/`pnpm`/`bun` tabs.

# Test Plan

See preview:
- https://pr-46967.expo-docs.pages.dev/develop/tools/#expo-go-cli
- https://pr-46967.expo-docs.pages.dev/workflow/upgrading-expo-sdk-walkthrough/
- https://pr-46967.expo-docs.pages.dev/workflow/android-studio-emulator/#how-do-i-install-a-specific-version-of-expo-go
- https://pr-46967.expo-docs.pages.dev/workflow/ios-simulator/#how-do-i-install-a-specific-version-of-expo-go

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
