### PR TITLE
fix(scripts): Force override `rootDir` when outputting declarations

### DIFF
--- a/packages/expo-module-scripts/bin/expo-build
+++ b/packages/expo-module-scripts/bin/expo-build
@@ -59,7 +59,7 @@ function parseTargets(positionals) {
   });
 }
 
-function createBuildHost(baseDir, outDir, typecheck) {
+function createBuildHost(baseDir, inputDir, outDir, typecheck) {
   const configPath = path.join(baseDir, 'tsconfig.json');
   const parsed = ts.getParsedCommandLineOfConfigFile(
     configPath,
@@ -69,6 +69,7 @@ function createBuildHost(baseDir, outDir, typecheck) {
       declaration: true,
       declarationMap: false,
       noCheck: !typecheck,
+      rootDir: path.resolve(baseDir, inputDir),
       outDir: path.resolve(baseDir, outDir),
     },
     {
@@ -245,6 +246,7 @@ if (allFiles.length === 0 && allDeclFiles.length === 0 && allAssetFiles.length =
 
 const { parsed, compilerHost, writtenFiles, writeFileIfChanged } = createBuildHost(
   baseDir,
+  targets[0].input,
   targets[0].output,
   typecheck
 );


### PR DESCRIPTION
## Summary

We have three (or more) distinct output patterns:
- "normal" packages like `expo-audio` only have a `src` root and build to `build`
- "larger" packages like `@expo/cli` may have more than one root (`src`, `bin`, `metro-require`) set a `.` root and build to `build` with nested folders
- "special" packages like `expo-file-system` may build to `build` from `src`, but have a higher root directory, to accommodate parallel non-shipped folders (`mocks`)

This breaks the `expo-build` script's assumptions and is a footgun. We should just ignore and override `rootDir` to align it with the input folder.

See how #47089 broke.

## Set of changes

- Force `rootDir` for declaration outputs