### PR TITLE
[dom-webview][ios] Fix DOM component props containing double quotes

### DIFF
--- a/packages/@expo/dom-webview/ios/DomWebView.swift
+++ b/packages/@expo/dom-webview/ios/DomWebView.swift
@@ -207,7 +207,7 @@ internal final class DomWebView: ExpoView, UIScrollViewDelegate, WKUIDelegate, W
       let script = """
       window.ReactNativeWebView = window.ReactNativeWebView || {};
       window.ReactNativeWebView.injectedObjectJson = function () {
-        return `\(source)`;
+        return JSON.stringify(\(source));
       }
       true;
       """


### PR DESCRIPTION
Fixes #47016 

# Why?

Here's a minimal repro to test it in browser console.

```
https://github.com/expo/expo/blob/9be13fd21712607e1d6b6031c4df7b2dbc258952/packages/%40expo/dom-webview/src/DomWebView.tsx#L44
a = JSON.stringify({ font: '"Inter"' });  

// https://github.com/expo/expo/blob/9be13fd21712607e1d6b6031c4df7b2dbc258952/packages/%40expo/dom-webview/ios/DomWebView.swift#L228
b = new Function('return `' + source + '`;');    

// https://github.com/expo/expo/blob/9be13fd21712607e1d6b6031c4df7b2dbc258952/packages/%40expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts#L122
JSON.parse(b())
// throws error
```


## How?

Add `JSON.stringify` to function returned object so it stays compatible with `JSON.parse`.


## Test Plan

Tested the original user repro.