### PR TITLE
[ios][core] Tie AppContext lifetime to the expo.modules host object

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [Android] Fixed Expo UI re-compose when switching screens in react-native-screens. ([#46650](https://github.com/expo/expo/pull/46650) by [@kudo](https://github.com/kudo))
 - [iOS] Fix Expo DevTools Network response bodies for JSON content types with parameters. ([#46336](https://github.com/expo/expo/pull/46336) by [@SJvaca30](https://github.com/SJvaca30))
 - [iOS] Resolve the key window across connected scenes in `currentViewController()` so it keeps working with multiple scenes, and expose `Utilities.keyWindow()` for modules to reuse. ([#46956](https://github.com/expo/expo/pull/46956) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix a crash on `Updates.reloadAsync()` where the previous `AppContext` could deallocate before the old runtime finished teardown, releasing cached JSI objects against a dying runtime. Tie its lifetime to the `expo.modules` host object so it is torn down during the runtime's own finalization. ([#47051](https://github.com/expo/expo/issues/47051) by [@HaiyiMei](https://github.com/HaiyiMei)) ([#47080](https://github.com/expo/expo/pull/47080) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
+++ b/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
@@ -46,8 +46,12 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
       getPropertyNames: { [weak appContext] in
         return appContext?.getModuleNames() ?? []
       },
-      dealloc: { [weak appContext] in
-        appContext?.destroy()
+      dealloc: { [appContext] in
+        // Captured strongly so the host object owns the app context's lifetime: it's released
+        // during the runtime's own finalization, where `destroy()` clears the cached JSI objects
+        // while the runtime is still valid, rather than from a `reloadAsync()` race that could free
+        // them against a dying runtime on the wrong thread.
+        appContext.destroy()
       }
     )
 


### PR DESCRIPTION
## Why

Fixes #47051: a crash on `Updates.reloadAsync()` (iOS), reported with this stack:

```
Thread 15 Crashed (com.facebook.react.runtime.JavaScript):
2  ExpoModulesCore   ModuleHolder.deinit
17 ExpoModulesCore   @objc AppContext.__ivar_destroyer
21 ExpoModulesCore   AppContext.__deallocating_deinit
23 app binary        -[EXReactNativeFactory host:didInitializeRuntime:]
```

On reload the old runtime tears down on the old JS thread while the new one initializes on another, unordered. `ExpoReactNativeFactory.host:didInitializeRuntime:` reassigns its `_appContext` ivar from the new thread, and that ivar is currently the *only* strong owner of the previous `AppContext`, so the reassignment drops it synchronously there. Its deinit cascade then releases each module's cached `JavaScriptObject` against the old runtime while that runtime is being destroyed, causing the `EXC_BAD_ACCESS`.

The cleanup path from #45082 (the `expo.modules` host object's finalizer calling `destroy()` while the runtime is still valid) is meant to prevent this, but the race frees the context before those finalizers run.

## How

The host object's `dealloc` closure now captures the `AppContext` strongly instead of weakly. The host object lives in the runtime's heap, so this makes it own the context's lifetime: the context is released only when the runtime is finalized, where the #45082 path runs `destroy()` to clear the cached JSI objects safely before the deinit cascade. `destroy()` is idempotent and the `get`/`getPropertyNames` closures stay weak.

This supersedes the fixed-delay approach in #46853 by tying lifetime to the teardown event itself.

## Test Plan

Needs verification with the reporter's repro: repeated `Updates.reloadAsync()` on a build that crashes today. The crash is a release-build timing race with no deterministic local repro, so a canary build with the reporter (#47051) is the strongest confirmation.
