### PR TITLE
[expo-router] Fix withAnchor seeding a param-less anchor for a dynami…

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - Fix type inference for `unstable_createStandardRouterNavigator` ([#46737](https://github.com/expo/expo/pull/46737) by [@Ubax](https://github.com/Ubax))
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
-- Fix `withAnchor` navigation seeding a duplicate, param-less screen when a nested stack's only (initial) route is a dynamic route (e.g. `[userId]`). ([#XXXXX](https://github.com/expo/expo/pull/47117) by [@Elalfy74](https://github.com/Elalfy74))
+- Fix `withAnchor` navigation seeding bad anchors for dynamic routes: no longer creates a param-less duplicate when a nested stack's only (initial) route is a dynamic route (e.g. `[userId]`), and a seeded anchor nested under a dynamic segment now keeps its dynamic params. ([#47117](https://github.com/expo/expo/pull/47117) by [@Elalfy74](https://github.com/Elalfy74))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - Fix type inference for `unstable_createStandardRouterNavigator` ([#46737](https://github.com/expo/expo/pull/46737) by [@Ubax](https://github.com/Ubax))
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
+- Fix `withAnchor` navigation seeding a duplicate, param-less screen when a nested stack's only (initial) route is a dynamic route (e.g. `[userId]`). ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@Elalfy74](https://github.com/Elalfy74))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - Fix type inference for `unstable_createStandardRouterNavigator` ([#46737](https://github.com/expo/expo/pull/46737) by [@Ubax](https://github.com/Ubax))
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
-- Fix `withAnchor` navigation seeding a duplicate, param-less screen when a nested stack's only (initial) route is a dynamic route (e.g. `[userId]`). ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@Elalfy74](https://github.com/Elalfy74))
+- Fix `withAnchor` navigation seeding a duplicate, param-less screen when a nested stack's only (initial) route is a dynamic route (e.g. `[userId]`). ([#XXXXX](https://github.com/expo/expo/pull/47117) by [@Elalfy74](https://github.com/Elalfy74))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/__tests__/issues.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/issues.test.ios.tsx
@@ -257,3 +257,29 @@ it('push withAnchor still seeds the real initial route of a nested stack with mu
   expect(screen).toHavePathname('/shop');
   expect(screen.getByTestId('shop-index')).toBeVisible();
 });
+
+it('push withAnchor seeds an anchor under a dynamic segment with its dynamic params', () => {
+  // Issue #47114: when the seeded anchor lives under a dynamic segment (e.g.
+  // `[id]/index` reached via `/posts/1/details`), the anchor must carry the
+  // dynamic param, otherwise back lands on a param-less screen.
+  renderRouter({
+    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/index': () => <Text testID="home">home</Text>,
+    '(tabs)/posts/_layout': () => <Stack />,
+    '(tabs)/posts/[id]/_layout': () => <Stack />,
+    '(tabs)/posts/[id]/index': function PostDetail() {
+      const { id } = useLocalSearchParams<{ id: string }>();
+      return <Text testID="detail">id: {id}</Text>;
+    },
+    '(tabs)/posts/[id]/details': () => <Text testID="details">details</Text>,
+  });
+
+  act(() => router.push('/posts/1/details', { withAnchor: true }));
+  expect(screen.getByTestId('details')).toBeVisible();
+
+  // Back lands on the seeded anchor, which keeps the dynamic `id` param.
+  act(() => router.back());
+
+  expect(screen).toHavePathname('/posts/1');
+  expect(screen.getByTestId('detail')).toHaveTextContent('id: 1');
+});

--- a/packages/expo-router/src/__tests__/issues.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/issues.test.ios.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Text } from 'react-native';
 
-import { usePathname } from '../hooks';
+import { usePathname, useLocalSearchParams } from '../hooks';
 import { router } from '../imperative-api';
 import { Stack } from '../layouts/Stack';
 import { Tabs } from '../layouts/Tabs';
