### PR TITLE
[expo-router] remove the history property from the tabs navigation state

### DIFF
--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -327,17 +327,9 @@ it('works in a nested layout Stack->Tab->Stack', () => {
               },
               path: undefined,
               state: {
-                history: [
-                  {
-                    key: expect.any(String),
-                    type: 'route',
-                  },
-                  {
-                    key: expect.any(String),
-                    type: 'route',
-                  },
-                ],
-                index: 2,
+                // firstRoute arranges the back stack as `[first, focused, ...rest]`,
+                // so focusing `c` gives `[a, c, b]` with `c` at index 1.
+                index: 1,
                 key: expect.any(String),
                 preloadedRouteKeys: [],
                 routeNames: ['a', 'b', 'c'],
@@ -345,12 +337,6 @@ it('works in a nested layout Stack->Tab->Stack', () => {
                   {
                     key: expect.any(String),
                     name: 'a',
-                    params: {},
-                    path: undefined,
-                  },
-                  {
-                    key: expect.any(String),
-                    name: 'b',
                     params: {},
                     path: undefined,
                   },
@@ -389,6 +375,12 @@ it('works in a nested layout Stack->Tab->Stack', () => {
                       ],
                       stale: false,
                     },
+                  },
+                  {
+                    key: expect.any(String),
+                    name: 'b',
+                    params: {},
+                    path: undefined,
                   },
                 ],
                 stale: false,

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -162,16 +162,6 @@ test.skip('dismissAll nested', () => {
         name: '__root',
         params: undefined,
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
           index: 2,
           key: expect.any(String),
           preloadedRouteKeys: [],
@@ -283,16 +273,6 @@ test.skip('dismissAll nested', () => {
         name: '__root',
         params: undefined,
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
           index: 2,
           key: expect.any(String),
           preloadedRouteKeys: [],
@@ -392,16 +372,6 @@ test.skip('dismissAll nested', () => {
         name: '__root',
         params: undefined,
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
           index: 2,
           key: expect.any(String),
           preloadedRouteKeys: [],

--- a/packages/expo-router/src/__tests__/tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tabs.test.ios.tsx
@@ -358,28 +358,24 @@ it('can use replace navigation', () => {
         name: '__root',
         params: undefined,
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
-          index: 1,
+          // `replace` prunes the replaced `one` from the back stack: it moves past
+          // the focused `two`, which lands at index 0 (so back is blocked).
+          index: 0,
           key: expect.any(String),
           preloadedRouteKeys: [],
           routeNames: ['one', 'two'],
           routes: [
             {
               key: expect.any(String),
-              name: 'one',
-              params: undefined,
-              path: '/one',
-            },
-            {
-              key: expect.any(String),
               name: 'two',
               params: {},
               path: undefined,
+            },
+            {
+              key: expect.any(String),
+              name: 'one',
+              params: undefined,
+              path: '/one',
             },
           ],
           stale: false,
@@ -412,6 +408,8 @@ it('can use replace navigation with history backBehavior', () => {
 
   act(() => router.back());
 
+  // `replace` drops the route it replaced (`/two`) from the history, so back skips
+  // it and returns to `/one`.
   expect(screen.getByTestId('one')).toBeVisible();
 });
 

--- a/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
+++ b/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
@@ -123,12 +123,6 @@ describe(getTabPathFromRootStateByHref, () => {
             key: 'tab-IBiK_OuEIIGFJ_YDRF760',
             index: 1,
             routeNames: ['index', 'faces', 'explore'],
-            history: [
-              {
-                type: 'route',
-                key: 'faces-BlzNnnAhZ7c9t5bfSf4kR',
-              },
-            ],
             routes: [
               {
                 name: 'index',
@@ -198,12 +192,6 @@ describe(getTabPathFromRootStateByHref, () => {
             key: 'tab-gFrqtQnDMQQ8qMMIptL6E',
             index: 0,
             routeNames: ['index', 'faces', 'explore'],
-            history: [
-              {
-                type: 'route',
-                key: 'index-rYeU6j6cRmkJK1pXpEFHs',
-              },
-            ],
             routes: [
               {
                 name: 'index',
@@ -293,12 +281,6 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
             key: 'tab-IBiK_OuEIIGFJ_YDRF760',
             index: 1,
             routeNames: ['index', 'faces', 'explore'],
-            history: [
-              {
-                type: 'route',
-                key: 'faces-BlzNnnAhZ7c9t5bfSf4kR',
-              },
-            ],
             routes: [
               {
                 name: 'index',
@@ -369,12 +351,6 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
             key: 'tab-gFrqtQnDMQQ8qMMIptL6E',
             index: 0,
             routeNames: ['index', 'faces', 'explore'],
-            history: [
-              {
-                type: 'route',
-                key: 'index-rYeU6j6cRmkJK1pXpEFHs',
-              },
-            ],
             routes: [
               {
                 name: 'index',

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -16,6 +16,7 @@ import type {
 import { convertIconColorPropToObject, convertLabelStylePropToObject } from './utils';
 import { withLayoutContext } from '../layouts/withLayoutContext';
 import { getPathFromState } from '../link/linking';
+import { useStableTabOrder } from '../react-navigation/core/useStableTabOrder';
 import type {
   ParamListBase,
   TabNavigationState,
@@ -92,11 +93,13 @@ export function NativeTabsNavigator({
     },
   });
 
-  const { routes } = state;
+  // `state.routes` is ordered by the navigator's back stack; render the native tab bar
+  // in stable declaration order while resolving focus from `state.routes`.
+  const orderedRoutes = useStableTabOrder(state);
 
   const visibleTabs = useMemo(
     () =>
-      routes
+      orderedRoutes
         // The <NativeTab.Trigger> always sets `hidden` to defined boolean value.
         // If it is not defined, then it was not specified, and we should hide the tab.
         .filter((route) => descriptors[route.key]!.options?.hidden !== true)
@@ -108,11 +111,11 @@ export function NativeTabsNavigator({
             contentRenderer: () => descriptors[route.key]!.render(),
           })
         ),
-    [routes, descriptors]
+    [orderedRoutes, descriptors]
   );
   const visibleFocusedTabIndex = useMemo(
-    () => visibleTabs.findIndex((tab) => tab.routeKey === routes[state.index]!.key),
-    [visibleTabs, routes, state.index]
+    () => visibleTabs.findIndex((tab) => tab.routeKey === state.routes[state.index]!.key),
+    [visibleTabs, state.routes, state.index]
   );
   const visibleTabsKeys = useMemo(
     () => visibleTabs.map((tab) => tab.routeKey).join(';'),

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
@@ -12,6 +12,7 @@ import {
 import type { EdgeInsets } from 'react-native-safe-area-context';
 
 import { BottomTabItem } from './BottomTabItem';
+import { useStableTabOrder } from '../../core/useStableTabOrder';
 import { getDefaultSidebarWidth, getLabel, MissingIcon, useFrameSize } from '../../elements';
 import {
   CommonActions,
@@ -237,7 +238,9 @@ export function BottomTabBar({ state, navigation, descriptors, insets, style }: 
     });
   };
 
-  const { routes } = state;
+  // `state.routes` is ordered by the navigator's back stack; render the bar in stable
+  // declaration order and detect focus by key.
+  const routes = useStableTabOrder(state);
 
   const tabBarHeight = useFrameSize((dimensions) =>
     getTabBarHeight({
@@ -340,7 +343,7 @@ export function BottomTabBar({ state, navigation, descriptors, insets, style }: 
       </View>
       <View role="tablist" style={sidebar ? styles.sideContent : styles.bottomContent}>
         {routes.map((route, index) => {
-          const focused = index === state.index;
+          const focused = route.key === focusedRoute.key;
           const { options } = descriptors[route.key]!;
 
           const onPress = () => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useStableTabOrder.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useStableTabOrder.test.ios.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-native';
+
+import type { ParamListBase, TabNavigationState } from '../../routers';
+import { useStableTabOrder } from '../useStableTabOrder';
+
+const makeState = ({
+  routeNames,
+  routesOrder,
+  index = 0,
+}: {
+  routeNames: string[];
+  routesOrder: string[];
+  index?: number;
+}): TabNavigationState<ParamListBase> => ({
+  stale: false,
+  key: 'tab',
+  index,
+  routeNames,
+  routes: routesOrder.map((name) => ({ key: `${name}-key`, name })),
+  preloadedRouteKeys: [],
+});
+
+test('returns routes in declaration order regardless of the routes (back-stack) order', () => {
+  const state = makeState({ routeNames: ['a', 'b', 'c'], routesOrder: ['b', 'c', 'a'] });
+
+  const { result } = renderHook(() => useStableTabOrder(state));
+
+  expect(result.current.map((route) => route.name)).toEqual(['a', 'b', 'c']);
+  // The route objects (and their keys) are the ones from `state.routes`.
+  expect(result.current.map((route) => route.key)).toEqual(['a-key', 'b-key', 'c-key']);
+});
+
+test('reflects tabs being added and removed', () => {
+  const { result, rerender } = renderHook(({ state }) => useStableTabOrder(state), {
+    initialProps: { state: makeState({ routeNames: ['a', 'b'], routesOrder: ['b', 'a'] }) },
+  });
+
+  expect(result.current.map((route) => route.name)).toEqual(['a', 'b']);
+
+  rerender({ state: makeState({ routeNames: ['a', 'b', 'c'], routesOrder: ['c', 'b', 'a'] }) });
+  expect(result.current.map((route) => route.name)).toEqual(['a', 'b', 'c']);
+
+  rerender({ state: makeState({ routeNames: ['a', 'c'], routesOrder: ['c', 'a'] }) });
+  expect(result.current.map((route) => route.name)).toEqual(['a', 'c']);
+});
+
+test('drops declared names that have no matching route', () => {
+  const state = makeState({ routeNames: ['a', 'b', 'c'], routesOrder: ['a', 'c'] }); // `b` not present in routes
+
+  const { result } = renderHook(() => useStableTabOrder(state));
+
+  expect(result.current.map((route) => route.name)).toEqual(['a', 'c']);
+});
+
+test('returns a stable reference while the state is unchanged', () => {
+  const state = makeState({ routeNames: ['a', 'b'], routesOrder: ['b', 'a'] });
+
+  const { result, rerender } = renderHook(() => useStableTabOrder(state));
+  const first = result.current;
+
+  rerender({});
+
+  expect(result.current).toBe(first);
+});

--- a/packages/expo-router/src/react-navigation/core/useStableTabOrder.ts
+++ b/packages/expo-router/src/react-navigation/core/useStableTabOrder.ts
@@ -1,0 +1,21 @@
+'use client';
+import * as React from 'react';
+
+import type { NavigationState } from '../routers';
+
+/**
+ * A tab navigator's `state.routes` is ordered by its back stack, not declaration order.
+ * The tab bar / drawer items / screens render in declaration order, so this returns the
+ * routes in `routeNames` (declaration) order.
+ */
+export function useStableTabOrder<State extends NavigationState>(state: State): State['routes'] {
+  const { routeNames, routes } = state;
+
+  return React.useMemo(
+    () =>
+      routeNames
+        .map((name) => routes.find((route) => route.name === name))
+        .filter(Boolean) as State['routes'],
+    [routeNames, routes]
+  );
+}

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerItemList.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerItemList.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 
+import { useStableTabOrder } from '../../core/useStableTabOrder';
 import {
   CommonActions,
   DrawerActions,
@@ -34,8 +35,12 @@ export function DrawerItemList({ state, navigation, descriptors }: Props) {
     drawerInactiveBackgroundColor,
   } = focusedOptions;
 
-  return state.routes.map((route, i) => {
-    const focused = i === state.index;
+  // `state.routes` is ordered by the navigator's back stack; render the drawer items
+  // in stable declaration order and detect focus by key.
+  const orderedRoutes = useStableTabOrder(state);
+
+  return orderedRoutes.map((route) => {
+    const focused = route.key === focusedRoute.key;
 
     const onPress = () => {
       const event = navigation.emit({

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   CommonActions,
   type ParamListBase,
@@ -13,6 +15,7 @@ import type {
   MaterialTopTabNavigationHelpers,
 } from '../types';
 import { MaterialTopTabBar } from './MaterialTopTabBar';
+import { useStableTabOrder } from '../../core/useStableTabOrder';
 import { TabAnimationContext } from '../utils/TabAnimationContext';
 
 // Use dynamic import to avoid having direct dependency on react-native-tab-view.
@@ -45,6 +48,29 @@ export function MaterialTopTabView({
   const { colors } = useTheme();
   const { direction } = useLocale();
 
+  // `state.routes` is ordered by the navigator's back stack; render the strip and
+  // pager in stable declaration order and detect focus by key.
+  const orderedRoutes = useStableTabOrder(state);
+  const focusedKey = state.routes[state.index]!.key;
+  const focusedIndex = useMemo(() => {
+    const index = orderedRoutes.findIndex((route) => route.key === focusedKey);
+    if (index === -1) {
+      console.warn(
+        `Could not find the focused route (key "${focusedKey}") in the ordered tab routes. Falling back to the first tab.`
+      );
+      return 0;
+    }
+    return index;
+  }, [orderedRoutes, focusedKey]);
+  const orderedState = useMemo(
+    () => ({
+      ...state,
+      routes: orderedRoutes,
+      index: focusedIndex,
+    }),
+    [state, orderedRoutes, focusedIndex]
+  );
+
   const renderTabBar: React.ComponentProps<any>['renderTabBar'] = ({
     /* eslint-disable @typescript-eslint/no-unused-vars */
     navigationState,
@@ -54,20 +80,20 @@ export function MaterialTopTabView({
   }: any) => {
     return tabBar({
       ...rest,
-      state,
+      state: orderedState,
       navigation,
       descriptors,
     });
   };
 
-  const focusedOptions = descriptors[state.routes[state.index]!.key]!.options;
+  const focusedOptions = descriptors[focusedKey]!.options;
 
   return (
     <TabView<Route<string>>
       {...rest}
       onIndexChange={(index: number) => {
         navigation.dispatch({
-          ...CommonActions.navigate(state.routes[index]!),
+          ...CommonActions.navigate(orderedRoutes[index]!),
           target: state.key,
         });
       }}
@@ -76,7 +102,7 @@ export function MaterialTopTabView({
           {descriptors[route.key]!.render()}
         </TabAnimationContext.Provider>
       )}
-      navigationState={state}
+      navigationState={orderedState}
       renderTabBar={renderTabBar}
       renderLazyPlaceholder={({ route }: any) =>
         descriptors[route.key]!.options.lazyPlaceholder?.() ?? null

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -150,6 +150,7 @@ export function DrawerRouter({
 
       return {
         ...state,
+        history: [],
         default: defaultStatus,
         stale: false,
         key: `drawer-${nanoid()}`,
@@ -161,23 +162,25 @@ export function DrawerRouter({
         return partialState;
       }
 
-      let state = router.getRehydratedState(partialState, {
+      const tabState = router.getRehydratedState(partialState, {
         routeNames,
         routeParamList,
         routeGetIdList,
       });
 
-      if (isDrawerInHistory(partialState)) {
-        // Re-sync the drawer entry in history to correct it if it was wrong
-        state = removeDrawerFromHistory(state);
-        state = addDrawerToHistory(state);
-      }
-
-      return {
-        ...state,
+      let state: DrawerNavigationState<ParamListBase> = {
+        ...tabState,
+        history: [],
         default: defaultStatus,
         key: `drawer-${nanoid()}`,
       };
+
+      if (isDrawerInHistory(partialState)) {
+        // Restore the open drawer that was persisted.
+        state = addDrawerToHistory(state);
+      }
+
+      return state;
     },
 
     getStateForRouteFocus(state, key) {
@@ -206,7 +209,13 @@ export function DrawerRouter({
         case 'NAVIGATE_DEPRECATED': {
           const result = router.getStateForAction(state, action, options);
 
-          if (result != null && result.index !== state.index) {
+          // A tab change closes the drawer. The focused route is identified by key —
+          // its index in `routes` depends on the active back behavior.
+          if (
+            result != null &&
+            result.index != null &&
+            result.routes[result.index]?.key !== state.routes[state.index]?.key
+          ) {
             return closeDrawer(result as DrawerNavigationState<ParamListBase>);
           }
 

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -20,13 +20,7 @@ export type TabActionType = {
   target?: string;
 };
 
-export type BackBehavior =
-  | 'firstRoute'
-  | 'initialRoute'
-  | 'order'
-  | 'history'
-  | 'fullHistory'
-  | 'none';
+export type BackBehavior = 'firstRoute' | 'initialRoute' | 'order' | 'history' | 'none';
 
 export type TabRouterOptions = DefaultRouterOptions & {
   /**
@@ -34,8 +28,7 @@ export type TabRouterOptions = DefaultRouterOptions & {
    * - `firstRoute` - return to the first defined route
    * - `initialRoute` - return to the route from `initialRouteName`
    * - `order` - return to the route defined before the focused route
-   * - `history` - return to last visited route; if the same route is visited multiple times, the older entries are dropped from the history
-   * - `fullHistory` - return to last visited route; doesn't drop duplicate entries unlike `history` - matches behavior of web pages
+   * - `history` - return to the previously focused route
    * - `none` - do not handle going back
    */
   backBehavior?: BackBehavior;
@@ -45,10 +38,6 @@ export type TabNavigationState<ParamList extends ParamListBase> = Omit<
   NavigationState<ParamList>,
   'history'
 > & {
-  /**
-   * List of previously visited route keys.
-   */
-  history: { type: 'route'; key: string; params?: object | undefined }[];
   /**
    * List of routes' key, which are supposed to be preloaded before navigating to.
    */
@@ -71,8 +60,6 @@ export type TabActionHelpers<ParamList extends ParamListBase> = {
   ): void;
 };
 
-const TYPE_ROUTE = 'route' as const;
-
 export const TabActions = {
   jumpTo(name: string, params?: object) {
     return {
@@ -82,100 +69,84 @@ export const TabActions = {
   },
 };
 
-const getRouteHistory = (
+const focusRouteInHistory = (
   routes: Route<string>[],
-  index: number,
-  backBehavior: BackBehavior,
-  initialRouteName: string | undefined
-) => {
-  const history = [
-    {
-      type: TYPE_ROUTE,
-      key: routes[index]!.key,
-    },
-  ];
-
-  let initialRouteIndex;
-
-  switch (backBehavior) {
-    case 'order':
-      for (let i = index; i > 0; i--) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[i - 1]!.key,
-        });
-      }
-      break;
-    case 'firstRoute':
-      if (index !== 0) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[0]!.key,
-        });
-      }
-      break;
-    case 'initialRoute':
-      initialRouteIndex = routes.findIndex((route) => route.name === initialRouteName);
-      initialRouteIndex = initialRouteIndex === -1 ? 0 : initialRouteIndex;
-
-      if (index !== initialRouteIndex) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[initialRouteIndex]!.key,
-        });
-      }
-      break;
-    case 'history':
-    case 'fullHistory':
-      // The history will fill up on navigation
-      break;
-  }
-
-  return history;
+  fromIndex: number,
+  focusedIndex: number,
+  route: Route<string>
+): { routes: Route<string>[]; index: number } => {
+  const next = routes.filter((_, i) => i !== fromIndex);
+  const insertAt = fromIndex <= focusedIndex ? focusedIndex : focusedIndex + 1;
+  next.splice(insertAt, 0, route);
+  return { routes: next, index: insertAt };
 };
 
-const changeIndex = (
-  state: TabNavigationState<ParamListBase>,
-  index: number,
+const arrangeBackStack = (
+  routes: Route<string>[],
+  focusedName: string,
   backBehavior: BackBehavior,
-  initialRouteName: string | undefined
-) => {
-  let history = state.history;
+  initialRouteName: string | undefined,
+  routeNames: string[]
+): { routes: Route<string>[]; index: number } => {
+  const byName = (name: string) => routes.find((route) => route.name === name)!;
 
-  if (backBehavior === 'history' || backBehavior === 'fullHistory') {
-    const currentRoute = state.routes[index]!;
-
-    if (backBehavior === 'history') {
-      // Remove the existing key from the history to de-duplicate it
-      history = history.filter((it) => (it.type === 'route' ? it.key !== currentRoute.key : false));
-    } else if (backBehavior === 'fullHistory') {
-      const lastHistoryRouteItemIndex = history.findLastIndex((item) => item.type === 'route');
-
-      if (currentRoute.key === history[lastHistoryRouteItemIndex]?.key) {
-        // For full-history, only remove if it matches the last route
-        // Useful for drawer, if current route was in history, then drawer state changed
-        // Then we only need to move the route to the front
-        history = [
-          ...history.slice(0, lastHistoryRouteItemIndex),
-          ...history.slice(lastHistoryRouteItemIndex + 1),
-        ];
-      }
-    }
-
-    history = history.concat({
-      type: TYPE_ROUTE,
-      key: currentRoute.key,
-      params: backBehavior === 'fullHistory' ? currentRoute.params : undefined,
-    });
-  } else {
-    history = getRouteHistory(state.routes, index, backBehavior, initialRouteName);
+  if (backBehavior === 'order' || backBehavior === 'none') {
+    return { routes: routeNames.map(byName), index: routeNames.indexOf(focusedName) };
   }
 
-  return {
-    ...state,
-    index,
-    history,
-  };
+  const anchorName =
+    backBehavior === 'initialRoute' &&
+    initialRouteName !== undefined &&
+    routeNames.includes(initialRouteName)
+      ? initialRouteName
+      : routeNames[0]!;
+
+  const others = routeNames
+    .filter((name) => name !== anchorName && name !== focusedName)
+    .map(byName);
+
+  if (focusedName === anchorName) {
+    return { routes: [byName(anchorName), ...others], index: 0 };
+  }
+
+  return { routes: [byName(anchorName), byName(focusedName), ...others], index: 1 };
+};
+
+const focusRoute = (
+  routes: Route<string>[],
+  focused: Route<string>,
+  fromIndex: number,
+  currentIndex: number,
+  backBehavior: BackBehavior,
+  initialRouteName: string | undefined,
+  routeNames: string[]
+): { routes: Route<string>[]; index: number } => {
+  if (backBehavior === 'history') {
+    return focusRouteInHistory(routes, fromIndex, currentIndex, focused);
+  }
+
+  return arrangeBackStack(
+    routes.map((route, i) => (i === fromIndex ? focused : route)),
+    focused.name,
+    backBehavior,
+    initialRouteName,
+    routeNames
+  );
+};
+
+export const pruneReplacedRoute = (
+  state: TabNavigationState<ParamListBase>
+): TabNavigationState<ParamListBase> => {
+  if (state.index <= 0) {
+    return state;
+  }
+
+  const replacedIndex = state.index - 1;
+  const replaced = state.routes[replacedIndex]!;
+  const routes = state.routes.filter((_, i) => i !== replacedIndex);
+  routes.splice(state.index, 0, replaced);
+
+  return { ...state, routes, index: state.index - 1 };
 };
 
 // TODO(@ubax): unify the logic into single router instead of BaseTabRouter and override
@@ -188,25 +159,39 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
     ...BaseRouter,
 
     getInitialState({ routeNames, routeParamList }) {
-      const index =
+      const initialIndex =
         initialRouteName !== undefined && routeNames.includes(initialRouteName)
           ? routeNames.indexOf(initialRouteName)
           : 0;
 
-      const routes = routeNames.map((name) => ({
+      const declarationRoutes = routeNames.map((name) => ({
         name,
         key: `${name}-${nanoid()}`,
         params: routeParamList[name],
       }));
 
-      const history = getRouteHistory(routes, index, backBehavior, initialRouteName);
+      const { routes, index } =
+        backBehavior === 'history'
+          ? {
+              routes: [
+                declarationRoutes[initialIndex]!,
+                ...declarationRoutes.filter((_, i) => i !== initialIndex),
+              ],
+              index: 0,
+            }
+          : arrangeBackStack(
+              declarationRoutes,
+              routeNames[initialIndex]!,
+              backBehavior,
+              initialRouteName,
+              routeNames
+            );
 
       return {
         stale: false,
         key: `tab-${nanoid()}`,
         index,
         routeNames,
-        history,
         routes,
         preloadedRouteKeys: [],
       };
@@ -219,12 +204,10 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
         return state;
       }
 
-      const routes = routeNames.map((name) => {
-        const route = (state as PartialState<TabNavigationState<ParamListBase>>).routes.find(
-          (r) => r.name === name
-        );
+      const partialRoutes = (state as PartialState<TabNavigationState<ParamListBase>>).routes;
 
-        return {
+      const buildRoute = (name: string, route: Route<string> | undefined) =>
+        ({
           ...route,
           name,
           key: route && route.name === name && route.key ? route.key : `${name}-${nanoid()}`,
@@ -237,59 +220,85 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
               : route
                 ? route.params
                 : undefined,
-        } as Route<string>;
-      });
+        }) as Route<string>;
 
-      const index = Math.min(
-        Math.max(routeNames.indexOf(state.routes[state?.index ?? 0]?.name as string), 0),
-        routes.length - 1
-      );
+      const seen = new Set<string>();
+      const rebuilt: Route<string>[] = [];
+
+      for (const route of partialRoutes) {
+        if (routeNames.includes(route.name) && !seen.has(route.name)) {
+          seen.add(route.name);
+          rebuilt.push(buildRoute(route.name, route as Route<string>));
+        }
+      }
+
+      for (const name of routeNames) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          rebuilt.push(buildRoute(name, undefined));
+        }
+      }
+
+      const persistedFocusedName = partialRoutes[state?.index ?? 0]?.name;
+      const focusedName =
+        persistedFocusedName !== undefined && seen.has(persistedFocusedName)
+          ? persistedFocusedName
+          : rebuilt[0]!.name;
+
+      const { routes, index } =
+        backBehavior === 'history'
+          ? { routes: rebuilt, index: rebuilt.findIndex((route) => route.name === focusedName) }
+          : arrangeBackStack(rebuilt, focusedName, backBehavior, initialRouteName, routeNames);
 
       const routeKeys = routes.map((route) => route.key);
 
-      const history = state.history?.filter((it) => routeKeys.includes(it.key)) ?? [];
-
-      return changeIndex(
-        {
-          stale: false,
-          key: `tab-${nanoid()}`,
-          index,
-          routeNames,
-          history,
-          routes,
-          preloadedRouteKeys:
-            state.preloadedRouteKeys?.filter((key) => routeKeys.includes(key)) ?? [],
-        },
+      return {
+        stale: false,
+        key: `tab-${nanoid()}`,
         index,
-        backBehavior,
-        initialRouteName
-      );
+        routeNames,
+        routes,
+        preloadedRouteKeys:
+          state.preloadedRouteKeys?.filter((key) => routeKeys.includes(key)) ?? [],
+      };
     },
 
     getStateForRouteNamesChange(state, { routeNames, routeParamList, routeKeyChanges }) {
-      const routes = routeNames.map(
-        (name) =>
-          state.routes.find((r) => r.name === name && !routeKeyChanges.includes(r.name)) || {
+      const seen = new Set<string>();
+      const rebuilt: Route<string>[] = [];
+
+      for (const route of state.routes) {
+        if (
+          routeNames.includes(route.name) &&
+          !routeKeyChanges.includes(route.name) &&
+          !seen.has(route.name)
+        ) {
+          seen.add(route.name);
+          rebuilt.push(route);
+        }
+      }
+
+      for (const name of routeNames) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          rebuilt.push({
             name,
             key: `${name}-${nanoid()}`,
             params: routeParamList[name],
-          }
-      );
-
-      const index = Math.max(0, routeNames.indexOf(state.routes[state.index]!.name));
-
-      let history = state.history.filter(
-        // Type will always be 'route' for tabs, but could be different in a router extending this (e.g. drawer)
-        (it) => it.type !== 'route' || routes.find((r) => r.key === it.key)
-      );
-
-      if (!history.length) {
-        history = getRouteHistory(routes, index, backBehavior, initialRouteName);
+          });
+        }
       }
+
+      const previousFocusedName = state.routes[state.index]!.name;
+      const focusedName = seen.has(previousFocusedName) ? previousFocusedName : rebuilt[0]!.name;
+
+      const { routes, index } =
+        backBehavior === 'history'
+          ? { routes: rebuilt, index: rebuilt.findIndex((route) => route.name === focusedName) }
+          : arrangeBackStack(rebuilt, focusedName, backBehavior, initialRouteName, routeNames);
 
       return {
         ...state,
-        history,
         routeNames,
         routes,
         index,
@@ -297,16 +306,26 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
     },
 
     getStateForRouteFocus(state, key) {
-      const index = state.routes.findIndex((r) => r.key === key);
+      const fromIndex = state.routes.findIndex((r) => r.key === key);
 
-      if (index === -1 || index === state.index) {
+      if (fromIndex === -1 || fromIndex === state.index) {
         return state;
       }
 
-      return changeIndex(state, index, backBehavior, initialRouteName);
+      const { routes, index } = focusRoute(
+        state.routes,
+        state.routes[fromIndex]!,
+        fromIndex,
+        state.index,
+        backBehavior,
+        initialRouteName,
+        state.routeNames
+      );
+
+      return { ...state, routes, index };
     },
 
-    getStateForAction(state, action, { routeParamList, routeGetIdList }) {
+    getStateForAction(state, action, { routeNames, routeParamList, routeGetIdList }) {
       switch (action.type) {
         case 'JUMP_TO':
         case 'NAVIGATE':
@@ -319,130 +338,83 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
             return null;
           }
 
-          const updatedState = changeIndex(
-            {
-              ...state,
-              routes: state.routes.map((route) => {
-                if (route.name !== action.payload.name) {
-                  return route;
-                }
+          const route = state.routes[index]!;
 
-                const getId = routeGetIdList[route.name];
+          const getId = routeGetIdList[route.name];
 
-                const currentId = getId?.({ params: route.params });
-                const nextId = getId?.({ params: action.payload.params });
+          const currentId = getId?.({ params: route.params });
+          const nextId = getId?.({ params: action.payload.params });
 
-                const key = currentId === nextId ? route.key : `${route.name}-${nanoid()}`;
+          const key = currentId === nextId ? route.key : `${route.name}-${nanoid()}`;
 
-                let params;
-
-                if (
-                  (action.type === 'NAVIGATE' || action.type === 'NAVIGATE_DEPRECATED') &&
-                  action.payload.merge &&
-                  currentId === nextId
-                ) {
-                  params =
-                    action.payload.params !== undefined || routeParamList[route.name] !== undefined
-                      ? {
-                          ...routeParamList[route.name],
-                          ...route.params,
-                          ...action.payload.params,
-                        }
-                      : route.params;
-                } else {
-                  params = createParamsFromAction({ action, routeParamList });
-                }
-
-                const path =
-                  action.type === 'NAVIGATE' && action.payload.path != null
-                    ? action.payload.path
-                    : route.path;
-
-                return params !== route.params || path !== route.path
-                  ? { ...route, key, path, params }
-                  : route;
-              }),
-            },
-            index,
-            backBehavior,
-            initialRouteName
-          );
-
-          return {
-            ...updatedState,
-            preloadedRouteKeys: updatedState.preloadedRouteKeys.filter(
-              (key) => key !== state.routes[updatedState.index]!.key
-            ),
-          };
-        }
-
-        case 'SET_PARAMS':
-        case 'REPLACE_PARAMS': {
-          const nextState = BaseRouter.getStateForAction(state, action);
-
-          if (nextState !== null) {
-            const index = nextState.index;
-
-            if (index != null) {
-              const focusedRoute = nextState.routes[index]!;
-              const historyItemIndex = state.history.findLastIndex(
-                (item) => item.key === focusedRoute.key
-              );
-
-              let updatedHistory = state.history;
-
-              if (historyItemIndex !== -1) {
-                updatedHistory = [...state.history];
-                updatedHistory[historyItemIndex] = {
-                  ...updatedHistory[historyItemIndex]!,
-                  params: focusedRoute.params,
-                };
-              }
-
-              return {
-                ...nextState,
-                history: updatedHistory,
-              };
-            }
-          }
-
-          return nextState;
-        }
-
-        case 'GO_BACK': {
-          if (state.history.length === 1) {
-            return null;
-          }
-
-          const previousHistoryItem = state.history[state.history.length - 2];
-          const previousKey = previousHistoryItem?.key;
-          const index = state.routes.findLastIndex((route) => route.key === previousKey);
-
-          if (index === -1) {
-            return null;
-          }
-
-          let routes = state.routes;
+          let params;
 
           if (
-            backBehavior === 'fullHistory' &&
-            routes[index]!.params !== previousHistoryItem!.params
+            (action.type === 'NAVIGATE' || action.type === 'NAVIGATE_DEPRECATED') &&
+            action.payload.merge &&
+            currentId === nextId
           ) {
-            routes = [...state.routes];
-            routes[index] = {
-              ...routes[index]!,
-              params: previousHistoryItem!.params,
-            };
+            params =
+              action.payload.params !== undefined || routeParamList[route.name] !== undefined
+                ? {
+                    ...routeParamList[route.name],
+                    ...route.params,
+                    ...action.payload.params,
+                  }
+                : route.params;
+          } else {
+            params = createParamsFromAction({ action, routeParamList });
           }
+
+          const path =
+            action.type === 'NAVIGATE' && action.payload.path != null
+              ? action.payload.path
+              : route.path;
+
+          const updatedRoute =
+            params !== route.params || path !== route.path || key !== route.key
+              ? { ...route, key, path, params }
+              : route;
+
+          if (updatedRoute === route && index === state.index) {
+            return state;
+          }
+
+          const { routes, index: newIndex } = focusRoute(
+            state.routes,
+            updatedRoute,
+            index,
+            state.index,
+            backBehavior,
+            initialRouteName,
+            routeNames
+          );
 
           return {
             ...state,
             routes,
-            preloadedRouteKeys: state.preloadedRouteKeys.filter(
-              (key) => key !== state.routes[index]!.key
-            ),
-            history: state.history.slice(0, -1),
+            index: newIndex,
+            preloadedRouteKeys: state.preloadedRouteKeys.filter((k) => k !== updatedRoute.key),
+          };
+        }
+
+        case 'SET_PARAMS':
+        case 'REPLACE_PARAMS':
+          return BaseRouter.getStateForAction(state, action);
+
+        case 'GO_BACK': {
+          if (backBehavior === 'none' || state.index <= 0) {
+            return null;
+          }
+
+          const index = state.index - 1;
+
+          return {
+            ...state,
             index,
+            preloadedRouteKeys: state.preloadedRouteKeys.filter(
+              (k) => k !== state.routes[index]!.key
+            ),
           };
         }
 
@@ -471,10 +443,6 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
               .filter((key) => key !== route.key)
               .concat(newRoute.key),
             routes: state.routes.map((route, index) => (index === routeIndex ? newRoute : route)),
-            history:
-              key === route.key
-                ? state.history
-                : state.history.filter((record) => record.key !== route.key),
           };
         }
 
@@ -505,8 +473,7 @@ export function TabRouter(
 
       if ((action.type as string) === 'REPLACE') {
         const replaceAction = action as unknown as Extract<StackActionType, { type: 'REPLACE' }>;
-        // Generate the state as if we were using JUMP_TO
-        let nextState = base.getStateForAction(
+        const nextState = base.getStateForAction(
           state,
           {
             ...replaceAction,
@@ -515,27 +482,11 @@ export function TabRouter(
           options
         );
 
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
+        if (nextState == null) {
           return null;
         }
 
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (nextState.index !== 0) {
-          const previousIndex = nextState.index - 1;
-
-          nextState = {
-            ...nextState,
-            key: `${nextState.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...nextState.history.slice(0, previousIndex),
-              ...nextState.history.splice(nextState.index),
-            ],
-          };
-        }
-
-        return nextState;
+        return pruneReplacedRoute(nextState as TabNavigationState<ParamListBase>);
       }
 
       return base.getStateForAction(state, action, options);

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -33,10 +33,7 @@ test('gets initial state from route names and params with initialRouteName', () 
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
+    history: [],
     default: 'closed',
     stale: false,
   });
@@ -64,13 +61,37 @@ test('gets initial state from route names and params without initialRouteName', 
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [{ type: 'route', key: 'bar-test' }],
+    history: [],
     default: 'closed',
     stale: false,
   });
 });
 
-test('gets rehydrated state from partial state', () => {
+test('seeds an open drawer in initial state when defaultStatus is open', () => {
+  const router = DrawerRouter({ defaultStatus: 'open' });
+
+  expect(
+    router.getInitialState({
+      routeNames: ['bar', 'baz'],
+      routeParamList: {},
+      routeGetIdList: {},
+    })
+  ).toEqual({
+    index: 0,
+    key: 'drawer-test',
+    routeNames: ['bar', 'baz'],
+    preloadedRouteKeys: [],
+    routes: [
+      { key: 'bar-test', name: 'bar' },
+      { key: 'baz-test', name: 'baz' },
+    ],
+    history: [],
+    default: 'open',
+    stale: false,
+  });
+});
+
+test('rehydrates preserving the persisted route order and appending new tabs', () => {
   const router = DrawerRouter({});
 
   const options: RouterConfigOptions = {
@@ -82,9 +103,12 @@ test('gets rehydrated state from partial state', () => {
     routeGetIdList: {},
   };
 
+  // Persisted state focuses qux (index 1 of its own routes). baz is newly
+  // declared, so it is appended at the end in declaration order.
   expect(
     router.getRehydratedState(
       {
+        index: 1,
         routes: [
           { key: 'bar-0', name: 'bar' },
           { key: 'qux-1', name: 'qux' },
@@ -93,20 +117,36 @@ test('gets rehydrated state from partial state', () => {
       options
     )
   ).toEqual({
-    index: 0,
+    index: 1,
     key: 'drawer-test',
     routeNames: ['bar', 'baz', 'qux'],
     preloadedRouteKeys: [],
     routes: [
       { key: 'bar-0', name: 'bar' },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-1', name: 'qux', params: { name: 'Jane' } },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
     ],
-    history: [{ type: 'route', key: 'bar-0' }],
+    history: [],
     default: 'closed',
     stale: false,
   });
+});
 
+test('rehydrates focusing the previously-focused route and falling back to 0', () => {
+  const router = DrawerRouter({});
+
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {
+      baz: { answer: 42 },
+      qux: { name: 'Jane' },
+    },
+    routeGetIdList: {},
+  };
+
+  // No index given → focused falls back to the persisted route 'baz'. The drawer's
+  // default `firstRoute` arranges the back stack as [first, focused, ...rest], so
+  // anchor 'bar' leads and 'baz' sits at index 1 (its persisted key is kept).
   expect(
     router.getRehydratedState(
       {
@@ -124,44 +164,12 @@ test('gets rehydrated state from partial state', () => {
       { key: 'baz-0', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-0' },
-    ],
+    history: [],
     default: 'closed',
     stale: false,
   });
 
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-1', name: 'baz' },
-          { key: 'qux-2', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 2,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-1', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-2', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
-    ],
-    default: 'closed',
-    stale: false,
-  });
-
+  // Empty routes → everything rebuilt in declaration order, index falls back to 0.
   expect(
     router.getRehydratedState(
       {
@@ -180,22 +188,32 @@ test('gets rehydrated state from partial state', () => {
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [{ type: 'route', key: 'bar-test' }],
+    history: [],
     default: 'closed',
     stale: false,
   });
+});
 
+test('rehydrates a persisted open drawer and drops route history entries', () => {
+  const router = DrawerRouter({});
+
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {
+      baz: { answer: 42 },
+      qux: { name: 'Jane' },
+    },
+    routeGetIdList: {},
+  };
+
+  // The drawer entry in the persisted history restores an open drawer; the
+  // returned history holds only the drawer entry.
   expect(
     router.getRehydratedState(
       {
-        index: 1,
-        history: [
-          { type: 'route', key: 'bar-test' },
-          { type: 'route', key: 'qux-test' },
-          { type: 'route', key: 'foo-test' },
-          { type: 'drawer', status: 'open' },
-        ],
-        routes: [],
+        index: 0,
+        history: [{ type: 'drawer', status: 'open' }],
+        routes: [{ key: 'bar-0', name: 'bar' }],
       },
       options
     )
@@ -205,14 +223,11 @@ test('gets rehydrated state from partial state', () => {
     routeNames: ['bar', 'baz', 'qux'],
     preloadedRouteKeys: [],
     routes: [
-      { key: 'bar-test', name: 'bar' },
+      { key: 'bar-0', name: 'bar' },
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'drawer', status: 'open' },
-    ],
+    history: [{ type: 'drawer', status: 'open' }],
     default: 'closed',
     stale: false,
   });
@@ -231,10 +246,7 @@ test("doesn't rehydrate state if it's not stale", () => {
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'drawer', status: 'open' },
-    ],
+    history: [{ type: 'drawer', status: 'open' }],
     default: 'closed',
     stale: false as const,
   };
@@ -248,27 +260,30 @@ test("doesn't rehydrate state if it's not stale", () => {
   ).toBe(state);
 });
 
-test('handles navigate action', () => {
+test('handles navigate action by focusing the target route in place', () => {
   const router = DrawerRouter({});
   const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
+    routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
     routeGetIdList: {},
   };
 
+  // The drawer uses the default `firstRoute` back behavior, so `routes` stays in
+  // declaration order; navigating to baz just focuses it (index → its position).
   expect(
     router.getStateForAction(
       {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
+        index: 2,
+        routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz', params: { color: 'tomato' } },
           { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
+        history: [],
         default: 'closed',
       },
       CommonActions.navigate('baz', { answer: 42 }),
@@ -278,57 +293,60 @@ test('handles navigate action', () => {
     stale: false,
     key: 'root',
     index: 0,
-    routeNames: ['baz', 'bar'],
+    routeNames: ['baz', 'bar', 'qux'],
     preloadedRouteKeys: [],
     routes: [
-      { key: 'baz', name: 'baz', params: { answer: 42 } },
+      { key: 'baz', name: 'baz', params: { answer: 42 }, path: undefined },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
+    history: [],
     default: 'closed',
   });
 });
 
-test('handles navigate action with open drawer', () => {
+test('handles navigate action with open drawer by closing it', () => {
   const router = DrawerRouter({});
   const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
+    routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
     routeGetIdList: {},
   };
 
+  // Focus starts on baz. The drawer's default `firstRoute` arranges the back stack
+  // as [first, focused, ...rest], so navigating to qux gives [baz, qux, bar] with
+  // qux focused at index 1. The focused route changed, so the open drawer is closed.
   expect(
     router.getStateForAction(
       {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
+        index: 0,
+        routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
         ],
-        history: [
-          { type: 'route', key: 'bar' },
-          { type: 'drawer', status: 'open' },
-        ],
+        history: [{ type: 'drawer', status: 'open' }],
         default: 'closed',
       },
-      CommonActions.navigate('baz', { answer: 42 }),
+      CommonActions.navigate('qux', { answer: 42 }),
       options
     )
   ).toEqual({
     stale: false,
     key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
     preloadedRouteKeys: [],
     routes: [
-      { key: 'baz', name: 'baz', params: { answer: 42 } },
+      { key: 'baz', name: 'baz' },
+      { key: 'qux', name: 'qux', params: { answer: 42 }, path: undefined },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
+    history: [],
     default: 'closed',
   });
 });
@@ -353,7 +371,7 @@ test('handles open drawer action', () => {
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
+        history: [],
         default: 'closed',
       },
       DrawerActions.openDrawer(),
@@ -369,13 +387,11 @@ test('handles open drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
+    history: [{ type: 'drawer', status: 'open' }],
     default: 'closed',
   });
 
+  // Opening an already-open drawer is a no-op (same reference returned).
   const state: DrawerNavigationState<ParamListBase> = {
     stale: false as const,
     key: 'root',
@@ -386,10 +402,7 @@ test('handles open drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
+    history: [{ type: 'drawer', status: 'open' }],
     default: 'closed',
   };
 
@@ -416,10 +429,7 @@ test('handles close drawer action', () => {
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [
-          { type: 'route', key: 'bar' },
-          { type: 'drawer', status: 'open' },
-        ],
+        history: [{ type: 'drawer', status: 'open' }],
         default: 'closed',
       },
       DrawerActions.closeDrawer(),
@@ -435,10 +445,11 @@ test('handles close drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'bar' }],
+    history: [],
     default: 'closed',
   });
 
+  // Closing an already-closed drawer is a no-op (same reference returned).
   const state: DrawerNavigationState<ParamListBase> = {
     stale: false as const,
     key: 'root',
@@ -449,10 +460,7 @@ test('handles close drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'route', key: 'baz' },
-    ],
+    history: [],
     default: 'closed',
   };
 
@@ -467,6 +475,7 @@ test('handles toggle drawer action', () => {
     routeGetIdList: {},
   };
 
+  // Open → closed (drawer entry removed).
   expect(
     router.getStateForAction(
       {
@@ -479,10 +488,7 @@ test('handles toggle drawer action', () => {
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [
-          { type: 'route', key: 'bar' },
-          { type: 'drawer', status: 'open' },
-        ],
+        history: [{ type: 'drawer', status: 'open' }],
         default: 'closed',
       },
       DrawerActions.toggleDrawer(),
@@ -498,10 +504,11 @@ test('handles toggle drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'bar' }],
+    history: [],
     default: 'closed',
   });
 
+  // Closed → open (drawer entry added).
   expect(
     router.getStateForAction(
       {
@@ -514,7 +521,7 @@ test('handles toggle drawer action', () => {
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
+        history: [],
         default: 'closed',
       },
       DrawerActions.toggleDrawer(),
@@ -530,115 +537,70 @@ test('handles toggle drawer action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
+    history: [{ type: 'drawer', status: 'open' }],
     default: 'closed',
   });
 });
 
-test('updates history on focus change with backBehavior: history', () => {
+test('GO_BACK closes an open drawer without changing routes or index', () => {
   const router = DrawerRouter({ backBehavior: 'history' });
-
-  let state: DrawerNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['baz', 'bar'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
-    stale: false as const,
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
   };
 
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-});
-
-test('updates history on focus change with backBehavior: fullHistory', () => {
-  const router = DrawerRouter({ backBehavior: 'fullHistory' });
-
-  let state: DrawerNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['baz', 'bar'],
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        key: 'root',
+        index: 1,
+        routeNames: ['bar', 'baz', 'qux'],
+        preloadedRouteKeys: [],
+        routes: [
+          { key: 'bar-0', name: 'bar' },
+          { key: 'baz-0', name: 'baz' },
+          { key: 'qux-0', name: 'qux' },
+        ],
+        history: [{ type: 'drawer', status: 'open' }],
+        default: 'closed',
+      },
+      CommonActions.goBack(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    key: 'root',
+    index: 1,
+    routeNames: ['bar', 'baz', 'qux'],
     preloadedRouteKeys: [],
     routes: [
       { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
+      { key: 'baz-0', name: 'baz' },
+      { key: 'qux-0', name: 'qux' },
     ],
-    history: [{ type: 'route', key: 'bar-0' }],
+    history: [],
     default: 'closed',
-    stale: false as const,
+  });
+});
+
+test('GO_BACK delegates to the tab router when the drawer is closed', () => {
+  const router = DrawerRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
   };
 
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-});
-
-test('closes drawer on focus change with backBehavior: history', () => {
-  const router = DrawerRouter({ backBehavior: 'history' });
-
+  // No drawer entry → tab GO_BACK with backBehavior 'history' moves focus to the
+  // previous route (index - 1). Routes are left untouched.
   expect(
-    router.getStateForRouteFocus(
+    router.getStateForAction(
       {
-        index: 0,
-        key: 'drawer-test',
+        stale: false,
+        key: 'root',
+        index: 2,
         routeNames: ['bar', 'baz', 'qux'],
         preloadedRouteKeys: [],
         routes: [
@@ -646,15 +608,16 @@ test('closes drawer on focus change with backBehavior: history', () => {
           { key: 'baz-0', name: 'baz' },
           { key: 'qux-0', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'bar-0' }],
+        history: [],
         default: 'closed',
-        stale: false,
       },
-      'baz-0'
+      CommonActions.goBack(),
+      options
     )
   ).toEqual({
+    stale: false,
+    key: 'root',
     index: 1,
-    key: 'drawer-test',
     routeNames: ['bar', 'baz', 'qux'],
     preloadedRouteKeys: [],
     routes: [
@@ -662,93 +625,16 @@ test('closes drawer on focus change with backBehavior: history', () => {
       { key: 'baz-0', name: 'baz' },
       { key: 'qux-0', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
+    history: [],
     default: 'closed',
-    stale: false,
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        preloadedRouteKeys: [],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        default: 'closed',
-        stale: false,
-      },
-      'bar-0'
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
-    stale: false,
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        preloadedRouteKeys: [],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        default: 'closed',
-        stale: false,
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    default: 'closed',
-    stale: false,
   });
 });
 
-test('closes drawer on focus change with backBehavior: fullHistory', () => {
-  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+test('getStateForRouteFocus focuses the route in place and closes the drawer', () => {
+  const router = DrawerRouter({});
 
+  // Default `firstRoute` back behavior: `routes` stays in declaration order, focus
+  // just moves to the route's index, and the open drawer is closed.
   expect(
     router.getStateForRouteFocus(
       {
@@ -761,7 +647,7 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
           { key: 'baz-0', name: 'baz' },
           { key: 'qux-0', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'bar-0' }],
+        history: [{ type: 'drawer', status: 'open' }],
         default: 'closed',
         stale: false,
       },
@@ -777,85 +663,7 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
       { key: 'baz-0', name: 'baz' },
       { key: 'qux-0', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    default: 'closed',
-    stale: false,
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        preloadedRouteKeys: [],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        default: 'closed',
-        stale: false,
-      },
-      'bar-0'
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
-    stale: false,
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        preloadedRouteKeys: [],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        default: 'closed',
-        stale: false,
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
+    history: [],
     default: 'closed',
     stale: false,
   });

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,9 +1,10 @@
-import { expect, jest, test } from '@jest/globals';
+import { expect, test } from '@jest/globals';
 
 import {
   CommonActions,
   type ParamListBase,
   type RouterConfigOptions,
+  StackActions,
   TabActions,
   type TabNavigationState,
   TabRouter,
@@ -11,7 +12,38 @@ import {
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
 
-test('gets initial state from route names and params with initialRouteName', () => {
+const names = (state: { routes: { name: string }[] }) => state.routes.map((r) => r.name);
+
+// --- getInitialState ---------------------------------------------------------
+
+test('gets initial state focusing the first route', () => {
+  const router = TabRouter({});
+
+  expect(
+    router.getInitialState({
+      routeNames: ['bar', 'baz', 'qux'],
+      routeParamList: {
+        baz: { answer: 42 },
+        qux: { name: 'Jane' },
+      },
+      routeGetIdList: {},
+    })
+  ).toEqual({
+    index: 0,
+    key: 'tab-test',
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'bar-test', name: 'bar' },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+    ],
+    stale: false,
+    preloadedRouteKeys: [],
+  });
+});
+
+test('gets initial state with initialRouteName, anchoring the first route', () => {
+  // anchor = first route (bar), focused = baz -> [bar, baz, qux] index 1.
   const router = TabRouter({ initialRouteName: 'baz' });
 
   expect(
@@ -32,43 +64,116 @@ test('gets initial state from route names and params with initialRouteName', () 
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('gets initial state from route names and params without initialRouteName', () => {
-  const router = TabRouter({});
+test('gets initial state placing the initial route after the firstRoute anchor', () => {
+  // declaration [bar, baz, qux], anchor = bar, focused = qux -> [bar, qux, baz] index 1.
+  const router = TabRouter({ backBehavior: 'firstRoute', initialRouteName: 'qux' });
+
+  const state = router.getInitialState({
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  });
+
+  expect(names(state)).toEqual(['bar', 'qux', 'baz']);
+  expect(state.index).toBe(1);
+});
+
+test('gets initial state anchored on the initial route with initialRoute back behavior', () => {
+  // declaration [a, b, c], initialRoute b, focused = b (the initial = anchor) ->
+  // [b, a, c] index 0.
+  const router = TabRouter({ backBehavior: 'initialRoute', initialRouteName: 'b' });
+
+  const state = router.getInitialState({
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  });
+
+  expect(names(state)).toEqual(['b', 'a', 'c']);
+  expect(state.index).toBe(0);
+});
+
+test('gets initial state in declaration order for order and none back behaviors', () => {
+  // declaration [a, b, c], initial c -> stay [a, b, c], index 2.
+  for (const backBehavior of ['order', 'none'] as const) {
+    const router = TabRouter({ backBehavior, initialRouteName: 'c' });
+
+    expect(
+      router.getInitialState({
+        routeNames: ['a', 'b', 'c'],
+        routeParamList: {},
+        routeGetIdList: {},
+      })
+    ).toEqual({
+      index: 2,
+      key: 'tab-test',
+      routeNames: ['a', 'b', 'c'],
+      routes: [
+        { key: 'a-test', name: 'a' },
+        { key: 'b-test', name: 'b' },
+        { key: 'c-test', name: 'c' },
+      ],
+      stale: false,
+      preloadedRouteKeys: [],
+    });
+  }
+});
+
+test('gets initial state moving a non-first initial route to the front with history', () => {
+  // declaration [a, b, c], initial c, history -> [c, a, b] index 0.
+  const router = TabRouter({ backBehavior: 'history', initialRouteName: 'c' });
 
   expect(
     router.getInitialState({
-      routeNames: ['bar', 'baz', 'qux'],
-      routeParamList: {
-        baz: { answer: 42 },
-        qux: { name: 'Jane' },
-      },
+      routeNames: ['a', 'b', 'c'],
+      routeParamList: {},
       routeGetIdList: {},
     })
   ).toEqual({
     index: 0,
     key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
+    routeNames: ['a', 'b', 'c'],
     routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+      { key: 'c-test', name: 'c' },
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
     ],
-    history: [{ type: 'route', key: 'bar-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('gets rehydrated state from partial state', () => {
+test('gets initial state in declaration order when the initial route is already first with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+
+  expect(
+    router.getInitialState({
+      routeNames: ['a', 'b', 'c'],
+      routeParamList: {},
+      routeGetIdList: {},
+    })
+  ).toEqual({
+    index: 0,
+    key: 'tab-test',
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+    ],
+    stale: false,
+    preloadedRouteKeys: [],
+  });
+});
+
+// --- getRehydratedState ------------------------------------------------------
+
+test('rehydrates partial state, appending newly-declared tabs at the end', () => {
   const router = TabRouter({});
 
   const options: RouterConfigOptions = {
@@ -80,6 +185,9 @@ test('gets rehydrated state from partial state', () => {
     routeGetIdList: {},
   };
 
+  // Persisted [bar, qux] (baz missing). Persisted keys are preserved, but firstRoute
+  // re-arranges into the declaration-order back-stack: anchor = first declared (bar),
+  // focused = bar -> [bar, baz, qux] index 0.
   expect(
     router.getRehydratedState(
       {
@@ -99,11 +207,12 @@ test('gets rehydrated state from partial state', () => {
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-1', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [{ type: 'route', key: 'bar-0' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 
+  // Single persisted tab baz; missing tabs appended in declaration order. firstRoute
+  // anchor = first declared (bar), focused = baz -> [bar, baz, qux] index 1.
   expect(
     router.getRehydratedState(
       {
@@ -120,71 +229,75 @@ test('gets rehydrated state from partial state', () => {
       { key: 'baz-0', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-0' },
-    ],
     stale: false,
     preloadedRouteKeys: [],
   });
+});
 
+test('rehydrates with history, preserving persisted order and indexing by focused name', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {
+      baz: { answer: 42 },
+      qux: { name: 'Jane' },
+    },
+    routeGetIdList: {},
+  };
+
+  // history keeps the persisted visit order; missing baz appended at the end.
+  // Focused persisted index 0 = qux -> position 0.
   expect(
     router.getRehydratedState(
       {
-        index: 2,
+        index: 0,
         routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-1', name: 'baz' },
-          { key: 'qux-2', name: 'qux' },
+          { key: 'qux-9', name: 'qux' },
+          { key: 'bar-9', name: 'bar' },
         ],
       },
       options
     )
   ).toEqual({
-    index: 2,
+    index: 0,
     key: 'tab-test',
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-1', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-2', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
+      { key: 'qux-9', name: 'qux', params: { name: 'Jane' } },
+      { key: 'bar-9', name: 'bar' },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
     ],
     stale: false,
     preloadedRouteKeys: [],
   });
 
+  // Focused persisted index 1 = bar -> resolves to bar's position 1.
   expect(
     router.getRehydratedState(
       {
         index: 1,
         routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'qux-2', name: 'qux' },
+          { key: 'qux-9', name: 'qux' },
+          { key: 'bar-9', name: 'bar' },
         ],
       },
       options
     )
   ).toEqual({
-    index: 2,
+    index: 1,
     key: 'tab-test',
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
-      { key: 'bar-0', name: 'bar' },
+      { key: 'qux-9', name: 'qux', params: { name: 'Jane' } },
+      { key: 'bar-9', name: 'bar' },
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-2', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
     ],
     stale: false,
     preloadedRouteKeys: [],
   });
 
+  // Empty persisted routes -> declaration order, index falls back to 0.
   expect(
     router.getRehydratedState(
       {
@@ -202,34 +315,6 @@ test('gets rehydrated state from partial state', () => {
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [{ type: 'route', key: 'bar-test' }],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 1,
-        history: [
-          { type: 'route', key: 'bar-test' },
-          { type: 'route', key: 'qux-test' },
-          { type: 'route', key: 'foo-test' },
-        ],
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
@@ -247,7 +332,6 @@ test("doesn't rehydrate state if it's not stale", () => {
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
     ],
-    history: [{ type: 'route', key: 'bar-test' }],
     stale: false,
     preloadedRouteKeys: [],
   };
@@ -261,8 +345,8 @@ test("doesn't rehydrate state if it's not stale", () => {
   ).toBe(state);
 });
 
-test('restores correct history on rehydrating with backBehavior: order', () => {
-  const router = TabRouter({ backBehavior: 'order' });
+test('rehydrates with history, preserving persisted route order verbatim', () => {
+  const router = TabRouter({ backBehavior: 'history', initialRouteName: 'bar' });
 
   const options: RouterConfigOptions = {
     routeNames: ['foo', 'bar', 'baz', 'qux'],
@@ -293,221 +377,19 @@ test('restores correct history on rehydrating with backBehavior: order', () => {
       { key: 'baz-0', name: 'baz' },
       { key: 'qux-0', name: 'qux' },
     ],
-    history: [
-      { key: 'foo-0', type: 'route' },
-      { key: 'bar-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('restores correct history on rehydrating with backBehavior: history', () => {
+// --- getStateForRouteNamesChange ---------------------------------------------
+
+test('keeps surviving order and appends new tabs on route names change with history', () => {
   const router = TabRouter({ backBehavior: 'history' });
 
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: firstRoute', () => {
-  const router = TabRouter({
-    backBehavior: 'firstRoute',
-    initialRouteName: 'bar',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { key: 'foo-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: initialRoute', () => {
-  const router = TabRouter({
-    backBehavior: 'initialRoute',
-    initialRouteName: 'bar',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { key: 'bar-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: none', () => {
-  const router = TabRouter({ backBehavior: 'none' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    preloadedRouteKeys: [],
-  });
-});
-
-test('gets state on route names change', () => {
-  const router = TabRouter({});
-
+  // Surviving tabs (baz, qux) keep their existing order; new tabs (foo, fiz)
+  // appended at the end in declaration order. Focused bar removed -> fall back to
+  // first rebuilt tab (baz) at index 0.
   expect(
     router.getStateForRouteNamesChange(
       {
@@ -519,7 +401,6 @@ test('gets state on route names change', () => {
           { key: 'baz-test', name: 'baz', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
         ],
-        history: [{ type: 'route', key: 'bar-test' }],
         stale: false,
         preloadedRouteKeys: [],
       },
@@ -538,16 +419,16 @@ test('gets state on route names change', () => {
     key: 'tab-test',
     routeNames: ['qux', 'baz', 'foo', 'fiz'],
     routes: [
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
       { key: 'foo-test', name: 'foo' },
       { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
     ],
-    history: [{ type: 'route', key: 'qux-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 
+  // No surviving tabs -> all new, declaration order.
   expect(
     router.getStateForRouteNamesChange(
       {
@@ -558,7 +439,6 @@ test('gets state on route names change', () => {
           { key: 'bar-test', name: 'bar' },
           { key: 'baz-test', name: 'baz', params: { answer: 42 } },
         ],
-        history: [{ type: 'route', key: 'bar-test' }],
         stale: false,
         preloadedRouteKeys: [],
       },
@@ -577,15 +457,16 @@ test('gets state on route names change', () => {
       { key: 'foo-test', name: 'foo' },
       { key: 'fiz-test', name: 'fiz' },
     ],
-    history: [{ type: 'route', key: 'foo-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('preserves focused route on route names change', () => {
-  const router = TabRouter({});
+test('preserves the focused route and indexes by name on route names change with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
 
+  // Focused baz survives; surviving baz, qux keep old order (baz then qux), so
+  // focused baz lands at index 0.
   expect(
     router.getStateForRouteNamesChange(
       {
@@ -597,7 +478,6 @@ test('preserves focused route on route names change', () => {
           { key: 'baz-test', name: 'baz', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
         ],
-        history: [{ type: 'route', key: 'baz-test' }],
         stale: false,
         preloadedRouteKeys: [],
       },
@@ -612,23 +492,105 @@ test('preserves focused route on route names change', () => {
       }
     )
   ).toEqual({
-    index: 3,
+    index: 0,
     key: 'tab-test',
     routeNames: ['qux', 'foo', 'fiz', 'baz'],
     routes: [
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
       { key: 'foo-test', name: 'foo' },
       { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
     ],
-    history: [{ type: 'route', key: 'baz-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('falls back to first route if route is removed on route names change', () => {
-  const router = TabRouter({});
+test('appends key-changed tabs at the end on route names change', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+
+  // bar is listed in routeKeyChanges -> treated as new and appended at the end
+  // with a fresh key, even though its name still exists. Focused name is still bar
+  // -> resolves by name to bar's new position (2).
+  expect(
+    router.getStateForRouteNamesChange(
+      {
+        index: 0,
+        key: 'tab-test',
+        routeNames: ['bar', 'baz', 'qux'],
+        routes: [
+          { key: 'bar-old', name: 'bar' },
+          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+        ],
+        stale: false,
+        preloadedRouteKeys: [],
+      },
+      {
+        routeNames: ['bar', 'baz', 'qux'],
+        routeParamList: {},
+        routeGetIdList: {},
+        routeKeyChanges: ['bar'],
+      }
+    )
+  ).toEqual({
+    index: 2,
+    key: 'tab-test',
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+      { key: 'bar-test', name: 'bar', params: undefined },
+    ],
+    stale: false,
+    preloadedRouteKeys: [],
+  });
+});
+
+test('re-arranges the back stack around the anchor on route names change with firstRoute', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+
+  // Focused baz survives. Surviving order is [baz, qux]; rebuilt with appended
+  // foo, fiz -> [baz, qux, foo, fiz]. firstRoute anchor = first declared (qux),
+  // focused = baz -> [qux, baz, foo, fiz] index 1.
+  expect(
+    router.getStateForRouteNamesChange(
+      {
+        index: 1,
+        key: 'tab-test',
+        routeNames: ['bar', 'baz', 'qux'],
+        routes: [
+          { key: 'bar-test', name: 'bar' },
+          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+        ],
+        stale: false,
+        preloadedRouteKeys: [],
+      },
+      {
+        routeNames: ['qux', 'baz', 'foo', 'fiz'],
+        routeParamList: {},
+        routeGetIdList: {},
+        routeKeyChanges: [],
+      }
+    )
+  ).toEqual({
+    index: 1,
+    key: 'tab-test',
+    routeNames: ['qux', 'baz', 'foo', 'fiz'],
+    routes: [
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'foo-test', name: 'foo' },
+      { key: 'fiz-test', name: 'fiz' },
+    ],
+    stale: false,
+    preloadedRouteKeys: [],
+  });
+});
+
+test('falls back to the first rebuilt tab when the focused route is removed on route names change', () => {
+  const router = TabRouter({ backBehavior: 'history' });
 
   expect(
     router.getStateForRouteNamesChange(
@@ -641,7 +603,6 @@ test('falls back to first route if route is removed on route names change', () =
           { key: 'baz-test', name: 'baz', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
         ],
-        history: [{ type: 'route', key: 'baz-test' }],
         stale: false,
         preloadedRouteKeys: [],
       },
@@ -664,20 +625,22 @@ test('falls back to first route if route is removed on route names change', () =
       { key: 'foo-test', name: 'foo' },
       { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
     ],
-    history: [{ type: 'route', key: 'qux-test' }],
     stale: false,
     preloadedRouteKeys: [],
   });
 });
 
-test('handles navigate action', () => {
-  const router = TabRouter({});
+// --- navigate / JUMP_TO: order keeps declaration layout ----------------------
+
+test('navigates keeping declaration order and focusing the target with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
+    routeNames: ['baz', 'bar'],
     routeParamList: {},
     routeGetIdList: {},
   };
 
+  // Navigate baz (declaration position 0). routes stay [baz, bar]; index 0.
   expect(
     router.getStateForAction(
       {
@@ -690,7 +653,6 @@ test('handles navigate action', () => {
           { key: 'baz', name: 'baz', params: { color: 'tomato' } },
           { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
       },
       CommonActions.navigate('baz', { answer: 42 }),
       options
@@ -705,14 +667,13 @@ test('handles navigate action', () => {
       { key: 'baz', name: 'baz', params: { answer: 42 } },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
   });
 });
 
-test('merges params on navigate when specified', () => {
-  const router = TabRouter({});
+test('jumps to a tab keeping declaration order, no-op when already focused with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
+    routeNames: ['baz', 'bar'],
     routeParamList: {},
     routeGetIdList: {},
   };
@@ -726,12 +687,11 @@ test('merges params on navigate when specified', () => {
         index: 1,
         routeNames: ['baz', 'bar'],
         routes: [
-          { key: 'baz', name: 'baz', params: { color: 'tomato' } },
+          { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
       },
-      CommonActions.navigate('baz', { answer: 42 }, { merge: true }),
+      TabActions.jumpTo('baz'),
       options
     )
   ).toEqual({
@@ -741,11 +701,95 @@ test('merges params on navigate when specified', () => {
     index: 0,
     routeNames: ['baz', 'bar'],
     routes: [
-      { key: 'baz', name: 'baz', params: { color: 'tomato', answer: 42 } },
+      { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
   });
+
+  // jumpTo the already-focused tab with no change -> returns the same state.
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  };
+  expect(router.getStateForAction(state, TabActions.jumpTo('bar'), options)).toBe(state);
+});
+
+// --- navigate / JUMP_TO: firstRoute / initialRoute arrange [anchor, focused, ...] --
+
+test('navigates arranging [first, focused, ...rest] with firstRoute', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // Focus c -> [a, c, b] index 1.
+  const next = router.getStateForAction(
+    {
+      stale: false,
+      preloadedRouteKeys: [],
+      key: 'root',
+      index: 0,
+      routeNames: ['a', 'b', 'c'],
+      routes: [
+        { key: 'a-test', name: 'a' },
+        { key: 'b-test', name: 'b' },
+        { key: 'c-test', name: 'c' },
+      ],
+    },
+    CommonActions.navigate('c'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(names(next)).toEqual(['a', 'c', 'b']);
+  expect(next.index).toBe(1);
+
+  // Focus the first route a -> [a, b, c] index 0 (anchor === focused).
+  const backToAnchor = router.getStateForAction(
+    next,
+    CommonActions.navigate('a'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(backToAnchor)).toEqual(['a', 'b', 'c']);
+  expect(backToAnchor.index).toBe(0);
+});
+
+test('navigates arranging [initial, focused, ...rest] with initialRoute', () => {
+  const router = TabRouter({ backBehavior: 'initialRoute', initialRouteName: 'b' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // Focus c, anchor b -> [b, c, a] index 1.
+  const next = router.getStateForAction(
+    {
+      stale: false,
+      preloadedRouteKeys: [],
+      key: 'root',
+      index: 1,
+      routeNames: ['a', 'b', 'c'],
+      routes: [
+        { key: 'b-test', name: 'b' },
+        { key: 'a-test', name: 'a' },
+        { key: 'c-test', name: 'c' },
+      ],
+    },
+    CommonActions.navigate('c'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(names(next)).toEqual(['b', 'c', 'a']);
+  expect(next.index).toBe(1);
 });
 
 test("doesn't navigate to nonexistent screen", () => {
@@ -756,146 +800,7 @@ test("doesn't navigate to nonexistent screen", () => {
     routeGetIdList: {},
   };
 
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('non-existent'),
-      options
-    )
-  ).toBeNull();
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('foo', { answer: 42 }),
-      options
-    )
-  ).toBeNull();
-});
-
-test('ensures unique ID for navigate', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {
-      baz: ({ params }) => params?.foo,
-      bar: ({ params }) => params?.foo,
-    },
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('baz', { foo: 'a' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz', params: { foo: 'a' } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('bar', { foo: 'a' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar-test' },
-    ],
-  });
-});
-
-test('handles jump to action', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar'),
-      options
-    )
-  ).toEqual({
+  const state: TabNavigationState<ParamListBase> = {
     stale: false,
     preloadedRouteKeys: [],
     key: 'root',
@@ -905,11 +810,14 @@ test('handles jump to action', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
+  };
+
+  expect(
+    router.getStateForAction(state, CommonActions.navigate('non-existent'), options)
+  ).toBeNull();
+  expect(
+    router.getStateForAction(state, CommonActions.navigate('foo', { answer: 42 }), options)
+  ).toBeNull();
 });
 
 test("doesn't jump to nonexistent screen", () => {
@@ -932,7 +840,6 @@ test("doesn't jump to nonexistent screen", () => {
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
       },
       TabActions.jumpTo('foo', { answer: 42 }),
       options
@@ -940,8 +847,10 @@ test("doesn't jump to nonexistent screen", () => {
   ).toBeNull();
 });
 
-test('ensures unique ID for jump to', () => {
-  const router = TabRouter({});
+// --- navigate / JUMP_TO: per-route id / params / path (order keeps layout) ----
+
+test('ensures a fresh key for navigate when the route id changes with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
@@ -951,6 +860,8 @@ test('ensures unique ID for jump to', () => {
     },
   };
 
+  // Navigate bar; declaration order [baz, bar, ...] -> [baz, bar] with bar focused
+  // at index 1 and a fresh key.
   expect(
     router.getStateForAction(
       {
@@ -960,42 +871,11 @@ test('ensures unique ID for jump to', () => {
         index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
-          { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('baz', { foo: 'a' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz', params: { foo: 'a' } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
           { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
         ],
-        history: [{ type: 'route', key: 'bar' }],
       },
-      TabActions.jumpTo('bar', { foo: 'a' }),
+      CommonActions.navigate('bar', { foo: 'a' }),
       options
     )
   ).toEqual({
@@ -1008,755 +888,11 @@ test('ensures unique ID for jump to', () => {
       { key: 'baz', name: 'baz' },
       { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar-test' },
-    ],
   });
 });
 
-test('handles back action with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-});
-
-test('handles back action with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-});
-
-test('handles back action with backBehavior: order', () => {
+test('adds path on navigate if provided with order', () => {
   const router = TabRouter({ backBehavior: 'order' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: initialRoute', () => {
-  const router = TabRouter({ backBehavior: 'initialRoute' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: initialRoute and initialRouteName', () => {
-  const router = TabRouter({
-    backBehavior: 'initialRoute',
-    initialRouteName: 'baz',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'tab-test',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: none', () => {
-  const router = TabRouter({ backBehavior: 'none' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState(options);
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('updates route key history on navigate and jump to with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 1,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    history: [{ type: 'route', key: 'baz-0' }],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    stale: false as const,
-    preloadedRouteKeys: [],
-  };
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([{ type: 'route', key: 'qux-0' }]);
-});
-
-test('updates route key history on focus change with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-0' }],
-    stale: false,
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-});
-
-test('updates route key history on navigate and jump to with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 1,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    history: [{ type: 'route', key: 'baz-0' }],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    stale: false as const,
-    preloadedRouteKeys: [],
-  };
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('qux'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('bar'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    TabActions.jumpTo('baz'),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-});
-
-test('preserves params in history with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  let state = router.getInitialState({
-    routeNames: ['bar', 'baz', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { value: 'first' }),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[1]!.params).toEqual({ value: 'first' });
-  expect(state.history[1]!.params).toEqual({ value: 'first' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('qux', { value: 'second' }),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'second' });
-  expect(state.history[2]!.params).toEqual({ value: 'second' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.setParams({ value: 'updated with setParams' }),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'updated with setParams' });
-  expect(state.history[2]!.params).toEqual({ value: 'updated with setParams' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.replaceParams({ value: 'replaced params' }),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'replaced params' });
-  expect(state.history[2]!.params).toEqual({ value: 'replaced params' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { value: 'updated' }),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[1]!.params).toEqual({ value: 'updated' });
-  expect(state.history[3]!.params).toEqual({ value: 'updated' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.index).toBe(2);
-  expect(state.routes[2]!.params).toEqual({ value: 'replaced params' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.goBack(),
-    options
-  ) as TabNavigationState<ParamListBase>;
-
-  expect(state.index).toBe(1);
-  expect(state.routes[1]!.params).toEqual({ value: 'first' });
-});
-
-test('updates route key history on focus change with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    preloadedRouteKeys: [],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-0' }],
-    stale: false,
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-});
-
-test('adds path on navigate if provided', () => {
-  const router = TabRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
@@ -1769,19 +905,15 @@ test('adds path on navigate if provided', () => {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
       },
-      CommonActions.navigate({
-        name: 'bar',
-        path: '/foo/bar',
-      }),
+      CommonActions.navigate({ name: 'bar', path: '/foo/bar' }),
       options
     )
   ).toEqual({
@@ -1795,36 +927,24 @@ test('adds path on navigate if provided', () => {
       { key: 'bar', name: 'bar', path: '/foo/bar' },
       { key: 'qux', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
   });
 
+  // Navigate bar replacing its path -> path replaced, params set, in place.
   expect(
     router.getStateForAction(
       {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
-          {
-            key: 'bar',
-            name: 'bar',
-            path: '/foo/bar',
-          },
+          { key: 'bar', name: 'bar', path: '/foo/bar' },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
       },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        path: '/foo/baz',
-      }),
+      CommonActions.navigate({ name: 'bar', params: { fruit: 'orange' }, path: '/foo/baz' }),
       options
     )
   ).toEqual({
@@ -1835,23 +955,14 @@ test('adds path on navigate if provided', () => {
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
-      {
-        key: 'bar',
-        name: 'bar',
-        params: { fruit: 'orange' },
-        path: '/foo/baz',
-      },
+      { key: 'bar', name: 'bar', params: { fruit: 'orange' }, path: '/foo/baz' },
       { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
     ],
   });
 });
 
-test("doesn't remove existing path on navigate if not provided", () => {
-  const router = TabRouter({});
+test("doesn't remove existing path on navigate if not provided with order", () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
@@ -1864,14 +975,13 @@ test("doesn't remove existing path on navigate if not provided", () => {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', path: '/foo/bar' },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
       },
       CommonActions.navigate({ name: 'bar' }),
       options
@@ -1887,15 +997,11 @@ test("doesn't remove existing path on navigate if not provided", () => {
       { key: 'bar', name: 'bar', path: '/foo/bar' },
       { key: 'qux', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
   });
 });
 
-test("doesn't merge params on navigate to an existing screen", () => {
-  const router = TabRouter({});
+test("doesn't merge params on navigate to an existing screen with order", () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {
@@ -1904,20 +1010,20 @@ test("doesn't merge params on navigate to an existing screen", () => {
     routeGetIdList: {},
   };
 
+  // Navigate bar, no params -> existing params dropped, in place.
   expect(
     router.getStateForAction(
       {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', params: { answer: 42 } },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
       },
       CommonActions.navigate('bar'),
       options
@@ -1933,61 +1039,22 @@ test("doesn't merge params on navigate to an existing screen", () => {
       { key: 'bar', name: 'bar' },
       { key: 'qux', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
   });
 
+  // Navigate qux -> params come from routeParamList merged with the action params.
   expect(
     router.getStateForAction(
       {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 1,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('bar', { fruit: 'orange' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
       },
       CommonActions.navigate('qux', { test: 12 }),
       options
@@ -2003,186 +1070,15 @@ test("doesn't merge params on navigate to an existing screen", () => {
       { key: 'bar', name: 'bar' },
       { key: 'qux', name: 'qux', params: { color: 'indigo', test: 12 } },
     ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'qux' },
-    ],
   });
 });
 
-test('merges params on navigate to an existing screen if merge: true', () => {
-  const router = TabRouter({});
+test('merges params on navigate to an existing screen if merge: true with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
     routeParamList: {},
     routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        merge: true,
-      }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { answer: 42 } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        merge: true,
-      }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { answer: 42, fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test("doesn't merge params on jump to an existing screen", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar'),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar', { fruit: 'orange' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test('handles screen preloading', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeParamList: {},
-    routeGetIdList: {
-      bar: ({ params }) => `bar-${params?.answer}`,
-    },
   };
 
   expect(
@@ -2198,7 +1094,533 @@ test('handles screen preloading', () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
           { key: 'qux', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz' }],
+      },
+      CommonActions.navigate({ name: 'bar', params: { fruit: 'orange' }, merge: true }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 42, fruit: 'orange' } },
+      { key: 'qux', name: 'qux' },
+    ],
+  });
+});
+
+// --- navigate / JUMP_TO: history splices into the back-stack -----------------
+
+test('navigates splicing the target into the back-stack with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['A', 'B', 'C', 'D', 'E'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // Start: routes [A, B, C, D, E], focus A (index 0).
+  let state = router.getInitialState(options) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['A', 'B', 'C', 'D', 'E']);
+  expect(state.index).toBe(0);
+
+  // navigate B (from 1 > focused 0 -> insert at 1) -> order unchanged, index 1.
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('B'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['A', 'B', 'C', 'D', 'E']);
+  expect(state.index).toBe(1);
+
+  // navigate C (from 2 > focused 1 -> insert at 2) -> order unchanged, index 2.
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('C'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['A', 'B', 'C', 'D', 'E']);
+  expect(state.index).toBe(2);
+
+  // navigate A (from 0 <= focused 2 -> remove A, insert at 2) -> [B, C, A, D, E], index 2.
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('A'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['B', 'C', 'A', 'D', 'E']);
+  expect(state.index).toBe(2);
+
+  // navigate D (from 3 > focused 2 -> insert at 3) -> order unchanged, index 3.
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('D'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['B', 'C', 'A', 'D', 'E']);
+  expect(state.index).toBe(3);
+});
+
+// --- GO_BACK: history --------------------------------------------------------
+
+test('walks the visit order on back with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['A', 'B', 'C', 'D', 'E'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  let state = router.getInitialState(options) as TabNavigationState<ParamListBase>;
+  for (const name of ['B', 'C', 'A', 'D']) {
+    state = router.getStateForAction(
+      state,
+      CommonActions.navigate(name),
+      options
+    ) as TabNavigationState<ParamListBase>;
+  }
+  // After A->B->C->A->D: routes [B, C, A, D, E], focus D (index 3).
+  expect(names(state)).toEqual(['B', 'C', 'A', 'D', 'E']);
+  expect(state.routes[state.index]!.name).toBe('D');
+
+  // Visit order [B, C, A, D] (A re-visited, so it moved to the top).
+  // back walks D -> A -> C -> B, routes order never changes.
+  for (const expectedName of ['A', 'C', 'B']) {
+    state = router.getStateForAction(
+      state,
+      CommonActions.goBack(),
+      options
+    ) as TabNavigationState<ParamListBase>;
+    expect(names(state)).toEqual(['B', 'C', 'A', 'D', 'E']);
+    expect(state.routes[state.index]!.name).toBe(expectedName);
+  }
+
+  // At B (index 0) there's nowhere further back -> null.
+  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
+});
+
+test('walks back then navigates with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['A', 'B', 'C'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  let state = router.getInitialState(options) as TabNavigationState<ParamListBase>;
+  for (const name of ['B', 'C']) {
+    state = router.getStateForAction(
+      state,
+      CommonActions.navigate(name),
+      options
+    ) as TabNavigationState<ParamListBase>;
+  }
+  // routes [A, B, C], focus C (index 2).
+  expect(names(state)).toEqual(['A', 'B', 'C']);
+  expect(state.index).toBe(2);
+
+  // back -> B (index 1).
+  state = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(state.routes[state.index]!.name).toBe('B');
+  expect(state.index).toBe(1);
+
+  // navigate A (from 0 <= focused 1 -> remove A, insert at 1) -> [B, A, C], index 1.
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('A'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['B', 'A', 'C']);
+  expect(state.index).toBe(1);
+
+  // back -> B (index 0).
+  state = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(state.routes[state.index]!.name).toBe('B');
+  expect(state.index).toBe(0);
+});
+
+test('returns null on back when at index 0 with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const state = router.getInitialState(options) as TabNavigationState<ParamListBase>;
+  expect(state.index).toBe(0);
+  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
+});
+
+// --- GO_BACK: position-based behaviors (uniformly index - 1, no reorder) ------
+
+test('walks to the declaration-previous tab on back with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // order layout is declaration order; focus c (index 2). back -> b (index 1).
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 2,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+    ],
+  };
+
+  const next = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(next)).toEqual(['a', 'b', 'c']);
+  expect(next.routes[next.index]!.name).toBe('b');
+  expect(next.index).toBe(1);
+
+  // From the first declared tab (index 0) there's nowhere to go -> null.
+  expect(
+    router.getStateForAction({ ...state, index: 0 }, CommonActions.goBack(), options)
+  ).toBeNull();
+});
+
+test('goes to the first route on back with firstRoute, null when already first', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // firstRoute layout [a, focused, ...]; focus b at index 1. back -> a (index 0).
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 1,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+    ],
+  };
+
+  const next = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(next.routes[next.index]!.name).toBe('a');
+  expect(next.index).toBe(0);
+
+  // Already focused on the first route (index 0) -> null.
+  expect(
+    router.getStateForAction({ ...state, index: 0 }, CommonActions.goBack(), options)
+  ).toBeNull();
+});
+
+test('goes to the initial route on back with initialRoute, null when already initial', () => {
+  const router = TabRouter({ backBehavior: 'initialRoute', initialRouteName: 'b' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // initialRoute layout [b, focused, ...]; focus c at index 1. back -> b (index 0).
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 1,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+      { key: 'a-test', name: 'a' },
+    ],
+  };
+
+  const next = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(next.routes[next.index]!.name).toBe('b');
+  expect(next.index).toBe(0);
+
+  // Already focused on the initial route (index 0) -> null.
+  expect(
+    router.getStateForAction({ ...state, index: 0 }, CommonActions.goBack(), options)
+  ).toBeNull();
+});
+
+test('returns null on back with none', () => {
+  const router = TabRouter({ backBehavior: 'none' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 2,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+    ],
+  };
+
+  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
+});
+
+test('GO_BACK drops the target key from preloadedRouteKeys without reordering', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // firstRoute layout [a, c, b]; focus c at index 1. back -> a (index 0).
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: ['a-test', 'b-test'],
+    key: 'tab-test',
+    index: 1,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'c-test', name: 'c' },
+      { key: 'b-test', name: 'b' },
+    ],
+  };
+
+  const next = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(next.index).toBe(0);
+  expect(names(next)).toEqual(['a', 'c', 'b']);
+  // a's key (the new focused route) is removed from preloadedRouteKeys.
+  expect(next.preloadedRouteKeys).toEqual(['b-test']);
+});
+
+// --- REPLACE: prunes the replaced route from the back stack ------------------
+
+test('drops the replaced route so back is blocked with firstRoute', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+  const options: RouterConfigOptions = {
+    routeNames: ['one', 'two'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // Focus one (the first route) at index 0. replace two: JUMP_TO two -> firstRoute
+  // [one, two] index 1, then prune route at index 0 (one) just past focused ->
+  // [two, one] index 0. GO_BACK -> null.
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 0,
+    routeNames: ['one', 'two'],
+    routes: [
+      { key: 'one', name: 'one' },
+      { key: 'two', name: 'two' },
+    ],
+  };
+
+  const replaced = router.getStateForAction(
+    state,
+    // REPLACE isn't part of the tab action union; the wrapper handles it at runtime.
+    StackActions.replace('two') as unknown as Parameters<typeof router.getStateForAction>[1],
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(replaced)).toEqual(['two', 'one']);
+  expect(replaced.index).toBe(0);
+
+  expect(router.getStateForAction(replaced, CommonActions.goBack(), options)).toBeNull();
+});
+
+test('drops the replaced route so back skips it with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['one', 'two', 'three'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  // Start [one, two, three] focus one. navigate two -> index 1 (back stack one->two).
+  let state = router.getInitialState(options) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    CommonActions.navigate('two'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['one', 'two', 'three']);
+  expect(state.index).toBe(1);
+
+  // replace three: JUMP_TO three (from 2 > focused 1 -> insert at 2) -> [one, two,
+  // three] index 2; then prune the route at index 1 (two) past focused ->
+  // [one, three, two] index 1. GO_BACK -> one.
+  state = router.getStateForAction(
+    state,
+    StackActions.replace('three') as unknown as Parameters<typeof router.getStateForAction>[1],
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(names(state)).toEqual(['one', 'three', 'two']);
+  expect(state.index).toBe(1);
+
+  const back = router.getStateForAction(
+    state,
+    CommonActions.goBack(),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  expect(back.routes[back.index]!.name).toBe('one');
+  expect(back.index).toBe(0);
+});
+
+// --- getStateForRouteFocus ---------------------------------------------------
+
+test('focuses a route arranging [anchor, focused, ...] with firstRoute', () => {
+  const router = TabRouter({ backBehavior: 'firstRoute' });
+
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 0,
+    routeNames: ['a', 'b', 'c'],
+    routes: [
+      { key: 'a-test', name: 'a' },
+      { key: 'b-test', name: 'b' },
+      { key: 'c-test', name: 'c' },
+    ],
+  };
+
+  // Focus c -> [a, c, b] index 1.
+  const next = router.getStateForRouteFocus(state, 'c-test');
+  expect(names(next)).toEqual(['a', 'c', 'b']);
+  expect(next.index).toBe(1);
+
+  // Unknown key -> same state.
+  expect(router.getStateForRouteFocus(state, 'missing')).toBe(state);
+  // Already focused -> same state.
+  expect(router.getStateForRouteFocus(state, 'a-test')).toBe(state);
+});
+
+test('focuses a route splicing into the back-stack with history', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+
+  // routes [A, B, C, D, E], focus C (index 2). Focus A (from 0 <= 2) -> remove A,
+  // insert at 2 -> [B, C, A, D, E], index 2.
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'tab-test',
+    index: 2,
+    routeNames: ['A', 'B', 'C', 'D', 'E'],
+    routes: [
+      { key: 'A-test', name: 'A' },
+      { key: 'B-test', name: 'B' },
+      { key: 'C-test', name: 'C' },
+      { key: 'D-test', name: 'D' },
+      { key: 'E-test', name: 'E' },
+    ],
+  };
+
+  const next = router.getStateForRouteFocus(state, 'A-test');
+  expect(names(next)).toEqual(['B', 'C', 'A', 'D', 'E']);
+  expect(next.index).toBe(2);
+
+  // Already focused -> same state.
+  expect(router.getStateForRouteFocus(state, 'C-test')).toBe(state);
+});
+
+// --- SET_PARAMS --------------------------------------------------------------
+
+test('setParams updates the focused route without reordering', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['a', 'b', 'c'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const next = router.getStateForAction(
+    {
+      stale: false,
+      preloadedRouteKeys: [],
+      key: 'tab-test',
+      index: 1,
+      routeNames: ['a', 'b', 'c'],
+      routes: [
+        { key: 'a-test', name: 'a' },
+        { key: 'b-test', name: 'b' },
+        { key: 'c-test', name: 'c' },
+      ],
+    },
+    CommonActions.setParams({ answer: 42 }),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(names(next)).toEqual(['a', 'b', 'c']);
+  expect(next.index).toBe(1);
+  expect(next.routes[1]).toEqual({ key: 'b-test', name: 'b', params: { answer: 42 } });
+});
+
+// --- PRELOAD -----------------------------------------------------------------
+
+test('handles screen preloading in place without reordering', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
+
+  // Preload qux -> added to preloadedRouteKeys, routes unchanged, index unchanged.
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        preloadedRouteKeys: [],
+        key: 'root',
+        index: 0,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', params: { answer: 42 } },
+          { key: 'qux', name: 'qux' },
+        ],
       },
       CommonActions.preload('qux'),
       options
@@ -2214,9 +1636,9 @@ test('handles screen preloading', () => {
       { key: 'bar', name: 'bar', params: { answer: 42 } },
       { key: 'qux', name: 'qux' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
   });
 
+  // Preload bar with a new id -> fresh key, params updated in place.
   expect(
     router.getStateForAction(
       {
@@ -2230,7 +1652,6 @@ test('handles screen preloading', () => {
           { key: 'bar-test', name: 'bar', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz-test' }],
       },
       CommonActions.preload('bar', { answer: 43 }),
       options
@@ -2246,9 +1667,9 @@ test('handles screen preloading', () => {
       { key: 'bar-test', name: 'bar', params: { answer: 43 } },
       { key: 'qux-test', name: 'qux' },
     ],
-    history: [{ type: 'route', key: 'baz-test' }],
   });
 
+  // Preload bar replacing an existing preloaded entry (key changes -> old key dropped).
   expect(
     router.getStateForAction(
       {
@@ -2259,14 +1680,9 @@ test('handles screen preloading', () => {
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test-old',
-            name: 'bar',
-            params: { answer: 42, willBe: 'removed' },
-          },
+          { key: 'bar-test-old', name: 'bar', params: { answer: 42, willBe: 'removed' } },
           { key: 'qux-test', name: 'qux' },
         ],
-        history: [{ type: 'route', key: 'baz-test' }],
       },
       CommonActions.preload('bar', { answer: 43 }),
       options
@@ -2282,135 +1698,9 @@ test('handles screen preloading', () => {
       { key: 'bar-test', name: 'bar', params: { answer: 43 } },
       { key: 'qux-test', name: 'qux' },
     ],
-    history: [{ type: 'route', key: 'baz-test' }],
   });
 
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: [],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'overrode' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.preload('bar', { answer: 42 }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: ['bar-test'],
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42 },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: ['qux-test'],
-        key: 'root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'merged' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.navigate('qux'),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42, willBe: 'merged' },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        preloadedRouteKeys: ['baz-test'],
-        key: 'root',
-        index: 2,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'merged' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'baz-test' },
-          { type: 'route', key: 'qux-test' },
-        ],
-      },
-      CommonActions.goBack(),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: [],
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42, willBe: 'merged' },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
+  // Preload with the same id keeps the existing key.
   expect(
     router.getStateForAction(
       {
@@ -2421,16 +1711,8 @@ test('handles screen preloading', () => {
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-some',
-            name: 'bar',
-            params: { answer: 42 },
-          },
+          { key: 'bar-some', name: 'bar', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-some' },
-          { type: 'route', key: 'qux-test' },
         ],
       },
       CommonActions.preload('bar', { answer: 42 }),
@@ -2444,18 +1726,58 @@ test('handles screen preloading', () => {
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-some',
-        name: 'bar',
-        params: { answer: 42 },
-      },
+      { key: 'bar-some', name: 'bar', params: { answer: 42 } },
       { key: 'qux-test', name: 'qux' },
     ],
-    history: [
-      { type: 'route', key: 'bar-some' },
-      { type: 'route', key: 'qux-test' },
+  });
+});
+
+test('navigates to a preloaded route, focusing it and dropping it from preloadedRouteKeys with order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        preloadedRouteKeys: ['qux-test'],
+        key: 'root',
+        index: 0,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz-test', name: 'baz' },
+          { key: 'bar-test', name: 'bar', params: { answer: 42 } },
+          { key: 'qux-test', name: 'qux' },
+        ],
+      },
+      CommonActions.navigate('qux'),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 2,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz-test', name: 'baz' },
+      { key: 'bar-test', name: 'bar', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux' },
     ],
   });
+});
+
+test("doesn't preload a nonexistent screen", () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
 
   expect(
     router.getStateForAction(
@@ -2463,40 +1785,16 @@ test('handles screen preloading', () => {
         stale: false,
         preloadedRouteKeys: [],
         key: 'root',
-        index: 2,
+        index: 0,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-some',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-some' },
-          { type: 'route', key: 'qux-test' },
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
         ],
       },
-      CommonActions.preload('bar', { answer: 43 }),
+      CommonActions.preload('non-existent'),
       options
     )
-  ).toEqual({
-    stale: false,
-    preloadedRouteKeys: ['bar-test'],
-    key: 'root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 43 },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'qux-test' }],
-  });
+  ).toBeNull();
 });

--- a/packages/expo-router/src/ui/TabContext.tsx
+++ b/packages/expo-router/src/ui/TabContext.tsx
@@ -102,7 +102,6 @@ export const TabsNavigatorContext = createContext<TabsContextValue['navigation']
  */
 export const TabsStateContext = createContext<TabsContextValue['state']>({
   preloadedRouteKeys: [],
-  history: [],
   index: -1,
   key: '',
   stale: false,

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -10,6 +10,7 @@ import {
   type NavigationAction,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
+import { pruneReplacedRoute } from '../react-navigation/routers/TabRouter';
 
 export type ExpoTabRouterOptions = RNTabRouterOptions & {
   triggerMap: TriggerMap;
@@ -41,7 +42,9 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   > = {
     ...rnTabRouter,
     getStateForAction(state, action, options) {
-      if (isReplaceAction(action)) {
+      const isReplace = isReplaceAction(action);
+
+      if (isReplace) {
         action = {
           ...action,
           type: 'JUMP_TO',
@@ -49,45 +52,37 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
         // Generate the state as if we were using JUMP_TO
         const nextState = rnTabRouter.getStateForAction(state, action, options);
 
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
+        if (!nextState || nextState.index === undefined) {
           return null;
         }
 
-        // We can assert that nextState is TabNavigationState here, because we checked for index and history above
+        // TODO(@ubax): Remove the casting once there is only a single state shape
+        // We can assert that nextState is TabNavigationState here, because we checked for index above
         state = nextState as TabNavigationState<ParamListBase>;
-
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (state.index !== 0) {
-          const previousIndex = state.index - 1;
-
-          state = {
-            ...state,
-            key: `${state.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...state.history.slice(0, previousIndex),
-              ...state.history.splice(state.index),
-            ],
-          };
-        }
       } else if (action.type !== 'JUMP_TO') {
         return rnTabRouter.getStateForAction(state, action, options);
       }
 
+      if (!state || !state.routeNames.includes(action.payload.name)) {
+        // This shouldn't occur, but lets just hand it off to the next navigator in case.
+        return null;
+      }
+
       const route = state.routes.find((route) => route.name === action.payload.name);
 
-      if (!route || !state) {
+      if (!route) {
         // This shouldn't occur, but lets just hand it off to the next navigator in case.
         return null;
       }
 
       // We should reset if this is the first time visiting the route
-      let shouldReset = !state.history?.some((item) => item.key === route?.key) && !route.state;
+      let shouldReset = !route.state;
 
       if (!shouldReset && 'resetOnFocus' in action.payload && action.payload.resetOnFocus) {
         shouldReset = state.routes[state.index ?? 0]!.key !== route.key;
       }
+
+      let nextState: ReturnType<typeof rnTabRouter.getStateForAction>;
 
       if (shouldReset) {
         options.routeParamList[route.name] = {
@@ -102,10 +97,17 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
             return { ...r, state: undefined };
           }),
         };
-        return rnTabRouter.getStateForAction(state, action, options);
+        nextState = rnTabRouter.getStateForAction(state, action, options);
       } else {
-        return rnTabRouter.getStateForRouteFocus(state, route.key);
+        nextState = rnTabRouter.getStateForRouteFocus(state, route.key);
       }
+
+      // A REPLACE drops the route it replaced from the back stack.
+      if (isReplace && nextState) {
+        return pruneReplacedRoute(nextState as TabNavigationState<ParamListBase>);
+      }
+
+      return nextState;
     },
   };
 

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -152,13 +152,18 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         return;
       }
 
+      const routeName = state.routeNames[config.index];
+      const route = state.routes.find((r) => r.name === routeName);
+      const focusedKey = state.routes[state.index]?.key;
+
       return {
-        isFocused: state.index === config.index,
-        route: state.routes[config.index]!,
+        isFocused: route?.key !== undefined && route.key === focusedKey,
+        route: route!,
         resolvedHref: stripGroupSegmentsFromPath(appendBaseUrl(config.href)),
         ...config,
       };
     },
+    // TODO(@ubax): Investigate why state.index and state.routes are not in the array
     [triggerMap]
   );
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
