### PR TITLE
[docs] Update Watchman install steps as applicable for SDK 55 and earlier

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -133,6 +133,7 @@ exceptions:
   - '.*HTTPS.*'
   - '.*Info\.plist.*'
   - '.*iOS.*Simulator.*'
+  - '.*JDK.*'
   - '.*JSON.*'
   - '.*JavaScript.*'
   - '.*JavaScriptCore.*'

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -21,7 +21,7 @@ Creating a release build locally for Android requires signing it with an [upload
 <Prerequisites>
   <Requirement title="OpenJDK installed">
     Install an [OpenJDK
-    distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk)
+    distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-jdk)
     to access the `keytool` command.
   </Requirement>
   <Requirement title="android directory generated">

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
@@ -2,7 +2,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-## Install Watchman and JDK
+## Install JDK
 
 <Tabs>
 
@@ -15,6 +15,8 @@ Use a package manager such as [Homebrew](https://brew.sh/) to install the follow
 #### Install dependencies
 
 <Step label="1">
+
+> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
 
 [Install Watchman](https://facebook.github.io/watchman/docs/install#macos) using a tool such as Homebrew:
 
@@ -59,6 +61,8 @@ Install [Java SE Development Kit (JDK)](https://openjdk.org/):
 #### Install dependencies
 
 <Step label="1">
+
+> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
 
 Follow [instructions from the Watchman documentation](https://facebook.github.io/watchman/docs/install#linux) to compile and install it from the source.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
@@ -16,7 +16,7 @@ Use a package manager such as [Homebrew](https://brew.sh/) to install the follow
 
 <Step label="1">
 
-> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
+> **info** Installing Watchman is only required for projects on SDK 55 and earlier.
 
 [Install Watchman](https://facebook.github.io/watchman/docs/install#macos) using a tool such as Homebrew:
 
@@ -62,7 +62,7 @@ Install [Java SE Development Kit (JDK)](https://openjdk.org/):
 
 <Step label="1">
 
-> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
+> **info** Installing Watchman is only required for projects on SDK 55 and earlier.
 
 Follow [instructions from the Watchman documentation](https://facebook.github.io/watchman/docs/install#linux) to compile and install it from the source.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
@@ -34,7 +34,9 @@ To install an iOS Simulator, open **Xcode > Settings... > Components**, and unde
 
 <Step label="4">
 
-### Install Watchman
+### Install Watchman (optional)
+
+> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
 
 [Watchman](https://facebook.github.io/watchman/docs/install#macos) is a tool for watching changes in the filesystem. Installing it will result in better performance. You can install it with:
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
@@ -34,9 +34,9 @@ To install an iOS Simulator, open **Xcode > Settings... > Components**, and unde
 
 <Step label="4">
 
-### Install Watchman (optional)
+### Install Watchman
 
-> **info** Installing Watchman is optional and only relevant for projects on SDK 55 and earlier.
+> **info** Installing Watchman is only required for projects on SDK 55 and earlier.
 
 [Watchman](https://facebook.github.io/watchman/docs/install#macos) is a tool for watching changes in the filesystem. Installing it will result in better performance. You can install it with:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22018

# How

Add an info callout marking Watchman optional and only relevant for SDK 55 and earlier at each Watchman step in `_xcodeInstructions.mdx` and `_androidStudioEnvironmentInstructions.mdx`. The iOS section becomes `Install Watchman (optional)` and the Android section becomes `Install JDK`; the renamed Android anchor is updated in `local-app-production.mdx`, and `JDK` is added to the Vale `HeadingCase.yml` exceptions.

# Test Plan

See diff and proofread.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
