### PR TITLE
[docs] Update SWM library names and links in Edit rich text

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -22,7 +22,7 @@ There is currently no default solution for that in the React Native ecosystem. H
 
 There are a lot of good options to display rich text:
 
-- For markdown content, you can use a markdown renderer such as [`react-native-enriched-markdown`](https://github.com/software-mansion-labs/react-native-enriched-markdown) or another.
+- For markdown content, you can use a markdown renderer such as [`react-native-enriched-markdown`](https://github.com/software-mansion/react-native-enriched-markdown) or another.
 
 - For HTML content, you can use [`@expo/html-elements`](https://www.npmjs.com/package/@expo/html-elements) or a webview ([`react-native-webview`](/versions/latest/sdk/webview/)).
 
@@ -106,8 +106,8 @@ You can use a native Android or iOS rich text editor wrapped into a React Native
 - [`react-native-aztec`](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-aztec)
 - [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile)
 - [`react-native-live-markdown`](https://github.com/Expensify/react-native-live-markdown)
-- [`react-native-enriched-markdown`](https://github.com/software-mansion-labs/react-native-enriched-markdown)
-- [`react-native-enriched`](https://github.com/software-mansion-labs/react-native-enriched)
+- [`react-native-enriched-markdown`](https://github.com/software-mansion/react-native-enriched-markdown)
+- [`react-native-enriched-html`](https://github.com/software-mansion/react-native-enriched-html)
 
 You can also wrap any native rich text editor using [Expo Modules API](/modules/overview/), but if you use different ones on each platform, you need to unify their APIs and input formats.
 


### PR DESCRIPTION
# Why

https://github.com/software-mansion/react-native-enriched-html/releases/tag/v1.0.0

Software Mansion renamed `react-native-enriched` to `react-native-enriched-html` in v1.0.0 (the old package is now deprecated) and moved it and `react-native-enriched-markdown` to the `software-mansion` org, so the rich text guide pointed at the deprecated package name and stale org URLs.

# How

In `pages/guides/editing-richtext.mdx`, rename the `react-native-enriched` reference to `react-native-enriched-html` and repoint all three Software Mansion links from `software-mansion-labs` to the `software-mansion` org.

# Test Plan

On the Edit rich text guide, confirm the Native editors list links to `react-native-enriched-html` and that the three Software Mansion links resolve directly without a GitHub redirect.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).