### PR TITLE
[widgets][iOS][plugin] Fix extension CFBundleVersion sync

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Basic Android components. ([#46951](https://github.com/expo/expo/pull/46951) by [@jakex7](https://github.com/jakex7))
 - [Android] Implement widgets. ([#46961](https://github.com/expo/expo/pull/46961) by [@jakex7](https://github.com/jakex7))
 - [Android] Support interactions. ([#47035](https://github.com/expo/expo/pull/47035) by [@jakex7](https://github.com/jakex7))
+- [iOS][plugin] Fix extension `CFBundleVersion` sync. ([#47061](https://github.com/expo/expo/pull/47061) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/plugin/src/ios/xcode/withTargetXcodeProject.ts
+++ b/packages/expo-widgets/plugin/src/ios/xcode/withTargetXcodeProject.ts
@@ -25,6 +25,8 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.generateUuid();
     const groupName = 'Embed Foundation Extensions';
+    const marketingVersion = config.ios?.version ?? config.version ?? '1.0';
+    const currentProjectVersion = config.ios?.buildNumber ?? '1';
 
     // TODO(@kitten): This was untyped before and is now failing
     const xCConfigurationList: any = addXCConfigurationList(xcodeProject, {
@@ -32,8 +34,8 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
       bundleIdentifier,
       deploymentTarget,
       appleTeamId,
-      marketingVersion: '1.0',
-      currentProjectVersion: '1',
+      marketingVersion,
+      currentProjectVersion,
     });
     // TODO(@kitten): This was untyped before and is now failing
     const productFile: any = addProductFile(xcodeProject, {


### PR DESCRIPTION
# Why

Config plugin was expecting that xcode will override the values using `Info.plist` but it wasn't. 
Fixes https://github.com/expo/expo/issues/43740

# How

Adds `marketingVersion` and `currentProjectVersion` to xcode target project.

`1.0` and `1` fallback should never be reached but just to be extra safe here.

# Test Plan

`widgets-test-version/builds/267ec4d6-816c-4f61-a8d0-648e4b005168`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
