### PR TITLE
[test-suite] Disable redundant import/* lint rules

### DIFF
--- a/apps/test-suite/.eslintrc.js
+++ b/apps/test-suite/.eslintrc.js
@@ -3,5 +3,11 @@ module.exports = {
   extends: ['universe/native', 'universe/web'],
   rules: {
     'no-useless-escape': 0,
+    // TODO(@kitten): Disable in universe in general; redundant with TypeScript
+    'import/default': 'off',
+    'import/export': 'off',
+    'import/named': 'off',
+    'import/namespace': 'off',
+    'import/no-duplicates': 'off',
   },
 };


### PR DESCRIPTION
# Why

`pnpm lint` fails in `apps/test-suite` with `import/namespace` errors like `'StringFormat' not found in imported namespace 'Clipboard'` and several `'Android*' not found in imported namespace 'Notifications'`. This surfaced as a failing CI job: https://github.com/expo/expo/actions/runs/27720980721/job/82006044469?pr=46923

These are false positives. The flagged symbols are all enums (`StringFormat`, `AndroidImportance`, `AndroidNotificationVisibility`, `AndroidAudioUsage`, `AndroidAudioContentType`) that genuinely exist, re-exported from their package's entry `.d.ts` via `export *` chains. The `import/namespace` rule (eslint-plugin-import) can't trace enum members through those chained re-exports in declaration files.

It's not limited to those two files either: ~17 test files dereference an enum through a namespace import of an expo package and are all latent candidates for the same false positive. Only Clipboard and Notifications surface today because the rule stops reporting once enough modules fail to resolve.

# How

Disabled `import/namespace` along with the sibling `import/*` rules (`import/default`, `import/export`, `import/named`, `import/no-duplicates`) for `apps/test-suite`, matching what `apps/native-component-list` already does (`.eslintrc.js`). These rules are redundant with TypeScript, which already validates these references.

# Test Plan

`pnpm lint` in `apps/test-suite` now passes with no errors (previously 11).