@@ -188,4 +188,72 @@ it('can navigate during first render of nested navigator', async () => {
   expect(innerLayoutMount).toHaveBeenCalledTimes(1);
   expect(innerIndexMount).toHaveBeenCalledTimes(1);
   expect(innerSecondMount).toHaveBeenCalledTimes(1);
+});
+
+it('push withAnchor into a nested stack whose only screen is a dynamic route does not create a param-less anchor', () => {
+  // Issue #47114: withAnchor used to seed a param-less duplicate of the dynamic
+  // route (its own initial route), so back landed on it instead of the parent.
+  const userMount = jest.fn();
+  renderRouter({
+    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/index': () => <Text testID="home">home</Text>,
+    '(tabs)/social/_layout': () => <Stack />,
+    '(tabs)/social/index': () => <Text testID="social-index">social</Text>,
+    '(tabs)/social/users/_layout': () => <Stack />,
+    '(tabs)/social/users/[userId]': function User() {
+      const { userId } = useLocalSearchParams<{ userId: string }>();
+      useEffect(() => {
+        userMount();
+      }, []);
+      return <Text testID="user">userId: {userId}</Text>;
+    },
+  });
+
+  act(() => router.navigate('/social'));
+  act(() => router.push('/social/users/1', { withAnchor: true }));
+
+  expect(screen).toHavePathname('/social/users/1');
+  expect(screen.getByTestId('user')).toHaveTextContent('userId: 1');
+  // Instantiated exactly once (no param-less anchor).
+  expect(userMount).toHaveBeenCalledTimes(1);
+
+  // Back returns to the parent, not a param-less [userId].
+  act(() => router.back());
+
+  expect(screen).toHavePathname('/social');
+  expect(screen.getByTestId('social-index')).toBeVisible();
+});
+
+it('push withAnchor still seeds the real initial route of a nested stack with multiple screens', () => {
+  // Issue #47114 guard: the self-anchor check must use the runtime initial route
+  // (sorted: `index` before `[id]`), so `index` is still seeded as the anchor.
+  const indexMount = jest.fn();
+  renderRouter({
+    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/index': () => <Text testID="home">home</Text>,
+    // `[id]` declared before `index`, but `index` is the runtime initial route.
+    '(tabs)/shop/_layout': () => <Stack />,
+    '(tabs)/shop/[id]': function ShopItem() {
+      return <Text testID="shop-item">{useLocalSearchParams<{ id: string }>().id}</Text>;
+    },
+    '(tabs)/shop/index': function ShopIndex() {
+      useEffect(() => {
+        indexMount();
+      }, []);
+      return <Text testID="shop-index">shop</Text>;
+    },
+  });
+
+  // Push into the fresh shop stack (still on the home tab).
+  act(() => router.push('/shop/7', { withAnchor: true }));
+
+  expect(screen).toHavePathname('/shop/7');
+  expect(screen.getByTestId('shop-item')).toHaveTextContent('7');
+  // The `index` anchor was seeded below the target.
+  expect(indexMount).toHaveBeenCalledTimes(1);
+
+  act(() => router.back());
+
+  expect(screen).toHavePathname('/shop');
+  expect(screen.getByTestId('shop-index')).toBeVisible();
 });

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -252,6 +252,49 @@ describe(getNavigateAction, () => {
     expect(params.params.params.initial).toBe(false);
   });
 
