### PR TITLE
docs: fix `textDirection` → `textAlign` in localization RTL text alignment section

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -327,9 +327,9 @@ return <View dir={getLocales()[0].textDirection || 'ltr'}>...</View>;
 
 ### Text alignment
 
-The React Native's `textDirection` property does not accept `start` or `end` values that you can use in flex properties. Instead, `left` effectively works as `start` (aligns to the left on LTR and the right on RTL), and `right` works as `end`.
+The React Native's `textAlign` property does not accept `start` or `end` values that you can use in flex properties. Instead, `left` effectively works as `start` (aligns to the left on LTR and the right on RTL), and `right` works as `end`.
 
-However, the default unset value of `textDirection` property signifies the actual left (aligns to the left both on LTR and RTL). This means each `<Text>` tag should have the `textDirection: left` or `textDirection: right` style set if you want it to be aligned correctly.
+However, the default unset value of `textAlign` property signifies the actual left (aligns to the left both on LTR and RTL). This means each `<Text>` tag should have the `textAlign: left` or `textAlign: right` style set if you want it to be aligned correctly.
 
 It's best to define this style in your custom reusable `<Text>` component that you can then import everywhere you need to render text strings.
 


### PR DESCRIPTION
## Why

The **Text alignment** section of the Localization guide refers to a `textDirection` style property, but the property it describes (and uses in the accompanying code samples) is `textAlign`. `textDirection` is not a React Native style prop, so the prose is incorrect and confusing.

The behavior described is correct — under RTL, `textAlign: 'left'` acts as the start edge — only the property name was wrong.

## What

In the "Text alignment" section only, rename the prose references `textDirection` → `textAlign`. The legitimate `getLocales()[0].textDirection` (locale field) and the Firefox `textDirection` browser note are left untouched.

No code/behavior change — docs only.

## Related

- Issue: #39752 (RTL behavior confusion)
- Background on the `textAlign` vs `textDirection` naming and RTL semantics: [this comment](https://github.com/expo/expo/issues/39752#issuecomment-4762160953)