### PR TITLE
test(expo-sqlite): Replace `better-sqlite3` with `node:sqlite` built-in

### DIFF
--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -66,11 +66,9 @@
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.0",
-    "@types/better-sqlite3": "^7.6.6",
     "@types/jest": "^29.2.1",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
-    "better-sqlite3": "^11.6.0",
     "expo": "workspace:*",
     "expo-module-scripts": "workspace:*",
     "react-error-boundary": "^4.0.11"

--- a/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
+++ b/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
@@ -1,5 +1,8 @@
 import assert from 'assert';
-import sqlite3 from 'better-sqlite3';
+import fs from 'fs';
+import { DatabaseSync, type SQLInputValue, type StatementSync } from 'node:sqlite';
+import os from 'os';
+import path from 'path';
 
 import type { SQLiteOpenOptions } from '../NativeDatabase';
 import type {
@@ -11,10 +14,13 @@ import type {
   SQLiteRunResult,
 } from '../NativeStatement';
 
+// Per-worker temp directory: node:sqlite refuses concurrent opens of the same path across processes.
+const defaultDatabaseDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-sqlite-test-'));
+
 export default {
   deleteDatebaseAsync: jest.fn(),
 
-  defaultDatabaseDirectory: '.',
+  defaultDatabaseDirectory,
   bundledExtensions: {},
 
   ensureDatabasePathExistsAsync: jest.fn().mockImplementation(async (databasePath: string) => {}),
@@ -30,41 +36,32 @@ export default {
   NativeStatement: jest.fn().mockImplementation(() => new NativeStatement()),
 };
 
-//#region async sqlite3
+//#region node:sqlite
 
-/**
- * A sqlite3.Database wrapper with async methods and conforming to the NativeDatabase interface.
- */
+/** node:sqlite (bundled with Node 22+) backs the mock, avoiding a node-gyp-compiled dependency. */
 class NativeDatabase {
-  private readonly sqlite3Db: sqlite3.Database;
+  private readonly nodeDb: DatabaseSync;
 
   constructor(databaseName: string, options?: SQLiteOpenOptions, serializedData?: Uint8Array) {
     if (serializedData != null) {
-      this.sqlite3Db = new sqlite3(Buffer.from(serializedData));
+      // node:sqlite gained buffer construction after Node 22; unreachable while serialize is skipped.
+      this.nodeDb = new DatabaseSync(Buffer.from(serializedData) as unknown as string);
     } else {
-      this.sqlite3Db = new sqlite3(databaseName);
+      this.nodeDb = new DatabaseSync(databaseName);
     }
   }
 
   //#region Asynchronous API
 
   initAsync = jest.fn().mockResolvedValue(null);
-  isInTransactionAsync = jest.fn().mockImplementation(async () => {
-    return this.sqlite3Db.inTransaction;
-  });
-  closeAsync = jest.fn().mockImplementation(async () => {
-    return this.sqlite3Db.close();
-  });
-  execAsync = jest.fn().mockImplementation(async (source: string) => {
-    return this.sqlite3Db.exec(source);
-  });
-  serializeAsync = jest.fn().mockImplementation(async (databaseName: string) => {
-    return this.sqlite3Db.serialize({ attached: databaseName });
-  });
+  isInTransactionAsync = jest.fn().mockImplementation(async () => this.nodeDb.isTransaction);
+  closeAsync = jest.fn().mockImplementation(async () => this._close());
+  execAsync = jest.fn().mockImplementation(async (source: string) => this.nodeDb.exec(source));
+  serializeAsync = jest.fn().mockImplementation(async (databaseName: string) => this._serialize());
   prepareAsync = jest
     .fn()
     .mockImplementation(async (nativeStatement: NativeStatement, source: string) => {
-      nativeStatement.sqlite3Stmt = this.sqlite3Db.prepare(source);
+      nativeStatement.prepare(this.nodeDb, source);
     });
 
   //#endregion
@@ -72,25 +69,51 @@ class NativeDatabase {
   //#region Synchronous API
 
   initSync = jest.fn();
-  isInTransactionSync = jest.fn().mockImplementation(() => this.sqlite3Db.inTransaction);
-  closeSync = jest.fn().mockImplementation(() => this.sqlite3Db.close());
-  execSync = jest.fn().mockImplementation((source: string) => this.sqlite3Db.exec(source));
-  serializeSync = jest.fn().mockImplementation((databaseName: string) => {
-    return this.sqlite3Db.serialize({ attached: databaseName });
-  });
+  isInTransactionSync = jest.fn().mockImplementation(() => this.nodeDb.isTransaction);
+  closeSync = jest.fn().mockImplementation(() => this._close());
+  execSync = jest.fn().mockImplementation((source: string) => this.nodeDb.exec(source));
+  serializeSync = jest.fn().mockImplementation((databaseName: string) => this._serialize());
   prepareSync = jest.fn().mockImplementation((nativeStatement: NativeStatement, source: string) => {
-    nativeStatement.sqlite3Stmt = this.sqlite3Db.prepare(source);
+    nativeStatement.prepare(this.nodeDb, source);
   });
 
   //#endregion
+
+  // node:sqlite throws when closing an already-closed database; callers may close more than once.
+  private _close() {
+    if (this.nodeDb.isOpen) {
+      this.nodeDb.close();
+    }
+  }
+
+  private _serialize(): Uint8Array {
+    const serialize = (this.nodeDb as unknown as { serialize?: () => Uint8Array }).serialize;
+    if (typeof serialize !== 'function') {
+      throw new Error(
+        'node:sqlite does not implement serialize() on this Node version, so the mock cannot serialize the database.'
+      );
+    }
+    return serialize.call(this.nodeDb);
+  }
 }
 
 /**
- * A sqlite3.Statement wrapper with async methods and conforming to the NativeStatement interface.
+ * node:sqlite re-executes a statement's side effects on each run/get/all call, so row-returning
+ * statements are driven through one iterator created in `_run()` to execute exactly once.
  */
 class NativeStatement {
-  public sqlite3Stmt: sqlite3.Statement | null = null;
-  private iterator: ReturnType<sqlite3.Statement['iterate']> | null = null;
+  private nodeStmt: StatementSync | null = null;
+  private iterator: Iterator<unknown> | null = null;
+  private boundParams: SQLiteBindParams = [];
+
+  prepare(nodeDb: DatabaseSync, source: string) {
+    const stmt = nodeDb.prepare(source);
+    // The native module strips the `:@$` prefixes from named parameters.
+    stmt.setAllowBareNamedParameters(true);
+    // The JS layer expects rows as value arrays.
+    stmt.setReturnArrays(true);
+    this.nodeStmt = stmt;
+  }
 
   //#region Asynchronous API
 
@@ -107,25 +130,18 @@ class NativeStatement {
           this._run(normalizeSQLite3Args(bindParams, bindBlobParams, shouldPassAsArray))
         )
     );
-  public stepAsync = jest.fn().mockImplementation((database: NativeDatabase): Promise<any> => {
-    assert(this.sqlite3Stmt);
-    if (this.iterator == null) {
-      this.iterator = this.sqlite3Stmt.iterate();
-      // Since the first row is retrieved by `_run()`, we need to skip the first row here.
-      this.iterator.next();
-    }
-    const result = this.iterator.next();
-    const columnValues =
-      result.done === false ? Object.values(result.value as Record<string, any>) : null;
-    return Promise.resolve(columnValues);
-  });
+  public stepAsync = jest
+    .fn()
+    .mockImplementation(
+      (database: NativeDatabase): Promise<SQLiteColumnValues | null> =>
+        Promise.resolve(this._step())
+    );
   public getAllAsync = jest
     .fn()
     .mockImplementation((database: NativeDatabase) => Promise.resolve(this._allValues()));
-  public getColumnNamesAsync = jest.fn().mockImplementation(async (database: NativeDatabase) => {
-    assert(this.sqlite3Stmt);
-    return this.sqlite3Stmt.columns().map((column) => column.name);
-  });
+  public getColumnNamesAsync = jest
+    .fn()
+    .mockImplementation(async (database: NativeDatabase) => this._columnNames());
   public resetAsync = jest.fn().mockImplementation(async (database: NativeDatabase) => {
     this._reset();
   });
@@ -148,24 +164,13 @@ class NativeStatement {
       ): SQLiteRunResult & { firstRowValues: SQLiteColumnValues } =>
         this._run(normalizeSQLite3Args(bindParams, bindBlobParams, shouldPassAsArray))
     );
-  public stepSync = jest.fn().mockImplementation((database: NativeDatabase): any => {
-    assert(this.sqlite3Stmt);
-    if (this.iterator == null) {
-      this.iterator = this.sqlite3Stmt.iterate();
-      // Since the first row is retrieved by `_run()`, we need to skip the first row here.
-      this.iterator.next();
-    }
-
-    const result = this.iterator.next();
-    const columnValues =
-      result.done === false ? Object.values(result.value as Record<string, any>) : null;
-    return columnValues;
-  });
+  public stepSync = jest
+    .fn()
+    .mockImplementation((database: NativeDatabase): SQLiteColumnValues | null => this._step());
   public getAllSync = jest.fn().mockImplementation((database: NativeDatabase) => this._allValues());
-  public getColumnNamesSync = jest.fn().mockImplementation((database: NativeDatabase) => {
-    assert(this.sqlite3Stmt);
-    return this.sqlite3Stmt.columns().map((column) => column.name);
-  });
+  public getColumnNamesSync = jest
+    .fn()
+    .mockImplementation((database: NativeDatabase) => this._columnNames());
   public resetSync = jest.fn().mockImplementation((database: NativeDatabase) => {
     this._reset();
   });
@@ -175,40 +180,63 @@ class NativeStatement {
 
   //#endregion
 
-  private _run = (...params: any[]): SQLiteRunResult & { firstRowValues: SQLiteColumnValues } => {
-    assert(this.sqlite3Stmt);
-    this.sqlite3Stmt.bind(...params);
-    const result = this.sqlite3Stmt.run();
+  private _run = (
+    params: SQLiteBindParams
+  ): SQLiteRunResult & { firstRowValues: SQLiteColumnValues } => {
+    assert(this.nodeStmt);
+    this.boundParams = params;
+    this.iterator = null;
 
-    // better-sqlite3 does not support run() returning the first row, use get() instead.
-    let firstRow;
-    try {
-      firstRow = this.sqlite3Stmt.get();
-    } catch {
-      // better-sqlite3 may throw `TypeError: This statement does not return data. Use run() instead`
-      firstRow = null;
+    if (this.nodeStmt.columns().length === 0) {
+      const result = this.nodeStmt.run(...asBindArgs(params));
+      return {
+        lastInsertRowId: Number(result.lastInsertRowid),
+        changes: Number(result.changes),
+        firstRowValues: [],
+      };
     }
+
+    // node:sqlite exposes no changes/lastInsertRowId for row-returning statements.
+    this.iterator = this.nodeStmt.iterate(...asBindArgs(params));
+    const first = this.iterator.next();
     return {
-      lastInsertRowId: Number(result.lastInsertRowid),
-      changes: result.changes,
-      firstRowValues: firstRow ? Object.values(firstRow) : [],
+      lastInsertRowId: 0,
+      changes: 0,
+      firstRowValues: first.done ? [] : (first.value as SQLiteColumnValues),
     };
   };
 
-  private _allValues = (): SQLiteColumnNames[] => {
-    assert(this.sqlite3Stmt);
-    const sqlite3Stmt = this.sqlite3Stmt as any;
-    // Since the first row is retrieved by `_run()`, we need to skip the first row here.
-    return sqlite3Stmt
-      .all()
-      .slice(1)
-      .map((row: any) => Object.values(row));
+  private _step = (): SQLiteColumnValues | null => {
+    if (this.iterator == null) {
+      return null;
+    }
+    const result = this.iterator.next();
+    return result.done ? null : (result.value as SQLiteColumnValues);
+  };
+
+  private _allValues = (): SQLiteColumnValues[] => {
+    if (this.iterator == null) {
+      return [];
+    }
+    // _run() already consumed the first row.
+    const rows: SQLiteColumnValues[] = [];
+    let result = this.iterator.next();
+    while (!result.done) {
+      rows.push(result.value as SQLiteColumnValues);
+      result = this.iterator.next();
+    }
+    return rows;
+  };
+
+  private _columnNames = (): SQLiteColumnNames => {
+    assert(this.nodeStmt);
+    return this.nodeStmt.columns().map((column) => column.name);
   };
 
   private _reset = () => {
-    assert(this.sqlite3Stmt);
+    assert(this.nodeStmt);
     this.iterator?.return?.();
-    this.iterator = this.sqlite3Stmt.iterate();
+    this.iterator = this.nodeStmt.iterate(...asBindArgs(this.boundParams));
   };
 
   private _finalize = () => {
@@ -218,6 +246,11 @@ class NativeStatement {
 }
 
 //#endregion
+
+function asBindArgs(params: SQLiteBindParams): SQLInputValue[] {
+  // Booleans are already normalized to 1/0 upstream, so values fit node:sqlite's input types.
+  return (Array.isArray(params) ? params : [params]) as unknown as SQLInputValue[];
+}
 
 function normalizeSQLite3Args(
   bindParams: SQLiteBindPrimitiveParams,

--- a/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
+++ b/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
@@ -43,11 +43,16 @@ class NativeDatabase {
   private readonly nodeDb: DatabaseSync;
 
   constructor(databaseName: string, options?: SQLiteOpenOptions, serializedData?: Uint8Array) {
+    this.nodeDb = new DatabaseSync(databaseName);
     if (serializedData != null) {
-      // node:sqlite gained buffer construction after Node 22; unreachable while serialize is skipped.
-      this.nodeDb = new DatabaseSync(Buffer.from(serializedData) as unknown as string);
-    } else {
-      this.nodeDb = new DatabaseSync(databaseName);
+      const deserialize = (this.nodeDb as unknown as { deserialize?: (data: Uint8Array) => void })
+        .deserialize;
+      if (typeof deserialize !== 'function') {
+        throw new Error(
+          'node:sqlite does not implement deserialize() on this Node version, so the mock cannot deserialize the database.'
+        );
+      }
+      deserialize.call(this.nodeDb, serializedData);
     }
   }
 

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -223,13 +223,13 @@ INSERT INTO users (name) VALUES ('aaa');
           throw new Error(`Exception from promise1: Expected aaa but received ${result?.name}}`);
         }
         await txn.runAsync('UPDATE users SET name = ?', 'aaa');
-        await delayAsync(200);
+        await delayAsync(30);
       }
     });
 
     const promise2 = new Promise(async (resolve, reject) => {
       try {
-        await delayAsync(100);
+        await delayAsync(50);
         await db?.runAsync('UPDATE users SET name = ?', 'bbb');
         const result = await db?.getFirstAsync<{ name: string }>('SELECT name FROM users');
         if (result?.name !== 'bbb') {

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -2,7 +2,12 @@
 import fs from 'fs/promises';
 
 import type { SQLiteDatabase } from '../SQLiteDatabase';
-import { deserializeDatabaseAsync, openDatabaseAsync, openDatabaseSync } from '../SQLiteDatabase';
+import {
+  deserializeDatabaseAsync,
+  deserializeDatabaseSync,
+  openDatabaseAsync,
+  openDatabaseSync,
+} from '../SQLiteDatabase';
 
 jest.mock('expo/devtools', () => ({
   getDevToolsPluginClientAsync: jest.fn(),
@@ -324,17 +329,23 @@ describe('Database - Synchronous calls', () => {
   });
 });
 
-// node:sqlite (the test mock) doesn't implement serialize on Node 22. Skipping is safe: the JS
-// wrappers are pass-throughs and the native behavior is covered by the Swift/Kotlin unit tests.
+// Skipping is safe where node:sqlite lacks serialize/deserialize: the JS wrappers are pass-throughs
+// and the native behavior is covered by the Swift/Kotlin unit tests.
 function supportsSerialize(): boolean {
   const db = openDatabaseSync(':memory:');
+  let serialized: Uint8Array;
   try {
-    db.serializeSync();
-    return true;
+    serialized = db.serializeSync();
   } catch {
     return false;
   } finally {
     db.closeSync();
+  }
+  try {
+    deserializeDatabaseSync(serialized).closeSync();
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -324,7 +324,21 @@ describe('Database - Synchronous calls', () => {
   });
 });
 
-describe('Database - serialize / deserialize', () => {
+// node:sqlite (the test mock) doesn't implement serialize on Node 22. Skipping is safe: the JS
+// wrappers are pass-throughs and the native behavior is covered by the Swift/Kotlin unit tests.
+function supportsSerialize(): boolean {
+  const db = openDatabaseSync(':memory:');
+  try {
+    db.serializeSync();
+    return true;
+  } catch {
+    return false;
+  } finally {
+    db.closeSync();
+  }
+}
+
+(supportsSerialize() ? describe : describe.skip)('Database - serialize / deserialize', () => {
   it('serialize / deserialize in between should keep the data', async () => {
     const db = await openDatabaseAsync(':memory:');
     await db.execAsync(

--- a/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
+++ b/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
@@ -22,12 +22,9 @@ describe(useSQLiteContext, () => {
       <SQLiteProvider databaseName=":memory:">{children}</SQLiteProvider>
     );
     const { result } = renderHook(() => useSQLiteContext(), { wrapper });
-    await act(async () => {
-      await waitFor(() => {
-        expect(result).not.toBeNull();
-      });
+    await waitFor(() => {
+      expect(result.current).toHaveProperty('execAsync');
     });
-    expect(result.current).toHaveProperty('execAsync');
     expect(result.current).toHaveProperty('runAsync');
   });
 
@@ -60,6 +57,8 @@ describe(useSQLiteContext, () => {
     rerender(<SQLiteProviderWithView databaseName="test.db" />);
     expect(openDatabaseSpy).toHaveBeenCalledTimes(3);
 
+    // Flush the providers' deferred open/state updates so they settle inside act().
+    await act(async () => {});
     openDatabaseSpy.mockRestore();
   });
 
@@ -68,10 +67,8 @@ describe(useSQLiteContext, () => {
       <SQLiteProvider databaseName=":memory:">{children}</SQLiteProvider>
     );
     const { result, rerender } = renderHook(() => useSQLiteContext(), { wrapper });
-    await act(async () => {
-      await waitFor(() => {
-        expect(result).not.toBeNull();
-      });
+    await waitFor(() => {
+      expect(result.current).toHaveProperty('execAsync');
     });
     const firstResult = result.current;
     rerender({});
@@ -86,12 +83,9 @@ describe(useSQLiteContext, () => {
       </SQLiteProvider>
     );
     const { result } = renderHook(() => useSQLiteContext(), { wrapper });
-    await act(async () => {
-      await waitFor(() => {
-        expect(result).not.toBeNull();
-      });
+    await waitFor(() => {
+      expect(mockonInit).toHaveBeenCalled();
     });
-    expect(mockonInit).toHaveBeenCalled();
     expect(mockonInit.mock.calls[0][0]).toBe(result.current);
   });
 
@@ -111,17 +105,14 @@ describe(useSQLiteContext, () => {
         </SQLiteProvider>
       </React.Suspense>
     );
-    const { result } = renderHook(() => useSQLiteContext(), { wrapper });
+    renderHook(() => useSQLiteContext(), { wrapper });
 
     expect(screen.queryByText(loadingText)).not.toBeNull();
 
     // Ensure that the loading fallback is removed after the database is ready
-    await act(async () => {
-      await waitFor(() => {
-        expect(result).not.toBeNull();
-      });
+    await waitFor(() => {
+      expect(screen.queryByText(loadingText)).toBeNull();
     });
-    expect(screen.queryByText(loadingText)).toBeNull();
   }, 10000);
 
   it('should call onError from SQLiteProvider if failed to open database', async () => {
@@ -154,13 +145,10 @@ describe(useSQLiteContext, () => {
         </React.Suspense>
       </ErrorBoundary>
     );
-    const { result } = renderHook(() => useSQLiteContext(), { wrapper });
-    await act(async () => {
-      await waitFor(() => {
-        expect(result).not.toBeNull();
-      });
+    renderHook(() => useSQLiteContext(), { wrapper });
+    await waitFor(() => {
+      expect(screen.queryByText(errorText)).not.toBeNull();
     });
-    expect(screen.queryByText(errorText)).not.toBeNull();
   });
 
   it('should throw when using `onError` and `useSuspense` together', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5631,9 +5631,6 @@ importers:
       '@testing-library/react-native':
         specifier: ^13.3.0
         version: 13.3.3(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
-      '@types/better-sqlite3':
-        specifier: ^7.6.6
-        version: 7.6.13
       '@types/jest':
         specifier: ^29.2.1
         version: 29.5.14
@@ -5643,9 +5640,6 @@ importers:
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14
-      better-sqlite3:
-        specifier: ^11.6.0
-        version: 11.10.0
       expo:
         specifier: workspace:*
         version: link:../expo
@@ -9156,9 +9150,6 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -10084,9 +10075,6 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -10094,9 +10082,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bit-twiddle@1.0.2:
     resolution: {integrity: sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==}
@@ -10261,9 +10246,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -11198,10 +11180,6 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -11330,9 +11308,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -11445,9 +11420,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
@@ -11536,9 +11508,6 @@ packages:
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   gl-mat4@1.2.0:
     resolution: {integrity: sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==}
@@ -12937,9 +12906,6 @@ packages:
     resolution: {integrity: sha512-VUhC7/wotZwooobTlBl5+ZAgHoLCdckDqGz9HqdiXeYIXeATKWiiuas4HIjzOs3/qIstv+3e0u/lYYbXACIbOQ==}
     engines: {node: '>=4'}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   mkdirp@0.3.0:
     resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
     deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
@@ -12984,9 +12950,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -13023,10 +12986,6 @@ packages:
   nock@14.0.11:
     resolution: {integrity: sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
-
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -13472,12 +13431,6 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -14221,12 +14174,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   simple-plist@1.3.1:
     resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
 
@@ -14505,13 +14452,6 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -14679,9 +14619,6 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.18:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
@@ -18243,10 +18180,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 22.19.15
-
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -19294,18 +19227,9 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
   big-integer@1.6.52: {}
 
   binary-extensions@2.3.0: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bit-twiddle@1.0.2: {}
 
@@ -19519,8 +19443,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -20579,8 +20501,6 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   expect@29.7.0:
@@ -20810,8 +20730,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
-
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
@@ -20944,8 +20862,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
-
   fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
@@ -21030,8 +20946,6 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   getenv@2.0.0: {}
-
-  github-from-package@0.0.0: {}
 
   gl-mat4@1.2.0: {}
 
@@ -22736,8 +22650,6 @@ snapshots:
 
   mk-dirs@1.0.0: {}
 
-  mkdirp-classic@0.5.3: {}
-
   mkdirp@0.3.0: {}
 
   mkdirp@0.5.6:
@@ -22776,8 +22688,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
-
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -22809,10 +22719,6 @@ snapshots:
       '@mswjs/interceptors': 0.41.3
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
-
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
 
   node-addon-api@7.1.1:
     optional: true
@@ -23258,21 +23164,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
 
@@ -24145,14 +24036,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   simple-plist@1.3.1:
     dependencies:
       bplist-creator: 0.1.0
@@ -24458,21 +24341,6 @@ snapshots:
 
   tapable@2.3.2: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -24645,10 +24513,6 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   turbo@2.9.18:
     optionalDependencies:


### PR DESCRIPTION
## Summary

We don't have to keep these tests on `better-sqlite3` and there's different candidates to replace it (e.g. libsql and `node:sqlite`). Since `node:sqlite` is now a built-in (as of Node 22+), it's probably the best candidate to replace `better-sqlite3`.

The problem with keeping `better-sqlite3` is a minor one, but the compilaton slows down CI on every install (since the build output isn't cached in CI), since there's no prebuilts (fresh `node-gyp` per install)

## Set of changes

- Drop `better-sqlite3`
- Update mock to `node:sqlite`
- Conditioanlly skip `serialize` test (it's just a passthrough and `node:sqlite` on lowest supported Node 22 doesn't yet support `serialize`)
- Reduce delays since tests are just artificially slow