### PR TITLE
[android][ios][video] Add maxResolution player option

### DIFF
--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -118,6 +118,14 @@ export const VideoScreens = [
     },
   },
   {
+    name: 'Video Tracks',
+    route: 'video/tracks',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./VideoTracksScreen'));
+    },
+  },
+  {
     name: 'Generating video thumbnails',
     route: 'video/thumbnails',
     options: {},

--- a/apps/native-component-list/src/screens/Video/VideoTracksScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoTracksScreen.tsx
@@ -1,0 +1,144 @@
+import { Picker } from '@react-native-picker/picker';
+import { Platform, useEvent } from 'expo';
+import { useVideoPlayer, VideoView, VideoSource, VideoSize, VideoTrack } from 'expo-video';
+import React, { useRef, useState } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+
+import ConsoleBox from '../../components/ConsoleBox';
+import { bigBuckBunnySource, dashSource, hlsSource } from './videoSources';
+import { styles } from './videoStyles';
+const videoLabels = ['Big Buck Bunny', 'Tears Of Steel (HLS)', 'Tears Of Steel (DASH)'];
+const videoSources: VideoSource[] = [bigBuckBunnySource, hlsSource, dashSource];
+
+type MaxResolutionOption = {
+  label: string;
+  size: VideoSize | null;
+};
+
+export default function VideoTracksScreen() {
+  const ref = useRef<VideoView>(null);
+  const [currentSourceIndex, setCurrentSourceIndex] = useState(0);
+  const [maxResolutionIndex, setMaxResolutionIndex] = useState(0);
+
+  const player = useVideoPlayer(videoSources[0], (player) => {
+    player.play();
+    player.loop = true;
+    player.muted = true;
+  });
+
+  const { videoTrack } = useEvent(player, 'videoTrackChange', { videoTrack: player.videoTrack });
+  const { availableVideoTracks } = useEvent(player, 'sourceLoad', {
+    videoSource: null,
+    duration: player.duration,
+    availableVideoTracks: player.availableVideoTracks,
+    availableSubtitleTracks: player.availableSubtitleTracks,
+    availableAudioTracks: player.availableAudioTracks,
+  });
+
+  const maxResolutionOptions = React.useMemo<MaxResolutionOption[]>(() => {
+    const seen = new Set<string>();
+    const trackOptions = availableVideoTracks
+      .map((track) => track.size)
+      .filter((size): size is VideoSize => size != null && size.width > 0 && size.height > 0)
+      .filter((size) => {
+        const key = `${size.width}x${size.height}`;
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      })
+      .sort((a, b) => b.height - a.height)
+      .map((size) => ({ label: `${size.width}×${size.height}`, size }));
+    return [{ label: 'No limit', size: null }, ...trackOptions];
+  }, [availableVideoTracks]);
+
+  const optionsKey = maxResolutionOptions.map((option) => option.label).join(',');
+  React.useEffect(() => {
+    setMaxResolutionIndex(0);
+    player.maxResolution = null;
+  }, [optionsKey, player]);
+
+  return (
+    <View style={styles.contentContainer}>
+      <VideoView
+        ref={ref}
+        style={styles.video}
+        player={player}
+        contentFit="contain"
+        contentPosition={{ dx: 0, dy: 0 }}
+        showsTimecodes={false}
+      />
+      <ScrollView style={styles.controlsContainer}>
+        <View style={styles.row}>
+          <View style={{ flex: 1 }}>
+            <Text>VideoSource:</Text>
+            <Picker
+              itemStyle={Platform.OS === 'ios' && { height: 150 }}
+              style={styles.picker}
+              mode="dropdown"
+              selectedValue={currentSourceIndex}
+              onValueChange={async (value: number) => {
+                setCurrentSourceIndex(value);
+                await player.replaceAsync(videoSources[value]);
+              }}>
+              {videoSources.map((source, index) => (
+                <Picker.Item key={index} label={videoLabels[index]} value={index} />
+              ))}
+            </Picker>
+          </View>
+
+          <View style={{ flex: 1 }}>
+            <Text>Max resolution:</Text>
+            <Picker
+              itemStyle={Platform.OS === 'ios' && { height: 150 }}
+              style={styles.picker}
+              mode="dropdown"
+              selectedValue={maxResolutionIndex}
+              onValueChange={(value: number) => {
+                setMaxResolutionIndex(value);
+                player.maxResolution = maxResolutionOptions[value]?.size ?? null;
+              }}>
+              {maxResolutionOptions.map((option, index) => (
+                <Picker.Item key={option.label} label={option.label} value={index} />
+              ))}
+            </Picker>
+          </View>
+        </View>
+
+        <Text style={styles.switchTitle}>Current Video Track:</Text>
+        <ConsoleBox>{videoTrackToString(videoTrack)}</ConsoleBox>
+
+        <Text style={styles.switchTitle}>Available Video Tracks:</Text>
+        <ConsoleBox>{videoTracksToString(availableVideoTracks)}</ConsoleBox>
+      </ScrollView>
+    </View>
+  );
+}
+
+function videoTrackToString(track: VideoTrack | null) {
+  if (!track) {
+    return 'null';
+  }
+  return (
+    `{\n` +
+    `\tid: "${track.id}",\n` +
+    `\tsize: "${track.size.width}x${track.size.height}",\n` +
+    `\tbitrate: ${track.bitrate},\n` +
+    `\tframe rate: ${track.frameRate},\n` +
+    `\tmimeType: "${track.mimeType}",\n` +
+    `\tisSupported: ${track.isSupported}\n` +
+    `}`
+  );
+}
+
+function videoTracksToString(tracks: VideoTrack[]) {
+  if (tracks.length === 0) {
+    return '[]';
+  }
+  let result = '[';
+  for (const track of tracks) {
+    result += ` \n\t{size: "${track.size.width}x${track.size.height}", bitrate: ${track.bitrate}, mimeType: "${track.mimeType}", isSupported: ${track.isSupported}, id: "${track.id}"}`;
+  }
+  return result + ' \n]';
+}

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [Android] Added the `controllerAutoShow` prop to `VideoView` to control whether the native controls auto-show on play. ([#46665](https://github.com/expo/expo/pull/46665) by [@stevesouth](https://github.com/stevesouth))
-- [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection.
+- [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection. ([#46992](https://github.com/expo/expo/pull/46992) by [@vargajacint](https://github.com/vargajacint))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Added the `controllerAutoShow` prop to `VideoView` to control whether the native controls auto-show on play. ([#46665](https://github.com/expo/expo/pull/46665) by [@stevesouth](https://github.com/stevesouth))
+- [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -23,6 +23,7 @@ import expo.modules.video.records.SubtitleTrack
 import expo.modules.video.records.AudioTrack
 import expo.modules.video.records.ScrubbingModeOptions
 import expo.modules.video.records.SeekTolerance
+import expo.modules.video.records.VideoSize
 import expo.modules.video.records.VideoSource
 import expo.modules.video.records.VideoThumbnailOptions
 import expo.modules.video.utils.runWithPiPMisconfigurationSoftHandling
@@ -131,6 +132,14 @@ class VideoModule : Module() {
       Property("videoTrack")
         .get { ref: VideoPlayer ->
           ref.currentVideoTrack
+        }
+
+      Property("maxResolution")
+        .get { ref: VideoPlayer ->
+          ref.maxResolution
+        }
+        .set { ref: VideoPlayer, maxResolution: VideoSize? ->
+          ref.maxResolution = maxResolution
         }
 
       Property("availableSubtitleTracks")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -233,11 +233,15 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   var maxResolution: VideoSize? = null
     set(value) {
-      field = value
+      val normalized = value?.takeIf { it.width > 0 && it.height > 0 }
+      if (value != null && normalized == null) {
+        appContext?.jsLogger?.warn("[expo-video] Ignoring invalid `maxResolution` (${value.width}x${value.height}): `width` and `height` must both be greater than zero. Clearing the resolution limit.")
+      }
+      field = normalized
       appContext?.mainQueue?.launch {
         val parameters = player.trackSelectionParameters.buildUpon()
-        if (value != null && value.width > 0 && value.height > 0) {
-          parameters.setMaxVideoSize(value.width, value.height)
+        if (normalized != null) {
+          parameters.setMaxVideoSize(normalized.width, normalized.height)
         } else {
           parameters.clearVideoSizeConstraints()
         }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -45,8 +45,9 @@ import expo.modules.video.records.ScrubbingModeOptions
 import expo.modules.video.records.SeekTolerance
 import expo.modules.video.records.TimeUpdate
 import expo.modules.video.records.VideoSource
-import expo.modules.video.utils.MutableWeakReference
+import expo.modules.video.records.VideoSize
 import expo.modules.video.records.VideoTrack
+import expo.modules.video.utils.MutableWeakReference
 import expo.modules.video.utils.buildBasicMediaSession
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -229,6 +230,20 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   var availableVideoTracks: List<VideoTrack> = emptyList()
     private set
+
+  var maxResolution: VideoSize? = null
+    set(value) {
+      field = value
+      appContext?.mainQueue?.launch {
+        val parameters = player.trackSelectionParameters.buildUpon()
+        if (value != null && value.width > 0 && value.height > 0) {
+          parameters.setMaxVideoSize(value.width, value.height)
+        } else {
+          parameters.clearVideoSizeConstraints()
+        }
+        player.trackSelectionParameters = parameters.build()
+      }
+    }
 
   var keepScreenOnWhilePlaying by VideoPlayerKeepAwake(this, appContext)
 

--- a/packages/expo-video/ios/Records/VideoSize.swift
+++ b/packages/expo-video/ios/Records/VideoSize.swift
@@ -11,5 +11,12 @@ internal struct VideoSize: Record {
   static func from(_ size: CGSize) -> Self {
     return VideoSize(width: Int(size.width), height: Int(size.height))
   }
+
+  func toCGSize() -> CGSize {
+    guard let width, let height, width > 0, height > 0 else {
+      return .zero
+    }
+    return CGSize(width: width, height: height)
+  }
 }
 // swiftlint:enable redundant_optional_initialization

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -283,6 +283,13 @@ public final class VideoModule: Module {
         return player.currentVideoTrack
       }
 
+      Property("maxResolution") { player -> VideoSize? in
+        return player.maxResolution
+      }
+      .set { (player, maxResolution: VideoSize?) in
+        player.maxResolution = maxResolution
+      }
+
       Property("availableSubtitleTracks") { player -> [SubtitleTrack] in
         return player.subtitles.availableSubtitleTracks
       }

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -144,7 +144,12 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   var maxResolution: VideoSize? {
     didSet {
-      ref.currentItem?.preferredMaximumResolution = maxResolution?.toCGSize() ?? .zero
+      let resolution = maxResolution?.toCGSize() ?? .zero
+      if resolution == .zero && maxResolution != nil {
+        appContext?.jsLogger.warn("[expo-video] Ignoring invalid `maxResolution`: `width` and `height` must both be greater than zero. Clearing the resolution limit.")
+        maxResolution = nil
+      }
+      ref.currentItem?.preferredMaximumResolution = resolution
     }
   }
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -142,6 +142,12 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     }
   }
 
+  var maxResolution: VideoSize? {
+    didSet {
+      ref.currentItem?.preferredMaximumResolution = maxResolution?.toCGSize() ?? .zero
+    }
+  }
+
   var bufferedPosition: Double {
     return getBufferedPosition()
   }
@@ -421,6 +427,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     )
     safeEmit(event: "sourceChange", payload: payload)
     newVideoPlayerItem?.preferredForwardBufferDuration = bufferOptions.preferredForwardBufferDuration
+    newVideoPlayerItem?.preferredMaximumResolution = maxResolution?.toCGSize() ?? .zero
   }
 
   func onTimeUpdate(player: AVPlayer, timeUpdate: TimeUpdate) {

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -225,6 +225,20 @@ export declare class VideoPlayer extends SharedObject<VideoPlayerEvents> {
   readonly availableVideoTracks: VideoTrack[];
 
   /**
+   * Specifies the maximum resolution that the player will select when choosing between the video tracks of an adaptive stream.
+   * The player picks the highest-quality track that does not exceed this resolution.
+   *
+   * Set this property to `null` to remove the limit and allow all available resolutions.
+   *
+   * > On Android this is applied through ExoPlayer's `TrackSelectionParameters.Builder.setMaxVideoSize`. On iOS it maps to [`AVPlayerItem.preferredMaximumResolution`](https://developer.apple.com/documentation/avfoundation/avplayeritem/preferredmaximumresolution).
+   *
+   * @default null
+   * @platform android
+   * @platform ios
+   */
+  maxResolution: VideoSize | null;
+
+  /**
    * Indicates whether the player is currently playing back the media to an external device via AirPlay.
    *
    * @platform ios

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -228,9 +228,14 @@ export declare class VideoPlayer extends SharedObject<VideoPlayerEvents> {
    * Specifies the maximum resolution that the player will select when choosing between the video tracks of an adaptive stream.
    * The player picks the highest-quality track that does not exceed this resolution.
    *
-   * Set this property to `null` to remove the limit and allow all available resolutions.
+   * Set this property to `null` to remove the limit and allow all available resolutions. Dimensions
+   * which are not greater than zero are treated the same as `null`.
    *
-   * > Note: on iOS this property only applies to HTTP Live Streaming (HLS) sources.
+   * The cap is enforced differently per platform:
+   * - On Android it is a hard constraint, unless no track satisfies it, in which case the lowest-resolution track is used.
+   * - On iOS it is a preferred maximum, which the player treats as a soft hint when selecting a track.
+   *
+   * > **Note:** On iOS this property only applies to HTTP Live Streaming (HLS) sources.
    *
    * @default null
    * @platform android

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -230,7 +230,7 @@ export declare class VideoPlayer extends SharedObject<VideoPlayerEvents> {
    *
    * Set this property to `null` to remove the limit and allow all available resolutions.
    *
-   * > On Android this is applied through ExoPlayer's `TrackSelectionParameters.Builder.setMaxVideoSize`. On iOS it maps to [`AVPlayerItem.preferredMaximumResolution`](https://developer.apple.com/documentation/avfoundation/avplayeritem/preferredmaximumresolution).
+   * > Note: on iOS this property only applies to HTTP Live Streaming (HLS) sources.
    *
    * @default null
    * @platform android

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -14,6 +14,7 @@ import type {
   AudioTrack,
   ScrubbingModeOptions,
   SeekTolerance,
+  VideoSize,
 } from './VideoPlayer.types';
 import type { VideoPlayerEvents } from './VideoPlayerEvents.types';
 import type { VideoThumbnail } from './VideoThumbnail';
@@ -106,6 +107,7 @@ export default class VideoPlayerWeb
   availableAudioTracks: AudioTrack[] = []; // Not supported on web. Dummy to match the interface.
   videoTrack: VideoTrack | null = null; // Not supported on web. Dummy to match the interface.
   availableVideoTracks: VideoTrack[] = []; // Not supported on web. Dummy to match the interface.
+  maxResolution: VideoSize | null = null; // Not supported on web. Dummy to match the interface.
   isExternalPlaybackActive: boolean = false; // Not supported on web. Dummy to match the interface.
   keepScreenOnWhilePlaying: boolean = false; // Not supported on web. Dummy to match the interface
   seekTolerance: SeekTolerance = {} as SeekTolerance; // Not supported on web. Dummy to match the interface.


### PR DESCRIPTION
# Why

`expo-video` exposes the available video tracks for adaptive streams, but there is currently no way to ask the native player to stay below a maximum rendition size. This adds a cross-platform `maxResolution` player option for apps that need to cap adaptive track selection.

# How

- Adds a settable `maxResolution: VideoSize | null` property to `VideoPlayer`.
- Applies the cap on Android through ExoPlayer `TrackSelectionParameters.Builder.setMaxVideoSize` and clears video size constraints when the value is `null` or invalid.
- Applies the cap on iOS through `AVPlayerItem.preferredMaximumResolution`, including when the current item is replaced.
- Updates the generated type declaration and package changelog.