### PR TITLE
chore(expo-module-template): Revert expo-module-template change

### DIFF
--- a/packages/expo-module-template/tsconfig.json
+++ b/packages/expo-module-template/tsconfig.json
@@ -21,7 +21,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "rootDir": "./src",
-    "noEmit": true
+    "outDir": "./build"
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
## Summary

The changes to `tsconfig.json`s that were scripted manipulated this template when it shouldn't.

**Out-of-scope notes:**
- we may not want this to be a package in `packages/*`, since it's actually a template and not a package, otherwise it'll be misaligned
- the `tsconfig.json` is wide and potentially excessive (if it's a module template it should use `expo/tsconfig.base`
- it seems to have a lot of setup that doesn't align anymore with our own practices (hence, notes on recent PRs to detach `expo-module-scripts` from the monorepo for external consumers, rename it in our monorepo, and re-align `create-expo-module` and this template with a slimmer setup

## Set of changes

- Revert `tsconfig.json` change in `expo-module-template`