### PR TITLE
[core][ios] Add `SharedObject.native(from:)` to recover the native object from its JS counterpart

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4066,7 +4066,7 @@ SPEC CHECKSUMS:
   ExpoMaps: 4cf2ea2eb8d9369fbfa4cc613fe2932619624d59
   ExpoMediaLibrary: 5ab82b8ace3f9ab7ac4ca3b2060bd915a4f1568f
   ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
-  ExpoModulesCore: 7ee5c9715b287b20ec9caa7f2577007597adf25a
+  ExpoModulesCore: 17bcaab73cb8d760aafe4f1f6b4f066975c317db
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesTestCore: 768a9a2b0401e87090bc7280cdb0607ab4cad382
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -3147,7 +3147,7 @@ SPEC CHECKSUMS:
   ExpoClipboard: 40221903a1caa68259e022517af49d12962821fe
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
   ExpoMediaLibrary: 5ab82b8ace3f9ab7ac4ca3b2060bd915a4f1568f
-  ExpoModulesCore: 7ee5c9715b287b20ec9caa7f2577007597adf25a
+  ExpoModulesCore: 17bcaab73cb8d760aafe4f1f6b4f066975c317db
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesTestCore: 768a9a2b0401e87090bc7280cdb0607ab4cad382
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] `@ExpoModule` now synthesizes the module's JavaScript name from the class name or its `@ExpoModule("CustomName")` argument, so a `Name(…)` definition entry is no longer required. ([#46938](https://github.com/expo/expo/pull/46938) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `Module.emit` that sends an event directly to the module's own JavaScript object, mirroring `SharedObject.emit`. Both now share an `EventEmitter` protocol. ([#46555](https://github.com/expo/expo/pull/46555) by [@tsapeta](https://github.com/tsapeta))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
+- [iOS] Added `SharedObject.native(from:)` that recovers the native shared object paired with a JavaScript object, with a generic overload that returns the concrete subclass directly. ([#47054](https://github.com/expo/expo/pull/47054) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -128,5 +128,13 @@ Pod::Spec.new do |s|
     test_spec.dependency 'ExpoModulesTestCore'
 
     test_spec.source_files = 'ios/Tests/**/*.{m,swift}'
+
+    # The library's -lc++ lives in `user_target_xcconfig` (for consuming apps), which a
+    # test_spec target doesn't inherit. The test bundle links libExpoModulesCore.a (C++)
+    # but has no C++/Obj-C++ source of its own, so the linker driver is clang, not clang++,
+    # and libc++ isn't linked implicitly. Link it explicitly here.
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
   end
 end

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -41,7 +41,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
       let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native {
       return nativeSharedObject
     }
-    throw NativeSharedObjectNotFoundException()
+    throw SharedObject.NotFoundException()
   }
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
@@ -49,7 +49,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
       let sharedObjectId = jsValue.getInt() as SharedObjectId
 
       guard let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native else {
-        throw NativeSharedObjectNotFoundException()
+        throw SharedObject.NotFoundException()
       }
       return nativeSharedObject
     }
@@ -57,7 +57,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
       let nativeSharedObject = appContext.sharedObjectRegistry.toNativeObject(jsObject) {
       return nativeSharedObject
     }
-    throw NativeSharedObjectNotFoundException()
+    throw SharedObject.NotFoundException()
   }
 
   var description: String {
@@ -82,7 +82,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
 
       return jsObject.asValue()
     }
-    throw NativeSharedObjectNotFoundException()
+    throw SharedObject.NotFoundException()
   }
 }
 
@@ -97,10 +97,4 @@ private func newBaseSharedObject(_ appContext: AppContext, nativeType: AnyShared
   let jsClass = try getBaseSharedType(appContext, nativeType: nativeType)
   let prototype = try jsClass.asObject().getPropertyAsObject("prototype")
   return try appContext.runtime.createObject(prototype: prototype)
-}
-
-internal final class NativeSharedObjectNotFoundException: Exception {
-  override var reason: String {
-    "Unable to find the native shared object associated with given JavaScript object"
-  }
 }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -94,3 +94,66 @@ extension SharedObject: EventEmitter {
     return try body(target)
   }
 }
