### PR TITLE
[dev-launcher] Add defaultServerUrl option to auto-connect to a baked-in dev server

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -86,6 +86,13 @@ You can configure development client launcher using its built-in [config plugin]
       default: '"most-recent"',
       platform: 'ios',
     },
+    {
+      name: 'defaultServerUrl',
+      description: [
+        'A development server URL (for example `http://192.168.1.50:8081`) to bake into the build and auto-connect to on launch, instead of waiting for the user to scan a QR code or pick a development server. Useful for headless, CI, or agent-driven workflows, or when running several Metro servers on fixed, dedicated ports that are known ahead of build time.',
+        'If the server is unreachable, the launcher falls back to its home screen, and a recently opened project still takes precedence (unless `launchMode` is `launcher`). Can be set per-platform with `ios.defaultServerUrl` / `android.defaultServerUrl`, or overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` environment variable.',
+      ].join('\n'),
+    },
   ]}
 />
 

--- a/docs/pages/versions/v55.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/dev-client.mdx
@@ -86,6 +86,13 @@ You can configure development client launcher using its built-in [config plugin]
       default: '"most-recent"',
       platform: 'ios',
     },
+    {
+      name: 'defaultServerUrl',
+      description: [
+        'A development server URL (for example `http://192.168.1.50:8081`) to bake into the build and auto-connect to on launch, instead of waiting for the user to scan a QR code or pick a development server. Useful for headless, CI, or agent-driven workflows, or when running several Metro servers on fixed, dedicated ports that are known ahead of build time.',
+        'If the server is unreachable, the launcher falls back to its home screen, and a recently opened project still takes precedence (unless `launchMode` is `launcher`). Can be set per-platform with `ios.defaultServerUrl` / `android.defaultServerUrl`, or overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` environment variable.',
+      ].join('\n'),
+    },
   ]}
 />
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Add NDS service discovery.
+- Add `defaultServerUrl` config plugin option (and `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var) to bake a development server URL into the build and auto-connect on launch without scanning a QR code. ([#PR](https://github.com/expo/expo/pull/PR) by [@qwertey6](https://github.com/qwertey6))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [Android] Add NDS service discovery.
-- Add `defaultServerUrl` config plugin option (and `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var) to bake a development server URL into the build and auto-connect on launch without scanning a QR code. ([#PR](https://github.com/expo/expo/pull/PR) by [@qwertey6](https://github.com/qwertey6))
+- Add `defaultServerUrl` config plugin option (and `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var) to bake a development server URL into the build and auto-connect on launch without scanning a QR code. ([#46980](https://github.com/expo/expo/pull/46980) by [@qwertey6](https://github.com/qwertey6))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -282,6 +282,22 @@ class DevLauncherController private constructor(
         }
         return true
       }
+
+      // A development server URL can be baked into the build (e.g. by the expo-dev-client config plugin or the
+      // EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL env var). When no recent app was launched above, auto-connect to it
+      // so headless/CI/multi-server setups don't need to scan a QR code. Falls back to the launcher if unreachable.
+      val defaultServerUrl = getMetadataValue(context, "DEV_CLIENT_DEFAULT_SERVER_URL", "")
+      if (defaultServerUrl.isNotEmpty()) {
+        coroutineScope.launch {
+          try {
+            loadApp(defaultServerUrl.toUri(), activityToBeInvalidated)
+          } catch (_: Throwable) {
+            navigateToLauncher()
+          }
+        }
+        return true
+      }
+
       return handleExternalIntent(it)
     }
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -221,6 +221,19 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     [self loadApp:_lastOpenedAppUrl withProjectUrl:nil withTimeout:EXDevLauncherDefaultRequestTimeout onSuccess:nil onError:navigateToLauncher];
     return;
   }
+
+  // A development server URL can be baked into the build (e.g. by the expo-dev-client config plugin or the
+  // EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL env var). When no recent app was launched above, auto-connect to it
+  // so headless/CI/multi-server setups don't need to scan a QR code. Falls back to the launcher if unreachable.
+  NSString *defaultServerUrlString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_DEFAULT_SERVER_URL"];
+  if (defaultServerUrlString.length > 0 && hasGrantedNetworkPermission && [launchOptions objectForKey:@"UIApplicationLaunchOptionsURLKey"] == nil) {
+    NSURL *defaultServerUrl = [NSURL URLWithString:defaultServerUrlString];
+    if (defaultServerUrl != nil) {
+      [self loadApp:defaultServerUrl withProjectUrl:nil withTimeout:EXDevLauncherDefaultRequestTimeout onSuccess:nil onError:navigateToLauncher];
+      return;
+    }
+  }
+
   [self navigateToLauncher];
 }
 

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -36,6 +36,18 @@ export type PluginConfigOptions = {
      * @deprecated use the `launchMode` property instead
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
+    /**
+     * A development server URL (for example `http://192.168.1.50:8081`) to bake into the build and
+     * auto-connect to on launch, instead of waiting for the user to scan a QR code or pick a server.
+     *
+     * Useful for headless/CI/agent-driven workflows, or when running several Metro servers on fixed,
+     * dedicated ports where the address is known ahead of build time. If the server is unreachable,
+     * the dev launcher falls back to its home screen. A recently opened app still takes precedence
+     * (unless `launchMode` is `'launcher'`).
+     *
+     * Can be overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` environment variable.
+     */
+    defaultServerUrl?: string;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -16,6 +16,10 @@ const schema = {
             enum: ['most-recent', 'launcher'],
             nullable: true,
         },
+        defaultServerUrl: {
+            type: 'string',
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
@@ -27,6 +31,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                defaultServerUrl: {
+                    type: 'string',
                     nullable: true,
                 },
             },
@@ -43,6 +51,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                defaultServerUrl: {
+                    type: 'string',
                     nullable: true,
                 },
             },

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,4 +1,15 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
 import { PluginConfigType } from './pluginConfig';
+/**
+ * Resolves the development server URL to bake into the build for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var (build-time override)
+ * 2. platform-specific `ios.defaultServerUrl` / `android.defaultServerUrl`
+ * 3. top-level `defaultServerUrl`
+ *
+ * @ignore
+ */
+export declare function resolveDefaultServerUrl(props: PluginConfigType, platform: 'ios' | 'android', env?: NodeJS.ProcessEnv): string | undefined;
 declare const _default: ConfigPlugin<PluginConfigType>;
 export default _default;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,4 +1,4 @@
-import { type ConfigPlugin } from 'expo/config-plugins';
+import { AndroidConfig, type ConfigPlugin } from 'expo/config-plugins';
 import { PluginConfigType } from './pluginConfig';
 /**
  * Resolves the development server URL to bake into the build for the given platform.
@@ -11,5 +11,18 @@ import { PluginConfigType } from './pluginConfig';
  * @ignore
  */
 export declare function resolveDefaultServerUrl(props: PluginConfigType, platform: 'ios' | 'android', env?: NodeJS.ProcessEnv): string | undefined;
+/** The Info.plist key / AndroidManifest meta-data name the native launcher reads on startup. */
+export declare const DEFAULT_SERVER_URL_KEY = "DEV_CLIENT_DEFAULT_SERVER_URL";
+/**
+ * Writes the default server URL into the Info.plist so the iOS dev launcher can auto-connect on launch.
+ * @ignore
+ */
+export declare function setDefaultServerUrlInfoPlist<T extends Record<string, any>>(infoPlist: T, url: string): T;
+/**
+ * Writes the default server URL as main-application meta-data so the Android dev launcher can
+ * auto-connect on launch. Idempotent — re-applying replaces the existing value rather than duplicating it.
+ * @ignore
+ */
+export declare function setDefaultServerUrlAndroidManifest(androidManifest: AndroidConfig.Manifest.AndroidManifest, url: string): AndroidConfig.Manifest.AndroidManifest;
 declare const _default: ConfigPlugin<PluginConfigType>;
 export default _default;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -1,8 +1,24 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveDefaultServerUrl = resolveDefaultServerUrl;
 const config_plugins_1 = require("expo/config-plugins");
 const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
+/**
+ * Resolves the development server URL to bake into the build for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var (build-time override)
+ * 2. platform-specific `ios.defaultServerUrl` / `android.defaultServerUrl`
+ * 3. top-level `defaultServerUrl`
+ *
+ * @ignore
+ */
+function resolveDefaultServerUrl(props, platform, env = process.env) {
+    return (env.EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL ??
+        props[platform]?.defaultServerUrl ??
+        props.defaultServerUrl);
+}
 /**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
  * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
@@ -110,6 +126,24 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', false?.toString());
+            return config;
+        });
+    }
+    // A default development server URL baked into the build so headless/CI/multi-server setups can
+    // auto-connect on launch without scanning a QR code. The `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL`
+    // env var, when set, takes precedence so it can be overridden per build invocation.
+    const iOSDefaultServerUrl = resolveDefaultServerUrl(props, 'ios');
+    if (iOSDefaultServerUrl) {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['DEV_CLIENT_DEFAULT_SERVER_URL'] = iOSDefaultServerUrl;
+            return config;
+        });
+    }
+    const androidDefaultServerUrl = resolveDefaultServerUrl(props, 'android');
+    if (androidDefaultServerUrl) {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_DEFAULT_SERVER_URL', androidDefaultServerUrl);
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -1,6 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_SERVER_URL_KEY = void 0;
 exports.resolveDefaultServerUrl = resolveDefaultServerUrl;
+exports.setDefaultServerUrlInfoPlist = setDefaultServerUrlInfoPlist;
+exports.setDefaultServerUrlAndroidManifest = setDefaultServerUrlAndroidManifest;
 const config_plugins_1 = require("expo/config-plugins");
 const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
@@ -18,6 +21,26 @@ function resolveDefaultServerUrl(props, platform, env = process.env) {
     return (env.EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL ??
         props[platform]?.defaultServerUrl ??
         props.defaultServerUrl);
+}
+/** The Info.plist key / AndroidManifest meta-data name the native launcher reads on startup. */
+exports.DEFAULT_SERVER_URL_KEY = 'DEV_CLIENT_DEFAULT_SERVER_URL';
+/**
+ * Writes the default server URL into the Info.plist so the iOS dev launcher can auto-connect on launch.
+ * @ignore
+ */
+function setDefaultServerUrlInfoPlist(infoPlist, url) {
+    infoPlist[exports.DEFAULT_SERVER_URL_KEY] = url;
+    return infoPlist;
+}
+/**
+ * Writes the default server URL as main-application meta-data so the Android dev launcher can
+ * auto-connect on launch. Idempotent — re-applying replaces the existing value rather than duplicating it.
+ * @ignore
+ */
+function setDefaultServerUrlAndroidManifest(androidManifest, url) {
+    const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+    config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, exports.DEFAULT_SERVER_URL_KEY, url);
+    return androidManifest;
 }
 /**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
@@ -135,15 +158,14 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
     const iOSDefaultServerUrl = resolveDefaultServerUrl(props, 'ios');
     if (iOSDefaultServerUrl) {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
-            config.modResults['DEV_CLIENT_DEFAULT_SERVER_URL'] = iOSDefaultServerUrl;
+            config.modResults = setDefaultServerUrlInfoPlist(config.modResults, iOSDefaultServerUrl);
             return config;
         });
     }
     const androidDefaultServerUrl = resolveDefaultServerUrl(props, 'android');
     if (androidDefaultServerUrl) {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
-            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
-            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_DEFAULT_SERVER_URL', androidDefaultServerUrl);
+            config.modResults = setDefaultServerUrlAndroidManifest(config.modResults, androidDefaultServerUrl);
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/jest.config.js
+++ b/packages/expo-dev-launcher/plugin/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
@@ -1,0 +1,51 @@
+import { validateConfig } from '../pluginConfig';
+import { resolveDefaultServerUrl } from '../withDevLauncher';
+
+describe(resolveDefaultServerUrl, () => {
+  const emptyEnv: NodeJS.ProcessEnv = {};
+
+  it(`returns undefined when nothing is configured`, () => {
+    expect(resolveDefaultServerUrl({}, 'ios', emptyEnv)).toBeUndefined();
+    expect(resolveDefaultServerUrl({}, 'android', emptyEnv)).toBeUndefined();
+  });
+
+  it(`uses the top-level value for both platforms`, () => {
+    const props = { defaultServerUrl: 'http://192.168.1.50:8081' };
+    expect(resolveDefaultServerUrl(props, 'ios', emptyEnv)).toBe('http://192.168.1.50:8081');
+    expect(resolveDefaultServerUrl(props, 'android', emptyEnv)).toBe('http://192.168.1.50:8081');
+  });
+
+  it(`prefers the platform-specific value over the top-level one`, () => {
+    const props = {
+      defaultServerUrl: 'http://192.168.1.50:8081',
+      ios: { defaultServerUrl: 'http://192.168.1.50:8082' },
+    };
+    expect(resolveDefaultServerUrl(props, 'ios', emptyEnv)).toBe('http://192.168.1.50:8082');
+    // android has no override, so it falls back to the top-level value
+    expect(resolveDefaultServerUrl(props, 'android', emptyEnv)).toBe('http://192.168.1.50:8081');
+  });
+
+  it(`lets the env var override everything`, () => {
+    const props = {
+      defaultServerUrl: 'http://192.168.1.50:8081',
+      ios: { defaultServerUrl: 'http://192.168.1.50:8082' },
+    };
+    const env = { EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL: 'http://10.0.0.2:9000' };
+    expect(resolveDefaultServerUrl(props, 'ios', env)).toBe('http://10.0.0.2:9000');
+    expect(resolveDefaultServerUrl(props, 'android', env)).toBe('http://10.0.0.2:9000');
+  });
+});
+
+describe(validateConfig, () => {
+  it(`accepts a defaultServerUrl string`, () => {
+    expect(() => validateConfig({ defaultServerUrl: 'http://192.168.1.50:8081' })).not.toThrow();
+    expect(() =>
+      validateConfig({ ios: { defaultServerUrl: 'http://192.168.1.50:8082' } })
+    ).not.toThrow();
+  });
+
+  it(`rejects a non-string defaultServerUrl`, () => {
+    // @ts-expect-error intentionally invalid type
+    expect(() => validateConfig({ defaultServerUrl: 8081 })).toThrow();
+  });
+});

--- a/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
@@ -1,5 +1,21 @@
+import { AndroidConfig } from 'expo/config-plugins';
+
 import { validateConfig } from '../pluginConfig';
-import { resolveDefaultServerUrl } from '../withDevLauncher';
+import {
+  DEFAULT_SERVER_URL_KEY,
+  resolveDefaultServerUrl,
+  setDefaultServerUrlAndroidManifest,
+  setDefaultServerUrlInfoPlist,
+} from '../withDevLauncher';
+
+function createAndroidManifest(): AndroidConfig.Manifest.AndroidManifest {
+  return {
+    manifest: {
+      $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android', package: 'com.app' },
+      application: [{ $: { 'android:name': '.MainApplication' } }],
+    },
+  };
+}
 
 describe(resolveDefaultServerUrl, () => {
   const emptyEnv: NodeJS.ProcessEnv = {};
@@ -33,6 +49,36 @@ describe(resolveDefaultServerUrl, () => {
     const env = { EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL: 'http://10.0.0.2:9000' };
     expect(resolveDefaultServerUrl(props, 'ios', env)).toBe('http://10.0.0.2:9000');
     expect(resolveDefaultServerUrl(props, 'android', env)).toBe('http://10.0.0.2:9000');
+  });
+});
+
+describe(setDefaultServerUrlInfoPlist, () => {
+  it(`sets the key the iOS launcher reads`, () => {
+    const infoPlist = setDefaultServerUrlInfoPlist({}, 'http://192.168.1.50:8081');
+    expect(infoPlist[DEFAULT_SERVER_URL_KEY]).toBe('http://192.168.1.50:8081');
+  });
+});
+
+describe(setDefaultServerUrlAndroidManifest, () => {
+  it(`adds main-application meta-data the Android launcher reads`, () => {
+    const manifest = setDefaultServerUrlAndroidManifest(
+      createAndroidManifest(),
+      'http://192.168.1.50:8082'
+    );
+    expect(AndroidConfig.Manifest.getMainApplicationMetaDataValue(manifest, DEFAULT_SERVER_URL_KEY)).toBe(
+      'http://192.168.1.50:8082'
+    );
+  });
+
+  it(`replaces rather than duplicates on re-apply (idempotent prebuild)`, () => {
+    let manifest = createAndroidManifest();
+    manifest = setDefaultServerUrlAndroidManifest(manifest, 'http://192.168.1.50:8082');
+    manifest = setDefaultServerUrlAndroidManifest(manifest, 'http://192.168.1.50:9000');
+
+    const metaData = AndroidConfig.Manifest.getMainApplicationOrThrow(manifest)['meta-data'] ?? [];
+    const matching = metaData.filter((e) => e.$['android:name'] === DEFAULT_SERVER_URL_KEY);
+    expect(matching).toHaveLength(1);
+    expect(matching[0].$['android:value']).toBe('http://192.168.1.50:9000');
   });
 });
 

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -40,6 +40,18 @@ export type PluginConfigOptions = {
    * @deprecated use the `launchMode` property instead
    */
   launchModeExperimental?: 'most-recent' | 'launcher';
+  /**
+   * A development server URL (for example `http://192.168.1.50:8081`) to bake into the build and
+   * auto-connect to on launch, instead of waiting for the user to scan a QR code or pick a server.
+   *
+   * Useful for headless/CI/agent-driven workflows, or when running several Metro servers on fixed,
+   * dedicated ports where the address is known ahead of build time. If the server is unreachable,
+   * the dev launcher falls back to its home screen. A recently opened app still takes precedence
+   * (unless `launchMode` is `'launcher'`).
+   *
+   * Can be overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` environment variable.
+   */
+  defaultServerUrl?: string;
 };
 
 const schema: JSONSchema<PluginConfigType> = {
@@ -56,6 +68,10 @@ const schema: JSONSchema<PluginConfigType> = {
       enum: ['most-recent', 'launcher'],
       nullable: true,
     },
+    defaultServerUrl: {
+      type: 'string',
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
@@ -67,6 +83,10 @@ const schema: JSONSchema<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        defaultServerUrl: {
+          type: 'string',
           nullable: true,
         },
       },
@@ -83,6 +103,10 @@ const schema: JSONSchema<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        defaultServerUrl: {
+          type: 'string',
           nullable: true,
         },
       },

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -33,6 +33,39 @@ export function resolveDefaultServerUrl(
   );
 }
 
+/** The Info.plist key / AndroidManifest meta-data name the native launcher reads on startup. */
+export const DEFAULT_SERVER_URL_KEY = 'DEV_CLIENT_DEFAULT_SERVER_URL';
+
+/**
+ * Writes the default server URL into the Info.plist so the iOS dev launcher can auto-connect on launch.
+ * @ignore
+ */
+export function setDefaultServerUrlInfoPlist<T extends Record<string, any>>(
+  infoPlist: T,
+  url: string
+): T {
+  infoPlist[DEFAULT_SERVER_URL_KEY as keyof T] = url as T[keyof T];
+  return infoPlist;
+}
+
+/**
+ * Writes the default server URL as main-application meta-data so the Android dev launcher can
+ * auto-connect on launch. Idempotent — re-applying replaces the existing value rather than duplicating it.
+ * @ignore
+ */
+export function setDefaultServerUrlAndroidManifest(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  url: string
+): AndroidConfig.Manifest.AndroidManifest {
+  const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+  AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+    mainApplication,
+    DEFAULT_SERVER_URL_KEY,
+    url
+  );
+  return androidManifest;
+}
+
 /**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
  * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
@@ -176,7 +209,7 @@ export default createRunOncePlugin<PluginConfigType>(
     const iOSDefaultServerUrl = resolveDefaultServerUrl(props, 'ios');
     if (iOSDefaultServerUrl) {
       config = withInfoPlist(config, (config) => {
-        config.modResults['DEV_CLIENT_DEFAULT_SERVER_URL'] = iOSDefaultServerUrl;
+        config.modResults = setDefaultServerUrlInfoPlist(config.modResults, iOSDefaultServerUrl);
         return config;
       });
     }
@@ -184,11 +217,8 @@ export default createRunOncePlugin<PluginConfigType>(
     const androidDefaultServerUrl = resolveDefaultServerUrl(props, 'android');
     if (androidDefaultServerUrl) {
       config = withAndroidManifest(config, (config) => {
-        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
-
-        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
-          mainApplication,
-          'DEV_CLIENT_DEFAULT_SERVER_URL',
+        config.modResults = setDefaultServerUrlAndroidManifest(
+          config.modResults,
           androidDefaultServerUrl
         );
         return config;

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -12,6 +12,28 @@ import { PluginConfigType, validateConfig } from './pluginConfig';
 const pkg = require('expo-dev-launcher/package.json');
 
 /**
+ * Resolves the development server URL to bake into the build for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` env var (build-time override)
+ * 2. platform-specific `ios.defaultServerUrl` / `android.defaultServerUrl`
+ * 3. top-level `defaultServerUrl`
+ *
+ * @ignore
+ */
+export function resolveDefaultServerUrl(
+  props: PluginConfigType,
+  platform: 'ios' | 'android',
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return (
+    env.EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL ??
+    props[platform]?.defaultServerUrl ??
+    props.defaultServerUrl
+  );
+}
+
+/**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
  * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
  * but removes only the dev-launcher entries from production builds.
@@ -143,6 +165,31 @@ export default createRunOncePlugin<PluginConfigType>(
           mainApplication,
           'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE',
           false?.toString()
+        );
+        return config;
+      });
+    }
+
+    // A default development server URL baked into the build so headless/CI/multi-server setups can
+    // auto-connect on launch without scanning a QR code. The `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL`
+    // env var, when set, takes precedence so it can be overridden per build invocation.
+    const iOSDefaultServerUrl = resolveDefaultServerUrl(props, 'ios');
+    if (iOSDefaultServerUrl) {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['DEV_CLIENT_DEFAULT_SERVER_URL'] = iOSDefaultServerUrl;
+        return config;
+      });
+    }
+
+    const androidDefaultServerUrl = resolveDefaultServerUrl(props, 'android');
+    if (androidDefaultServerUrl) {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'DEV_CLIENT_DEFAULT_SERVER_URL',
+          androidDefaultServerUrl
         );
         return config;
       });


### PR DESCRIPTION
# Why

A development build's Metro server address (host + port) is often known ahead of build time, yet the dev launcher always requires a QR scan, manual URL entry, or server discovery to connect. That breaks down for:

- **Headless / CI / agent-driven** workflows where no human is present to scan a QR code.
- Running **several Metro servers from one machine**, each on a fixed dedicated port, where concurrent terminal QR codes clobber each other.
- Cases where per-app deep links are awkward because you only want *the app you just installed* to connect to *its own* server.

This is also the manual workaround many users in #29005 are doing by hand ("I have to type `exp://192.168.x.x:8081` every time").

# How

Adds a build-time-baked default dev server URL that the launcher auto-connects to on startup.

- **Config plugin**: new `defaultServerUrl` option (top-level or per-platform) on the `expo-dev-launcher` plugin (also reachable via `expo-dev-client`).
- **Env override**: `EXPO_DEV_LAUNCHER_DEFAULT_SERVER_URL` takes precedence so it can be set per build invocation.
- The plugin writes a `DEV_CLIENT_DEFAULT_SERVER_URL` **Info.plist** key / **AndroidManifest** meta-data value.
- Native launchers (`EXDevLauncherController.m`, `DevLauncherController.kt`) read it on startup and auto-connect.

**Precedence** (unchanged for existing users): explicit deep link / `--initialUrl` → recently-opened app → **baked default** → launcher home screen. An unreachable URL falls back to the launcher, mirroring the existing recently-opened behavior. The feature is inert unless the key is set.

# Test Plan

- New unit tests for `resolveDefaultServerUrl` (env > platform > top-level precedence) and schema validation of `defaultServerUrl` — `expo-dev-launcher/plugin` suite green.
- Existing `expo-dev-client` plugin tests still pass.
- Plugin typechecks; regenerated committed `build/` artifacts.
- Manual: set `defaultServerUrl` / env var, prebuild, confirm the key lands in Info.plist + AndroidManifest and a debug build auto-connects on launch without scanning; unreachable URL falls back to the launcher.

# Related

- Related to #29005 — offers a deterministic alternative to manual URL entry for fixed-host setups (does not fix the underlying discovery/permission issue).
- Related to #19846 — adjacent initial-URL handling in the dev client.

---
*Note to reviewers: env var name kept distinct from `REACT_NATIVE_PACKAGER_HOSTNAME` (#45902) on purpose — this is a full launcher-specific URL, not just a packager host.*