### PR TITLE
[core][android] Fix Compose Host disappearing before react-native-screens pop animation

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix Jetpack Compose `Host` content disappearing before a react-native-screens pop animation finishes, by deferring composition disposal to window detach while the view is still on-screen for a transition. ([#45914](https://github.com/expo/expo/issues/45914), [#47086](https://github.com/expo/expo/issues/47086) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `Record` arguments crashing with a `NullPointerException` in R8-optimized release builds when converted through the reflection fallback path. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Keep the `Record` marker interface so its consumer ProGuard rule keeps matching after R8 optimization removes empty marker interfaces. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
 - [android] Add a synchronous shadow node size update path, fixing a layout shift for `Host` `matchContents` views. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix Jetpack Compose `Host` content disappearing before a react-native-screens pop animation finishes, by deferring composition disposal to window detach while the view is still on-screen for a transition. ([#45914](https://github.com/expo/expo/issues/45914), [#47086](https://github.com/expo/expo/issues/47086) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix Jetpack Compose `Host` content disappearing before a react-native-screens pop animation finishes, by deferring composition disposal to window detach while the view is still on-screen for a transition. ([#45914](https://github.com/expo/expo/issues/45914), [#47086](https://github.com/expo/expo/issues/47086) by [@aubrey-wodonga](https://github.com/aubrey-wodonga)) ([#47099](https://github.com/expo/expo/pull/47099) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `Record` arguments crashing with a `NullPointerException` in R8-optimized release builds when converted through the reflection fallback path. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Keep the `Record` marker interface so its consumer ProGuard rule keeps matching after R8 optimization removes empty marker interfaces. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))
 - [android] Add a synchronous shadow node size update path, fixing a layout shift for `Host` `matchContents` views. ([#46604](https://github.com/expo/expo/pull/46604) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -245,7 +245,13 @@ abstract class ExpoComposeView<T : ComposeProps>(
       // registered on the Activity, which leaks this view.
       // Swapping the strategy first detaches that observer, then we dispose.
       it.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-      it.disposeComposition()
+      // If the view is still attached when RN drops it, react-native-screens is keeping it
+      // on-screen for an in-progress navigation transition (e.g. a pop). Disposing now blanks
+      // the Compose content before the animation finishes (https://github.com/expo/expo/issues/47086).
+      // Defer to DisposeOnDetachedFromWindow, which disposes once the transition removes the view.
+      if (!it.isAttachedToWindow) {
+        it.disposeComposition()
+      }
     }
   }
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -248,7 +248,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
       // If the view is still attached when RN drops it, react-native-screens is keeping it
       // on-screen for an in-progress navigation transition (e.g. a pop). Disposing now blanks
       // the Compose content before the animation finishes (https://github.com/expo/expo/issues/47086).
-      // Defer to DisposeOnDetachedFromWindow, which disposes once the transition removes the view.
+      // View eventually gets decomposed when RN screen detatches view from window
       if (!it.isAttachedToWindow) {
         it.disposeComposition()
       }


### PR DESCRIPTION
# Why

Fixes #47086. on Android, Jetpack Compose `Host` content blinks out of view before a react-native-screens **pop** animation finishes. It's a regression of #45914 (originally fixed in #45942) that was reintroduced by #46650.

# How

Added a check to `disposeComposition` which gets called when RN drops the instance. We want to preserve the composition because React Native screen still holds the instance during transition. Eventually react native screens calls detach from window which disposes the composition.


# Test Plan

Tested repro on `bare-expo` 

https://github.com/user-attachments/assets/c68b4baa-ef64-41f9-827f-660f954ed9d7



# Checklist

- [x] I added a `CHANGELOG.md` entry.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (Android native change in `expo-modules-core`; no plugin/config impact).
- [x] Conforms with the Documentation Writing Style Guide.
