### PR TITLE
[observe] Remove the legacy non-OpenTelemetry dispatch path

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -11,3 +11,5 @@
 ### 🐛 Bug fixes
 
 ### 💡 Others
+
+- Remove the legacy non-OpenTelemetry dispatch path; metrics and logs are now always sent in the OTLP wire format. ([#47030](https://github.com/expo/expo/pull/47030) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.Log
 import expo.modules.easclient.EASClientID
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -18,7 +16,6 @@ class EventDispatcher(
   val context: Context,
   val projectId: String,
   val baseUrl: String,
-  private val useOpenTelemetry: Boolean = false,
   private val httpClient: OkHttpClient = OkHttpClient()
 ) {
   private val baseProjectUrl: String
@@ -27,8 +24,7 @@ class EventDispatcher(
       else -> "$baseUrl/$projectId"
     }
 
-  private fun metricsEndpointUrl(): String =
-    if (useOpenTelemetry) "$baseProjectUrl/v1/metrics" else baseProjectUrl
+  private fun metricsEndpointUrl(): String = "$baseProjectUrl/v1/metrics"
 
   private fun logsEndpointUrl(): String = "$baseProjectUrl/v1/logs"
 
@@ -40,22 +36,9 @@ class EventDispatcher(
       }
       val easId = EASClientID(context).uuid.toString()
       try {
-        val json = Json {
-          prettyPrint = true
-        }
-
-        val body = if (useOpenTelemetry) {
-          val otRequestBody = OTRequestBody(
-            resourceMetrics = events.map { it.toOTEvent(easId) }
-          )
-          otRequestBody.toJson(prettyPrint = true)
-        } else {
-          val payload = Payload(
-            easClientId = easId,
-            events = events
-          )
-          json.encodeToString(Payload.serializer(), payload)
-        }
+        val body = OTRequestBody(
+          resourceMetrics = events.map { it.toOTEvent(easId) }
+        ).toJson(prettyPrint = true)
 
         executePost(continuation, metricsEndpointUrl(), body)
       } catch (e: Exception) {
@@ -131,9 +114,3 @@ class EventDispatcher(
     private const val TAG = "EasObserve"
   }
 }
-
-@Serializable
-data class Payload(
-  val easClientId: String,
-  val events: List<Event>
-)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ExpoManifest.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ExpoManifest.kt
@@ -5,7 +5,6 @@ import expo.modules.interfaces.constants.ConstantsInterface
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -37,12 +36,6 @@ internal value class ExpoManifest(
    */
   val baseUrl: String?
     get() = getProperty("extra.eas.observe.endpointUrl")?.jsonPrimitive?.contentOrNull
-
-  /**
-   * Gets the extra.eas.observe.useOpenTelemetry from the manifest. Defaults to true.
-   */
-  val useOpenTelemetry: Boolean
-    get() = getProperty("extra.eas.observe.useOpenTelemetry")?.jsonPrimitive?.booleanOrNull ?: true
 }
 
 internal fun getManifest(constants: ConstantsInterface?): ExpoManifest? {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -33,7 +33,6 @@ class ObservabilityBackgroundWorker(
   private val observabilityManager: BaseObservabilityManager? = run {
     val projectId = inputData.getString("projectId")
     val baseUrl = inputData.getString("baseUrl")
-    val useOpenTelemetry = inputData.getBoolean("useOpenTelemetry", false)
 
     if (projectId == null || baseUrl == null) {
       return@run null
@@ -53,8 +52,7 @@ class ObservabilityBackgroundWorker(
       pendingMetricsManager = pendingMetricsManager,
       pendingLogsManager = pendingLogsManager,
       baseUrl = baseUrl,
-      isDebugBuild = BuildConfig.DEBUG,
-      useOpenTelemetry = useOpenTelemetry
+      isDebugBuild = BuildConfig.DEBUG
     )
   }
 
@@ -100,8 +98,7 @@ class ObservabilityBackgroundWorker(
     fun scheduleBackgroundDispatch(
       context: Context,
       projectId: String,
-      baseUrl: String,
-      useOpenTelemetry: Boolean = false
+      baseUrl: String
     ) {
       val constraints = Constraints
         .Builder()
@@ -110,8 +107,7 @@ class ObservabilityBackgroundWorker(
 
       val data = workDataOf(
         Pair("projectId", projectId),
-        Pair("baseUrl", baseUrl),
-        Pair("useOpenTelemetry", useOpenTelemetry)
+        Pair("baseUrl", baseUrl)
       )
 
       val periodicWork = OneTimeWorkRequestBuilder<ObservabilityBackgroundWorker>()

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -14,7 +14,6 @@ class ObservabilityManager(
   val sessionManager: SessionManager
 ) {
   private val baseManager: BaseObservabilityManager
-  private val useOpenTelemetry: Boolean
 
   // TODO: Can this information change during expo module lifecycle?
   init {
@@ -28,7 +27,6 @@ class ObservabilityManager(
       "Project ID is required to send observability metrics. Make sure you have configured it correctly in app.json."
     }
     val baseUrl = manifest.baseUrl ?: OBSERVE_DEFAULT_BASE_URL
-    useOpenTelemetry = manifest.useOpenTelemetry
 
     val pendingMetricsManager = PendingMetricsManager(context)
     val pendingLogsManager = PendingLogsManager(context)
@@ -40,8 +38,7 @@ class ObservabilityManager(
       pendingLogsManager = pendingLogsManager,
       projectId = projectId,
       baseUrl = baseUrl,
-      isDebugBuild = BuildConfig.DEBUG,
-      useOpenTelemetry = useOpenTelemetry
+      isDebugBuild = BuildConfig.DEBUG
     )
 
     sessionManager.addMetricsInsertListener { metricIds ->
@@ -64,8 +61,7 @@ class ObservabilityManager(
     ObservabilityBackgroundWorker.scheduleBackgroundDispatch(
       context = context,
       projectId = baseManager.projectId,
-      baseUrl = baseManager.baseUrl,
-      useOpenTelemetry = useOpenTelemetry
+      baseUrl = baseManager.baseUrl
     )
   }
 }
@@ -78,7 +74,6 @@ class BaseObservabilityManager(
   val projectId: String,
   val baseUrl: String,
   private val isDebugBuild: Boolean = false,
-  private val useOpenTelemetry: Boolean = false,
   private val deterministicUniformValueProvider: () -> Double = {
     EASClientID.deterministicUniformValue(EASClientID(context).uuid)
   }
@@ -86,8 +81,7 @@ class BaseObservabilityManager(
   private val eventDispatcher = EventDispatcher(
     context = context,
     projectId = projectId,
-    baseUrl = baseUrl,
-    useOpenTelemetry = useOpenTelemetry
+    baseUrl = baseUrl
   )
 
   suspend fun dispatchUnsentMetrics() {

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -158,7 +158,7 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch includes correct easClientId in payload`() =
+  fun `dispatch includes the easClientId as a resource attribute`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -176,7 +176,16 @@ class EventDispatcherTest {
       val request = mockServer.takeRequest()
       val requestBody = request.body.readUtf8()
       val json = JSONObject(requestBody)
-      assertEquals(testEasClientId.toString(), json.getString("easClientId"))
+      val resource = json.getJSONArray("resourceMetrics").getJSONObject(0).getJSONObject("resource")
+      val attributes = resource.getJSONArray("attributes")
+
+      val clientIdAttribute = (0 until attributes.length())
+        .map { attributes.getJSONObject(it) }
+        .first { it.getString("key") == "expo.eas_client.id" }
+      assertEquals(
+        testEasClientId.toString(),
+        clientIdAttribute.getJSONObject("value").getString("stringValue")
+      )
     }
 
   @Test
@@ -205,20 +214,9 @@ class EventDispatcherTest {
       val request = mockServer.takeRequest()
       val requestBody = request.body.readUtf8()
       val json = JSONObject(requestBody)
-      val eventsArray = json.getJSONArray("events")
+      val resourceMetrics = json.getJSONArray("resourceMetrics")
 
-      assertEquals(3, eventsArray.length())
-
-      val metricNames = mutableListOf<String>()
-      for (i in 0 until eventsArray.length()) {
-        val event = eventsArray.getJSONObject(i)
-        val metrics = event.getJSONArray("metrics")
-        metricNames.add(metrics.getJSONObject(0).getString("name"))
-      }
-
-      assertTrue(metricNames.contains("metric1"))
-      assertTrue(metricNames.contains("metric2"))
-      assertTrue(metricNames.contains("metric3"))
+      assertEquals(3, resourceMetrics.length())
     }
 
   @Test
@@ -238,7 +236,7 @@ class EventDispatcherTest {
 
       // Assert
       val request = mockServer.takeRequest()
-      assertEquals("/$testProjectId", request.path)
+      assertEquals("/$testProjectId/v1/metrics", request.path)
     }
 
   @Test
@@ -260,7 +258,7 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch includes all metadata fields in payload`() =
+  fun `dispatch maps metadata to OTel resource attributes`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -288,7 +286,7 @@ class EventDispatcherTest {
 
       val metric = EASMetric(
         sessionId = "session-123",
-        timestamp = "2025-11-26T10:00:00Z",
+        timestamp = "2025-11-26T10:00:00.000Z",
         category = "performance",
         name = "app_start",
         value = 1500.0
@@ -303,22 +301,25 @@ class EventDispatcherTest {
       val request = mockServer.takeRequest()
       val requestBody = request.body.readUtf8()
       val json = JSONObject(requestBody)
-      val eventsArray = json.getJSONArray("events")
-      val event = eventsArray.getJSONObject(0)
-      val metadataJson = event.getJSONObject("metadata")
+      val resource = json.getJSONArray("resourceMetrics").getJSONObject(0).getJSONObject("resource")
+      val attributes = resource.getJSONArray("attributes")
 
-      assertEquals("TestApp", metadataJson.getString("appName"))
-      assertEquals("com.test.app", metadataJson.getString("appIdentifier"))
-      assertEquals("1.0.0", metadataJson.getString("appVersion"))
-      assertEquals("100", metadataJson.getString("appBuildNumber"))
-      assertEquals("en-US", metadataJson.getString("languageTag"))
-      assertEquals("Android", metadataJson.getString("deviceOs"))
-      assertEquals("14", metadataJson.getString("deviceOsVersion"))
-      assertEquals("Pixel 8", metadataJson.getString("deviceModel"))
-      assertEquals("TestDevice", metadataJson.getString("deviceName"))
-      assertEquals("52.0.0", metadataJson.getString("expoSdkVersion"))
-      assertEquals("0.76.0", metadataJson.getString("reactNativeVersion"))
-      assertEquals("1.0.0", metadataJson.getString("clientVersion"))
+      val stringAttributes = (0 until attributes.length())
+        .map { attributes.getJSONObject(it) }
+        .associate { it.getString("key") to it.getJSONObject("value").getString("stringValue") }
+
+      assertEquals("com.test.app", stringAttributes["service.name"])
+      assertEquals("1.0.0", stringAttributes["service.version"])
+      assertEquals("100", stringAttributes["expo.app.build_number"])
+      assertEquals("en-US", stringAttributes["browser.language"])
+      assertEquals("Android", stringAttributes["os.name"])
+      assertEquals("14", stringAttributes["os.version"])
+      assertEquals("Pixel 8", stringAttributes["device.model.identifier"])
+      assertEquals("TestDevice", stringAttributes["device.model.name"])
+      assertEquals("52.0.0", stringAttributes["expo.sdk.version"])
+      assertEquals("0.76.0", stringAttributes["expo.react_native.version"])
+      assertEquals("1.0.0", stringAttributes["telemetry.sdk.version"])
+      assertEquals("TestApp", stringAttributes["expo.app.name"])
     }
 
   @Test
@@ -361,7 +362,7 @@ class EventDispatcherTest {
 
     val metric = EASMetric(
       sessionId = "test-session",
-      timestamp = "2025-11-26T10:00:00Z",
+      timestamp = "2025-11-26T10:00:00.000Z",
       category = "test",
       name = metricName,
       value = 123.45

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -8,7 +8,6 @@ internal struct ObservabilityManager {
   private static var metricsEndpointUrl: URL? = nil
   private static var logsEndpointUrl: URL? = nil
   private static var projectId: String? = nil
-  private static var useOpenTelemetry = false
 
   internal static func dispatch() async {
     // Compute once and reuse for both signals — `shouldDispatch()` reads the persisted config, the
@@ -51,12 +50,7 @@ internal struct ObservabilityManager {
       return
     }
     do {
-      let body: any Encodable
-      if useOpenTelemetry {
-        body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
-      } else {
-        body = RequestBody(easClientId: easClientId, events: events)
-      }
+      let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
       let success = try await sendRequest(to: endpointUrl, body: body)
       if success {
         ObserveUserDefaults.lastDispatchDate = Date.now
@@ -68,10 +62,6 @@ internal struct ObservabilityManager {
   }
 
   private static func dispatchLogs(shouldDispatch: Bool) async {
-    // Logs are only sent in OpenTelemetry mode — there is no legacy logs endpoint.
-    guard useOpenTelemetry else {
-      return
-    }
     repairLogCursorIfStale()
 
     let cursor = ObserveUserDefaults.lastDispatchedLogId
@@ -193,20 +183,8 @@ internal struct ObservabilityManager {
       return
     }
     AppMetricsActor.isolated {
-      if useOpenTelemetry {
-        self.metricsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/metrics")
-        self.logsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/logs")
-      } else {
-        self.metricsEndpointUrl = url.appendingPathComponent(projectId)
-        self.logsEndpointUrl = nil
-      }
-    }
-  }
-
-  internal nonisolated static func setUseOpenTelemetry(_ enabled: Bool?) {
-    let enabled = enabled ?? true
-    AppMetricsActor.isolated {
-      self.useOpenTelemetry = enabled
+      self.metricsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/metrics")
+      self.logsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/logs")
     }
   }
 

--- a/packages/expo-observe/ios/ObserveModule.swift
+++ b/packages/expo-observe/ios/ObserveModule.swift
@@ -26,9 +26,6 @@ public final class ObserveModule: Module {
       // which is not great as it requires the app context. Ideally if we move EAS-specific config to `expo-eas-client` at some point.
       if let manifest = getManifest(appContext), let projectId = getProjectId(manifest: manifest) {
         let baseUrl = getBaseUrl(manifest)
-        let useOpenTelemetry = getUseOpenTelemetry(manifest)
-        ObservabilityManager.setUseOpenTelemetry(useOpenTelemetry)
-        // Set the endpoint URL after enabling Open Telemetry
         ObservabilityManager.setEndpointUrl(baseUrl, projectId: projectId)
       }
     }
@@ -91,10 +88,6 @@ private func getProjectId(manifest: [String: Any]) -> String? {
 
 private func getBaseUrl(_ manifest: [String: Any]) -> String? {
   return getManifestProperty("extra.eas.observe.endpointUrl", manifest) as? String
-}
-
-private func getUseOpenTelemetry(_ manifest: [String: Any]) -> Bool? {
-  return getManifestProperty("extra.eas.observe.useOpenTelemetry", manifest) as? Bool
 }
 
 /// Traverses the manifest using a dot-separated property chain.

--- a/packages/expo-observe/ios/RequestBody.swift
+++ b/packages/expo-observe/ios/RequestBody.swift
@@ -1,7 +1,0 @@
-// Copyright 2025-present 650 Industries. All rights reserved.
-
-/// Body of the request containing events with metrics for the EAS server.
-internal struct RequestBody: Codable, Sendable {
-  let easClientId: String
-  let events: [Event]
-}


### PR DESCRIPTION
## Why

`expo-observe` carried two dispatch paths gated by the `extra.eas.observe.useOpenTelemetry` manifest flag: the OTLP (OpenTelemetry) wire format and an older `RequestBody`/`Payload` envelope sent to a bare `/{projectId}` endpoint. The flag already defaulted to OpenTelemetry on both platforms, and logs were OTLP-only to begin with, so the legacy branch was dead weight that the server no longer needs.

## How

Removed the `useOpenTelemetry` flag and every branch behind it so metrics and logs always serialize to OTLP and post to `/{projectId}/v1/metrics` and `/{projectId}/v1/logs`:

- **iOS:** dropped `useOpenTelemetry` state, `setUseOpenTelemetry`, `getUseOpenTelemetry`, and the legacy `RequestBody.swift`; the metrics path and endpoint setter are now unconditional.
- **Android:** dropped the flag from `EventDispatcher`, `ObservabilityManager`, `BaseObservabilityManager`, `ObservabilityBackgroundWorker`, and `ExpoManifest`, plus the `Payload` data class.
- Rewrote `EventDispatcherTest` assertions that relied on the legacy `Payload` shape to verify the OTLP `resourceMetrics`/resource-attribute structure and the `/v1/metrics` endpoint instead.

The platform-neutral `Event` model stays: it's still built from DB rows and converted to OTLP (`Event.toOTEvent` / `toOTResourceLogs`). Its now-unused serialization conformances are left in place to keep this change focused on the dispatch path.

## Test Plan

- `et native-unit-tests -p android --packages expo-observe` — passes.
- `et native-unit-tests -p ios --packages expo-observe` — passes.
