### PR TITLE
[android][updates] Use OkHttpClientProvider in FileDownloader

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 💡 Others
 
+- [Android] Use `OkHttpClientProvider` instead of raw `OkHttpClient` in `FileDownloader` so React Native's shared client and its interceptors are applied. ([#46926](https://github.com/expo/expo/pull/46926) by [@cortinico](https://github.com/cortinico))
 - [Android] Log purge completion errors via `android.util.Log.e` directly instead of `logger.error`, so the failure path doesn't re-enter the `PersistentFileLog` dispatch queue from inside one of its own tasks. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 
 ## 56.0.17 — 2026-05-26

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.loader
 
 import androidx.annotation.VisibleForTesting
+import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.jsonutils.require
 import expo.modules.structuredheaders.Dictionary
 import expo.modules.structuredheaders.OuterList
@@ -71,7 +72,7 @@ class FileDownloader(
   // If the configured launch wait milliseconds is greater than the okhttp default (10_000)
   // we should use that as the timeout. For example, let's say launchWaitMs is 20 seconds,
   // the HTTP timeout should be at least 20 seconds.
-  private var client: OkHttpClient = OkHttpClient.Builder()
+  private var client: OkHttpClient = OkHttpClientProvider.getOkHttpClient().newBuilder()
     .cache(getCache())
     .connectTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)
     .readTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)


### PR DESCRIPTION
# Why

Use React Native's shared OkHttpClient via OkHttpClientProvider instead
of constructing a bare OkHttpClient, so its interceptors are applied.
The dedicated cache, timeouts, and CompressionInterceptor are preserved
via newBuilder().

# Test Plan

Tested in my local app

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