+
+// MARK: - Recovering the native object from JS
+
+extension SharedObject {
+  /// Recovers the native shared object paired with the given JS object, reading it off the object's
+  /// `SharedObjectNativeState`. Callers holding a `JavaScriptValue` or borrowed `JavaScriptUnownedValue`
+  /// convert it first via `asObject()` / `asObject(in:)`.
+  ///
+  /// Returns the base `SharedObject`. Callers wanting a concrete subclass use the `as:` overload, which
+  /// performs a checked downcast.
+  ///
+  /// Throws `NotFoundException` when the object carries no native state.
+  @JavaScriptActor
+  public static func native(from jsObject: borrowing JavaScriptObject) throws -> SharedObject {
+    guard let native = jsObject.getNativeState(as: SharedObjectNativeState.self)?.native else {
+      throw NotFoundException()
+    }
+    return native
+  }
+
+  /// Recovers the native shared object and casts it to the given subclass, e.g.
+  /// `SharedObject.native(from: jsObject, as: Cache.self)`. The target type is an explicit argument
+  /// rather than inferred from the return type, so the checked cast can never be skipped by omitting a
+  /// contextual type. `@inlinable` so the `as?` specializes in the caller's module as a plain
+  /// concrete-class cast. Throws `TypeMismatchException` when the paired native object isn't `type`.
+  @JavaScriptActor
+  @inlinable
+  public static func native<SharedObjectType: SharedObject>(
+    from jsObject: borrowing JavaScriptObject,
+    as type: SharedObjectType.Type
+  ) throws -> SharedObjectType {
+    let native = try native(from: jsObject)
+    guard let typed = native as? SharedObjectType else {
+      throw TypeMismatchException((expected: SharedObjectType.self, actual: Swift.type(of: native)))
+    }
+    return typed
+  }
+
+  /// Thrown when a JS object has no paired native object, for example a foreign JS object that carries
+  /// no `SharedObjectNativeState`.
+  internal final class NotFoundException: Exception, @unchecked Sendable {
+    override var code: String {
+      "ERR_NATIVE_SHARED_OBJECT_NOT_FOUND"
+    }
+
+    override var reason: String {
+      "Unable to find the native shared object associated with given JavaScript object"
+    }
+  }
+
+  /// Thrown when the native shared object paired with a JS object exists but isn't the expected subclass.
+  /// `@usableFromInline` so `native(from:)`'s inlinable generic overloads can throw it.
+  @usableFromInline
+  internal final class TypeMismatchException: GenericException<(expected: Any.Type, actual: Any.Type)>, @unchecked Sendable {
+    override var code: String {
+      "ERR_NATIVE_SHARED_OBJECT_TYPE_MISMATCH"
+    }
+
+    override var reason: String {
+      "Expected the native shared object to be '\(param.expected)', but found '\(param.actual)'"
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -174,8 +174,8 @@ public final class SharedObjectRegistry: Sendable {
    */
   @JavaScriptActor
   internal func toNativeObject(_ jsObject: borrowing JavaScriptObject) -> SharedObject? {
-    if let nativeState = jsObject.getNativeState(as: SharedObjectNativeState.self) {
-      return nativeState.native
+    if let native = try? SharedObject.native(from: jsObject) {
+      return native
     }
     // Fallback to the id-based lookup for cases where the JS object was registered
     // through a path that doesn't attach a `SharedObjectNativeState` (e.g. worklet

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -660,8 +660,8 @@ struct DynamicTypeTests {
     }
 
     @Test
-    func `throws NativeSharedObjectNotFoundException`() {
-      #expect(throws: NativeSharedObjectNotFoundException.self) {
+    func `throws SharedObject.NotFoundException`() {
+      #expect(throws: SharedObject.NotFoundException.self) {
         try (~TestSharedObject.self).cast("a string", appContext: appContext)
       }
     }

--- a/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
@@ -251,6 +251,57 @@ struct SharedObjectTests {
     detached.emit(event: "ignored", payload: .undefined)
   }
 
+  // MARK: - native(from:)
+
+  @Test
+  func `native(from:) recovers the paired native object as its concrete subclass`() throws {
+    let runtime = try runtime
+    let nativeObject = SharedObjectExample()
+    let jsObject = runtime.createObject()
+    appContext.sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+
+    // The `as:` overload returns the concrete subclass directly.
+    let recovered = try SharedObject.native(from: jsObject, as: SharedObjectExample.self)
+
+    #expect(recovered === nativeObject)
+  }
+
+  @Test
+  func `native(from:) throws for a foreign object without native state`() throws {
+    let runtime = try runtime
+    // A plain object carries no `SharedObjectNativeState`.
+    let foreignObject = try runtime.eval("({})").asObject()
+
+    #expect(throws: SharedObject.NotFoundException.self) {
+      _ = try SharedObject.native(from: foreignObject)
+    }
+  }
+
+  @Test
+  func `native(from:) throws not-found before the subclass cast`() throws {
+    let runtime = try runtime
+    // A foreign object reports not-found rather than a type mismatch: the `as:` overload checks for a
+    // paired native object before attempting the subclass cast.
+    let foreignObject = try runtime.eval("({})").asObject()
+
+    #expect(throws: SharedObject.NotFoundException.self) {
+      _ = try SharedObject.native(from: foreignObject, as: SharedObjectExample.self)
+    }
+  }
+
+  @Test
+  func `native(from:) throws when the native object is a different subclass`() throws {
+    let runtime = try runtime
+    let nativeObject = SharedObjectExample()
+    let jsObject = runtime.createObject()
+    appContext.sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+
+    // The object is paired with a `SharedObjectExample`, so requesting a different subclass mismatches.
+    #expect(throws: SharedObject.TypeMismatchException.self) {
+      _ = try SharedObject.native(from: jsObject, as: OtherSharedObjectExample.self)
+    }
+  }
+
   @Test
   func `emits NativeArrayBuffer`() throws {
     let jsObject = try runtime
@@ -311,3 +362,6 @@ private class SharedObjectModule: Module {
 }
 
 private final class SharedObjectExample: SharedObject {}
+
+/// A second, unrelated subclass used to exercise the type-mismatch path of `native(from:)`.
+private final class OtherSharedObjectExample: SharedObject {}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -111,6 +111,23 @@ public struct JavaScriptUnownedValue: ~Copyable {
     return String(pointer.pointee.getString(runtime).utf8(runtime))
   }
 
+  /// Returns the value as a ``JavaScriptObject`` *without* materializing an owning ``JavaScriptValue``
+  /// first, or asserts if not an object. Mirrors ``JavaScriptValue/getObject()``: `jsi::Value::getObject`
+  /// borrows the value and hands back a `jsi::Object` (a ref-count bump on the object pointer), so this
+  /// skips the per-call owning-value allocation and `PointerValue` clone that ``copied(in:)`` pays.
+  ///
+  /// The returned object owns its `jsi::Object` and so may outlive this borrowed value; only the
+  /// borrowed `jsi::Value` must not. Takes the ``JavaScriptRuntime`` wrapper because the object needs
+  /// it (the unowned value stores only the raw `IRuntime` to avoid per-call ARC); `runtime` must be
+  /// the runtime that owns the borrowed value, same contract as ``copied(in:)``.
+  public func getObject(in runtime: JavaScriptRuntime) -> JavaScriptObject {
+    assert(isObject(), "Value is not an object")
+    assert(
+      Unmanaged.passUnretained(runtime.pointee).toOpaque() == Unmanaged.passUnretained(self.runtime).toOpaque(),
+      "`getObject(in:)` must be passed the runtime that owns the borrowed value")
+    return JavaScriptObject(runtime, pointer.pointee.getObject(self.runtime))
+  }
+
   // MARK: - Throwing conversions ("as functions")
 
   /// Returns the value as a boolean, or throws `TypeError` if it is not a boolean.
@@ -143,5 +160,14 @@ public struct JavaScriptUnownedValue: ~Copyable {
       throw JavaScriptValue.TypeError(type: String.self)
     }
     return getString()
+  }
+
+  /// Returns the value as a ``JavaScriptObject``, or throws `TypeError` if it is not an object. The
+  /// zero-copy counterpart of ``JavaScriptValue/asObject()``; see ``getObject(in:)``.
+  public func asObject(in runtime: JavaScriptRuntime) throws(JavaScriptValue.TypeError) -> JavaScriptObject {
+    guard isObject() else {
+      throw JavaScriptValue.TypeError(type: JavaScriptObject.self)
+    }
+    return getObject(in: runtime)
   }
 }


### PR DESCRIPTION
# Why

The `@SharedObject` macro's synthesized bindings (and other native call sites) need to recover the native `SharedObject` paired with a JavaScript object. The existing path goes through `SharedObjectRegistry`'s id table, which needs an `appContext` and a dictionary lookup. Reading the `SharedObjectNativeState` straight off the JS object is cheaper and decoupled from the registry, which we're working toward retiring.

# How

Adds `SharedObject.native(from:)`, recovering the native shared object paired with a `JavaScriptObject` by reading its `SharedObjectNativeState` directly (no registry id lookup, no `appContext`). Two overloads:

- a non-generic workhorse returning the base `SharedObject`, and
- an `@inlinable` generic overload that casts to the concrete subclass, so callers can write `Cache.native(from: jsObject)`. The cast is `@inlinable` so it specializes in the caller's own module as a plain concrete-class downcast, keeping the call free of generic type-metadata threading (the function lives in a prebuilt module that wouldn't specialize a `<T>` at the call site).

Both throw rather than trap: `SharedObject.NotFoundException` when the object carries no native state, and `SharedObject.TypeMismatchException` when the paired native object isn't the requested subclass (so a wrong type is catchable and testable instead of crashing). Callers holding a `JavaScriptValue` or borrowed `JavaScriptUnownedValue` convert it first via `asObject()` / `asObject(in:)`.

`SharedObjectRegistry.toNativeObject` now goes through `native(from:)` first, falling back to the id-based lookup for objects without a `SharedObjectNativeState` (e.g. worklet proxies). This makes `native(from:)` the single source of truth for the native-state read on the way to retiring the registry.

To support reading `this` without materializing an owning value, adds `JavaScriptUnownedValue.getObject(in:)` / `asObject(in:)`: they wrap the borrowed `jsi::Value` as a `JavaScriptObject` via `jsi::Value::getObject`, skipping the owning-`JavaScriptValue` allocation and `PointerValue` clone that `copied(in:)` pays.

# Test Plan

Added `SharedObject` native-unit-tests covering `native(from:)`: recovering the paired native object as its concrete subclass, throwing `NotFoundException` for a foreign object (both directly and before the subclass cast), and throwing `TypeMismatchException` for a mismatched subclass.

`et native-unit-tests -p ios --packages expo-modules-core` — `ExpoModulesCore-Unit-Tests` passes (61 tests, 0 failures), including the new `native(from:)` cases.


# Future directions

- Add `pair` / `unpair` functions to establish and tear down the native ↔ JS association directly.
- Recover the JS object from a native instance (the reverse of `native(from:)`; a bigger task).
- Integrate with worklets, which requires a native instance to be paired with multiple JS instances, one per runtime.
- Move off the `SharedObjectRegistry` entirely.

<!-- disable:changelog-checks -->