### PR TITLE
[docs][dev-client] Fix boolean config plugin example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -60,9 +60,9 @@ You can configure development client launcher using its built-in [config plugin]
           "android": {
             "defaultLaunchURL": "http://10.0.0.2:8081"
           },
-          "toolsButton": "true",
-          "skipOnboarding": "false",
-          "showMenuAtLaunch": "true"
+          "toolsButton": true,
+          "skipOnboarding": false,
+          "showMenuAtLaunch": true
         }
       ]
     ]

--- a/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
@@ -60,9 +60,9 @@ You can configure development client launcher using its built-in [config plugin]
           "android": {
             "defaultLaunchURL": "http://10.0.0.2:8081"
           },
-          "toolsButton": "true",
-          "skipOnboarding": "false",
-          "showMenuAtLaunch": "true"
+          "toolsButton": true,
+          "skipOnboarding": false,
+          "showMenuAtLaunch": true
         }
       ]
     ]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `expo-dev-client` package reference shows `toolsButton`, `skipOnboarding` and `showMenuAtLaunch` as string values in the `app.json` config plugin example.

These options are booleans in the `expo-dev-launcher` config plugin schema.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the `v56.0.0` and `unversioned` dev-client docs examples to use booleans instead of strings.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
