### PR TITLE
[dev-launcher] Override defaultLaunchURL via env var + add plugin tests

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -95,6 +95,7 @@ You can configure development client launcher using its built-in [config plugin]
       description: [
         'Launch directly into this URL instead of navigating to launcher screen.',
         'If `launchMode` is set to `most-recent`, then launcher will use the `defaultLaunchURL` as a fallback.',
+        'Set the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment variable to override this property at build time, which is useful for headless, CI, or multi-server build scripts.',
       ].join('\n'),
     },
     {

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [plugin] Allow overriding the `defaultLaunchURL` option at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment variable, and add plugin tests for `defaultLaunchURL`. ([#PR](https://github.com/expo/expo/pull/PR) by [@qwertey6](https://github.com/qwertey6))
+- [plugin] Allow overriding the `defaultLaunchURL` option at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment variable, and add plugin tests for `defaultLaunchURL`. ([#47009](https://github.com/expo/expo/pull/47009) by [@qwertey6](https://github.com/qwertey6))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Allow overriding the `defaultLaunchURL` option at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment variable, and add plugin tests for `defaultLaunchURL`. ([#PR](https://github.com/expo/expo/pull/PR) by [@qwertey6](https://github.com/qwertey6))
+
 ### 🐛 Bug fixes
 
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -35,6 +35,9 @@ export type PluginConfigOptions = {
     /**
      * Instead of navigating to launcher screen launch directly into this URL.
      * If `launchMode` is set to `most-recent` then launcher will use the defaultLaunchURL if launching previously opened project fails.
+     *
+     * Can be overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment
+     * variable, which takes precedence over this property (and its per-platform variants).
      */
     defaultLaunchURL?: string;
     /**

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,4 +1,16 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
 import { PluginConfigType } from './pluginConfig';
+/**
+ * Resolves the dev launcher's `defaultLaunchURL` for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` env var — a build-time override, useful for headless/CI
+ *    or multi-server build scripts that set the URL per build invocation rather than in app config.
+ * 2. platform-specific `android.defaultLaunchURL` / `ios.defaultLaunchURL`
+ * 3. top-level `defaultLaunchURL`
+ *
+ * @ignore
+ */
+export declare function resolveDefaultLaunchURL(props: PluginConfigType, platform: 'ios' | 'android', env?: NodeJS.ProcessEnv): string | undefined;
 declare const _default: ConfigPlugin<PluginConfigType>;
 export default _default;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -1,8 +1,25 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveDefaultLaunchURL = resolveDefaultLaunchURL;
 const config_plugins_1 = require("expo/config-plugins");
 const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('../../package.json');
+/**
+ * Resolves the dev launcher's `defaultLaunchURL` for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` env var — a build-time override, useful for headless/CI
+ *    or multi-server build scripts that set the URL per build invocation rather than in app config.
+ * 2. platform-specific `android.defaultLaunchURL` / `ios.defaultLaunchURL`
+ * 3. top-level `defaultLaunchURL`
+ *
+ * @ignore
+ */
+function resolveDefaultLaunchURL(props, platform, env = process.env) {
+    return (env.EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL ??
+        props[platform]?.defaultLaunchURL ??
+        props.defaultLaunchURL);
+}
 /**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
  * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
@@ -102,8 +119,8 @@ const withLocalNetworkPermission = (config) => {
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
     (0, pluginConfig_1.validateConfig)(props);
-    const androidDefaultLaunchURL = props.android?.defaultLaunchURL ?? props.defaultLaunchURL;
-    const iosDefaultLaunchURL = props.ios?.defaultLaunchURL ?? props.defaultLaunchURL;
+    const androidDefaultLaunchURL = resolveDefaultLaunchURL(props, 'android');
+    const iosDefaultLaunchURL = resolveDefaultLaunchURL(props, 'ios');
     const iOSLaunchMode = props.ios?.launchMode ??
         props.launchMode ??
         props.ios?.launchModeExperimental ??

--- a/packages/expo-dev-launcher/plugin/jest.config.js
+++ b/packages/expo-dev-launcher/plugin/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
@@ -1,0 +1,54 @@
+import { validateConfig } from '../pluginConfig';
+import { resolveDefaultLaunchURL } from '../withDevLauncher';
+
+describe(resolveDefaultLaunchURL, () => {
+  const emptyEnv: NodeJS.ProcessEnv = {};
+
+  it(`returns undefined when nothing is configured`, () => {
+    expect(resolveDefaultLaunchURL({}, 'ios', emptyEnv)).toBeUndefined();
+    expect(resolveDefaultLaunchURL({}, 'android', emptyEnv)).toBeUndefined();
+  });
+
+  it(`uses the top-level value for both platforms`, () => {
+    const props = { defaultLaunchURL: 'http://localhost:8081' };
+    expect(resolveDefaultLaunchURL(props, 'ios', emptyEnv)).toBe('http://localhost:8081');
+    expect(resolveDefaultLaunchURL(props, 'android', emptyEnv)).toBe('http://localhost:8081');
+  });
+
+  it(`prefers the platform-specific value over the top-level one`, () => {
+    const props = {
+      defaultLaunchURL: 'http://localhost:8081',
+      ios: { defaultLaunchURL: 'http://localhost:8082' },
+    };
+    expect(resolveDefaultLaunchURL(props, 'ios', emptyEnv)).toBe('http://localhost:8082');
+    // android has no override, so it falls back to the top-level value
+    expect(resolveDefaultLaunchURL(props, 'android', emptyEnv)).toBe('http://localhost:8081');
+  });
+
+  it(`lets the EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL env var override everything`, () => {
+    const props = {
+      defaultLaunchURL: 'http://localhost:8081',
+      ios: { defaultLaunchURL: 'http://localhost:8082' },
+    };
+    const env = { EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL: 'http://10.0.0.2:9000' };
+    expect(resolveDefaultLaunchURL(props, 'ios', env)).toBe('http://10.0.0.2:9000');
+    expect(resolveDefaultLaunchURL(props, 'android', env)).toBe('http://10.0.0.2:9000');
+  });
+});
+
+describe(validateConfig, () => {
+  it(`accepts a defaultLaunchURL string (top-level and per-platform)`, () => {
+    expect(() => validateConfig({ defaultLaunchURL: 'http://localhost:8081' })).not.toThrow();
+    expect(() =>
+      validateConfig({ ios: { defaultLaunchURL: 'http://localhost:8082' } })
+    ).not.toThrow();
+    expect(() =>
+      validateConfig({ android: { defaultLaunchURL: 'http://localhost:8083' } })
+    ).not.toThrow();
+  });
+
+  it(`rejects a non-string defaultLaunchURL`, () => {
+    // @ts-expect-error intentionally invalid type
+    expect(() => validateConfig({ defaultLaunchURL: 8081 })).toThrow();
+  });
+});

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -39,6 +39,9 @@ export type PluginConfigOptions = {
   /**
    * Instead of navigating to launcher screen launch directly into this URL.
    * If `launchMode` is set to `most-recent` then launcher will use the defaultLaunchURL if launching previously opened project fails.
+   *
+   * Can be overridden at build time with the `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` environment
+   * variable, which takes precedence over this property (and its per-platform variants).
    */
   defaultLaunchURL?: string;
   /**

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -12,6 +12,29 @@ import { PluginConfigType, validateConfig } from './pluginConfig';
 const pkg = require('../../package.json');
 
 /**
+ * Resolves the dev launcher's `defaultLaunchURL` for the given platform.
+ *
+ * Precedence (highest first):
+ * 1. `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` env var — a build-time override, useful for headless/CI
+ *    or multi-server build scripts that set the URL per build invocation rather than in app config.
+ * 2. platform-specific `android.defaultLaunchURL` / `ios.defaultLaunchURL`
+ * 3. top-level `defaultLaunchURL`
+ *
+ * @ignore
+ */
+export function resolveDefaultLaunchURL(
+  props: PluginConfigType,
+  platform: 'ios' | 'android',
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return (
+    env.EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL ??
+    props[platform]?.defaultLaunchURL ??
+    props.defaultLaunchURL
+  );
+}
+
+/**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
  * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
  * but removes only the dev-launcher entries from production builds.
@@ -132,8 +155,8 @@ export default createRunOncePlugin<PluginConfigType>(
   (config, props = {}) => {
     validateConfig(props);
 
-    const androidDefaultLaunchURL = props.android?.defaultLaunchURL ?? props.defaultLaunchURL;
-    const iosDefaultLaunchURL = props.ios?.defaultLaunchURL ?? props.defaultLaunchURL;
+    const androidDefaultLaunchURL = resolveDefaultLaunchURL(props, 'android');
+    const iosDefaultLaunchURL = resolveDefaultLaunchURL(props, 'ios');
     const iOSLaunchMode =
       props.ios?.launchMode ??
       props.launchMode ??


### PR DESCRIPTION
# Why

Follow-up to #44419 (`defaultLaunchURL`). Two small additive pieces:

1. **Build-time env override.** `defaultLaunchURL` is currently declarative-only (set in app config). An env var is convenient for **headless / CI / agent-driven** workflows and **multi-server** build scripts that run several apps on fixed, dedicated ports and want to set the dev server URL *per build invocation* rather than editing each app's config.

2. **Tests.** The `defaultLaunchURL` option shipped without any plugin tests. Notably, the iOS cold-start no-op fixed in #46185 is exactly the kind of regression test coverage would have caught — so this also adds the first unit tests for the `expo-dev-launcher` config plugin.

This closes the gap left by my earlier duplicate PR (#46980, now closed): rather than land a redundant `defaultServerUrl` option, this contributes only the deltas on top of the existing `defaultLaunchURL`.

# How

- Extract `resolveDefaultLaunchURL(props, platform, env)` with precedence: `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` env var → platform-specific `android.defaultLaunchURL`/`ios.defaultLaunchURL` → top-level `defaultLaunchURL`. The resolved value still writes the same `DEV_CLIENT_DEFAULT_LAUNCHER_URL` native key, so no native changes are needed.
- Add plugin tests (`resolveDefaultLaunchURL` precedence + `validateConfig` accepting/rejecting `defaultLaunchURL`). Wires up the plugin's previously-empty `jest.config.js` to the standard `expo-module-scripts` plugin preset.
- Document the env var on the `defaultLaunchURL` reference entry; JSDoc + CHANGELOG.
- Regenerated committed `plugin/build/` artifacts.

# Test Plan

- `expo-dev-launcher/plugin` test suite passes (6 tests).
- Plugin typechecks; `build/` regenerated.
- Env var override verified by unit test (env beats both per-platform and top-level props).

# Notes

- Env var name `EXPO_DEV_LAUNCHER_DEFAULT_LAUNCH_URL` chosen to mirror the `defaultLaunchURL` prop and the `EXPO_*` convention — happy to rename if you'd prefer a different scheme.
- No behavior change when the env var is unset; purely additive.