### PR TITLE
test: Merge RSC test runs into Jest composite setups and update `tsconfig.json`s

### DIFF
--- a/packages/@expo/devtools/tsconfig.json
+++ b/packages/@expo/devtools/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/@expo/local-build-cache-provider/tsconfig.json
+++ b/packages/@expo/local-build-cache-provider/tsconfig.json
@@ -6,6 +6,5 @@
     "sourceMap": true,
     "types": ["node", "jest"]
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/@expo/router-server/jest-rsc.config.js
+++ b/packages/@expo/router-server/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/@expo/router-server/package.json
+++ b/packages/@expo/router-server/package.json
@@ -24,7 +24,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "test:tsd": "EXPORT_ROUTER_JEST_TSD=true jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",

--- a/packages/@expo/router-server/tsconfig.json
+++ b/packages/@expo/router-server/tsconfig.json
@@ -10,5 +10,5 @@
   // `*.tsd.ts` files are type-assertion tests run by `jest-runner-tsd` (see `test:tsd`),
   // which uses its own compiler that understands `expectError`. They intentionally contain
   // type errors, so they must be excluded from the regular `tsc` typecheck.
-  "exclude": ["**/__rsc_tests__/*", "**/*.tsd.ts"]
+  "exclude": ["**/*.tsd.ts"]
 }

--- a/packages/expo-age-range/tsconfig.json
+++ b/packages/expo-age-range/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-app-integrity/tsconfig.json
+++ b/packages/expo-app-integrity/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-app-metrics/tsconfig.json
+++ b/packages/expo-app-metrics/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-apple-authentication/tsconfig.json
+++ b/packages/expo-apple-authentication/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-application/tsconfig.json
+++ b/packages/expo-application/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-asset/jest-rsc.config.js
+++ b/packages/expo-asset/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-asset/jest.config.js
+++ b/packages/expo-asset/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -15,7 +15,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"
@@ -59,9 +58,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/asset/",
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/image-utils": "workspace:^0.10.1",
     "expo-constants": "workspace:~56.0.16"

--- a/packages/expo-asset/tsconfig.json
+++ b/packages/expo-asset/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-audio/tsconfig.json
+++ b/packages/expo-audio/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-auth-session/tsconfig.json
+++ b/packages/expo-auth-session/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src", "../expo/src/ts-declarations"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src", "../expo/src/ts-declarations"]
 }

--- a/packages/expo-background-fetch/tsconfig.json
+++ b/packages/expo-background-fetch/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-background-task/tsconfig.json
+++ b/packages/expo-background-task/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-battery/tsconfig.json
+++ b/packages/expo-battery/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-blob/tsconfig.json
+++ b/packages/expo-blob/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-blur/tsconfig.json
+++ b/packages/expo-blur/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-brightness/tsconfig.json
+++ b/packages/expo-brightness/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-brownfield/tsconfig.json
+++ b/packages/expo-brownfield/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-calendar/tsconfig.json
+++ b/packages/expo-calendar/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-camera/tsconfig.json
+++ b/packages/expo-camera/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-cellular/tsconfig.json
+++ b/packages/expo-cellular/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-checkbox/tsconfig.json
+++ b/packages/expo-checkbox/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-clipboard/tsconfig.json
+++ b/packages/expo-clipboard/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-constants/jest-rsc.config.js
+++ b/packages/expo-constants/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-constants/jest.config.js
+++ b/packages/expo-constants/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -29,7 +29,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -p tsconfig.json"
@@ -50,9 +49,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/constants/",
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/env": "workspace:~2.3.0"
   },

--- a/packages/expo-constants/tsconfig.json
+++ b/packages/expo-constants/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-contacts/tsconfig.json
+++ b/packages/expo-contacts/tsconfig.json
@@ -6,6 +6,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-crypto/tsconfig.json
+++ b/packages/expo-crypto/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-dev-client/tsconfig.json
+++ b/packages/expo-dev-client/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-dev-menu/tsconfig.json
+++ b/packages/expo-dev-menu/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-device/tsconfig.json
+++ b/packages/expo-device/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-document-picker/tsconfig.json
+++ b/packages/expo-document-picker/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-eas-client/tsconfig.json
+++ b/packages/expo-eas-client/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-font/jest-rsc.config.js
+++ b/packages/expo-font/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-font/jest.config.js
+++ b/packages/expo-font/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, ['plugin']);
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, ['plugin'], {
+  rsc: true,
+});

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -41,7 +41,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"

