### PR TITLE
[cli][router-server] Move asset injection from `htmlFromSerialAssets()` to `getStaticContent()`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Update `expo start --private-key-path` help text ([#47795](https://github.com/expo/expo/pull/47795) by [@kitten](https://github.com/kitten))
 - Re-enable sextant QR code for Zed ([#48382](https://github.com/expo/expo/pull/48382) by [@mchisolm0](https://github.com/mchisolm0))
 - Bump to `multitars@1.0.2` to address symlink and unicode bugs ([#48833](https://github.com/expo/expo/pull/48833) by [@kitten](https://github.com/kitten))
+- [Internal] Move static HTML asset injection into `getStaticContent()`. ([#47006](https://github.com/expo/expo/pull/47006) by [@hassankhan](https://github.com/hassankhan))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -26,7 +26,7 @@ import { SSG_LOADER_HEADER_ALLOWLIST } from '../start/server/metro/resolveLoader
 import { getApiRoutesForDirectory, getMiddlewareForDirectory } from '../start/server/metro/router';
 import {
   assetsRequiresSort,
-  serializeHtmlWithAssets,
+  serialAssetsToStaticContentAssets,
   sortMatchedAssetsByEntryPoints,
 } from '../start/server/metro/serializeHtml';
 import { learnMore } from '../utils/link';
@@ -220,7 +220,6 @@ export async function exportFromServerAsync(
   Log.log(logOutput);
 
   const platform = 'web';
-  const isExporting = true;
   const isExportingWithSSR =
     exportServer && useServerRendering && !devServer.isReactServerComponentsEnabled;
   const appDir = path.join(projectRoot, routerRoot);
@@ -296,19 +295,15 @@ export async function exportFromServerAsync(
         }
       }
 
-      if (faviconAsset) {
-        renderOpts.assets = { css: [], js: [], favicon: faviconAsset.href };
-      }
-
-      const template = await renderAsync(normalizedPathname, route, renderOpts);
-      let html = serializeHtmlWithAssets({
-        isExporting,
-        resources: resources.artifacts,
-        template,
+      renderOpts.hydrate = true;
+      renderOpts.assets = serialAssetsToStaticContentAssets(resources.artifacts, {
+        isExporting: true,
         baseUrl,
         route,
-        hydrate: true,
+        favicon: faviconAsset?.href,
       });
+
+      let html = await renderAsync(normalizedPathname, route, renderOpts);
 
       if (scriptTags) {
         // Inject script tags into the HTML.

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -100,7 +100,7 @@ import {
   isApiRouteConvention,
   warnInvalidWebOutput,
 } from './router';
-import { serializeHtmlWithAssets } from './serializeHtml';
+import { serialAssetsToStaticContentAssets } from './serializeHtml';
 import { observeAnyFileChanges, observeFileChanges } from './waitForMetroToObserveTypeScriptFile';
 
 export type ExpoRouterRuntimeManifest = Awaited<
@@ -737,40 +737,30 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       return { content };
     }
 
-    const bundleStaticHtml = async (): Promise<string> => {
-      const { getStaticContent } = await this.ssrLoadModule<
-        typeof import('@expo/router-server/build/static/renderStaticContent')
-      >(require.resolve('@expo/router-server/node/render.js'), {
-        // This must always use the legacy rendering resolution (no `react-server`) because it leverages
-        // the previous React SSG utilities which aren't available in React 19.
-        environment: 'node',
-        minify: false,
-        isExporting,
-        platform,
-      });
-
-      const { loader } = await this.getDevServerRenderOptionsAsync({
-        location,
-        route,
-        request,
-      });
-
-      return await getStaticContent(location, loader ? { loader } : undefined);
-    };
-
-    const [{ artifacts: resources }, staticHtml] = await Promise.all([
-      this.getStaticResourcesAsync({
-        clientBoundaries: [],
-      }),
-      bundleStaticHtml(),
+    const [{ artifacts: resources }, { getStaticContent }, { loader }] = await Promise.all([
+      this.getStaticResourcesAsync({ clientBoundaries: [] }),
+      this.ssrLoadModule<typeof import('@expo/router-server/build/static/renderStaticContent')>(
+        require.resolve('@expo/router-server/node/render.js'),
+        {
+          // This must always use the legacy rendering resolution (no `react-server`) because it leverages
+          // the previous React SSG utilities which aren't available in React 19.
+          environment: 'node',
+          minify: false,
+          isExporting,
+          platform,
+        }
+      ),
+      this.getDevServerRenderOptionsAsync({ location, route, request }),
     ]);
-    const content = serializeHtmlWithAssets({
-      isExporting,
-      resources,
-      template: staticHtml,
-      devBundleUrl: devBundleUrlPathname,
-      baseUrl,
+
+    const content = await getStaticContent(location, {
+      ...(loader ? { loader } : {}),
       hydrate: env.EXPO_WEB_DEV_HYDRATE,
+      assets: serialAssetsToStaticContentAssets(resources, {
+        isExporting: false,
+        baseUrl,
+        bundleUrl: devBundleUrlPathname,
+      }),
     });
     return {
       content,

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -396,10 +396,14 @@ describe('getStaticPageAsync', () => {
 
     expect(typeof result.content).toBe('string');
     expect(result.resources).toEqual([]);
-    expect(getStaticContent).toHaveBeenCalledWith(
-      new URL('http://localhost:8081/posts/123'),
-      undefined
-    );
+    expect(getStaticContent).toHaveBeenCalledWith(new URL('http://localhost:8081/posts/123'), {
+      hydrate: false,
+      assets: {
+        css: [],
+        js: [expect.stringContaining('/index.bundle?')],
+        favicon: undefined,
+      },
+    });
   });
 
   it('normalizes loader Response data and passes dynamic params to metadata', async () => {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -2,9 +2,90 @@ import type { SerialAsset } from '@expo/metro-config/src/serializer/serializerAs
 
 import {
   serializeHtmlWithAssets,
+  serialAssetsToStaticContentAssets,
   assetsRequiresSort,
   sortMatchedAssetsByEntryPoints,
 } from '../serializeHtml';
+
+describe(serialAssetsToStaticContentAssets, () => {
+  const js = (filename: string, metadata: any): SerialAsset =>
+    ({ filename, originFilename: filename, type: 'js', metadata, source: '' }) as any;
+
+  it('builds linked CSS and dependency-ordered, route-scoped JS when exporting', () => {
+    const resources: SerialAsset[] = [
+      {
+        type: 'css-external',
+        filename: 'https://x/y.css',
+        originFilename: 'y',
+        source: '<link rel="stylesheet" href="https://x/y.css">',
+        metadata: {},
+      } as any,
+      {
+        type: 'css',
+        filename: 'dist/styles.css',
+        originFilename: 'styles',
+        source: '',
+        metadata: {},
+      } as any,
+      js('dist/runtime.js', { isAsync: false, requires: [], modulePaths: [] }),
+      js('dist/entry.js', { isAsync: false, requires: ['dist/runtime.js'], modulePaths: [] }),
+      js('dist/chunk-page.js', { isAsync: true, requires: [], modulePaths: ['/app/[slug].tsx'] }),
+      js('dist/chunk-layout.js', {
+        isAsync: true,
+        requires: [],
+        modulePaths: ['/app/_layout.tsx'],
+      }),
+      js('dist/chunk-unrelated.js', {
+        isAsync: true,
+        requires: [],
+        modulePaths: ['/app/other.tsx'],
+      }),
+    ];
+    const route = {
+      contextKey: './[slug].tsx',
+      entryPoints: ['/app/_layout.tsx', '/app/[slug].tsx'],
+    } as any;
+
+    const assets = serialAssetsToStaticContentAssets(resources, {
+      isExporting: true,
+      baseUrl: '',
+      route,
+    });
+
+    expect(assets.js).toEqual([
+      '/dist/runtime.js',
+      '/dist/chunk-layout.js',
+      '/dist/chunk-page.js',
+      '/dist/entry.js',
+    ]);
+    expect(assets.css).toEqual([
+      { type: 'external', source: '<link rel="stylesheet" href="https://x/y.css">' },
+      { type: 'css', href: '/dist/styles.css' },
+    ]);
+  });
+
+  it('builds inline CSS and a single dev bundle in development', () => {
+    const resources: SerialAsset[] = [
+      {
+        type: 'css',
+        filename: 'dist/a.css',
+        originFilename: 'a',
+        source: '.a{}',
+        metadata: { hmrId: 'a' },
+      } as any,
+      js('dist/ignored.js', { isAsync: false, requires: [], modulePaths: [] }),
+    ];
+
+    const assets = serialAssetsToStaticContentAssets(resources, {
+      isExporting: false,
+      baseUrl: '',
+      bundleUrl: '/index.bundle?platform=web',
+    });
+
+    expect(assets.css).toEqual([{ type: 'inline', source: '.a{}', hmrId: 'a' }]);
+    expect(assets.js).toEqual(['/index.bundle?platform=web']);
+  });
+});
 
 it('serializes development static html', () => {
   const res = serializeHtmlWithAssets({

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -1,8 +1,7 @@
 import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import {
-  createInjectedCssAsString,
-  createInjectedScriptsAsString,
-  getHydrationFlagScriptAsString,
+  injectAssetsIntoHtml,
+  type StaticContentAssets,
 } from '@expo/router-server/build/utils/html';
 import type { RouteNode } from 'expo-router/build/Route';
 
@@ -29,14 +28,13 @@ export function serializeHtmlWithAssets({
   if (!resources) {
     return '';
   }
-  return htmlFromSerialAssets(resources, {
+  const assets = serialAssetsToStaticContentAssets(resources, {
     isExporting,
-    template,
     baseUrl,
     bundleUrl: isExporting ? undefined : devBundleUrl,
     route,
-    hydrate,
   });
+  return injectAssetsIntoHtml(template, { assets, hydrate });
 }
 
 /**
@@ -55,40 +53,42 @@ function combineUrlPath(baseUrl: string, ...segments: string[]) {
     .join('/');
 }
 
-function htmlFromSerialAssets(
+export function serialAssetsToStaticContentAssets(
   assets: SerialAsset[],
   {
     isExporting,
-    template,
     baseUrl,
     bundleUrl,
     route,
-    hydrate,
+    favicon,
   }: {
     isExporting: boolean;
-    template: string;
     baseUrl: string;
-    /** This is dev-only. */
     bundleUrl?: string;
     route?: RouteNode;
-    hydrate?: boolean;
+    favicon?: string;
   }
-) {
-  // Combine the CSS modules into tags that have hot refresh data attributes.
-  const styleString = assets
-    .filter((asset) => asset.type.startsWith('css'))
-    .map(({ type, metadata, filename, source }) => {
-      if (type === 'css') {
-        if (isExporting) {
-          return createInjectedCssAsString([combineUrlPath(baseUrl, filename)]);
-        } else {
-          return `<style data-expo-css-hmr="${metadata.hmrId}">` + source + '\n</style>';
-        }
+): StaticContentAssets {
+  const css = assets
+    .filter((asset) => asset.type === 'css' || asset.type === 'css-external')
+    .map((asset) => {
+      // NOTE(@hassankhan): External CSS assets are always injected into the HTML as `<link>`s,
+      // both in development and in production
+      if (asset.type === 'css-external') {
+        return { type: 'external' as const, source: asset.source };
       }
-      // External link tags will be passed through as-is.
-      return source;
-    })
-    .join('');
+      // NOTE(@hassankhan): `isExporting` means export-time rendering (SSG/SPA/DOM components),
+      // where CSS is linked from standalone files. In development, we inline CSS into the HTML
+      // document directly for HMR
+      if (isExporting) {
+        return { type: 'css' as const, href: combineUrlPath(baseUrl, asset.filename) };
+      }
+      return { type: 'inline' as const, source: asset.source, hmrId: asset.metadata.hmrId };
+    });
+
+  if (bundleUrl) {
+    return { css, js: [bundleUrl], favicon };
+  }
 
   let orderedJsAssets = assetsRequiresSort(assets.filter((asset) => asset.type === 'js'));
 
@@ -103,46 +103,38 @@ function htmlFromSerialAssets(
     orderedJsAssets = [...runtimeAssets, ...sortedAsync, ...entryAssets];
   }
 
-  const scripts = bundleUrl
-    ? `<script src="${bundleUrl}" defer></script>`
-    : orderedJsAssets
-        .map(({ filename, metadata }) => {
-          // TODO: Mark dependencies of the HTML and include them to prevent waterfalls.
-          if (metadata.isAsync) {
-            // We have the data required to match async chunks to the route's HTML file.
-            if (
-              route?.entryPoints &&
-              metadata.modulePaths &&
-              Array.isArray(route.entryPoints) &&
-              Array.isArray(metadata.modulePaths)
-            ) {
-              // TODO: Handle module IDs like `expo-router/build/views/Unmatched.js`
-              const doesAsyncChunkContainRouteEntryPoint = route.entryPoints.some((entryPoint) =>
-                (metadata.modulePaths as string[]).includes(entryPoint)
-              );
-              if (!doesAsyncChunkContainRouteEntryPoint) {
-                return '';
-              }
-              event('html_async_chunk_linked', { filename, contextKey: route.contextKey });
-              // Pass through to the next condition.
-            } else {
-              return '';
-            }
-            // Mark async chunks as defer so they don't block the page load.
-            // return `<script src="${combineUrlPath(baseUrl, filename)" defer></script>`;
-          }
+  const js = orderedJsAssets
+    .filter((asset) => {
+      // Sync assets are always linked in the HTML
+      if (!asset.metadata.isAsync) {
+        return true;
+      }
+      // Link async chunks that contain one of the route's entry points in the HTML, so the
+      // route's own code doesn't wait on a dynamic `import()` waterfall; all other async chunks
+      // are left for the runtime to fetch on-demand.
+      // TODO: Mark dependencies of the HTML and include them to prevent waterfalls.
+      // TODO: Handle module IDs like `expo-router/build/views/Unmatched.js`
+      if (
+        route?.entryPoints &&
+        Array.isArray(route.entryPoints) &&
+        Array.isArray(asset.metadata.modulePaths)
+      ) {
+        const matches = route.entryPoints.some((entryPoint) =>
+          (asset.metadata.modulePaths as string[]).includes(entryPoint)
+        );
+        if (matches) {
+          event('html_async_chunk_linked', {
+            filename: asset.filename,
+            contextKey: route.contextKey,
+          });
+        }
+        return matches;
+      }
+      return false;
+    })
+    .map((asset) => combineUrlPath(baseUrl, asset.filename));
 
-          return createInjectedScriptsAsString([combineUrlPath(baseUrl, filename)]);
-        })
-        .join('');
-
-  if (hydrate) {
-    template = template.replace('</head>', `${getHydrationFlagScriptAsString()}</head>`);
-  }
-
-  return template
-    .replace('</head>', `${styleString}</head>`)
-    .replace('</body>', `${scripts}\n</body>`);
+  return { css, js, favicon };
 }
 
 /**

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Internal] Inject CSS and JavaScript bundle tags within `getStaticContent()`. ([#47006](https://github.com/expo/expo/pull/47006) by [@hassankhan](https://github.com/hassankhan))
+
 ## 57.0.4 - 2026-07-22
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/router-server/src/static/renderStaticContent.tsx
+++ b/packages/@expo/router-server/src/static/renderStaticContent.tsx
@@ -15,11 +15,10 @@ import ReactDOMServer from 'react-dom/server';
 
 import { createDebug } from '../utils/debug';
 import {
-  createFaviconAsString,
-  createInjectedCssAsString,
-  createInjectedScriptsAsString,
   createLoaderDataScriptAsString,
+  injectAssetsIntoHtml,
   serializeHelmetToHtml,
+  type StaticContentAssets,
 } from '../utils/html';
 import { getRootComponent } from './getRootComponent';
 
@@ -42,13 +41,8 @@ export type GetStaticContentOptions = {
     key: string;
   };
   request?: Request;
-  /** Asset manifest for hydration bundles (JS/CSS). Used in SSR. */
-  assets?: {
-    css: string[];
-    js: string[];
-    /** Public href of a favicon generated from `web.favicon` in the app config. */
-    favicon?: string;
-  };
+  hydrate?: boolean;
+  assets?: StaticContentAssets;
 };
 
 /**
@@ -120,26 +114,7 @@ export async function getStaticContent(
       output = output.replace('</head>', `${createLoaderDataScriptAsString(loadedData)}</head>`);
     }
 
-    // Inject favicon link tag. Mirrors `assets.favicon` handling in `getStreamingContent`.
-    if (options?.assets?.favicon) {
-      output = output.replace('</head>', `${createFaviconAsString(options.assets.favicon)}</head>`);
-    }
-
-    // Inject hydration assets (JS/CSS bundles). Used in SSR mode
-    if (options?.assets) {
-      if (options.assets.css.length > 0) {
-        const injectedCSS = createInjectedCssAsString(options.assets.css);
-        output = output.replace('</head>', `${injectedCSS}\n</head>`);
-      }
-
-      if (options.assets.js.length > 0) {
-        // In non-streaming mode, use deferred scripts in the body
-        output = output.replace(
-          '</body>',
-          `${createInjectedScriptsAsString(options.assets.js)}\n</body>`
-        );
-      }
-    }
+    output = injectAssetsIntoHtml(output, { assets: options?.assets, hydrate: options?.hydrate });
 
     return '<!DOCTYPE html>' + output;
   });

--- a/packages/@expo/router-server/src/utils/__tests__/html.test.ts
+++ b/packages/@expo/router-server/src/utils/__tests__/html.test.ts
@@ -5,6 +5,7 @@ import {
   createLoaderDataScriptAsString,
   escapeUnsafeCharacters,
   getHydrationFlagScriptAsString,
+  injectAssetsIntoHtml,
   serializeHelmetToHtml,
 } from '../html';
 
@@ -130,6 +131,109 @@ describe(createLoaderDataScriptAsString, () => {
   });
 });
 
+describe(injectAssetsIntoHtml, () => {
+  const TEMPLATE = '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>';
+
+  it('returns the template unchanged when there is nothing to inject', () => {
+    expect(injectAssetsIntoHtml(TEMPLATE, {})).toBe(TEMPLATE);
+    expect(injectAssetsIntoHtml(TEMPLATE, { assets: { css: [], js: [] } })).toBe(TEMPLATE);
+  });
+
+  it('injects the favicon before the hydration flag and styles', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, {
+      hydrate: true,
+      assets: { css: [{ type: 'css', href: '/a.css' }], js: [], favicon: '/favicon.ico' },
+    });
+    expect(result).toContain(
+      expectedHead([
+        '<link rel="icon" href="/favicon.ico"/>',
+        '<script type="module">globalThis.__EXPO_ROUTER_HYDRATE__=true;</script>',
+        '<link rel="preload" href="/a.css" as="style">\n<link rel="stylesheet" href="/a.css">',
+      ])
+    );
+  });
+
+  it('only injects the hydration flag when `hydrate` is truthy', () => {
+    expect(injectAssetsIntoHtml(TEMPLATE, { hydrate: false })).not.toContain(
+      '__EXPO_ROUTER_HYDRATE__'
+    );
+    expect(injectAssetsIntoHtml(TEMPLATE, {})).not.toContain('__EXPO_ROUTER_HYDRATE__');
+    expect(injectAssetsIntoHtml(TEMPLATE, { hydrate: true })).toContain('__EXPO_ROUTER_HYDRATE__');
+  });
+
+  it('treats legacy plain-string CSS entries as bundled hrefs', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, {
+      assets: { css: ['/a.css'], js: [] },
+    });
+    expect(result).toContain(
+      expectedHead([
+        '<link rel="preload" href="/a.css" as="style">\n<link rel="stylesheet" href="/a.css">',
+      ])
+    );
+  });
+
+  it('injects export CSS hrefs as link tags, joined without separators', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, {
+      assets: {
+        css: [
+          { type: 'css', href: '/a.css' },
+          { type: 'css', href: '/b.css' },
+        ],
+        js: [],
+      },
+    });
+    expect(result).toContain(
+      expectedHead([
+        '<link rel="preload" href="/a.css" as="style">\n<link rel="stylesheet" href="/a.css">',
+        '<link rel="preload" href="/b.css" as="style">\n<link rel="stylesheet" href="/b.css">',
+      ])
+    );
+  });
+
+  it('injects development inline CSS as style tags with HMR IDs', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, {
+      assets: {
+        css: [
+          { type: 'inline', source: '.a{}', hmrId: 'a' },
+          { type: 'inline', source: '.b{}', hmrId: 'b' },
+        ],
+        js: [],
+      },
+    });
+    expect(result).toContain(
+      expectedHead([
+        '<style data-expo-css-hmr="a">.a{}\n</style>',
+        '<style data-expo-css-hmr="b">.b{}\n</style>',
+      ])
+    );
+  });
+
+  it('preserves the original order of bundled and external CSS entries', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, {
+      assets: {
+        css: [
+          { type: 'external', source: '<link rel="stylesheet" href="https://x/y.css">' },
+          { type: 'css', href: '/a.css' },
+        ],
+        js: [],
+      },
+    });
+    expect(result).toContain(
+      expectedHead([
+        '<link rel="stylesheet" href="https://x/y.css">',
+        '<link rel="preload" href="/a.css" as="style">\n<link rel="stylesheet" href="/a.css">',
+      ])
+    );
+  });
+
+  it('injects JS as deferred scripts before </body>, joined without separators', () => {
+    const result = injectAssetsIntoHtml(TEMPLATE, { assets: { css: [], js: ['/a.js', '/b.js'] } });
+    expect(result).toContain(
+      expectedBody(['<script src="/a.js" defer></script>', '<script src="/b.js" defer></script>'])
+    );
+  });
+});
+
 describe(serializeHelmetToHtml, () => {
   it.each([null, undefined])('returns empty strings for %j helmet', () => {
     expect(serializeHelmetToHtml(null)).toEqual({
@@ -177,3 +281,11 @@ describe(serializeHelmetToHtml, () => {
     expect(result.bodyAttributes).toBe('');
   });
 });
+
+function expectedHead(parts: string[]): string {
+  return [...parts, '</head>'].join('');
+}
+
+function expectedBody(parts: string[]): string {
+  return [...parts, '\n</body>'].join('');
+}

--- a/packages/@expo/router-server/src/utils/html.ts
+++ b/packages/@expo/router-server/src/utils/html.ts
@@ -115,6 +115,68 @@ export function createLoaderDataScriptAsString(data: Record<string, unknown>): s
   return `<script id="expo-router-data">${getLoaderDataScriptContents(data)}</script>`;
 }
 
+export type StaticContentCssAsset =
+  | { type: 'css'; href: string }
+  | { type: 'inline'; source: string; hmrId?: string }
+  | { type: 'external'; source: string };
+
+export type StaticContentAssets = {
+  /**
+   * NOTE(@hassankhan): We still need to support SDK 55 deployments, where CSS assets are
+   * exported as plain hrefs
+   */
+  css: (StaticContentCssAsset | string)[];
+  js: string[];
+  favicon?: string;
+};
+
+/**
+ * Injects favicon, hydration flag, and CSS (in that order) before `</head>`, and deferred scripts
+ * before `</body>`.
+ */
+export function injectAssetsIntoHtml(
+  html: string,
+  { assets, hydrate }: { assets?: StaticContentAssets; hydrate?: boolean }
+): string {
+  if (assets?.favicon) {
+    html = html.replace('</head>', `${createFaviconAsString(assets.favicon)}</head>`);
+  }
+
+  if (hydrate) {
+    html = html.replace('</head>', `${getHydrationFlagScriptAsString()}</head>`);
+  }
+
+  if (assets) {
+    const styleString = assets.css
+      .map((entry) => {
+        // NOTE(@hassankhan): We still need to support SDK 55 deployments, where CSS assets are
+        // exported as plain hrefs
+        if (typeof entry === 'string') {
+          return createInjectedCssAsString([entry]);
+        }
+        switch (entry.type) {
+          case 'css':
+            return createInjectedCssAsString([entry.href]);
+          case 'inline':
+            return `<style data-expo-css-hmr="${entry.hmrId}">${entry.source}\n</style>`;
+          case 'external':
+            return entry.source;
+        }
+      })
+      .join('');
+    if (styleString) {
+      html = html.replace('</head>', `${styleString}</head>`);
+    }
+
+    const scripts = assets.js.map((src) => createInjectedScriptsAsString([src])).join('');
+    if (scripts) {
+      html = html.replace('</body>', `${scripts}\n</body>`);
+    }
+  }
+
+  return html;
+}
+
 const HELMET_HEAD_KEYS = ['title', 'priority', 'meta', 'link', 'script', 'style'] as const;
 
 /**


### PR DESCRIPTION
# Why

Currently, SSR and SSG inject assets into the HTML at different places. SSR passes an assets manifest into `getStaticContent()`, which injects the tags during rendering. SSG and the dev server instead use a HTML template and run an string-replace pass in the CLI using `serializeHtmlWithAssets()`.

This PR moves all paths onto the SSR-style mechanism, every caller now passes an assets manifest into `getStaticContent()` where they are injected into the HTML.

# How

- `@expo/router-server`: added `injectAssetsIntoHtml()` and a `StaticContentAssets` type. `getStaticContent()` now accepts `hydrate` and `assets` properties, and replaces its previous inline favicon/CSS/JS handling with `injectAssetsIntoHtml()`. 
- `@expo/cli`: replaced `htmlFromSerialAssets()` with `serialAssetsToStaticContentAssets()`, which converts Metro `SerialAsset`s into `StaticContentAssets`.
- The dev server and SSG export pipeline now pass `assets`/`hydrate` into `getStaticContent()` and no longer post-process the returned HTML. 
- CSS assets are now a list of entries with a `type` property denoting either `inline`, `css` or `external`. They are also serialized in-order, so `css` entries that rely on an `external` stylesheet being first are now handled correctly.
- Legacy `assets.css` entries (which were an array of `href` strings) are now normalized as `css` entries for backwards-compatibility (see also #48351).

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
