### PR TITLE
[core][Android] Share a single precompiled header across native targets

### DIFF
--- a/packages/expo-modules-core/android/cmake/common.cmake
+++ b/packages/expo-modules-core/android/cmake/common.cmake
@@ -1,10 +1,5 @@
 add_library(EXPO_COMMON INTERFACE)
 
-target_precompile_headers(
-  EXPO_COMMON
-  INTERFACE
-  ${CMAKE_SOURCE_DIR}/src/main/cpp/ExpoHeader.pch
-)
 
 target_compile_options(
   EXPO_COMMON
@@ -35,3 +30,33 @@ target_link_libraries(
 function(use_expo_common target_name)
   target_link_libraries(${target_name} PRIVATE EXPO_COMMON)
 endfunction()
+
+add_library(
+  expo-modules-pch
+  STATIC
+  EXCLUDE_FROM_ALL
+  ${CMAKE_SOURCE_DIR}/src/main/cpp/pch/ExpoHeaderPchOwner.cpp
+)
+
+use_expo_common(expo-modules-pch)
+
+# The PCH includes `react/jni/*` headers.
+target_include_directories(
+  expo-modules-pch
+  PRIVATE
+  "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni"
+)
+
+target_precompile_headers(
+  expo-modules-pch
+  PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/main/cpp/ExpoHeader.pch
+)
+
+# Drop the timestamp embedded in the .pch so it stays bit-for-bit stable across
+# rebuilds. Without this, the PCH timestamp changes every build and ccache can't reuse it.
+target_compile_options(
+  expo-modules-pch
+  PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>"
+)

--- a/packages/expo-modules-core/android/cmake/jsi.cmake
+++ b/packages/expo-modules-core/android/cmake/jsi.cmake
@@ -10,6 +10,8 @@ add_library(
 
 use_expo_common(expo-modules-jsi)
 
+target_precompile_headers(expo-modules-jsi REUSE_FROM expo-modules-pch)
+
 target_include_directories(
   expo-modules-jsi
   PUBLIC

--- a/packages/expo-modules-core/android/cmake/main.cmake
+++ b/packages/expo-modules-core/android/cmake/main.cmake
@@ -27,6 +27,8 @@ add_library(
 
 use_expo_common(expo-modules-core)
 
+target_precompile_headers(expo-modules-core REUSE_FROM expo-modules-pch)
+
 target_include_directories(
   expo-modules-core
   PRIVATE

--- a/packages/expo-modules-core/android/cmake/worklets.cmake
+++ b/packages/expo-modules-core/android/cmake/worklets.cmake
@@ -14,6 +14,8 @@ add_library(
 
 use_expo_common(expo-modules-worklets)
 
+target_precompile_headers(expo-modules-worklets REUSE_FROM expo-modules-pch)
+
 target_include_directories(
   expo-modules-worklets
   PRIVATE

--- a/packages/expo-modules-core/android/src/main/cpp/pch/ExpoHeaderPchOwner.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/pch/ExpoHeaderPchOwner.cpp
@@ -1,0 +1,2 @@
+// This translation unit exists solely so the `expo-modules-pch` target can
+// compile the precompiled header once.


### PR DESCRIPTION
# Why

Shares a single precompiled header across native targets

# How

Introduced a dedicated, otherwise-empty `expo-modules-pch` target whose only job is to compile the PCH once. The three real targets now reuse it via `target_precompile_headers(<target> REUSE_FROM expo-modules-pch)`.

# Test Plan

- bare-expo ✅ 