### PR TITLE
chore(workflows/sdk): Separate out lint/depscheck task from "Check changed packages"

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -77,10 +77,20 @@ jobs:
         env:
           TURBO_SCM_BASE: ${{ github.base_ref || github.event.before || 'main' }}
         run: |
-          pnpm turbo run build typecheck depscheck test lint \
+          pnpm turbo run build typecheck test \
             --affected \
             --filter="./packages/**" \
             --continue=dependencies-successful
+
+      - name: ✨ Lint changed packages
+        if: github.event_name != 'schedule' &&
+          github.event.inputs.checkAll != 'check-all'
+        env:
+          TURBO_SCM_BASE: ${{ github.base_ref || github.event.before || 'main' }}
+        run: |
+          pnpm turbo run depscheck lint \
+            --filter="{./packages/**}[$TURBO_SCM_BASE...HEAD]"
+            --continue
 
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -89,7 +89,7 @@ jobs:
           TURBO_SCM_BASE: ${{ github.base_ref || github.event.before || 'main' }}
         run: |
           pnpm turbo run depscheck lint \
-            --filter="{./packages/**}[$TURBO_SCM_BASE...HEAD]"
+            --filter="{./packages/**}[$TURBO_SCM_BASE...HEAD]" \
             --continue
 
       - name: 🔔 Notify on Slack
@@ -128,7 +128,7 @@ jobs:
       - name: 🧐 Check all packages
         shell: bash
         run: |
-          pnpm turbo run build typecheck depscheck test lint \
+          pnpm turbo run build test \
             --filter="./packages/**" \
             --filter='!@expo/cli' \
             --filter='!@expo/config' \


### PR DESCRIPTION
# Why

The `lint` task takes up almost more than half the time (sometimes) relative to the other tasks, even `test`, in local testing, and we don't always need to run it.

`build`, `typecheck`, and `test` are "dependent" tasks, where we want to run all dependents to be sure that a change in one package doesn't break another, and `--affected` does this for us, intersected with the Git base of that branch (or last commit).

(Side-note: `build` explicitly has a `dependsOn` entry, so it'll always build in order of the dependency graph, but that's not relevant here. It's more relevant that we build before running tests)

However, `depscheck` and `lint` are "independent" tasks, and one package shouldn't affect another's validity. As such, we don't want them to be run on all dependents.

# How

- Separate out `✨ Lint changed packages` from `🧐 Check changed packages` with identical filter conditions on the workflow step
- Mark the `lint` and `depscheck` tasks as `--filter="{./packages/**}[$TURBO_SCM_BASE...HEAD]"` i.e. the intersection of `packages/**` and a diff of the Git base to `HEAD`
- Limit Windows run to `build` and `test` (we can assume `typecheck`, `lint`, etc are identical between Linux and Windows)

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
