### PR TITLE
[docs] Use async render in unit testing examples for RNTL 14

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -235,8 +235,8 @@ import { render } from '@testing-library/react-native';
 import HomeScreen, { CustomText } from '@/app/index';
 
 describe('<HomeScreen />', () => {
-  test('Text renders correctly on HomeScreen', () => {
-    const { getByText } = render(<HomeScreen />);
+  test('Text renders correctly on HomeScreen', async () => {
+    const { getByText } = await render(<HomeScreen />);
 
     getByText('Welcome!');
   });
@@ -303,8 +303,8 @@ To add a snapshot test for `<HomeScreen />`, add the following code snippet in t
 describe('<HomeScreen />', () => {
   /* @hide ... */ /* @end */
 
-  test('CustomText renders correctly', () => {
-    const tree = render(<CustomText>Some text</CustomText>).toJSON();
+  test('CustomText renders correctly', async () => {
+    const tree = (await render(<CustomText>Some text</CustomText>)).toJSON();
 
     expect(tree).toMatchSnapshot();
   });


### PR DESCRIPTION
# Why

The unit testing guide's examples call `render()` from `@testing-library/react-native` synchronously. As of React Native Testing Library v14, `render`, `rerender` and `unmount` are **async** (they return a `Promise`) to support React 19's concurrent rendering.

Running the documented examples as-is against RNTL ≥14 fails: the queries run before the component is committed, and the snapshot example calls `.toJSON()` on the returned Promise.

# What

- Mark the `test` callbacks `async` and `await render(...)`.
- Snapshot example: wrap the awaited result before `.toJSON()` → `(await render(...)).toJSON()`.

# Test Plan

Verified against `@testing-library/react-native@14.0.0`, whose `render` type signature is `render<T>(...): Promise<{ ... }>`. The awaited examples pass; the previous synchronous form throws.

Docs-only change.

# Evidence
<img width="829" height="425" alt="image" src="https://github.com/user-attachments/assets/7bfe7cb8-10b0-4341-9ae6-f459f0026585" />

