### PR TITLE
[expo-doctor] Fix local project module loading in bundled builds

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix local bundled builds loading modules from checked projects. ([#47137](https://github.com/expo/expo/pull/47137) by [@entiendonull](https://github.com/entiendonull))
 - Recognize the React Native Directory `new-arch-only` status so New-Architecture-only libraries aren't flagged ([#46755](https://github.com/expo/expo/pull/46755) by [@zoontek](https://github.com/zoontek))
 - Fix SDK 55 Metro config check for missing `metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo-doctor/README.md
+++ b/packages/expo-doctor/README.md
@@ -30,7 +30,8 @@ For more information run `npx expo-doctor --help` (or `-h`)
 
 ## Testing and development
 
-Run `pnpm build` (or `pnpm watch`) inside of `expo-doctor`'s project folder.
+Run `pnpm build` inside of `expo-doctor`'s project folder. Re-run this after making
+source changes, since the CLI runs the generated `build/index.js` bundle.
 
 Then, in your test project, run `path-to-expo/packages/expo-doctor/bin/expo-doctor.js`
 

--- a/packages/expo-doctor/src/utils/autolinkingResolutions.ts
+++ b/packages/expo-doctor/src/utils/autolinkingResolutions.ts
@@ -1,4 +1,6 @@
 import type { DependencyResolution } from 'expo-modules-autolinking/exports';
+import * as Module from 'node:module';
+import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import type { VersionedNativeModuleNamesCache } from './versionedNativeModules';
@@ -17,7 +19,9 @@ export function importAutolinkingExportsFromProject(
     );
   }
   try {
-    const mod = require(autolinkingExportsResolved);
+    const mod = Module.createRequire(path.join(projectDir, 'package.json'))(
+      autolinkingExportsResolved
+    );
     if (
       typeof mod.makeCachedDependenciesLinker !== 'function' ||
       typeof mod.scanDependencyResolutionsForPlatform !== 'function'

--- a/packages/expo-doctor/src/utils/metroConfigLoader.ts
+++ b/packages/expo-doctor/src/utils/metroConfigLoader.ts
@@ -1,4 +1,5 @@
 import type { InputConfigT } from '@expo/metro/metro-config';
+import * as Module from 'node:module';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -17,13 +18,13 @@ function importMetroConfigFromProject(
   if (!expoResolved) {
     throw notFoundError('expo');
   }
+  const projectRequire = Module.createRequire(path.join(projectDir, 'package.json'));
   try {
     // NOTE(@kitten): We need to use the version of metro-config that Expo uses
     // Luckily, we can import `@expo/metro` via `expo` to get to the same version
-    const expoMetro = require.resolve('@expo/metro/metro-config', {
-      paths: [path.dirname(expoResolved)],
-    });
-    return require(expoMetro);
+    const expoRequire = Module.createRequire(expoResolved);
+    const expoMetro = expoRequire.resolve('@expo/metro/metro-config');
+    return projectRequire(expoMetro);
   } catch {
     // NOTE(@kitten): Older versions of expo will not have `@expo/metro`. Let's try to
     // require `metro-config` directly
@@ -31,7 +32,7 @@ function importMetroConfigFromProject(
     if (!metroConfig) {
       throw notFoundError('react-native');
     }
-    return require(metroConfig);
+    return projectRequire(metroConfig);
   }
 }
 
@@ -45,7 +46,9 @@ function loadExpoMetroConfig(projectDir: string): typeof import('expo/metro-conf
   if (!expoMetroConfigResolved) {
     throw notFoundError('expo');
   }
-  _expoMetroConfig = require(expoMetroConfigResolved);
+  _expoMetroConfig = Module.createRequire(path.join(projectDir, 'package.json'))(
+    expoMetroConfigResolved
+  );
   return _expoMetroConfig!;
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="773" height="200" alt="Screenshot 2026-06-22 at 13 41 16" src="https://github.com/user-attachments/assets/e1a557a8-6f89-480f-bf29-846ac4a814f9" />


Built and ran `expo-doctor` locally against a fresh project and got these failures.

- `Cannot find module '<project>/node_modules/expo/metro-config.js'`
- `The package "expo-modules-autolinking" is out-of-date and isn't available to check dependency conflicts.`

The published version was working fine.


# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `Module.createRequire(...)` when `expo-doctor` loads modules from the project it is checking, instead of dynamic `require(...)`. The local bundled build rewrote those dynamic project module imports in a way that made them fail at runtime.

Also snuck this in; removed the stale `pnpm watch` instruction from the `expo-doctor` README.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

Tests passed.

Also made manual tests:
- Ran against fresh project (`bun create expo --template default@sdk-56`)
- No errors; all checks passed
- Introduced errors; accurate warnings/errors displayed
- Compared results with `npx expo-doctor@latest`

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
