### PR TITLE
[android][dev-menu] Restore "Open React Native dev menu" entry

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#PR](https://github.com/expo/expo/pull/PR) by [@lindboe](https://github.com/lindboe))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#PR](https://github.com/expo/expo/pull/PR) by [@lindboe](https://github.com/lindboe))
+- [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#47047](https://github.com/expo/expo/pull/47047) by [@lindboe](https://github.com/lindboe))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuIcons.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuIcons.kt
@@ -187,6 +187,22 @@ object MenuIcons {
   }
 
   @Composable
+  fun Gear(
+    size: Dp,
+    tint: Color,
+    modifier: Modifier = Modifier
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.gear_fill),
+      contentDescription = "React Native dev menu",
+      tint = tint,
+      modifier = Modifier
+        .size(size)
+        .then(modifier)
+    )
+  }
+
+  @Composable
   fun Refresh(
     size: Dp,
     tint: Color,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
@@ -114,6 +114,26 @@ fun ToolsSection(
         }
       )
 
+      Divider(thickness = 0.5.dp)
+
+      NewMenuButton(
+        withSurface = false,
+        icon = {
+          MenuIcons.Gear(
+            size = 20.dp,
+            tint = NewAppTheme.colors.icon.tertiary
+          )
+        },
+        content = {
+          NewText(
+            text = "Open React Native dev menu"
+          )
+        },
+        onClick = {
+          onAction(DevMenuAction.OpenReactNativeDevMenu)
+        }
+      )
+
       // TODO(@lukmccall): Re-enable when toggling fast refresh is not longer crashing app
 //      Divider(thickness = 0.5.dp)
 //


### PR DESCRIPTION
# Why

We noticed after an SDK 53->55 upgrade, pn Android, the dev menu no longer has an "Open React Native dev menu" entry, even though the underlying action (`DevMenuAction.OpenReactNativeDevMenu`) and its handler — which calls `reactHost?.devSupportManager?.showDevOptionsDialog()` — still exist.

That menu item does still exist on iOS. The iOS menu renders [`DevMenuRNDevMenu`](https://github.com/expo/expo/blob/0b840f12505298c6c95ef7cc700318719b19704a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift#L10) — a button labeled "Open React Native dev menu" — from [`DevMenuMainView`](https://github.com/expo/expo/blob/0b840f12505298c6c95ef7cc700318719b19704a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift#L38-L39).

**This entry also used to exist on Android.** The Jetpack Compose rewrite ([#37422](https://github.com/expo/expo/pull/37422)) included the button and dispatched the action here: [`DevMenuScreen.kt#L109`](https://github.com/expo/expo/blob/a062b48a6d0a6749908a7baf56811ec22babb42b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuScreen.kt#L109). The later UI refresh ([#38759](https://github.com/expo/expo/pull/38759)) reorganized the menu into `ToolsSection` and dropped that row, while leaving the `DevMenuAction.OpenReactNativeDevMenu` action and its handler in place — making it unreachable.

Our team asked about it missing after it was removed, so we did find developers were using it.

# How

- Re-add a row to `ToolsSection` (after "Open DevTools") that dispatches the existing `DevMenuAction.OpenReactNativeDevMenu`.
- Add a `MenuIcons.Gear` composable backed by the existing `gear_fill.xml` drawable (no new asset).
The entry shows unconditionally, matching the previous Android behavior. (On iOS it's gated behind the `devMenuShouldShowReactNativeDevMenu` host delegate; Android has no equivalent delegate, so this restores the prior unconditional behavior.)

# Test Plan

- Built `apps/bare-expo` before and after the change.
- Confirmed after changes:
  - the "Open React Native dev menu" row appears under TOOLS, below "Open DevTools".
  - Tap it → the React Native dev options dialog appears and the Expo dev menu closes 

### Screenshots (Android)
| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5da90aa9-6567-42e3-abc2-00fdb697f7f6" width=300 /> | <video src="https://github.com/user-attachments/assets/c6676837-512b-46e1-a03b-6f307a8d1de8" width=300 /> |








# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to this short guide
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the Documentation Writing Style Guide
