### PR TITLE
[ios][expo-widgets] Fix Live Activity color scheme by evaluating layout in the render views

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Evaluate the Live Activity layout in the rendered views so `env.colorScheme` matches the presentation. ([#46987](https://github.com/expo/expo/pull/46987) by [@crockalet](https://github.com/crockalet))
 - [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -12,49 +12,33 @@ struct LiveActivityAttributes: ActivityAttributes {
 
 @available(iOS 16.1, *)
 public struct WidgetLiveActivity: Widget {
-  @Environment(\.self) var env
-  
   let widgetContext: AppContext = AppContext()
-  
-  var environment: [String: Any] {
-    return getLiveActivityEnvironment(environment: env)
-  }
 
   public init() {}
 
   public var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivityAttributes.self) { context in
-      let nodes = getLiveActivityNodes(
-        forName: context.state.name,
-        props: context.state.props,
-        environment: environment
-      )
-      LiveActivityBannerView(context: context, nodes: nodes)
+      LiveActivityBannerView(context: context)
     } dynamicIsland: { context in
-      let nodes = getLiveActivityNodes(
-        forName: context.state.name,
-        props: context.state.props,
-        environment: environment
-      )
-      return DynamicIsland {
+      DynamicIsland {
         DynamicIslandExpandedRegion(.center) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedCenter")
+          LiveActivitySectionView(context: context, sectionName: "expandedCenter")
         }
         DynamicIslandExpandedRegion(.leading) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedLeading")
+          LiveActivitySectionView(context: context, sectionName: "expandedLeading")
         }
         DynamicIslandExpandedRegion(.trailing) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedTrailing")
+          LiveActivitySectionView(context: context, sectionName: "expandedTrailing")
         }
         DynamicIslandExpandedRegion(.bottom) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedBottom")
+          LiveActivitySectionView(context: context, sectionName: "expandedBottom")
         }
       } compactLeading: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactLeading")
+        LiveActivitySectionView(context: context, sectionName: "compactLeading")
       } compactTrailing: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactTrailing")
+        LiveActivitySectionView(context: context, sectionName: "compactTrailing")
       } minimal: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "minimal")
+        LiveActivitySectionView(context: context, sectionName: "minimal")
       }
       .widgetURL(getLiveActivityUrl(forName: context.state.name))
     }
@@ -64,11 +48,16 @@ public struct WidgetLiveActivity: Widget {
 
 @available(iOS 16.1, *)
 private struct LiveActivitySectionView: View {
+  @Environment(\.self) var env
   let context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
   let sectionName: String
 
   var body: some View {
+    let nodes = getLiveActivityNodes(
+      forName: context.state.name,
+      props: context.state.props,
+      environment: getLiveActivityEnvironment(environment: env)
+    )
     if let node = nodes[sectionName] as? [String: Any] {
       WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
@@ -79,10 +68,15 @@ private struct LiveActivitySectionView: View {
 
 @available(iOS 16.1, *)
 private struct LiveActivityBannerView: View {
+  @Environment(\.self) var env
   var context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
 
   var body: some View {
+    let nodes = getLiveActivityNodes(
+      forName: context.state.name,
+      props: context.state.props,
+      environment: getLiveActivityEnvironment(environment: env)
+    )
     if #available(iOS 18.0, *) {
       LiveActivityBanner(context: context, nodes: nodes)
     } else if let node = nodes["banner"] as? [String: Any] {


### PR DESCRIPTION
# Why

A Live Activity's JS layout receives an `env` object (built from the SwiftUI environment) that includes `colorScheme`. Today `WidgetLiveActivity` reads `@Environment(\.self)` on the **`Widget`** struct and evaluates the layout (`getLiveActivityNodes(… environment:)`) inside the `WidgetConfiguration` body. A `Widget`'s environment is its registration-time environment, not the per-presentation render environment of the Lock Screen / Dynamic Island — so `env.colorScheme` doesn't track the actual rendering context, and a dark Lock Screen activity can be evaluated as `light`.

The regular widget already does this correctly: `WidgetsEntryView` is a `View` that reads `@Environment(\.self)` in its `body` and evaluates the layout there, so it receives the real render environment.

# How

Move the `getLiveActivityNodes` evaluation out of `WidgetLiveActivity.body` and into the rendered views — `LiveActivityBannerView` and `LiveActivitySectionView` — each of which now reads its own `@Environment(\.self)` and resolves its nodes in `body`. The configuration body just passes `context` down. This mirrors `WidgetsEntryView`.

Note: the layout is now evaluated per rendered view (i.e. each Dynamic Island region resolves its own node, rather than one shared evaluation). This matches the widget path and keeps the environment correct per presentation; happy to introduce a shared parent view if maintainers prefer a single evaluation for the island.

# Test Plan

Reproduced in a standalone Expo SDK 56 app with an `expo-widgets` Live Activity whose layout branches on `env.colorScheme`:

- **Before:** the Lock Screen banner rendered with the wrong (`light`) color scheme regardless of the render context.
- **After:** the banner reads the per-presentation environment and renders the correct dark variant on the dark Lock Screen.

Built with Xcode 26.5 / iOS 26.5 simulator. Tested in a standalone app (not `apps/bare-expo`); I couldn't run the full monorepo lint/test locally (needs Node 22 + a complete install), so CI / reviewers can validate. iOS-only Swift change — no JS/TS, so no `build/` regeneration.