### PR TITLE
[ios][core] Bind `@SharedObject` `@JS` members directly into JS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Added `Module.emit` that sends an event directly to the module's own JavaScript object, mirroring `SharedObject.emit`. Both now share an `EventEmitter` protocol. ([#46555](https://github.com/expo/expo/pull/46555) by [@tsapeta](https://github.com/tsapeta))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
 - [iOS] Added `SharedObject.native(from:)` that recovers the native shared object paired with a JavaScript object, with a generic overload that returns the concrete subclass directly. ([#47054](https://github.com/expo/expo/pull/47054) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `@SharedObject` now binds `@JS` methods, properties and the `@JS init` directly onto the class prototype, so they no longer need `Function(…)` / `Property(…)` / `Constructor { … }` definition entries. ([#47107](https://github.com/expo/expo/pull/47107) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -51,17 +51,20 @@ public final class ClassDefinition: ObjectDefinition {
 
   @JavaScriptActor
   public override func build(appContext: AppContext) throws -> JavaScriptObject {
+    // The concrete `SharedObject` subclass backing this class, used to dispatch to the
+    // `@SharedObject` macro's `_constructSharedObject` / `_decorateSharedObject` overrides.
+    let sharedObjectType = ((associatedType as? DynamicSharedObjectType)?.innerType) as? SharedObject.Type
+
     let constructorClosure: JavaScriptRuntime.SyncFunctionClosure = { [weak self, weak appContext] this, arguments in
       guard let self, let appContext else {
         throw Exceptions.AppContextLost()
       }
-      // Call the native constructor when defined. Any thrown `Exception` (which
-      // conforms to `JavaScriptThrowable`) propagates to the host function closure,
-      // which converts it to a JS `Error` preserving `message` and `code`.
-      if let constructor {
-        // Run the body natively so we can pair a returned `SharedObject` with `this`
-        // directly. `this` was created by `new` with the correct class prototype; returning
-        // a different JS object would replace `this` and drop that prototype chain.
+      // Build the native instance and pair it with `this` (returning a different object would drop
+      // the prototype chain `new` set up). Prefer the macro-synthesized `_constructSharedObject`,
+      // falling back to the DSL `Constructor` body.
+      if let sharedObject = try sharedObjectType?._constructSharedObject(this: this, arguments: arguments, in: appContext.runtime) {
+        appContext.sharedObjectRegistry.add(native: sharedObject, javaScript: this.getObject())
+      } else if let constructor {
         let result = try constructor.runBody(appContext, in: appContext.runtime, this: this, arguments: arguments)
 
         if let sharedObject = result as? SharedObject {
@@ -74,6 +77,12 @@ public final class ClassDefinition: ObjectDefinition {
     let klass = try createClass(appContext: appContext, name: name, constructorClosure).asObject()
 
     try decorate(object: klass, appContext: appContext)
+
+    // Bind the macro's `@JS` members onto the prototype.
+    if let sharedObjectType {
+      let prototype = klass.getProperty("prototype").getObject()
+      try sharedObjectType._decorateSharedObject(prototype: prototype, in: appContext.runtime)
+    }
 
     // Register the JS class and its associated native type.
     if let sharedObjectType = associatedType as? DynamicSharedObjectType {
@@ -121,6 +130,10 @@ public final class ClassDefinition: ObjectDefinition {
       if let syncFn = fn as? AnySyncFunctionDefinition {
         proto.setProperty(fn.name, value: try syncFn.build(appContext: appContext, in: runtime))
       }
+    }
+    // Bind the macro's `@JS` members, which aren't in the DSL `properties`/`functions` dictionaries.
+    if let sharedObjectType = (associatedType as? DynamicSharedObjectType)?.innerType as? SharedObject.Type {
+      try sharedObjectType._decorateSharedObject(prototype: proto, in: runtime)
     }
     return proto
   }

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -71,7 +71,7 @@ public macro Event(_ name: String? = nil, sync: Bool = false) =
 /// `expo-modules-core` calls it automatically and merges the result into the module's
 /// definition, so the user doesn't have to reference it from `definition()`. `@JS` functions are
 /// additionally bound directly into the module's JS object by a synthesized
-/// `_decorateModule(object:in:appContext:)`.
+/// `_decorateModule(object:in:)`.
 ///
 /// The module's JavaScript name is synthesized into a `_jsName` static and read by core, so there
 /// is no `Name(…)` DSL entry. It defaults to the class name; pass `@ExpoModule("CustomName")` to
@@ -100,6 +100,12 @@ public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
 /// The companion `@ExpoModule(classes: [Foo.self])` wires the class into the module's
 /// exposed surface.
 ///
+/// `@JS` methods and properties are bound directly onto the class prototype by an override of
+/// `_decorateSharedObject(prototype:in:)`, and a single `@JS init(...)` becomes an override
+/// of `_constructSharedObject(this:arguments:in:)` that builds the native instance from the
+/// JS arguments. Core calls both when building the class, so the synthesized `Class(…)` block carries
+/// no DSL entries for the `@JS` members.
+///
 /// Usage:
 ///
 ///     @SharedObject
@@ -113,7 +119,10 @@ public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
 ///       @JS
 ///       var size: Int { 42 }
 ///     }
-@attached(member, names: named(_synthesizedClassDefinition))
+@attached(
+  member,
+  names:
+    named(_synthesizedClassDefinition), named(_decorateSharedObject), named(_constructSharedObject))
 @attached(memberAttribute)
 public macro SharedObject(_ name: String? = nil) =
   #externalMacro(module: "ExpoModulesMacros", type: "SharedObjectMacro")

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -139,7 +139,7 @@ public final class ModuleHolder {
 
       // Install the `@JS` members the `@ExpoModule` macro binds directly into the JS object
       // (the direct-JSI path). A no-op for modules that don't use the macro.
-      try module._decorateModule(object: object, in: appContext.runtime, appContext: appContext)
+      try module._decorateModule(object: object, in: appContext.runtime)
 
       return object
     } catch {

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
@@ -34,7 +34,7 @@ public protocol AnyModule: AnyObject, AnyArgument {
   /// host functions are installed alongside the DSL-described surface. Framework-internal
   /// (leading underscore). Modules that don't use the macro fall back to the default no-op.
   @JavaScriptActor
-  func _decorateModule(object: borrowing JavaScriptObject, in runtime: JavaScriptRuntime, appContext: AppContext) throws
+  func _decorateModule(object: borrowing JavaScriptObject, in runtime: JavaScriptRuntime) throws
 }
 
 public extension AnyModule {
@@ -53,7 +53,7 @@ public extension AnyModule {
   }
 
   @JavaScriptActor
-  func _decorateModule(object: borrowing JavaScriptObject, in runtime: JavaScriptRuntime, appContext: AppContext) throws {
+  func _decorateModule(object: borrowing JavaScriptObject, in runtime: JavaScriptRuntime) throws {
     // No-op by default — only `@ExpoModule`-macro modules synthesize a real implementation.
   }
 }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -83,6 +83,20 @@ open class SharedObject: AnySharedObject {
   public func emit<P: AnyArgument>(event: String, arguments: sending P) {
     emit(event: event, payload: arguments)
   }
+
+  // MARK: - Macro-synthesized JSI hooks
+
+  /// Binds the class's `@JS` members onto its JavaScript prototype. Overridden by the `@SharedObject`
+  /// macro; a `class func` (not a protocol requirement) so dispatch resolves per subclass.
+  @JavaScriptActor
+  open class func _decorateSharedObject(prototype: borrowing JavaScriptObject, in runtime: JavaScriptRuntime) throws {}
+
+  /// Builds a native instance from the JS constructor arguments, or `nil` to use the DSL `Constructor`
+  /// path. Overridden by the `@SharedObject` macro from the class's `@JS init`.
+  @JavaScriptActor
+  open class func _constructSharedObject(this: JavaScriptValue, arguments: borrowing JavaScriptValuesBuffer, in runtime: JavaScriptRuntime) throws -> SharedObject? {
+    return nil
+  }
 }
 
 extension SharedObject: EventEmitter {

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroSharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroSharedObjectTests.swift
@@ -1,0 +1,269 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+
+// MARK: - Test shared object and module
+
+@Record
+private struct MacroPoint {
+  var x: Int = 0
+  var y: Int = 0
+}
+
+@SharedObject
+private final class MacroCounter: SharedObject {
+  private var value: Int
+
+  @JS
+  init(value: Int) {
+    self.value = value
+  }
+
+  @JS
+  func increment(by amount: Int) -> Int {
+    value += amount
+    return value
+  }
+
+  @JS
+  var current: Int {
+    return value
+  }
+
+  // A settable stored property.
+  @JS
+  var label: String = ""
+
+  // A `Record` argument and return.
+  @JS
+  func shift(by point: MacroPoint) -> MacroPoint {
+    value += point.x + point.y
+    return MacroPoint(x: point.x, y: value)
+  }
+
+  // A value-returning method with an omittable trailing optional, plus an optional return: omitting
+  // the argument (or passing a negative limit) returns `nil`. Exercises the arity-branched `switch`
+  // codegen for a value-returning method.
+  @JS
+  func clamp(to limit: Int? = nil) -> Int? {
+    guard let limit, limit >= 0 else {
+      return nil
+    }
+    value = min(value, limit)
+    return value
+  }
+
+  // A `SharedObject` argument and return.
+  @JS
+  func added(to other: MacroCounter) -> MacroCounter {
+    return MacroCounter(value: value + other.current)
+  }
+
+  // A throwing member.
+  @JS
+  func validate() throws {
+    throw TestCodedException()
+  }
+}
+
+@SharedObject("RenamedCounter")
+private final class MacroNamedCounter: SharedObject {
+  @JS
+  init(label: String) {}
+
+  @JS
+  func ping() -> String {
+    return "pong"
+  }
+}
+
+@ExpoModule(classes: [MacroCounter.self, MacroNamedCounter.self])
+private final class MacroSharedObjectModule: Module {}
+
+@Suite("Macro shared object")
+@JavaScriptActor
+private struct MacroSharedObjectTests {
+  let appContext: AppContext
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  init() {
+    appContext = AppContext.create()
+  }
+
+  private func register(_ module: AnyModule) {
+    // `name: nil` so module naming falls through to the macro-synthesized `_jsName`.
+    appContext.moduleRegistry.register(module: module, name: nil)
+  }
+
+  // MARK: - Class exposure
+
+  @Test
+  func `class is exposed under the module by its name`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    #expect(try runtime.eval("typeof expo.modules.MacroSharedObjectModule.MacroCounter").asString() == "function")
+  }
+
+  @Test
+  func `class name honors the @SharedObject argument`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    #expect(try runtime.eval("typeof expo.modules.MacroSharedObjectModule.RenamedCounter").asString() == "function")
+    #expect(try runtime.eval("'MacroNamedCounter' in expo.modules.MacroSharedObjectModule").asBool() == false)
+  }
+
+  // MARK: - Construction
+
+  @Test
+  func `@JS init constructs the instance from JS arguments`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(7)
+      object.current
+      """)
+    #expect(try value.asInt() == 7)
+  }
+
+  // MARK: - @JS methods
+
+  @Test
+  func `binds a @JS method on the prototype, unwrapping the receiver`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(10)
+      object.increment(5)
+      """)
+    #expect(try value.asInt() == 15)
+  }
+
+  @Test
+  func `method mutates the paired native instance across calls`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(0)
+      object.increment(1)
+      object.increment(2)
+      object.increment(3)
+      """)
+    #expect(try value.asInt() == 6)
+  }
+
+  @Test
+  func `honors the @SharedObject name override on a bound method`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    #expect(try runtime.eval("new expo.modules.MacroSharedObjectModule.RenamedCounter('x').ping()").asString() == "pong")
+  }
+
+  // MARK: - @JS properties
+
+  @Test
+  func `binds a @JS property on the prototype`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(42)
+      object.current
+      """)
+    #expect(try value.asInt() == 42)
+  }
+
+  @Test
+  func `binds a settable @JS property, decoding the assigned value`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(0)
+      object.label = 'hello'
+      object.label
+      """)
+    #expect(try value.asString() == "hello")
+  }
+
+  // MARK: - Non-primitive decode/encode
+
+  @Test
+  func `decodes and encodes a Record across a @JS method`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let result = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(10)
+      object.shift({ x: 3, y: 4 })
+      """).asObject()
+    #expect(try result.getProperty("x").asInt() == 3)
+    // value (10) + x (3) + y (4) = 17
+    #expect(try result.getProperty("y").asInt() == 17)
+  }
+
+  @Test
+  func `round-trips an optional return: value and null`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let clamped = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(100)
+      object.clamp(40)
+      """)
+    #expect(try clamped.asInt() == 40)
+
+    // A negative limit returns nil, which encodes as `null`.
+    let passthrough = try runtime.eval("object.clamp(-1)")
+    #expect(passthrough.isNull() == true)
+
+    // Omitting the trailing argument hits the arity-0 branch and returns nil.
+    let omitted = try runtime.eval("new expo.modules.MacroSharedObjectModule.MacroCounter(7).clamp()")
+    #expect(omitted.isNull() == true)
+  }
+
+  @Test
+  func `decodes and encodes another SharedObject across a @JS method`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      a = new expo.modules.MacroSharedObjectModule.MacroCounter(10)
+      b = new expo.modules.MacroSharedObjectModule.MacroCounter(5)
+      a.added(b).current
+      """)
+    #expect(try value.asInt() == 15)
+  }
+
+  // MARK: - Error propagation
+
+  @Test
+  func `a throwing @JS method surfaces a coded JS error`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+    let code = try runtime.eval(
+      """
+      object = new expo.modules.MacroSharedObjectModule.MacroCounter(0)
+      try { object.validate() } catch (error) { error.code }
+      """)
+    #expect(try code.asString() == "E_TEST_CODE")
+  }
+
+  // MARK: - Alternate-runtime prototype
+
+  @Test
+  func `buildPrototype decorates the @JS members for alternate runtimes`() throws {
+    register(MacroSharedObjectModule(appContext: appContext))
+
+    // `buildPrototype` is how a SharedObject's proxy is rebuilt in an alternate runtime (e.g. a
+    // worklet). The macro's `@JS` members aren't in the DSL `properties`/`functions`, so the
+    // prototype must be decorated via `_decorateSharedObject` here too.
+    let basePrototype = try runtime.eval("expo.SharedObject.prototype").asObject()
+    let prototype = try MacroCounter._synthesizedClassDefinition().buildPrototype(
+      in: runtime,
+      appContext: appContext,
+      basePrototype: basePrototype
+    )
+    // Read into plain values first; `#expect` can't capture the non-copyable `JavaScriptObject`.
+    let hasMethod = prototype.hasProperty("increment")
+    let hasProperty = prototype.hasProperty("current")
+    #expect(hasMethod)
+    #expect(hasProperty)
+  }
+}

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -75,7 +75,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "0.3.0",
+    "@expo/expo-modules-macros-plugin": "0.6.1",
     "expo-modules-jsi": "workspace:~56.0.7",
     "invariant": "^2.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5052,8 +5052,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.6.1
