### PR TITLE
[jsi][ios] Add `JavaScriptRuntime.id` for stable runtime identity

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [iOS] Add `createFunction`/`setProperty` overloads taking a `UnownedThisSyncFunctionClosure`, which receives `this` as a borrowed `JavaScriptUnownedValue` instead of an owning `JavaScriptValue`. Used by host functions that ignore `this` to skip the per-call owning-value allocation and its `weak`-runtime traffic. ([#46949](https://github.com/expo/expo/pull/46949) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add closure-taking `JavaScriptObject.setProperty(_:function:)` overloads that create a sync or async host function from the given closure. ([#46622](https://github.com/expo/expo/pull/46622) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Conform `JavaScriptRuntime` to `Identifiable` with an `id` based on the underlying runtime, equal across multiple wrappers of the same runtime. ([#47068](https://github.com/expo/expo/pull/47068) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -17,7 +17,7 @@ internal import jsi
 ///
 /// The runtime maintains a weak reference pattern for values, objects, and arrays to prevent
 /// retain cycles. Ensure the runtime remains alive while any derived JavaScript objects are in use.
-open class JavaScriptRuntime: Equatable, @unchecked Sendable {
+open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   /// The underlying JSI runtime this `JavaScriptRuntime` points to, exposed as
   /// `IRuntime` — the abstract base interface that virtually all JSI value/object/
   /// function methods take (`Value::getString`, `Object::setProperty`,
@@ -613,6 +613,24 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   public static func == (lhs: JavaScriptRuntime, rhs: JavaScriptRuntime) -> Bool {
     return lhs === rhs
+  }
+
+  // MARK: - Identifiable
+
+  /// Identity of the underlying JSI runtime, as its pointer address.
+  ///
+  /// Stable for the runtime's lifetime: JSI runtimes are non-movable and pinned (every
+  /// `jsi::Value`/`Object` stores a `Runtime&` and assumes it never moves), so the address is a sound
+  /// identity while the runtime is alive. It is *not* unique across time, though: once a runtime is
+  /// destroyed its address may be reused by a later runtime, so don't treat the value as a
+  /// permanent/global id or hold it past the runtime's lifetime.
+  public typealias ID = UInt
+
+  /// The runtime's `ID`. Unlike `==` (which compares `JavaScriptRuntime` wrapper identity), this is
+  /// stable across multiple wrappers of the same underlying runtime, so it's safe to use as a key that
+  /// must agree regardless of which wrapper produced it.
+  public var id: ID {
+    return UInt(bitPattern: Unmanaged.passUnretained(runtimePointee).toOpaque())
   }
 
   // MARK: - Caching JavaScriptPropNameID

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -774,6 +774,22 @@ struct JavaScriptRuntimeTests {
     let result = try newRuntime.eval("1 + 2")
     #expect(result.getInt() == 3)
   }
+
+  @Test
+  func `id is equal across wrappers of the same underlying runtime`() {
+    // A second wrapper around the same underlying `jsi::Runtime` shares the runtime's identity, even
+    // though it is a distinct `JavaScriptRuntime` instance (so `===` differs). This is the guarantee
+    // `id` provides over wrapper identity.
+    let otherWrapper = runtime.withUnsafePointee { JavaScriptRuntime(unsafePointer: $0) }
+    #expect(otherWrapper.id == runtime.id)
+    #expect(otherWrapper !== runtime)
+  }
+
+  @Test
+  func `id differs between distinct runtimes`() {
+    let otherRuntime = JavaScriptRuntime()
+    #expect(otherRuntime.id != runtime.id)
+  }
 }
 
 /// Runs `body` on a freshly spawned synchronous thread and bridges the result back into the


### PR DESCRIPTION
# Why

A follow-up change lets a single native shared object be paired with more than one JS object, one per runtime (the main runtime, the UI runtime, worklet contexts). To support that, a shared object's native state keeps a dictionary of its per-runtime JS counterparts, keyed by the runtime. This PR adds the key type.

The `JavaScriptRuntime` wrapper isn't a reliable key: a single underlying `jsi::Runtime` can have more than one wrapper (the app context's runtime, host-function trampolines, the UI runtime), so `==` (wrapper identity) and `ObjectIdentifier(wrapper)` would store and look up under different keys for the same runtime. The key has to be based on the underlying runtime, not the wrapper.

# How

Conform `JavaScriptRuntime` to `Identifiable` with `ID = UInt` and an `id` derived from the underlying `jsi::Runtime` pointer address. Because it's based on the underlying runtime rather than the wrapper, `id` is equal across multiple wrappers of the same runtime, so it's safe as a dictionary key that must agree regardless of which wrapper produced it.

The address is stable for the runtime's lifetime (JSI runtimes are non-movable and pinned: every `jsi::Value`/`Object` stores a `Runtime&` and assumes it never moves). It is not unique across time (once a runtime is destroyed its address may be reused), so it's documented as not a permanent/global id.

# Test Plan

Added `JavaScriptRuntime` tests: two wrappers around the same underlying runtime share the same `id` (while remaining distinct instances), and two distinct runtimes have different ids.
