### PR TITLE
[ios][jsi] Release promise JSI object on JS thread to prevent off-thread invalidate()

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -11,7 +11,6 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
   private weak let runtime: JavaScriptRuntime?
-  private var object: JavaScriptObject
   private let deferredPromise = DeferredPromise()
 
   // Create refs for resolve and reject functions.
@@ -19,12 +18,17 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private let resolveFunction = JavaScriptValue.Ref()
   private let rejectFunction = JavaScriptValue.Ref()
 
+  // Stored as a class so dropping the struct off-thread only decrements an ARC count.
+  // resolve() and reject() capture this in their runtime.schedule blocks, ensuring
+  // jsi::Value::~Value (which calls ptr_->invalidate()) always runs on the JS thread.
+  private var value: JavaScriptValue
+
   /// Initializes a promise from the existing object. The promise may already be settled.
   /// It cannot be resolved/rejected from the outside, i.e. `resolve` and `reject` functions are no-op.
   @JavaScriptActor
-  public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) throws {
+  public init(_ runtime: JavaScriptRuntime, _ jsObject: consuming JavaScriptObject) throws {
     self.runtime = runtime
-    self.object = object
+    self.value = jsObject.asValue()
     try setUpCallbacks()
   }
 
@@ -32,9 +36,9 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
-    // Initialize the non-copyable field before any throwing work. Swift requires a
-    // consistently initialized value on every throwing initializer path.
-    self.object = runtime.createObject()
+    // Initialize value before any throwing work. Swift requires a ~Copyable field to be
+    // consistently initialized on every code path through a throwing initializer.
+    self.value = .undefined
 
     // Create function that is the promise setup. It is called immediately on `callAsConstructor`.
     let setup = runtime.createFunction { [weak resolveFunction, weak rejectFunction] this, arguments in
@@ -43,19 +47,18 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       return .undefined
     }
 
-    self.object =
+    self.value =
       try runtime
       .global()
       .getPropertyAsFunction(.cached(runtime, "Promise"))
       .callAsConstructor(setup.asValue())
-      .getObject()
 
     try setUpCallbacks()
   }
 
   @JavaScriptActor
-  internal init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.Object) throws {
-    try self.init(runtime, JavaScriptObject(runtime, object))
+  internal init(_ runtime: JavaScriptRuntime, _ jsObject: consuming facebook.jsi.Object) throws {
+    try self.init(runtime, JavaScriptObject(runtime, jsObject))
   }
 
   public var isDeferred: Bool {
@@ -68,7 +71,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   }
 
   public func asValue() -> JavaScriptValue {
-    return object.asValue()
+    return value
   }
 
   public func resolve<V: JavaScriptRepresentable>(_ value: V) {
@@ -77,7 +80,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     }
 
     // `resolve` is not isolated, so make sure to jump to JS thread.
-    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction, value = self.value] in
       // If the promise is already settled, do nothing.
       guard let resolver = resolveFunction.take() else {
         return
@@ -86,8 +89,10 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       // This will also call `deferredPromise.resolve` in the `then` handler.
       _ = try! resolver.getFunction().call(arguments: value)
 
-      // Release the rejecter, we cannot call it anymore.
+      // Release the rejecter and the promise value on the JS thread so their
+      // jsi::Value destructors (which call back into the runtime) run here.
       rejectFunction.release()
+      // `value` is released when this closure drops at the end of the scheduled block.
     }
   }
 
@@ -97,7 +102,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     }
 
     // `reject` is not isolated, so make sure to jump to JS thread.
-    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction, value = self.value] in
       // If the promise is already settled, do nothing.
       guard let rejecter = rejectFunction.take() else {
         return
@@ -112,8 +117,10 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       // This will also call `deferredPromise.reject` in the `then` handler.
       _ = try! rejecter.getFunction().call(arguments: errorValue)
 
-      // Release the resolver, we cannot call it anymore.
+      // Release the resolver and the promise value on the JS thread so their
+      // jsi::Value destructors (which call back into the runtime) run here.
       resolveFunction.release()
+      // `value` is released when this closure drops at the end of the scheduled block.
     }
   }
 
@@ -140,6 +147,6 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       }
       return .undefined
     }
-    try object.callFunction(.cached(runtime, "then"), arguments: onFulfilled.asValue(), onRejected.asValue())
+    try value.getObject().callFunction(.cached(runtime, "then"), arguments: onFulfilled.asValue(), onRejected.asValue())
   }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -1,4 +1,5 @@
 import ExpoModulesJSI
+import Foundation
 import Testing
 
 @Suite
@@ -369,5 +370,22 @@ struct JavaScriptPromiseTests {
     let promise = try runtime.eval("Promise.resolve(42)").getPromise()
 
     #expect(promise.isDeferred == false)
+  }
+
+  @Test
+  func `promise dropped off JS thread after resolve does not crash`() async throws {
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+
+    // Simulate the real crash scenario: resolve and drop the promise from a background queue.
+    // Before the fix, dropping JavaScriptPromise off the JS thread would destroy the inline
+    // jsi::Object there, calling ptr_->invalidate() back into the runtime — a crash.
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        promise.resolve(42)
+        // promise is dropped here, off the JS thread — this must not crash
+        continuation.resume()
+      }
+    }
   }
 }


### PR DESCRIPTION
## Why

`jsi::Object::~Object` calls `ptr_->invalidate()` which dispatches back into the Hermes runtime via a virtual call. When `JavaScriptPromise` is dropped on a background queue (e.g. `expo.modules.AsyncFunctionQueue` after an async function completes), that destructor runs off the JS thread, causing a null dereference inside Hermes.

This is the root cause of the `EXC_BAD_ACCESS` crash reported in #46945, which affects `checkForUpdateAsync()` (and any other async function) on iOS. The promise resolves successfully; the crash happens later during ARC teardown of the native closure chain on the background queue.

The stack confirms it: `_Block_release` on `_dispatch_workloop_worker_thread` → `destroyGenericBox` → `JavaScriptPromise` deinit → `jsi::Object::~Object` → `ptr_->invalidate()`.

## How

Previously `JavaScriptPromise` stored the JS promise object as `object: JavaScriptObject` — a `~Copyable` struct with an inline `facebook::jsi::Object`. Dropping the struct on a background thread called `~Object()` there directly.

The fix stores it as `value: JavaScriptValue` instead. `JavaScriptValue` is a `final class`, so dropping the `JavaScriptPromise` struct off-thread only decrements an ARC reference count — no JSI destructor runs there. Both `resolve` and `reject` capture `value` in their `runtime.schedule` blocks, so the last reference always drops on the JS thread, where `ptr_->invalidate()` is safe.

## Test Plan

Added `promise dropped off JS thread after resolve does not crash` to `JavaScriptPromiseTests`. It creates a promise on the JS thread, resolves it from `DispatchQueue.global()`, and drops it there — exercising the exact path that crashed before the fix. The test passes now and would have crashed before.

The crash itself is a GC-timing race in release builds with no deterministic local repro, so a canary build with the reporter (#46945, 569 affected users) would be the strongest final confirmation.

Fixes #46945.