+        version: 0.6.1
       expo-modules-jsi:
         specifier: workspace:~56.0.7
         version: link:../expo-modules-jsi
@@ -7704,8 +7704,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.3.0':
-    resolution: {integrity: sha512-2tRq8kiIZTVZcI5uggh86HefQ7s++Zk5WkFFomNp4aUqyN5ownHHvj1jPEP9jWXaXjPDmWuf5SUZTGD5G6AKkg==}
+  '@expo/expo-modules-macros-plugin@0.6.1':
+    resolution: {integrity: sha512-cpsLZE4rqkc1Y3eZTkxB98jrqY1YXgetmtxFt8q89jBRmk3quRuk1BZo+VcnCSObZardjg99r1k5xijEMONFGA==}
 
   '@expo/material-symbols@0.1.1':
     resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
@@ -16703,7 +16703,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/expo-modules-macros-plugin@0.3.0': {}
+  '@expo/expo-modules-macros-plugin@0.6.1': {}
 
   '@expo/material-symbols@0.1.1': {}
 


### PR DESCRIPTION
# Why

`@SharedObject` binds its `@JS` members directly onto the class prototype (the direct-JSI path), mirroring what `@ExpoModule` does for modules. A `@SharedObject`'s `@JS` methods, properties and `@JS init` no longer need `Function(…)` / `Property(…)` / `Constructor { … }` definition entries.