+  it('withAnchor does not set initial on a navigator whose initial route is the target (self-anchor)', () => {
+    // Issue #47114: don't anchor a route to itself; it seeds a param-less duplicate.
+    const usersRoute = {
+      name: 'users',
+      state: { routes: [{ name: '[userId]', params: { userId: '1' } }] },
+    };
+    (store.linking!.getStateFromPath as jest.Mock).mockReturnValue({ routes: [usersRoute] });
+    mockFindDivergentState.mockReturnValue({
+      actionState: { routes: [usersRoute] },
+      navigationState: {
+        key: 'nav-key',
+        type: 'stack',
+        routes: [{ key: 'root-key', name: '__root' }],
+        index: 0,
+        routeNames: ['__root'],
+        stale: false,
+      },
+      // Same object as the state above so identity matching can find it.
+      actionStateRoute: usersRoute,
+      navigationRoutes: [],
+    });
+    mockGetPayload.mockReturnValue({
+      screen: 'users',
+      params: { userId: '1', screen: '[userId]', params: { userId: '1' } },
+    });
+    // Root node maps to the top level; its only child `[userId]` is the initial route.
+    (store as any).routeNode = {
+      route: 'users',
+      initialRouteName: undefined,
+      children: [{ route: '[userId]', dynamic: [{ name: 'userId', deep: false }], children: [] }],
+    };
+
+    const result = getNavigateAction('/users/1', {}, 'PUSH', true);
+
+    const params = result!.payload.params as Record<string, any>;
+    // Initial route `[userId]` is the target, so `initial` must not be set here.
+    expect(params.initial).toBeUndefined();
+    // Deeper levels with no self-anchor keep the anchor behavior.
+    expect(params.params.initial).toBe(false);
+
+    (store as any).routeNode = undefined;
+  });
+
   it('isPreviewNavigation adds preview and no-animation params', () => {
     const isPreviewNavigation = true;
     const result = getNavigateAction(

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -1,6 +1,8 @@
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
 import { store } from './store';
 import type { LinkToOptions } from './types';
+import type { RouteNode } from '../Route';
+import type { ResultState } from '../fork/getStateFromPath';
 import { applyRedirects } from '../getRoutesRedirects';
 import { resolveHrefStringWithSegments } from '../link/href';
 import {
@@ -9,6 +11,8 @@ import {
   INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME,
   type InternalExpoRouterParams,
 } from '../navigationParams';
+import type { PartialRoute, PartialState, NavigationState } from '../react-navigation/native';
+import { sortRoutesWithInitial } from '../sortRoutes';
 import type { SingularOptions } from '../useScreens';
 
 export function getNavigateAction(
@@ -97,10 +101,25 @@ export function getNavigateAction(
      *   True: You want the initialRouteName to load.
      *   False: You do not want the initialRouteName to load.
      */
-    // Set initial on root and all nested params so anchors are loaded at every level
+    // Load anchors at every nested level, but skip levels where the navigator's
+    // initial route is the target itself: anchoring a route to itself seeds a
+    // duplicate (param-less for dynamic routes). See #47114.
+    let navigatorNode = findNavigatorNodeForRoute(state, actionStateRoute, store.routeNode);
     let currentParams = rootPayload.params;
     while (currentParams) {
-      currentParams.initial = !withAnchor;
+      const initialRouteName = getInitialRouteName(navigatorNode);
+      const isSelfAnchor =
+        initialRouteName !== undefined && initialRouteName === currentParams.screen;
+
+      if (!isSelfAnchor) {
+        currentParams.initial = !withAnchor;
+      }
+
+      // Descend into the navigator targeted by this level.
+      navigatorNode =
+        currentParams.screen != null
+          ? navigatorNode?.children.find((child) => child.route === currentParams!.screen)
+          : undefined;
       currentParams = currentParams.params;
     }
   }
@@ -123,4 +142,47 @@ export function getNavigateAction(
       singular,
     },
   };
+}
+
+/**
+ * Route tree node for the navigator containing the divergence route. The root
+ * node maps to the action state's top (`__root`) level; deeper levels descend
+ * through its children.
+ */
+function findNavigatorNodeForRoute(
+  state: ResultState | undefined,
+  actionStateRoute: PartialRoute<any> | undefined,
+  rootNode: RouteNode | null
+): RouteNode | undefined {
+  let navigatorNode: RouteNode | undefined = rootNode ?? undefined;
+  let navigatorState: PartialState<NavigationState> | undefined = state;
+  let isRoot = true;
+  while (navigatorState?.routes?.length) {
+    const route = navigatorState.routes[navigatorState.routes.length - 1]!;
+    if (!isRoot) {
+      navigatorNode = navigatorNode?.children.find((child) => child.route === route.name);
+    }
+    isRoot = false;
+    // actionStateRoute is a reference into state; identity marks the divergence.
+    if (route === actionStateRoute) {
+      break;
+    }
+    navigatorState = route.state;
+  }
+  return navigatorNode;
+}
+
+/**
+ * A navigator's effective initial route: explicit `initialRouteName`, else the
+ * runtime-sorted first child (matching `routeNames[0]`).
+ */
+function getInitialRouteName(node: RouteNode | undefined): string | undefined {
+  if (!node?.children.length) {
+    return undefined;
+  }
+  if (node.initialRouteName) {
+    return node.initialRouteName;
+  }
+  // Copy first: sort mutates.
+  return [...node.children].sort(sortRoutesWithInitial(node.initialRouteName))[0]?.route;
 }

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -462,6 +462,20 @@ export function useNavigationBuilder<
       return [undefined, state, false, undefined];
     }
 
+    // When an anchor is seeded via `initial: false`, the loose params on the
+    // navigator route (e.g. a dynamic segment like `[id]`) belong to this
+    // navigator level and must reach the seeded initial route too — otherwise it
+    // loses the dynamic param and the anchor renders empty (see #47114).
+    const looseRouteEntries =
+      route?.params?.initial === false && route?.params?.state == null
+        ? Object.entries(route.params).filter(
+            ([key]) => !['screen', 'params', 'initial', 'state'].includes(key)
+          )
+        : [];
+    const looseRouteParams = looseRouteEntries.length
+      ? Object.fromEntries(looseRouteEntries)
+      : undefined;
+
     const initialRouteParamList = routeNames.reduce<Record<string, object | undefined>>(
       (acc, curr) => {
         const { initialParams } = screens[curr]!.props;
@@ -473,9 +487,12 @@ export function useNavigationBuilder<
             : undefined;
 
         acc[curr] =
-          initialParams !== undefined || initialParamsFromParams !== undefined
+          initialParams !== undefined ||
+          initialParamsFromParams !== undefined ||
+          looseRouteParams !== undefined
             ? {
                 ...initialParams,
+                ...looseRouteParams,
                 ...initialParamsFromParams,
               }
             : undefined;


### PR DESCRIPTION
Why

Fixes #47114. Pushing withAnchor into a nested stack whose only screen is a dynamic route (e.g. [userId]) instantiated the route twice — once param-less as an anchor, once with params — so Back landed on the empty screen instead of the parent.

While fixing it, a closely related case surfaced: pushing withAnchor to a route nested under a dynamic segment (e.g. /posts/1/details, where posts/[id]/index is the anchor) seeded the anchor without the dynamic param, so Back landed on a param-less /posts/1.

How

withAnchor set initial: false on every nested level, making React Navigation seed each navigator's initial route as an anchor. Two problems followed:

Self-anchor (the param-less duplicate). When a navigator's initial route is the same (dynamic) route being navigated to, the seeded anchor is a param-less duplicate. The fix resolves each navigator's effective initial route (explicit initialRouteName, else the runtime-sorted first child via sortRoutesWithInitial, matching routeNames[0]) and skips initial: false for such self-anchor levels — mirroring the rule findInitialRoute already applies in getStateFromPath. Legitimate anchors (a distinct initial route, e.g. index in an index + [id] stack) are still seeded.
Anchors under a dynamic segment lost their params. When an anchor is seeded (initial: false), React Navigation's getInitialState only copies params to the navigated screen, so a seeded anchor under a dynamic segment (e.g. [id]) never received the dynamic param. useNavigationBuilder now propagates the navigator route's loose path params (everything except the reserved screen/params/initial/state keys) to the seeded initial route. This is narrowly gated to the initial: false seeding path, so normal navigation is unaffected.
Test Plan

Added regression tests in issues.test.ios.tsx:

Reproduces #47114 — a dynamic-only nested stack pushed with withAnchor instantiates the screen exactly once and Back returns to the parent.
Guard — a multi-screen stack ([id] declared before index) still seeds its real runtime initial route (index) as the anchor.
A seeded anchor nested under a dynamic segment (/posts/1/details) keeps its dynamic param, so Back lands on /posts/1 with id intact.
Plus a unit test in getNavigationAction.test.ios.ts for the self-anchor skip.

pnpm test, pnpm build:lib, and pnpm lint pass.