### PR TITLE
test(file-system): Remove re-entry import to fix type check and adjust type root

### DIFF
--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -1,6 +1,6 @@
-import { DownloadTask, File, Directory, Paths, UploadTask } from '../..';
 import { __resetMockFileSystem } from '../../mocks/FileSystem';
 import { FileMode } from '../File.types';
+import { DownloadTask, File, Directory, Paths, UploadTask } from '../index';
 
 beforeEach(() => {
   __resetMockFileSystem();


### PR DESCRIPTION
## Summary

The test fails the type-check here since it re-enters the package with `../..` i.e. the package root itself. This _can_ in theory work with the custom condition of `expo-source`, but is redundant, since it means to just get common shared modules.

## Set of changes

- Replace `../..` (package root) with `../index` in test
- ~~Fix accidentally changed `rootDir` on `tsconfig.json`~~ (See #47094 which overrides `rootDir` and makes this non-loadbearing and not a footgun)