### PR TITLE
[app-metrics][ios] Log an internal event on memory warning

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add native-side filtering to `NetworkRequestObserver` by host and method, configurable at construction or at runtime via `setFilter`, so non-matching requests never cross into JS. ([#46775](https://github.com/expo/expo/pull/46775) by [@tsapeta](https://github.com/tsapeta))
 - Capture unhandled JavaScript errors on iOS and Android by wrapping React Native's `global.ErrorUtils` handler, recording each as an `exception` log event following OpenTelemetry's exception conventions (`exception.type`/`exception.message`/`exception.stacktrace`). Fatal errors are written to disk synchronously before the process terminates and ingested on the next launch. ([#46923](https://github.com/expo/expo/pull/46923) by [@tsapeta](https://github.com/tsapeta))
 - Add android crash reports ([#46869](https://github.com/expo/expo/pull/46869) by [@Ubax](https://github.com/Ubax))
+- Record an `expo.memory.warning` log event on iOS when the system delivers a low-memory warning, carrying the memory usage snapshot (`expo.memory.*`) taken at warning time. ([#47108](https://github.com/expo/expo/pull/47108) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix integer metric and log attributes equal to `0` or `1` serializing as booleans on iOS. ([#47108](https://github.com/expo/expo/pull/47108) by [@tsapeta](https://github.com/tsapeta))
 - fix race condition between db inserts ([#46702](https://github.com/expo/expo/pull/46702) by [@Ubax](https://github.com/Ubax))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-app-metrics/ios/Memory/MemoryMonitoring.swift
+++ b/packages/expo-app-metrics/ios/Memory/MemoryMonitoring.swift
@@ -21,7 +21,33 @@ final class MemoryMonitoring: MetricReporter, Sendable {
         lastMemoryUsageSnapshot: snapshot
       )
       reportMetrics(snapshot)
-      print(snapshot)
+      AppMetrics.mainSession.receiveLog(
+        makeMemoryWarningLogRecord(snapshot: snapshot, warningsCount: data.warningsCount))
     }
   }
+}
+
+/// Builds the internal `expo.memory.warning` log event emitted when the system delivers a low-memory
+/// warning. The memory usage snapshot taken at warning time rides as `expo.memory.*` attributes,
+/// and `expo.memory.warningsCount` carries how many warnings this session has seen so far.
+///
+/// Emitted via `receiveLog` directly rather than the JS `logEvent` path, so the SDK-reserved `expo.`
+/// event name and `expo.memory.*` attribute keys bypass the validation that would otherwise drop them.
+func makeMemoryWarningLogRecord(snapshot: MemoryUsageSnapshot, warningsCount: Int) -> LogRecord {
+  var attributes: [String: Any] = [
+    "expo.memory.allocated": snapshot.memoryFootprint,
+    "expo.memory.physical": snapshot.residentSize,
+    "expo.memory.warningsCount": warningsCount,
+  ]
+  // `freeMemory` (`os_proc_available_memory()`) counts down from the process' jetsam limit, which
+  // only exists on a real device (the simulator has no limit and always reports 0). Omit the
+  // attribute in that case rather than record a meaningless 0.
+  if snapshot.freeMemory > 0 {
+    attributes["expo.memory.available"] = snapshot.freeMemory
+  }
+  return LogRecord(
+    name: "expo.memory.warning",
+    attributes: attributes,
+    severity: .warn
+  )
 }

--- a/packages/expo-app-metrics/ios/Tests/AnyCodableTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/AnyCodableTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("AnyCodable")
+struct AnyCodableTests {
+  @Test
+  func `encodes a real boolean as a JSON boolean`() throws {
+    #expect(try encodedJSON(for: true) == "true")
+    #expect(try encodedJSON(for: false) == "false")
+  }
+
+  @Test
+  func `encodes integer 0 and 1 as numbers, not booleans`() throws {
+    // `0`/`1` boxed through Foundation become `NSNumber`, which `as? Bool` happily matches. The
+    // encoder must distinguish a genuine `Bool` from such a number so numeric attributes (e.g.
+    // `expo.memory.available` returning 0 on the simulator) don't serialize as `false`/`true`.
+    #expect(try encodedJSON(for: Int(0)) == "0")
+    #expect(try encodedJSON(for: Int(1)) == "1")
+    #expect(try encodedJSON(for: UInt(0)) == "0")
+    #expect(try encodedJSON(for: UInt(1)) == "1")
+  }
+
+  @Test
+  func `preserves numeric 0 and 1 carried as Any through Foundation bridging`() throws {
+    // Mirrors the real path: attributes live in `[String: Any]`, so the values arrive as `NSNumber`.
+    let attributes: [String: Any] = ["available": UInt(0), "warningsCount": 1]
+    let json = try encodedJSON(for: attributes)
+    #expect(json.contains("\"available\":0"))
+    #expect(json.contains("\"warningsCount\":1"))
+    #expect(!json.contains("false"))
+    #expect(!json.contains("true"))
+  }
+}
+
+private func encodedJSON<T>(for value: T) throws -> String {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+  let data = try encoder.encode(AnyCodable(value))
+  return String(decoding: data, as: UTF8.self)
+}

--- a/packages/expo-app-metrics/ios/Tests/MemoryMonitoringTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MemoryMonitoringTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("MemoryMonitoring")
+struct MemoryMonitoringTests {
+  @Test
+  func `builds an expo.memory.warning event from the snapshot`() throws {
+    let snapshot = MemoryUsageSnapshot(
+      residentSize: 200,
+      memoryFootprint: 100,
+      freeMemory: 300
+    )
+    let record = makeMemoryWarningLogRecord(snapshot: snapshot, warningsCount: 2)
+
+    #expect(record.name == "expo.memory.warning")
+    #expect(record.severity == .warn)
+
+    let attributes = try #require(record.attributes?.value as? [String: Any])
+    #expect(attributes["expo.memory.allocated"] as? UInt == 100)
+    #expect(attributes["expo.memory.physical"] as? UInt == 200)
+    #expect(attributes["expo.memory.available"] as? UInt == 300)
+    #expect(attributes["expo.memory.warningsCount"] as? Int == 2)
+  }
+
+  @Test
+  func `omits available memory when it is 0`() throws {
+    // `os_proc_available_memory()` returns 0 on the simulator (no jetsam limit), so the attribute is
+    // dropped rather than recorded as a meaningless 0.
+    let snapshot = MemoryUsageSnapshot(
+      residentSize: 200,
+      memoryFootprint: 100,
+      freeMemory: 0
+    )
+    let record = makeMemoryWarningLogRecord(snapshot: snapshot, warningsCount: 1)
+
+    let attributes = try #require(record.attributes?.value as? [String: Any])
+    #expect(attributes["expo.memory.available"] == nil)
+    #expect(attributes["expo.memory.allocated"] as? UInt == 100)
+  }
+}

--- a/packages/expo-app-metrics/ios/Utils/AnyCodable.swift
+++ b/packages/expo-app-metrics/ios/Utils/AnyCodable.swift
@@ -1,3 +1,6 @@
+import CoreFoundation
+import Foundation
+
 /// Type-erased struct that is used to encode/decode types that use `Any` which itself is not conforming to `Encodable` nor `Decodable`.
 public struct AnyCodable: Codable, Sendable {
   // Similarly, `Any` does not conform to `Sendable`, but it is safe
@@ -33,11 +36,14 @@ public struct AnyCodable: Codable, Sendable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
 
-    // `Bool` must come before the integer cases — Swift bridges `Bool` and the numeric types
+    // `Bool` must come before the integer cases. Swift bridges `Bool` and the numeric types
     // bidirectionally for `as?`, and on Objective-C runtime values, `Bool` round-trips through
-    // `NSNumber` indistinguishably from an integer. Matching `Bool` first preserves type.
+    // `NSNumber` indistinguishably from an integer. Matching `Bool` first preserves type, but the
+    // `as? Bool` cast alone isn't enough: a numeric `0`/`1` boxed as `NSNumber` also matches it, so
+    // it would serialize as `false`/`true`. Gate the `Bool` case on the value actually being a
+    // `CFBoolean` so genuine numbers fall through to the integer cases.
     switch value {
-    case let value as Bool:
+    case let value as Bool where AnyCodable.isBoolean(self.value):
       try container.encode(value)
     case let value as Int:
       try container.encode(value)
@@ -62,5 +68,15 @@ public struct AnyCodable: Codable, Sendable {
     default:
       try container.encodeNil()
     }
+  }
+
+  /// Whether the boxed value is a genuine boolean rather than a numeric `NSNumber` that merely casts
+  /// to `Bool` (any `0`/`1`). Foundation bridges both to `NSNumber`, so the only reliable test is the
+  /// underlying CoreFoundation type: real booleans are backed by `CFBoolean`.
+  private static func isBoolean(_ value: Any?) -> Bool {
+    guard let value else {
+      return false
+    }
+    return CFGetTypeID(value as CFTypeRef) == CFBooleanGetTypeID()
   }
 }


### PR DESCRIPTION
## Why

`expo-app-metrics` records a memory usage snapshot when the system delivers a low-memory warning, but it only updates an in-memory counter and reports a metric. There was no log event marking the warning itself, so consumers couldn't see *when* the app came under memory pressure or the memory state at that moment.

## How

When the system delivers a low-memory warning, `MemoryMonitoring.receivedMemoryWarning()` now emits an `expo.memory.warning` log event alongside the existing metric. The snapshot taken at warning time rides as `expo.memory.*` attributes:

- `expo.memory.allocated` — physical footprint (`phys_footprint`)
- `expo.memory.physical` — resident size
- `expo.memory.available` — free memory
- `expo.memory.warningsCount` — how many warnings this session has seen so far

It's emitted via `AppMetrics.mainSession.receiveLog(...)` directly rather than the JS `logEvent` path, so the SDK-reserved `expo.` event name and `expo.memory.*` attribute keys bypass the validation/sanitization that would otherwise drop them (that gating exists to reserve the `expo.` namespace for SDK-internal events like this one). This mirrors how the `exception` event is emitted. The stray `print(snapshot)` debug line on that path was removed.

## Test Plan

Added `MemoryMonitoringTests` (Swift Testing), which builds a `LogRecord` from a fixed `MemoryUsageSnapshot` via `makeMemoryWarningLogRecord` and asserts the event name, severity, and `expo.memory.*` attribute mapping.

```
et native-unit-tests -p ios --packages expo-app-metrics
```
