### PR TITLE
[ios][dev-launcher] Make dev server discovery reliable and detect stopped servers

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -19,6 +19,8 @@
 - [iOS] Make the development server list reliable, keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found". ([#46811](https://github.com/expo/expo/pull/46811) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
+- [iOS] Keep the dev server list in sync by reconciling discovery against each server's `/status` on a fixed cadence, so a server that has stopped is removed and a missed one is recovered within a few seconds. ([#47116](https://github.com/expo/expo/pull/47116) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Match the Recently Opened "online" indicator on host and port instead of port alone, so a recent app no longer shows green just because another server is running on the same port. ([#47116](https://github.com/expo/expo/pull/47116) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -13,6 +13,11 @@ private let DEV_LAUNCHER_DEFAULT_SCHEME = "expo-dev-launcher"
 private let BONJOUR_TYPE = "_expo._tcp"
 private let networkPermissionGrantedKey = "expo.devlauncher.hasGrantedNetworkPermission"
 
+/// How often we re-resolve the currently advertised servers. Each tick re-probes
+/// every browsed endpoint's `/status`, so a server that stopped falls out of the
+/// list within one interval and a server that started is picked up just as fast.
+private let reconcileInterval: Duration = .seconds(3)
+
 enum LocalNetworkPermissionStatus: Equatable, Sendable {
   case unknown
   case checking
@@ -57,14 +62,20 @@ class DevLauncherViewModel: ObservableObject {
   @Published var isLoadingServer: Bool = false
   @Published var isLoadingLocalBundle: Bool = false
   @Published var permissionStatus: LocalNetworkPermissionStatus = .unknown
-
   @Published var devServers: [DevServer] = []
 
   private var browser: NWBrowser?
-  private var pingTask: Task<Void, Never>?
-  private var periodicRefreshTask: Task<Void, Never>?
-  private var pendingEmptyVerification = false
-  private static let refreshInterval: UInt64 = 10_000_000_000
+  private var reconcileTask: Task<Void, Never>?
+
+  /// Bumped at the start of every `reconcile()`. Reconciles can overlap (timer
+  /// tick, browse callback, pull-to-refresh), so a slower pass over a now-stale
+  /// browsed set must not publish after a newer pass has started. Each reconcile
+  /// captures this on entry and refuses to publish if it's been superseded.
+  private var reconcileGeneration = 0
+
+  /// The full set of endpoints the browser currently advertises, refreshed on
+  /// every browse callback. The reconcile loop reads this each tick.
+  private var browsedResults: [DiscoveryResult] = []
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -97,20 +108,6 @@ class DevLauncherViewModel: ObservableObject {
     loadData()
     checkAuthenticationStatus()
     checkForStoredCrashes()
-  }
-
-  private func updateDevServers(_ servers: [DevServer]) {
-    if servers.isEmpty && !devServers.isEmpty && !pendingEmptyVerification {
-      pendingEmptyVerification = true
-      stopServerDiscovery()
-      startServerDiscovery()
-      return
-    }
-    pendingEmptyVerification = false
-    if !servers.isEmpty {
-      markNetworkPermissionGranted()
-    }
-    devServers = servers.sorted(by: <)
   }
 
   private func extractPort(from url: String) -> String? {
@@ -210,66 +207,39 @@ class DevLauncherViewModel: ObservableObject {
     return runtimeVersion == structuredBuildInfo.runtimeVersion
   }
 
+  // MARK: - Dev server discovery
+  //
+  // Detection is poll-based rather than purely event-driven. `NWBrowser` only
+  // tells us when records change, and a stopped dev server often never emits an
+  // mDNS goodbye (and the simulator caches records), so the only reliable way to
+  // know a server is still up (or gone) is to keep probing its `/status`
+  // endpoint. A reconcile loop re-resolves the full browsed set on a fixed
+  // cadence: a newly started server appears within one tick, a stopped one drops
+  // out once its probe fails.
+
   func startServerDiscovery() {
-    if browser != nil {
+    // Restart unless the browser is genuinely active. A browser stuck in
+    // `.waiting`/`.failed` (e.g. after a permission grant or network change)
+    // must be recreated, otherwise discovery wedges permanently.
+    if let browser, browser.state == .ready || browser.state == .setup {
       return
     }
 
     stopServerDiscovery()
     startDevServerBrowser()
-    startPeriodicRefresh()
+    startReconcileLoop()
+  }
+
+  func stopServerDiscovery() {
+    reconcileTask?.cancel()
+    browser?.cancel()
+    reconcileTask = nil
+    browser = nil
+    browsedResults = []
   }
 
   func refreshDevServers() async {
-    await restartBrowser()
-  }
-
-  private func restartBrowser() async {
-    pingTask?.cancel()
-    browser?.cancel()
-    pingTask = nil
-    browser = nil
-    startDevServerBrowser()
-    try? await Task.sleep(nanoseconds: 3_000_000_000)
-    await pingCurrentBrowseResults()
-  }
-
-  private func pingCurrentBrowseResults() async {
-    guard let browser, !browser.browseResults.isEmpty else {
-      return
-    }
-    await pingDiscoveryResults(browser.browseResults.map { result in
-      DiscoveryResult(
-        name: NetworkUtilities.getNWBrowserResultName(result),
-        endpoint: result.endpoint
-      )
-    })
-  }
-
-  private func startPeriodicRefresh() {
-    periodicRefreshTask?.cancel()
-    periodicRefreshTask = Task { [weak self] in
-      while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: Self.refreshInterval)
-        guard !Task.isCancelled else {
-          return
-        }
-        await self?.refreshIfNeeded()
-      }
-    }
-  }
-
-  private func refreshIfNeeded() async {
-    guard let browser else {
-      return
-    }
-    if devServers.isEmpty {
-      await restartBrowser()
-    } else if browser.browseResults.isEmpty {
-      updateDevServers([])
-    } else {
-      await pingCurrentBrowseResults()
-    }
+    await reconcile()
   }
 
   func markNetworkPermissionGranted() {
@@ -281,7 +251,7 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   var hasGrantedNetworkPermission: Bool {
-    UserDefaults.standard.bool(forKey: networkPermissionGrantedKey)
+    return UserDefaults.standard.bool(forKey: networkPermissionGrantedKey)
   }
 
   func refreshPermissionStatus() {
@@ -307,7 +277,9 @@ class DevLauncherViewModel: ObservableObject {
 
       let browser = NWBrowser(for: .bonjour(type: serviceType, domain: nil), using: .tcp)
       browser.browseResultsChangedHandler = { results, _ in
-        guard !done else { return }
+        guard !done else {
+          return
+        }
         if !results.isEmpty {
           done = true
           continuation.resume(returning: true)
@@ -317,7 +289,9 @@ class DevLauncherViewModel: ObservableObject {
       }
 
       browser.stateUpdateHandler = { state in
-        guard !done else { return }
+        guard !done else {
+          return
+        }
         if case .waiting(let error) = state,
            case .dns(let dnsError) = error,
            dnsError == kDNSServiceErr_PolicyDenied {
@@ -331,7 +305,9 @@ class DevLauncherViewModel: ObservableObject {
       browser.start(queue: queue)
 
       queue.asyncAfter(deadline: .now() + 2) {
-        guard !done else { return }
+        guard !done else {
+          return
+        }
         done = true
         continuation.resume(returning: false)
         browser.cancel()
@@ -340,19 +316,7 @@ class DevLauncherViewModel: ObservableObject {
     }
   }
 
-  func stopServerDiscovery() {
-    periodicRefreshTask?.cancel()
-    pingTask?.cancel()
-    browser?.cancel()
-    periodicRefreshTask = nil
-    pingTask = nil
-    browser = nil
-  }
-
   private func startDevServerBrowser() {
-    pingTask?.cancel()
-    browser?.cancel()
-
     let params = NWParameters()
     params.includePeerToPeer = true
     params.allowLocalEndpointReuse = true
@@ -364,7 +328,9 @@ class DevLauncherViewModel: ObservableObject {
 
     browser?.stateUpdateHandler = { [weak self] state in
       Task { @MainActor [weak self] in
-        guard let self else { return }
+        guard let self else {
+          return
+        }
         switch state {
         case .waiting(let error):
           if case .dns(let dnsError) = error, dnsError == kDNSServiceErr_PolicyDenied {
@@ -381,30 +347,44 @@ class DevLauncherViewModel: ObservableObject {
     }
 
     browser?.browseResultsChangedHandler = { [weak self] results, _ in
-      guard let self else { return }
       Task { @MainActor [weak self, results] in
-        guard let self else { return }
-        self.markNetworkPermissionGranted()
-        self.pingTask?.cancel()
-        self.pingTask = Task {
-          defer { self.pingTask = nil }
-          await self.pingDiscoveryResults(results.map { result in
-            DiscoveryResult(
-              name: NetworkUtilities.getNWBrowserResultName(result),
-              endpoint: result.endpoint
-            )
-          })
+        guard let self else {
+          return
         }
+        self.markNetworkPermissionGranted()
+        // Store the full current set (not just the delta) and resolve it right
+        // away so newly advertised servers show up without waiting a tick.
+        self.browsedResults = results.map { result in
+          DiscoveryResult(
+            name: NetworkUtilities.getNWBrowserResultName(result),
+            endpoint: result.endpoint
+          )
+        }
+        await self.reconcile()
       }
     }
 
     browser?.start(queue: DispatchQueue(label: "expo.devlauncher.discovery"))
   }
 
-  private func pingDiscoveryResults(_ results: [DiscoveryResult]) async {
-    guard !Task.isCancelled else {
-      return
+  private func startReconcileLoop() {
+    reconcileTask?.cancel()
+    reconcileTask = Task { [weak self] in
+      while !Task.isCancelled {
+        await self?.reconcile()
+        try? await Task.sleep(for: reconcileInterval)
+      }
     }
+  }
+
+  /// Re-probe every advertised endpoint and publish only the ones currently
+  /// reachable. A full replace is correct here because we resolve the entire
+  /// browsed set each pass: a stopped server fails its `/status` probe and drops
+  /// out, a started one resolves and appears.
+  private func reconcile() async {
+    reconcileGeneration += 1
+    let generation = reconcileGeneration
+    let results = browsedResults
 
     var discoveredServers: [DevServer] = []
     await withTaskGroup(of: DevServer?.self) { group in
@@ -424,10 +404,13 @@ class DevLauncherViewModel: ObservableObject {
     guard !Task.isCancelled else {
       return
     }
-
-    await MainActor.run {
-      self.updateDevServers(discoveredServers)
+    // A newer reconcile started while we were probing, so its (fresher) browsed
+    // set supersedes ours. Bail rather than overwrite it with a stale list.
+    guard generation == reconcileGeneration else {
+      return
     }
+
+    updateDevServers(discoveredServers)
   }
 
   private func resolveDevServer(_ result: DiscoveryResult) async -> DevServer? {
@@ -445,6 +428,21 @@ class DevLauncherViewModel: ObservableObject {
     } catch {}
 
     return nil
+  }
+
+  private func updateDevServers(_ servers: [DevServer]) {
+    let sorted = servers.sorted(by: <)
+    // Avoid republishing an unchanged list so the view doesn't redraw every tick.
+    // `DevServer.==` compares the url alone, so compare the displayed fields too:
+    // a server can keep its url while advertising a new name (description).
+    let unchanged = sorted.count == devServers.count
+      && zip(sorted, devServers).allSatisfy { new, old in
+        new.url == old.url && new.description == old.description && new.source == old.source
+      }
+    guard !unchanged else {
+      return
+    }
+    devServers = sorted
   }
 
   func showError(_ error: EXDevLauncherAppError) {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -128,17 +128,31 @@ struct RecentlyOpenedAppRow: View {
 
   private var isServerActive: Bool {
     guard let url = URL(string: app.url),
-    let port = url.port else {
+      let host = url.host,
+      let port = url.port else {
       return false
     }
 
     return viewModel.devServers.contains { server in
       guard let serverURL = URL(string: server.url),
+        let serverHost = serverURL.host,
         let serverPort = serverURL.port else {
         return false
       }
-      return serverPort == port
+      // Match on both host and port: every Metro server defaults to port 8081,
+      // so matching on port alone marks a recent app green whenever any server
+      // is running, even one on a different machine.
+      return serverPort == port && hostsMatch(serverHost, host)
     }
+  }
+
+  private func hostsMatch(_ lhs: String, _ rhs: String) -> Bool {
+    if lhs == rhs {
+      return true
+    }
+    // Treat loopback forms as the same host.
+    let loopback: Set<String> = ["localhost", "127.0.0.1", "::1"]
+    return loopback.contains(lhs) && loopback.contains(rhs)
   }
 
   var body: some View {

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -150,7 +150,24 @@ class NetworkUtilities {
   ) async throws -> String? {
     return try await withThrowingTaskGroup(of: String?.self) { group in
       group.addTask {
-        return try await performBundlerEndpointResolution(endpoint: endpoint, queue: queue)
+        do {
+          // Prefer the interface the service was discovered on; correct on
+          // devices and multi-interface setups.
+          return try await performBundlerEndpointResolution(
+            endpoint: endpoint,
+            requiredInterface: endpoint.interface,
+            queue: queue
+          )
+        } catch {
+          // The simulator often reaches the host via NAT rather than the
+          // advertised interface, so a pinned interface never connects. Retry
+          // without the constraint before giving up.
+          return try await performBundlerEndpointResolution(
+            endpoint: endpoint,
+            requiredInterface: nil,
+            queue: queue
+          )
+        }
       }
 
       group.addTask {
@@ -166,13 +183,14 @@ class NetworkUtilities {
 
   private static func performBundlerEndpointResolution(
     endpoint: NWEndpoint,
+    requiredInterface: NWInterface?,
     queue: DispatchQueue
   ) async throws -> String? {
     let params = NWParameters.tcp
     params.includePeerToPeer = true
     params.allowLocalEndpointReuse = true
     params.preferNoProxies = true
-    params.requiredInterface = endpoint.interface
+    params.requiredInterface = requiredInterface
     params.expiredDNSBehavior = NWParameters.ExpiredDNSBehavior.allow
 
     let connection = NWConnection(to: endpoint, using: params)


### PR DESCRIPTION
# Why

While developing against a local dev server, the dev launcher's server list was unreliable. The symptoms I kept hitting:

- **A running server often didn't show up.** With a dev server running and the launcher open, the server frequently never appeared under Development Servers. Restarting the dev server would usually make it pop in, then it would go stale again.
- **A stopped server never went away.** Once a server was listed, stopping the dev server left it sitting there with a green "online" dot indefinitely. The list was effectively frozen on whatever it last showed.
- **Recently Opened showed false "online" dots.** A recently-opened app lit up green whenever *any* server was running on the same port (8081 by default), even a different machine or a stale IP from a previous session.

Root causes:

1. **Discovery was event-driven only.** It resolved servers from `NWBrowser` deltas, and recovered from a missed or flaky result through a periodic full restart that could take ~10s. A stopped dev server often never emits an mDNS goodbye (and the simulator caches records), so a dead server had nothing to evict it and the list went stale until the dev server was restarted.
2. **The Recently Opened "online" check matched on port alone**, so it couldn't tell two hosts apart.
3. **On the simulator, a discovered server sometimes failed to resolve** because the `/status` probe pinned `requiredInterface` to the advertised interface, which doesn't match the NAT path the simulator reaches the host on.

This builds on @alanjhughes's earlier reliability work in [#46811](https://github.com/expo/expo/pull/46811) (continuous lifecycle, pull-to-refresh) and supersedes its periodic-restart approach.

# How

- Replaced the event-only model with a **reconcile loop**: every 3s it re-resolves the full browsed set and probes each server's `/status`. It still resolves immediately on the browse callback so a freshly advertised server appears as soon as Bonjour reports it; a stopped one drops out when its probe fails, independent of the mDNS goodbye; a missed one is recovered within a few seconds. Overlapping reconciles (timer tick, browse callback, pull-to-refresh) are guarded by a generation counter so a slower pass can't publish a stale list over a newer one, and results are deduped by url.
- Match the Recently Opened indicator on host **and** port (with loopback equivalence).
- Retry endpoint resolution without a pinned `requiredInterface`, so simulator servers reached over NAT still resolve.

# Test Plan

On bare-expo, iOS simulator, with a dev server running:

- Open the launcher: the server appears under Development Servers with a green dot.
- Stop the dev server: it drops out of the list within a few seconds.
- Restart the dev server: it reappears.
- Run two servers for the same app on different ports: both appear and stay in sync.
- A Recently Opened entry on a different host than the running server shows gray, not green.

# Future plans

When two dev servers run for the same app (e.g. two worktrees), the rows are identical except for the port. In a monorepo even the project directory basename is the same across worktrees, so there's nothing meaningful to tell them apart. A follow-up could advertise the current **git branch** in the Bonjour TXT record (in `@expo/cli`) and show it in the launcher row (`BareExpo (main)` vs `BareExpo (sdk-57)`), with matching support on Android. That's a coordinated CLI + iOS + Android change and a (still-unstable) wire-format addition, so it's intentionally out of scope here and left for a separate PR.
