### PR TITLE
[docs] Note how to present a bottom sheet over another on iOS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -169,6 +169,8 @@ This difference is intentional. `@gorhom/bottom-sheet` owns the gesture and anim
 | Pan down to close      | Also enables back button and scrim tap dismiss | Also enables backdrop tap dismiss | Enables drawer dismiss        |
 | Persistent inline peek | Not supported                                  | Not supported                     | Not supported                 |
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Supported exports
 
 | Export                     | Supported   | Notes                                                     |

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -22,6 +22,8 @@ Expo UI BottomSheet matches the official SwiftUI [sheet API](<https://developer.
   alt="A BottomSheet at medium detent showing a Sort By list with Most Recent selected"
 />
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/bottomsheet.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 A modal sheet that slides up from the bottom of the screen. The sheet's visibility is controlled — toggle [`isPresented`](#ispresented) from React state and dismiss it from [`onDismiss`](#ondismiss) (called when the user swipes down or taps the overlay).
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -169,6 +169,8 @@ This difference is intentional. `@gorhom/bottom-sheet` owns the gesture and anim
 | Pan down to close      | Also enables back button and scrim tap dismiss | Also enables backdrop tap dismiss | Enables drawer dismiss        |
 | Persistent inline peek | Not supported                                  | Not supported                     | Not supported                 |
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Supported exports
 
 | Export                     | Supported   | Notes                                                     |

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
@@ -22,6 +22,8 @@ Expo UI BottomSheet matches the official SwiftUI [sheet API](<https://developer.
   alt="A BottomSheet at medium detent showing a Sort By list with Most Recent selected"
 />
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/bottomsheet.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 A modal sheet that slides up from the bottom of the screen. The sheet's visibility is controlled — toggle [`isPresented`](#ispresented) from React state and dismiss it from [`onDismiss`](#ondismiss) (called when the user swipes down or taps the overlay).
 
+> **info** On iOS, to show a bottom sheet on top of another, nest the second `BottomSheet` inside the first sheet's content rather than beside it. This is a limitation of the underlying SwiftUI [`sheet`](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) modifier. See [how to present multiple sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets) for more information.
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

Closes [#47122](https://github.com/expo/expo/issues/47122).


# How

Adds a note for nested bottomsheet on iOS


# Checklist

- [x] Documentation change only; no `CHANGELOG.md` entry or package rebuild required.
- [x] Note added to both unversioned and SDK 56 docs.
- [ ] Follows the [Expo Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
