### PR TITLE
[ios][audio] Fix main thread hang with deactivateSession

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Deactivate the audio session off the main thread to avoid app hangs.
+- [iOS] Deactivate the audio session off the main thread to avoid app hangs. ([#47066](https://github.com/expo/expo/pull/47066) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Deactivate the audio session off the main thread to avoid app hangs.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -825,18 +825,17 @@ public class AudioModule: Module {
   }
 
   private func deactivateSession() {
-    // We need to give isPlaying time to update before running this
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-      guard let self else {
+    Task {
+      // Give isPlaying time to update before deciding whether to deactivate.
+      try? await Task.sleep(for: .milliseconds(100))
+      let hasActivePlayables = registry.allPlayables.contains { $0.isPlaying }
+      guard !hasActivePlayables else {
         return
       }
-      let hasActivePlayables = self.registry.allPlayables.contains { $0.isPlaying }
-      if !hasActivePlayables {
-        do {
-          try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-        } catch {
-          print("Failed to deactivate audio session: \(error)")
-        }
+      do {
+        try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+      } catch {
+        print("Failed to deactivate audio session: \(error)")
       }
     }
   }


### PR DESCRIPTION
# Why
Closes #47045

# How
deactivateSession now runs in a Task instead of dispatching to the main queue, so the blocking setActive(false) call no longer touches the main thread.

# Test Plan
Bare expo

