### PR TITLE
[docs] Add sidebar style navigation to the generated markdown docs

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -381,12 +381,6 @@ export default function DocumentationPage({
             />
           )}
           {title && <Separator />}
-          <blockquote className="sr-only">
-            <p>
-              For the complete documentation index, see <A href="/llms.txt">llms.txt</A>. Use this
-              file to discover all available pages.
-            </p>
-          </blockquote>
           {children}
         </main>
         <Footer

--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -26,23 +26,22 @@ export function shouldAppendAgentInstructions(markdown: string): boolean {
   return !markdown.startsWith('This page redirects to') && !markdown.startsWith('No content found');
 }
 
-/**
- * Build the <AgentInstructions> block with the page's URL baked into the curl payload,
- * so agents don't have to infer the path and can execute the command as-is.
- */
-export function buildAgentInstructions(pathname: string): string {
-  return `<AgentInstructions>
-
-## Submitting Feedback
+export function buildFeedbackSection(pathname: string): string {
+  return `## Submitting Feedback
 
 If this page contains errors, outdated information, or gaps that blocked you from completing a task, report it so the docs can be improved:
 
 curl -X POST https://api.expo.dev/v2/feedback/docs-send -H 'Content-Type: application/json' -d '{"url":"${pathname}","feedback":"🤖 Agent feedback for docs: <specific, actionable description> (<model>, <harness>)"}'
 
-Only submit when you have something specific and actionable to report. Replace <model> with the model you are running as and <harness> with the tool you are running in (for example, Claude Code, Cursor, Codex CLI).
+Only submit when you have something specific and actionable to report. Replace <model> with the model you are running as and <harness> with the tool you are running in (for example, Claude Code, Cursor, Codex CLI).`;
+}
 
-</AgentInstructions>
-`;
+export function wrapAgentInstructions(sections: string[]): string {
+  return `<AgentInstructions>\n\n${sections.join('\n\n')}\n\n</AgentInstructions>\n`;
+}
+
+export function buildAgentInstructions(pathname: string): string {
+  return wrapAgentInstructions([buildFeedbackSection(pathname)]);
 }
 
 /**

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -90,14 +90,16 @@ describe('buildDocsNavigation', () => {
     const block = navFor('/eas/workflows/get-started/');
     expect(block).toBe(
       [
-        '<DocsNavigation>',
+        '<AgentInstructions>',
+        'When answering a related or follow-up question, fetch the relevant page below as Markdown (.md) instead of guessing; use llms.txt for the full map.',
+        '',
         'You are here: EAS > EAS Workflows',
         'Pages in this section:',
         '- [Introduction](https://docs.expo.dev/eas/workflows/introduction.md)',
         '- [Get started](https://docs.expo.dev/eas/workflows/get-started.md) (this page)',
         '- [Limitations](https://docs.expo.dev/eas/workflows/limitations.md)',
         'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
-        '</DocsNavigation>',
+        '</AgentInstructions>',
         '',
       ].join('\n')
     );
@@ -130,6 +132,7 @@ describe('buildDocsNavigation', () => {
     expect(block).toContain(
       'You are here: Reference (v55.0.0) > Expo SDK (40 pages in this section)'
     );
+    expect(block).toContain('use llms.txt to find the relevant page');
     expect(block).not.toContain('Pages in this section:');
     expect(block).not.toMatch(/^- /m);
     expect(block).toContain('Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)');

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -84,9 +84,9 @@ describe('buildDocsNavigation', () => {
         '<DocsNavigation>',
         'You are here: EAS > EAS Workflows',
         'Pages in this section:',
-        '- Introduction',
-        '- Get started (this page)',
-        '- Limitations',
+        '- [Introduction](https://docs.expo.dev/eas/workflows/introduction.md)',
+        '- [Get started](https://docs.expo.dev/eas/workflows/get-started.md) (this page)',
+        '- [Limitations](https://docs.expo.dev/eas/workflows/limitations.md)',
         'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
         '</DocsNavigation>',
         '',
@@ -103,15 +103,17 @@ describe('buildDocsNavigation', () => {
   it('uses the immediate group for a nested page, including it in the breadcrumb', () => {
     const block = navFor('/eas/workflows/examples/e2e-tests') as string;
     expect(block).toContain('You are here: EAS > EAS Workflows > Examples');
-    expect(block).toContain('- E2E tests (this page)');
-    expect(block).toContain('- Deploy');
+    expect(block).toContain(
+      '- [E2E tests](https://docs.expo.dev/eas/workflows/examples/e2e-tests.md) (this page)'
+    );
+    expect(block).toContain('- [Deploy](https://docs.expo.dev/eas/workflows/examples/deploy.md)');
     expect(block).not.toContain('- Introduction');
   });
 
   it('omits a title-less section from the breadcrumb', () => {
     const block = navFor('/eas/overview') as string;
     expect(block).toContain('You are here: EAS\n');
-    expect(block).toContain('- Overview (this page)');
+    expect(block).toContain('- [Overview](https://docs.expo.dev/eas/overview.md) (this page)');
   });
 
   it('trims a large reference section to breadcrumb + count', () => {
@@ -127,8 +129,12 @@ describe('buildDocsNavigation', () => {
   it('lists a small reference section instead of trimming', () => {
     const block = navFor('/versions/v55.0.0/config/app') as string;
     expect(block).toContain('You are here: Reference (v55.0.0) > Configuration files');
-    expect(block).toContain('- app.json (this page)');
-    expect(block).toContain('- metro.config.js');
+    expect(block).toContain(
+      '- [app.json](https://docs.expo.dev/versions/v55.0.0/config/app.md) (this page)'
+    );
+    expect(block).toContain(
+      '- [metro.config.js](https://docs.expo.dev/versions/v55.0.0/config/metro.md)'
+    );
   });
 
   it('does not trim a large non-reference section', () => {

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -9,6 +9,15 @@ function pages(prefix: string, count: number) {
   }));
 }
 
+const moreSection = {
+  type: 'section' as const,
+  name: 'More',
+  children: [
+    { type: 'page' as const, name: 'Expo CLI', href: '/more/expo-cli' },
+    { type: 'page' as const, name: 'Glossary of terms', href: '/more/glossary-of-terms' },
+  ],
+};
+
 const index = buildNavIndexFrom([
   {
     area: 'eas',
@@ -33,11 +42,9 @@ const index = buildNavIndexFrom([
               { type: 'page', name: 'Deploy', href: '/eas/workflows/examples/deploy' },
             ],
           },
-          // External links must be ignored.
           { type: 'page', name: 'External', href: 'https://example.com' },
         ],
       },
-      // A large NON-reference section: must still list (trimming is reference-only).
       { type: 'section', name: 'Big EAS', children: pages('/eas/big', 40) },
     ],
   },
@@ -45,9 +52,7 @@ const index = buildNavIndexFrom([
     area: 'reference',
     versionKey: 'v55.0.0',
     nodes: [
-      // Large reference section: must trim.
       { type: 'section', name: 'Expo SDK', children: pages('/versions/v55.0.0/sdk', 40) },
-      // Small reference section: must list.
       {
         type: 'section',
         name: 'Configuration files',
@@ -56,12 +61,16 @@ const index = buildNavIndexFrom([
           { type: 'page', name: 'metro.config.js', href: '/versions/v55.0.0/config/metro' },
         ],
       },
+      moreSection,
     ],
   },
   {
     area: 'reference',
     versionKey: 'latest',
-    nodes: [{ type: 'section', name: 'Expo SDK', children: pages('/versions/latest/sdk', 40) }],
+    nodes: [
+      { type: 'section', name: 'Expo SDK', children: pages('/versions/latest/sdk', 40) },
+      moreSection,
+    ],
   },
 ]);
 
@@ -107,7 +116,7 @@ describe('buildDocsNavigation', () => {
       '- [E2E tests](https://docs.expo.dev/eas/workflows/examples/e2e-tests.md) (this page)'
     );
     expect(block).toContain('- [Deploy](https://docs.expo.dev/eas/workflows/examples/deploy.md)');
-    expect(block).not.toContain('- Introduction');
+    expect(block).not.toContain('- [Introduction]');
   });
 
   it('omits a title-less section from the breadcrumb', () => {
@@ -137,6 +146,17 @@ describe('buildDocsNavigation', () => {
     );
   });
 
+  it('omits the version for a shared, non-versioned reference page', () => {
+    const block = navFor('/more/glossary-of-terms') as string;
+    expect(block).toContain('You are here: Reference > More');
+    expect(block).not.toContain('Reference (v55.0.0) > More');
+    expect(block).not.toContain('Reference (v56.0.0) > More');
+    expect(block).toContain(
+      '- [Glossary of terms](https://docs.expo.dev/more/glossary-of-terms.md) (this page)'
+    );
+    expect(block).toContain('- [Expo CLI](https://docs.expo.dev/more/expo-cli.md)');
+  });
+
   it('does not trim a large non-reference section', () => {
     const block = navFor('/eas/big/page-0') as string;
     expect(block).toContain('You are here: EAS > Big EAS');
@@ -148,20 +168,25 @@ describe('buildDocsNavigation', () => {
     expect(block).toContain(`You are here: Reference (${LATEST_VERSION}) > Expo SDK`);
   });
 
-  it('lists every Expo SDK module in full on the version index page (ENG-21931)', () => {
+  it('lists every Reference section grouped on the version index page (ENG-21931)', () => {
     const block = navFor('/versions/v55.0.0/') as string;
-    expect(block).toContain('You are here: Reference (v55.0.0) > Expo SDK');
-    expect(block).toContain('Pages in this section:');
-    expect(block).not.toContain('40 pages in this section');
+    expect(block).toContain('You are here: Reference (v55.0.0)');
+    expect(block).toContain('### Expo SDK');
+    expect(block).toContain('### Configuration files');
+    expect(block).toContain('### More');
     expect(block).toContain('- [Page 0](https://docs.expo.dev/versions/v55.0.0/sdk/page-0.md)');
     expect(block).toContain('- [Page 39](https://docs.expo.dev/versions/v55.0.0/sdk/page-39.md)');
-    expect(block).toContain('Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)');
+    expect(block).toContain('- [app.json](https://docs.expo.dev/versions/v55.0.0/config/app.md)');
+    expect(block).toContain(
+      '- [Glossary of terms](https://docs.expo.dev/more/glossary-of-terms.md)'
+    );
+    expect(block).not.toContain('40 pages in this section');
   });
 
   it('resolves the latest label on the version index page', () => {
     const block = navFor('/versions/latest/') as string;
-    expect(block).toContain(`You are here: Reference (${LATEST_VERSION}) > Expo SDK`);
-    expect(block).toContain('- [Page 0](https://docs.expo.dev/versions/latest/sdk/page-0.md)');
+    expect(block).toContain('You are here: Reference (v56.0.0)');
+    expect(block).toContain('### Expo SDK');
   });
 
   it('is insensitive to a trailing slash', () => {

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -1,0 +1,152 @@
+import { LATEST_VERSION } from '../constants/versions.js';
+import { buildDocsNavigation, buildNavIndexFrom, normalizeNavKey } from './docs-navigation.ts';
+
+function pages(prefix: string, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    type: 'page' as const,
+    name: `Page ${i}`,
+    href: `${prefix}/page-${i}`,
+  }));
+}
+
+const index = buildNavIndexFrom([
+  {
+    area: 'eas',
+    nodes: [
+      {
+        type: 'section',
+        name: '',
+        children: [{ type: 'page', name: 'Overview', href: '/eas/overview' }],
+      },
+      {
+        type: 'section',
+        name: 'EAS Workflows',
+        children: [
+          { type: 'page', name: 'Introduction', href: '/eas/workflows/introduction' },
+          { type: 'page', name: 'Get started', href: '/eas/workflows/get-started' },
+          { type: 'page', name: 'Limitations', href: '/eas/workflows/limitations' },
+          {
+            type: 'group',
+            name: 'Examples',
+            children: [
+              { type: 'page', name: 'E2E tests', href: '/eas/workflows/examples/e2e-tests' },
+              { type: 'page', name: 'Deploy', href: '/eas/workflows/examples/deploy' },
+            ],
+          },
+          // External links must be ignored.
+          { type: 'page', name: 'External', href: 'https://example.com' },
+        ],
+      },
+      // A large NON-reference section: must still list (trimming is reference-only).
+      { type: 'section', name: 'Big EAS', children: pages('/eas/big', 40) },
+    ],
+  },
+  {
+    area: 'reference',
+    versionKey: 'v55.0.0',
+    nodes: [
+      // Large reference section: must trim.
+      { type: 'section', name: 'Expo SDK', children: pages('/versions/v55.0.0/sdk', 40) },
+      // Small reference section: must list.
+      {
+        type: 'section',
+        name: 'Configuration files',
+        children: [
+          { type: 'page', name: 'app.json', href: '/versions/v55.0.0/config/app' },
+          { type: 'page', name: 'metro.config.js', href: '/versions/v55.0.0/config/metro' },
+        ],
+      },
+    ],
+  },
+  {
+    area: 'reference',
+    versionKey: 'latest',
+    nodes: [{ type: 'section', name: 'Expo SDK', children: pages('/versions/latest/sdk', 40) }],
+  },
+]);
+
+const navFor = (pathname: string) => buildDocsNavigation(pathname, index);
+
+describe('normalizeNavKey', () => {
+  it('adds a leading slash, drops trailing slashes, and maps empty to root', () => {
+    expect(normalizeNavKey('/a/b/')).toBe('/a/b');
+    expect(normalizeNavKey('a/b')).toBe('/a/b');
+    expect(normalizeNavKey('/')).toBe('/');
+    expect(normalizeNavKey('')).toBe('/');
+  });
+});
+
+describe('buildDocsNavigation', () => {
+  it('renders a section page with breadcrumb, siblings, and the current-page marker', () => {
+    const block = navFor('/eas/workflows/get-started/');
+    expect(block).toBe(
+      [
+        '<DocsNavigation>',
+        'You are here: EAS > EAS Workflows',
+        'Pages in this section:',
+        '- Introduction',
+        '- Get started (this page)',
+        '- Limitations',
+        'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
+        '</DocsNavigation>',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('lists only the immediate container and ignores external links', () => {
+    const block = navFor('/eas/workflows/get-started/') as string;
+    expect(block).not.toContain('E2E tests');
+    expect(block).not.toContain('https://example.com');
+  });
+
+  it('uses the immediate group for a nested page, including it in the breadcrumb', () => {
+    const block = navFor('/eas/workflows/examples/e2e-tests') as string;
+    expect(block).toContain('You are here: EAS > EAS Workflows > Examples');
+    expect(block).toContain('- E2E tests (this page)');
+    expect(block).toContain('- Deploy');
+    expect(block).not.toContain('- Introduction');
+  });
+
+  it('omits a title-less section from the breadcrumb', () => {
+    const block = navFor('/eas/overview') as string;
+    expect(block).toContain('You are here: EAS\n');
+    expect(block).toContain('- Overview (this page)');
+  });
+
+  it('trims a large reference section to breadcrumb + count', () => {
+    const block = navFor('/versions/v55.0.0/sdk/page-0') as string;
+    expect(block).toContain(
+      'You are here: Reference (v55.0.0) > Expo SDK (40 pages in this section)'
+    );
+    expect(block).not.toContain('Pages in this section:');
+    expect(block).not.toMatch(/^- /m);
+    expect(block).toContain('Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)');
+  });
+
+  it('lists a small reference section instead of trimming', () => {
+    const block = navFor('/versions/v55.0.0/config/app') as string;
+    expect(block).toContain('You are here: Reference (v55.0.0) > Configuration files');
+    expect(block).toContain('- app.json (this page)');
+    expect(block).toContain('- metro.config.js');
+  });
+
+  it('does not trim a large non-reference section', () => {
+    const block = navFor('/eas/big/page-0') as string;
+    expect(block).toContain('You are here: EAS > Big EAS');
+    expect(block).toContain('Pages in this section:');
+  });
+
+  it('resolves the latest version segment to the real version label', () => {
+    const block = navFor('/versions/latest/sdk/page-0') as string;
+    expect(block).toContain(`You are here: Reference (${LATEST_VERSION}) > Expo SDK`);
+  });
+
+  it('is insensitive to a trailing slash', () => {
+    expect(navFor('/eas/workflows/get-started')).toBe(navFor('/eas/workflows/get-started/'));
+  });
+
+  it('returns null for a page that is not in the navigation', () => {
+    expect(navFor('/this/does/not/exist/')).toBeNull();
+  });
+});

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -148,6 +148,22 @@ describe('buildDocsNavigation', () => {
     expect(block).toContain(`You are here: Reference (${LATEST_VERSION}) > Expo SDK`);
   });
 
+  it('lists every Expo SDK module in full on the version index page (ENG-21931)', () => {
+    const block = navFor('/versions/v55.0.0/') as string;
+    expect(block).toContain('You are here: Reference (v55.0.0) > Expo SDK');
+    expect(block).toContain('Pages in this section:');
+    expect(block).not.toContain('40 pages in this section');
+    expect(block).toContain('- [Page 0](https://docs.expo.dev/versions/v55.0.0/sdk/page-0.md)');
+    expect(block).toContain('- [Page 39](https://docs.expo.dev/versions/v55.0.0/sdk/page-39.md)');
+    expect(block).toContain('Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)');
+  });
+
+  it('resolves the latest label on the version index page', () => {
+    const block = navFor('/versions/latest/') as string;
+    expect(block).toContain(`You are here: Reference (${LATEST_VERSION}) > Expo SDK`);
+    expect(block).toContain('- [Page 0](https://docs.expo.dev/versions/latest/sdk/page-0.md)');
+  });
+
   it('is insensitive to a trailing slash', () => {
     expect(navFor('/eas/workflows/get-started')).toBe(navFor('/eas/workflows/get-started/'));
   });

--- a/docs/scripts/docs-navigation.test.ts
+++ b/docs/scripts/docs-navigation.test.ts
@@ -1,5 +1,5 @@
 import { LATEST_VERSION } from '../constants/versions.js';
-import { buildDocsNavigation, buildNavIndexFrom, normalizeNavKey } from './docs-navigation.ts';
+import { buildNavIndexFrom, buildNavigationSection, normalizeNavKey } from './docs-navigation.ts';
 
 function pages(prefix: string, count: number) {
   return Array.from({ length: count }, (_, i) => ({
@@ -74,7 +74,7 @@ const index = buildNavIndexFrom([
   },
 ]);
 
-const navFor = (pathname: string) => buildDocsNavigation(pathname, index);
+const navFor = (pathname: string) => buildNavigationSection(pathname, index);
 
 describe('normalizeNavKey', () => {
   it('adds a leading slash, drops trailing slashes, and maps empty to root', () => {
@@ -85,12 +85,13 @@ describe('normalizeNavKey', () => {
   });
 });
 
-describe('buildDocsNavigation', () => {
+describe('buildNavigationSection', () => {
   it('renders a section page with breadcrumb, siblings, and the current-page marker', () => {
     const block = navFor('/eas/workflows/get-started/');
     expect(block).toBe(
       [
-        '<AgentInstructions>',
+        '## Navigation',
+        '',
         'When answering a related or follow-up question, fetch the relevant page below as Markdown (.md) instead of guessing; use llms.txt for the full map.',
         '',
         'You are here: EAS > EAS Workflows',
@@ -99,8 +100,6 @@ describe('buildDocsNavigation', () => {
         '- [Get started](https://docs.expo.dev/eas/workflows/get-started.md) (this page)',
         '- [Limitations](https://docs.expo.dev/eas/workflows/limitations.md)',
         'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
-        '</AgentInstructions>',
-        '',
       ].join('\n')
     );
   });

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -10,6 +10,10 @@ const AREA_LABELS: Record<string, string> = {
   reference: 'Reference',
   learn: 'Learn',
 };
+const FETCH_INSTRUCTION =
+  'When answering a related or follow-up question, fetch the relevant page below as Markdown (.md) instead of guessing; use llms.txt for the full map.';
+const FETCH_INSTRUCTION_TRIMMED =
+  'When answering a related or follow-up question, use llms.txt to find the relevant page as Markdown (.md) instead of guessing.';
 
 type NavNode = {
   type: 'section' | 'group' | 'page';
@@ -188,10 +192,10 @@ export function buildDocsNavigation(
   }
 
   const breadcrumb = [areaLabel(location), ...location.trail].join(' > ');
-  const lines = ['<DocsNavigation>'];
+  const lines = ['<AgentInstructions>'];
 
   if (location.isVersionIndex && location.referenceSections) {
-    lines.push(`You are here: ${breadcrumb}`);
+    lines.push(FETCH_INSTRUCTION, '', `You are here: ${breadcrumb}`);
     for (const section of location.referenceSections) {
       lines.push(`### ${section.title}`);
       for (const page of section.pages) {
@@ -199,10 +203,13 @@ export function buildDocsNavigation(
       }
     }
   } else if (isTrimmedSection(location)) {
-    lines.push(`You are here: ${breadcrumb} (${location.sectionPageCount} pages in this section)`);
+    lines.push(
+      FETCH_INSTRUCTION_TRIMMED,
+      '',
+      `You are here: ${breadcrumb} (${location.sectionPageCount} pages in this section)`
+    );
   } else {
-    lines.push(`You are here: ${breadcrumb}`);
-    lines.push('Pages in this section:');
+    lines.push(FETCH_INSTRUCTION, '', `You are here: ${breadcrumb}`, 'Pages in this section:');
     for (const sibling of location.siblings) {
       const isCurrent = normalizeNavKey(sibling.href) === key;
       lines.push(
@@ -212,7 +219,7 @@ export function buildDocsNavigation(
   }
 
   lines.push(`Full documentation tree: [llms.txt](${DOCS_BASE_URL}/llms.txt)`);
-  lines.push('</DocsNavigation>');
+  lines.push('</AgentInstructions>');
 
   return `${lines.join('\n')}\n`;
 }

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -181,7 +181,7 @@ function isTrimmedSection(location: NavLocation): boolean {
   );
 }
 
-export function buildDocsNavigation(
+export function buildNavigationSection(
   pathname: string,
   index: Map<string, NavLocation> = buildNavIndex()
 ): string | null {
@@ -192,7 +192,7 @@ export function buildDocsNavigation(
   }
 
   const breadcrumb = [areaLabel(location), ...location.trail].join(' > ');
-  const lines = ['<AgentInstructions>'];
+  const lines = ['## Navigation', ''];
 
   if (location.isVersionIndex && location.referenceSections) {
     lines.push(FETCH_INSTRUCTION, '', `You are here: ${breadcrumb}`);
@@ -219,7 +219,6 @@ export function buildDocsNavigation(
   }
 
   lines.push(`Full documentation tree: [llms.txt](${DOCS_BASE_URL}/llms.txt)`);
-  lines.push('</AgentInstructions>');
 
-  return `${lines.join('\n')}\n`;
+  return lines.join('\n');
 }

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -3,7 +3,6 @@ import { LATEST_VERSION } from '../constants/versions.js';
 import { DOCS_BASE_URL, getMarkdownUrl } from './markdown-link-utils.ts';
 
 const TRIM_SECTION_PAGE_THRESHOLD = 30;
-const SDK_INDEX_SECTION_NAME = 'Expo SDK';
 const AREA_LABELS: Record<string, string> = {
   home: 'Home',
   general: 'Guides',
@@ -21,17 +20,16 @@ type NavNode = {
 
 type Sibling = { name: string; href: string };
 
+type ReferenceSection = { title: string; pages: Sibling[] };
+
 type NavLocation = {
   area: string;
-  /** Present only for `reference` pages; the version segment such as `latest` or `v55.0.0`. */
   versionKey?: string;
-  /** Breadcrumb segments after the area label, e.g. `['EAS Workflows']`. */
   trail: string[];
-  /** Pages in the immediate section/group, in sidebar order. */
   siblings: Sibling[];
-  /** Number of pages in the immediate section/group (drives the SDK trim). */
   sectionPageCount: number;
-  isSdkIndex?: boolean;
+  isVersionIndex?: boolean;
+  referenceSections?: ReferenceSection[];
 };
 
 type NavArea = {
@@ -48,6 +46,22 @@ export function normalizeNavKey(pathOrHref: string): string {
 
 function isInternalPage(node: NavNode): boolean {
   return node.type === 'page' && typeof node.href === 'string' && !node.href.startsWith('http');
+}
+
+function referenceVersionFromHref(href: string): string | undefined {
+  return href.match(/^\/versions\/([^/]+)\//)?.[1];
+}
+
+function collectPages(node: NavNode): Sibling[] {
+  const pages: Sibling[] = [];
+  for (const child of node.children ?? []) {
+    if (isInternalPage(child)) {
+      pages.push({ name: child.name ?? '', href: child.href as string });
+    } else if (child.type === 'section' || child.type === 'group') {
+      pages.push(...collectPages(child));
+    }
+  }
+  return pages;
 }
 
 function indexNodes(
@@ -69,9 +83,11 @@ function indexNodes(
     }));
 
     for (const page of pageChildren) {
-      index.set(normalizeNavKey(page.href as string), {
+      const href = page.href as string;
+      index.set(normalizeNavKey(href), {
         area: context.area,
-        versionKey: context.versionKey,
+        versionKey:
+          context.area === 'reference' ? referenceVersionFromHref(href) : context.versionKey,
         trail,
         siblings,
         sectionPageCount: pageChildren.length,
@@ -87,26 +103,33 @@ function indexNodes(
   }
 }
 
-function registerSdkIndex(
+function registerVersionIndex(
   versionKey: string,
   nodes: NavNode[],
   index: Map<string, NavLocation>
 ): void {
-  const sdkSection = nodes.find(
-    node => node.type === 'section' && node.name === SDK_INDEX_SECTION_NAME
-  );
-  const sdkPages = (sdkSection?.children ?? []).filter(isInternalPage);
-  if (sdkPages.length === 0) {
+  const referenceSections: ReferenceSection[] = [];
+  for (const node of nodes) {
+    if (node.type !== 'section' || !node.name) {
+      continue;
+    }
+    const pages = collectPages(node);
+    if (pages.length > 0) {
+      referenceSections.push({ title: node.name, pages });
+    }
+  }
+  if (referenceSections.length === 0) {
     return;
   }
 
   index.set(normalizeNavKey(`/versions/${versionKey}`), {
     area: 'reference',
     versionKey,
-    trail: [SDK_INDEX_SECTION_NAME],
-    siblings: sdkPages.map(page => ({ name: page.name ?? '', href: page.href as string })),
-    sectionPageCount: sdkPages.length,
-    isSdkIndex: true,
+    trail: [],
+    siblings: [],
+    sectionPageCount: 0,
+    isVersionIndex: true,
+    referenceSections,
   });
 }
 
@@ -115,7 +138,7 @@ export function buildNavIndexFrom(areas: NavArea[]): Map<string, NavLocation> {
   for (const { area, versionKey, nodes } of areas) {
     indexNodes(nodes, { area, versionKey, trail: [] }, index);
     if (area === 'reference' && versionKey) {
-      registerSdkIndex(versionKey, nodes, index);
+      registerVersionIndex(versionKey, nodes, index);
     }
   }
   return index;
@@ -149,7 +172,7 @@ function areaLabel(location: NavLocation): string {
 function isTrimmedSection(location: NavLocation): boolean {
   return (
     location.area === 'reference' &&
-    !location.isSdkIndex &&
+    !location.isVersionIndex &&
     location.sectionPageCount > TRIM_SECTION_PAGE_THRESHOLD
   );
 }
@@ -167,7 +190,15 @@ export function buildDocsNavigation(
   const breadcrumb = [areaLabel(location), ...location.trail].join(' > ');
   const lines = ['<DocsNavigation>'];
 
-  if (isTrimmedSection(location)) {
+  if (location.isVersionIndex && location.referenceSections) {
+    lines.push(`You are here: ${breadcrumb}`);
+    for (const section of location.referenceSections) {
+      lines.push(`### ${section.title}`);
+      for (const page of section.pages) {
+        lines.push(`- [${page.name}](${getMarkdownUrl(page.href)})`);
+      }
+    }
+  } else if (isTrimmedSection(location)) {
     lines.push(`You are here: ${breadcrumb} (${location.sectionPageCount} pages in this section)`);
   } else {
     lines.push(`You are here: ${breadcrumb}`);

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -3,6 +3,7 @@ import { LATEST_VERSION } from '../constants/versions.js';
 import { DOCS_BASE_URL, getMarkdownUrl } from './markdown-link-utils.ts';
 
 const TRIM_SECTION_PAGE_THRESHOLD = 30;
+const SDK_INDEX_SECTION_NAME = 'Expo SDK';
 const AREA_LABELS: Record<string, string> = {
   home: 'Home',
   general: 'Guides',
@@ -30,6 +31,7 @@ type NavLocation = {
   siblings: Sibling[];
   /** Number of pages in the immediate section/group (drives the SDK trim). */
   sectionPageCount: number;
+  isSdkIndex?: boolean;
 };
 
 type NavArea = {
@@ -85,10 +87,36 @@ function indexNodes(
   }
 }
 
+function registerSdkIndex(
+  versionKey: string,
+  nodes: NavNode[],
+  index: Map<string, NavLocation>
+): void {
+  const sdkSection = nodes.find(
+    node => node.type === 'section' && node.name === SDK_INDEX_SECTION_NAME
+  );
+  const sdkPages = (sdkSection?.children ?? []).filter(isInternalPage);
+  if (sdkPages.length === 0) {
+    return;
+  }
+
+  index.set(normalizeNavKey(`/versions/${versionKey}`), {
+    area: 'reference',
+    versionKey,
+    trail: [SDK_INDEX_SECTION_NAME],
+    siblings: sdkPages.map(page => ({ name: page.name ?? '', href: page.href as string })),
+    sectionPageCount: sdkPages.length,
+    isSdkIndex: true,
+  });
+}
+
 export function buildNavIndexFrom(areas: NavArea[]): Map<string, NavLocation> {
   const index = new Map<string, NavLocation>();
   for (const { area, versionKey, nodes } of areas) {
     indexNodes(nodes, { area, versionKey, trail: [] }, index);
+    if (area === 'reference' && versionKey) {
+      registerSdkIndex(versionKey, nodes, index);
+    }
   }
   return index;
 }
@@ -119,7 +147,11 @@ function areaLabel(location: NavLocation): string {
 }
 
 function isTrimmedSection(location: NavLocation): boolean {
-  return location.area === 'reference' && location.sectionPageCount > TRIM_SECTION_PAGE_THRESHOLD;
+  return (
+    location.area === 'reference' &&
+    !location.isSdkIndex &&
+    location.sectionPageCount > TRIM_SECTION_PAGE_THRESHOLD
+  );
 }
 
 export function buildDocsNavigation(

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -36,7 +36,7 @@ type NavLocation = {
 type NavArea = {
   area: string;
   versionKey?: string;
-  nodes: NavNode[]
+  nodes: NavNode[];
 };
 
 export function normalizeNavKey(pathOrHref: string): string {

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -1,8 +1,7 @@
 import { home, general, eas, learn, reference } from '../constants/navigation.js';
 import { LATEST_VERSION } from '../constants/versions.js';
-import { DOCS_BASE_URL } from './markdown-link-utils.ts';
+import { DOCS_BASE_URL, getMarkdownUrl } from './markdown-link-utils.ts';
 
-const LLMS_TXT_URL = `${DOCS_BASE_URL}/llms.txt`;
 const TRIM_SECTION_PAGE_THRESHOLD = 30;
 const AREA_LABELS: Record<string, string> = {
   home: 'Home',
@@ -97,19 +96,17 @@ export function buildNavIndexFrom(areas: NavArea[]): Map<string, NavLocation> {
 let cachedIndex: Map<string, NavLocation> | null = null;
 
 export function buildNavIndex(): Map<string, NavLocation> {
-  if (!cachedIndex) {
-    cachedIndex = buildNavIndexFrom([
-      { area: 'home', nodes: home as NavNode[] },
-      { area: 'general', nodes: general as NavNode[] },
-      { area: 'eas', nodes: eas as NavNode[] },
-      { area: 'learn', nodes: learn as NavNode[] },
-      ...Object.entries(reference as Record<string, NavNode[]>).map(([versionKey, nodes]) => ({
-        area: 'reference',
-        versionKey,
-        nodes,
-      })),
-    ]);
-  }
+  cachedIndex ??= buildNavIndexFrom([
+    { area: 'home', nodes: home as NavNode[] },
+    { area: 'general', nodes: general as NavNode[] },
+    { area: 'eas', nodes: eas as NavNode[] },
+    { area: 'learn', nodes: learn as NavNode[] },
+    ...Object.entries(reference as Record<string, NavNode[]>).map(([versionKey, nodes]) => ({
+      area: 'reference',
+      versionKey,
+      nodes,
+    })),
+  ]);
   return cachedIndex;
 }
 
@@ -145,11 +142,13 @@ export function buildDocsNavigation(
     lines.push('Pages in this section:');
     for (const sibling of location.siblings) {
       const isCurrent = normalizeNavKey(sibling.href) === key;
-      lines.push(`- ${sibling.name}${isCurrent ? ' (this page)' : ''}`);
+      lines.push(
+        `- [${sibling.name}](${getMarkdownUrl(sibling.href)})${isCurrent ? ' (this page)' : ''}`
+      );
     }
   }
 
-  lines.push(`Full documentation tree: [llms.txt](${LLMS_TXT_URL})`);
+  lines.push(`Full documentation tree: [llms.txt](${DOCS_BASE_URL}/llms.txt)`);
   lines.push('</DocsNavigation>');
 
   return `${lines.join('\n')}\n`;

--- a/docs/scripts/docs-navigation.ts
+++ b/docs/scripts/docs-navigation.ts
@@ -1,0 +1,156 @@
+import { home, general, eas, learn, reference } from '../constants/navigation.js';
+import { LATEST_VERSION } from '../constants/versions.js';
+import { DOCS_BASE_URL } from './markdown-link-utils.ts';
+
+const LLMS_TXT_URL = `${DOCS_BASE_URL}/llms.txt`;
+const TRIM_SECTION_PAGE_THRESHOLD = 30;
+const AREA_LABELS: Record<string, string> = {
+  home: 'Home',
+  general: 'Guides',
+  eas: 'EAS',
+  reference: 'Reference',
+  learn: 'Learn',
+};
+
+type NavNode = {
+  type: 'section' | 'group' | 'page';
+  name?: string;
+  href?: string;
+  children?: NavNode[];
+};
+
+type Sibling = { name: string; href: string };
+
+type NavLocation = {
+  area: string;
+  /** Present only for `reference` pages; the version segment such as `latest` or `v55.0.0`. */
+  versionKey?: string;
+  /** Breadcrumb segments after the area label, e.g. `['EAS Workflows']`. */
+  trail: string[];
+  /** Pages in the immediate section/group, in sidebar order. */
+  siblings: Sibling[];
+  /** Number of pages in the immediate section/group (drives the SDK trim). */
+  sectionPageCount: number;
+};
+
+type NavArea = {
+  area: string;
+  versionKey?: string;
+  nodes: NavNode[]
+};
+
+export function normalizeNavKey(pathOrHref: string): string {
+  const withLeadingSlash = pathOrHref.startsWith('/') ? pathOrHref : `/${pathOrHref}`;
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+  return withoutTrailingSlash === '' ? '/' : withoutTrailingSlash;
+}
+
+function isInternalPage(node: NavNode): boolean {
+  return node.type === 'page' && typeof node.href === 'string' && !node.href.startsWith('http');
+}
+
+function indexNodes(
+  nodes: NavNode[],
+  context: { area: string; versionKey?: string; trail: string[] },
+  index: Map<string, NavLocation>
+): void {
+  for (const node of nodes) {
+    if (node.type !== 'section' && node.type !== 'group') {
+      continue;
+    }
+
+    const trail = node.name ? [...context.trail, node.name] : context.trail;
+
+    const pageChildren = (node.children ?? []).filter(isInternalPage);
+    const siblings: Sibling[] = pageChildren.map(page => ({
+      name: page.name ?? '',
+      href: page.href as string,
+    }));
+
+    for (const page of pageChildren) {
+      index.set(normalizeNavKey(page.href as string), {
+        area: context.area,
+        versionKey: context.versionKey,
+        trail,
+        siblings,
+        sectionPageCount: pageChildren.length,
+      });
+    }
+
+    const subContainers = (node.children ?? []).filter(
+      child => child.type === 'section' || child.type === 'group'
+    );
+    if (subContainers.length > 0) {
+      indexNodes(subContainers, { ...context, trail }, index);
+    }
+  }
+}
+
+export function buildNavIndexFrom(areas: NavArea[]): Map<string, NavLocation> {
+  const index = new Map<string, NavLocation>();
+  for (const { area, versionKey, nodes } of areas) {
+    indexNodes(nodes, { area, versionKey, trail: [] }, index);
+  }
+  return index;
+}
+
+let cachedIndex: Map<string, NavLocation> | null = null;
+
+export function buildNavIndex(): Map<string, NavLocation> {
+  if (!cachedIndex) {
+    cachedIndex = buildNavIndexFrom([
+      { area: 'home', nodes: home as NavNode[] },
+      { area: 'general', nodes: general as NavNode[] },
+      { area: 'eas', nodes: eas as NavNode[] },
+      { area: 'learn', nodes: learn as NavNode[] },
+      ...Object.entries(reference as Record<string, NavNode[]>).map(([versionKey, nodes]) => ({
+        area: 'reference',
+        versionKey,
+        nodes,
+      })),
+    ]);
+  }
+  return cachedIndex;
+}
+
+function areaLabel(location: NavLocation): string {
+  if (location.area === 'reference') {
+    const version = location.versionKey === 'latest' ? LATEST_VERSION : location.versionKey;
+    return version ? `Reference (${version})` : 'Reference';
+  }
+  return AREA_LABELS[location.area] ?? location.area;
+}
+
+function isTrimmedSection(location: NavLocation): boolean {
+  return location.area === 'reference' && location.sectionPageCount > TRIM_SECTION_PAGE_THRESHOLD;
+}
+
+export function buildDocsNavigation(
+  pathname: string,
+  index: Map<string, NavLocation> = buildNavIndex()
+): string | null {
+  const key = normalizeNavKey(pathname);
+  const location = index.get(key);
+  if (!location) {
+    return null;
+  }
+
+  const breadcrumb = [areaLabel(location), ...location.trail].join(' > ');
+  const lines = ['<DocsNavigation>'];
+
+  if (isTrimmedSection(location)) {
+    lines.push(`You are here: ${breadcrumb} (${location.sectionPageCount} pages in this section)`);
+  } else {
+    lines.push(`You are here: ${breadcrumb}`);
+    lines.push('Pages in this section:');
+    for (const sibling of location.siblings) {
+      const isCurrent = normalizeNavKey(sibling.href) === key;
+      lines.push(`- ${sibling.name}${isCurrent ? ' (this page)' : ''}`);
+    }
+  }
+
+  lines.push(`Full documentation tree: [llms.txt](${LLMS_TXT_URL})`);
+  lines.push('</DocsNavigation>');
+
+  return `${lines.join('\n')}\n`;
+}

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -51,17 +51,11 @@ const CONTENT_SEPARATOR = '\n\n---\n\n';
 
 const AGENT_INSTRUCTIONS_BLOCK_REGEX = /<AgentInstructions>[\S\s]*?<\/AgentInstructions>\n*/g;
 
-const DOCS_NAVIGATION_BLOCK_REGEX = /<DocsNavigation>[\S\s]*?<\/DocsNavigation>\n*/g;
-
 const DOC_INDEX_BLOCKQUOTE =
   '> For the complete documentation index, see [llms.txt](/llms.txt). Use this Use this file to discover all available pages.';
 
 export function stripAgentInstructions(content) {
   return content.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, '');
-}
-
-export function stripDocsNavigation(content) {
-  return content.replace(DOCS_NAVIGATION_BLOCK_REGEX, '');
 }
 
 export function stripDocIndexBlockquote(content) {
@@ -158,7 +152,7 @@ export function readUniqueMarkdownContent(markdownPaths, { warnOnMissing = false
     }
 
     const content = rewriteDocsLinksToMarkdown(
-      stripDocIndexBlockquote(stripDocsNavigation(stripAgentInstructions(rawContent)))
+      stripDocIndexBlockquote(stripAgentInstructions(rawContent))
     ).trim();
     if (!content) {
       continue;

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -51,11 +51,17 @@ const CONTENT_SEPARATOR = '\n\n---\n\n';
 
 const AGENT_INSTRUCTIONS_BLOCK_REGEX = /<AgentInstructions>[\S\s]*?<\/AgentInstructions>\n*/g;
 
+const DOCS_NAVIGATION_BLOCK_REGEX = /<DocsNavigation>[\S\s]*?<\/DocsNavigation>\n*/g;
+
 const DOC_INDEX_BLOCKQUOTE =
   '> For the complete documentation index, see [llms.txt](/llms.txt). Use this Use this file to discover all available pages.';
 
 export function stripAgentInstructions(content) {
   return content.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, '');
+}
+
+export function stripDocsNavigation(content) {
+  return content.replace(DOCS_NAVIGATION_BLOCK_REGEX, '');
 }
 
 export function stripDocIndexBlockquote(content) {
@@ -152,7 +158,7 @@ export function readUniqueMarkdownContent(markdownPaths, { warnOnMissing = false
     }
 
     const content = rewriteDocsLinksToMarkdown(
-      stripDocIndexBlockquote(stripAgentInstructions(rawContent))
+      stripDocIndexBlockquote(stripDocsNavigation(stripAgentInstructions(rawContent)))
     ).trim();
     if (!content) {
       continue;

--- a/docs/scripts/generate-llms/shared.test.js
+++ b/docs/scripts/generate-llms/shared.test.js
@@ -2,7 +2,7 @@ import {
   getMarkdownHref,
   getMarkdownUrl,
   rewriteDocsLinksToMarkdown,
-  stripDocsNavigation,
+  stripAgentInstructions,
 } from './shared.js';
 
 describe('getMarkdownHref', () => {
@@ -111,31 +111,38 @@ describe('rewriteDocsLinksToMarkdown', () => {
   });
 });
 
-describe('stripDocsNavigation', () => {
-  it('removes the per-page DocsNavigation block so it does not leak into aggregates', () => {
+describe('stripAgentInstructions', () => {
+  it('removes every AgentInstructions block so they do not leak into aggregates', () => {
     const content = [
       '---',
       'title: Camera',
       '---',
-      '<DocsNavigation>',
-      'You are here: Reference (v56.0.0) > Expo SDK (86 pages in this section)',
-      'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
-      '</DocsNavigation>',
+      '<AgentInstructions>',
+      '## Submitting Feedback',
+      'curl -X POST https://api.expo.dev/v2/feedback/docs-send',
+      '</AgentInstructions>',
+      '',
+      '<AgentInstructions>',
+      'When answering a related or follow-up question, fetch the relevant page below as Markdown (.md) instead of guessing; use llms.txt for the full map.',
+      '',
+      'You are here: Reference (v56.0.0) > Expo SDK',
+      '</AgentInstructions>',
       '',
       '# Camera',
       'Body content.',
     ].join('\n');
 
-    const stripped = stripDocsNavigation(content);
+    const stripped = stripAgentInstructions(content);
 
-    expect(stripped).not.toContain('<DocsNavigation>');
+    expect(stripped).not.toContain('<AgentInstructions>');
+    expect(stripped).not.toContain('Submitting Feedback');
     expect(stripped).not.toContain('You are here:');
     expect(stripped).toContain('title: Camera');
     expect(stripped).toContain('# Camera');
   });
 
   it('leaves content without a block unchanged', () => {
-    const content = '# Heading\n\nNo navigation block here.';
-    expect(stripDocsNavigation(content)).toBe(content);
+    const content = '# Heading\n\nNo instructions block here.';
+    expect(stripAgentInstructions(content)).toBe(content);
   });
 });

--- a/docs/scripts/generate-llms/shared.test.js
+++ b/docs/scripts/generate-llms/shared.test.js
@@ -112,20 +112,24 @@ describe('rewriteDocsLinksToMarkdown', () => {
 });
 
 describe('stripAgentInstructions', () => {
-  it('removes every AgentInstructions block so they do not leak into aggregates', () => {
+  it('removes the combined AgentInstructions block so it does not leak into aggregates', () => {
     const content = [
       '---',
       'title: Camera',
       '---',
       '<AgentInstructions>',
+      '',
       '## Submitting Feedback',
+      '',
       'curl -X POST https://api.expo.dev/v2/feedback/docs-send',
-      '</AgentInstructions>',
       '',
-      '<AgentInstructions>',
-      'When answering a related or follow-up question, fetch the relevant page below as Markdown (.md) instead of guessing; use llms.txt for the full map.',
+      '## Navigation',
       '',
-      'You are here: Reference (v56.0.0) > Expo SDK',
+      'When answering a related or follow-up question, use llms.txt to find the relevant page as Markdown (.md) instead of guessing.',
+      '',
+      'You are here: Reference (v56.0.0) > Expo SDK (86 pages in this section)',
+      'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
+      '',
       '</AgentInstructions>',
       '',
       '# Camera',
@@ -135,7 +139,8 @@ describe('stripAgentInstructions', () => {
     const stripped = stripAgentInstructions(content);
 
     expect(stripped).not.toContain('<AgentInstructions>');
-    expect(stripped).not.toContain('Submitting Feedback');
+    expect(stripped).not.toContain('## Submitting Feedback');
+    expect(stripped).not.toContain('## Navigation');
     expect(stripped).not.toContain('You are here:');
     expect(stripped).toContain('title: Camera');
     expect(stripped).toContain('# Camera');

--- a/docs/scripts/generate-llms/shared.test.js
+++ b/docs/scripts/generate-llms/shared.test.js
@@ -1,4 +1,9 @@
-import { getMarkdownHref, getMarkdownUrl, rewriteDocsLinksToMarkdown } from './shared.js';
+import {
+  getMarkdownHref,
+  getMarkdownUrl,
+  rewriteDocsLinksToMarkdown,
+  stripDocsNavigation,
+} from './shared.js';
 
 describe('getMarkdownHref', () => {
   it('converts docs page hrefs to sibling markdown hrefs', () => {
@@ -103,5 +108,34 @@ describe('rewriteDocsLinksToMarkdown', () => {
     const content = ['~~~md', '```', '[Inside](/get-started/create-a-project/)', '~~~'].join('\n');
 
     expect(rewriteDocsLinksToMarkdown(content)).toBe(content);
+  });
+});
+
+describe('stripDocsNavigation', () => {
+  it('removes the per-page DocsNavigation block so it does not leak into aggregates', () => {
+    const content = [
+      '---',
+      'title: Camera',
+      '---',
+      '<DocsNavigation>',
+      'You are here: Reference (v56.0.0) > Expo SDK (86 pages in this section)',
+      'Full documentation tree: [llms.txt](https://docs.expo.dev/llms.txt)',
+      '</DocsNavigation>',
+      '',
+      '# Camera',
+      'Body content.',
+    ].join('\n');
+
+    const stripped = stripDocsNavigation(content);
+
+    expect(stripped).not.toContain('<DocsNavigation>');
+    expect(stripped).not.toContain('You are here:');
+    expect(stripped).toContain('title: Camera');
+    expect(stripped).toContain('# Camera');
+  });
+
+  it('leaves content without a block unchanged', () => {
+    const content = '# Heading\n\nNo navigation block here.';
+    expect(stripDocsNavigation(content)).toBe(content);
   });
 });

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -9,12 +9,13 @@ import path from 'node:path';
 import { parentPort, workerData } from 'node:worker_threads';
 
 import {
-  buildAgentInstructions,
+  buildFeedbackSection,
   buildPageSpecificNote,
   shouldAppendAgentInstructions,
   urlPathFromHtmlPath,
+  wrapAgentInstructions,
 } from './agent-instructions.ts';
-import { buildDocsNavigation } from './docs-navigation.ts';
+import { buildNavigationSection } from './docs-navigation.ts';
 import {
   checkMarkdownQuality,
   convertMdxInstructionToMarkdown,
@@ -195,11 +196,17 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
     const mdxPath = findMdxSource(htmlPath, outDir, pagesDir);
     const frontmatter = mdxPath ? extractFrontmatter(mdxPath) : null;
     const pathname = urlPathFromHtmlPath(relHtmlPath);
-    const agentBlock = shouldAppendAgentInstructions(markdown)
-      ? buildAgentInstructions(pathname)
-      : null;
+    const instructionSections: string[] = [];
+    if (shouldAppendAgentInstructions(markdown)) {
+      instructionSections.push(buildFeedbackSection(pathname));
+    }
+    const navigationSection = buildNavigationSection(pathname);
+    if (navigationSection) {
+      instructionSections.push(navigationSection);
+    }
+    const agentInstructions =
+      instructionSections.length > 0 ? wrapAgentInstructions(instructionSections) : null;
     const pageNote = buildPageSpecificNote(pathname);
-    const docsNavigation = buildDocsNavigation(pathname);
 
     const parts: string[] = [];
     if (frontmatter) {
@@ -208,11 +215,8 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
     if (pageNote) {
       parts.push(pageNote);
     }
-    if (agentBlock) {
-      parts.push(agentBlock);
-    }
-    if (docsNavigation) {
-      parts.push(docsNavigation);
+    if (agentInstructions) {
+      parts.push(agentInstructions);
     }
     parts.push(markdown);
     markdown = parts.join('\n');

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -205,14 +205,14 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
     if (frontmatter) {
       parts.push(frontmatter);
     }
-    if (docsNavigation) {
-      parts.push(docsNavigation);
-    }
     if (pageNote) {
       parts.push(pageNote);
     }
     if (agentBlock) {
       parts.push(agentBlock);
+    }
+    if (docsNavigation) {
+      parts.push(docsNavigation);
     }
     parts.push(markdown);
     markdown = parts.join('\n');

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -14,6 +14,7 @@ import {
   shouldAppendAgentInstructions,
   urlPathFromHtmlPath,
 } from './agent-instructions.ts';
+import { buildDocsNavigation } from './docs-navigation.ts';
 import {
   checkMarkdownQuality,
   convertMdxInstructionToMarkdown,
@@ -198,10 +199,14 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
       ? buildAgentInstructions(pathname)
       : null;
     const pageNote = buildPageSpecificNote(pathname);
+    const docsNavigation = buildDocsNavigation(pathname);
 
     const parts: string[] = [];
     if (frontmatter) {
       parts.push(frontmatter);
+    }
+    if (docsNavigation) {
+      parts.push(docsNavigation);
     }
     if (pageNote) {
       parts.push(pageNote);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21931 ENG-21930

Here are the two sections, formatted for the PR. (I kept it to How + Test Plan as you asked; say the word if you also want the title, Why, or Checklist.)

---

# How

- Add `scripts/docs-navigation.ts`, which walks `constants/navigation.js` to inject an `<AgentInstructions>` navigation block (a breadcrumb, the section's neighboring pages as absolute `.md` links, and an `llms.txt` pointer) into every generated per-page `.md`. 
- Large SDK reference sections are trimmed to a page count, each version index page (`/versions/<v>/`) lists the full Reference tree, the block is stripped from the `llms.txt` aggregates by the existing `stripAgentInstructions`, and the now-redundant `sr-only` `llms.txt` blockquote is removed from `DocumentationPage.tsx`.

# Test Plan

**Generated output** 

For local, run `pnpm export-preview` and then `pnpm export-server`. Open `https://localhost:8000` and visit the docs to confirm example output below.

| File                                      | Expect                                                                                                                                                                                              |
| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `out/eas/workflows/get-started/index.md`  | `You are here: EAS > EAS Workflows`, the 7 section pages as `https://docs.expo.dev/...md` links, `(this page)` on Get started                                                                       |
| `out/versions/latest/sdk/camera/index.md` | Trimmed: `You are here: Reference (v56.0.0) > Expo SDK (86 pages in this section)`, no page list                                                                                                    |
| `out/versions/latest/index.md`            | Full tree: `Reference (v56.0.0)` then `### Configuration files / Expo Router / Expo UI / Expo SDK / Third-party libraries / Technical specs / More`, ~249 links, original page body preserved below |
| `out/more/glossary-of-terms/index.md`     | `You are here: Reference > More` with no version (shared page)                                                                                                                                      |


**Or, use Preview:**
- Expo SDK reference index page: https://pr-47001.expo-docs.pages.dev/versions/latest/index.md
- Expo UI index page: https://pr-47001.expo-docs.pages.dev/versions/latest/sdk/ui/index.md
- A page from EAS docs: https://pr-47001.expo-docs.pages.dev/build/setup/index.md


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
