### PR TITLE
[expo-notifications][ios] Fix EXC_BAD_ACCESS when AppContext is destroyed with a pending device-token promise

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Settle the pending `getDevicePushTokenAsync()` promise on module destroy to avoid an `EXC_BAD_ACCESS` crash when the `AppContext` is deallocated with a device-token request still in flight (e.g. on a dev-client reload). ([#46985](https://github.com/expo/expo/pull/46985) by [@josephrexme](https://github.com/josephrexme))
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-26

--- a/packages/expo-notifications/ios/ExpoNotifications/PushToken/PushTokenModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/PushToken/PushTokenModule.swift
@@ -20,6 +20,13 @@ public class PushTokenModule: Module, NotificationDelegate {
 
     OnDestroy {
       NotificationCenterManager.shared.removeDelegate(self)
+      // Settle any in-flight device-token promise before the module (and its
+      // AppContext) is deallocated. Once the delegate is removed this module can
+      // never receive didRegister/didFailRegistration, so an unsettled promise
+      // would be destroyed in deinit against an already-torn-down JS runtime,
+      // causing an EXC_BAD_ACCESS crash (e.g. on a dev-client reload).
+      promiseNotYetResolved?.reject("E_APP_DESTROYED", "The app context was destroyed before a device push token was returned.")
+      promiseNotYetResolved = nil
     }
 
     AsyncFunction("getDevicePushTokenAsync") { (promise: Promise) in


### PR DESCRIPTION
# Why

`PushTokenModule` stores the `getDevicePushTokenAsync()` promise in `promiseNotYetResolved` and only settles it from the APNs delegate callbacks (`didRegister` / `didFailRegistration`). Its `OnDestroy` removes the notification delegate but never settles that promise.

On the New Architecture, when the `AppContext` is deallocated while a device-token request is still in flight, the module has already removed its delegate in `OnDestroy`, so it can **never** receive the APNs callback that would settle the promise. The pending JSI `Promise` is then destroyed in `deinit` against an already-torn-down `jsi::Runtime`, producing an `EXC_BAD_ACCESS (SIGSEGV)` crash in `destroy for JavaScriptPromise`.

This is easy to hit with a **development build**: `DevicePushTokenAutoRegistration` fires `getDevicePushTokenAsync()` at boot on every launch, so there is almost always a pending promise during the brief APNs window. A dev-client reload / root-view recreation in that window deallocates the old `AppContext` and crashes.

Representative crash (physical device, New Arch / bridgeless `RCTHost`):

```
Thread N Crashed: com.facebook.react.runtime.JavaScript
0  ExpoModulesJSI    destroy for JavaScriptPromise
...
   ExpoModulesCore   destroy for Promise
   <app>             PushTokenModule.deinit
   <app>             PushTokenModule.__deallocating_deinit
...
   ExpoModulesCore   ModuleRegistry.deinit
   ExpoModulesCore   AppContext.__deallocating_deinit
   <app>             -[EXReactNativeFactory host:didInitializeRuntime:]
Exception Type: EXC_BAD_ACCESS (SIGSEGV) — KERN_INVALID_ADDRESS at 0x0
```

Related prior report: #15788 (its fix, #17285, addressed only the event-emitter "Bridge is not set" path, not the pending-promise teardown).

# How

Reject and clear `promiseNotYetResolved` in `OnDestroy`, so there is no dangling promise left for `deinit` to destroy. `OnDestroy` runs while the runtime is still valid, so settling there is safe; `didRegister` / `didFailRegistration` already guard with optional chaining and remain correct.

# Test Plan

This fix was diagnosed from a real device crash report (the stack above), which terminates in `PushTokenModule.deinit` destroying an unsettled `Promise?` during `AppContext` deallocation — the only place `promiseNotYetResolved` can outlive the runtime, since `OnDestroy` detaches the delegate without settling it.

I have not yet attached an automated test or a verified before/after device run; runtime validation against a patched development build is in progress and I will update this PR with the result. Reviewers' guidance on a suitable test approach for this teardown path is welcome.

# Checklist

- [x] Added a changelog entry to `packages/expo-notifications/CHANGELOG.md`.
