### PR TITLE
[expo-type-information] Fix record structs parsing

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -220,6 +220,22 @@ enum IntBackedEnum1: Int {
 enum IntBackedEnum2: Something, Int, SomethingElse {
   case simpleCase
 }
+
+protocol SimpleProtocol: Record {
+  var id: String { get }
+}
+
+struct StructConformingToProtocol: SimpleProtocol {
+  @Field
+  var id: String { get }
+  @Field
+  var someInt: Int
+}
+
+struct EmptyStruct: Record {
+  init(){}
+}
+
 // Global variable names
 let globalEventName = "onGlobalEvent"
 

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -32,6 +32,11 @@ export type TestRecordClass = {
   field1: number;
   field2: string;
 };
+export type StructConformingToProtocol = {
+  id: string;
+  someInt: number;
+};
+export type EmptyStruct = {};
 
 export enum TestEnum {
   simpleCase = 'simpleCase',
@@ -259,6 +264,8 @@ import {
   TestRecord,
   TestRecord2,
   TestRecordClass,
+  StructConformingToProtocol,
+  EmptyStruct,
   TestClassWithConstructor,
   TestBasicClass,
   TestEmptyClass,
@@ -349,6 +356,11 @@ export type TestRecordClass = {
   field1: number;
   field2: string;
 };
+export type StructConformingToProtocol = {
+  id: string;
+  someInt: number;
+};
+export type EmptyStruct = {};
 
 export enum TestEnum {
   simpleCase = 'simpleCase',
@@ -464,6 +476,11 @@ export type TestRecordClass = {
     field1: number;
     field2: string;
 };
+export type StructConformingToProtocol = {
+    id: string;
+    someInt: number;
+};
+export type EmptyStruct = {};
 
 
 export enum TestEnum {
@@ -635,6 +652,11 @@ export type TestRecordClass = {
   field1: number;
   field2: string;
 };
+export type StructConformingToProtocol = {
+  id: string;
+  someInt: number;
+};
+export type EmptyStruct = {};
 
 export enum TestEnum {
   simpleCase = 'simpleCase',
@@ -762,10 +784,12 @@ export default _default;
 exports[`Same type information 1`] = `
 {
   "declaredTypeIdentifiersList": [
+    "EmptyStruct",
     "EventNames",
     "IntBackedEnum1",
     "IntBackedEnum2",
     "OuterNamespace",
+    "StructConformingToProtocol",
     "TestBasicClass",
     "TestClassWithConstructor",
     "TestEmptyClass",
@@ -1692,8 +1716,41 @@ exports[`Same type information 1`] = `
       ],
       "name": "TestRecordClass",
     },
+    {
+      "fields": [
+        {
+          "name": "id",
+          "type": {
+            "kind": 0,
+            "type": 1,
+          },
+        },
+        {
+          "name": "someInt",
+          "type": {
+            "kind": 0,
+            "type": 2,
+          },
+        },
+      ],
+      "name": "StructConformingToProtocol",
+    },
+    {
+      "fields": [],
+      "name": "EmptyStruct",
+    },
   ],
   "typeIdentifierDefinitionList": [
+    [
+      "EmptyStruct",
+      {
+        "definition": {
+          "fields": [],
+          "name": "EmptyStruct",
+        },
+        "kind": 2,
+      },
+    ],
     [
       "EventNames",
       {
@@ -1742,6 +1799,31 @@ exports[`Same type information 1`] = `
           "stringBacked": true,
         },
         "kind": 1,
+      },
+    ],
+    [
+      "StructConformingToProtocol",
+      {
+        "definition": {
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": 0,
+                "type": 1,
+              },
+            },
+            {
+              "name": "someInt",
+              "type": {
+                "kind": 0,
+                "type": 2,
+              },
+            },
+          ],
+          "name": "StructConformingToProtocol",
+        },
+        "kind": 2,
       },
     ],
     [

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -92,17 +92,27 @@ function isStructStructure(structure: Structure): boolean {
   return structure['key.kind'] === swiftDeclarationKind.struct;
 }
 
-function isRecordStructure(structure: Structure): boolean {
+function containsFieldAnnotation(file: FileType, structure: Structure): boolean {
+  const startIndex = structure['key.offset'];
+  const endIndex = startIndex + structure['key.length'];
+  const fieldIndex = file.content.substring(startIndex, endIndex).indexOf('@Field');
+  return fieldIndex !== -1;
+}
+
+function isRecordStructure(file: FileType, structure: Structure): boolean {
   const isRecordOrClass =
     structure['key.kind'] === swiftDeclarationKind.struct ||
     structure['key.kind'] === swiftDeclarationKind.class;
 
+  // To check whether a structure represents a record, check if it has any @Field annotated fields.
+  // For the case of empty structs add a check if the struct directly conforms to the Record.
+  const hasFields = containsFieldAnnotation(file, structure);
   const inheritsFromRecord =
     structure['key.inheritedtypes']?.find((type) => {
       return type['key.name'] === 'Record';
     }) !== undefined;
 
-  return isRecordOrClass && inheritsFromRecord;
+  return isRecordOrClass && (hasFields || inheritsFromRecord);
 }
 
 function isModuleStructure(structure: Structure): boolean {
@@ -972,6 +982,7 @@ async function parseModuleStructure(
 }
 
 function parseStructure(
+  file: FileType,
   structure: Structure,
   name: string,
   modulesStructures: { structure: Structure; name: string }[],
@@ -979,20 +990,21 @@ function parseStructure(
   enumsStructures: Structure[]
 ) {
   // TODO(@HubertBer): Find out why sometimes the structure is undefined (for example when parsing expo-audio)
-  if (!structure || !structure['key.substructure']) {
+  const substructure = structure['key.substructure'];
+  if (!structure || !substructure) {
     return;
   }
-  const substructure = structure['key.substructure'];
 
   if (isModuleStructure(structure)) {
     modulesStructures.push({ structure, name });
-  } else if (isRecordStructure(structure)) {
+  } else if (isRecordStructure(file, structure)) {
     recordsStructures.push(structure);
   } else if (isEnumStructure(structure)) {
     enumsStructures.push(structure);
   } else if (Array.isArray(substructure) && substructure.length > 0) {
     for (const substructure of structure['key.substructure']) {
       parseStructure(
+        file,
         substructure,
         structure['key.name'] ?? name,
         modulesStructures,
@@ -1112,7 +1124,7 @@ function parseNamespaces(
 ) {
   if (
     isModuleStructure(structure) ||
-    isRecordStructure(structure) ||
+    isRecordStructure(file, structure) ||
     isStructStructure(structure) ||
     isEnumStructure(structure) ||
     isClassStructure(structure)
@@ -1153,8 +1165,14 @@ export async function getSwiftFileTypeInformation(
   const recordsStructures: Structure[] = [];
   const enumsStructures: Structure[] = [];
   const fileStructure = getStructureFromFile(file);
-  parseStructure(fileStructure, '', modulesStructures, recordsStructures, enumsStructures);
-
+  parseStructure(
+    file,
+    getStructureFromFile(file),
+    '',
+    modulesStructures,
+    recordsStructures,
+    enumsStructures
+  );
   const namespaces: { [key: string]: namespace } = {};
   namespaces[''] = {};
   parseNamespaces(fileStructure, namespaces, file, namespaces['']);

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -981,14 +981,24 @@ async function parseModuleStructure(
   return moduleClassDeclaration;
 }
 
+type ParseStructuresOutput = {
+  modulesStructures: { structure: Structure; name: string }[];
+  recordsStructures: Structure[];
+  enumsStructures: Structure[];
+};
+
+type ParseStructureOptions = {
+  file: FileType;
+  structure: Structure;
+  name: string;
+};
+
 function parseStructure(
-  file: FileType,
-  structure: Structure,
-  name: string,
-  modulesStructures: { structure: Structure; name: string }[],
-  recordsStructures: Structure[],
-  enumsStructures: Structure[]
+  { file, structure, name }: ParseStructureOptions,
+  // Note that instead of returning and merging the enum, record and module arrays, we're just collecting the items in the 3 arrays inside this object.
+  parsedStructuresOutput: ParseStructuresOutput
 ) {
+  const { modulesStructures, recordsStructures, enumsStructures } = parsedStructuresOutput;
   // TODO(@HubertBer): Find out why sometimes the structure is undefined (for example when parsing expo-audio)
   const substructure = structure['key.substructure'];
   if (!structure || !substructure) {
@@ -1004,12 +1014,12 @@ function parseStructure(
   } else if (Array.isArray(substructure) && substructure.length > 0) {
     for (const substructure of structure['key.substructure']) {
       parseStructure(
-        file,
-        substructure,
-        structure['key.name'] ?? name,
-        modulesStructures,
-        recordsStructures,
-        enumsStructures
+        {
+          file,
+          structure: substructure,
+          name: structure['key.name'] ?? name,
+        },
+        parsedStructuresOutput
       );
     }
   }
@@ -1166,12 +1176,16 @@ export async function getSwiftFileTypeInformation(
   const enumsStructures: Structure[] = [];
   const fileStructure = getStructureFromFile(file);
   parseStructure(
-    file,
-    getStructureFromFile(file),
-    '',
-    modulesStructures,
-    recordsStructures,
-    enumsStructures
+    {
+      file,
+      structure: getStructureFromFile(file),
+      name: '',
+    },
+    {
+      modulesStructures,
+      recordsStructures,
+      enumsStructures,
+    }
   );
   const namespaces: { [key: string]: namespace } = {};
   namespaces[''] = {};


### PR DESCRIPTION
# Why
Previously we've only parsed structs that directly conform to the `Record` protocol, but we want to also parse structs that can conform indirectly. This means that previously we wouldn't parse this struct:
```
struct StructConformingToProtocol: SimpleProtocol {
  @Field
  var id: String { get }
}

protocol SimpleProtocol: Record {
  var id: String { get }
}
```
And now we do! 
# How
Changed the check for whether the `sourcekitten` structure is a `Record`, from does it inherit from (conform to) `Record`, to does it have any `@Field` annotated fields or it conforms to Record directly. This means that if the struct conforms to some other protocol that conforms to `Record` and defines its `@Field`s it will now be parsed.

Note that building a graph of struct-protocol conformance may not be possible (not all protocols may be visible when parsing single files) and it would be much heavier, this solution is simpler and should be enough.
# Test Plan
- [x] Checked and added new tests, updated snapshots
- [x] Checked manually on the `expo-contacts` package
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