--- a/packages/expo-font/tsconfig.json
+++ b/packages/expo-font/tsconfig.json
@@ -6,6 +6,5 @@
     "noEmit": true,
     "types": ["jest", "node"]
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-glass-effect/tsconfig.json
+++ b/packages/expo-glass-effect/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-image-picker/tsconfig.json
+++ b/packages/expo-image-picker/tsconfig.json
@@ -7,6 +7,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-image/jest-rsc.config.js
+++ b/packages/expo-image/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-image/jest.config.js
+++ b/packages/expo-image/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -24,7 +24,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"
@@ -60,8 +59,5 @@
     "react-native-web": {
       "optional": true
     }
-  },
-  "jest": {
-    "preset": "expo-module-scripts"
   }
 }

--- a/packages/expo-image/src/__rsc_tests__/index.test.tsx
+++ b/packages/expo-image/src/__rsc_tests__/index.test.tsx
@@ -1,8 +1,6 @@
 /// <reference types="jest-expo/rsc/expect" />
 
-// @ts-expect-error
 import { Image } from 'expo-image';
-import * as React from 'react';
 
 it(`renders Image`, async () => {
   await expect(<Image />).toMatchFlightSnapshot();

--- a/packages/expo-image/tsconfig.json
+++ b/packages/expo-image/tsconfig.json
@@ -6,6 +6,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-insights/tsconfig.json
+++ b/packages/expo-insights/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-intent-launcher/tsconfig.json
+++ b/packages/expo-intent-launcher/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-keep-awake/tsconfig.json
+++ b/packages/expo-keep-awake/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-linear-gradient/jest-rsc.config.js
+++ b/packages/expo-linear-gradient/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-linear-gradient/jest.config.js
+++ b/packages/expo-linear-gradient/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -10,13 +10,9 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -p tsconfig.json"
-  },
-  "jest": {
-    "preset": "expo-module-scripts"
   },
   "keywords": [
     "react-native",

--- a/packages/expo-linear-gradient/tsconfig.json
+++ b/packages/expo-linear-gradient/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-linking/jest-rsc.config.js
+++ b/packages/expo-linking/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-linking/jest.config.js
+++ b/packages/expo-linking/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -28,7 +28,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -p tsconfig.json"
@@ -61,8 +60,5 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*"
-  },
-  "jest": {
-    "preset": "expo-module-scripts"
   }
 }

--- a/packages/expo-linking/tsconfig.json
+++ b/packages/expo-linking/tsconfig.json
@@ -4,6 +4,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-live-photo/tsconfig.json
+++ b/packages/expo-live-photo/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-local-authentication/tsconfig.json
+++ b/packages/expo-local-authentication/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-localization/tsconfig.json
+++ b/packages/expo-localization/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-location/tsconfig.json
+++ b/packages/expo-location/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src", "../expo/src/ts-declarations"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src", "../expo/src/ts-declarations"]
 }

--- a/packages/expo-mail-composer/tsconfig.json
+++ b/packages/expo-mail-composer/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-manifests/tsconfig.json
+++ b/packages/expo-manifests/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-maps/tsconfig.json
+++ b/packages/expo-maps/tsconfig.json
@@ -7,6 +7,5 @@
     "noEmit": true,
     "types": ["node", "jest"]
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-media-library/tsconfig.json
+++ b/packages/expo-media-library/tsconfig.json
@@ -7,6 +7,5 @@
     "noEmit": true,
     "types": ["jest", "node"]
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-mesh-gradient/tsconfig.json
+++ b/packages/expo-mesh-gradient/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-module-scripts/createCompositeJestPreset.cjs
+++ b/packages/expo-module-scripts/createCompositeJestPreset.cjs
@@ -19,7 +19,14 @@ const basePreset = require('./jest-preset.cjs');
 //   external `--rootDir` (as `expo-module test <target>` does).
 // `opts.srcProjects` overrides the default `src` projects — used by packages whose `src`
 // tests are platform-specific (e.g. iOS-only) rather than the full multi-platform set.
