### PR TITLE
chore(precompile) change gz -> xz compression to reduce size

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -215,7 +215,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcframeworks-${{ matrix.flavor }}
-          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
+          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.xz
           if-no-files-found: warn
           retention-days: 14
           include-hidden-files: true
@@ -247,7 +247,7 @@ jobs:
             --verbose \
             --prune-empty-dirs \
             --include='*/' \
-            --include='*/xcframeworks/*.tar.gz' \
+            --include='*/xcframeworks/*.tar.xz' \
             --exclude='*' \
             packages/precompile/.build/ \
             "$SYNC_ROOT/"
@@ -258,7 +258,7 @@ jobs:
           fi
 
           # Sync each top-level package directory separately so objects still land under:
-          #   gs://eas-build-precompiled-modules/<pkg>/output/.../xcframeworks/*.tar.gz
+          #   gs://eas-build-precompiled-modules/<pkg>/output/.../xcframeworks/*.tar.xz
           # without requiring bucket-level metadata access for a root rsync target.
           shopt -s nullglob
           for package_dir in "$SYNC_ROOT"/*; do

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Recognize precompiled XCFramework artifacts compressed with xz (`.tar.xz`), in addition to the legacy `.tar.gz`, when enumerating prebuilt modules.
+
 ### 💡 Others
 
 ## 56.0.15 — 2026-05-26

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Recognize precompiled XCFramework artifacts compressed with xz (`.tar.xz`), in addition to the legacy `.tar.gz`, when enumerating prebuilt modules.
+- [iOS] Recognize precompiled XCFramework artifacts compressed with xz (`.tar.xz`), in addition to the legacy `.tar.gz`, when enumerating prebuilt modules. ([#47032](https://github.com/expo/expo/pull/47032) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/cli/src/utils/precompiled.ts
+++ b/packages/expo-brownfield/cli/src/utils/precompiled.ts
@@ -20,6 +20,13 @@ const RESERVED_POD_DIRS = new Set([
 ]);
 
 /**
+ * Matches the compressed-tarball artifacts written next to a precompiled xcframework. Both xz
+ * (current, written by `ensure_artifacts`) and gzip (legacy) are accepted so enumeration keeps
+ * working across an in-place upgrade where a stale `.tar.gz` can linger beside a fresh `.tar.xz`.
+ */
+const PRECOMPILED_TARBALL_RE = /\.tar\.(gz|xz)$/;
+
+/**
  * Returns true when an `entry` refers to a directory either directly OR via a symlink whose
  * target is a directory.
  */
@@ -38,7 +45,7 @@ export const isDirentDirectory = (entry: fs.Dirent, parentDir: string): boolean 
 /**
  * Scans `ios/Pods/` for prebuilt xcframeworks installed by autolinking when
  * `EXPO_USE_PRECOMPILED_MODULES=1` is set. A pod is "precompiled" when its directory contains
- * a `<Product>.xcframework/` dir and an `artifacts/<Product>-{debug,release}.tar.gz` tarball —
+ * a `<Product>.xcframework/` dir and an `artifacts/<Product>-{debug,release}.tar.{xz,gz}` tarball —
  * the exact signature written by `Expo::PrecompiledModules.ensure_artifacts` in
  * expo-modules-autolinking.
  *
@@ -71,7 +78,7 @@ export const enumeratePrecompiledModules = (iosDir: string): ModuleXCFramework[]
       continue;
     }
 
-    const tarballs = fs.readdirSync(artifactsDir).filter((f) => f.endsWith('.tar.gz'));
+    const tarballs = fs.readdirSync(artifactsDir).filter((f) => PRECOMPILED_TARBALL_RE.test(f));
     if (tarballs.length === 0) {
       continue;
     }
@@ -81,10 +88,14 @@ export const enumeratePrecompiledModules = (iosDir: string): ModuleXCFramework[]
       .filter((f) => f.name.endsWith('.xcframework') && isDirentDirectory(f, podDir))
       .map((f) => f.name.replace(/\.xcframework$/, ''));
 
-    // Identify the "main" product for this pod — the xcframework whose name matches a tarball.
+    // Identify the "main" product for this pod — the xcframework whose name matches a tarball
+    // (regardless of the tarball's compression extension).
     // Used as the `-m` argument when reconciling debug/release flavors via replace-xcframework.js.
     const mainProduct = xcframeworks.find((name) =>
-      tarballs.some((f) => f === `${name}-debug.tar.gz` || f === `${name}-release.tar.gz`)
+      tarballs.some((f) => {
+        const base = f.replace(PRECOMPILED_TARBALL_RE, '');
+        return base === `${name}-debug` || base === `${name}-release`;
+      })
     );
     if (!mainProduct) {
       // No xcframework lines up with the tarball — defensive skip (treat as unrelated vendored fw).

--- a/packages/expo-brownfield/cli/src/utils/types.ts
+++ b/packages/expo-brownfield/cli/src/utils/types.ts
@@ -49,7 +49,7 @@ export interface ModuleXCFramework {
   /** Absolute path to the `<name>.xcframework` directory. */
   xcframeworkPath: string;
   /**
-   * The pod's main product name — the one that matches the `artifacts/<product>-{debug,release}.tar.gz`
+   * The pod's main product name — the one that matches the `artifacts/<product>-{debug,release}.tar.{xz,gz}`
    * tarball pattern. Differs from `name` for SPM-dependency xcframeworks (e.g. SDWebImage bundled
    * alongside ExpoImage has `name: "SDWebImage"` but `mainProduct: "ExpoImage"`).
    */

