### PR TITLE
[docs] Sync Skills and EAS CLI

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 20.2.0
+cliVersion: 20.3.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,11 +1,16 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-06-16T07:03:16.187Z",
-    "cliVersion": "20.2.0"
+    "fetchedAt": "2026-06-19T11:22:00.287Z",
+    "cliVersion": "20.3.0"
   },
-  "totalCommands": 123,
+  "totalCommands": 127,
   "commands": [
+    {
+      "command": "eas account:audit [ACCOUNT_NAME]",
+      "description": "view the audit logs for an account",
+      "usage": "USAGE\n  $ eas account:audit [ACCOUNT_NAME] [--limit <value>] [--after <value>] [--json] [--non-interactive]\n\nARGUMENTS\n  [ACCOUNT_NAME]  Account name to view audit logs for. If not provided, the account will be selected interactively (or\n                  defaults to the only account if there is just one)\n\nFLAGS\n  --after=<value>    Cursor for pagination. Use the endCursor from a previous query to fetch the next page.\n  --json             Enable JSON output, non-JSON messages will be printed to stderr.\n  --limit=<value>    The number of items to fetch each query. Defaults to 50 and is capped at 100.\n  --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  view the audit logs for an account"
+    },
     {
       "command": "eas account:login",
       "description": "log in with your Expo account",
@@ -367,6 +372,21 @@
       "usage": "USAGE\n  $ eas integrations:convex:team:invite [CONVEX_TEAM] [--non-interactive]\n\nARGUMENTS\n  [CONVEX_TEAM]  Slug of the Convex team to invite yourself to\n\nFLAGS\n  --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  send a Convex team invitation to your verified email address"
     },
     {
+      "command": "eas integrations:posthog:connect",
+      "description": "connect PostHog to your Expo project",
+      "usage": "USAGE\n  $ eas integrations:posthog:connect [--json] [--non-interactive] [--region US|EU] [--session-replay] [--error-tracking]\n    [--posthog-cli-api-key <value>] [--overwrite]\n\nFLAGS\n  --[no-]error-tracking          Set up PostHog error tracking / source maps (requires a personal API key)\n  --json                         Enable JSON output, non-JSON messages will be printed to stderr. Implies\n                                 --non-interactive.\n  --non-interactive              Run the command in non-interactive mode.\n  --overwrite                    Overwrite existing PostHog environment variables without prompting\n  --posthog-cli-api-key=<value>  PostHog personal API key for error-tracking source-map uploads (enables error tracking\n                                 non-interactively)\n  --region=<option>              PostHog region\n                                 <options: US|EU>\n  --[no-]session-replay          Set up PostHog session replay (default: yes)\n\nDESCRIPTION\n  connect PostHog to your Expo project"
+    },
+    {
+      "command": "eas integrations:posthog:dashboard",
+      "description": "open the PostHog dashboard for the linked PostHog project",
+      "usage": "USAGE\n  $ eas integrations:posthog:dashboard [--json] [--non-interactive]\n\nFLAGS\n  --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.\n  --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  open the PostHog dashboard for the linked PostHog project"
+    },
+    {
+      "command": "eas integrations:posthog:disconnect",
+      "description": "remove the PostHog project link for the current Expo app from EAS servers",
+      "usage": "USAGE\n  $ eas integrations:posthog:disconnect [--json] [--non-interactive] [-y]\n\nFLAGS\n  -y, --yes              Skip confirmation prompt\n      --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.\n      --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  remove the PostHog project link for the current Expo app from EAS servers"
+    },
+    {
       "command": "eas login",
       "description": "log in with your Expo account",
       "usage": "USAGE\n  $ eas login [-s] [-b]\n\nFLAGS\n  -b, --[no-]browser  Log in with your browser (default; use --no-browser for CLI-based login)\n  -s, --sso           Log in with SSO\n\nDESCRIPTION\n  log in with your Expo account\n\nALIASES\n  $ eas login"
@@ -529,7 +549,7 @@
     {
       "command": "eas update:view GROUPID",
       "description": "update group details",
-      "usage": "USAGE\n  $ eas update:view GROUPID [--insights] [--days <value> | --start <value> | --end <value>] [--json]\n\nARGUMENTS\n  GROUPID  The ID of an update group.\n\nFLAGS\n  --days=<value>   Show insights from the last N days (default 7). Only used with --insights.\n  --end=<value>    End of insights time range (ISO date). Only used with --insights.\n  --insights       Also show insights (launches, crash rate, unique users, payload size) for the update group.\n  --json           Enable JSON output, non-JSON messages will be printed to stderr.\n  --start=<value>  Start of insights time range (ISO date). Only used with --insights.\n\nDESCRIPTION\n  update group details"
+      "usage": "USAGE\n  $ eas update:view GROUPID [--insights] [--days <value> | --start <value> | --end <value>] [--json]\n\nARGUMENTS\n  GROUPID  The ID of an update group, or the ID of a platform-specific update.\n\nFLAGS\n  --days=<value>   Show insights from the last N days (default 7). Only used with --insights.\n  --end=<value>    End of insights time range (ISO date). Only used with --insights.\n  --insights       Also show insights (launches, crash rate, unique users, payload size) for the update group.\n  --json           Enable JSON output, non-JSON messages will be printed to stderr.\n  --start=<value>  Start of insights time range (ISO date). Only used with --insights.\n\nDESCRIPTION\n  update group details"
     },
     {
       "command": "eas upload",

--- a/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
+++ b/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
@@ -2,9 +2,9 @@
   "source": {
     "repo": "expo/skills",
     "url": "https://api.github.com/repos/expo/skills/contents/plugins/expo/skills",
-    "fetchedAt": "2026-06-15T11:39:09.228Z"
+    "fetchedAt": "2026-06-19T11:21:53.683Z"
   },
-  "totalSkills": 15,
+  "totalSkills": 16,
   "skills": [
     {
       "name": "add-app-clip",
@@ -45,6 +45,11 @@
       "name": "expo-dev-client",
       "description": "Build and distribute Expo development clients locally or via TestFlight.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-dev-client/SKILL.md"
+    },
+    {
+      "name": "expo-examples",
+      "description": "Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more). Use when integrating a third-party library or service into an existing Expo app and you want the canonical, version-matched pattern to adapt, or when scaffolding a new project from one with `npx create-expo --example`.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-examples/SKILL.md"
     },
     {
       "name": "expo-module",


### PR DESCRIPTION
# Why

The generated Expo Skills table and EAS CLI reference had drifted from upstream, so the docs were missing the latest skill and CLI commands.

# How

Regenerate the reference data with the docs sync generators: `expo-skills-sync` adds the `expo-examples` entry to `expo-skills.json`, and `eas-cli-sync` bumps `cliVersion` to 20.3.0 in `pages/eas/cli.mdx` and updates `eas-cli-commands.json` with the new `eas account:audit` and `eas integrations:posthog:*` commands.

# Test Plan

Open the EAS CLI reference page and confirm it renders v20.3.0 with the new `account:audit` and `integrations:posthog:*` commands, and confirm the Expo Skills table lists `expo-examples`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
