### PR TITLE
[android][cli] Fall back to output-metadata.json when resolving custom APK filenames

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Place static entries last in serialized HTML output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Include external CSS imports in the production server manifest ([#46984](https://github.com/expo/expo/pull/46984) by [@hassankhan](https://github.com/hassankhan))
+- Fall back to AGP's `output-metadata.json` when resolving APK filenames to support projects that override `outputFileName` in `applicationVariants` ([#47083](https://github.com/expo/expo/pull/47083) by [@NikhilVashistha](https://github.com/NikhilVashistha))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
@@ -57,4 +57,123 @@ describe(resolveInstallApkNameAsync, () => {
     jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
     await expect(runCheck()).resolves.toBe('app-arm64-debug.apk');
   });
+
+  describe('output-metadata.json fallback', () => {
+    it(`resolves a custom-named APK when no pattern-based APK is found`, async () => {
+      vol.fromJSON(
+        {
+          'android/app/build/outputs/apk/debug/output-metadata.json': JSON.stringify({
+            elements: [
+              { type: 'SINGLE', filters: [], outputFile: 'myapp-1.0.0-100-abc1234-debug.apk' },
+            ],
+          }),
+          'android/app/build/outputs/apk/debug/myapp-1.0.0-100-abc1234-debug.apk': '',
+        },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
+      await expect(runCheck()).resolves.toBe('myapp-1.0.0-100-abc1234-debug.apk');
+    });
+
+    it(`resolves an ABI-split APK matching the device ABI`, async () => {
+      vol.fromJSON(
+        {
+          'android/app/build/outputs/apk/debug/output-metadata.json': JSON.stringify({
+            elements: [
+              {
+                type: 'ONE_OF_MANY',
+                filters: [{ filterType: 'ABI', value: 'arm64-v8a' }],
+                outputFile: 'myapp-arm64-v8a-debug.apk',
+              },
+              {
+                type: 'ONE_OF_MANY',
+                filters: [{ filterType: 'ABI', value: 'x86_64' }],
+                outputFile: 'myapp-x86_64-debug.apk',
+              },
+            ],
+          }),
+          'android/app/build/outputs/apk/debug/myapp-arm64-v8a-debug.apk': '',
+          'android/app/build/outputs/apk/debug/myapp-x86_64-debug.apk': '',
+        },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64v8a]);
+      await expect(runCheck()).resolves.toBe('myapp-arm64-v8a-debug.apk');
+    });
+
+    it(`returns null when output-metadata.json is absent and no pattern-based APK is found`, async () => {
+      vol.fromJSON({}, '/');
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
+      await expect(runCheck()).resolves.toBeNull();
+    });
+
+    it(`returns null when output-metadata.json is malformed`, async () => {
+      vol.fromJSON(
+        { 'android/app/build/outputs/apk/debug/output-metadata.json': 'not valid json' },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
+      await expect(runCheck()).resolves.toBeNull();
+    });
+
+    it(`returns null when no ABI split element matches the device`, async () => {
+      vol.fromJSON(
+        {
+          'android/app/build/outputs/apk/debug/output-metadata.json': JSON.stringify({
+            elements: [
+              {
+                type: 'ONE_OF_MANY',
+                filters: [{ filterType: 'ABI', value: 'x86_64' }],
+                outputFile: 'myapp-x86_64-debug.apk',
+              },
+            ],
+          }),
+          'android/app/build/outputs/apk/debug/myapp-x86_64-debug.apk': '',
+        },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64v8a]);
+      await expect(runCheck()).resolves.toBeNull();
+    });
+
+    it(`returns null when the APK referenced by output-metadata.json does not exist on disk`, async () => {
+      vol.fromJSON(
+        {
+          'android/app/build/outputs/apk/debug/output-metadata.json': JSON.stringify({
+            elements: [{ type: 'SINGLE', filters: [], outputFile: 'myapp-1.0.0-debug.apk' }],
+          }),
+          // APK file intentionally absent
+        },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
+      await expect(runCheck()).resolves.toBeNull();
+    });
+
+    it(`returns null for density splits when no ABI filter is present`, async () => {
+      vol.fromJSON(
+        {
+          'android/app/build/outputs/apk/debug/output-metadata.json': JSON.stringify({
+            elements: [
+              {
+                type: 'ONE_OF_MANY',
+                filters: [{ filterType: 'DENSITY', value: 'hdpi' }],
+                outputFile: 'myapp-hdpi-debug.apk',
+              },
+              {
+                type: 'ONE_OF_MANY',
+                filters: [{ filterType: 'DENSITY', value: 'xhdpi' }],
+                outputFile: 'myapp-xhdpi-debug.apk',
+              },
+            ],
+          }),
+          'android/app/build/outputs/apk/debug/myapp-hdpi-debug.apk': '',
+          'android/app/build/outputs/apk/debug/myapp-xhdpi-debug.apk': '',
+        },
+        '/'
+      );
+      jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64v8a]);
+      await expect(runCheck()).resolves.toBeNull();
+    });
+  });
 });

