### PR TITLE
[docs] Fix invalid config plugin examples for expo-sqlite and expo-system-ui

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -44,7 +44,7 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
           },
           "ios": {
             // You can also override the shared configurations for iOS
-            "customBuildFlags": ["-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"]
+            "customBuildFlags": "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"
           }
         }
       ]

--- a/docs/pages/versions/unversioned/sdk/system-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/system-ui.mdx
@@ -28,12 +28,12 @@ You can configure `expo-system-ui` using its built-in [config plugin](/config-pl
     "backgroundColor": "#ffffff",
     "userInterfaceStyle": "light",
     "ios": {
-      "backgroundColor": "#ffffff",
-    }
+      "backgroundColor": "#ffffff"
+    },
     "android": {
       "userInterfaceStyle": "light"
     },
-    "plugins": ["expo-system-ui"],
+    "plugins": ["expo-system-ui"]
   }
 }
 ```

--- a/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
@@ -44,7 +44,7 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
           },
           "ios": {
             // You can also override the shared configurations for iOS
-            "customBuildFlags": ["-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"]
+            "customBuildFlags": "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"
           }
         }
       ]

--- a/docs/pages/versions/v56.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/system-ui.mdx
@@ -28,12 +28,12 @@ You can configure `expo-system-ui` using its built-in [config plugin](/config-pl
     "backgroundColor": "#ffffff",
     "userInterfaceStyle": "light",
     "ios": {
-      "backgroundColor": "#ffffff",
-    }
+      "backgroundColor": "#ffffff"
+    },
     "android": {
       "userInterfaceStyle": "light"
     },
-    "plugins": ["expo-system-ui"],
+    "plugins": ["expo-system-ui"]
   }
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

ENG-21978

# How

- In `sqlite.mdx`, change `ios.customBuildFlags` from a single-element array to a string, since the plugin types it as `string` and not `string[]` ([`withSQLite.ts#L26`](https://github.com/expo/expo/blob/cd51b6634f5cc5c6dcd3899154d9761a5c65982f/packages/expo-sqlite/plugin/src/withSQLite.ts#L26)), so the array form was never valid. 
- In `system-ui.mdx`, make the example valid JSON by adding the missing comma after the `ios` block and removing two trailing commas. Both fixes are applied to the `unversioned` and `v56.0.0` docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