--- a/packages/expo-brownfield/e2e/cli/__tests__/precompiled.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/precompiled.test.ts
@@ -55,7 +55,7 @@ describe('enumeratePrecompiledModules', () => {
   it('picks up an Expo module that has both an xcframework and matching artifact tarballs', () => {
     seedPod(tmpDir, 'ExpoModulesCore', {
       xcframework: 'ExpoModulesCore',
-      tarballs: ['ExpoModulesCore-debug.tar.gz', 'ExpoModulesCore-release.tar.gz'],
+      tarballs: ['ExpoModulesCore-debug.tar.xz', 'ExpoModulesCore-release.tar.xz'],
     });
 
     const modules = enumeratePrecompiledModules(tmpDir);
@@ -66,6 +66,22 @@ describe('enumeratePrecompiledModules', () => {
       podDir: path.join(tmpDir, 'Pods', 'ExpoModulesCore'),
       xcframeworkPath: path.join(tmpDir, 'Pods', 'ExpoModulesCore', 'ExpoModulesCore.xcframework'),
     });
+  });
+
+  it('accepts both the current .tar.xz and legacy .tar.gz artifact tarballs', () => {
+    // ensure_artifacts writes .tar.xz today, but an in-place upgrade can leave a stale .tar.gz
+    // next to it; the enumerator must recognize either extension.
+    seedPod(tmpDir, 'ExpoXz', {
+      xcframework: 'ExpoXz',
+      tarballs: ['ExpoXz-release.tar.xz'],
+    });
+    seedPod(tmpDir, 'ExpoGz', {
+      xcframework: 'ExpoGz',
+      tarballs: ['ExpoGz-release.tar.gz'],
+    });
+
+    const modules = enumeratePrecompiledModules(tmpDir);
+    expect(modules.map((m) => m.name).sort()).toEqual(['ExpoGz', 'ExpoXz']);
   });
 
   it('excludes the reserved Hermes / React / ReactNativeDependencies pods', () => {

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 💡 Others
 
+- [iOS] Compress precompiled XCFramework archives with xz (`.tar.xz`) instead of gzip (`.tar.gz`) for smaller downloads.
 - [Android] Make the autolinking Gradle plugin compatible with Android Gradle Plugin 9. ([#46766](https://github.com/expo/expo/pull/46766) by [@lukmccall](https://github.com/lukmccall))
 - Add experimental `tvos` and `macos` resolution ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- [iOS] Compress precompiled XCFramework archives with xz (`.tar.xz`) instead of gzip (`.tar.gz`) for smaller downloads.
+- [iOS] Compress precompiled XCFramework archives with xz (`.tar.xz`) instead of gzip (`.tar.gz`) for smaller downloads. ([#47032](https://github.com/expo/expo/pull/47032) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Make the autolinking Gradle plugin compatible with Android Gradle Plugin 9. ([#46766](https://github.com/expo/expo/pull/46766) by [@lukmccall](https://github.com/lukmccall))
 - Add experimental `tvos` and `macos` resolution ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -8,7 +8,7 @@
 # When EXPO_USE_PRECOMPILED_MODULES=1 is set, packages with matching XCFrameworks
 # in the centralized build output will be linked as vendored frameworks.
 #
-# Build output:     packages/precompile/.build/<pkg>/output/<flavor>/xcframeworks/<Product>.tar.gz
+# Build output:     packages/precompile/.build/<pkg>/output/<flavor>/xcframeworks/<Product>.tar.xz
 # Custom path:      Set EXPO_PRECOMPILED_MODULES_PATH to override the base directory
 #                   (replaces packages/precompile/.build/), keeping <pkg>/output/... structure
 #
@@ -22,8 +22,8 @@
 #
 # Resulting layout in Pods/<PodName>/:
 #   <Product>.xcframework/                    (extracted by CocoaPods from source tarball)
-#   artifacts/<Product>-debug.tar.gz          (copied by prepare_command)
-#   artifacts/<Product>-release.tar.gz        (copied by prepare_command)
+#   artifacts/<Product>-debug.tar.xz          (copied by prepare_command)
+#   artifacts/<Product>-release.tar.xz        (copied by prepare_command)
 #   artifacts/.last_build_configuration       (written by prepare_command / switch script)
 
 require 'fileutils'
@@ -97,7 +97,7 @@ module Expo
       # Returns custom base path for precompiled module output, if set.
       # When set, replaces the default `packages/precompile/.build/` base directory.
       # The directory structure under this path must match:
-      #   <npm_package>/output/<flavor>/xcframeworks/<Product>.tar.gz
+      #   <npm_package>/output/<flavor>/xcframeworks/<Product>.tar.xz
       def custom_modules_path
         ENV[MODULES_PATH_ENV_VAR]
       end
@@ -773,7 +773,7 @@ module Expo
           # Copy both flavor tarballs
           ['debug', 'release'].each do |flavor|
             src = resolve_prebuilt_tarball(info, product_name, flavor, pod_name)
-            dst = File.join(artifacts_dir, "#{product_name}-#{flavor}.tar.gz")
+            dst = File.join(artifacts_dir, "#{product_name}-#{flavor}.tar.xz")
             FileUtils.cp(src, dst) if File.exist?(src) && !File.exist?(dst)
           end
 
@@ -787,7 +787,7 @@ module Expo
             tarball = resolve_prebuilt_tarball(info, product_name, build_flavor, pod_name)
             if File.exist?(tarball)
               Pod::UI.info "#{'[Expo-precompiled] '.blue}Extracting #{product_name}.xcframework (cache miss)"
-              system("tar", "xzf", tarball, "-C", pod_dir)
+              system("tar", "xf", tarball, "-C", pod_dir)
             end
           end
         end
@@ -1274,10 +1274,10 @@ module Expo
         <<~SH
           # Self-healing: extract xcframework from tarball if CocoaPods cache was stale/empty
           if [ ! -d "#{product_name}.xcframework" ]; then
-            TARBALL="#{build_output_dir}/#{build_flavor}/xcframeworks/#{product_name}.tar.gz"
+            TARBALL="#{build_output_dir}/#{build_flavor}/xcframeworks/#{product_name}.tar.xz"
             if [ -f "$TARBALL" ]; then
               echo "[Expo XCFramework] #{product_name}: Extracting xcframework from build output (cache miss)"
-              tar xzf "$TARBALL"
+              tar xf "$TARBALL"
             fi
           fi
         SH
@@ -1767,7 +1767,7 @@ module Expo
 
           unless has_prebuilt_xcframework?(pod_name)
             product_name = info[:product_name] || pod_name
-            expected = File.join(info[:build_output_dir], build_flavor, 'xcframeworks', "#{product_name}.tar.gz")
+            expected = File.join(info[:build_output_dir], build_flavor, 'xcframeworks', "#{product_name}.tar.xz")
             Pod::UI.puts "#{'[Expo-precompiled] '.blue}#{"#{pod_name}: prebuilt xcframework unavailable; building from source".yellow}"
             Pod::UI.puts "#{'[Expo-precompiled] '.blue}#{gray("  Expected tarball: #{expected}")}"
             next
@@ -1966,7 +1966,7 @@ module Expo
       end
 
       def resolve_prebuilt_tarball(pod_info, product_name, flavor, pod_name = nil)
-        tarball = File.join(pod_info[:build_output_dir], flavor, 'xcframeworks', "#{product_name}.tar.gz")
+        tarball = File.join(pod_info[:build_output_dir], flavor, 'xcframeworks', "#{product_name}.tar.xz")
         return tarball if File.exist?(tarball)
 
         base_url = external_modules_base_url
@@ -1978,7 +1978,7 @@ module Expo
           (idx ? pod_info[:build_output_dir][idx..] : output_prefix),
           flavor,
           'xcframeworks',
-          "#{product_name}.tar.gz"
+          "#{product_name}.tar.xz"
         ].join('/')
         remote_url = "#{base_url.chomp('/')}/#{relative_path}"
         remote_tarball = File.join(remote_precompiled_artifacts_dir, relative_path)
@@ -2022,7 +2022,7 @@ module Expo
       end
 
       def read_xcframework_info_plists_from_tarball(tarball)
-        entries_output, status = Open3.capture2e('tar', 'tzf', tarball)
+        entries_output, status = Open3.capture2e('tar', 'tf', tarball)
         unless status.success?
           Pod::UI.warn "[Expo-precompiled] Failed to inspect #{File.basename(tarball)}: #{entries_output.strip}"
           return []
@@ -2033,7 +2033,7 @@ module Expo
         Pod::UI.warn "[Expo-precompiled] No XCFramework Info.plist found in #{File.basename(tarball)}" if plist_entries.empty?
 
         plist_entries.filter_map do |entry|
-          plist_data, plist_status = Open3.capture2e('tar', 'xOzf', tarball, entry)
+          plist_data, plist_status = Open3.capture2e('tar', 'xOf', tarball, entry)
           unless plist_status.success?
             Pod::UI.warn "[Expo-precompiled] Failed to extract #{entry} from #{File.basename(tarball)}: #{plist_data.strip}"
             next

--- a/packages/expo-modules-autolinking/scripts/ios/replace-xcframework.js
+++ b/packages/expo-modules-autolinking/scripts/ios/replace-xcframework.js
@@ -2,7 +2,7 @@
 /**
  * Replace XCFramework for Debug/Release Configuration
  *
- * Per-pod product swap: extracts <xcframeworksDir>/artifacts/<module>-<config>.tar.gz
+ * Per-pod product swap: extracts <xcframeworksDir>/artifacts/<module>-<config>.tar.xz
  * over <Product>.xcframework, gated on <xcframeworksDir>/artifacts/.last_build_configuration.
  * Sibling shared-dep symlinks under <xcframeworksDir>/ are preserved (only the product
  * xcframework is wiped before re-extracting).
@@ -75,7 +75,7 @@ function processPerPodSwap(args, configLower) {
 
   const artifactsDir = path.join(xcframeworksDir, 'artifacts');
   fs.mkdirSync(artifactsDir, { recursive: true });
-  const tarballPath = path.join(artifactsDir, `${moduleName}-${configLower}.tar.gz`);
+  const tarballPath = path.join(artifactsDir, `${moduleName}-${configLower}.tar.xz`);
   const lastConfigFile = path.join(artifactsDir, '.last_build_configuration');
 
   if (!fs.existsSync(tarballPath)) {
@@ -100,7 +100,7 @@ function processPerPodSwap(args, configLower) {
     }
   }
 
-  const result = spawnSync('tar', ['-xzf', tarballPath, '-C', xcframeworksDir], { stdio: 'pipe' });
+  const result = spawnSync('tar', ['-xf', tarballPath, '-C', xcframeworksDir], { stdio: 'pipe' });
   if (result.status !== 0) {
     console.error(`${LOG_PREFIX} ${moduleName}: tar failed: ${result.stderr?.toString().trim()}`);
     process.exit(1);

--- a/packages/precompile/README.md
+++ b/packages/precompile/README.md
@@ -18,8 +18,8 @@ The precompiled modules system allows Expo packages to be distributed as prebuil
 │                                                    │                        │
 │                                                    ▼                        │
 │                                   packages/precompile/.build/<pkg>/output/  │
-│                                   ├── debug/xcframeworks/<Product>.tar.gz   │
-│                                   └── release/xcframeworks/<Product>.tar.gz │
+│                                   ├── debug/xcframeworks/<Product>.tar.xz   │
+│                                   └── release/xcframeworks/<Product>.tar.xz │
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
@@ -37,7 +37,7 @@ The precompiled modules system allows Expo packages to be distributed as prebuil
 │                                     (compile from source as usual)          │
 │                                                                             │
 │   sandbox.rb hook:  patch_spec_for_prebuilt(spec)  [auto-patching]        │
-│     - Sets spec.source = {:http => "file:///...tar.gz", :flatten => false} │
+│     - Sets spec.source = {:http => "file:///...tar.xz", :flatten => false} │
 │     - Sets spec.vendored_frameworks                                        │
 │     - Strips bundled SPM dependencies                                      │
 │     - Adds script phases for build-time switching                          │
@@ -51,8 +51,8 @@ The precompiled modules system allows Expo packages to be distributed as prebuil
 │                                                                             │
 │   Result in Pods/<PodName>/:                                               │
 │     <Product>.xcframework/            (extracted by CocoaPods)             │
-│     artifacts/<Product>-debug.tar.gz  (copied by ensure_artifacts)        │
-│     artifacts/<Product>-release.tar.gz                                     │
+│     artifacts/<Product>-debug.tar.xz  (copied by ensure_artifacts)        │
+│     artifacts/<Product>-release.tar.xz                                     │
 │     artifacts/.last_build_configuration                                    │
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -595,7 +595,7 @@ This means **most podspecs don't need manual modification** to support precompil
 | Variable                       | Values             | Description                                    |
 | ------------------------------ | ------------------ | ---------------------------------------------- |
 | `EXPO_USE_PRECOMPILED_MODULES` | `0`, `1`           | Enable/disable precompiled modules             |
-| `EXPO_PRECOMPILED_MODULES_PATH`| path               | Custom base directory for prebuilt XCFrameworks (replaces `packages/precompile/.build/`). Structure: `<pkg>/output/<flavor>/xcframeworks/<Product>.tar.gz` |
+| `EXPO_PRECOMPILED_MODULES_PATH`| path               | Custom base directory for prebuilt XCFrameworks (replaces `packages/precompile/.build/`). Structure: `<pkg>/output/<flavor>/xcframeworks/<Product>.tar.xz` |
 | `EXPO_PRECOMPILED_FLAVOR`      | `debug`, `release` | Which XCFramework flavor to use (default: debug) |
 | `USE_FRAMEWORKS`               | `dynamic`, `static`| CocoaPods framework linking mode               |
 | `RCT_USE_PREBUILT_RNCORE`      | `1`                | Indicates prebuilt React.xcframework is active  |
@@ -615,9 +615,9 @@ packages/precompile/.build/<package-name>/    # Build artifacts (gitignored)
 │   └── <TargetName>/          # Symlinked sources
 ├── output/
 │   ├── debug/xcframeworks/
-│   │   └── <ProductName>.tar.gz   # Debug flavor tarball (source of truth)
+│   │   └── <ProductName>.tar.xz   # Debug flavor tarball (source of truth)
 │   └── release/xcframeworks/
-│       └── <ProductName>.tar.gz   # Release flavor tarball (source of truth)
+│       └── <ProductName>.tar.xz   # Release flavor tarball (source of truth)
 └── codegen/                   # React Native codegen output
 ```
 
@@ -636,8 +636,8 @@ Pods/<PodName>/
 │       ├── <ProductName>.framework/
 │       └── dSYMs/
 └── artifacts/                        # Copied by ensure_artifacts (post-install)
-    ├── <ProductName>-debug.tar.gz
-    ├── <ProductName>-release.tar.gz
+    ├── <ProductName>-debug.tar.xz
+    ├── <ProductName>-release.tar.xz
     └── .last_build_configuration     # Tracks current flavor for incremental builds
 ```
 

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -638,9 +638,11 @@ const copySPMDependencyXCFrameworksAsync = async (
  * the work across all cores. The standalone `xz` binary is needed only here at build time
  * (present on CI/dev machines); consumers extract with libarchive's `tar -xf` and need no `xz`.
  *
- * tar and xz run as two piped processes; the archive is only considered written once tar exits
- * 0, xz exits 0, and the output file descriptor has closed. On any failure the partial archive
- * is removed so a later step can't mistake a truncated `.tar.xz` for a complete one.
+ * tar and xz run as two piped processes writing to a temp file; the archive is renamed into
+ * place only once tar exits 0, xz exits 0, and the output fd has closed — so a truncated
+ * `.tar.xz` can never appear at the final path (even on a crash) and be mistaken for a complete
+ * one. Pipe-level stream errors (e.g. EPIPE when xz dies before tar finishes) are funneled
+ * through the same failure path as process spawn/exit errors.
  */
 const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[]): Promise<void> =>
   new Promise<void>((resolve, reject) => {
@@ -648,7 +650,11 @@ const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const xz = spawn('xz', ['-9', '-T0', '-c'], { stdio: ['pipe', 'pipe', 'pipe'] });
-    const out = fs.createWriteStream(tarballPath);
+    // Write to a temp file and rename on success so a partial/corrupt archive can never appear
+    // at `tarballPath` (reads here go through `tar -xf` with no integrity check, so a leftover
+    // truncated file would otherwise look like a valid cache hit).
+    const tmpPath = `${tarballPath}.${process.pid}.tmp`;
+    const out = fs.createWriteStream(tmpPath);
 
     let stderr = '';
     let tarDone = false;
@@ -661,21 +667,31 @@ const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[
       settled = true;
       tar.kill();
       xz.kill();
-      // Close the output fd and delete the partial/corrupt archive so it can't be mistaken
-      // for a complete tarball by a later step or a subsequent run.
+      // Close the output fd and delete the partial temp archive. The final `tarballPath` is
+      // only ever produced by the atomic rename on success, so it's never left half-written.
       out.destroy();
       try {
-        fs.removeSync(tarballPath);
+        fs.removeSync(tmpPath);
       } catch {
         // Best-effort cleanup; the original error is what matters.
       }
       reject(error);
     };
     const maybeResolve = () => {
-      if (tarDone && xzDone && outDone && !settled) {
-        settled = true;
-        resolve();
+      if (settled || !tarDone || !xzDone || !outDone) {
+        return;
       }
+      // Publish the completed archive atomically — only a fully-written tarball reaches the
+      // final path.
+      try {
+        fs.renameSync(tmpPath, tarballPath);
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        fail(new Error(`Failed to finalize ${path.basename(tarballPath)}: ${err.message}`));
+        return;
+      }
+      settled = true;
+      resolve();
     };
 
     tar.stderr.on('data', (d) => (stderr += d));
@@ -696,6 +712,12 @@ const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[
       )
     );
     out.on('error', fail);
+    // Funnel pipe-level stream errors through fail() too. Without these, if xz dies before tar
+    // finishes (SIGPIPE/EPIPE, OOM-kill, disk full), the unhandled 'error' on the writable side
+    // throws as an uncaught exception and crashes the whole prebuild with a raw stack trace.
+    tar.stdout.on('error', fail);
+    xz.stdin.on('error', fail);
+    xz.stdout.on('error', fail);
 
     tar.stdout.pipe(xz.stdin);
     xz.stdout.pipe(out);

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -639,7 +639,8 @@ const copySPMDependencyXCFrameworksAsync = async (
  * (present on CI/dev machines); consumers extract with libarchive's `tar -xf` and need no `xz`.
  *
  * tar and xz run as two piped processes; the archive is only considered written once tar exits
- * 0, xz exits 0, and the output file stream has flushed.
+ * 0, xz exits 0, and the output file descriptor has closed. On any failure the partial archive
+ * is removed so a later step can't mistake a truncated `.tar.xz` for a complete one.
  */
 const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[]): Promise<void> =>
   new Promise<void>((resolve, reject) => {
@@ -660,6 +661,14 @@ const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[
       settled = true;
       tar.kill();
       xz.kill();
+      // Close the output fd and delete the partial/corrupt archive so it can't be mistaken
+      // for a complete tarball by a later step or a subsequent run.
+      out.destroy();
+      try {
+        fs.removeSync(tarballPath);
+      } catch {
+        // Best-effort cleanup; the original error is what matters.
+      }
       reject(error);
     };
     const maybeResolve = () => {
@@ -713,7 +722,9 @@ const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[
       xzDone = true;
       maybeResolve();
     });
-    out.on('finish', () => {
+    // Resolve on 'close' (fd fully closed), not 'finish' (data flushed) — avoids a race where a
+    // later step reads the archive before the descriptor is released.
+    out.on('close', () => {
       outDone = true;
       maybeResolve();
     });

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -1,5 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
+import { spawn } from 'child_process';
 import fs from 'fs-extra';
 import { glob } from 'glob';
 import path from 'path';
@@ -232,7 +233,7 @@ export const Frameworks = {
   ): string => {
     return path.join(
       Frameworks.getFrameworksOutputPath(buildPath, buildType, versionPrefix),
-      `${productName}.tar.gz`
+      `${productName}.tar.xz`
     );
   },
 
@@ -632,6 +633,93 @@ const copySPMDependencyXCFrameworksAsync = async (
 };
 
 /**
+ * Streams `tar -cf - | xz -9 -T0` to produce a `.tar.xz` at xz preset 9, which roughly halves
+ * the archive compared to the default preset 6 (and is ~60% smaller than gzip). `-T0` spreads
+ * the work across all cores. The standalone `xz` binary is needed only here at build time
+ * (present on CI/dev machines); consumers extract with libarchive's `tar -xf` and need no `xz`.
+ *
+ * tar and xz run as two piped processes; the archive is only considered written once tar exits
+ * 0, xz exits 0, and the output file stream has flushed.
+ */
+const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[]): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const tar = spawn('tar', ['-cf', '-', '-C', cwd, ...entries], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const xz = spawn('xz', ['-9', '-T0', '-c'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const out = fs.createWriteStream(tarballPath);
+
+    let stderr = '';
+    let tarDone = false;
+    let xzDone = false;
+    let outDone = false;
+    let settled = false;
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      tar.kill();
+      xz.kill();
+      reject(error);
+    };
+    const maybeResolve = () => {
+      if (tarDone && xzDone && outDone && !settled) {
+        settled = true;
+        resolve();
+      }
+    };
+
+    tar.stderr.on('data', (d) => (stderr += d));
+    xz.stderr.on('data', (d) => (stderr += d));
+
+    tar.on('error', (e) =>
+      fail(
+        new Error(`Failed to spawn tar while archiving ${path.basename(tarballPath)}: ${e.message}`)
+      )
+    );
+    xz.on('error', (e) =>
+      fail(
+        new Error(
+          `Failed to run xz while compressing ${path.basename(tarballPath)}. The xz binary is ` +
+            `required to build precompiled XCFrameworks; install it (e.g. \`brew install xz\`) and ` +
+            `retry. Underlying error: ${e.message}`
+        )
+      )
+    );
+    out.on('error', fail);
+
+    tar.stdout.pipe(xz.stdin);
+    xz.stdout.pipe(out);
+
+    tar.on('close', (code) => {
+      if (code !== 0) {
+        return fail(
+          new Error(
+            `tar exited with code ${code} while archiving ${path.basename(tarballPath)}:\n${stderr}`
+          )
+        );
+      }
+      tarDone = true;
+      maybeResolve();
+    });
+    xz.on('close', (code) => {
+      if (code !== 0) {
+        return fail(
+          new Error(
+            `xz exited with code ${code} while compressing ${path.basename(tarballPath)}:\n${stderr}`
+          )
+        );
+      }
+      xzDone = true;
+      maybeResolve();
+    });
+    out.on('finish', () => {
+      outDone = true;
+      maybeResolve();
+    });
+  });
+
+/**
  * Creates a tarball containing the product xcframework and any SPM dependency xcframeworks.
  * The tarball is the source of truth for build-time switching between debug/release flavors.
  *
@@ -680,10 +768,7 @@ const createProductTarballAsync = async (
     `📦 Creating tarball for ${chalk.green(product.name)} (${buildType}): ${xcframeworkEntries.join(', ')}`
   );
 
-  // Create tarball: tar -czf <Product>.tar.gz -C <outputDir> <entries...>
-  await spawnAsync('tar', ['-czf', tarballPath, '-C', outputDir, ...xcframeworkEntries], {
-    stdio: 'pipe',
-  });
+  await createXzTarballAsync(tarballPath, outputDir, xcframeworkEntries);
 
   logger.info(
     `✅ Created ${path.basename(tarballPath)} (${xcframeworkEntries.length} framework(s))`

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -1,8 +1,9 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { pipeline } from 'node:stream/promises';
 import path from 'path';
 
 import { getPrecompileDir } from '../Directories';
@@ -638,119 +639,92 @@ const copySPMDependencyXCFrameworksAsync = async (
  * the work across all cores. The standalone `xz` binary is needed only here at build time
  * (present on CI/dev machines); consumers extract with libarchive's `tar -xf` and need no `xz`.
  *
- * tar and xz run as two piped processes writing to a temp file; the archive is renamed into
- * place only once tar exits 0, xz exits 0, and the output fd has closed — so a truncated
- * `.tar.xz` can never appear at the final path (even on a crash) and be mistaken for a complete
- * one. Pipe-level stream errors (e.g. EPIPE when xz dies before tar finishes) are funneled
- * through the same failure path as process spawn/exit errors.
+ * The data path is wired with `stream.pipeline`, which propagates stream errors as rejections
+ * and tears down every stream on failure — so an EPIPE from xz dying mid-write can't escape as
+ * an uncaught exception. Output goes to a temp file that's renamed into place only after both
+ * processes exit 0, so a truncated `.tar.xz` can never appear at the final path (even on a
+ * crash) and be mistaken for a complete cache hit. A spawn failure / non-zero exit is the
+ * authoritative error; the inter-process pipe's symptom errors (EPIPE / premature close, tar
+ * killed by SIGPIPE) are suppressed so the actionable cause surfaces instead.
  */
-const createXzTarballAsync = (tarballPath: string, cwd: string, entries: string[]): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
-    const tar = spawn('tar', ['-cf', '-', '-C', cwd, ...entries], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const xz = spawn('xz', ['-9', '-T0', '-c'], { stdio: ['pipe', 'pipe', 'pipe'] });
-    // Write to a temp file and rename on success so a partial/corrupt archive can never appear
-    // at `tarballPath` (reads here go through `tar -xf` with no integrity check, so a leftover
-    // truncated file would otherwise look like a valid cache hit).
-    const tmpPath = `${tarballPath}.${process.pid}.tmp`;
-    const out = fs.createWriteStream(tmpPath);
+const createXzTarballAsync = async (
+  tarballPath: string,
+  cwd: string,
+  entries: string[]
+): Promise<void> => {
+  const base = path.basename(tarballPath);
+  // Write to a temp file and rename on success so a partial/corrupt archive can never appear at
+  // `tarballPath` (reads here go through `tar -xf` with no integrity check, so a leftover
+  // truncated file would otherwise look like a valid cache hit).
+  const tmpPath = `${tarballPath}.${process.pid}.tmp`;
 
-    let stderr = '';
-    let tarDone = false;
-    let xzDone = false;
-    let outDone = false;
-    let settled = false;
-
-    const fail = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      tar.kill();
-      xz.kill();
-      // Close the output fd and delete the partial temp archive. The final `tarballPath` is
-      // only ever produced by the atomic rename on success, so it's never left half-written.
-      out.destroy();
-      try {
-        fs.removeSync(tmpPath);
-      } catch {
-        // Best-effort cleanup; the original error is what matters.
-      }
-      reject(error);
-    };
-    const maybeResolve = () => {
-      if (settled || !tarDone || !xzDone || !outDone) {
-        return;
-      }
-      // Publish the completed archive atomically — only a fully-written tarball reaches the
-      // final path.
-      try {
-        fs.renameSync(tmpPath, tarballPath);
-      } catch (e) {
-        const err = e instanceof Error ? e : new Error(String(e));
-        fail(new Error(`Failed to finalize ${path.basename(tarballPath)}: ${err.message}`));
-        return;
-      }
-      settled = true;
-      resolve();
-    };
-
-    tar.stderr.on('data', (d) => (stderr += d));
-    xz.stderr.on('data', (d) => (stderr += d));
-
-    tar.on('error', (e) =>
-      fail(
-        new Error(`Failed to spawn tar while archiving ${path.basename(tarballPath)}: ${e.message}`)
-      )
-    );
-    xz.on('error', (e) =>
-      fail(
-        new Error(
-          `Failed to run xz while compressing ${path.basename(tarballPath)}. The xz binary is ` +
-            `required to build precompiled XCFrameworks; install it (e.g. \`brew install xz\`) and ` +
-            `retry. Underlying error: ${e.message}`
-        )
-      )
-    );
-    out.on('error', fail);
-    // Funnel pipe-level stream errors through fail() too. Without these, if xz dies before tar
-    // finishes (SIGPIPE/EPIPE, OOM-kill, disk full), the unhandled 'error' on the writable side
-    // throws as an uncaught exception and crashes the whole prebuild with a raw stack trace.
-    tar.stdout.on('error', fail);
-    xz.stdin.on('error', fail);
-    xz.stdout.on('error', fail);
-
-    tar.stdout.pipe(xz.stdin);
-    xz.stdout.pipe(out);
-
-    tar.on('close', (code) => {
-      if (code !== 0) {
-        return fail(
-          new Error(
-            `tar exited with code ${code} while archiving ${path.basename(tarballPath)}:\n${stderr}`
-          )
-        );
-      }
-      tarDone = true;
-      maybeResolve();
-    });
-    xz.on('close', (code) => {
-      if (code !== 0) {
-        return fail(
-          new Error(
-            `xz exited with code ${code} while compressing ${path.basename(tarballPath)}:\n${stderr}`
-          )
-        );
-      }
-      xzDone = true;
-      maybeResolve();
-    });
-    // Resolve on 'close' (fd fully closed), not 'finish' (data flushed) — avoids a race where a
-    // later step reads the archive before the descriptor is released.
-    out.on('close', () => {
-      outDone = true;
-      maybeResolve();
-    });
+  // `--` stops tar from treating an entry that begins with `-` as a flag. (spawn array args are
+  // already shell-safe — each entry is its own argv, with no word-splitting or injection.)
+  const tar = spawn('tar', ['-cf', '-', '-C', cwd, '--', ...entries], {
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
+  const xz = spawn('xz', ['-9', '-T0', '-c'], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+  let tarErr = '';
+  let xzErr = '';
+  tar.stderr.on('data', (d) => (tarErr += d));
+  xz.stderr.on('data', (d) => (xzErr += d));
+
+  // A spawn failure or non-zero exit is the authoritative cause of a failed run; report it with
+  // an actionable message.
+  const childExited = (
+    child: ChildProcess,
+    label: 'tar' | 'xz',
+    describe: (reason: string) => string
+  ): Promise<void> =>
+    new Promise((resolve, reject) => {
+      child.once('error', (e: Error) => reject(new Error(describe(e.message))));
+      child.once('close', (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else if (label === 'tar' && signal === 'SIGPIPE') {
+          // tar was killed writing into xz's closed stdin — xz died first and its watcher
+          // reports the real cause, so don't mask it with a generic tar failure.
+          resolve();
+        } else {
+          reject(
+            new Error(describe(code != null ? `exited with code ${code}` : `was terminated by ${signal}`))
+          );
+        }
+      });
+    });
+
+  // Stream errors on the inter-process pipe (EPIPE / premature close) are downstream symptoms of
+  // a child dying; the cause is reported by childExited(). Real sink errors (e.g. ENOSPC) rethrow.
+  const suppressPipeSymptom = (e: NodeJS.ErrnoException) => {
+    if (e?.code === 'EPIPE' || e?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      return;
+    }
+    throw e;
+  };
+
+  try {
+    await Promise.all([
+      pipeline(tar.stdout, xz.stdin).catch(suppressPipeSymptom),
+      pipeline(xz.stdout, fs.createWriteStream(tmpPath)).catch(suppressPipeSymptom),
+      childExited(tar, 'tar', (r) => `tar ${r} while archiving ${base}${tarErr ? `:\n${tarErr}` : ''}`),
+      childExited(
+        xz,
+        'xz',
+        (r) =>
+          `xz ${r} while compressing ${base}. The xz binary is required to build precompiled ` +
+          `XCFrameworks; install it (e.g. \`brew install xz\`) and retry.${xzErr ? `\n${xzErr}` : ''}`
+      ),
+    ]);
+    // Publish atomically — only a fully-written archive ever reaches the final path.
+    await fs.promises.rename(tmpPath, tarballPath);
+  } catch (error) {
+    tar.kill();
+    xz.kill();
+    await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+};
 
 /**
  * Creates a tarball containing the product xcframework and any SPM dependency xcframeworks.

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -688,7 +688,9 @@ const createXzTarballAsync = async (
           resolve();
         } else {
           reject(
-            new Error(describe(code != null ? `exited with code ${code}` : `was terminated by ${signal}`))
+            new Error(
+              describe(code != null ? `exited with code ${code}` : `was terminated by ${signal}`)
+            )
           );
         }
       });
@@ -707,7 +709,11 @@ const createXzTarballAsync = async (
     await Promise.all([
       pipeline(tar.stdout, xz.stdin).catch(suppressPipeSymptom),
       pipeline(xz.stdout, fs.createWriteStream(tmpPath)).catch(suppressPipeSymptom),
-      childExited(tar, 'tar', (r) => `tar ${r} while archiving ${base}${tarErr ? `:\n${tarErr}` : ''}`),
+      childExited(
+        tar,
+        'tar',
+        (r) => `tar ${r} while archiving ${base}${tarErr ? `:\n${tarErr}` : ''}`
+      ),
       childExited(
         xz,
         'xz',

--- a/tools/src/prebuilds/PathBuilders.test.ts
+++ b/tools/src/prebuilds/PathBuilders.test.ts
@@ -126,23 +126,23 @@ describe('Frameworks path functions', () => {
   });
 
   describe('getTarballPath', () => {
-    it('returns .tar.gz path for Debug', () => {
+    it('returns .tar.xz path for Debug', () => {
       const result = Frameworks.getTarballPath(buildPath, 'ExpoFoo', 'Debug');
       assert.equal(
         result,
-        path.join(buildPath, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.gz')
+        path.join(buildPath, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.xz')
       );
     });
 
-    it('returns .tar.gz path for Release', () => {
+    it('returns .tar.xz path for Release', () => {
       const result = Frameworks.getTarballPath(buildPath, 'ExpoFoo', 'Release');
       assert.equal(
         result,
-        path.join(buildPath, 'output', 'release', 'xcframeworks', 'ExpoFoo.tar.gz')
+        path.join(buildPath, 'output', 'release', 'xcframeworks', 'ExpoFoo.tar.xz')
       );
     });
 
-    it('returns versioned .tar.gz path when version prefix provided', () => {
+    it('returns versioned .tar.xz path when version prefix provided', () => {
       const versionPrefix = path.join('3.16.7', '0.83.0', '1.0.0');
       const result = Frameworks.getTarballPath(buildPath, 'ExpoFoo', 'Debug', versionPrefix);
       assert.equal(
@@ -155,7 +155,7 @@ describe('Frameworks path functions', () => {
           '1.0.0',
           'debug',
           'xcframeworks',
-          'ExpoFoo.tar.gz'
+          'ExpoFoo.tar.xz'
         )
       );
     });

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -198,7 +198,7 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
 
               const files = await fs.promises.readdir(srcDir);
               for (const file of files) {
-                if (file.endsWith('.tar.gz')) {
+                if (file.endsWith('.tar.xz')) {
                   await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
                 }
               }


### PR DESCRIPTION
# Why

We distribute our XCFrameworks as tar.gz files today, and include them in our npm packages for easy downloads and caching.

To reduce size we have decided to change the compression type to xz since it reduces the size of the packages and makes downloads smaller.

Closes #ENG-21969

**Size reduction:**

  |                | Codec          | Archive size | Reduction |
  | -------------- | -------------- | ------------ | --------- |
  | Before this PR | gzip (level 6) | 14.82 MB     | —         |
  | After this PR  | xz (-9 -T0)    | 5.56 MB      | ~62%      |

# How

- Change how precompiled_modules.rb reads packages - now looking for.xz files.
- Updated the debug/release switch scripts to look for .xz files as well
- Update the prebuild-external-xcframeworks workflow to look for xz files as well

Updated prebuilds tools:
- Updated Frameworks.ts to generate xz compressed packages
- Updated tests
- Updated bundleIOSPrebuilds.ts to test for .xz files.

## Test-plan

✅ Rebuild local XCFrameworks and verify they're packaged using .xz files 
✅ Run pod install on BareExpo and verify it is using .xz files 
✅ Run npm packager to ensure it includes the correct files
✅ expo-brownfield build:ios --release
✅ generated Swift Package

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

