### PR TITLE
[image-manipulator][Android] Replace deprecated `RuntimeContext` with `Runtime`

### DIFF
--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorContext.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorContext.kt
@@ -2,9 +2,9 @@ package expo.modules.imagemanipulator
 
 import android.graphics.Bitmap
 import expo.modules.imagemanipulator.transformers.ImageTransformer
-import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
+import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -76,9 +76,9 @@ class ManipulatorTask(
 }
 
 class ImageManipulatorContext(
-  runtimeContext: RuntimeContext,
+  runtime: Runtime,
   private val task: ManipulatorTask
-) : SharedObject(runtimeContext) {
+) : SharedObject(runtime) {
   fun addTransformer(transformer: ImageTransformer) = apply { task.addTransformer(transformer) }
 
   fun reset() = apply { task.reset() }

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
@@ -50,12 +50,12 @@ class ImageManipulatorModule : Module() {
     }
 
     val task = ManipulatorTask(appContext.backgroundCoroutineScope, loader)
-    return ImageManipulatorContext(runtimeContext, task)
+    return ImageManipulatorContext(runtime, task)
   }
 
   private fun createManipulatorContext(bitmap: Bitmap): ImageManipulatorContext {
     val task = ManipulatorTask(appContext.backgroundCoroutineScope) { bitmap }
-    return ImageManipulatorContext(runtimeContext, task)
+    return ImageManipulatorContext(runtime, task)
   }
 
   override fun definition() = ModuleDefinition {
@@ -102,7 +102,7 @@ class ImageManipulatorModule : Module() {
 
       AsyncFunction("renderAsync") Coroutine { context: ImageManipulatorContext ->
         val image = context.render()
-        ImageRef(image, runtimeContext)
+        ImageRef(image, runtime)
       }
     }
 

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt
@@ -1,10 +1,10 @@
 package expo.modules.imagemanipulator
 
 import android.graphics.Bitmap
-import expo.modules.kotlin.RuntimeContext
+import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.sharedobjects.SharedRef
 
-class ImageRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext) {
+class ImageRef(bitmap: Bitmap, runtime: Runtime) : SharedRef<Bitmap>(bitmap, runtime) {
   override val nativeRefType: String = "image"
 
   override fun getAdditionalMemoryPressure(): Int {


### PR DESCRIPTION
# Why

This PR is part of a series aimed at removing compilation warnings.

It removes the following warnings:
```gradle 
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorContext.kt:5:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorContext.kt:79:19` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt:53:36` - 'val runtimeContext: Runtime' is deprecated. Use 'runtime' property instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt:58:36` - 'val runtimeContext: Runtime' is deprecated. Use 'runtime' property instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt:105:25` - 'val runtimeContext: Runtime' is deprecated. Use 'runtime' property instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt:4:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt:7:48` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
``` 
# How

Replaces deprecated `RuntimeContext` with `Runtime`.

# Test Plan

Green CI