-module.exports = function createCompositeJestPreset(rootDir, subdirs = [], { srcProjects } = {}) {
+// `opts.rsc` appends the React Server Component per-platform projects (from
+// `jest-expo/rsc/jest-preset`) so a package's `__rsc_tests__` run as part of the single `jest`
+// invocation instead of a separate `test:rsc` script.
+module.exports = function createCompositeJestPreset(
+  rootDir,
+  subdirs = [],
+  { srcProjects, rsc = false } = {}
+) {
   return {
     ...basePreset,
     projects: [
@@ -36,6 +43,9 @@ module.exports = function createCompositeJestPreset(rootDir, subdirs = [], { src
         // Name the project after its folder so failures are attributable in multi-project output.
         return { displayName: dir, ...config, rootDir: path.join(rootDir, dir) };
       }),
+      // RSC `__rsc_tests__` as their own per-platform projects (named `rsc/<platform>`). These
+      // only match `**/__rsc_tests__/**`, so they're inert for packages without such tests.
+      ...(rsc ? require('jest-expo/rsc/jest-preset').projects : []),
     ],
   };
 };

--- a/packages/expo-module-scripts/templates/tsconfig.json
+++ b/packages/expo-module-scripts/templates/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-modules-core/jest-rsc.config.js
+++ b/packages/expo-modules-core/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-modules-core/jest.config.js
+++ b/packages/expo-modules-core/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, [], {
+  rsc: true,
+});

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -50,7 +50,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "depscheck": "expo-module depscheck",
@@ -74,9 +73,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/main/packages/expo-modules-core",
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/expo-modules-macros-plugin": "0.3.0",
     "expo-modules-jsi": "workspace:~56.0.7",

--- a/packages/expo-modules-core/tsconfig.json
+++ b/packages/expo-modules-core/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-navigation-bar/tsconfig.json
+++ b/packages/expo-navigation-bar/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-network-addons/tsconfig.json
+++ b/packages/expo-network-addons/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-network/tsconfig.json
+++ b/packages/expo-network/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-notifications/tsconfig.json
+++ b/packages/expo-notifications/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-observe/tsconfig.json
+++ b/packages/expo-observe/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-print/tsconfig.json
+++ b/packages/expo-print/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-router/CLAUDE.md
+++ b/packages/expo-router/CLAUDE.md
@@ -302,7 +302,7 @@ Native tabs (`expo-router/unstable-native-tabs`) provide native bottom tab navig
 
 After developing a feature, run these commands in `packages/expo-router`:
 
-1. `CI=1 pnpm test` - Run all tests. During development use `pnpm test [test file]` for efficiency. For RSC tests: `pnpm test:rsc`
+1. `CI=1 pnpm test` - Run all tests, including the RSC `__rsc_tests__` (they run as the `rsc/<platform>` Jest projects). During development use `pnpm test [test file]` for efficiency, or `pnpm test --selectProjects rsc/web` to run only RSC tests.
 2. `pnpm build` - Build and verify TypeScript correctness. If you moved or deleted files, run `pnpm clean` first.
 3. `pnpm test:types` - Verify type correctness in tests
 4. `pnpm lint` - Run last to find linting issues

