### PR TITLE
[autolinking] Add support for compile-only inline module files

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
+- Added support for compile-only inline module files, which are compiled into the target without being registered as Expo modules. ([#46969](https://github.com/expo/expo/pull/46969) by [@behenate](https://github.com/behenate))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
+++ b/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
@@ -1,4 +1,4 @@
-import { error } from 'console';
+import { error, warn } from 'console';
 import * as fs from 'fs';
 import { vol } from 'memfs';
 
@@ -10,6 +10,8 @@ import {
 import type { InlineModulesMirror } from '../inlineModules/inlineModules';
 import {
   getMirrorStateObject,
+  hasKotlinModuleDefinition,
+  hasSwiftModuleDefinition,
   getKotlinFileNameWithItsPackage,
   inlineModuleFileNameInformation,
 } from '../inlineModules/inlineModules';
@@ -71,9 +73,17 @@ describe('inlineModules.ts', () => {
       });
     });
 
-    it('rejects files with extra dots (e.g. .android.kt)', () => {
+    it('accepts files with extra dots because module registration is content-based', () => {
       expect(inlineModuleFileNameInformation('SomeModule.android.kt')).toEqual({
-        valid: false,
+        valid: true,
+        ext: '.kt',
+      });
+      expect(inlineModuleFileNameInformation('Nested.compile.extra.swift')).toEqual({
+        valid: true,
+        ext: '.swift',
+      });
+      expect(inlineModuleFileNameInformation('Helpers.compile.kt')).toEqual({
+        valid: true,
         ext: '.kt',
       });
     });
@@ -83,6 +93,74 @@ describe('inlineModules.ts', () => {
         valid: false,
         ext: '.ts',
       });
+    });
+  });
+
+  describe('hasKotlinModuleDefinition', () => {
+    it('detects an inline module returning ModuleDefinition', async () => {
+      vol.fromJSON({
+        '/example-project/SimpleModule.kt':
+          'class SimpleModule : Module() {\n  override fun definition() = ModuleDefinition { Name("SimpleModule") }\n}',
+      });
+
+      await expect(hasKotlinModuleDefinition('/example-project/SimpleModule.kt')).resolves.toBe(
+        true
+      );
+    });
+
+    it('detects an inline module returning a fully-qualified ModuleDefinition', async () => {
+      vol.fromJSON({
+        '/example-project/SimpleModule.kt':
+          'class SimpleModule : Module() {\n  override fun definition() = expo.modules.kotlin.modules.ModuleDefinition { Name("SimpleModule") }\n}',
+      });
+
+      await expect(hasKotlinModuleDefinition('/example-project/SimpleModule.kt')).resolves.toBe(
+        true
+      );
+    });
+
+    it('does not treat supporting kotlin files as modules', async () => {
+      vol.fromJSON({
+        '/example-project/Helper.compile.kt': 'package some.pkg\nclass Helper',
+      });
+
+      await expect(hasKotlinModuleDefinition('/example-project/Helper.compile.kt')).resolves.toBe(
+        false
+      );
+    });
+  });
+
+  describe('hasSwiftModuleDefinition', () => {
+    it('detects an inline module returning ModuleDefinition', async () => {
+      vol.fromJSON({
+        '/example-project/AppIntentsSetup.swift':
+          'import ExpoModulesCore\nfinal class AppIntentsSetup: Module {\n  func definition() -> ModuleDefinition { Name("AppIntentsSetup") }\n}',
+      });
+
+      await expect(
+        hasSwiftModuleDefinition('/example-project/AppIntentsSetup.swift')
+      ).resolves.toBe(true);
+    });
+
+    it('detects an inline module returning ExpoModulesCore.ModuleDefinition', async () => {
+      vol.fromJSON({
+        '/example-project/AppIntentsSetup.swift':
+          'import ExpoModulesCore\nfinal class AppIntentsSetup: Module {\n  func definition() -> ExpoModulesCore.ModuleDefinition { Name("AppIntentsSetup") }\n}',
+      });
+
+      await expect(
+        hasSwiftModuleDefinition('/example-project/AppIntentsSetup.swift')
+      ).resolves.toBe(true);
+    });
+
+    it('does not treat supporting swift files as modules', async () => {
+      vol.fromJSON({
+        '/example-project/TrailEntity.compile.swift': 'import AppIntents\nstruct TrailEntity {}',
+      });
+
+      await expect(
+        hasSwiftModuleDefinition('/example-project/TrailEntity.compile.swift')
+      ).resolves.toBe(false);
     });
   });
 
