### PR TITLE
[contacts][legacy][Android] Suppress deprecation and cast warnings

### DIFF
--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -122,7 +122,10 @@ class Contact(var contactId: String, var appContext: AppContext) {
         emails.add(item)
       }
 
-      CommonDataKinds.Im.CONTENT_ITEM_TYPE -> {
+      // Legacy API supports IM addresses, deprecated since Android API 35. The new Contacts API removes these fields.
+      @Suppress("DEPRECATION")
+      CommonDataKinds.Im.CONTENT_ITEM_TYPE
+      -> {
         val item = ImAddressModel()
         item.fromCursor(cursor)
         imAddresses.add(item)
@@ -320,6 +323,8 @@ class Contact(var contactId: String, var appContext: AppContext) {
     get() = arrayOf(
       CommonDataKinds.Event.CONTENT_ITEM_TYPE,
       CommonDataKinds.Email.CONTENT_ITEM_TYPE,
+      // Legacy API supports IM addresses, deprecated since Android API 35. The new Contacts API removes these fields.
+      @Suppress("DEPRECATION")
       CommonDataKinds.Im.CONTENT_ITEM_TYPE,
       CommonDataKinds.Phone.CONTENT_ITEM_TYPE,
       CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE,

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -457,6 +457,8 @@ class ContactsModule : Module() {
     data["birthday"]?.takeIf { it is Map<*, *> }?.let {
       contact.dates.add(
         BirthdayModel().apply {
+          // Legacy API uses raw maps instead of Record; fixed in the new API.
+          @Suppress("UNCHECKED_CAST")
           fromMap(it as Map<String, Any>)
         }
       )
@@ -582,6 +584,8 @@ class ContactsModule : Module() {
       selection += " OR " + ContactsContract.Data.MIMETYPE + "=?"
       selectionArgs.add(CommonDataKinds.Event.CONTENT_ITEM_TYPE)
     }
+    // Legacy API supports IM addresses, deprecated since Android API 35. The new Contacts API removes these fields.
+    @Suppress("DEPRECATION")
     if (keysToFetch.contains("instantMessageAddresses")) {
       projection.add(CommonDataKinds.Im.DATA)
       projection.add(CommonDataKinds.Im.TYPE)

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/ImAddressModel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/ImAddressModel.kt
@@ -4,6 +4,8 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.provider.ContactsContract.CommonDataKinds
 
+// Legacy API supports IM addresses, deprecated since Android API 35. The new Contacts API removes these fields.
+@Suppress("DEPRECATION")
 class ImAddressModel : BaseModel() {
   override val contentType: String = CommonDataKinds.Im.CONTENT_ITEM_TYPE
 


### PR DESCRIPTION
# Why

This PR is part of a series aimed at removing compilation warnings.

It removes warnings related to the `ImAddress` property and one unchecked cast warning:
```gradle
packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt:460:22 - Unchecked cast of 'Any' to 'Map<String, Any>'.
packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt:586:38 - 'class Im : Any, ContactsContract.CommonDataKinds.CommonColumns, ContactsContract.DataColumnsWithJoins' is deprecated. Deprecated in Java.
```
# How

The `IM` contact field has been deprecated since Android API 35 and is not supported in the new contacts API. 
The new API also uses records, which resolves the casting issue.

Since we do not plan to support the legacy API, the best solution is to suppress these warnings.

# Test Plan

Green CI