### PR TITLE
[network][Android] use `LinkProperties` in `getIpAddressAsync`

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Remove legacy `fetchNetworkState` path. ([#47007](https://github.com/expo/expo/pull/47007) by [@Wenszel](https://github.com/Wenszel))
+- [Android] Use `LinkProperties` in `getIpAddressAsync`. ([#47028](https://github.com/expo/expo/pull/47028) by [@Wenszel](https://github.com/Wenszel))
 
 ## 56.0.4 — 2026-05-19
 

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkExceptions.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkExceptions.kt
@@ -4,6 +4,3 @@ import expo.modules.kotlin.exception.CodedException
 
 internal class NetworkAccessException(e: Exception) :
   CodedException("Unable to access network information", e.cause)
-
-internal class NetworkWifiException(e: Exception) :
-  CodedException("Wi-Fi information could not be acquired", e.cause)

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -3,8 +3,6 @@ package expo.modules.network
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.net.wifi.WifiInfo
-import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -13,10 +11,7 @@ import android.util.Log
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import java.math.BigInteger
-import java.net.InetAddress
-import java.net.UnknownHostException
-import java.nio.ByteOrder
+import java.net.Inet4Address
 
 private val TAG = NetworkModule::class.java.simpleName
 
@@ -135,7 +130,7 @@ class NetworkModule : Module() {
     }
 
     AsyncFunction<String>("getIpAddressAsync") {
-      return@AsyncFunction rawIpToString(wifiInfo.ipAddress)
+      return@AsyncFunction getIpAddress()
     }
 
     AsyncFunction<Boolean>("isAirplaneModeEnabledAsync") {
@@ -211,15 +206,6 @@ class NetworkModule : Module() {
     }
   }
 
-  private val wifiInfo: WifiInfo
-    get() = try {
-      val manager = context.getSystemService(Context.WIFI_SERVICE) as WifiManager
-      manager.connectionInfo
-    } catch (e: Exception) {
-      Log.e(TAG, e.message ?: "expo-network could not acquire Wi-Fi information")
-      throw NetworkWifiException(e)
-    }
-
   private fun getConnectionType(netCapabilities: NetworkCapabilities?): NetworkStateType =
     when {
       netCapabilities == null -> NetworkStateType.UNKNOWN
@@ -231,23 +217,18 @@ class NetworkModule : Module() {
       else -> NetworkStateType.UNKNOWN
     }
 
-  private fun rawIpToString(ipAddress: Int): String {
-    // Convert little-endian to big-endian if needed
-    val ip = if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
-      Integer.reverseBytes(ipAddress)
-    } else {
-      ipAddress
-    }
+  private fun getIpAddress(): String {
+    val network = connectivityManager.activeNetwork ?: return "0.0.0.0"
+    val linkProperties = connectivityManager.getLinkProperties(network) ?: return "0.0.0.0"
+    val addresses = linkProperties.linkAddresses
+      .map { it.address }
+      .filterIsInstance<Inet4Address>()
+      .filterNot { it.isLoopbackAddress || it.isMulticastAddress || it.isAnyLocalAddress }
 
-    var ipByteArray = BigInteger.valueOf(ip.toLong()).toByteArray()
-    if (ipByteArray.size < 4) {
-      ipByteArray = frontPadWithZeros(ipByteArray)
-    }
+    val address = addresses
+      .firstOrNull { !it.isLinkLocalAddress }
+      ?: addresses.firstOrNull()
 
-    return try {
-      InetAddress.getByAddress(ipByteArray).hostAddress as String
-    } catch (e: UnknownHostException) {
-      "0.0.0.0"
-    }
+    return address?.hostAddress ?: "0.0.0.0"
   }
 }

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkUtils.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkUtils.kt
@@ -8,12 +8,6 @@ import android.util.Log
 
 private val TAG = NetworkModule::class.java.simpleName
 
-internal fun frontPadWithZeros(inputArray: ByteArray): ByteArray {
-  val newByteArray = byteArrayOf(0, 0, 0, 0)
-  System.arraycopy(inputArray, 0, newByteArray, 4 - inputArray.size, inputArray.size)
-  return newByteArray
-}
-
 /**
  * Returns whether the device can reach the Internet.
  * Checks that the active network has both the INTERNET and VALIDATED


### PR DESCRIPTION
# Why
This PR is part of a series aimed at removing compilation warnings.
It removes the following warnings:
```gradle
packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:141:51 - 'val ipAddress: Int' is deprecated
packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt:234:15 - 'val connectionInfo: WifiInfo!' is deprecated
```

# How
Changes the implementation of the `getIpAddressAsync` function to use `connectivityManager.getLinkProperties` instead of `WifiInfo`

# Test Plan 

BareExpo ✅