### PR TITLE
[image-picker][Android] Migrate `ExpoCropImageActivity` away from `CropImageActivity`

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - [Web] Drop dependency on `expo-modules-core` `Platform` in favor of inline `window`/`document` checks. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))
 - Switch package entry to TypeScript source and emit declarations only. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))
+- [Android] Migrate `ExpoCropImageActivity` away from `CropImageActivity` ([#47141](https://github.com/expo/expo/pull/47141) by [@Wenszel](https://github.com/Wenszel))
 
 ## 56.0.14 — 2026-05-26
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -1,88 +1,90 @@
 package expo.modules.imagepicker
 
+import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.util.Log
 import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
+import androidx.appcompat.app.ActionBar
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.get
+import androidx.core.view.size
 import androidx.core.view.updateLayoutParams
-import com.canhub.cropper.CropImageActivity
+import com.canhub.cropper.CropImage
 import com.canhub.cropper.CropImageOptions
 import com.canhub.cropper.CropImageView
+import com.canhub.cropper.R as CropperR
+import com.canhub.cropper.databinding.CropImageActivityBinding
+import com.canhub.cropper.parcelable
 import expo.modules.imagepicker.ExpoCropImageUtils.getColorResource
 import expo.modules.imagepicker.ExpoCropImageUtils.getThemeColor
 
-/**
- * A wrapper around `CropImageActivity` to provide custom theming and functionality.
- *
- * This activity applies a custom color palette based on the application's theme
+/*
+ * This code is based on the CropImageActivity implementation from the Android-Image-Cropper library:
+ * ref: https://github.com/CanHub/Android-Image-Cropper/blob/91fa86dd5f48b9f4e5398dc77c0d40ba26903d7a/cropper/src/main/kotlin/com/canhub/cropper/CropImageActivity.kt
+ * Additionally, this activity applies a custom color palette based on the application's theme
  * and ensures that all icons are tinted correctly for both light and dark modes.
- * It uses reflection to access private fields in the base `CropImageActivity`
- * to avoid forking the library.
  */
-class ExpoCropImageActivity : CropImageActivity() {
+class ExpoCropImageActivity :
+  AppCompatActivity(),
+  CropImageView.OnSetImageUriCompleteListener,
+  CropImageView.OnCropImageCompleteListener {
   private var currentIconColor: Int = Color.BLACK
-  private var cropImageViewRef: CropImageView? = null
+  private var cropImageUri: Uri? = null
+  private lateinit var cropImageOptions: CropImageOptions
+  private var cropImageView: CropImageView? = null
+  private lateinit var binding: CropImageActivityBinding
 
-  // region Lifecycle Methods
-  override fun onCreate(savedInstanceState: android.os.Bundle?) {
+  // region OnCreate Flow
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    // Fetch the private cropImageOptions and apply the palette as early as possible so
-    // the toolbar and menu icons are tinted correctly on first render.
-    getCropOptions()?.let { opts ->
-      val isNight = (resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) == android.content.res.Configuration.UI_MODE_NIGHT_YES
-      applyCustomization(isNight, opts)
-      invokeSetCustomizations()
-      invalidateOptionsMenu() // Recreate the menu to apply the new icon colors.
+    readCropImageOptions()
+    val colors = resolveCustomizationColors()
+    applyCustomizationToOptions(cropImageOptions, colors)
+    setupContentView()
+    applyWindowCustomization(colors)
+    if (savedInstanceState == null) {
+      // The cropImageView image should only be set if savedInstanceState is null
+      // otherwise it would override user changes like zooming or cropping
+      cropImageView?.setImageUriAsync(cropImageUri)
     }
+    applyActivityBackground()
+    applyToolbarCustomization()
+    setupBackHandling()
   }
 
-  override fun onDestroy() {
-    ViewCompat.setOnApplyWindowInsetsListener(window.decorView, null)
-
-    cropImageViewRef?.let { ViewCompat.setOnApplyWindowInsetsListener(it, null) }
-    cropImageViewRef = null
-
-    super.onDestroy()
-  }
-
-  override fun onCreateOptionsMenu(menu: Menu): Boolean {
-    val result = super.onCreateOptionsMenu(menu)
-    tintAllMenuItems(menu)
-    return result
-  }
-
-  override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-    val result = super.onPrepareOptionsMenu(menu)
-    tintAllMenuItems(menu)
-    return result
-  }
-
-  override fun setCropImageView(cropImageView: CropImageView) {
-    super.setCropImageView(cropImageView)
-
-    cropImageViewRef = cropImageView
-
-    // Inset the crop view margins so it doesn't overlap with system bars or display cutouts
-    ViewCompat.setOnApplyWindowInsetsListener(cropImageView) { view, insets ->
-      val values = insets.getInsets(
-        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-      )
-
-      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-        setMargins(values.left, values.top, values.right, values.bottom)
-      }
-
-      insets
+  private fun readCropImageOptions() {
+    val bundle = intent.getBundleExtra(CropImage.CROP_IMAGE_EXTRA_BUNDLE)
+    cropImageUri = bundle?.parcelable(CropImage.CROP_IMAGE_EXTRA_SOURCE)
+    requireNotNull(cropImageUri) {
+      "Crop image source URI is required but was not provided."
     }
+    cropImageOptions = bundle?.parcelable(CropImage.CROP_IMAGE_EXTRA_OPTIONS)
+      ?: CropImageOptions()
   }
 
-  // endregion
-
-  private fun applyCustomization(isNight: Boolean, options: CropImageOptions) {
+  private fun resolveCustomizationColors(): CustomizationColors {
+    val isNight = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
     val defaultBackgroundColor = if (isNight) Color.BLACK else Color.WHITE
     val defaultContentColor = if (isNight) Color.WHITE else Color.BLACK
 
@@ -102,34 +104,70 @@ class ExpoCropImageActivity : CropImageActivity() {
     val toolbarColor = expoCropToolbarColor ?: defaultBackgroundColor
     val toolbarIconColor = expoCropToolbarIconColor ?: defaultContentColor
 
-    // Set the current icon color for menu tinting
-    currentIconColor = toolbarIconColor
+    return CustomizationColors(
+      isNight = isNight,
+      activityBackgroundColor = activityBackgroundColor,
+      toolbarColor = toolbarColor,
+      toolbarIconColor = toolbarIconColor,
+      toolbarActionTextColor = expoCropToolbarActionTextColor ?: defaultContentColor,
+      backButtonIconColor = expoCropBackButtonIconColor ?: toolbarIconColor
+    )
+  }
 
+  private fun applyCustomizationToOptions(options: CropImageOptions, colors: CustomizationColors) {
+    // Set the current icon color for menu tinting
+    currentIconColor = colors.toolbarIconColor
+
+    options.activityBackgroundColor = colors.activityBackgroundColor
+    options.activityMenuIconColor = colors.toolbarIconColor
+    options.activityMenuTextColor = colors.toolbarActionTextColor
+    options.toolbarBackButtonColor = colors.backButtonIconColor
+    options.toolbarColor = colors.toolbarColor
+    options.toolbarTitleColor = colors.toolbarIconColor
+  }
+
+  private fun setupContentView() {
+    binding = CropImageActivityBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+    setCropImageView(binding.cropImageView)
+  }
+
+  private fun setCropImageView(cropImageView: CropImageView) {
+    this.cropImageView = cropImageView
+
+    // Inset the crop view margins so it doesn't overlap with system bars or display cutouts
+    ViewCompat.setOnApplyWindowInsetsListener(cropImageView) { view, insets ->
+      val values = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      )
+
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        setMargins(values.left, values.top, values.right, values.bottom)
+      }
+
+      insets
+    }
+  }
+
+  private fun applyWindowCustomization(colors: CustomizationColors) {
     // Remove action bar elevation for a flat design
     supportActionBar?.elevation = 0f
 
-    options.activityBackgroundColor = activityBackgroundColor
-    options.activityMenuIconColor = toolbarIconColor
-    options.activityMenuTextColor = expoCropToolbarActionTextColor ?: defaultContentColor
-    options.toolbarBackButtonColor = expoCropBackButtonIconColor ?: toolbarIconColor
-    options.toolbarColor = toolbarColor
-    options.toolbarTitleColor = toolbarIconColor
-
     window.run {
       // Create a view that will sit behind the status bar, colored to match the toolbar
-      val statusBarView = View(context).apply { setBackgroundColor(toolbarColor) }
+      val statusBarView = View(context).apply { setBackgroundColor(colors.toolbarColor) }
 
       // Draw content edge-to-edge, behind system bars
       WindowCompat.enableEdgeToEdge(this)
 
       // Set system bar icon colors based on the current theme (dark icons on light bg, and vice versa)
       WindowInsetsControllerCompat(this, decorView).run {
-        isAppearanceLightStatusBars = !isNight
-        isAppearanceLightNavigationBars = !isNight
+        isAppearanceLightStatusBars = !colors.isNight
+        isAppearanceLightNavigationBars = !colors.isNight
       }
 
       // Set the root background color so it shows through transparent system bars
-      decorView.setBackgroundColor(activityBackgroundColor)
+      decorView.setBackgroundColor(colors.activityBackgroundColor)
 
       // Add the status bar view with zero initial height (will be sized by insets listener below)
       addContentView(
@@ -148,25 +186,307 @@ class ExpoCropImageActivity : CropImageActivity() {
     }
   }
 
-  // region Helper Methods
-  private fun getCropOptions(): CropImageOptions? =
-    runCatching {
-      CropImageActivity::class.java.getDeclaredField("cropImageOptions")
-        .apply { isAccessible = true }
-        .get(this) as? CropImageOptions
-    }.getOrNull()
-
-  private fun invokeSetCustomizations() =
-    runCatching {
-      CropImageActivity::class.java.getDeclaredMethod("setCustomizations")
-        .apply { isAccessible = true }
-        .invoke(this)
+  private fun applyActivityBackground() {
+    cropImageOptions.activityBackgroundColor.let { activityBackgroundColor ->
+      binding.root.setBackgroundColor(activityBackgroundColor)
     }
+  }
 
-  private fun tintAllMenuItems(menu: Menu) {
-    for (i in 0 until menu.size()) {
-      menu.getItem(i)?.icon?.mutate()?.setTint(currentIconColor)
+  private fun applyToolbarCustomization() {
+    supportActionBar?.let { actionBar ->
+      title = cropImageOptions.activityTitle.ifEmpty { "" }
+      actionBar.setDisplayHomeAsUpEnabled(true)
+      applyToolbarColor(actionBar)
+      applyToolbarTitleColor()
+      applyToolbarBackButtonColor(actionBar)
+    }
+  }
+
+  private fun applyToolbarColor(actionBar: ActionBar) {
+    cropImageOptions.toolbarColor?.let { toolbarColor ->
+      actionBar.setBackgroundDrawable(toolbarColor.toDrawable())
+    }
+  }
+
+  private fun applyToolbarTitleColor() {
+    cropImageOptions.toolbarTitleColor?.let { toolbarTitleColor ->
+      val spannableTitle: Spannable = SpannableString(title)
+      spannableTitle.setSpan(
+        ForegroundColorSpan(toolbarTitleColor),
+        0,
+        spannableTitle.length,
+        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+      )
+      title = spannableTitle
+    }
+  }
+
+  private fun applyToolbarBackButtonColor(actionBar: ActionBar) {
+    cropImageOptions.toolbarBackButtonColor?.let { backBtnColor ->
+      try {
+        val upArrow = ContextCompat.getDrawable(
+          this,
+          CropperR.drawable.ic_arrow_back_24
+        )
+        upArrow?.colorFilter = PorterDuffColorFilter(backBtnColor, PorterDuff.Mode.SRC_ATOP)
+        actionBar.setHomeAsUpIndicator(upArrow)
+      } catch (e: Exception) {
+        Log.w("ExpoCropImage", "Failed to set back button color", e)
+      }
+    }
+  }
+
+  private fun setupBackHandling() {
+    onBackPressedDispatcher.addCallback {
+      setResultCancel()
     }
   }
   // endregion
+
+  // region Activity Overrides
+  public override fun onStart() {
+    super.onStart()
+    cropImageView?.setOnSetImageUriCompleteListener(this)
+    cropImageView?.setOnCropImageCompleteListener(this)
+  }
+
+  public override fun onStop() {
+    super.onStop()
+    cropImageView?.setOnSetImageUriCompleteListener(null)
+    cropImageView?.setOnCropImageCompleteListener(null)
+  }
+
+  override fun onDestroy() {
+    ViewCompat.setOnApplyWindowInsetsListener(window.decorView, null)
+
+    cropImageView?.let { ViewCompat.setOnApplyWindowInsetsListener(it, null) }
+    cropImageView = null
+
+    super.onDestroy()
+  }
+
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    if (cropImageOptions.skipEditing) return true
+    menuInflater.inflate(CropperR.menu.crop_image_menu, menu)
+
+    if (!cropImageOptions.allowRotation) {
+      menu.removeItem(CropperR.id.ic_rotate_left_24)
+      menu.removeItem(CropperR.id.ic_rotate_right_24)
+    } else if (cropImageOptions.allowCounterRotation) {
+      menu.findItem(CropperR.id.ic_rotate_left_24).isVisible = true
+    }
+
+    if (!cropImageOptions.allowFlipping) menu.removeItem(CropperR.id.ic_flip_24)
+
+    if (cropImageOptions.cropMenuCropButtonTitle != null) {
+      menu.findItem(CropperR.id.crop_image_menu_crop).title =
+        cropImageOptions.cropMenuCropButtonTitle
+    }
+
+    var cropIcon: Drawable? = null
+    try {
+      if (cropImageOptions.cropMenuCropButtonIcon != 0) {
+        cropIcon = ContextCompat.getDrawable(this, cropImageOptions.cropMenuCropButtonIcon)
+        menu.findItem(CropperR.id.crop_image_menu_crop).icon = cropIcon
+      }
+    } catch (e: Exception) {
+      Log.w("ExpoCropImage", "Failed to read menu crop drawable", e)
+    }
+
+    if (cropImageOptions.activityMenuIconColor != 0) {
+      updateMenuItemIconColor(
+        menu,
+        CropperR.id.ic_rotate_left_24,
+        cropImageOptions.activityMenuIconColor
+      )
+      updateMenuItemIconColor(
+        menu,
+        CropperR.id.ic_rotate_right_24,
+        cropImageOptions.activityMenuIconColor
+      )
+      updateMenuItemIconColor(menu, CropperR.id.ic_flip_24, cropImageOptions.activityMenuIconColor)
+
+      if (cropIcon != null) {
+        updateMenuItemIconColor(
+          menu,
+          CropperR.id.crop_image_menu_crop,
+          cropImageOptions.activityMenuIconColor
+        )
+      }
+    }
+    cropImageOptions.activityMenuTextColor?.let { menuItemsTextColor ->
+      val menuItemIds = listOf(
+        CropperR.id.ic_rotate_left_24,
+        CropperR.id.ic_rotate_right_24,
+        CropperR.id.ic_flip_24,
+        CropperR.id.ic_flip_24_horizontally,
+        CropperR.id.ic_flip_24_vertically,
+        CropperR.id.crop_image_menu_crop
+      )
+      for (itemId in menuItemIds) {
+        updateMenuItemTextColor(menu, itemId, menuItemsTextColor)
+      }
+    }
+
+    tintAllMenuItems(menu)
+    return true
+  }
+
+  override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+    val result = super.onPrepareOptionsMenu(menu)
+    tintAllMenuItems(menu)
+    return result
+  }
+
+  override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+    CropperR.id.crop_image_menu_crop -> {
+      cropImage()
+      true
+    }
+    CropperR.id.ic_rotate_left_24 -> {
+      cropImageView?.rotateImage(-cropImageOptions.rotationDegrees)
+      true
+    }
+    CropperR.id.ic_rotate_right_24 -> {
+      cropImageView?.rotateImage(cropImageOptions.rotationDegrees)
+      true
+    }
+    CropperR.id.ic_flip_24_horizontally -> {
+      cropImageView?.flipImageHorizontally()
+      true
+    }
+    CropperR.id.ic_flip_24_vertically -> {
+      cropImageView?.flipImageVertically()
+      true
+    }
+    android.R.id.home -> {
+      setResultCancel()
+      true
+    }
+    else -> super.onOptionsItemSelected(item)
+  }
+
+  override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception?) {
+    if (error == null) {
+      if (cropImageOptions.initialCropWindowRectangle != null) {
+        cropImageView?.cropRect = cropImageOptions.initialCropWindowRectangle
+      }
+
+      if (cropImageOptions.initialRotation > 0) {
+        cropImageView?.rotatedDegrees = cropImageOptions.initialRotation
+      }
+
+      if (cropImageOptions.skipEditing) {
+        cropImage()
+      }
+    } else {
+      setResult(null, error, 1)
+    }
+  }
+
+  override fun onCropImageComplete(view: CropImageView, result: CropImageView.CropResult) {
+    setResult(result.uriContent, result.error, result.sampleSize)
+  }
+  // endregion
+
+  // region Menu Helpers
+  private fun tintAllMenuItems(menu: Menu) {
+    for (i in 0 until menu.size) {
+      menu[i].icon?.mutate()?.setTint(currentIconColor)
+    }
+  }
+
+  private fun updateMenuItemTextColor(menu: Menu, itemId: Int, color: Int) {
+    val menuItem = menu.findItem(itemId) ?: return
+    val menuTitle = menuItem.title
+    if (menuTitle?.isNotBlank() == true) {
+      try {
+        val spannableTitle: Spannable = SpannableString(menuTitle)
+        spannableTitle.setSpan(
+          ForegroundColorSpan(color),
+          0,
+          spannableTitle.length,
+          Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        menuItem.title = spannableTitle
+      } catch (e: Exception) {
+        Log.w("ExpoCropImage", "Failed to update menu item color", e)
+      }
+    }
+  }
+
+  private fun updateMenuItemIconColor(menu: Menu, itemId: Int, color: Int) {
+    val menuItem = menu.findItem(itemId)
+    if (menuItem != null) {
+      val menuItemIcon = menuItem.icon
+      if (menuItemIcon != null) {
+        try {
+          menuItemIcon.apply {
+            mutate()
+            colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+              color,
+              BlendModeCompat.SRC_ATOP
+            )
+          }
+          menuItem.icon = menuItemIcon
+        } catch (e: Exception) {
+          Log.w("ExpoCropImage", "Failed to update menu item color", e)
+        }
+      }
+    }
+  }
+  // endregion
+
+  // region Crop Result
+  private fun cropImage() {
+    if (cropImageOptions.noOutputImage) {
+      setResult(null, null, 1)
+    } else {
+      cropImageView?.croppedImageAsync(
+        saveCompressFormat = cropImageOptions.outputCompressFormat,
+        saveCompressQuality = cropImageOptions.outputCompressQuality,
+        reqWidth = cropImageOptions.outputRequestWidth,
+        reqHeight = cropImageOptions.outputRequestHeight,
+        options = cropImageOptions.outputRequestSizeOptions,
+        customOutputUri = cropImageOptions.customOutputUri
+      )
+    }
+  }
+
+  private fun setResultCancel() {
+    setResult(RESULT_CANCELED)
+    finish()
+  }
+
+  private fun setResult(uri: Uri?, error: Exception?, sampleSize: Int) {
+    setResult(
+      error?.let { CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE } ?: RESULT_OK,
+      getResultIntent(uri, error, sampleSize)
+    )
+    finish()
+  }
+
+  private fun getResultIntent(uri: Uri?, error: Exception?, sampleSize: Int): Intent {
+    val result = CropImage.ActivityResult(
+      originalUri = cropImageView?.imageUri,
+      uriContent = uri,
+      error = error,
+      cropPoints = cropImageView?.cropPoints,
+      cropRect = cropImageView?.cropRect,
+      rotation = cropImageView?.rotatedDegrees ?: 0,
+      wholeImageRect = cropImageView?.wholeImageRect,
+      sampleSize = sampleSize
+    )
+    return Intent().putExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, result)
+  }
+  // endregion
+
+  private data class CustomizationColors(
+    val isNight: Boolean,
+    val activityBackgroundColor: Int,
+    val toolbarColor: Int,
+    val toolbarIconColor: Int,
+    val toolbarActionTextColor: Int,
+    val backButtonIconColor: Int
+  )
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -5,8 +5,8 @@ import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
@@ -27,8 +27,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.core.view.get
-import androidx.core.view.size
+import androidx.core.view.forEach
 import androidx.core.view.updateLayoutParams
 import com.canhub.cropper.CropImage
 import com.canhub.cropper.CropImageOptions
@@ -117,13 +116,14 @@ class ExpoCropImageActivity :
   private fun applyCustomizationToOptions(options: CropImageOptions, colors: CustomizationColors) {
     // Set the current icon color for menu tinting
     currentIconColor = colors.toolbarIconColor
-
-    options.activityBackgroundColor = colors.activityBackgroundColor
-    options.activityMenuIconColor = colors.toolbarIconColor
-    options.activityMenuTextColor = colors.toolbarActionTextColor
-    options.toolbarBackButtonColor = colors.backButtonIconColor
-    options.toolbarColor = colors.toolbarColor
-    options.toolbarTitleColor = colors.toolbarIconColor
+    with(options) {
+      activityBackgroundColor = colors.activityBackgroundColor
+      activityMenuIconColor = colors.toolbarIconColor
+      activityMenuTextColor = colors.toolbarActionTextColor
+      toolbarBackButtonColor = colors.backButtonIconColor
+      toolbarColor = colors.toolbarColor
+      toolbarTitleColor = colors.toolbarIconColor
+    }
   }
 
   private fun setupContentView() {
@@ -137,9 +137,8 @@ class ExpoCropImageActivity :
 
     // Inset the crop view margins so it doesn't overlap with system bars or display cutouts
     ViewCompat.setOnApplyWindowInsetsListener(cropImageView) { view, insets ->
-      val values = insets.getInsets(
-        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-      )
+      val insetsType = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      val values = insets.getInsets(insetsType)
 
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
         setMargins(values.left, values.top, values.right, values.bottom)
@@ -187,52 +186,48 @@ class ExpoCropImageActivity :
   }
 
   private fun applyActivityBackground() {
-    cropImageOptions.activityBackgroundColor.let { activityBackgroundColor ->
-      binding.root.setBackgroundColor(activityBackgroundColor)
-    }
+    val activityBackgroundColor = cropImageOptions.activityBackgroundColor
+    binding.root.setBackgroundColor(activityBackgroundColor)
   }
 
   private fun applyToolbarCustomization() {
-    supportActionBar?.let { actionBar ->
-      title = cropImageOptions.activityTitle.ifEmpty { "" }
-      actionBar.setDisplayHomeAsUpEnabled(true)
-      applyToolbarColor(actionBar)
-      applyToolbarTitleColor()
-      applyToolbarBackButtonColor(actionBar)
-    }
+    val actionBar = supportActionBar ?: return
+    title = cropImageOptions.activityTitle.ifEmpty { "" }
+    actionBar.setDisplayHomeAsUpEnabled(true)
+    actionBar.applyToolbarColor()
+    applyToolbarTitleColor()
+    actionBar.applyToolbarBackButtonColor()
   }
 
-  private fun applyToolbarColor(actionBar: ActionBar) {
-    cropImageOptions.toolbarColor?.let { toolbarColor ->
-      actionBar.setBackgroundDrawable(toolbarColor.toDrawable())
+  private fun ActionBar.applyToolbarColor() {
+    cropImageOptions.toolbarColor?.toDrawable().let { toolbarColorDrawable ->
+      setBackgroundDrawable(toolbarColorDrawable)
     }
   }
 
   private fun applyToolbarTitleColor() {
-    cropImageOptions.toolbarTitleColor?.let { toolbarTitleColor ->
-      val spannableTitle: Spannable = SpannableString(title)
-      spannableTitle.setSpan(
-        ForegroundColorSpan(toolbarTitleColor),
-        0,
-        spannableTitle.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-      )
-      title = spannableTitle
-    }
+    val toolbarTitleColor = cropImageOptions.toolbarTitleColor ?: return
+    val spannableTitle: Spannable = SpannableString(title)
+    spannableTitle.setSpan(
+      ForegroundColorSpan(toolbarTitleColor),
+      0,
+      spannableTitle.length,
+      Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+    )
+    title = spannableTitle
   }
 
-  private fun applyToolbarBackButtonColor(actionBar: ActionBar) {
-    cropImageOptions.toolbarBackButtonColor?.let { backBtnColor ->
-      try {
-        val upArrow = ContextCompat.getDrawable(
-          this,
-          CropperR.drawable.ic_arrow_back_24
-        )
-        upArrow?.colorFilter = PorterDuffColorFilter(backBtnColor, PorterDuff.Mode.SRC_ATOP)
-        actionBar.setHomeAsUpIndicator(upArrow)
-      } catch (e: Exception) {
-        Log.w("ExpoCropImage", "Failed to set back button color", e)
-      }
+  private fun ActionBar.applyToolbarBackButtonColor() {
+    val backBtnColor = cropImageOptions.toolbarBackButtonColor ?: return
+    try {
+      val upArrow = ContextCompat.getDrawable(
+        this@ExpoCropImageActivity,
+        CropperR.drawable.ic_arrow_back_24
+      )
+      upArrow?.colorFilter = PorterDuffColorFilter(backBtnColor, PorterDuff.Mode.SRC_ATOP)
+      setHomeAsUpIndicator(upArrow)
+    } catch (e: Exception) {
+      Log.w("ExpoCropImage", "Failed to set back button color", e)
     }
   }
 
@@ -266,121 +261,90 @@ class ExpoCropImageActivity :
   }
 
   override fun onCreateOptionsMenu(menu: Menu): Boolean {
-    if (cropImageOptions.skipEditing) return true
+    if (cropImageOptions.skipEditing) {
+      return true
+    }
     menuInflater.inflate(CropperR.menu.crop_image_menu, menu)
-
-    if (!cropImageOptions.allowRotation) {
-      menu.removeItem(CropperR.id.ic_rotate_left_24)
-      menu.removeItem(CropperR.id.ic_rotate_right_24)
-    } else if (cropImageOptions.allowCounterRotation) {
-      menu.findItem(CropperR.id.ic_rotate_left_24).isVisible = true
+    menu.setItemsVisibility()
+    menu.setCropIcon()
+    if (cropImageOptions.activityMenuIconColor != 0) {
+      menu.forEachItem {
+        it.updateIconColor(cropImageOptions.activityMenuIconColor)
+      }
     }
-
-    if (!cropImageOptions.allowFlipping) menu.removeItem(CropperR.id.ic_flip_24)
-
-    if (cropImageOptions.cropMenuCropButtonTitle != null) {
-      menu.findItem(CropperR.id.crop_image_menu_crop).title =
-        cropImageOptions.cropMenuCropButtonTitle
+    cropImageOptions.activityMenuTextColor?.let { menuItemsTextColor ->
+      menu.forEachItem {
+        it.updateTextColor(menuItemsTextColor)
+      }
     }
+    menu.forEachItem {
+      it.setIconTintColor(currentIconColor)
+    }
+    return true
+  }
 
-    var cropIcon: Drawable? = null
+  private fun Menu.setCropIcon() {
     try {
       if (cropImageOptions.cropMenuCropButtonIcon != 0) {
-        cropIcon = ContextCompat.getDrawable(this, cropImageOptions.cropMenuCropButtonIcon)
-        menu.findItem(CropperR.id.crop_image_menu_crop).icon = cropIcon
+        val cropIcon = ContextCompat.getDrawable(this@ExpoCropImageActivity, cropImageOptions.cropMenuCropButtonIcon)
+        findItem(CropperR.id.crop_image_menu_crop).icon = cropIcon
       }
     } catch (e: Exception) {
       Log.w("ExpoCropImage", "Failed to read menu crop drawable", e)
     }
+  }
 
-    if (cropImageOptions.activityMenuIconColor != 0) {
-      updateMenuItemIconColor(
-        menu,
-        CropperR.id.ic_rotate_left_24,
-        cropImageOptions.activityMenuIconColor
-      )
-      updateMenuItemIconColor(
-        menu,
-        CropperR.id.ic_rotate_right_24,
-        cropImageOptions.activityMenuIconColor
-      )
-      updateMenuItemIconColor(menu, CropperR.id.ic_flip_24, cropImageOptions.activityMenuIconColor)
-
-      if (cropIcon != null) {
-        updateMenuItemIconColor(
-          menu,
-          CropperR.id.crop_image_menu_crop,
-          cropImageOptions.activityMenuIconColor
-        )
-      }
+  private fun Menu.setItemsVisibility() {
+    if (!cropImageOptions.allowRotation) {
+      removeItem(CropperR.id.ic_rotate_left_24)
+      removeItem(CropperR.id.ic_rotate_right_24)
+    } else if (cropImageOptions.allowCounterRotation) {
+      findItem(CropperR.id.ic_rotate_left_24).isVisible = true
     }
-    cropImageOptions.activityMenuTextColor?.let { menuItemsTextColor ->
-      val menuItemIds = listOf(
-        CropperR.id.ic_rotate_left_24,
-        CropperR.id.ic_rotate_right_24,
-        CropperR.id.ic_flip_24,
-        CropperR.id.ic_flip_24_horizontally,
-        CropperR.id.ic_flip_24_vertically,
-        CropperR.id.crop_image_menu_crop
-      )
-      for (itemId in menuItemIds) {
-        updateMenuItemTextColor(menu, itemId, menuItemsTextColor)
-      }
+    if (!cropImageOptions.allowFlipping) {
+      removeItem(CropperR.id.ic_flip_24)
     }
-
-    tintAllMenuItems(menu)
-    return true
+    if (cropImageOptions.cropMenuCropButtonTitle != null) {
+      findItem(CropperR.id.crop_image_menu_crop).title =
+        cropImageOptions.cropMenuCropButtonTitle
+    }
   }
 
   override fun onPrepareOptionsMenu(menu: Menu): Boolean {
     val result = super.onPrepareOptionsMenu(menu)
-    tintAllMenuItems(menu)
+    menu.forEachItem {
+      it.setIconTintColor(currentIconColor)
+    }
     return result
   }
 
-  override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
-    CropperR.id.crop_image_menu_crop -> {
-      cropImage()
-      true
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    when (item.itemId) {
+      CropperR.id.crop_image_menu_crop -> cropImage()
+      CropperR.id.ic_rotate_left_24 -> cropImageView?.rotateImage(-cropImageOptions.rotationDegrees)
+      CropperR.id.ic_rotate_right_24 -> cropImageView?.rotateImage(cropImageOptions.rotationDegrees)
+      CropperR.id.ic_flip_24_horizontally -> cropImageView?.flipImageHorizontally()
+      CropperR.id.ic_flip_24_vertically -> cropImageView?.flipImageVertically()
+      android.R.id.home -> setResultCancel()
+      else -> return super.onOptionsItemSelected(item)
     }
-    CropperR.id.ic_rotate_left_24 -> {
-      cropImageView?.rotateImage(-cropImageOptions.rotationDegrees)
-      true
-    }
-    CropperR.id.ic_rotate_right_24 -> {
-      cropImageView?.rotateImage(cropImageOptions.rotationDegrees)
-      true
-    }
-    CropperR.id.ic_flip_24_horizontally -> {
-      cropImageView?.flipImageHorizontally()
-      true
-    }
-    CropperR.id.ic_flip_24_vertically -> {
-      cropImageView?.flipImageVertically()
-      true
-    }
-    android.R.id.home -> {
-      setResultCancel()
-      true
-    }
-    else -> super.onOptionsItemSelected(item)
+    return true
   }
 
   override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception?) {
-    if (error == null) {
-      if (cropImageOptions.initialCropWindowRectangle != null) {
-        cropImageView?.cropRect = cropImageOptions.initialCropWindowRectangle
-      }
-
-      if (cropImageOptions.initialRotation > 0) {
-        cropImageView?.rotatedDegrees = cropImageOptions.initialRotation
-      }
-
-      if (cropImageOptions.skipEditing) {
-        cropImage()
-      }
-    } else {
+    if (error != null) {
       setResult(null, error, 1)
+    }
+    if (cropImageOptions.initialCropWindowRectangle != null) {
+      cropImageView?.cropRect = cropImageOptions.initialCropWindowRectangle
+    }
+
+    if (cropImageOptions.initialRotation > 0) {
+      cropImageView?.rotatedDegrees = cropImageOptions.initialRotation
+    }
+
+    if (cropImageOptions.skipEditing) {
+      cropImage()
     }
   }
 
@@ -390,49 +354,55 @@ class ExpoCropImageActivity :
   // endregion
 
   // region Menu Helpers
-  private fun tintAllMenuItems(menu: Menu) {
-    for (i in 0 until menu.size) {
-      menu[i].icon?.mutate()?.setTint(currentIconColor)
+  private fun Menu.forEachItem(action: (MenuItem) -> Unit) {
+    forEach { menuItem ->
+      action(menuItem)
+      menuItem.subMenu?.forEachItem(action)
     }
   }
 
-  private fun updateMenuItemTextColor(menu: Menu, itemId: Int, color: Int) {
-    val menuItem = menu.findItem(itemId) ?: return
-    val menuTitle = menuItem.title
-    if (menuTitle?.isNotBlank() == true) {
-      try {
-        val spannableTitle: Spannable = SpannableString(menuTitle)
-        spannableTitle.setSpan(
-          ForegroundColorSpan(color),
-          0,
-          spannableTitle.length,
-          Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-        )
-        menuItem.title = spannableTitle
-      } catch (e: Exception) {
-        Log.w("ExpoCropImage", "Failed to update menu item color", e)
+  private fun MenuItem.updateTextColor(color: Int) {
+    val menuTitle = title
+    if (menuTitle.isNullOrBlank()) {
+      Log.w("ExpoCropImage", "Menu item title is null or blank, cannot update text color")
+      return
+    }
+
+    try {
+      val plainTitle = menuTitle.toString()
+      val spannableTitle = SpannableString(menuTitle)
+      spannableTitle.setSpan(
+        ForegroundColorSpan(color),
+        0,
+        spannableTitle.length,
+        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+      )
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        tooltipText = plainTitle
+        contentDescription = plainTitle
       }
+      title = spannableTitle
+    } catch (e: Exception) {
+      Log.w("ExpoCropImage", "Failed to update menu item color", e)
     }
   }
 
-  private fun updateMenuItemIconColor(menu: Menu, itemId: Int, color: Int) {
-    val menuItem = menu.findItem(itemId)
-    if (menuItem != null) {
-      val menuItemIcon = menuItem.icon
-      if (menuItemIcon != null) {
-        try {
-          menuItemIcon.apply {
-            mutate()
-            colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
-              color,
-              BlendModeCompat.SRC_ATOP
-            )
-          }
-          menuItem.icon = menuItemIcon
-        } catch (e: Exception) {
-          Log.w("ExpoCropImage", "Failed to update menu item color", e)
-        }
-      }
+  private fun MenuItem.setIconTintColor(color: Int) {
+    icon?.mutate()?.setTint(color)
+  }
+
+  private fun MenuItem.updateIconColor(color: Int) {
+    val menuItemIcon = icon?.mutate()
+      ?: return
+
+    try {
+      menuItemIcon.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+        color,
+        BlendModeCompat.SRC_ATOP
+      )
+      icon = menuItemIcon
+    } catch (e: Exception) {
+      Log.w("ExpoCropImage", "Failed to update menu item icon color", e)
     }
   }
   // endregion

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -334,6 +334,7 @@ class ExpoCropImageActivity :
   override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception?) {
     if (error != null) {
       setResult(null, error, 1)
+      return
     }
     if (cropImageOptions.initialCropWindowRectangle != null) {
       cropImageView?.cropRect = cropImageOptions.initialCropWindowRectangle

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -11,6 +11,7 @@ import com.canhub.cropper.CropImage
 import com.canhub.cropper.CropImageOptions
 import com.canhub.cropper.CropImageView
 import expo.modules.imagepicker.CropShape
+import expo.modules.imagepicker.ExpoCropImageActivity
 import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.MediaType
 import expo.modules.imagepicker.copyExifData
@@ -24,7 +25,7 @@ import java.io.Serializable
 internal class CropImageContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<CropImageContractOptions, ImagePickerContractResult> {
-  override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, expo.modules.imagepicker.ExpoCropImageActivity::class.java).apply {
+  override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, ExpoCropImageActivity::class.java).apply {
     val outputUri = input.outputFile.getContentUri(context)
 
     putExtra(


### PR DESCRIPTION
# Why

Migrate `ExpoCropImageActivity` away from the deprecated `CropImageActivity`. This also removes the reflection that `ExpoCropImageActivity` previously relied on to access private fields in `CropImageActivity`.

The main goal of this refactor is to use `CropImageView` directly in our activity instead of extending `CropImageActivity`.

# How

- Copied the `CropImageActivity` source code and removed the code that is unnecessary for our use case, while keeping `ExpoCropImageActivity` theming logic
- Refactored `onCreate` into smaller orchestration methods

# Test Plan

BareExpo on both a simulator and a physical device; tested that theme changes work correctly
