### PR TITLE
[ui][iOS] Fix DateTimePicker collapsing to zero width in centered parents

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix Mac Catalyst build failure with `activityBackgroundTint` ([#46929](https://github.com/expo/expo/pull/46929) by [@theeket](https://github.com/theeket))
 - [iOS] Fix the SwiftUI `listRowInsets` modifier being ignored when every edge is set to `0`, so a row can now reset all of its insets. ([#47000](https://github.com/expo/expo/pull/47000) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Fix `FieldGroup` rendering an empty row/section when a conditional child (e.g. `{condition && <FieldGroup.Section>…</FieldGroup.Section>}`) evaluates to `false`. ([##46874](https://github.com/expo/expo/pull/46874) by [@dileepapeiris](https://github.com/dileepapeiris))

--- a/packages/expo-ui/src/community/datetime-picker/DateTimePicker.tsx
+++ b/packages/expo-ui/src/community/datetime-picker/DateTimePicker.tsx
@@ -94,7 +94,7 @@ export function DateTimePicker(props: DateTimePickerProps) {
   return (
     <Host
       matchContents={isCompactStyle ? true : { vertical: true }}
-      style={[style, { backgroundColor: 'red' }]}
+      style={style}
       ignoreSafeArea="all">
       <DatePicker {...iosProps} />
     </Host>

--- a/packages/expo-ui/src/community/datetime-picker/DateTimePicker.tsx
+++ b/packages/expo-ui/src/community/datetime-picker/DateTimePicker.tsx
@@ -54,6 +54,11 @@ export function DateTimePicker(props: DateTimePickerProps) {
 
   const pickerStyle = displayToDatePickerStyle(display);
 
+  // The compact style hugs its content, so the Host must match it
+  // on both axes, otherwise it collapses to 0 width under a non-stretch parent like
+  // `alignItems: 'center'` https://github.com/expo/expo/issues/46904.
+  const isCompactStyle = pickerStyle === 'compact' || pickerStyle === 'automatic';
+
   const modifiers: ModifierConfig[] = [datePickerStyle(pickerStyle)];
   if (accentColor) {
     modifiers.push(tint(accentColor));
@@ -87,7 +92,10 @@ export function DateTimePicker(props: DateTimePickerProps) {
   };
 
   return (
-    <Host matchContents={{ vertical: true }} style={style} ignoreSafeArea="all">
+    <Host
+      matchContents={isCompactStyle ? true : { vertical: true }}
+      style={[style, { backgroundColor: 'red' }]}
+      ignoreSafeArea="all">
       <DatePicker {...iosProps} />
     </Host>
   );


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/46904

The default/compact `community/datetime-picker` collapses to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`).


# How

- The `Host` wrapping the SwiftUI `DatePicker` only matched content vertically (`matchContents={{ vertical: true }}`), so its width was parent-driven. When parent has 0 size, SwiftUI sizes it to 0. 
- Match contents on both axes when picker style is compact, for other styles they have intrinsic size so vertical match contents work there.

# Test Plan

Tested with the original repro.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