@@ -115,14 +193,19 @@ describe('inlineModules.ts', () => {
     it('scans directories and correctly builds the mirror object', async () => {
       vol.fromJSON({
         '/example-project/package.json': '{}',
-        '/example-project/app/ValidAndroid1.kt': 'package app.valid\nclass ValidAndroid1',
-        '/example-project/app/modules/ValidApple1.swift': 'internal import ExpoModulesCore',
+        '/example-project/app/ValidAndroid1.kt':
+          'package app.valid\nclass ValidAndroid1 : Module() {\n  override fun definition() = ModuleDefinition { Name("ValidAndroid1") }\n}',
+        '/example-project/app/modules/ValidApple1.swift':
+          'internal import ExpoModulesCore\nfunc definition() -> ModuleDefinition',
         '/example-project/app/Invalid.android.kt': 'package valid.package',
         '/example-project/src/nested/Invalid2.kt': 'class NoPackage',
         '/example-project/src/nested/Readme.md': '# Hello',
-        '/example-project/src/nested/ValidApple2.swift': 'internal import ExpoModulesCore',
-        '/example-project/other/ValidApple3.swift': 'internal import ExpoModulesCore',
-        '/other-project/src/ValidAndroid2.kt': 'package app.valid\nclass ValidAndroid2',
+        '/example-project/src/nested/ValidApple2.swift':
+          'internal import ExpoModulesCore\nfunc definition() -> ModuleDefinition',
+        '/example-project/other/ValidApple3.swift':
+          'internal import ExpoModulesCore\nfunc definition() -> ModuleDefinition',
+        '/other-project/src/ValidAndroid2.kt':
+          'package app.valid\nclass ValidAndroid2 : Module() {\n  override fun definition() = ModuleDefinition { Name("ValidAndroid2") }\n}',
       });
 
       const result = await getMirrorStateObject(
@@ -133,7 +216,7 @@ describe('inlineModules.ts', () => {
       expect(result.swiftModuleClassNames).toEqual(['ValidApple1', 'ValidApple2']);
       expect(result.kotlinClasses).toEqual(['app.valid.ValidAndroid1', 'app.valid.ValidAndroid2']);
 
-      expect(result.files).toHaveLength(4);
+      expect(result.files).toHaveLength(6);
       const sortingFunction = (
         o1: { filePath: string; watchedDir: string },
         o2: { filePath: string; watchedDir: string }
@@ -142,6 +225,10 @@ describe('inlineModules.ts', () => {
         [
           {
             filePath: '/example-project/app/ValidAndroid1.kt',
+            watchedDir: '/example-project/app',
+          },
+          {
+            filePath: '/example-project/app/Invalid.android.kt',
             watchedDir: '/example-project/app',
           },
           {
@@ -156,8 +243,82 @@ describe('inlineModules.ts', () => {
             filePath: '/example-project/src/nested/ValidApple2.swift',
             watchedDir: '/example-project/src/nested',
           },
+          {
+            filePath: '/example-project/src/nested/Invalid2.kt',
+            watchedDir: '/example-project/src/nested',
+          },
         ].sort(sortingFunction)
       );
+    });
+
+    it('includes native files without module definitions in files but not in class name lists', async () => {
+      vol.fromJSON({
+        '/example-project/package.json': '{}',
+        '/example-project/intents/MyModule.swift':
+          'internal import ExpoModulesCore\nfunc definition() -> ModuleDefinition',
+        '/example-project/intents/AppShortcuts.compile.swift': 'import AppIntents',
+        '/example-project/intents/Helper.compile.kt': 'package some.pkg',
+      });
+
+      const result = await getMirrorStateObject(['intents'], '/example-project');
+
+      expect(result.swiftModuleClassNames).toEqual(['MyModule']);
+      expect(result.kotlinClasses).toEqual([]);
+      expect(result.files.map((f) => f.filePath).sort()).toEqual([
+        '/example-project/intents/AppShortcuts.compile.swift',
+        '/example-project/intents/Helper.compile.kt',
+        '/example-project/intents/MyModule.swift',
+      ]);
+    });
+  });
+
+  describe('module filenames with dots', () => {
+    it('registers a kotlin module definition in a dotted filename', async () => {
+      (warn as jest.Mock).mockClear();
+      vol.fromJSON({
+        '/example-project/package.json': '{}',
+        '/example-project/modules/My.Module.kt':
+          'package some.pkg\nclass MyModule : Module() {\n  override fun definition() = ModuleDefinition { Name("MyModule") }\n}',
+      });
+
+      const result = await getMirrorStateObject(['modules'], '/example-project');
+
+      expect(result.kotlinClasses).toEqual(['some.pkg.My.Module']);
+      expect(result.files.map((file) => file.filePath)).toEqual([
+        '/example-project/modules/My.Module.kt',
+      ]);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('registers a swift module definition in a dotted filename', async () => {
+      (warn as jest.Mock).mockClear();
+      vol.fromJSON({
+        '/example-project/package.json': '{}',
+        '/example-project/intents/My.Module.swift':
+          'import ExpoModulesCore\nfunc definition() -> ModuleDefinition',
+      });
+
+      const result = await getMirrorStateObject(['intents'], '/example-project');
+
+      expect(result.swiftModuleClassNames).toEqual(['My.Module']);
+      expect(result.files.map((file) => file.filePath)).toEqual([
+        '/example-project/intents/My.Module.swift',
+      ]);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for supporting swift files without module definitions', async () => {
+      (warn as jest.Mock).mockClear();
+      vol.fromJSON({
+        '/example-project/package.json': '{}',
+        '/example-project/intents/MyModule.swift':
+          'internal import ExpoModulesCore\npublic final class MyModule: Module {}',
+      });
+
+      const result = await getMirrorStateObject(['intents'], '/example-project');
+
+      expect(result.swiftModuleClassNames).toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/expo-modules-autolinking/src/inlineModules/inlineModules.ts
+++ b/packages/expo-modules-autolinking/src/inlineModules/inlineModules.ts
@@ -18,19 +18,26 @@ export interface InlineModulesMirror {
 }
 
 const nativeExtensions = ['.kt', '.swift'];
+// Checks for func definition() -> <anything>ModuleDefinition. <anything> because ExpoModulesCore.ModuleDefinition is a valid usage
+const swiftModuleDefinitionRegex = /\bfunc\s+definition\s*\(\s*\)\s*->\s*[\w.]*ModuleDefinition\b/;
+// Checks for `override fun definition() = <anything>ModuleDefinition`
+const kotlinModuleDefinitionRegex =
+  /\boverride\s+fun\s+definition\s*\(\s*\)\s*=\s*[\w.]*ModuleDefinition\b/;
 
 /**
- * Checks if the fileName is valid for an inline module.
- * It needs to have suported extension and no dots in the basename as the basename has to match the module name.
+ * Checks if the fileName is valid for inline module scanning.
+ * Swift and Kotlin files are classified as modules by reading their contents.
  */
-export function inlineModuleFileNameInformation(fileName: string): { valid: boolean; ext: string } {
+export function inlineModuleFileNameInformation(fileName: string): {
+  valid: boolean;
+  ext: string;
+} {
   const ext = path.extname(fileName);
   if (!nativeExtensions.includes(ext)) {
     return { valid: false, ext };
   }
 
-  const baseName = path.basename(fileName, ext);
-  return { valid: !baseName.includes('.'), ext };
+  return { valid: true, ext };
 }
 
 export async function getKotlinFileNameWithItsPackage(
@@ -71,6 +78,26 @@ export function getSwiftModuleClassName(absoluteFilePath: string): string {
   return path.basename(absoluteFilePath, path.extname(absoluteFilePath));
 }
 
+export async function hasKotlinModuleDefinition(absoluteFilePath: string): Promise<boolean> {
+  try {
+    const contents = await fs.promises.readFile(absoluteFilePath, 'utf8');
+    return kotlinModuleDefinitionRegex.test(contents);
+  } catch {
+    warn(`Kotlin inline module '${absoluteFilePath}' could not be opened.`);
+    return false;
+  }
+}
+
+export async function hasSwiftModuleDefinition(absoluteFilePath: string): Promise<boolean> {
+  try {
+    const contents = await fs.promises.readFile(absoluteFilePath, 'utf8');
+    return swiftModuleDefinitionRegex.test(contents);
+  } catch {
+    warn(`Swift inline module '${absoluteFilePath}' could not be opened.`);
+    return false;
+  }
+}
+
 /**
  * Scans the project and returns information about all of the inline modules inside in an InlineModulesMirror object.
  */
@@ -91,24 +118,29 @@ export async function getMirrorStateObject(
   }
 
   await taskAll(taskInputs, async (absoluteDirPath) => {
-    for await (const { name, path } of scanFilesRecursively(absoluteDirPath)) {
+    for await (const { name, path: filePath } of scanFilesRecursively(absoluteDirPath)) {
       const { valid, ext } = inlineModuleFileNameInformation(name);
       if (!valid) {
         continue;
       }
 
-      const absoluteFilePath = await maybeRealpath(path);
+      const absoluteFilePath = await maybeRealpath(filePath);
       if (!absoluteFilePath) {
         continue;
       }
 
-      if (ext === '.kt') {
+      const hasKotlinDefinition =
+        ext === '.kt' && (await hasKotlinModuleDefinition(absoluteFilePath));
+      const hasSwiftDefinition =
+        ext === '.swift' && (await hasSwiftModuleDefinition(absoluteFilePath));
+
+      if (hasKotlinDefinition) {
         const kotlinFileWithPackage = await getKotlinFileNameWithItsPackage(absoluteFilePath);
         if (kotlinFileWithPackage === null) {
           continue;
         }
         inlineModulesMirror.kotlinClasses.push(kotlinFileWithPackage);
-      } else {
+      } else if (hasSwiftDefinition) {
         const swiftClassName = getSwiftModuleClassName(absoluteFilePath);
         inlineModulesMirror.swiftModuleClassNames.push(swiftClassName);
       }


### PR DESCRIPTION
# Why

This feature is needed for adding AppIntent support to expo-sdk - we need to add native files, which won't be treated as ExpoModule holders.  Currently inline modules treat every kotlin/swift file as a module holder.

# How

Autolink non-module files without treating them as a module. Use a regular expression to determine whether the file has a module definition

# Test Plan

Tested in BareExpo in my AppIntent PoC
