### PR TITLE
[core][ios] Tie AppContext lifetime to the runtime via global.expo native state

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,7 +33,7 @@
 - [Android] Fixed Expo UI re-compose when switching screens in react-native-screens. ([#46650](https://github.com/expo/expo/pull/46650) by [@kudo](https://github.com/kudo))
 - [iOS] Fix Expo DevTools Network response bodies for JSON content types with parameters. ([#46336](https://github.com/expo/expo/pull/46336) by [@SJvaca30](https://github.com/SJvaca30))
 - [iOS] Resolve the key window across connected scenes in `currentViewController()` so it keeps working with multiple scenes, and expose `Utilities.keyWindow()` for modules to reuse. ([#46956](https://github.com/expo/expo/pull/46956) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix a crash on `Updates.reloadAsync()` where the previous `AppContext` could deallocate before the old runtime finished teardown, releasing cached JSI objects against a dying runtime. Tie its lifetime to the `expo.modules` host object so it is torn down during the runtime's own finalization. ([#47051](https://github.com/expo/expo/issues/47051) by [@HaiyiMei](https://github.com/HaiyiMei)) ([#47080](https://github.com/expo/expo/pull/47080) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fix a crash on `Updates.reloadAsync()` where the previous `AppContext` could deallocate before the old runtime finished tearing down, releasing cached JSI objects against a dying runtime on the wrong thread. Its lifetime is now tied to the runtime via native state attached to the `global.expo` object. ([#47051](https://github.com/expo/expo/issues/47051) by [@HaiyiMei](https://github.com/HaiyiMei)) ([#47080](https://github.com/expo/expo/pull/47080), [#47098](https://github.com/expo/expo/pull/47098) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -466,6 +466,11 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
     // Install `global.expo`.
     let coreObject = installer.installCoreObject()
 
+    // Attach the native state that ties this app context's lifetime to the runtime and lets
+    // it be recovered from the runtime via `AppContext.from(runtime:)`. This is the main
+    // runtime, so its teardown owns the app context's `destroy()`.
+    installer.installAppContextNativeState(on: coreObject, ownsLifecycle: true)
+
     if let appIdentifier {
       coreObject.defineProperty("__expo_app_identifier__", value: appIdentifier)
     }
@@ -499,7 +504,12 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
       let installer = ExpoRuntimeInstaller(appContext: self, runtime: try uiRuntime)
 
       // Install `global.expo`.
-      installer.installCoreObject()
+      let coreObject = installer.installCoreObject()
+
+      // Attach the native state that ties this app context's lifetime to the UI runtime and
+      // lets it be recovered from the runtime via `AppContext.from(runtime:)`. The UI runtime
+      // is subordinate, so its teardown must not destroy the app context.
+      installer.installAppContextNativeState(on: coreObject, ownsLifecycle: false)
 
       // Install `global.expo.EventEmitter`.
       installer.installEventEmitterClass()
@@ -529,7 +539,7 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
    */
   @JavaScriptActor
   private func installModuleClasses(in runtime: JavaScriptRuntime) throws {
-    let coreObject = try runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
+    let coreObject = try runtime.global().getPropertyAsObject(globalCoreObjectPropertyName)
     let sharedObjectClass = try coreObject.getPropertyAsObject("SharedObject")
     let sharedObjectBaseProto = sharedObjectClass.getProperty("prototype")
 
@@ -599,6 +609,71 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
 
     for module in moduleRegistry {
       module.releaseJavaScriptObject()
+    }
+  }
+
+  // MARK: - Recovery
+
+  /// Returns the app context that prepared the given runtime, or `nil` if no app context did
+  /// (its `global.expo` object carries no `NativeState`). Lets code that only has a runtime
+  /// recover the app context without capturing a reference to it.
+  @JavaScriptActor
+  internal static func from(runtime: JavaScriptRuntime) -> AppContext? {
+    // Recovery may happen on every conversion, so look the core object up through a cached
+    // prop name id to avoid re-interning the "expo" string into JSI on each call.
+    let coreObjectPropName = JavaScriptPropNameID.cached(runtime, globalCoreObjectPropertyName)
+    guard let coreObject = try? runtime.global().getPropertyAsObject(coreObjectPropName) else {
+      return nil
+    }
+    return coreObject.getNativeState(as: NativeState.self)?.appContext
+  }
+
+  /// Native state attached to the `global.expo` object that holds a strong reference to the
+  /// app context. It serves two purposes:
+  ///
+  /// - Lifetime: because the native state lives on the runtime's heap and is torn down only
+  ///   when the runtime finalizes, holding the app context strongly ties its lifetime to the
+  ///   runtime. This defers the app context's release (and its `destroy()` cleanup of cached
+  ///   JSI objects) to runtime finalization, avoiding a teardown-ordering crash during reloads
+  ///   where the context could otherwise deallocate while the runtime is still tearing down on
+  ///   another thread.
+  /// - Recovery: any code holding the runtime can recover the app context via
+  ///   `AppContext.from(runtime:)` (which reads this native state off `global.expo`) instead of
+  ///   capturing a reference to it.
+  ///
+  /// A single app context can prepare several runtimes (e.g. the main and the UI runtime),
+  /// each getting its own native state. Only the one whose runtime owns the app context's
+  /// lifecycle (the main runtime) runs `destroy()` when it dies, so a subordinate runtime
+  /// tearing down doesn't destroy an app context still backing the others.
+  ///
+  /// This forms a strong reference cycle that routes through the runtime heap
+  /// (`AppContext` -> runtime -> `global.expo` -> `NativeState` -> `AppContext`). That is
+  /// intentional: the cycle is broken only when the runtime is torn down (which frees the
+  /// native state and fires its deallocator), which is exactly what defers the app context's
+  /// release until the runtime is gone. The app context never holds the native state directly.
+  internal final class NativeState: JavaScriptNativeState {
+    internal let appContext: AppContext
+
+    /// Whether releasing this native state should tear the app context down. Set only for the
+    /// main runtime; subordinate runtimes pin the app context and enable recovery without
+    /// destroying it.
+    internal let ownsLifecycle: Bool
+
+    internal init(appContext: AppContext, ownsLifecycle: Bool) {
+      self.appContext = appContext
+      self.ownsLifecycle = ownsLifecycle
+      super.init()
+      setDeallocator { nativeState in
+        guard let nativeState = nativeState as? NativeState, nativeState.ownsLifecycle else {
+          return
+        }
+        // `destroy()` asserts it runs on the JS thread (`JavaScriptActor.assumeIsolated`). That
+        // holds for the intended path, where the native state dies as the runtime finalizes on
+        // its own thread. A future cross-runtime sharing path that could drop this state's last
+        // JSI slot from another thread (see `JavaScriptNativeState.acquireShared`) would need to
+        // hop back to the JS thread here first.
+        nativeState.appContext.destroy()
+      }
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
@@ -9,7 +9,7 @@ import ExpoModulesJSI
 public class ExpoRuntime: JavaScriptRuntime, @unchecked Sendable {
   @JavaScriptActor
   internal func getCoreObject() throws -> JavaScriptObject {
-    return try global().getProperty(EXGlobalCoreObjectPropertyName).asObject()
+    return try global().getProperty(globalCoreObjectPropertyName).asObject()
   }
 
   @JavaScriptActor

--- a/packages/expo-modules-core/ios/JS/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JS/EXJSIInstaller.h
@@ -16,11 +16,6 @@
 @class RCTRuntimeExecutor;
 #endif // React Native >=0.74
 
-/**
- Property name of the core object in the global scope of the Expo JS runtime.
- */
-extern NSString *_Nonnull const EXGlobalCoreObjectPropertyName;
-
 @interface EXJavaScriptRuntimeManager : NSObject
 
 - (nonnull instancetype)initWithRuntime:(nonnull void *)runtime;

--- a/packages/expo-modules-core/ios/JS/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JS/EXJSIInstaller.mm
@@ -14,11 +14,6 @@
 namespace jsi = facebook::jsi;
 
 /**
- Property name of the core object in the global scope of the Expo JS runtime.
- */
-NSString *const EXGlobalCoreObjectPropertyName = @"expo";
-
-/**
  Property name used to define the modules host object in the main object of the
  Expo JS runtime.
  */

--- a/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
+++ b/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
@@ -2,6 +2,9 @@
 
 import ExpoModulesJSI
 
+/// Property name of the core object in the global scope of the Expo JS runtime, i.e. `global.expo`.
+internal let globalCoreObjectPropertyName = "expo"
+
 @JavaScriptActor
 internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
   private let appContext: AppContext
@@ -21,8 +24,24 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
   @discardableResult
   internal func installCoreObject() -> JavaScriptObject {
     let coreObject = runtime.createObject()
-    runtime.global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: [.enumerable])
+    runtime.global().defineProperty(globalCoreObjectPropertyName, value: coreObject, options: [.enumerable])
     return coreObject
+  }
+
+  /// Attaches the `AppContext.NativeState` to the `global.expo` object. This ties the app
+  /// context's lifetime to the runtime (its release defers to runtime finalization) and lets
+  /// code recover the app context from the runtime via `AppContext.from(runtime:)`.
+  ///
+  /// Pass `ownsLifecycle: true` for the runtime that owns the app context's lifecycle (the main
+  /// runtime), so only its teardown runs `destroy()`. Subordinate runtimes (e.g. the UI runtime)
+  /// pass `false` to pin the app context and enable recovery without destroying it.
+  @JavaScriptActor
+  internal func installAppContextNativeState(on coreObject: borrowing JavaScriptObject, ownsLifecycle: Bool) {
+    if coreObject.hasNativeState() {
+      // Already attached.
+      return
+    }
+    coreObject.setNativeState(AppContext.NativeState(appContext: appContext, ownsLifecycle: ownsLifecycle))
   }
 
   /**
@@ -30,7 +49,7 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
    */
   @JavaScriptActor
   internal func installExpoModulesHostObject() throws {
-    let coreObject = try runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
+    let coreObject = try runtime.global().getPropertyAsObject(globalCoreObjectPropertyName)
 
     if coreObject.hasProperty("modules") {
       // Host object already installed
@@ -45,13 +64,6 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
       },
       getPropertyNames: { [weak appContext] in
         return appContext?.getModuleNames() ?? []
-      },
-      dealloc: { [appContext] in
-        // Captured strongly so the host object owns the app context's lifetime: it's released
-        // during the runtime's own finalization, where `destroy()` clears the cached JSI objects
-        // while the runtime is still valid, rather than from a `reloadAsync()` race that could free
-        // them against a dying runtime on the wrong thread.
-        appContext.destroy()
       }
     )
 

--- a/packages/expo-modules-core/ios/Tests/AppContextTests.swift
+++ b/packages/expo-modules-core/ios/Tests/AppContextTests.swift
@@ -1,0 +1,231 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("AppContext")
+@JavaScriptActor
+struct AppContextTests {
+  let appContext = AppContext.create()
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  @Test
+  func `recovers the app context from the runtime`() throws {
+    let recovered = AppContext.from(runtime: try runtime)
+    #expect(recovered === appContext)
+  }
+
+  @Test
+  func `from(runtime:) returns nil for a runtime without the core object`() {
+    // A bare runtime that was never prepared by an app context has no `global.expo`.
+    let bareRuntime = JavaScriptRuntime()
+    #expect(AppContext.from(runtime: bareRuntime) == nil)
+  }
+
+  // MARK: - NativeState
+
+  @Suite("NativeState")
+  @JavaScriptActor
+  struct NativeStateTests {
+    let appContext = AppContext.create()
+    var runtime: ExpoRuntime {
+      get throws {
+        try appContext.runtime
+      }
+    }
+
+    @Test
+    func `is attached to the core object`() throws {
+      let coreObject = try runtime.global().getPropertyAsObject("expo")
+      let nativeState = coreObject.getNativeState(as: AppContext.NativeState.self)
+      #expect(nativeState != nil)
+      #expect(nativeState?.appContext === appContext)
+    }
+
+    @Test
+    func `the main runtime's installed native state owns the app context lifecycle`() throws {
+      // The real `prepareRuntime` path (run by `AppContext.create()`) must install a state that
+      // owns the lifecycle, otherwise the main runtime's teardown wouldn't destroy the context.
+      let coreObject = try runtime.global().getPropertyAsObject("expo")
+      let nativeState = coreObject.getNativeState(as: AppContext.NativeState.self)
+      #expect(nativeState?.ownsLifecycle == true)
+    }
+
+    @Test
+    func `installing the native state twice keeps the first one`() throws {
+      // The installer guards on `hasNativeState()`, so re-running it must not replace the state
+      // already attached by `prepareRuntime`.
+      let coreObject = try runtime.global().getPropertyAsObject("expo")
+      let original = coreObject.getNativeState(as: AppContext.NativeState.self)
+      #expect(original != nil)
+
+      let installer = ExpoRuntimeInstaller(appContext: appContext, runtime: try runtime)
+      installer.installAppContextNativeState(on: coreObject, ownsLifecycle: true)
+
+      #expect(coreObject.getNativeState(as: AppContext.NativeState.self) === original)
+    }
+
+    @Test
+    func `deallocator fires once when the native state is released`() throws {
+      var deallocatorCallCount = 0
+      let runtime = JavaScriptRuntime()
+      let coreObject = runtime.createObject()
+      let nativeState = AppContext.NativeState(appContext: appContext, ownsLifecycle: false)
+      nativeState.setDeallocator { _ in
+        deallocatorCallCount += 1
+      }
+      coreObject.setNativeState(nativeState)
+
+      coreObject.unsetNativeState()
+      try runtime.eval("gc() && gc() && gc()")
+
+      #expect(deallocatorCallCount == 1)
+    }
+
+    @Test
+    func `deallocator fires once even when the native state is attached to several objects`() throws {
+      var deallocatorCallCount = 0
+      let runtime = JavaScriptRuntime()
+      let firstObject = runtime.createObject()
+      let secondObject = runtime.createObject()
+      let nativeState = AppContext.NativeState(appContext: appContext, ownsLifecycle: false)
+      nativeState.setDeallocator { _ in
+        deallocatorCallCount += 1
+      }
+      firstObject.setNativeState(nativeState)
+      secondObject.setNativeState(nativeState)
+
+      // Releasing the first holder must not fire the deallocator while the second still holds it.
+      firstObject.unsetNativeState()
+      try runtime.eval("gc() && gc() && gc()")
+      #expect(deallocatorCallCount == 0)
+
+      // Releasing the last holder fires it exactly once.
+      secondObject.unsetNativeState()
+      try runtime.eval("gc() && gc() && gc()")
+      #expect(deallocatorCallCount == 1)
+    }
+
+    @Test
+    func `one app context prepares several runtimes and recovers from each`() throws {
+      // Each runtime gets its own native state pointing at the same app context, mirroring how
+      // `prepareRuntime` / `prepareUIRuntime` install one per runtime. Runtimes (reference
+      // types) are kept alive in the array; their core objects stay reachable through
+      // `global.expo`.
+      let runtimes = (0..<3).map { _ in JavaScriptRuntime() }
+
+      for runtime in runtimes {
+        let coreObject = runtime.createObject()
+        coreObject.setNativeState(AppContext.NativeState(appContext: appContext, ownsLifecycle: false))
+        runtime.global().defineProperty(globalCoreObjectPropertyName, value: coreObject, options: [.enumerable])
+      }
+
+      for runtime in runtimes {
+        #expect(AppContext.from(runtime: runtime) === appContext)
+      }
+    }
+
+    @Test
+    func `releasing a subordinate runtime's native state does not destroy the app context`() throws {
+      // A subordinate runtime (e.g. the UI runtime) is installed with `ownsLifecycle: false`,
+      // so tearing it down must not destroy an app context that still backs other runtimes.
+      let appContext = AppContext.create()
+      // The app context's own (main) runtime stays alive throughout this test.
+      _ = try appContext.runtime
+
+      // Stand in for a subordinate runtime: its own native state pointing at the same app context.
+      let subordinateRuntime = JavaScriptRuntime()
+      let coreObject = subordinateRuntime.createObject()
+      coreObject.setNativeState(AppContext.NativeState(appContext: appContext, ownsLifecycle: false))
+      subordinateRuntime.global().defineProperty(globalCoreObjectPropertyName, value: coreObject, options: [.enumerable])
+
+      // Tear the subordinate runtime down.
+      try subordinateRuntime.global().getPropertyAsObject(globalCoreObjectPropertyName).unsetNativeState()
+      try subordinateRuntime.eval("gc() && gc() && gc()")
+
+      // The app context survived: its main runtime is still recoverable.
+      #expect(throws: Never.self) {
+        _ = try appContext.runtime
+      }
+    }
+
+    @Test
+    func `releasing the main runtime's native state destroys the app context`() throws {
+      let appContext = AppContext.create()
+
+      // Stand in for the main runtime: a native state installed with `ownsLifecycle: true`.
+      let mainRuntime = JavaScriptRuntime()
+      let coreObject = mainRuntime.createObject()
+      coreObject.setNativeState(AppContext.NativeState(appContext: appContext, ownsLifecycle: true))
+      mainRuntime.global().defineProperty(globalCoreObjectPropertyName, value: coreObject, options: [.enumerable])
+
+      // Tearing it down runs `destroy()`, which unpins the app context's runtime.
+      try mainRuntime.global().getPropertyAsObject(globalCoreObjectPropertyName).unsetNativeState()
+      try mainRuntime.eval("gc() && gc() && gc()")
+
+      #expect(throws: Exceptions.RuntimeLost.self) {
+        _ = try appContext.runtime
+      }
+    }
+
+    @Test
+    func `subordinate runtime teardown leaves the app context backing the main runtime intact`() throws {
+      // The exact regression `ownsLifecycle` guards against: one app context backs both a main
+      // and a subordinate runtime. The subordinate is released first and must not destroy the
+      // context; only the later main-runtime teardown does.
+      //
+      // `AppContext.create()` already installs the owning (main) native state on the app
+      // context's own runtime, mirroring `prepareRuntime`. The subordinate is attached the same
+      // way `prepareUIRuntime` would, with `ownsLifecycle: false`.
+      let appContext = AppContext.create()
+      let mainRuntime = try appContext.runtime
+
+      let subordinateRuntime = JavaScriptRuntime()
+      let subordinateCoreObject = subordinateRuntime.createObject()
+      subordinateCoreObject.setNativeState(AppContext.NativeState(appContext: appContext, ownsLifecycle: false))
+      subordinateRuntime.global().defineProperty(globalCoreObjectPropertyName, value: subordinateCoreObject, options: [.enumerable])
+
+      // Both runtimes recover the same app context while alive.
+      #expect(AppContext.from(runtime: mainRuntime) === appContext)
+      #expect(AppContext.from(runtime: subordinateRuntime) === appContext)
+
+      // Tear the subordinate down first: it must not destroy the shared app context.
+      try subordinateRuntime.global().getPropertyAsObject(globalCoreObjectPropertyName).unsetNativeState()
+      try subordinateRuntime.eval("gc() && gc() && gc()")
+
+      #expect(throws: Never.self) {
+        _ = try appContext.runtime
+      }
+      #expect(AppContext.from(runtime: mainRuntime) === appContext)
+
+      // Now tear the main runtime down: this one owns the lifecycle, so it destroys the context.
+      try mainRuntime.global().getPropertyAsObject(globalCoreObjectPropertyName).unsetNativeState()
+      try mainRuntime.eval("gc() && gc() && gc()")
+
+      #expect(throws: Exceptions.RuntimeLost.self) {
+        _ = try appContext.runtime
+      }
+    }
+
+    @Test
+    func `destroy is safe to run repeatedly`() throws {
+      // The owning runtime's deallocator calls `appContext.destroy()`; it must tolerate being
+      // called more than once (e.g. the `_runtime = nil` path plus the deallocator).
+      let appContext = AppContext.create()
+      appContext.destroy()
+      appContext.destroy()
+
+      // After destruction the runtime is unpinned and can no longer be recovered.
+      #expect(throws: Exceptions.RuntimeLost.self) {
+        _ = try appContext.runtime
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

Fixes a crash on `Updates.reloadAsync()` ([#47051](https://github.com/expo/expo/issues/47051)) where the previous `AppContext` could deallocate before the old runtime finished tearing down, releasing cached JSI objects against a dying runtime on the wrong thread.

This supersedes [#47080](https://github.com/expo/expo/pull/47080), which fixed the same crash by capturing the app context strongly in the `expo.modules` host object's `dealloc` closure. The native-state approach here ties the lifetime more directly, doubles as a runtime-only way to recover the app context, and correctly handles an app context that prepares more than one runtime.

## How

The app context is now held by an `AppContext.NativeState` attached to each runtime's `global.expo` object. Because the native state lives on the runtime's heap and is torn down only when the runtime finalizes, holding the app context strongly there defers its release (and its `destroy()` cleanup of cached JSI objects) to runtime finalization, where it's safe.

A single app context can prepare several runtimes (the main runtime and the UI/worklet runtime), each getting its own native state. Only the native state on the lifecycle-owning **main** runtime runs `destroy()` when released (`ownsLifecycle: true`); subordinate runtimes pin the context and enable recovery but must not destroy a context still backing the others when they tear down independently.

Additional changes:

- Added `AppContext.from(runtime:)`, which recovers the app context from any runtime by reading the native state off `global.expo` (cached prop name id on the lookup, since this is meant for hot paths). This lets code that only has a runtime reach the app context without capturing a reference.
- Moved the `global.expo` property name from the Objective-C `EXGlobalCoreObjectPropertyName` constant to a Swift `globalCoreObjectPropertyName`, since it had no Objective-C consumers, and dropped the `EX` prefix.
- Removed the now-redundant `destroy()` call from the `expo.modules` host object's `dealloc` closure.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-core` — the new `AppContext` / nested `NativeState` suites pass. They cover:

- recovering the app context from a prepared runtime, and `nil` for a bare runtime;
- the installed main-runtime native state owns the lifecycle, and re-installing keeps the first state (the `hasNativeState()` guard);
- the native state deallocator fires exactly once, including when attached to multiple objects;
- one app context preparing several runtimes and recovering from each;
- the regression this fix targets: with one app context backing both a main and a subordinate runtime, tearing the subordinate down first leaves the context intact, and only the later main-runtime teardown destroys it;
- `destroy()` is safe to run repeatedly.
