### PR TITLE
[core][ios] Resolve AppContextTests merge conflict

### DIFF
--- a/packages/expo-modules-core/ios/Tests/AppContextTests.swift
+++ b/packages/expo-modules-core/ios/Tests/AppContextTests.swift
@@ -28,6 +28,48 @@ struct AppContextTests {
     #expect(AppContext.from(runtime: bareRuntime) == nil)
   }
 
+  // MARK: - moduleProviderClassNames
+
+  @Test
+  func `maps bundle names to qualified class names`() {
+    let classNames = AppContext.moduleProviderClassNames(
+      withName: "ExpoModulesProvider",
+      bundleNames: ["MyApp"]
+    )
+
+    #expect(classNames == [
+      "MyApp.ExpoModulesProvider"
+    ])
+  }
+
+  @Test
+  func `deduplicates identical candidates`() {
+    let classNames = AppContext.moduleProviderClassNames(
+      withName: "ExpoModulesProvider",
+      bundleNames: ["ExpoApp", "ExpoApp"]
+    )
+
+    #expect(classNames == [
+      "ExpoApp.ExpoModulesProvider"
+    ])
+  }
+
+  @Test
+  func `preserves order and emits both candidates when CFBundleExecutable differs from CFBundleName`() {
+    // When CFBundleExecutable differs from CFBundleName (e.g. dotted bundle name), both
+    // candidates are emitted with the executable-derived one first, since it is the Swift
+    // module name by construction.
+    let classNames = AppContext.moduleProviderClassNames(
+      withName: "ExpoModulesProvider",
+      bundleNames: ["Universal_internal", "Universal.internal"]
+    )
+
+    #expect(classNames == [
+      "Universal_internal.ExpoModulesProvider",
+      "Universal.internal.ExpoModulesProvider"
+    ])
+  }
+
   // MARK: - NativeState
 
   @Suite("NativeState")
@@ -226,66 +268,5 @@ struct AppContextTests {
         _ = try appContext.runtime
       }
     }
-}
-
-// MARK: - ModuleProvider
-
-extension AppContextTests {
-  @Suite("moduleProviderClassNames")
-  struct ModuleProviderClassNamesTests {
-    @Test
-    func `maps bundle names to qualified class names`() {
-      let classNames = AppContext.moduleProviderClassNames(
-        withName: "ExpoModulesProvider",
-        bundleNames: ["MyApp"]
-      )
-
-      #expect(classNames == [
-        "MyApp.ExpoModulesProvider"
-      ])
-    }
-
-    @Test
-    func `deduplicates identical candidates`() {
-      let classNames = AppContext.moduleProviderClassNames(
-        withName: "ExpoModulesProvider",
-        bundleNames: ["ExpoApp", "ExpoApp"]
-      )
-
-      #expect(classNames == [
-        "ExpoApp.ExpoModulesProvider"
-      ])
-    }
-
-    @Test
-    func `preserves order and emits both candidates when CFBundleExecutable differs from CFBundleName`() {
-      // When CFBundleExecutable differs from CFBundleName (e.g. dotted bundle name), both
-      // candidates are emitted with the executable-derived one first, since it is the Swift
-      // module name by construction.
-      let classNames = AppContext.moduleProviderClassNames(
-        withName: "ExpoModulesProvider",
-        bundleNames: ["Universal_internal", "Universal.internal"]
-      )
-
-      #expect(classNames == [
-        "Universal_internal.ExpoModulesProvider",
-        "Universal.internal.ExpoModulesProvider"
-      ])
-    }
-  }
-
-  @Test
-  func `module provider class names preserves order and deduplicates across CFBundleName and CFBundleExecutable`() {
-    // When CFBundleExecutable differs from CFBundleName (e.g. dotted bundle name), both candidates
-    // are emitted with the executable-derived one first, since it is the Swift module name by construction.
-    let classNames = AppContext.moduleProviderClassNames(
-      withName: "ExpoModulesProvider",
-      bundleNames: ["Universal_internal", "Universal.internal"]
-    )
-
-    #expect(classNames == [
-      "Universal_internal.ExpoModulesProvider",
-      "Universal.internal.ExpoModulesProvider"
-    ])
   }
 }


### PR DESCRIPTION
# Why

#46424 and #47098 both edited the tail of `AppContextTests.swift` and landed without a textual merge conflict, but the combined result was structurally broken. The closing brace for the `AppContextTests` struct was dropped, so the `ModuleProvider` extension #46424 added ended up nested inside the still-open struct and the `ExpoModulesCore-Unit-Tests` target stopped compiling on `main` (`Declaration is only valid at file scope`, `Type 'AppContextTests' has no member 'AppContextTests'`).

Red run: https://github.com/expo/expo/actions/runs/27941200278/job/82674750997

# How

Reconcile the two changes by hand:

- Restore the missing closing brace so `AppContextTests` is balanced again.
- Fold #46424's `moduleProviderClassNames` tests directly into `AppContextTests` (they exercise `AppContext`, not a nested type), dropping the separate `extension` and suite wrapper.
- Drop the now-duplicated standalone `preserves order and emits both candidates when CFBundleExecutable differs from CFBundleName` test.

# Test Plan

`et native-unit-tests -p ios --packages expo-modules-core` builds and runs green. Pure conflict resolution; no test behavior changes.
