### PR TITLE
[docs] Correct defaultLaunchURL typo in dev-client docs for Android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -58,7 +58,7 @@ You can configure development client launcher using its built-in [config plugin]
           "launchMode": "most-recent",
           "defaultLaunchURL": "http://localhost:8081",
           "android": {
-            "defaultLaunchURL": "http://10.0.0.2:8081"
+            "defaultLaunchURL": "http://10.0.2.2:8081"
           },
           "toolsButton": true,
           "skipOnboarding": false,


### PR DESCRIPTION
The default Android emulator address is 10.0.2.2, see https://developer.android.com/studio/run/emulator-networking-address?_gl=1*1a38ipu*_up*MQ..*_ga*MjYxODQ5NTEzLjE3ODE5NTcyNDY.*_ga_6HH9YJMN9M*czE3ODE5NTcyNDYkbzEkZzAkdDE3ODE5NTcyNDYkajYwJGwwJGgxMDIzMzY0OTE1

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The default Android emulator address has a typo in the docs, it should be `10.0.2.2` instead of `10.0.0.2`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Only changed the default emulator address.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Only a doc change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
