### PR TITLE
[widgets][Android] Support interactions

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Add Hermes runtime. ([#46684](https://github.com/expo/expo/pull/46684) by [@jakex7](https://github.com/jakex7))
 - [Android] Basic Android components. ([#46951](https://github.com/expo/expo/pull/46951) by [@jakex7](https://github.com/jakex7))
 - [Android] Implement widgets. ([#46961](https://github.com/expo/expo/pull/46961) by [@jakex7](https://github.com/jakex7))
+- [Android] Support interactions. ([#47035](https://github.com/expo/expo/pull/47035) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
+++ b/packages/expo-widgets/android/src/main/cpp/WidgetsHermesRuntime.cpp
@@ -15,13 +15,6 @@ namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 namespace expo::widgets {
-  std::optional<std::string> jstringToOptionalString(const jni::alias_ref<jstring> &value) {
-    if (!value) {
-      return std::nullopt;
-    }
-    return value->toStdString();
-  }
-
   void throwRuntimeException(const std::string &message) {
     jni::throwNewJavaException("java/lang/RuntimeException", message.c_str());
   }
@@ -61,6 +54,7 @@ namespace expo::widgets {
         makeNativeMethod("initHybrid", WidgetsHermesRuntime::initHybrid),
         makeNativeMethod("nativeEvaluateBundle", WidgetsHermesRuntime::nativeEvaluateBundle),
         makeNativeMethod("nativeRender", WidgetsHermesRuntime::nativeRender),
+        makeNativeMethod("nativeHandlePress", WidgetsHermesRuntime::nativeHandlePress),
       });
     }
 
@@ -85,7 +79,29 @@ namespace expo::widgets {
     ) {
       try {
         std::scoped_lock lock(mutex);
-        return renderWithFunction(
+        return callRender(
+          "__expoWidgetRender",
+          layout->toStdString(),
+          props,
+          environment
+        );
+      } catch (const jsi::JSError &error) {
+        throwRuntimeException(error.getMessage());
+      } catch (const std::exception &error) {
+        throwRuntimeException(error.what());
+      }
+      return nullptr;
+    }
+
+    jni::local_ref<react::ReadableNativeMap::jhybridobject> nativeHandlePress(
+      const jni::alias_ref<jstring> &layout,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &props,
+      const jni::alias_ref<react::ReadableNativeMap::javaobject> &environment
+    ) {
+      try {
+        std::scoped_lock lock(mutex);
+        return callRender(
+          "__expoWidgetHandlePress",
           layout->toStdString(),
           props,
           environment
@@ -116,7 +132,8 @@ namespace expo::widgets {
       layoutCache.emplace(layout, std::make_unique<jsi::Value>(*runtime, layoutValue));
     }
 
-    jni::local_ref<react::ReadableNativeMap::jhybridobject> renderWithFunction(
+    jni::local_ref<react::ReadableNativeMap::jhybridobject> callRender(
+      const char *functionName,
       const std::string &layout,
       const jni::alias_ref<react::ReadableNativeMap::javaobject> &propsMap,
       const jni::alias_ref<react::ReadableNativeMap::javaobject> &environmentMap
@@ -130,7 +147,7 @@ namespace expo::widgets {
       auto environment = readableMapToValue(rt, environmentMap);
       jsi::Value args[] = {std::move(props), std::move(environment)};
       const jsi::Value *argsPtr = args;
-      auto render = rt.global().getPropertyAsFunction(rt, "__expoWidgetRender");
+      auto render = rt.global().getPropertyAsFunction(rt, functionName);
       auto result = render.call(rt, argsPtr, static_cast<size_t>(2));
       if (!result.isObject()) {
         throw std::runtime_error("Widget render function must return an object");

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/DynamicView.kt
@@ -15,51 +15,71 @@ import expo.modules.ui.RadioButtonProps
 import expo.modules.ui.SpacerProps
 import expo.modules.ui.SwitchProps
 import expo.modules.ui.TextProps
-import expo.modules.ui.button.ButtonProps
-import expo.modules.widgets.ui.ButtonView
-import expo.modules.widgets.ui.ElevatedButtonView
-import expo.modules.widgets.ui.FilledTonalButtonView
-import expo.modules.widgets.ui.OutlinedButtonView
 import expo.modules.widgets.ui.BoxView
+import expo.modules.widgets.ui.ButtonView
 import expo.modules.widgets.ui.CheckboxView
 import expo.modules.widgets.ui.CircularProgressIndicatorView
 import expo.modules.widgets.ui.ColumnView
+import expo.modules.widgets.ui.ElevatedButtonView
+import expo.modules.widgets.ui.FilledTonalButtonView
 import expo.modules.widgets.ui.LinearProgressIndicatorView
 import expo.modules.widgets.ui.LoadingIndicatorView
+import expo.modules.widgets.ui.OutlinedButtonView
 import expo.modules.widgets.ui.RadioButtonView
 import expo.modules.widgets.ui.RowView
 import expo.modules.widgets.ui.SpacerView
 import expo.modules.widgets.ui.SwitchView
 import expo.modules.widgets.ui.TextButtonView
 import expo.modules.widgets.ui.TextView
+import expo.modules.widgets.ui.WidgetButtonProps
 
 @Composable
-internal fun DynamicView(node: ReadableMap) {
+internal fun DynamicView(node: ReadableMap, source: String) {
   val type = if (node.hasKey("type")) node.getString("type") else null
   when (type) {
-    "Button" -> ButtonView(node.props<ButtonProps>(), node.children())
-    "FilledTonalButton" -> FilledTonalButtonView(node.props<ButtonProps>(), node.children())
-    "OutlinedButton" -> OutlinedButtonView(node.props<ButtonProps>(), node.children())
-    "ElevatedButton" -> ElevatedButtonView(node.props<ButtonProps>(), node.children())
-    "TextButton" -> TextButtonView(node.props<ButtonProps>(), node.children())
     "BoxView" -> BoxView(node.props<LayoutProps>()) {
-      node.children().forEach { DynamicView(it) }
+      node.children().forEach { DynamicView(it, source) }
     }
     "CheckboxView" -> CheckboxView(node.props<CheckboxProps>())
     "CircularProgressIndicatorView" -> CircularProgressIndicatorView(node.props<CircularProgressIndicatorProps>())
     "ColumnView" -> ColumnView(node.props<LayoutProps>()) {
-      node.children().forEach { DynamicView(it) }
+      node.children().forEach { DynamicView(it, source) }
     }
     "LinearProgressIndicatorView" -> LinearProgressIndicatorView(node.props<LinearProgressIndicatorProps>())
     "LoadingIndicatorView" -> LoadingIndicatorView(node.props<LoadingIndicatorProps>())
     "RadioButtonView" -> RadioButtonView(node.props<RadioButtonProps>())
-    "react.fragment" -> node.children().forEach { DynamicView(it) }
+    "react.fragment" -> node.children().forEach { DynamicView(it, source) }
     "RowView" -> RowView(node.props<LayoutProps>()) {
-      node.children().forEach { DynamicView(it) }
+      node.children().forEach { DynamicView(it, source) }
     }
     "SpacerView" -> SpacerView(node.props<SpacerProps>())
     "SwitchView" -> SwitchView(node.props<SwitchProps>())
     "TextView" -> TextView(node.props<TextProps>())
+    "Button" -> ButtonView(
+      props = node.props<WidgetButtonProps>(),
+      children = node.children(),
+      source = source,
+    )
+    "FilledTonalButton" -> FilledTonalButtonView(
+      props = node.props<WidgetButtonProps>(),
+      children = node.children(),
+      source = source,
+    )
+    "OutlinedButton" -> OutlinedButtonView(
+      props = node.props<WidgetButtonProps>(),
+      children = node.children(),
+      source = source,
+    )
+    "ElevatedButton" -> ElevatedButtonView(
+      props = node.props<WidgetButtonProps>(),
+      children = node.children(),
+      source = source,
+    )
+    "TextButton" -> TextButtonView(
+      props = node.props<WidgetButtonProps>(),
+      children = node.children(),
+      source = source,
+    )
     else -> TextView(TextProps("View not found"))
   }
 }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetsGlanceWidget.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetsGlanceWidget.kt
@@ -32,6 +32,6 @@ internal fun ExpoWidgetsGlanceContent(context: Context, widgetName: String) {
   } ?: createErrorNode("No layout found for $widgetName")
 
   Box(modifier = GlanceModifier.fillMaxSize()) {
-    DynamicView(node)
+    DynamicView(node, widgetName)
   }
 }

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetInteractionAction.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetInteractionAction.kt
@@ -1,0 +1,51 @@
+package expo.modules.widgets
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.action.Action
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.action.actionRunCallback
+
+private val sourceKey = ActionParameters.Key<String>("source")
+private val targetKey = ActionParameters.Key<String>("target")
+
+internal data class WidgetInteraction(
+  val source: String,
+  val target: String
+)
+
+internal fun WidgetInteraction.toGlanceAction(): Action {
+  return actionRunCallback<WidgetInteractionAction>(
+    actionParametersOf(
+      sourceKey to source,
+      targetKey to target
+    )
+  )
+}
+
+class WidgetInteractionAction : ActionCallback {
+  override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+    val source = parameters[sourceKey] ?: return
+    val target = parameters[targetKey] ?: return
+
+    WidgetsInteraction.handle(context.applicationContext, source, target)
+  }
+}
+
+internal object WidgetsInteraction {
+  fun handle(context: Context, source: String, target: String) {
+    val layout = WidgetsLayoutRegistry.layout(context, source) ?: return
+    val props = WidgetsLayoutRegistry.props(context, source)
+    val environment = getWidgetEnvironment(context) + ("target" to target)
+    val updatedProps = evaluateWidgetButtonPress(context, layout, props, environment)
+
+    if (updatedProps != null) {
+      WidgetsStorage.set(context, props.orEmpty() + updatedProps, "__expo_widgets_${source}_props")
+    }
+
+    WidgetsEvents.sendUserInteraction(source, target)
+    WidgetsUpdater.reload(context, source)
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsEvents.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsEvents.kt
@@ -1,0 +1,33 @@
+package expo.modules.widgets
+
+internal const val ON_USER_INTERACTION = "onExpoWidgetsUserInteraction"
+
+private const val EVENT_TYPE_USER_INTERACTION = "ExpoWidgetsUserInteraction"
+
+internal object WidgetsEvents {
+  private var userInteractionObserver: ((Map<String, Any?>) -> Unit)? = null
+
+  @Synchronized
+  fun startObservingUserInteractions(observer: (Map<String, Any?>) -> Unit) {
+    userInteractionObserver = observer
+  }
+
+  @Synchronized
+  fun stopObservingUserInteractions() {
+    userInteractionObserver = null
+  }
+
+  @Synchronized
+  fun sendUserInteraction(source: String, target: String) {
+    userInteractionObserver?.invoke(userInteractionEvent(source, target))
+  }
+
+  private fun userInteractionEvent(source: String, target: String): Map<String, Any?> {
+    return mapOf(
+      "source" to source,
+      "target" to target,
+      "timestamp" to System.currentTimeMillis(),
+      "type" to EVENT_TYPE_USER_INTERACTION
+    )
+  }
+}

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsJSRuntime.kt
@@ -22,6 +22,20 @@ internal object WidgetsJSRuntime {
     )
   }
 
+  @Synchronized
+  fun handlePress(
+    context: Context,
+    layout: String,
+    props: Map<String, Any?>?,
+    environment: Map<String, Any?>
+  ): Map<String, Any?>? {
+    return getRuntime(context).handlePress(
+      layout,
+      Arguments.makeNativeMap(props),
+      Arguments.makeNativeMap(environment)
+    )?.toHashMap()
+  }
+
   private fun getRuntime(context: Context): WidgetsHermesRuntime {
     return runtime ?: WidgetsHermesRuntime().also {
       it.evaluateBundle(readBundle(context))

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsModule.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsModule.kt
@@ -13,6 +13,22 @@ class WidgetsModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoWidgets")
 
+    Events(ON_USER_INTERACTION)
+
+    OnStartObserving(ON_USER_INTERACTION) {
+      WidgetsEvents.startObservingUserInteractions { event ->
+        sendEvent(ON_USER_INTERACTION, event)
+      }
+    }
+
+    OnStopObserving(ON_USER_INTERACTION) {
+      WidgetsEvents.stopObservingUserInteractions()
+    }
+
+    OnDestroy {
+      WidgetsEvents.stopObservingUserInteractions()
+    }
+
     Constant("widgetsDirectory") {
       val directory = File(appContext.persistentFilesDirectory, "ExpoWidgets")
       if (directory.mkdirs() || directory.isDirectory) {

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsUtils.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/WidgetsUtils.kt
@@ -25,6 +25,17 @@ internal fun evaluateLayout(
   }
 }
 
+internal fun evaluateWidgetButtonPress(
+  context: Context,
+  layout: String,
+  props: Map<String, Any?>?,
+  environment: Map<String, Any?>
+): Map<String, Any?>? {
+  return runCatching {
+    WidgetsJSRuntime.handlePress(context, layout, props, environment)
+  }.getOrNull()
+}
+
 internal fun createErrorNode(message: String): ReadableMap {
   return Arguments.makeNativeMap(
     mapOf(

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/jni/WidgetsHermesRuntime.kt
@@ -18,12 +18,17 @@ internal class WidgetsHermesRuntime : Closeable {
     return nativeRender(layout, props, environment)
   }
 
+  fun handlePress(layout: String, props: ReadableNativeMap?, environment: ReadableNativeMap): ReadableNativeMap? {
+    return nativeHandlePress(layout, props, environment)
+  }
+
   override fun close() {
     mHybridData.resetNative()
   }
 
   private external fun nativeEvaluateBundle(script: String, sourceUrl: String)
   private external fun nativeRender(layout: String, props: ReadableNativeMap?, environment: ReadableNativeMap): ReadableNativeMap
+  private external fun nativeHandlePress(layout: String, props: ReadableNativeMap?, environment: ReadableNativeMap): ReadableNativeMap?
 
   companion object {
     init {

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ui/ButtonView.kt
@@ -5,121 +5,156 @@ import androidx.compose.ui.graphics.Color
 import androidx.glance.Button
 import androidx.glance.ButtonDefaults
 import androidx.glance.GlanceTheme
+import androidx.glance.action.Action
+import androidx.glance.action.action
+import androidx.glance.appwidget.components.FilledButton
+import androidx.glance.appwidget.components.OutlineButton
 import androidx.glance.unit.ColorProvider
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import expo.modules.ui.button.ButtonProps
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.OptimizedComposeProps
+import expo.modules.ui.ModifierList
+import expo.modules.ui.button.ButtonColors
 import expo.modules.ui.colorToComposeColorOrNull
-import androidx.glance.ButtonColors
-import androidx.glance.appwidget.components.FilledButton
-import androidx.glance.appwidget.components.OutlineButton
+import expo.modules.widgets.WidgetInteraction
+import expo.modules.widgets.toGlanceAction
+import androidx.glance.ButtonColors as GlanceButtonColors
+
+@OptimizedComposeProps
+data class WidgetButtonProps(
+  val colors: ButtonColors = ButtonColors(),
+  val enabled: Boolean = true,
+  val modifiers: ModifierList = emptyList(),
+  val target: String? = null
+) : ComposeProps
 
 @Composable
 internal fun ButtonView(
-  props: ButtonProps,
-  children: List<ReadableMap> = emptyList()
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  source: String,
 ) {
-  FilledButton(
-    text = props.textContent(children),
-    onClick = {},
-    modifier = props.modifiers.toGlanceModifier(),
-    enabled = props.enabled,
-    colors = props.toGlanceButtonColors(
-      defaultBackgroundColor = GlanceTheme.colors.primary,
-      defaultContentColor = GlanceTheme.colors.onPrimary
-    )
+  WidgetFilledButton(
+    props = props,
+    children = children,
+    onClick = buttonAction(source, props.target),
+    defaultBackgroundColor = GlanceTheme.colors.primary,
+    defaultContentColor = GlanceTheme.colors.onPrimary
   )
 }
 
 @Composable
 internal fun FilledTonalButtonView(
-  props: ButtonProps,
-  children: List<ReadableMap> = emptyList()
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  source: String,
 ) {
-  FilledButton(
-    text = props.textContent(children),
-    onClick = {},
-    modifier = props.modifiers.toGlanceModifier(),
-    enabled = props.enabled,
-    colors = props.toGlanceButtonColors(
-      defaultBackgroundColor = GlanceTheme.colors.secondaryContainer,
-      defaultContentColor = GlanceTheme.colors.onSecondaryContainer
-    )
+  WidgetFilledButton(
+    props = props,
+    children = children,
+    onClick = buttonAction(source, props.target),
+    defaultBackgroundColor = GlanceTheme.colors.secondaryContainer,
+    defaultContentColor = GlanceTheme.colors.onSecondaryContainer
   )
 }
 
 @Composable
 internal fun OutlinedButtonView(
-  props: ButtonProps,
-  children: List<ReadableMap> = emptyList()
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  source: String,
 ) {
+  val buttonText = props.textContent(children)
+  val contentColor = props.toGlanceContentColor(GlanceTheme.colors.primary)
+  val modifier = props.modifiers.toGlanceModifier()
+
   OutlineButton(
-    text = props.textContent(children),
-    contentColor = props.toGlanceContentColor(GlanceTheme.colors.primary),
-    onClick = {},
-    modifier = props.modifiers.toGlanceModifier(),
+    text = buttonText,
+    contentColor = contentColor,
+    onClick = buttonAction(source, props.target),
+    modifier = modifier,
     enabled = props.enabled
   )
 }
 
 @Composable
 internal fun ElevatedButtonView(
-  props: ButtonProps,
-  children: List<ReadableMap> = emptyList()
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  source: String,
 ) {
-  FilledButton(
-    text = props.textContent(children),
-    onClick = {},
-    modifier = props.modifiers.toGlanceModifier(),
-    enabled = props.enabled,
-    colors = props.toGlanceButtonColors(
-      defaultBackgroundColor = GlanceTheme.colors.surface,
-      defaultContentColor = GlanceTheme.colors.primary
-    )
+  WidgetFilledButton(
+    props = props,
+    children = children,
+    onClick = buttonAction(source, props.target),
+    defaultBackgroundColor = GlanceTheme.colors.surface,
+    defaultContentColor = GlanceTheme.colors.primary
   )
 }
 
 @Composable
 internal fun TextButtonView(
-  props: ButtonProps,
-  children: List<ReadableMap> = emptyList()
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  source: String,
 ) {
+  val buttonText = props.textContent(children)
+  val modifier = props.modifiers.toGlanceModifier()
+  val colors = props.toGlanceButtonColors(
+    defaultBackgroundColor = Color.Transparent.toGlanceColorProvider(),
+    defaultContentColor = GlanceTheme.colors.primary
+  )
+
   Button(
+    text = buttonText,
+    onClick = buttonAction(source, props.target),
+    modifier = modifier,
+    enabled = props.enabled,
+    colors = colors
+  )
+}
+
+@Composable
+private fun WidgetFilledButton(
+  props: WidgetButtonProps,
+  children: List<ReadableMap>,
+  onClick: Action,
+  defaultBackgroundColor: ColorProvider,
+  defaultContentColor: ColorProvider
+) {
+  FilledButton(
     text = props.textContent(children),
-    onClick = {},
+    onClick = onClick,
     modifier = props.modifiers.toGlanceModifier(),
     enabled = props.enabled,
-    colors = props.toGlanceButtonColors(
-      defaultBackgroundColor = Color.Transparent.toGlanceColorProvider(),
-      defaultContentColor = GlanceTheme.colors.primary
-    )
+    colors = props.toGlanceButtonColors(defaultBackgroundColor, defaultContentColor)
   )
 }
 
 // TODO(@jakex7): Find a better way to get text
-private fun ButtonProps.textContent(children: List<ReadableMap>): String {
+private fun WidgetButtonProps.textContent(children: List<ReadableMap>): String {
   return children.textContent() ?: ""
 }
 
 private fun List<ReadableMap>.textContent(): String? {
-  return mapNotNull { it.textFromTextNode() }
-    .joinToString(separator = "")
+  return mapNotNull { it.textFromTextNode() }.joinToString(separator = "")
     .takeIf { it.isNotEmpty() }
 }
 
 @Composable
-private fun ButtonProps.toGlanceButtonColors(
+private fun WidgetButtonProps.toGlanceButtonColors(
   defaultBackgroundColor: ColorProvider,
   defaultContentColor: ColorProvider
-): ButtonColors {
+): GlanceButtonColors {
   return ButtonDefaults.buttonColors(
     backgroundColor = toGlanceContainerColor(defaultBackgroundColor),
     contentColor = toGlanceContentColor(defaultContentColor)
   )
 }
 
-private fun ButtonProps.toGlanceContainerColor(defaultColor: ColorProvider): ColorProvider {
+private fun WidgetButtonProps.toGlanceContainerColor(defaultColor: ColorProvider): ColorProvider {
   return colorToComposeColorOrNull(
     if (enabled) {
       colors.containerColor
@@ -129,7 +164,7 @@ private fun ButtonProps.toGlanceContainerColor(defaultColor: ColorProvider): Col
   )?.toGlanceColorProvider() ?: defaultColor
 }
 
-private fun ButtonProps.toGlanceContentColor(defaultColor: ColorProvider): ColorProvider {
+private fun WidgetButtonProps.toGlanceContentColor(defaultColor: ColorProvider): ColorProvider {
   return colorToComposeColorOrNull(
     if (enabled) {
       colors.contentColor
@@ -137,6 +172,11 @@ private fun ButtonProps.toGlanceContentColor(defaultColor: ColorProvider): Color
       colors.disabledContentColor ?: colors.contentColor
     }
   )?.toGlanceColorProvider() ?: defaultColor
+}
+
+@Composable
+private fun buttonAction(source: String, target: String?): Action {
+  return target?.let { WidgetInteraction(source, it).toGlanceAction() } ?: action {}
 }
 
 private fun ReadableMap.textFromTextNode(): String? {

--- a/packages/expo-widgets/bundle/index.ts
+++ b/packages/expo-widgets/bundle/index.ts
@@ -36,11 +36,14 @@ const __expoWidgetHandlePress = function (
   function findAndCallOnPress(node?: Dictionary): Dictionary | undefined {
     const props = node?.props as {
       onButtonPress?: () => Dictionary;
+      onButtonPressed?: () => Dictionary;
       target?: string;
       children?: unknown;
     };
-    if (props?.onButtonPress && props?.target === target) {
-      return props.onButtonPress();
+    // TODO(@jakex7): on iOS it's named `onButtonPress` while on Android it's named `onButtonPressed`. We should unify this in the future.
+    const onPress = props?.onButtonPress ?? props?.onButtonPressed;
+    if (onPress && props?.target === target) {
+      return onPress();
     }
 
     for (const child of React.Children.toArray(props?.children)) {

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -1,6 +1,6 @@
 import type { EventSubscription } from 'expo-modules-core';
-
 import { Platform } from 'react-native';
+
 import ExpoWidgetsModule from './ExpoWidgets';
 import type {
   ExpoWidgetsEvents,


### PR DESCRIPTION
# Why

Android widgets did not support interactive button actions yet. This PR adds support for handling widget button presses, updating widget state from JS, and notifying the app about user interactions.

# How

This wires Android widget buttons into the widget runtime by passing button targets through Glance actions, evaluating the matching JS press handler, persisting returned prop updates, and refreshing the widget after interaction.

# Test Plan

Manually tested Android widgets with buttons.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)