### PR TITLE
[android][expo-ui] Fix `Switch` alignment when `label` is provided

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [iOS] Fix `TextField` and `SecureField` worklet `onTextChange` firing more than once per keystroke (when a change triggers reformatting) and on programmatic text updates. ([#46483](https://github.com/expo/expo/pull/46483) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `font` modifier dropping Dynamic Type scaling (`relativeTo`) and `weight` on concatenated `Text` runs. The Text-concatenation path now resolves the same `Font` as the view path. ([#46509](https://github.com/expo/expo/pull/46509) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [android] Fix universal `TextInput` ignoring `style` `backgroundColor` / `borderWidth` and not applying `textAlign` to the placeholder. ([#46441](https://github.com/expo/expo/pull/46441) by [@duyanhv](https://github.com/duyanhv))
+- [android] Fix `Switch` alignment when `label` is provided ([#47088](https://github.com/expo/expo/pull/47088) by [@rklomp](https://github.com/rklomp))
 
 ### 💡 Others
 

--- a/packages/expo-ui/src/universal/Switch/index.android.tsx
+++ b/packages/expo-ui/src/universal/Switch/index.android.tsx
@@ -1,5 +1,5 @@
 import { Row, Switch as ComposeSwitch, Text } from '@expo/ui/jetpack-compose';
-import { testID as testIDModifier } from '@expo/ui/jetpack-compose/modifiers';
+import { testID as testIDModifier, weight } from '@expo/ui/jetpack-compose/modifiers';
 
 import type { SwitchProps } from './types';
 
@@ -17,7 +17,7 @@ export function Switch({ value, onValueChange, label, disabled, testID, modifier
 
   return (
     <Row verticalAlignment="center" horizontalArrangement={{ spacedBy: 8 }}>
-      <Text>{label}</Text>
+      <Text modifiers={[weight(1)]}>{label}</Text>
       {toggle}
     </Row>
   );


### PR DESCRIPTION
# Why

The `Switch` on Android is not positioned correctly when using a `label`. It should be aligned to the right side.
Now with a small label its not pushed to the right. And with a long label its pushed off screen.

# How

Adding a `weight(1)` will give the `Text` the remaining space after `Switch` is rendered and position the `Swich` correclty.

# Test Plan
```
    <Switch
      label="This is a very long label and pushes the switch off the screen to the right"
      value={value}
      onValueChange={onValueChange}
    />
```

**Before**
<img width="372" height="76" alt="Screenshot 2026-06-20 095931" src="https://github.com/user-attachments/assets/026f3f90-b8eb-4836-9f1d-16f3ab9bea20" />
<img width="375" height="78" alt="Screenshot 2026-06-20 095746" src="https://github.com/user-attachments/assets/67db2f40-0e67-45b3-b175-3550107b71d7" />

**After**
<img width="373" height="77" alt="Screenshot 2026-06-20 100022" src="https://github.com/user-attachments/assets/3d4772d1-98f9-4f80-8063-47c353dff115" />
<img width="374" height="72" alt="Screenshot 2026-06-20 100039" src="https://github.com/user-attachments/assets/689a0ebb-c165-4abc-9810-21d9f451b657" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
