### PR TITLE
[widgets][Android] Add 16KB page size support

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
-- [Android] Add 16KB page size support.
+- [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
+- [Android] Add 16KB page size support.
 
 ### 💡 Others
 

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -47,6 +47,7 @@ android {
         def cppArguments = [
           "-DANDROID_STL=c++_shared",
           "-DREACT_NATIVE_DIR=${expoModule.reactNativeDir}",
+          "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
         ]
 
         abiFilters(*reactNativeArchitectures())


### PR DESCRIPTION
# Why

<img width="200" alt="image" src="https://github.com/user-attachments/assets/c2180199-1aa9-4e45-98b3-8552d39b6030" />

# How

Add `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` to support 16kb page size

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