--- a/packages/@expo/cli/src/run/android/resolveInstallApkName.ts
+++ b/packages/@expo/cli/src/run/android/resolveInstallApkName.ts
@@ -8,7 +8,7 @@ import { DeviceABI, getDeviceABIsAsync } from '../../start/platforms/android/adb
 const debug = require('debug')('expo:run:android:resolveInstallApkName') as typeof console.log;
 
 type OutputMetadataElement = {
-  filters: { filterType: string; value: string }[];
+  filters?: { filterType: string; value: string }[];
   outputFile: string;
 };
 
@@ -18,18 +18,14 @@ type OutputMetadata = {
 
 function resolveApkFromOutputMetadata(
   apkVariantDirectory: string,
-  availableCPUs: string[]
+  availableCPUs: DeviceABI[]
 ): string | null {
   const metadataPath = path.join(apkVariantDirectory, 'output-metadata.json');
-  if (!fs.existsSync(metadataPath)) {
-    return null;
-  }
-
   let metadata: OutputMetadata;
   try {
     metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-  } catch {
-    debug('Failed to parse output-metadata.json');
+  } catch (error) {
+    debug('Failed to parse output-metadata.json', error);
     return null;
   }
 
@@ -38,35 +34,34 @@ function resolveApkFromOutputMetadata(
     return null;
   }
 
-  debug('output-metadata.json elements:', elements.map((e) => e.outputFile).join(', '));
-
   // ABI split: match by device ABI. Exclude DeviceABI.universal — AGP never uses it as an ABI filter.
-  const isAbiSplit = elements.some((e) => e.filters.some((f) => f.filterType === 'ABI'));
+  const isAbiSplit = elements.some((e) => e?.filters?.some((f) => f?.filterType === 'ABI'));
   if (isAbiSplit) {
-    const deviceCPUs = availableCPUs.filter((cpu) => cpu !== DeviceABI.universal);
-    for (const cpu of deviceCPUs) {
+    for (const cpu of availableCPUs) {
+      if (cpu === DeviceABI.universal) {
+        continue;
+      }
       const match = elements.find((e) =>
-        e.filters.some((f) => f.filterType === 'ABI' && f.value === cpu)
+        e?.filters?.some((f) => f.filterType === 'ABI' && f.value === cpu)
       );
-      if (match && fs.existsSync(path.join(apkVariantDirectory, match.outputFile))) {
-        debug('Resolved ABI-split APK from output-metadata.json:', match.outputFile);
-        return match.outputFile;
+      const outputFile = match?.outputFile;
+      if (typeof outputFile === 'string' && fs.existsSync(path.join(apkVariantDirectory, outputFile))) {
+        debug('Resolved ABI-split APK from output-metadata.json:', outputFile);
+        return outputFile;
       }
     }
     return null;
   }
 
-  // Single universal APK. Density/language splits produce multiple elements without ABI filters;
-  // we don't attempt to resolve those here.
-  if (elements.length !== 1) {
-    return null;
-  }
-  const apkFile = elements[0]?.outputFile;
-  if (apkFile && fs.existsSync(path.join(apkVariantDirectory, apkFile))) {
-    debug('Resolved APK from output-metadata.json:', apkFile);
-    return apkFile;
+  if (elements.length === 1) {
+    const outputFile = elements[0]?.outputFile;
+    if (typeof outputFile === 'string' && fs.existsSync(path.join(apkVariantDirectory, outputFile))) {
+      debug('Resolved APK from output-metadata.json:', outputFile);
+      return outputFile;
+    }
   }
 
+  // Density/language splits produce multiple elements without ABI filters
   return null;
 }
 

--- a/packages/@expo/cli/src/run/android/resolveInstallApkName.ts
+++ b/packages/@expo/cli/src/run/android/resolveInstallApkName.ts
@@ -7,6 +7,69 @@ import { DeviceABI, getDeviceABIsAsync } from '../../start/platforms/android/adb
 
 const debug = require('debug')('expo:run:android:resolveInstallApkName') as typeof console.log;
 
+type OutputMetadataElement = {
+  filters: { filterType: string; value: string }[];
+  outputFile: string;
+};
+
+type OutputMetadata = {
+  elements: OutputMetadataElement[];
+};
+
+function resolveApkFromOutputMetadata(
+  apkVariantDirectory: string,
+  availableCPUs: string[]
+): string | null {
+  const metadataPath = path.join(apkVariantDirectory, 'output-metadata.json');
+  if (!fs.existsSync(metadataPath)) {
+    return null;
+  }
+
+  let metadata: OutputMetadata;
+  try {
+    metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+  } catch {
+    debug('Failed to parse output-metadata.json');
+    return null;
+  }
+
+  const { elements } = metadata;
+  if (!elements?.length) {
+    return null;
+  }
+
+  debug('output-metadata.json elements:', elements.map((e) => e.outputFile).join(', '));
+
+  // ABI split: match by device ABI. Exclude DeviceABI.universal — AGP never uses it as an ABI filter.
+  const isAbiSplit = elements.some((e) => e.filters.some((f) => f.filterType === 'ABI'));
+  if (isAbiSplit) {
+    const deviceCPUs = availableCPUs.filter((cpu) => cpu !== DeviceABI.universal);
+    for (const cpu of deviceCPUs) {
+      const match = elements.find((e) =>
+        e.filters.some((f) => f.filterType === 'ABI' && f.value === cpu)
+      );
+      if (match && fs.existsSync(path.join(apkVariantDirectory, match.outputFile))) {
+        debug('Resolved ABI-split APK from output-metadata.json:', match.outputFile);
+        return match.outputFile;
+      }
+    }
+    return null;
+  }
+
+  // Single universal APK. Density/language splits produce multiple elements without ABI filters;
+  // we don't attempt to resolve those here.
+  if (elements.length !== 1) {
+    return null;
+  }
+  const apkFile = elements[0]?.outputFile;
+  if (apkFile && fs.existsSync(path.join(apkVariantDirectory, apkFile))) {
+    debug('Resolved APK from output-metadata.json:', apkFile);
+    return apkFile;
+  }
+
+  return null;
+}
+
 export async function resolveInstallApkNameAsync(
   device: Pick<Device, 'name' | 'pid'>,
   { appName, buildType, flavors, apkVariantDirectory }: GradleProps
@@ -35,7 +98,8 @@ export async function resolveInstallApkNameAsync(
     return apkName;
   }
 
-  return null;
+  // Last resort: read AGP's output-metadata.json to handle custom outputFileName overrides.
+  return resolveApkFromOutputMetadata(apkVariantDirectory, availableCPUs);
 }
 
 function getApkFileName(


### PR DESCRIPTION
# Why

When projects override `outputFileName` in `applicationVariants` (a common Gradle pattern for embedding version names, git hashes, or environment names in the APK filename), Expo CLI's pattern-based APK lookup always fails because it constructs the expected filename as `app-<flavors>-<buildType>.apk`. This causes the CLI to fall back to a full Gradle install on every run, even when a pre-built APK already exists on disk.

# How

AGP writes an `output-metadata.json` file alongside every APK it produces. This file contains the exact `outputFile` name Gradle used, making it the canonical source of truth for artifact discovery — Android Studio itself uses this file.

Added `resolveApkFromOutputMetadata` as a last-resort fallback in `resolveInstallApkNameAsync`, called only when the existing pattern-based lookup finds nothing:

- For ABI splits (elements with `filterType: 'ABI'`): matches the element whose ABI intersects with the device's supported ABIs in priority order, with an existence check before returning
- For a single universal APK: returns the `outputFile` if it exists on disk
- Density/language splits (multiple elements without ABI filters) are not handled — falls through to Gradle in that case
- If the file is missing, malformed, or absent: returns `null` and falls through to Gradle as before

The existing pattern-based lookup is completely unchanged — this only activates when it returns `null`.

# Test Plan

## Automated tests

Run the existing test suite for `resolveInstallApkNameAsync`:

```sh
cd packages/@expo/cli
pnpm test src/run/android/__tests__/resolveInstallApkName-test.ts --verbose
```

Output:

<img width="582" height="351" alt="image" src="https://github.com/user-attachments/assets/6a2fb752-edd7-46e0-981a-1cbebf042125" />

## Manual reproduction

To reproduce the problem this fixes, add the following to your `android/app/build.gradle`:

```groovy
android {
    applicationVariants.all { variant ->
        variant.outputs.all {
            outputFileName = "myapp-${variant.versionName}-${variant.buildType.name}.apk"
        }
    }
}
```

**Before this fix:** `npx expo run:android` fails to locate the APK and falls back to `gradlew installDebug` on every run, even after the APK is already built.

**After this fix:** the CLI reads `android/app/build/outputs/apk/debug/output-metadata.json`, finds `myapp-1.0.0-debug.apk`, and installs it directly — skipping the Gradle step.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)