### PR TITLE
[expo/cli] Remove add-module entry point

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the deprecated `@expo/cli/add-module` entry point.
 - Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
 
 ### 🎉 New features

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Remove the deprecated `@expo/cli/add-module` entry point.
+- Remove the deprecated `@expo/cli/add-module` entry point. ([#47140](https://github.com/expo/expo/pull/47140) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
 
 ### 🎉 New features

--- a/packages/@expo/cli/add-module.js
+++ b/packages/@expo/cli/add-module.js
@@ -1,8 +1,0 @@
-const { loadModule } = require('@expo/require-utils');
-
-/**
- * @deprecated Will be removed in a future release.
- */
-module.exports = function importESM(name) {
-  return loadModule(name);
-};

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -20,7 +20,6 @@
   },
   "files": [
     "main.js",
-    "add-module.js",
     "internal",
     "static",
     "build"


### PR DESCRIPTION
Stacked on #47139.

Separate because removing `@expo/cli/add-module` is breaking if external consumers import that subpath.