### PR TITLE
chore(expo-test-runner): Drop `node-fetch`

### DIFF
--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@types/node": "^22.14.0",
-    "@types/node-fetch": "^2.5.12",
     "eslint-config-universe": "workspace:*",
     "expo-module-scripts": "workspace:*"
   },
@@ -38,7 +37,7 @@
     "chalk": "^4.1.2",
     "commander": "^7.2.0",
     "dot": "^2.0.0-beta.1",
-    "node-fetch": "^2.6.1",
+    "fetch-nodeshim": "^0.4.10",
     "temp-dir": "~2.0.0",
     "unique-string": "~2.0.0"
   }

--- a/packages/expo-test-runner/src/BundlerController.ts
+++ b/packages/expo-test-runner/src/BundlerController.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process';
 import { spawn } from 'child_process';
-import fetch from 'node-fetch';
+import fetch from 'fetch-nodeshim';
 
 import { delay } from './Utils';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5809,9 +5809,9 @@ importers:
       dot:
         specifier: ^2.0.0-beta.1
         version: 2.0.0-beta.1
-      node-fetch:
-        specifier: ^2.6.1
-        version: 2.7.0(encoding@0.1.13)
+      fetch-nodeshim:
+        specifier: ^0.4.10
+        version: 0.4.10
       temp-dir:
         specifier: ~2.0.0
         version: 2.0.0
@@ -5825,9 +5825,6 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.15
-      '@types/node-fetch':
-        specifier: ^2.5.12
-        version: 2.6.13
       eslint-config-universe:
         specifier: workspace:*
         version: link:../eslint-config-universe


### PR DESCRIPTION
## Summary

Drop `node-fetch`. This is temporarily replaced with `fetch-nodeshim` until we're sure dropping support for Node 20 (and below) is fine. Currently, I don't have enough context on this package to know whether that's desirable.

If it is, we can drop `fetch-nodeshim`.

## Set of changes

- Drop `node-fetch` and replace with `fetch-nodeshim`