### PR TITLE
chore(ncl): Disable `import/*` rules

### DIFF
--- a/apps/native-component-list/.eslintrc.js
+++ b/apps/native-component-list/.eslintrc.js
@@ -3,6 +3,12 @@ module.exports = {
   extends: ['universe/native'],
   env: { browser: true },
   rules: {
+    // TODO(@kitten): Disable in universe in general; redundant with TypeScript
+    'import/default': 'off',
+    'import/export': 'off',
+    'import/named': 'off',
+    'import/namespace': 'off',
+    'import/no-duplicates': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
The rules here are redundant and where also disabled for `test-suite`. For now, we're not modifying the `eslint-*` packages since (a) they'll be replaced with oxlint in this repo, (b) this would eventually affect other expo repos.

Small note: These rules really shouldn't have ever been active on `*.ts` / `*.tsx` files, but it's too late to check overrides now most likely, and a refactor would be a waste of time if we're replacing eslint