### PR TITLE
[docs] Remove duplicate UI component entries

### DIFF
--- a/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
@@ -16,8 +16,6 @@ Components are available for the following platforms:
 - **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
 - **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 - **[Universal](universal)**: Cross-platform components that run on Android, iOS, and web from a single source
-- **[Jetpack Compose](jetpack-compose)**: Build native Android interfaces with Jetpack Compose components
-- **[SwiftUI](swift-ui)**: Build native iOS interfaces with SwiftUI components
 
 ## Drop-in replacements
 


### PR DESCRIPTION
Removed duplicate entries for Jetpack Compose and SwiftUI.

# Why

<!--
I saw some repetitive entries; that's why I removed those duplicates.
-->
