### PR TITLE
[docs] Fix redirects

### DIFF
--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -646,4 +646,17 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // After archiving Configure JS engines guide
   '/guides/configuring-js-engines/': '/archive/configuring-js-engines/',
+
+  // Trailing-slash variants of `_redirects` rules that only matched the no-slash form
+  '/versions/latest/sdk/admob/': '/versions/latest/',
+  '/versions/latest/workflow/linking/': '/guides/linking/',
+  '/versions/latest/introduction/faq/': '/faq/',
+  '/guides/setting-up-continuous-integration/': '/build/building-on-ci/',
+  '/eas-update/debug-advanced/': '/eas-update/debug/',
+  '/eas-update/publish/': '/eas-update/getting-started/',
+  '/clients/installation/': '/versions/latest/sdk/dev-client/',
+  '/module-api/': '/modules/module-api/',
+  '/module-config/': '/modules/module-config/',
+  '/troubleshooting/clear-cache-mac/': '/troubleshooting/clear-cache-macos-linux/',
+  '/router/advance/router-setttings/': '/router/advanced/router-settings/',
 };

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -373,6 +373,7 @@
 
 # MCP server moved out of the EAS section to the top-level /mcp route
 /eas/ai/mcp /mcp 301
+/eas/ai/mcp/ /mcp/ 301
 
 # After archiving Configure JS engines guide
 /guides/configuring-js-engines/ /archive/configuring-js-engines/ 301


### PR DESCRIPTION
# Why

Moved pages only redirected from their no-slash form, so the trailing-slash canonical URL (for example `/eas/ai/mcp/`) still 404'd or served a stale cached copy of the old page.

# How

Add a trailing-slash rule for the moved MCP page in `public/_redirects`, and add 11 trailing-slash entries to `RENAMED_PAGES` in `common/client-redirects.ts` for renamed pages whose server-side rules only matched the no-slash form.

# Test Plan

Run docs locally and visit a trailing-slash old URL such as `/eas/ai/mcp/` or `/versions/latest/sdk/admob/` and confirm it redirects to the new location instead of returning a 404.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).