### PR TITLE
ci: Activate Turborepo remote cache for task runs

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -32,6 +32,9 @@ concurrency:
 env:
   # JS-only jobs, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
   SKIP_SKIA_DOWNLOAD: '1'
+  # Turborepo remote cache
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: expo
 
 jobs:
   check-packages:
@@ -57,11 +60,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
+
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: expo
 
       - name: 🧐 Check all packages
         if: github.event_name == 'schedule' ||
@@ -119,11 +120,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
+
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: expo
 
       - name: 🧐 Check all packages
         shell: bash


### PR DESCRIPTION
## Summary

This activates the remote cache for `sdk.yml`'s `turbo run ...` tasks, which I previously kept disabled for testing and to ensure all dependents are properly printed.

Things have gone fine, so it's time to enable this

## Set of changes

- Add global remote cache env to `sdk.yml`