### PR TITLE
[android][audio] Fix crash with microsoft intune

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
+- [Android] Fix recording crash in apps wrapped with Microsoft Intune.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
-- [Android] Fix recording crash in apps wrapped with Microsoft Intune.
+- [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -25,7 +25,6 @@ import java.io.File
 import java.io.IOException
 import java.lang.ref.WeakReference
 import java.util.UUID
-import kotlin.coroutines.Continuation
 import kotlin.math.log10
 
 private const val RECORDING_STATUS_UPDATE = "recordingStatusUpdate"

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -49,7 +49,6 @@ class AudioRecorder(
   var isPaused = false
   private var recordingTimerJob: Job? = null
   var useForegroundService = false
-  private var bindingContinuation: Continuation<Boolean>? = null
 
   val serviceConnection = AudioRecordingServiceConnection(WeakReference(this), appContext)
 
@@ -68,7 +67,7 @@ class AudioRecorder(
 
     val amplitude: Int = try {
       recorder?.maxAmplitude ?: 0
-    } catch (e: Exception) {
+    } catch (_: Exception) {
       // MediaRecorder maxAmplitude can throw various exceptions:
       // - IllegalStateException: invalid recorder state/race condition
       // - RuntimeException: getMaxAmplitude failed (hardware/driver issues)
@@ -223,13 +222,10 @@ class AudioRecorder(
     isPrepared = false
   }
 
+  @Suppress("DEPRECATION")
   private fun createRecorder(options: RecordingOptions): MediaRecorder {
     val outputFilePath = createRecordingFilePath(options)
-    val mediaRecorder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      MediaRecorder(context)
-    } else {
-      MediaRecorder()
-    }
+    val mediaRecorder = MediaRecorder()
 
     try {
       setRecordingOptions(mediaRecorder, options, outputFilePath)
@@ -250,7 +246,7 @@ class AudioRecorder(
     val directory = File(parentDirectory, "Audio")
     try {
       ensureDirExists(directory)
-    } catch (e: IOException) {
+    } catch (_: IOException) {
       // This only occurs in the case that the scoped path is not in this experience's scope,
       // which is never true.
     }
@@ -402,7 +398,7 @@ class AudioRecorder(
         // only returns a valid device when actively recording, and may throw otherwise.
         // https://developer.android.com/reference/android/media/MediaRecorder#getRoutedDevice()
         deviceInfo = recorder?.routedDevice
-      } catch (e: java.lang.Exception) {
+      } catch (_: java.lang.Exception) {
         // no-op
       }
     }
@@ -453,6 +449,7 @@ class AudioRecorder(
       }
     }
 
+  @Suppress("DEPRECATION")
   fun setInput(uid: String, audioManager: AudioManager) {
     val deviceInfo: AudioDeviceInfo? = getDeviceInfoFromUid(uid, audioManager)
 


### PR DESCRIPTION
# Why
`expo-audio` recording crashes on Android in apps wrapped with Microsoft Intune.

# How
Intune rewrites bytecode, replacing  androids `MediaRecorder` with its own `MAMMediaRecorder` subclass. `MAMMediaRecorder` declares only a no-arg constructor.

expo-audio constructed the recorder with `MediaRecorder(context)` on API 31+. After the rename, the (Context) has no matching `MAMMediaRecorder` constructor. Because MAMMediaRecorder's own constructor never runs, some required fields remain null, and the first call to setOutputFile(), NPEs.

The fix is to do the same as expo-av and use the no-arg constructor. We don't lose anything by doing this.

# Test Plan
We can't repro without enterprise access to intune but this is a safe change.

