### PR TITLE
[ios][updates] Isolate UpdatesLogReaderTests from concurrent suites

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Reduce accidental logout in the account selector with a confirmation step and a less prominent button, and add more spacing around the header title. ([#46761](https://github.com/expo/expo/pull/46761) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Make the development server list reliable, keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found". ([#46811](https://github.com/expo/expo/pull/46811) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -112,6 +112,17 @@ struct DevServersView: View {
         #endif
           .disableAutocorrection(true)
           .toolbar {
+            #if os(tvOS)
+            ToolbarItemGroup(placement: .automatic) {
+              ForEach(keyboardShortcuts, id: \.self) { shortcut in
+                Button {
+                  urlText += shortcut
+                } label: {
+                  Text(shortcut)
+                }
+              }
+            }
+            #else
             ToolbarItemGroup(placement: .keyboard) {
               ForEach(keyboardShortcuts, id: \.self) { shortcut in
                 Button {
@@ -121,6 +132,7 @@ struct DevServersView: View {
                 }
               }
             }
+            #endif
           }
           .padding(.horizontal, 16)
           .padding(.vertical, 12)

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
-- [iOS] Isolate UpdatesLogReaderTests from concurrent suites by [@douglowder](https://github.com/douglowder))
+- [iOS] Isolate UpdatesLogReaderTests from concurrent suites by [@douglowder](https://github.com/douglowder)) ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
-- [iOS] Isolate UpdatesLogReaderTests from concurrent suites by [@douglowder](https://github.com/douglowder)) ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
+- [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
+- [iOS] Isolate UpdatesLogReaderTests from concurrent suites by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -403,7 +403,7 @@ async function preparePackageJson(
       dependencies: {
         ...packageJson.dependencies,
         glob: '^11.0.0',
-        'react-native-tvos': '0.86.0-0rc3',
+        'react-native-tvos': '0.86.0-1',
         '@react-native-tvos/config-tv': '^0.1.6',
       },
     };

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogReader.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogReader.swift
@@ -1,18 +1,24 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+import ExpoModulesCore
 import Foundation
 import OSLog
 
-import ExpoModulesCore
-
-/**
- Class to read expo-updates logs using OSLogReader
- */
+/// Class to read expo-updates logs using OSLogReader
 public final class UpdatesLogReader {
   private let serialQueue = DispatchQueue(label: "dev.expo.updates.logging.reader")
-  private let logPersistence = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
+  private let logPersistence: PersistentFileLog
 
-  public init() {}
+  public init() {
+    self.logPersistence = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
+  }
+
+  /// Internal initializer that lets tests redirect the log file by passing a unique category.
+  /// Pairs with `UpdatesLogger(category:)` so a test instance reads back exactly what its sibling
+  /// logger wrote — without seeing writes from other test suites or production callers.
+  internal init(category: String) {
+    self.logPersistence = PersistentFileLog(category: category)
+  }
 
   /**
    Get expo-updates logs newer than the given date
@@ -55,11 +61,13 @@ public final class UpdatesLogReader {
    */
   public func purgeLogEntries(olderThan: Date, completion: @escaping (Error?) -> Void) {
     let epoch = epochFromDateOrOneDayAgo(date: olderThan)
-    logPersistence.purgeEntriesNotMatchingFilter(filter: { entryString in
-      self.logStringToFilteredLogEntry(entryString: entryString, epoch: epoch) != nil
-    }, {error in
-      completion(error)
-    })
+    logPersistence.purgeEntriesNotMatchingFilter(
+      filter: { entryString in
+        self.logStringToFilteredLogEntry(entryString: entryString, epoch: epoch) != nil
+      },
+      { error in
+        completion(error)
+      })
   }
 
   private func logStringToFilteredLogEntry(entryString: String, epoch: UInt) -> UpdatesLogEntry? {
@@ -72,16 +80,14 @@ public final class UpdatesLogReader {
     return entry?.timestamp ?? 0 >= epoch ? entry : nil
   }
 
-  private static let MAXIMUM_LOOKBACK_INTERVAL: TimeInterval = 86_400 // 1 day
+  private static let MAXIMUM_LOOKBACK_INTERVAL: TimeInterval = 86_400  // 1 day
 
   private func epochFromDateOrOneDayAgo(date: Date) -> UInt {
     // Returns the epoch (milliseconds since 1/1/1970)
     // If date is earlier than one day ago, then the epoch for one day ago is returned
     // instead
     let earliestDate = Date().addingTimeInterval(-UpdatesLogReader.MAXIMUM_LOOKBACK_INTERVAL)
-    let dateToUse = date.timeIntervalSince1970 < earliestDate.timeIntervalSince1970 ?
-      earliestDate :
-      date
+    let dateToUse = date.timeIntervalSince1970 < earliestDate.timeIntervalSince1970 ? earliestDate : date
     return UInt(dateToUse.timeIntervalSince1970) * 1000
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
@@ -2,25 +2,44 @@
 
 // swiftlint:disable function_parameter_count
 
+import ExpoModulesCore
 import Foundation
 import os.log
 
-import ExpoModulesCore
-
-/**
- Class that implements logging for expo-updates in its own os.log category
- */
+/// Class that implements logging for expo-updates in its own os.log category
 @objc(EXUpdatesLogger)
 @objcMembers
 public final class UpdatesLogger: NSObject {
   static let EXPO_UPDATES_LOG_CATEGORY = "expo-updates"
 
-  public override init() {}
+  /// The os.log category and `PersistentFileLog` file suffix this logger writes to. Exposed so
+  /// callers reading back logs (and tests) can construct a matching `UpdatesLogReader` /
+  /// `PersistentFileLog` instance against the same file.
+  internal let category: String
 
-  private let logger = Logger(logHandlers: [
-    createOSLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),
-    createPersistentFileLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
-  ])
+  private let logger: ExpoModulesCore.Logger
+
+  public override init() {
+    self.category = UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY
+    self.logger = Logger(logHandlers: [
+      createOSLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),
+      createPersistentFileLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),
+    ])
+    super.init()
+  }
+
+  /// Internal initializer that lets tests redirect the log file by passing a unique category.
+  /// Two `PersistentFileLog` instances with the same category share an on-disk file at
+  /// `<AppSupport>/dev.expo.modules.core.logging.<category>.txt`; using a per-test category
+  /// keeps test runs from colliding with each other or with production callers.
+  internal init(category: String) {
+    self.category = category
+    self.logger = Logger(logHandlers: [
+      createOSLogHandler(category: category),
+      createPersistentFileLogHandler(category: category),
+    ])
+    super.init()
+  }
 
   // MARK: - Public logging functions
 
@@ -30,7 +49,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .trace, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: message, code: code, level: .trace,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.trace(entry)
   }
 
@@ -51,7 +73,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .debug, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: message, code: code, level: .debug,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.debug(entry)
   }
 
@@ -72,7 +97,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .info, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: message, code: code, level: .info,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.info(entry)
   }
 
@@ -93,7 +121,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .warn, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: message, code: code, level: .warn,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.warn(entry)
   }
 
@@ -114,7 +145,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: cause.localizedDescription, code: code, level: .error, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: cause.localizedDescription, code: code, level: .error,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.error(entry)
   }
 
@@ -131,7 +165,10 @@ public final class UpdatesLogger: NSObject {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: cause.localizedDescription, code: code, level: .fatal, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(
+      message: cause.localizedDescription, code: code, level: .fatal,
+      duration: nil, updateId: updateId, assetId: assetId
+    )
     logger.fatal(entry)
   }
 

--- a/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
@@ -1,22 +1,35 @@
 //  Copyright (c) 2022 650 Industries, Inc. All rights reserved.
 
-import Testing
 import ExpoModulesCore
+import Testing
+
 @testable import EXUpdates
 
 @Suite("UpdatesLogReader", .serialized)
 struct UpdatesLogReaderTests {
+  /// Unique log category per test invocation. Swift Testing instantiates the suite struct fresh
+  /// for each `@Test`, so this UUID is regenerated every test — guaranteeing the underlying
+  /// `<AppSupport>/dev.expo.modules.core.logging.<category>.txt` file is unique. Without this,
+  /// other test suites that construct `UpdatesLogger()` (e.g. `ErrorRecoveryTests`,
+  /// `UpdatesBuildDataTests`, `DatabaseIntegrityCheckSpec`) write to the production
+  /// `"expo-updates"` file and intermittently break this suite's entry counts in CI.
+  private let category: String
+  private let logger: UpdatesLogger
+  private let logReader: UpdatesLogReader
+
   init() async {
+    let category = "expo-updates-tests-\(UUID().uuidString)"
+    self.category = category
+    self.logger = UpdatesLogger(category: category)
+    self.logReader = UpdatesLogReader(category: category)
     await clearLogAsync()
   }
 
   @Test
   @MainActor
   func `PurgeOldLogs`() async throws {
-    let logReader = UpdatesLogReader()
-
     let date1 = Date()
-    await purgeEntriesAsync(logReader: logReader, olderThan: date1)
+    await purgeEntriesAsync(olderThan: date1)
 
     await logErrorAsync(message: "Test message", code: .noUpdatesAvailable)
     try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -36,7 +49,7 @@ struct UpdatesLogReaderTests {
       }
     #expect(entries2.count == 1)
 
-    await purgeEntriesAsync(logReader: logReader, olderThan: date2)
+    await purgeEntriesAsync(olderThan: date2)
 
     let entries3: [String] = logReader.getLogEntries(newerThan: date1)
       .filter { entryString in
@@ -49,8 +62,6 @@ struct UpdatesLogReaderTests {
   @Test
   @MainActor
   func `BasicLoggingWorks`() async throws {
-    let logger = UpdatesLogger()
-
     // Mark the date
     let epoch = Date()
 
@@ -63,9 +74,6 @@ struct UpdatesLogReaderTests {
     logger.warn(message: "Warning message", code: .assetsFailedToLoad, updateId: "myUpdateId", assetId: "myAssetId")
 
     try await Task.sleep(nanoseconds: 100_000_000)
-
-    // Use reader to retrieve messages
-    let logReader = UpdatesLogReader()
 
     let logEntries: [String] = logReader.getLogEntries(newerThan: epoch)
 
@@ -101,9 +109,6 @@ struct UpdatesLogReaderTests {
   @Test
   @MainActor
   func `TimerWorks`() async throws {
-    let logger = UpdatesLogger()
-    let logReader = UpdatesLogReader()
-
     // Mark the date
     let epoch = Date()
 
@@ -114,7 +119,6 @@ struct UpdatesLogReaderTests {
 
     try await Task.sleep(nanoseconds: 100_000_000)
 
-    // Use reader to retrieve messages
     let logEntries: [String] = logReader.getLogEntries(newerThan: epoch)
 
     // Verify number of log entries and decoded values
@@ -123,7 +127,7 @@ struct UpdatesLogReaderTests {
     let logEntryText: String = logEntries[0]
     let logEntry = UpdatesLogEntry.create(from: logEntryText)
     #expect(logEntry?.message == "testlabel")
-    #expect(logEntry?.code  == UpdatesErrorCode.none.asString)
+    #expect(logEntry?.code == UpdatesErrorCode.none.asString)
     #expect(logEntry?.level == "\(LogType.timer)")
     #expect(logEntry?.updateId == nil)
     #expect(logEntry?.assetId == nil)
@@ -135,7 +139,7 @@ struct UpdatesLogReaderTests {
 
   func clearLogAsync() async {
     await withCheckedContinuation { continuation in
-      let persistentLog = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
+      let persistentLog = PersistentFileLog(category: category)
       persistentLog.clearEntries { _ in
         continuation.resume()
       }
@@ -144,25 +148,40 @@ struct UpdatesLogReaderTests {
 
   func logErrorAsync(message: String, code: UpdatesErrorCode) async {
     await withCheckedContinuation { continuation in
-      let persistentLog = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
-      let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .error, duration: nil, updateId: nil, assetId: nil)
+      let persistentLog = PersistentFileLog(category: category)
+      let logEntryString =
+        "xx"
+        + logger.logEntryString(
+          message: message, code: code, level: .error,
+          duration: nil, updateId: nil, assetId: nil
+        )
       persistentLog.appendEntry(entry: logEntryString) { _ in
         continuation.resume()
       }
     }
   }
 
-  func logWarnAsync(message: String, code: UpdatesErrorCode, updateId: String?, assetId: String?) async {
+  func logWarnAsync(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) async {
     await withCheckedContinuation { continuation in
-      let persistentLog = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
-      let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .warn, duration: nil, updateId: updateId, assetId: assetId)
+      let persistentLog = PersistentFileLog(category: category)
+      let logEntryString =
+        "xx"
+        + logger.logEntryString(
+          message: message, code: code, level: .warn,
+          duration: nil, updateId: updateId, assetId: assetId
+        )
       persistentLog.appendEntry(entry: logEntryString) { _ in
         continuation.resume()
       }
     }
   }
 
-  func purgeEntriesAsync(logReader: UpdatesLogReader, olderThan: Date) async {
+  func purgeEntriesAsync(olderThan: Date) async {
     await withCheckedContinuation { continuation in
       logReader.purgeLogEntries(olderThan: olderThan) { _ in
         continuation.resume()


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We have been seeing intermittent failures in the log reader tests.

# How

Tests were not isolated from other tests that wrote to the same log reader file, so the test is modified to use a separate file for each test run.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

CI should pass. (I found and fixed a tvOS compile issue in dev-launcher, fix is included here.)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)