### PR TITLE
refactor(ncl): modernize the `withGradleProperties` and `withSettingsImport` plugins

### DIFF
--- a/apps/native-component-list/plugins/withGradleProperties.js
+++ b/apps/native-component-list/plugins/withGradleProperties.js
@@ -1,42 +1,24 @@
-const { withDangerousMod } = require('@expo/config-plugins');
-const assert = require('assert');
-const fs = require('fs/promises');
-const path = require('path');
+const { withGradleProperties } = require('expo/config-plugins');
 
-// Use this improve gradle builds
-module.exports = (config, options) => {
-  assert(options, 'gradle.properties must be defined');
-  return withDangerousMod(config, [
-    'android',
-    async (config) => {
-      const filePath = path.join(config.modRequest.projectRoot, 'android', 'gradle.properties');
-      const contents = await fs.readFile(filePath, 'utf-8');
-      const results = [];
-      const lines = contents.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i].trim();
-        if (line && !line.startsWith('#')) {
-          const eok = line.indexOf('=');
-          const keyName = line.slice(0, eok);
-          let value;
-          if (keyName in options) {
-            value = options[keyName];
-            delete options[keyName];
-          } else {
-            value = line.slice(eok + 1, line.length);
-          }
-          results.push(`${keyName}=${value}`);
-        } else {
-          results.push(line);
-        }
-      }
+/**
+ * Apply the `{ [key]: value }` object to the Gradle properties.
+ * This will replace the value of existing properties, or append the property definition at the end.
+ * @type {import('expo/config-plugins').ConfigPlugin<Record<string, string>>}
+ */
+module.exports = (config, options = {}) => {
+  return withGradleProperties(config, (config) => {
+    for (const [key, value] of Object.entries(options)) {
+      const idx = config.modResults.findIndex((node) => {
+        return node.type === 'property' && node.key === key;
+      });
 
-      // Add the remaining options
-      for (const [key, value] of Object.entries(options)) {
-        results.push(`${key}=${value}`);
+      if (idx < 0) {
+        config.modResults.push({ type: 'property', key, value });
+      } else {
+        config.modResults[idx].value = value;
       }
-      await fs.writeFile(filePath, results.join('\n'));
-      return config;
-    },
-  ]);
+    }
+
+    return config;
+  });
 };

--- a/apps/native-component-list/plugins/withSettingsImport.js
+++ b/apps/native-component-list/plugins/withSettingsImport.js
@@ -1,4 +1,4 @@
-const { withSettingsGradle } = require('@expo/config-plugins');
+const { withSettingsGradle } = require('expo/config-plugins');
 
 const withSettingsImport = (config, { packageName, packagePath }) => {
   return withSettingsGradle(config, (config) => {


### PR DESCRIPTION
# Why

I was looking for good examples for the `withGradleProperties` config plugin, and spotted this in NCL. Modernized it a bit so it can function as an example.

# How

- Swapped `@expo/config-plugins` for `expo/config-plugins`
- Swapped `withDangerousMod` for `withGradleProperties`
- Replace existing property node or append new property node at the end

# Test Plan

- `cd ./apps/native-component-list`
- `pnpm expo prebuild -p android`
- Run prebuild a few times, while modifying **./apps/native-component-list/app.config.js** with different values
  - There should be no duplicates
  - All changes should be reflected properly 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
