### PR TITLE
[ios][audio] Fix app hang from main-thread AVAudioSession deactivation

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Move the blocking `AVAudioSession.setActive(false)` deactivation off the main thread and skip stale deactivations to fix app hangs during frequent back-to-back playback. ([#47079](https://github.com/expo/expo/pull/47079) by [@sbs44](https://github.com/sbs44))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -15,6 +15,12 @@ public class AudioModule: Module {
   private var sessionOptions: AVAudioSession.CategoryOptions = []
   private var lastConfiguredMode: AudioMode?
 
+  // Serializes the blocking AVAudioSession.setActive(...) calls off the main thread and
+  // guards a monotonic activation token used to drop stale deactivations.
+  private let sessionQueue = DispatchQueue(label: "expo.modules.audio.session")
+  private let sessionTokenLock = NSLock()
+  private var sessionActivationToken = 0
+
   public func definition() -> ModuleDefinition {
     Name("ExpoAudio")
 
@@ -613,7 +619,7 @@ public class AudioModule: Module {
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
     do {
-      try AVAudioSession.sharedInstance().setActive(true)
+      try activateSession()
       if options.contains(.shouldResume) {
         resumeInterruptedPlayers()
       }
@@ -658,7 +664,7 @@ public class AudioModule: Module {
       if let mode = lastConfiguredMode {
         try setAudioMode(mode: mode)
       }
-      try AVAudioSession.sharedInstance().setActive(true)
+      try activateSession()
     } catch {
       print("Failed to reconfigure audio session after media services reset: \(error)")
     }
@@ -743,6 +749,11 @@ public class AudioModule: Module {
     }
 
     do {
+      // Bump the activation token on activation so a pending deactivateSession() doesn't
+      // tear down the session we're explicitly activating here (see activateSession()).
+      if isActive {
+        bumpActivationToken()
+      }
       try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
       sessionIsActive = isActive
     } catch {
@@ -821,17 +832,36 @@ public class AudioModule: Module {
   }
 
   private func activateSession() throws {
+    // Supersede any deactivation scheduled before this activation so back-to-back
+    // playback isn't torn down by a stale setActive(false).
+    bumpActivationToken()
     try AVAudioSession.sharedInstance().setActive(true)
   }
 
   private func deactivateSession() {
-    // We need to give isPlaying time to update before running this
+    // Capture the activation token now: if the session is reactivated before the blocking
+    // call runs, the token changes and we skip the stale deactivation.
+    let requestedToken = currentActivationToken()
+    // We need to give isPlaying time to update before running this.
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
       guard let self else {
         return
       }
       let hasActivePlayables = self.registry.allPlayables.contains { $0.isPlaying }
-      if !hasActivePlayables {
+      guard !hasActivePlayables else {
+        return
+      }
+      // AVAudioSession.setActive(false) makes a synchronous, blocking XPC round-trip to the
+      // audio daemon that can stall for seconds under system contention. Running it on the
+      // main thread freezes the UI and surfaces as an iOS app hang, so dispatch it off-main.
+      self.sessionQueue.async {
+        // Best-effort supersede: the token read and setActive(false) aren't atomic relative to
+        // a concurrent activation, so a narrow TOCTOU window remains (far smaller than the
+        // untokened main-thread race before). iOS's own `isBusy` error covers the audible case
+        // where the next player is already producing audio.
+        guard self.currentActivationToken() == requestedToken else {
+          return
+        }
         do {
           try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
         } catch {
@@ -839,6 +869,18 @@ public class AudioModule: Module {
         }
       }
     }
+  }
+
+  private func bumpActivationToken() {
+    sessionTokenLock.lock()
+    defer { sessionTokenLock.unlock() }
+    sessionActivationToken += 1
+  }
+
+  private func currentActivationToken() -> Int {
+    sessionTokenLock.lock()
+    defer { sessionTokenLock.unlock() }
+    return sessionActivationToken
   }
 
   private func checkPermissions() throws {


### PR DESCRIPTION
# Why

On iOS, `AudioModule.deactivateSession()` ran the synchronous, blocking `AVAudioSession.setActive(false, …)` on the **main thread**. That call makes an XPC round-trip to the audio daemon that can stall for several seconds under system contention, freezing the UI and surfacing as an iOS app hang ("App Hang Fully Blocked").

It fires from `AudioPlayer`'s `onPlaybackComplete` and from `pause`, so apps that play short clips back-to-back (turn-by-turn navigation TTS, UI/game sound effects, message read-aloud) hit it constantly with the default `keepAudioSessionActive: false`.

Fixes #47045 — the symbolicated main-thread stack and a minimal reproduction are in the issue. Representative stack:

```
mach_msg → xpc_connection_send_message_with_reply_sync
  → __NSXPCCONNECTION_IS_WAITING_FOR_A_SYNCHRONOUS_REPLY__
    → -[AVAudioSession privateSetActive:withOptions:error:core:]
      → closure in AudioModule.deactivateSession (AudioModule.swift)
        → __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
```

# How

- **Off-main:** `setActive(false)` now runs on a dedicated serial `sessionQueue`. The `isPlaying`/registry read stays on the existing 100 ms main-thread debounce... safe, since `AudioComponentRegistry` is already internally synchronized.
- **Supersede stale deactivations:** once deactivation is async, a deactivation queued when clip A ends can race clip B's `setActive(true)` and tear B down. An `NSLock`-guarded monotonic token is bumped at every activation site... `activateSession()` (and `handleInterruptionEnded`/`reconfigureAudioSession`, now routed through it) plus `setIsAudioActive(true)`... captured at request time and re-checked before the blocking call... a reactivation skips the stale deactivation.

The re-check and `setActive(false)` aren't atomic, leaving a narrow TOCTOU window (far smaller than the prior untokened main-thread race) that iOS's `isBusy` covers; noted in-code. No public API change; iOS only.

# Test Plan

Repro, steps, and environment are in #47045: a blank app playing a short clip back-to-back with the default player intermittently hangs the main thread in `AudioModule.deactivateSession` → `setActive(false)` (Xcode Organizer → Hangs / MetricKit). Originated from production hang reports.

Ran locally, scoped to `expo-audio` (no monorepo build):

```
expo-build src                     # build:lib   → 18 files, ok
expo-build --base plugin cjs:src   # build:plugin →  2 files, ok
expo-module lint                   # clean
expo-module test                   # no JS suite in this package
```

JS gates only confirm no JS-layer regression (and that committed `build/` is unchanged)... the change is native Swift. Behavioral verification is on-device: build the repro, play clips back-to-back, confirm the `deactivateSession` hang is gone, consecutive clips still play, and other apps still un-duck between clips (`.notifyOthersOnDeactivation` preserved).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
