### PR TITLE
[docs] Update additional resources

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: May 21, 2026
+modificationDate: June 16, 2026
 title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -3,6 +3,7 @@ title: Introduction to EAS Observe
 sidebar_title: Introduction
 description: EAS Observe is a performance monitoring service that tracks how your app performs in production across real devices and conditions.
 searchRank: 10
+hasVideoLink: true
 ---
 
 import { ActivityIcon } from '@expo/styleguide-icons/outline/ActivityIcon';
@@ -13,6 +14,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **important** **EAS Observe** is in [Open Beta](/more/release-statuses/#beta). The first 10,000 monthly active users are free. For higher usage, contact [sales@expo.dev](mailto:sales@expo.dev).
 
@@ -25,6 +27,14 @@ Debugging performance in React Native has traditionally been limited to developm
   src="/static/images/expo-observe/observe-light.webp"
   darkSrc="/static/images/expo-observe/observe-dark.webp"
 />
+
+<VideoBoxLink
+  videoId="5JqK9JLD140"
+  title="Watch: Introducing EAS Observe"
+  description="See how EAS Observe surfaces real-world startup and rendering performance from your production app across different devices, networks, and conditions."
+/>
+
+<br />
 
 ## Quick start
 

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -1,5 +1,13 @@
 export const TALKS = [
   {
+    title: 'Expo keynote',
+    event: 'App.js Conf 2026',
+    description: 'Charlie Cheever',
+    videoId: '605Id2fhmXE',
+    uploadDate: '2026-06-12',
+    home: true,
+  },
+  {
     title: 'Keynote: streamline React Native development',
     event: 'App.js Conf 2025',
     description: 'Charlie Cheever, Jon Samp',
@@ -50,7 +58,6 @@ export const TALKS = [
     description: 'Gabriel Donadel',
     videoId: 'K7yC3JKfWYU',
     uploadDate: '2024-06-11',
-    home: true,
   },
   {
     title: 'Keynote: community & workflows',
@@ -437,6 +444,24 @@ export const LIVE_STREAMS = [
 ] as Talk[];
 
 export const YOUTUBE_VIDEOS = [
+  {
+    title: 'Introducing "Observe": Performance monitoring for React Native apps',
+    event: 'Expo Tutorials',
+    videoId: '5JqK9JLD140',
+    uploadDate: '2026-06-16',
+  },
+  {
+    title: "Highlights from the largest Expo conference of the year: App.js '26",
+    event: 'Expo Tutorials',
+    videoId: 'EEbdiZFXayg',
+    uploadDate: '2026-06-04',
+  },
+  {
+    title: 'Where is Expo Go?',
+    event: 'Expo Tutorials',
+    videoId: 'bu8X9mCL0Ek',
+    uploadDate: '2026-05-27',
+  },
   {
     title: "What's New in Expo SDK 56: Expo UI, Inline Swift/Kotlin Modules, and Faster Builds",
     event: 'Expo Tutorials',


### PR DESCRIPTION
# Why

Keep the additional resources page current with recently published Expo YouTube videos and the App.js Conf 2026 keynote.

# How

Adds the App.js Conf 2026 keynote to the `TALKS` array and three recent Expo-channel videos (Observe, the App.js '26 highlights reel, and "Where is Expo Go?") to `YOUTUBE_VIDEOS` in `talks.ts`, and swaps the new keynote into the homepage featured grid by moving `home: true` off the older "Launching Desktop Apps to Orbit" talk. Also embeds the Observe announcement video on the EAS Observe introduction page via `VideoBoxLink` (mirroring the workflows intro, with `hasVideoLink: true`) and bumps the additional-resources `modificationDate`.

# Test Plan

- On `/additional-resources`, confirm the App.js Conf 2026 keynote shows under Talks and the three new videos under Video tutorials: 

<img width="2454" height="2060" alt="CleanShot 2026-06-16 at 22 35 10@2x" src="https://github.com/user-attachments/assets/227d4a08-9984-4c0f-a2cb-ac1ba50e512c" />

<img width="2488" height="2034" alt="CleanShot 2026-06-16 at 22 35 16@2x" src="https://github.com/user-attachments/assets/173b4197-eb3d-463b-9495-9e9961632d90" />


- On homepage "Watch our latest talks" grid features the 2026 keynote

<img width="2558" height="864" alt="CleanShot 2026-06-16 at 22 33 58@2x" src="https://github.com/user-attachments/assets/385e6370-c377-4c96-bba6-c58dd2972c66" />


- On `/eas/observe/introduction`, confirm the Observe video card renders before Quick start.

<img width="2606" height="1796" alt="CleanShot 2026-06-16 at 22 36 24@2x" src="https://github.com/user-attachments/assets/c2e5cae5-e57e-48b3-94cf-800f4062e362" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).