# How

`expo-modules-core` consumes `@expo/expo-modules-macros-plugin` 0.6.1. The macro emits `_decorateSharedObject` (binds `@JS` methods/properties onto the prototype, recovering the per-instance receiver from `this`) and `_constructSharedObject` (builds the native instance from the JS constructor arguments) as `override class func`s.

These live on the base `SharedObject` class, **not** as `AnySharedObject` protocol requirements: every `@SharedObject` inherits the conformance from the base, which locks the witness table to the base, so a subclass's static method is never reached through protocol-witness dispatch. `class func` + `override` gives the per-subclass dispatch, and non-macro classes fall through to the base defaults.

`ClassDefinition.build()` recovers the concrete `SharedObject` subclass from the associated `DynamicSharedObjectType` and calls `_constructSharedObject` in the constructor closure and `_decorateSharedObject` on the prototype.

# Test Plan

`MacroSharedObjectTests` (run via `et native-unit-tests -p ios --packages expo-modules-core`) covers a `@SharedObject` exposed through `@ExpoModule(classes:)`:

- class exposure and the `@SharedObject("Name")` override;
- construction via `@JS init`; `@JS` method binding with per-instance native mutation across calls;
- gettable and settable `@JS` properties;
- a value-returning method with an omittable trailing optional;
- non-primitive decode/encode across `@JS` methods: `@Record`, optional return (value and `null`), and another `SharedObject`;
- a throwing `@JS` method surfacing a coded JS error.
