### PR TITLE
[docs] Add Argent toolkit in ai documentation

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -43,6 +43,7 @@ exceptions:
   - '.*Apple Developer Portal.*'
   - '.*Apple ID.*'
   - '.*Apple Pay.*'
+  - '.*Argent.*'
   - '.*Asset Links.*'
   - '.*Async Storage.*'
   - '.*Autolinking.*'

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -80,7 +80,12 @@ export const home = [
     makePage('mcp.mdx'),
     makeGroup(
       'AI agents',
-      [makePage('agents/claude.mdx'), makePage('agents/codex.mdx'), makePage('agents/cursor.mdx')],
+      [
+        makePage('agents/claude.mdx'),
+        makePage('agents/codex.mdx'),
+        makePage('agents/cursor.mdx'),
+        makePage('agents/argent.mdx'),
+      ],
       {
         expanded: false,
       }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -84,6 +84,14 @@ export const home = [
         makePage('agents/claude.mdx'),
         makePage('agents/codex.mdx'),
         makePage('agents/cursor.mdx'),
+      ],
+      {
+        expanded: false,
+      }
+    ),
+    makeGroup(
+      'Agent toolkits',
+      [
         makePage('agents/argent.mdx'),
       ],
       {

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -80,24 +80,14 @@ export const home = [
     makePage('mcp.mdx'),
     makeGroup(
       'AI agents',
-      [
-        makePage('agents/claude.mdx'),
-        makePage('agents/codex.mdx'),
-        makePage('agents/cursor.mdx'),
-      ],
+      [makePage('agents/claude.mdx'), makePage('agents/codex.mdx'), makePage('agents/cursor.mdx')],
       {
         expanded: false,
       }
     ),
-    makeGroup(
-      'Agent toolkits',
-      [
-        makePage('agents/argent.mdx'),
-      ],
-      {
-        expanded: false,
-      }
-    ),
+    makeGroup('Agent toolkits', [makePage('agents/argent.mdx')], {
+      expanded: false,
+    }),
     makePage('llms.mdx'),
   ]),
   makeSection('Develop', [

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -1,7 +1,7 @@
 ---
 title: Argent and Expo
 sidebar_title: Argent
-description: Use Argent to let your AI agent control, debug, and profile your Expo app on Android Emulators and iOS Simulators.
+description: Use Argent to let your AI agent control, debug, and profile your Expo project on Android Emulators and iOS Simulators.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -20,8 +20,7 @@ import { Terminal } from '~/ui/components/Snippet';
     Argent's CLI requires Node.js version 18 or newer.
   </Requirement>
   <Requirement title="A running Android Emulator or iOS Simulator">
-    For Android, install the Android SDK Platform Tools (`adb`) and make an emulator available on
-    your `PATH`. For iOS, use macOS with Xcode installed.
+    For Android, install the [Android SDK Platform Tools (`adb`)](/workflow/android-studio-emulator/#set-up-android-studio) and make an emulator available on your `PATH`. For iOS, use macOS with [Xcode installed](/workflow/ios-simulator/#setup-xcode-and-watchman).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -20,7 +20,10 @@ import { Terminal } from '~/ui/components/Snippet';
     Argent's CLI requires Node.js version 18 or newer.
   </Requirement>
   <Requirement title="A running Android Emulator or iOS Simulator">
-    For Android, install the [Android SDK Platform Tools (`adb`)](/workflow/android-studio-emulator/#set-up-android-studio) and make an emulator available on your `PATH`. For iOS, use macOS with [Xcode installed](/workflow/ios-simulator/#setup-xcode-and-watchman).
+    For Android, install the [Android SDK Platform Tools
+    (`adb`)](/workflow/android-studio-emulator/#set-up-android-studio) and make an emulator
+    available on your `PATH`. For iOS, use macOS with [Xcode
+    installed](/workflow/ios-simulator/#setup-xcode-and-watchman).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -11,9 +11,9 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-[Argent](https://argent.swmansion.com) is an agentic toolkit from Software Mansion. Where an AI agent like Claude Code or Cursor reads your code and documentation, Argent gives that same agent direct access to your running app: it can **control, debug, and profile** your Expo app on an Android Emulator or iOS Simulator. You set it up once and connect it to your editor through the [Model Context Protocol (MCP)](/mcp/).
+[Argent](https://argent.swmansion.com) is an agentic toolkit from Software Mansion. Where an AI agent like Claude Code or Codex reads your code and documentation, Argent gives that same agent direct access to your running app: it can **control, debug, and profile** your Expo app on an Android Emulator or iOS Simulator. You set it up once and connect it to your editor through the [Model Context Protocol (MCP)](/mcp/).
 
-> **info** Argent is built and maintained by [Software Mansion](https://swmansion.com), not by Expo. It is free to use, with source code under the Apache License 2.0 and proprietary binaries. For the complete list of its capabilities, see the [Argent website](https://argent.swmansion.com).
+> **info** Argent is built and maintained by [Software Mansion](https://swmansion.com). It is free to use, with source code under the Apache License 2.0 and proprietary binaries. For the complete list of its capabilities, see the [Argent website](https://argent.swmansion.com).
 
 <Prerequisites>
   <Requirement title="Node.js 18 or later">
@@ -51,8 +51,6 @@ Your editor launches the Argent MCP server with the `argent` command, so install
     bun: ['$ bun add -g @swmansion/argent'],
   }}
 />
-
-> **info** If your package manager's global bin directory is not on your `PATH` (for example, a Homebrew install of Bun uses **~/.bun/bin**), add it. With Bun, also run `bun pm trust @swmansion/argent` so its postinstall step can finish setting up Argent's device binaries.
 
 </Step>
 
@@ -151,11 +149,10 @@ Argent connects through MCP, so it works alongside Expo's own agent tooling. Pai
   ]}
 />
 
-## Good to know
+## Important notes
 
-- Argent supports Android Emulators and iOS Simulators. It does not target physical devices.
+- Argent supports Android Emulators and iOS Simulators.
 - Let Argent launch or relaunch the app on the device when it can. If you boot the device yourself, Argent may not be able to see system dialogs or native modals.
 - In Expo Go, Argent can control the app, read the React component tree, and run the React profiler. Native profiling needs a development build, because in Expo Go it profiles the Expo Go host app instead of your code.
-- Native profiling uses Instruments on iOS today. Android native profiling is on Argent's roadmap.
 - The React component tree and the React profiler rely on the JavaScript debugging connection, so keep your development server running.
 - For the complete and current list of capabilities, see the [Argent documentation](https://argent.swmansion.com).

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -13,7 +13,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [Argent](https://argent.swmansion.com) is an agentic toolkit from Software Mansion. Where an AI agent like Claude Code or Codex reads your code and documentation, Argent gives that same agent direct access to your running app: it can **control, debug, and profile** your Expo app on an Android Emulator or iOS Simulator. You set it up once and connect it to your editor through the [Model Context Protocol (MCP)](/mcp/).
 
-> **info** Argent is built and maintained by [Software Mansion](https://swmansion.com). It is free to use, with source code under the Apache License 2.0 and proprietary binaries. For the complete list of its capabilities, see the [Argent website](https://argent.swmansion.com).
+> **info** Argent is built and maintained by [Software Mansion](https://swmansion.com) and is free to use. For the complete list of its capabilities, see the [Argent website](https://argent.swmansion.com).
 
 <Prerequisites>
   <Requirement title="Node.js 18 or later">
@@ -21,8 +21,8 @@ import { Terminal } from '~/ui/components/Snippet';
   </Requirement>
   <Requirement title="A running Android Emulator or iOS Simulator">
     For Android, install the [Android SDK Platform Tools
-    (`adb`)](/workflow/android-studio-emulator/#set-up-android-studio) and make an emulator
-    available on your `PATH`. For iOS, use macOS with [Xcode
+    (`adb`)](/workflow/android-studio-emulator/#set-up-android-studio), make sure `adb` is on your
+    `PATH`, and have an emulator available. For iOS, use macOS with [Xcode
     installed](/workflow/ios-simulator/#setup-xcode-and-watchman).
   </Requirement>
 </Prerequisites>

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -1,0 +1,162 @@
+---
+title: Argent and Expo
+sidebar_title: Argent
+description: Use Argent to let your AI agent control, debug, and profile your Expo app on Android Emulators and iOS Simulators.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { Step } from '~/ui/components/Step';
+import { Terminal } from '~/ui/components/Snippet';
+
+[Argent](https://argent.swmansion.com) is an agentic toolkit from Software Mansion. Where an AI agent like Claude Code or Cursor reads your code and documentation, Argent gives that same agent direct access to your running app: it can **control, debug, and profile** your Expo app on an Android Emulator or iOS Simulator. You set it up once and connect it to your editor through the [Model Context Protocol (MCP)](/mcp/).
+
+> **info** Argent is built and maintained by [Software Mansion](https://swmansion.com), not by Expo. It is free to use, with source code under the Apache License 2.0 and proprietary binaries. For the complete list of its capabilities, see the [Argent website](https://argent.swmansion.com).
+
+<Prerequisites>
+  <Requirement title="Node.js 18 or later">
+    Argent's CLI requires Node.js version 18 or newer.
+  </Requirement>
+  <Requirement title="A running Android Emulator or iOS Simulator">
+    For Android, install the Android SDK Platform Tools (`adb`) and make an emulator available on
+    your `PATH`. For iOS, use macOS with Xcode installed.
+  </Requirement>
+</Prerequisites>
+
+## Quick start
+
+<Step label="1">
+
+### Set up Argent
+
+From your Expo project's root directory, run the init command. The wizard detects your editor, registers the Argent MCP server, and copies its skills and agent definitions into your workspace.
+
+<Terminal
+  cmd={{
+    npm: ['$ npx @swmansion/argent init'],
+    yarn: ['$ yarn dlx @swmansion/argent init'],
+    pnpm: ['$ pnpm dlx @swmansion/argent init'],
+    bun: ['$ bunx @swmansion/argent init'],
+  }}
+/>
+
+Your editor launches the Argent MCP server with the `argent` command, so install Argent globally and make sure that command is on your `PATH`. Then restart your editor so it picks up the new configuration.
+
+<Terminal
+  cmd={{
+    npm: ['$ npm install -g @swmansion/argent'],
+    yarn: ['$ yarn global add @swmansion/argent'],
+    pnpm: ['$ pnpm add -g @swmansion/argent'],
+    bun: ['$ bun add -g @swmansion/argent'],
+  }}
+/>
+
+> **info** If your package manager's global bin directory is not on your `PATH` (for example, a Homebrew install of Bun uses **~/.bun/bin**), add it. With Bun, also run `bun pm trust @swmansion/argent` so its postinstall step can finish setting up Argent's device binaries.
+
+</Step>
+
+<Step label="2">
+
+### Run your app on an emulator or simulator
+
+Argent acts on a running app, so start your Expo app on an Android Emulator or iOS Simulator. Use a [development build](/develop/development-builds/introduction/) or test in Expo Go, with the development server running.
+
+<Terminal
+  cmd={[
+    '# Run a development build on an emulator or simulator',
+    '$ npx expo run:android',
+    '$ npx expo run:ios',
+    '',
+    '# Or start the development server and test in Expo Go',
+    '$ npx expo start',
+  ]}
+/>
+
+</Step>
+
+<Step label="3">
+
+### Prompt your agent
+
+Open your project in your editor, then open its agent panel and describe what you want to do with the running app. For example, ask it to launch the app, tap a button, and read the logs.
+
+</Step>
+
+<Step label="4">
+
+### Verify setup
+
+In your agent panel, enter the following prompt to confirm Argent can reach the running app:
+
+```text Example prompt
+Take a screenshot of the running app and describe what's on screen.
+```
+
+If the agent returns a screenshot and describes your app's current screen, Argent is connected correctly.
+
+</Step>
+
+## What Argent lets your agent do
+
+Once connected, your agent can work against the live app on the emulator or simulator:
+
+- **Control**: launch the app, tap, swipe, type into fields, open deep links, and navigate through accessibility trees to run multi-step flows.
+- **Debug**: read console logs, explore the view hierarchy, inspect the React component tree, and examine network requests and their payloads at both the JavaScript and native layers.
+- **Profile**: record React and native profiles together, trace slow React commits to the native stack frames behind them, and surface UI hangs, render cascades, and memory leaks.
+
+## Example prompts
+
+After setup, describe tasks in plain language. For example:
+
+| Task                 | Example prompt                                                                     |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| Smoke-test a flow    | Launch the app, tap through onboarding, and tell me where it breaks from the logs. |
+| Verify the UI        | Take a screenshot of the home screen and confirm the product list rendered.        |
+| Debug a network call | Open the cart screen and show me the failing request and its response payload.     |
+| Inspect React state  | Open the settings screen and show me the React component tree for the toggle row.  |
+| Profile a slowdown   | Profile scrolling the products list and point me to the slowest commit.            |
+| Test a deep link     | Open the app through its deep link and confirm the right screen loads.             |
+
+## Use Argent with the rest of the Expo AI tooling
+
+Argent connects through MCP, so it works alongside Expo's own agent tooling. Pair it with Expo Skills and the Expo MCP Server so your agent knows Expo conventions and can reach your EAS while Argent drives the app.
+
+<BoxLink
+  title="Expo MCP Server"
+  description="Connect the remote Expo MCP Server to give agents live access to Expo documentation and EAS."
+  href="/mcp/#installation-and-setup"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Expo Skills"
+  description="Install the plugin that teaches agents known-good Expo patterns."
+  href="/skills/#install-expo-skills"
+  Icon={BookOpen02Icon}
+/>
+
+## Manage Argent
+
+<Terminal
+  cmd={[
+    '# Refresh to the latest version and configuration',
+    '$ argent update',
+    '',
+    '# List feature flags and their state',
+    '$ argent flags',
+    '',
+    '# Unregister the MCP server and remove Argent',
+    '$ argent remove',
+  ]}
+/>
+
+## Good to know
+
+- Argent supports Android Emulators and iOS Simulators. It does not target physical devices.
+- Let Argent launch or relaunch the app on the device when it can. If you boot the device yourself, Argent may not be able to see system dialogs or native modals.
+- In Expo Go, Argent can control the app, read the React component tree, and run the React profiler. Native profiling needs a development build, because in Expo Go it profiles the Expo Go host app instead of your code.
+- Native profiling uses Instruments on iOS today. Android native profiling is on Argent's roadmap.
+- The React component tree and the React profiler rely on the JavaScript debugging connection, so keep your development server running.
+- For the complete and current list of capabilities, see the [Argent documentation](https://argent.swmansion.com).

--- a/docs/pages/agents/argent.mdx
+++ b/docs/pages/agents/argent.mdx
@@ -121,7 +121,7 @@ After setup, describe tasks in plain language. For example:
 
 ## Use Argent with the rest of the Expo AI tooling
 
-Argent connects through MCP, so it works alongside Expo's own agent tooling. Pair it with Expo Skills and the Expo MCP Server so your agent knows Expo conventions and can reach your EAS while Argent drives the app.
+Argent connects through MCP, so it works alongside Expo's own agent tooling. Pair it with Expo Skills and the Expo MCP Server so your agent knows Expo conventions while Argent drives the app.
 
 <BoxLink
   title="Expo MCP Server"
@@ -152,7 +152,7 @@ Argent connects through MCP, so it works alongside Expo's own agent tooling. Pai
   ]}
 />
 
-## Important notes
+## Limitations and tips
 
 - Argent supports Android Emulators and iOS Simulators.
 - Let Argent launch or relaunch the app on the device when it can. If you boot the device yourself, Argent may not be able to see system dialogs or native modals.

--- a/docs/pages/agents/index.mdx
+++ b/docs/pages/agents/index.mdx
@@ -90,7 +90,7 @@ If the agent replies with the SDK version from **package.json**, the agent is re
 
 ## Agent toolkits
 
-The agents mention in [Pick an agent](#pick-an-agent) read your code and documentation, among other things. To let an agent also act on your Expo project while it runs, pair it with a third-party toolkit. An agent toolkit can then tap through flows, read logs, inspect the React component tree, and profile performance.
+The agents mentioned in [Pick an agent](#pick-an-agent) read your code and documentation, among other things. To let an agent also act on your Expo project while it runs, pair it with a third-party toolkit. An agent toolkit can then tap through flows, read logs, inspect the React component tree, and profile performance.
 
 <BoxLink
   title="Argent"

--- a/docs/pages/agents/index.mdx
+++ b/docs/pages/agents/index.mdx
@@ -87,3 +87,14 @@ Open package.json and tell me which Expo SDK version this project targets.
 ```
 
 If the agent replies with the SDK version from **package.json**, the agent is reading your project correctly.
+
+## Agent toolkits
+
+The agents mention in [Pick an agent](#pick-an-agent) read your code and documentation, among other things. To let an agent also act on your Expo project while it runs, pair it with a third-party toolkit. An agent toolkit can then tap through flows, read logs, inspect the React component tree, and profile performance.
+
+<BoxLink
+  title="Argent"
+  description="An agentic toolkit from Software Mansion that connects over MCP to control, debug, and profile your app on an Android Emulator or iOS Simulator."
+  href="/agents/argent/"
+  Icon={BookOpen02Icon}
+/>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21835

# How

Adds the `agents/argent.mdx` guide covering setup, capabilities, and example prompts, surfaces it from the AI overview (`agents/index.mdx`) and the sidebar (`navigation.js`) under a new `Agent toolkits` group, and adds an `Argent` exception to the Vale `HeadingCase.yml`.

# Test Plan

See preview and proofread.
- https://pr-47026.expo-docs.pages.dev/agents/argent/
- https://pr-47026.expo-docs.pages.dev/agents/#agent-toolkits

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).