--- a/packages/expo-router/jest-rsc.config.js
+++ b/packages/expo-router/jest-rsc.config.js
@@ -1,1 +1,0 @@
-module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-router/jest.config.js
+++ b/packages/expo-router/jest.config.js
@@ -46,6 +46,10 @@ const projects = [
 const { watchPlugins, prettierPath, ...pluginProject } = require('./plugin/jest.config.js');
 projects.push({ ...pluginProject, rootDir: path.join(__dirname, 'plugin') });
 
+// Run the RSC `__rsc_tests__` as their own per-platform projects (`rsc/<platform>`) so a single
+// `jest` covers them too. These match only `**/__rsc_tests__/**`, separate from the projects above.
+projects.push(...require('jest-expo/rsc/jest-preset').projects);
+
 const config = withWatchPlugins({
   ...require('jest-expo/config/maxWorkers'),
   projects,

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -271,7 +271,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "jest",
-    "test:rsc": "jest --config jest-rsc.config.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "depscheck": "expo-module depscheck",

--- a/packages/expo-screen-capture/tsconfig.json
+++ b/packages/expo-screen-capture/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-screen-orientation/tsconfig.json
+++ b/packages/expo-screen-orientation/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-secure-store/tsconfig.json
+++ b/packages/expo-secure-store/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-sensors/tsconfig.json
+++ b/packages/expo-sensors/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-sharing/tsconfig.json
+++ b/packages/expo-sharing/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-speech/tsconfig.json
+++ b/packages/expo-speech/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-splash-screen/tsconfig.json
+++ b/packages/expo-splash-screen/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-sqlite/tsconfig.json
+++ b/packages/expo-sqlite/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-standard-web-crypto/tsconfig.json
+++ b/packages/expo-standard-web-crypto/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-status-bar/tsconfig.json
+++ b/packages/expo-status-bar/tsconfig.json
@@ -6,6 +6,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-store-review/tsconfig.json
+++ b/packages/expo-store-review/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-symbols/tsconfig.json
+++ b/packages/expo-symbols/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-system-ui/tsconfig.json
+++ b/packages/expo-system-ui/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-task-manager/tsconfig.json
+++ b/packages/expo-task-manager/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-tracking-transparency/tsconfig.json
+++ b/packages/expo-tracking-transparency/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-ui/tsconfig.json
+++ b/packages/expo-ui/tsconfig.json
@@ -7,6 +7,5 @@
     "rootDir": "./src",
     "emitDeclarationOnly": true
   },
-  "include": ["./src/**/*"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src/**/*"]
 }

--- a/packages/expo-updates/tsconfig.json
+++ b/packages/expo-updates/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-video-thumbnails/tsconfig.json
+++ b/packages/expo-video-thumbnails/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-video/tsconfig.json
+++ b/packages/expo-video/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-web-browser/tsconfig.json
+++ b/packages/expo-web-browser/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/expo-widgets/tsconfig.json
+++ b/packages/expo-widgets/tsconfig.json
@@ -6,6 +6,5 @@
     "rootDir": "./src",
     "noEmit": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/html-elements/tsconfig.json
+++ b/packages/html-elements/tsconfig.json
@@ -5,6 +5,5 @@
     "noEmit": true,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["**/__rsc_tests__/*"]
+  "include": ["./src"]
 }

--- a/packages/jest-expo/config/withWatchPlugins.js
+++ b/packages/jest-expo/config/withWatchPlugins.js
@@ -21,6 +21,18 @@ function getWatchPlugins({ projects = [] } = {}) {
 
 function withWatchPlugins({ watchPlugins = [], ...config }) {
   const customPlugins = getWatchPlugins(config);
+  if (Array.isArray(config.projects)) {
+    let projectsWantPass = false;
+    config.projects = config.projects.map((project) => {
+      if (project && typeof project === 'object' && 'passWithNoTests' in project) {
+        const { passWithNoTests, ...rest } = project;
+        projectsWantPass ||= passWithNoTests;
+        return rest;
+      }
+      return project;
+    });
+    config.passWithNoTests ??= projectsWantPass;
+  }
   return {
     ...config,
     watchPlugins: [...watchPlugins, ...customPlugins],

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -148,10 +148,6 @@ export class Package {
     return fs.pathExistsSync(path.join(this.path, 'utils'));
   }
 
-  get hasReactServerComponents(): boolean {
-    return 'test:rsc' in this.packageJson.scripts;
-  }
-
   get packageName(): string {
     return this.packageJson.name;
   }

--- a/tools/src/check-packages/checkPackageAsync.ts
+++ b/tools/src/check-packages/checkPackageAsync.ts
@@ -75,12 +75,8 @@ export default async function checkPackageAsync(
           // Limit to one worker on CIs
           args.push('--maxWorkers', '1');
         }
-        await runPackageScriptAsync(pkg, 'test', args);
 
-        if (pkg.hasReactServerComponents && options.checkPackageType === 'package') {
-          // Test RSC if available...
-          await runPackageScriptAsync(pkg, 'test:rsc', args);
-        }
+        await runPackageScriptAsync(pkg, 'test', args);
       }
     }
     if (options.lint) {


### PR DESCRIPTION
## Summary

Follow-up to #47034 

Before this PR `jest-rsc.config.js` and `test:rsc` scripts/tasks were kept separately, which is redundant, now that we're squashing Jest runs into a composite `projects` run. Additionally, `__rsc_tests__` are typically the last remaining exclusions for `tsconfig.json`

We can remove all boilerplate RSC setups, add this to the preset creator of Jest configs, and remove the `tsconfig.json` exclusion to further simplify.

Net-effect is:
- `pnpm typecheck` now captures RSC tests
- `pnpm test` also runs all RSC tests

## Set of changes

- Add RSC preset creation to Jest preset creator
- Replace separate `jest-rsc.config.js` files
- Delete `test:rsc` scripts
- [expo-image] Fix a type error
- Remove `__rsc_tests__` from `tsconfig.json:exclude`s