### PR TITLE
[network][Android] Remove legacy `fetchNetworkState` path

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Remove legacy `fetchNetworkState` path. ([#47007](https://github.com/expo/expo/pull/47007) by [@Wenszel](https://github.com/Wenszel))
+
 ## 56.0.4 — 2026-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -2,12 +2,9 @@ package expo.modules.network
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkInfo
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -188,36 +185,22 @@ class NetworkModule : Module() {
     val result = Bundle()
 
     try {
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) { // use getActiveNetworkInfo before api level 29
-        val netInfo = connectivityManager.activeNetworkInfo
-        val connectionType = getConnectionType(netInfo)
-        val isInternetReachable = isInternetReachable(connectivityManager)
+      val network = connectivityManager.activeNetwork
+      val isInternetReachable = isInternetReachable(connectivityManager)
 
-        result.apply {
-          putBoolean("isInternetReachable", isInternetReachable)
-          putString("type", connectionType.value)
-          putBoolean("isConnected", connectionType.isDefined)
-        }
-
-        return result
+      val connectionType = if (network != null) {
+        val netCapabilities = connectivityManager.getNetworkCapabilities(network)
+        getConnectionType(netCapabilities)
       } else {
-        val network = connectivityManager.activeNetwork
-        val isInternetReachable = isInternetReachable(connectivityManager)
-
-        val connectionType = if (network != null) {
-          val netCapabilities = connectivityManager.getNetworkCapabilities(network)
-          getConnectionType(netCapabilities)
-        } else {
-          null
-        }
-
-        result.apply {
-          putString("type", connectionType?.value ?: NetworkStateType.NONE.value)
-          putBoolean("isInternetReachable", isInternetReachable)
-          putBoolean("isConnected", connectionType != null && connectionType.isDefined)
-        }
-        return result
+        null
       }
+
+      result.apply {
+        putString("type", connectionType?.value ?: NetworkStateType.NONE.value)
+        putBoolean("isInternetReachable", isInternetReachable)
+        putBoolean("isConnected", connectionType != null && connectionType.isDefined)
+      }
+      return result
     } catch (e: Exception) {
       result.apply {
         putString("type", NetworkStateType.UNKNOWN.value)
@@ -236,17 +219,6 @@ class NetworkModule : Module() {
       Log.e(TAG, e.message ?: "expo-network could not acquire Wi-Fi information")
       throw NetworkWifiException(e)
     }
-
-  private fun getConnectionType(netInfo: NetworkInfo?): NetworkStateType = when (netInfo?.type) {
-    ConnectivityManager.TYPE_MOBILE,
-    ConnectivityManager.TYPE_MOBILE_DUN -> NetworkStateType.CELLULAR
-    ConnectivityManager.TYPE_WIFI -> NetworkStateType.WIFI
-    ConnectivityManager.TYPE_BLUETOOTH -> NetworkStateType.BLUETOOTH
-    ConnectivityManager.TYPE_ETHERNET -> NetworkStateType.ETHERNET
-    ConnectivityManager.TYPE_WIMAX -> NetworkStateType.WIMAX
-    ConnectivityManager.TYPE_VPN -> NetworkStateType.VPN
-    else -> NetworkStateType.UNKNOWN
-  }
 
   private fun getConnectionType(netCapabilities: NetworkCapabilities?): NetworkStateType =
     when {


### PR DESCRIPTION
# Why
This PR is part of a series aimed at removing compilation warnings.

It removes the following warnings:
```gradle
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:7:8` - 'class NetworkInfo : Any, Parcelable' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:192:43` - 'val activeNetworkInfo: NetworkInfo?' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:240:42` - 'class NetworkInfo : Any, Parcelable' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:240:91` - 'val type: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:241:25` - 'static field TYPE_MOBILE: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:242:25` - 'static field TYPE_MOBILE_DUN: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:243:25` - 'static field TYPE_WIFI: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:244:25` - 'static field TYPE_BLUETOOTH: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:245:25` - 'static field TYPE_ETHERNET: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:246:25` - 'static field TYPE_WIMAX: Int' is deprecated. Deprecated in Java.
`packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:247:25` - 'static field TYPE_VPN: Int' is deprecated. Deprecated in Java.
```
# How

This split was originally added because `NetworkInfo` was deprecated in Android API 29. Back then we still supported API 21, so we had to keep the legacy path for older Android versions. Now that our minimum supported API is 24, the < Q branch is no longer needed.

Worth noting that this can potentially be a breaking change for devices running Android API 24-28, since we don’t know if `NetworkCapabilities` returns exactly the same network type values as `NetworkInfo`.

# Test Plan
BareExpo ✅