### PR TITLE
[docs] Use async renderHook in mocking example for RNTL 14

### DIFF
--- a/docs/pages/modules/mocking.mdx
+++ b/docs/pages/modules/mocking.mdx
@@ -130,18 +130,18 @@ jest.mock('../ExpoMyModule', () => ({
 }));
 
 describe('useMyHook', () => {
-  it('calls native methods on mount and unmount', () => {
-    const hook = renderHook(useMyHook);
+  it('calls native methods on mount and unmount', async () => {
+    const hook = await renderHook(useMyHook);
     expect(ExpoMyModule.startOperation).toHaveBeenCalledTimes(1);
 
-    hook.unmount();
+    await hook.unmount();
     expect(ExpoMyModule.stopOperation).toHaveBeenCalledTimes(1);
   });
 
-  it('handles parameter changes', () => {
-    const hook = renderHook(useMyHook, { initialProps: 'param1' });
+  it('handles parameter changes', async () => {
+    const hook = await renderHook(useMyHook, { initialProps: 'param1' });
 
-    hook.rerender('param2');
+    await hook.rerender('param2');
 
     expect(ExpoMyModule.startOperation).toHaveBeenCalledTimes(2);
     expect(ExpoMyModule.stopOperation).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Why

Follow-up https://github.com/expo/expo/pull/47125

As of React Native Testing Library v14, `renderHook` (and its returned `rerender` and `unmount`) are async and return Promises, so the synchronous example in the native module mocking guide breaks against RNTL >= 14.

# How

In `mocking.mdx`, mark the `it` callbacks `async` and `await` the `renderHook`, `hook.rerender`, and `hook.unmount` calls.

# Test Plan

Run the "Testing React hooks with native modules" example against `@testing-library/react-native@14`; the awaited form passes where the previous synchronous form threw.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).