### PR TITLE
[launcher][Android] Re-enable the Fast Refresh toggle

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#47047](https://github.com/expo/expo/pull/47047) by [@lindboe](https://github.com/lindboe))
-- [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section.
+- [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section. ([#47136](https://github.com/expo/expo/pull/47136) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#47047](https://github.com/expo/expo/pull/47047) by [@lindboe](https://github.com/lindboe))
+- [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section.
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
@@ -134,31 +134,30 @@ fun ToolsSection(
         }
       )
 
-      // TODO(@lukmccall): Re-enable when toggling fast refresh is not longer crashing app
-//      Divider(thickness = 0.5.dp)
-//
-//      NewMenuButton(
-//        withSurface = false,
-//        icon = {
-//          MenuIcons.Refresh(
-//            size = 20.dp,
-//            tint = NewAppTheme.colors.icon.tertiary
-//          )
-//        },
-//        content = {
-//          NewText(
-//            text = "Fast Refresh"
-//          )
-//        },
-//        rightComponent = {
-//          ToggleSwitch(
-//            isToggled = devToolsSettings.isHotLoadingEnabled
-//          )
-//        },
-//        onClick = {
-//          onAction(DevMenuAction.ToggleFastRefresh(!devToolsSettings.isHotLoadingEnabled))
-//        }
-//      )
+      Divider(thickness = 0.5.dp)
+
+      NewMenuButton(
+        withSurface = false,
+        icon = {
+          MenuIcons.Refresh(
+            size = 20.dp,
+            tint = NewAppTheme.colors.icon.tertiary
+          )
+        },
+        content = {
+          NewText(
+            text = "Fast Refresh"
+          )
+        },
+        rightComponent = {
+          ToggleSwitch(
+            isToggled = devToolsSettings.isHotLoadingEnabled
+          )
+        },
+        onClick = {
+          onAction(DevMenuAction.ToggleFastRefresh(!devToolsSettings.isHotLoadingEnabled))
+        }
+      )
 
       // Hide FAB toggle on Quest devices since FAB is always on there
       if (!VRUtilities.isQuest()) {

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
+import java.lang.reflect.Proxy
 
 class DevMenuDevToolsDelegate(
   private val weakDevSupportManager: WeakReference<out DevSupportManager>
@@ -77,14 +78,41 @@ class DevMenuDevToolsDelegate(
     internalSettings.isHotModuleReplacementEnabled = nextEnabled
 
     if (nextEnabled) {
-      reactContext?.getJSModule(HMRClient::class.java)?.enable()
+      reactContext?.callHMRClientMethod("enable")
     } else {
-      reactContext?.getJSModule(HMRClient::class.java)?.disable()
+      reactContext?.callHMRClientMethod("disable")
     }
 
     if (nextEnabled && !internalSettings.isJSDevModeEnabled) {
       internalSettings.isJSDevModeEnabled = true
       reload()
+    }
+  }
+
+  /**
+   * Invokes a no-argument [HMRClient] method (`enable`/`disable`) without tripping a bug in React
+   * Native's bridgeless JS module proxy.
+   *
+   * When a zero-argument method is invoked through the proxy returned by [ReactContext.getJSModule],
+   * the JDK passes a `null` args array to the invocation handler. In bridgeless mode that handler
+   * (`BridgelessReactContext.BridgelessJSModuleInvocationHandler`) declares the parameter non-null,
+   * so Kotlin's null check throws a [NullPointerException] before the call ever reaches JS. We
+   * invoke the handler directly with an explicit empty args array to sidestep the null. The legacy
+   * (bridge) handler tolerates the empty array too, so this is safe on both architectures.
+   */
+  private fun ReactContext.callHMRClientMethod(methodName: String) {
+    val hmrClient = getJSModule(HMRClient::class.java) ?: return
+    val method = HMRClient::class.java.getMethod(methodName)
+    if (Proxy.isProxyClass(hmrClient.javaClass)) {
+      Proxy
+        .getInvocationHandler(hmrClient)
+        .invoke(
+          hmrClient,
+          method,
+          emptyArray<Any?>()
+        )
+    } else {
+      method.invoke(hmrClient)
     }
   }
 


### PR DESCRIPTION
# Why

Re-enables the Fast Refresh toggle and adds a workaround for the RN bug. 
This bug was fixed upstream by https://github.com/react/react-native/commit/949b8049dfeb4f5cf449284f9d37093641757a1a.

# Test Plan

- bare-expo ✅ 