### PR TITLE
[dev-launcher] Add auto launch setting

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4098,7 +4098,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: e355eb94d3f8b7f4c08531a4d42af958d36c13de
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4738,7 +4738,7 @@ SPEC CHECKSUMS:
   ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
   ExpoMailComposer: ea650b89d3b93c7a277b11a8ab7010a7be6d595e
   ExpoMediaLibrary: 5ab82b8ace3f9ab7ac4ca3b2060bd915a4f1568f
-  ExpoModulesCore: 00076ada6b1f6abf05088c211487ef0bbe68ef19
+  ExpoModulesCore: de17e78667c61062bfe6fad1e0d1997f6bb5eed4
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesTestCore: 768a9a2b0401e87090bc7280cdb0607ab4cad382
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
@@ -4782,7 +4782,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: d5c6d584ad5c5461ad9e34e0afb5d40d56e428f5
+  hermes-engine: 42f0ed2cf70592b35e2ca49a6b725d31c8ad4136
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add a Settings toggle to switch between auto-launching the most recent app and showing the launcher.
+- Add a Settings toggle to switch between auto-launching the most recent app and showing the launcher. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 
@@ -21,7 +21,7 @@
 - [iOS] Make the development server list reliable, keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found". ([#46811](https://github.com/expo/expo/pull/46811) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
