### PR TITLE
[constants][Android] Replace deprecated `Constants` with `Constant`

### DIFF
--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
@@ -10,8 +10,10 @@ class ConstantsModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExponentConstants")
 
-    Constants {
-      return@Constants appContext.service<ConstantsInterface>()?.constants ?: emptyMap()
+    appContext.service<ConstantsInterface>()?.constants?.forEach {
+      Constant(it.key) {
+        it.value
+      }
     }
 
     AsyncFunction<String?>("getWebViewUserAgentAsync") {


### PR DESCRIPTION
# Why

This PR is part of a series of PRs aimed at removing warnings during BareExpo compilation

# How

Replaces a deprecated `Constants` declaration with a loop that declares `Constant` values

# Test Plan

BareExpo ✅