### PR TITLE
[metro-config] Fix findUpPackageJson infinite recursion at the Windows drive root

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix infinite recursion in `findUpPackageJson` when no `package.json` exists up the tree on Windows. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@patrickwehbe](https://github.com/patrickwehbe))
+- Fix infinite recursion in `findUpPackageJson` when no `package.json` exists up the tree on Windows. ([#47095](https://github.com/expo/expo/pull/47095) by [@patrickwehbe](https://github.com/patrickwehbe))
 - Fix stack frame collapsing for Windows paths. ([#46645](https://github.com/expo/expo/pull/46645) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Bump `hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix infinite recursion in `findUpPackageJson` when no `package.json` exists up the tree on Windows. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@patrickwehbe](https://github.com/patrickwehbe))
 - Fix stack frame collapsing for Windows paths. ([#46645](https://github.com/expo/expo/pull/46645) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Bump `hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
 

--- a/packages/@expo/metro-config/src/utils/__tests__/getPkgVersion.test.ts
+++ b/packages/@expo/metro-config/src/utils/__tests__/getPkgVersion.test.ts
@@ -116,4 +116,19 @@ describe(findUpPackageJson, () => {
   it('should return null for relative root', () => {
     expect(findUpPackageJson('.')).toBeNull();
   });
+
+  it('should return null when reaching a Windows drive root without recursing forever', () => {
+    // On Windows `path.dirname('D:\\')` returns `'D:\\'` (a fixed point), which is neither `.`
+    // nor `path.sep`. Force Windows path semantics so the case is exercised on any host (CI runs
+    // on POSIX). Without the parent-equality guard this walk recurses until the stack overflows.
+    const win32Dirname = path.win32.dirname;
+    const dirnameSpy = jest.spyOn(path, 'dirname').mockImplementation((p) => win32Dirname(p));
+    jest.mocked(resolveFrom.silent).mockReturnValue(undefined as any);
+
+    try {
+      expect(findUpPackageJson('D:\\project\\node_modules\\expo\\build\\index.js')).toBeNull();
+    } finally {
+      dirnameSpy.mockRestore();
+    }
+  });
 });

--- a/packages/@expo/metro-config/src/utils/getPkgVersion.ts
+++ b/packages/@expo/metro-config/src/utils/getPkgVersion.ts
@@ -20,11 +20,18 @@ export function getPkgVersionFromPath(packageJsonPath: string): string | null {
 }
 
 export function findUpPackageJson(cwd: string): string | null {
-  if (['.', path.sep].includes(cwd)) return null;
+  // Stop when we reach a directory whose parent is itself, e.g. the POSIX root `/` or a
+  // Windows drive root like `D:\`. `path.dirname('D:\\')` returns `'D:\\'`, which is neither
+  // `.` nor `path.sep`, so checking only against those values would recurse forever on Windows
+  // when no package.json exists up the tree. The sibling helpers in
+  // serializer/findUpPackageJsonPath.ts and install-expo-modules/src/utils/projectRoot.ts use
+  // this same `path.dirname(dir) !== dir` idiom.
+  const parent = path.dirname(cwd);
+  if (parent === cwd || cwd === '.') return null;
 
   const found = resolveFrom.silent(cwd, './package.json');
   if (found) {
     return found;
   }
-  return findUpPackageJson(path.dirname(cwd));
+  return findUpPackageJson(parent);
 }


### PR DESCRIPTION
# Why

`findUpPackageJson` in `@expo/metro-config` (used by `getPkgVersion` to read a dependency's installed version) walks up the directory tree until it reaches the root. Its stop condition only checks the current path against `'.'` and `path.sep`:

```ts
if (['.', path.sep].includes(cwd)) return null;
// ...
return findUpPackageJson(path.dirname(cwd));
```

On Windows the drive root is neither of those. `path.dirname('D:\\')` returns `'D:\\'` (a fixed point), which does not equal `'.'` and does not equal `path.sep` (`'\\'`). So if no `package.json` exists anywhere up the tree, the walk reaches `D:\` and keeps recursing on the same value forever, ending in:

```
RangeError: Maximum call stack size exceeded
```

On POSIX this never triggers because the walk lands on `path.sep` (`'/'`) and stops, which is why it has gone unnoticed. The real-world trigger is narrow: it requires a package to resolve to a location with no `package.json` in any ancestor directory on Windows, but when it happens the error is a confusing stack overflow rather than a clean `null`.

# How

Stop when a directory's parent equals itself (`path.dirname(cwd) === cwd`), which is true for both the POSIX root `/` and any Windows drive root such as `D:\`. The `cwd === '.'` case is kept for the relative-path entry.

This is the same idiom the two sibling helpers in this repo already use:

- `packages/@expo/metro-config/src/serializer/findUpPackageJsonPath.ts` — `for (let dir = root; path.dirname(dir) !== dir; dir = path.dirname(dir))`
- `packages/install-expo-modules/src/utils/projectRoot.ts` — same loop condition

# Test Plan

Added a regression test to `getPkgVersion.test.ts` that forces Windows path semantics (`path.win32.dirname`) so it runs on CI's POSIX environment, points `findUpPackageJson` at a drive-root path with no resolvable `package.json`, and asserts it returns `null`.

- Against the current code the new test fails with `RangeError: Maximum call stack size exceeded`.
- With the fix all tests pass:

```
  findUpPackageJson
    √ should return package.json path when found in the given directory
    √ should walk up directories until package.json is found
    √ should return null when reaching the root directory
    √ should return null for relative root
    √ should return null when reaching a Windows drive root without recursing forever

Tests:       12 passed, 12 total
```

The two pre-existing base-case tests (`path.sep` and `'.'`) still pass, so the change is backward compatible.

# Checklist

- [x] I added a `CHANGELOG.md` entry
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — n/a, no plugin/prebuild surface touched
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — n/a, no docs changes