-- [Android] Fix auto-launching into the most recently opened project on startup.
+- [Android] Fix auto-launching into the most recently opened project on startup. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add a Settings toggle to switch between auto-launching the most recent app and showing the launcher.
+
 ### 🐛 Bug fixes
 
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
@@ -19,6 +21,7 @@
 - [iOS] Make the development server list reliable, keep discovery running across tab switches, periodically re-verify discovered servers, add pull-to-refresh on the Home tab, and show a searching state instead of "No development servers found". ([#46811](https://github.com/expo/expo/pull/46811) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
+- [Android] Fix auto-launching into the most recently opened project on startup.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -317,10 +317,21 @@ class DevLauncherController private constructor(
         return@let
       }
 
-      val shouldTryToLaunchLastOpenedBundle = getMetadataValue(context, "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE", "true").toBoolean()
+      val shouldTryToLaunchLastOpenedBundle =
+        DependencyInjection.devMenuPreferences?.tryToLaunchLastBundle ?: true
       val lastOpenedApp = recentlyOpedAppsRegistry.getMostRecentApp()
       if (shouldTryToLaunchLastOpenedBundle && lastOpenedApp != null) {
-        launchDefaultUrlOrNavigateToLauncher(coroutineScope, defaultLaunchUrl, activityToBeInvalidated)
+        coroutineScope.launch {
+          try {
+            loadApp(lastOpenedApp.url.toUri(), activityToBeInvalidated)
+          } catch (_: Throwable) {
+            if (useDefaultLaunchUrlFallback) {
+              launchDefaultUrlOrNavigateToLauncher(coroutineScope, defaultLaunchUrl, activityToBeInvalidated)
+            } else {
+              navigateToLauncher()
+            }
+          }
+        }
         return true
       }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import expo.modules.devmenu.DevMenuPreferences
 
 data class SettingsState(
   val showMenuAtLaunch: Boolean = false,
+  val autoLaunchMostRecent: Boolean = true,
   val isShakeEnable: Boolean = true,
   val isThreeFingerLongPressEnable: Boolean = true,
   val isKeyCommandEnabled: Boolean = true,
@@ -23,6 +24,7 @@ data class SettingsState(
 
 sealed interface SettingsAction {
   data class ToggleShowMenuAtLaunch(val newValue: Boolean) : SettingsAction
+  data class ToggleAutoLaunchMostRecent(val newValue: Boolean) : SettingsAction
   data class ToggleShakeEnable(val newValue: Boolean) : SettingsAction
   data class ToggleThreeFingerLongPressEnable(val newValue: Boolean) : SettingsAction
   data class ToggleKeyCommandEnable(val newValue: Boolean) : SettingsAction
@@ -40,6 +42,7 @@ class SettingsViewModel : ViewModel() {
   private val _state = mutableStateOf(
     SettingsState(
       showMenuAtLaunch = menuPreferences.showsAtLaunch,
+      autoLaunchMostRecent = menuPreferences.tryToLaunchLastBundle,
       isShakeEnable = menuPreferences.motionGestureEnabled,
       isThreeFingerLongPressEnable = menuPreferences.touchGestureEnabled,
       isKeyCommandEnabled = menuPreferences.keyCommandsEnabled,
@@ -57,6 +60,7 @@ class SettingsViewModel : ViewModel() {
   private val menuListener = {
     _state.value = _state.value.copy(
       showMenuAtLaunch = menuPreferences.showsAtLaunch,
+      autoLaunchMostRecent = menuPreferences.tryToLaunchLastBundle,
       isShakeEnable = menuPreferences.motionGestureEnabled,
       isThreeFingerLongPressEnable = menuPreferences.touchGestureEnabled,
       isKeyCommandEnabled = menuPreferences.keyCommandsEnabled,
@@ -86,6 +90,7 @@ class SettingsViewModel : ViewModel() {
   fun onAction(action: SettingsAction) {
     when (action) {
       is SettingsAction.ToggleShowMenuAtLaunch -> menuPreferences.showsAtLaunch = action.newValue
+      is SettingsAction.ToggleAutoLaunchMostRecent -> menuPreferences.tryToLaunchLastBundle = action.newValue
       is SettingsAction.ToggleShakeEnable -> menuPreferences.motionGestureEnabled = action.newValue
       is SettingsAction.ToggleThreeFingerLongPressEnable -> menuPreferences.touchGestureEnabled = action.newValue
       is SettingsAction.ToggleKeyCommandEnable -> menuPreferences.keyCommandsEnabled = action.newValue

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
@@ -72,25 +72,7 @@ fun SettingsScreen(
       )
     }
 
-    NewMenuButton(
-      icon = {
-        LauncherIcons.ShowAtLaunch(
-          size = 20.dp,
-          tint = NewAppTheme.colors.icon.tertiary
-        )
-      },
-      content = {
-        NewText(
-          text = "Show menu at launch"
-        )
-      },
-      rightComponent = {
-        ToggleSwitch(
-          isToggled = state.showMenuAtLaunch
-        )
-      },
-      onClick = { onAction(SettingsAction.ToggleShowMenuAtLaunch(!state.showMenuAtLaunch)) }
-    )
+    LaunchBehaviourSection(state, onAction)
 
     Spacer(NewAppTheme.spacing.`6`)
 
@@ -128,6 +110,66 @@ fun SettingsScreen(
       runtimeVersion = (info as? ApplicationInfo.Updates)?.runtimeVersion,
       fullDataProvider = { info?.toJson() ?: "No application info available" }
     )
+  }
+}
+
+@Composable
+private fun LaunchBehaviourSection(state: SettingsState, onAction: (SettingsAction) -> Unit) {
+  Column(
+    verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`3`)
+  ) {
+    Section.Header("LAUNCH BEHAVIOUR")
+
+    RoundedSurface {
+      Column {
+        NewMenuButton(
+          withSurface = false,
+          icon = {
+            LauncherIcons.ShowAtLaunch(
+              size = 20.dp,
+              tint = NewAppTheme.colors.icon.tertiary
+            )
+          },
+          content = {
+            NewText(
+              text = "Show menu at launch"
+            )
+          },
+          rightComponent = {
+            ToggleSwitch(
+              isToggled = state.showMenuAtLaunch
+            )
+          },
+          onClick = { onAction(SettingsAction.ToggleShowMenuAtLaunch(!state.showMenuAtLaunch)) }
+        )
+
+        Divider(
+          thickness = 0.5.dp,
+          color = NewAppTheme.colors.border.default
+        )
+
+        NewMenuButton(
+          withSurface = false,
+          icon = {
+            LauncherIcons.ShowAtLaunch(
+              size = 20.dp,
+              tint = NewAppTheme.colors.icon.tertiary
+            )
+          },
+          content = {
+            NewText(
+              text = "Auto-launch most recent app"
+            )
+          },
+          rightComponent = {
+            ToggleSwitch(
+              isToggled = state.autoLaunchMostRecent
+            )
+          },
+          onClick = { onAction(SettingsAction.ToggleAutoLaunchMostRecent(!state.autoLaunchMostRecent)) }
+        )
+      }
+    }
   }
 }
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -235,8 +235,10 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     return;
   }
 
-  NSNumber *devClientTryToLaunchLastBundleValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
-  BOOL shouldTryToLaunchLastOpenedBundle = (devClientTryToLaunchLastBundleValue != nil) ? [devClientTryToLaunchLastBundleValue boolValue] : YES;
+  // A runtime preference set in Settings overrides the build-time default from the config plugin.
+  id tryToLaunchLastBundleValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"EXDevLauncherTryToLaunchLastBundle"]
+    ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
+  BOOL shouldTryToLaunchLastOpenedBundle = tryToLaunchLastBundleValue ? [tryToLaunchLastBundleValue boolValue] : YES;
   BOOL useDefaultLaunchUrlFallback = self.useDefaultLaunchUrlFallback;
 
   if (!hasGrantedNetworkPermission) {

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -90,6 +90,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     self.defaultLaunchURLString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_DEFAULT_LAUNCHER_URL"];
     self.useDefaultLaunchUrlFallback = self.defaultLaunchURLString.length != 0;
     self.defaultLaunchURL = [NSURL URLWithString:self.defaultLaunchURLString];
+
+    NSNumber *tryToLaunchLastBundle = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+      @"EXDevLauncherTryToLaunchLastBundle": tryToLaunchLastBundle ?: @YES
+    }];
   }
   return self;
 }
@@ -235,10 +240,8 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     return;
   }
 
-  // A runtime preference set in Settings overrides the build-time default from the config plugin.
-  id tryToLaunchLastBundleValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"EXDevLauncherTryToLaunchLastBundle"]
-    ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
-  BOOL shouldTryToLaunchLastOpenedBundle = tryToLaunchLastBundleValue ? [tryToLaunchLastBundleValue boolValue] : YES;
+  // Default registered from the config plugin in init; the Settings toggle overrides it.
+  BOOL shouldTryToLaunchLastOpenedBundle = [[NSUserDefaults standardUserDefaults] boolForKey:@"EXDevLauncherTryToLaunchLastBundle"];
   BOOL useDefaultLaunchUrlFallback = self.useDefaultLaunchUrlFallback;
 
   if (!hasGrantedNetworkPermission) {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -50,6 +50,11 @@ class DevLauncherViewModel: ObservableObject {
       DevMenuManager.shared.setShowsAtLaunch(showOnLaunch)
     }
   }
+  @Published var autoLaunchMostRecent = true {
+    didSet {
+      UserDefaults.standard.set(autoLaunchMostRecent, forKey: "EXDevLauncherTryToLaunchLastBundle")
+    }
+  }
   @Published var isAuthenticated = false
   @Published var isAuthenticating = false
   @Published var user: User?
@@ -482,6 +487,8 @@ class DevLauncherViewModel: ObservableObject {
     shakeDevice = defaults.object(forKey: "EXDevMenuMotionGestureEnabled") as? Bool ?? true
     threeFingerLongPress = defaults.object(forKey: "EXDevMenuTouchGestureEnabled") as? Bool ?? true
     showOnLaunch = defaults.object(forKey: "EXDevMenuShowsAtLaunch") as? Bool ?? false
+    let tryToLaunchLastBundleDefault = Bundle.main.object(forInfoDictionaryKey: "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE") as? Bool ?? true
+    autoLaunchMostRecent = defaults.object(forKey: "EXDevLauncherTryToLaunchLastBundle") as? Bool ?? tryToLaunchLastBundleDefault
   }
 
   private func checkAuthenticationStatus() {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -484,11 +484,10 @@ class DevLauncherViewModel: ObservableObject {
   private func loadMenuPreferences() {
     let defaults = UserDefaults.standard
 
-    shakeDevice = defaults.object(forKey: "EXDevMenuMotionGestureEnabled") as? Bool ?? true
-    threeFingerLongPress = defaults.object(forKey: "EXDevMenuTouchGestureEnabled") as? Bool ?? true
-    showOnLaunch = defaults.object(forKey: "EXDevMenuShowsAtLaunch") as? Bool ?? false
-    let tryToLaunchLastBundleDefault = Bundle.main.object(forInfoDictionaryKey: "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE") as? Bool ?? true
-    autoLaunchMostRecent = defaults.object(forKey: "EXDevLauncherTryToLaunchLastBundle") as? Bool ?? tryToLaunchLastBundleDefault
+    shakeDevice = defaults.bool(forKey: "EXDevMenuMotionGestureEnabled")
+    threeFingerLongPress = defaults.bool(forKey: "EXDevMenuTouchGestureEnabled")
+    showOnLaunch = defaults.bool(forKey: "EXDevMenuShowsAtLaunch")
+    autoLaunchMostRecent = defaults.bool(forKey: "EXDevLauncherTryToLaunchLastBundle")
   }
 
   private func checkAuthenticationStatus() {

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -33,7 +33,7 @@ struct SettingsTabView: View {
       VStack(alignment: .leading, spacing: 24) {
         SafeAreaTopPadding(manualInset: viewModel.topSafeAreaInset)
         titleSection
-        showMenuAtLaunch
+        launchBehaviour
         gestures
 
         Text(selectedGesturesInfoMessage)
@@ -82,17 +82,40 @@ struct SettingsTabView: View {
     #endif
   }
 
-  private var showMenuAtLaunch: some View {
-    HStack {
-      Image("show-menu-at-launch", bundle: getDevLauncherBundle())
-        .resizable()
-        .frame(width: 24, height: 24)
-        .opacity(0.6)
-      Toggle("Show menu at launch", isOn: $viewModel.showOnLaunch)
+  private var launchBehaviour: some View {
+    VStack(alignment: .leading) {
+      Text("Launch behaviour".uppercased())
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
+      VStack(spacing: 0) {
+        HStack {
+          Image("show-menu-at-launch", bundle: getDevLauncherBundle())
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 24, height: 24)
+            .opacity(0.6)
+          Toggle("Show menu at launch", isOn: $viewModel.showOnLaunch)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+
+        Divider()
+
+        HStack {
+          Image(systemName: "arrow.trianglehead.clockwise.rotate.90")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 24, height: 24)
+            .opacity(0.6)
+          Toggle("Auto-launch most recent app", isOn: $viewModel.autoLaunchMostRecent)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+      }
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
     }
-    .padding()
-    .background(Color.expoSecondarySystemBackground)
-    .cornerRadius(12)
   }
 
   private var titleSection: some View {

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add Components section to swap the active AppRegistry component ([#46613](https://github.com/expo/expo/pull/46613) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add a `tryToLaunchLastBundle` preference backing the dev launcher auto-launch toggle.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add Components section to swap the active AppRegistry component ([#46613](https://github.com/expo/expo/pull/46613) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add a `tryToLaunchLastBundle` preference backing the dev launcher auto-launch toggle.
+- Add a `tryToLaunchLastBundle` preference backing the dev launcher auto-launch toggle. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -49,6 +49,11 @@ interface DevMenuPreferences {
    * Whether to show a floating action button that pulls up the DevMenu at launch.
    */
   var showFab: Boolean
+
+  /**
+   * Whether to try to launch the most recently opened project at startup instead of showing the launcher.
+   */
+  var tryToLaunchLastBundle: Boolean
 }
 
 class DevMenuDefaultPreferences(
@@ -68,6 +73,7 @@ class DevMenuDefaultPreferences(
   private val fabDefault = metaDataBool("EXDevMenuShowFloatingActionButton", true)
   private val showsAtLaunchDefault = metaDataBool("EXDevMenuShowsAtLaunch", true)
   private val isOnboardingFinishedDefault = metaDataBool("EXDevMenuIsOnboardingFinished", false)
+  private val tryToLaunchLastBundleDefault = metaDataBool("DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE", true)
 
   private val listeners = mutableListOf<() -> Unit>()
 
@@ -108,4 +114,7 @@ class DevMenuDefaultPreferences(
 
   override var showFab: Boolean
     by preferences(sharedPreferences, fabDefault)
+
+  override var tryToLaunchLastBundle: Boolean
+    by preferences(sharedPreferences, tryToLaunchLastBundleDefault)
 }


### PR DESCRIPTION
# Why
Add an option to set the auto launch behaviour from the settings tab

# How
Same as we do for "show menu at launch"

# Test Plan
Bare expo

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 - 2026-06-22 at 10 42 56" src="https://github.com/user-attachments/assets/a58cc42b-3c38-4a13-a43c-ddab7c252180" />
<img width="450" height="1004" alt="Screenshot_1782120066" src="https://github.com/user-attachments/assets/8787f634-69d7-429b-a495-27fbaddc7edf" />
