### PR TITLE
docs(accounts/sso): document query-param SSO login pre-fill URL

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -69,7 +69,7 @@ The **Organization settings** > **Overview** page will now display an **Update S
 
 <Step label="1">
 
-Navigate to [expo.dev/sso-login](https://expo.dev/sso-login) and enter the account name of your organization. You can create a link that pre-fills the organization name. For example, [expo.dev/sso-login/test-org](https://expo.dev/sso-login/test-org) pre-fills `test-org`.
+Navigate to [expo.dev/sso-login](https://expo.dev/sso-login) and enter the account name of your organization. You can create a link that pre-fills the organization name, which is useful when configuring a tile in your identity provider (such as Okta). Two forms are supported: the path form [expo.dev/sso-login/test-org](https://expo.dev/sso-login/test-org) and the query-param form [expo.dev/sso-login?prefilledOrganizationName=test-org](https://expo.dev/sso-login?prefilledOrganizationName=test-org), both of which pre-fill `test-org`. The query-param form is the most reliable for pre-filling, so prefer it when in doubt.
 
 </Step>
 


### PR DESCRIPTION
## Why

The SSO sign-in docs only documented the path-form pre-fill URL (`expo.dev/sso-login/test-org`). That path form regressed and no longer reliably pre-fills the organization name. A sibling code PR in `universe` restores the path-form behavior, but the consistently-working form today is the query-param form: `https://expo.dev/sso-login?prefilledOrganizationName=test-org`.

## What

Updates the "SSO user sign in" > "Expo website" step in `docs/pages/accounts/sso.mdx` to document both forms:

- the path form `expo.dev/sso-login/test-org`
- the query-param form `expo.dev/sso-login?prefilledOrganizationName=test-org`

It notes the query-param form is the most reliable for pre-filling, which matters for customers configuring an IdP tile (such as Okta), so they always have a working URL regardless of the path-form regression.

Docs-only text change. No page restructure, no other files touched.

## Test Plan

Text-only change; rendered links point to the existing `expo.dev/sso-login` flow.

Related: ENG-22038
