### PR TITLE
[expo-image] add expo-observe integration

### DIFF
--- a/apps/observe-tester/app/(tabs)/examples/_layout.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/_layout.tsx
@@ -11,6 +11,7 @@ export default function ExamplesLayout() {
         headerTintColor: theme.text.default,
       }}>
       <Stack.Screen name="index" options={{ title: 'Examples' }} />
+      <Stack.Screen name="expo-image" options={{ headerShown: false }} />
       <Stack.Screen name="nested-stack" options={{ headerShown: false }} />
       <Stack.Screen name="preloaded" options={{ headerShown: false }} />
       <Stack.Screen name="modals" options={{ headerShown: false }} />

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/_layout.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack } from 'expo-router';
+
+import { useTheme } from '@/utils/theme';
+
+export default function ExpoImageLayout() {
+  const theme = useTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.background.screen },
+        headerTintColor: theme.text.default,
+      }}>
+      <Stack.Screen name="index" options={{ title: 'Expo Image' }} />
+      <Stack.Screen name="correct" options={{ title: 'Correctly sized' }} />
+      <Stack.Screen name="too-big" options={{ title: 'Too big' }} />
+      <Stack.Screen name="correct-image" options={{ title: 'Correct (<Image>)' }} />
+      <Stack.Screen name="too-big-image" options={{ title: 'Too big (<Image>)' }} />
+      <Stack.Screen name="too-big-phone" options={{ title: 'Too big on phone' }} />
+    </Stack>
+  );
+}

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/correct-image.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/correct-image.tsx
@@ -1,0 +1,61 @@
+import { Image, type ImageLoadEventData } from 'expo-image';
+import { useState } from 'react';
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// A declarative `<Image>` never goes through `Image.loadAsync` — the native view loads it and the
+// integration is fed from the view's `onLoad` decoded size. The source here is sized for display,
+// so its decoded size stays well within the screen budget on both platforms and no
+// `expo-image.oversized` warning is logged. (Note: on iOS `onLoad` reports the size before
+// downscaling, so shrinking a huge source with a small box or `allowDownscaling` does NOT avoid the
+// warning there — fetch a sensibly sized source instead, as below.)
+const SIZE = 220;
+const SOURCE = 'https://picsum.photos/seed/expo-image-view-ok/600/600';
+
+export default function CorrectImageView() {
+  const theme = useTheme();
+  const [decoded, setDecoded] = useState<{ width: number; height: number } | null>(null);
+
+  const onLoad = (event: ImageLoadEventData) => {
+    setDecoded({ width: event.source.width, height: event.source.height });
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      <Image style={styles.image} source={SOURCE} onLoad={onLoad} />
+      <Text style={[styles.heading, { color: theme.text.default }]}>Correct (&lt;Image&gt;)</Text>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        A 600×600px source rendered in a {SIZE}×{SIZE}pt box. Decoded:{' '}
+        {decoded ? `${decoded.width}×${decoded.height}px` : '…'} — well within the screen budget, so
+        no `expo-image.oversized` warning is logged.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  image: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/correct.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/correct.tsx
@@ -1,0 +1,64 @@
+import { Image, useImage } from 'expo-image';
+import { useState } from 'react';
+import { PixelRatio, Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// Load the same large source as the "Too big" page, but constrain decoding to the rendered box size
+// in device pixels with `maxWidth`/`maxHeight`. The decoded image stays well within the screen
+// budget, so no `expo-image.oversized` warning is logged. This is the recommended pattern.
+const SIZE = 220;
+const PIXELS = Math.round(SIZE * PixelRatio.get());
+const SOURCE = 'https://picsum.photos/seed/expo-image-correct/4000/4000';
+
+export default function CorrectImage() {
+  const theme = useTheme();
+  const [failed, setFailed] = useState(false);
+  const image = useImage(SOURCE, {
+    maxWidth: PIXELS,
+    maxHeight: PIXELS,
+    onError: () => setFailed(true),
+  });
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      {image ? <Image style={styles.image} source={image} /> : null}
+      <Text style={[styles.heading, { color: theme.text.default }]}>Correctly sized</Text>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        Rendered at {SIZE}×{SIZE}pt and decoded to at most {PIXELS}×{PIXELS}px with `maxWidth`/
+        `maxHeight`. Decoded:{' '}
+        {image ? `${image.width * image.scale}×${image.height * image.scale}px` : '…'}. No
+        `expo-image.oversized` warning is logged.
+      </Text>
+      {failed ? (
+        <Text style={[styles.body, { color: theme.text.secondary }]}>Failed to load the image.</Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  image: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/index.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/index.tsx
@@ -1,0 +1,76 @@
+import { router } from 'expo-router';
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { Button } from '@/components/Button';
+import { useTheme } from '@/utils/theme';
+
+export default function ExpoImageIndex() {
+  const theme = useTheme();
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        The `expo-image` integration logs a warning when an image is decoded far larger than the
+        screen needs, across every loading path: `Image.loadAsync`/`useImage` and declarative{' '}
+        {'`<Image>`'}. Enabled in the root layout with{' '}
+        {`integrations: { 'expo-image': { oversizeThreshold: 1.5 } }`}. Open a page below, then
+        check the Sessions tab for an `expo-image.oversized` log.
+      </Text>
+
+      <Text style={[styles.section, { color: theme.text.default }]}>useImage / loadAsync</Text>
+      <Button
+        title="Correctly sized"
+        description="Decoding constrained with maxWidth/maxHeight — no warning"
+        onPress={() => router.push('/examples/expo-image/correct')}
+      />
+      <Button
+        title="Too big"
+        description="A huge source loaded unconstrained — logs a warning"
+        onPress={() => router.push('/examples/expo-image/too-big')}
+      />
+
+      <Text style={[styles.section, { color: theme.text.default }]}>{'Declarative <Image>'}</Text>
+      <Button
+        title="Correct (<Image>)"
+        description="Default downscaling keeps it in budget — no warning"
+        onPress={() => router.push('/examples/expo-image/correct-image')}
+      />
+      <Button
+        title="Too big (<Image>)"
+        description="allowDownscaling=false keeps the full bitmap — logs a warning"
+        onPress={() => router.push('/examples/expo-image/too-big-image')}
+      />
+
+      <Text style={[styles.section, { color: theme.text.default }]}>Device-relative</Text>
+      <Button
+        title="Too big on phone"
+        description="Same image: warns on a phone, fine on an iPad"
+        onPress={() => router.push('/examples/expo-image/too-big-phone')}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  body: {
+    fontSize: 15,
+    marginBottom: 20,
+  },
+  section: {
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 12,
+    marginBottom: 8,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/too-big-image.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/too-big-image.tsx
@@ -1,0 +1,62 @@
+import { Image, type ImageLoadEventData } from 'expo-image';
+import { useState } from 'react';
+import { Dimensions, PixelRatio, Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// A declarative `<Image>` never goes through `Image.loadAsync` — the native view loads it and the
+// integration is fed from the view's `onLoad` decoded size. `allowDownscaling={false}` keeps the
+// full 4000×4000 bitmap on Android (where downscaling otherwise shrinks the decode to the box). On
+// iOS `onLoad` already reports the full pre-downscale size, so it warns regardless. Either way the
+// decoded size far exceeds the screen and an `expo-image.oversized` warning is logged.
+const SIZE = 220;
+const SOURCE = 'https://picsum.photos/seed/expo-image-view-big/4000/4000';
+
+export default function TooBigImageView() {
+  const theme = useTheme();
+  const [decoded, setDecoded] = useState<{ width: number; height: number } | null>(null);
+  const screen = Dimensions.get('screen');
+
+  const onLoad = (event: ImageLoadEventData) => {
+    setDecoded({ width: event.source.width, height: event.source.height });
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      <Image style={styles.image} source={SOURCE} allowDownscaling={false} onLoad={onLoad} />
+      <Text style={[styles.heading, { color: theme.text.default }]}>Too big (&lt;Image&gt;)</Text>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        A 4000×4000px source rendered with `allowDownscaling={'{false}'}`. Decoded:{' '}
+        {decoded ? `${decoded.width}×${decoded.height}px` : '…'} — far beyond the screen (
+        {Math.round(screen.width)}×{Math.round(screen.height)}pt @{PixelRatio.get()}x), so an
+        `expo-image.oversized` warning is logged. Check the Sessions tab.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  image: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/too-big-phone.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/too-big-phone.tsx
@@ -1,0 +1,68 @@
+import { Image, useImage } from 'expo-image';
+import { useState } from 'react';
+import { Dimensions, PixelRatio, Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// The criterion is screen-relative: `width*height > screenWidth*screenHeight*pixelRatio²*1.5`. A
+// 2370×2370px image (5.62M px) sits between a phone's budget (~4.5–5.4M on common phones) and a
+// tablet's (~5.8M and up), so it's flagged on a phone but not on an iPad — same image, same code,
+// different verdict by device. The margin against the smallest iPads is ~0.2M px, and numbers are
+// approximate and vary by exact screen size.
+const SIZE = 200;
+const IMAGE_PX = 2370;
+const SOURCE = `https://picsum.photos/seed/expo-image-phone/${IMAGE_PX}/${IMAGE_PX}`;
+
+export default function TooBigPhone() {
+  const theme = useTheme();
+  const [failed, setFailed] = useState(false);
+  const image = useImage(SOURCE, { onError: () => setFailed(true) });
+  const screen = Dimensions.get('screen');
+  const scale = PixelRatio.get();
+  const budget = Math.round(screen.width * screen.height * scale * scale * 1.5);
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      {image ? <Image style={styles.image} source={image} /> : null}
+      <Text style={[styles.heading, { color: theme.text.default }]}>Too big on phone</Text>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        A {IMAGE_PX}×{IMAGE_PX}px image ({(IMAGE_PX * IMAGE_PX).toLocaleString()}px²) loaded with
+        `useImage`. This device's threshold is {budget.toLocaleString()}px² (
+        {Math.round(screen.width)}×{Math.round(screen.height)}pt @{scale}x² × 1.5). On a phone the
+        image exceeds it and an `expo-image.oversized` warning is logged; on an iPad the same image
+        is within budget and no warning fires.
+      </Text>
+      {failed ? (
+        <Text style={[styles.body, { color: theme.text.secondary }]}>
+          Failed to load the image.
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  image: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/expo-image/too-big.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/too-big.tsx
@@ -1,0 +1,64 @@
+import { Image, useImage } from 'expo-image';
+import { useState } from 'react';
+import { Dimensions, PixelRatio, Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+// Load a very large remote image with no size constraints. The loader compares its decoded pixel
+// area against the screen budget (screen point area × pixel ratio² × 1.5) and logs an
+// `expo-image.oversized` warning because it is far beyond what any full-screen image needs. Use
+// `maxWidth`/`maxHeight` (see the "Correctly sized" page) to avoid this.
+const SIZE = 220;
+const SOURCE = 'https://picsum.photos/seed/expo-image-too-big/4000/4000';
+
+export default function TooBigImage() {
+  const theme = useTheme();
+  const [failed, setFailed] = useState(false);
+  const image = useImage(SOURCE, { onError: () => setFailed(true) });
+  const screen = Dimensions.get('screen');
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      {image ? <Text>Image loaded</Text> : null}
+      <Text style={[styles.heading, { color: theme.text.default }]}>Too big</Text>
+      <Text style={[styles.body, { color: theme.text.secondary }]}>
+        A 4000×4000px image loaded with no size constraints. Decoded:{' '}
+        {image ? `${image.width * image.scale}×${image.height * image.scale}px` : '…'} — far beyond
+        this device's screen ({Math.round(screen.width)}×{Math.round(screen.height)}pt @
+        {PixelRatio.get()}x), so an `expo-image.oversized` warning is logged. Check the Sessions
+        tab.
+      </Text>
+      {failed ? (
+        <Text style={[styles.body, { color: theme.text.secondary }]}>
+          Failed to load the image.
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  image: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/index.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/index.tsx
@@ -14,6 +14,11 @@ export default function ExamplesIndex() {
       contentContainerStyle={styles.content}>
       <ObserveInteractiveMarker />
       <Button
+        title="Expo Image"
+        description="Oversized-image reporting: correctly sized vs too big"
+        onPress={() => router.push('/examples/expo-image')}
+      />
+      <Button
         title="Nested stack"
         description="Network, heavy renders, params, nested modal"
         onPress={() => router.push('/examples/nested-stack')}

--- a/apps/observe-tester/app/_layout.tsx
+++ b/apps/observe-tester/app/_layout.tsx
@@ -9,6 +9,9 @@ Observe.configure({
   dispatchInDebug: true,
   integrations: {
     'expo-router': true,
+    'expo-image': {
+      oversizeThreshold: 1.5,
+    },
   },
 });
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `Image.writeToCacheAsync` and `Image.readFromCacheAsync` to seed and read the image cache by cache key. ([#46620](https://github.com/expo/expo/pull/46620) by [@tsapeta](https://github.com/tsapeta))
 - Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - [web] Improved `static` image source selection on web to be based on the rendered layout size by leading the generated `sizes` with `auto`, and default `static` images to `loading="lazy"` (opt out with `loading="eager"`). ([#46425](https://github.com/expo/expo/pull/46425) by [@sebholl](https://github.com/sebholl))
+- add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -47,7 +47,9 @@
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
     "expo": "workspace:*",
-    "expo-module-scripts": "workspace:*"
+    "expo-app-metrics": "workspace:*",
+    "expo-module-scripts": "workspace:*",
+    "expo-observe": "workspace:*"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -11,6 +11,7 @@ import type {
 import type { SFSymbol } from 'sf-symbols-typescript';
 
 import type ExpoImage from './ExpoImage';
+import type { ExpoImageIntegrationConfig } from './observe';
 
 export type ImageSource = {
   /**
@@ -885,3 +886,16 @@ export type ImageCacheConfig = {
    */
   maxMemoryCount?: number;
 };
+
+// Register the `'expo-image'` key on expo-observe's open `ObserveIntegrationsConfig` interface via
+// declaration merging, so `Observe.configure({ integrations: { 'expo-image': ... } })` is suggested
+// and type-checked. The config type itself lives in `observe.ts` (imported at the top of this file).
+// This augmentation lives here, not in `observe.ts`, because `index.ts` reaches `observe.ts` only
+// through a runtime value import that is elided from the emitted `index.d.ts` — so an augmentation
+// there would not ship to consumers. `Image.types.ts` is re-exported via `export *`, which survives
+// declaration emit, so the augmentation is always in the package's public type graph.
+declare module 'expo-observe' {
+  interface ObserveIntegrationsConfig {
+    'expo-image'?: boolean | ExpoImageIntegrationConfig;
+  }
+}

--- a/packages/expo-image/src/__tests__/observe.test.ts
+++ b/packages/expo-image/src/__tests__/observe.test.ts
@@ -1,0 +1,448 @@
+import { requireOptionalNativeModule } from 'expo';
+import type { ExpoAppMetricsModuleType } from 'expo-app-metrics';
+import type { ObserveModule, ObserveModuleEvents } from 'expo-observe';
+import { Dimensions, PixelRatio } from 'react-native';
+
+import type { ImageModuleEvents, ImageNativeModule } from '../Image.types';
+import {
+  activate,
+  handleImageLoaded,
+  initObserveIntegrationIfNeeded,
+  initObserveIntegrationIfNeededImpl,
+  reportIfOversized,
+} from '../observe';
+import type { IntegrationState, LoadedImage } from '../observe';
+
+jest.mock('expo', () => ({
+  requireOptionalNativeModule: jest.fn(),
+}));
+
+const requireNativeModule = requireOptionalNativeModule as unknown as jest.Mock;
+let getScreen: jest.SpyInstance;
+let getPixelRatio: jest.SpyInstance;
+
+function screenSize(width: number, height: number) {
+  return { width, height } as unknown as ReturnType<typeof Dimensions.get>;
+}
+
+type MockOf<T> = { [K in keyof T]: jest.Mock };
+
+const CONFIGURE = 'configure' satisfies keyof ObserveModuleEvents;
+const IMAGE_LOADED = 'imageLoaded' satisfies keyof ImageModuleEvents;
+
+type FakeObserve = MockOf<Pick<ObserveModule, 'getIntegrations' | 'addListener'>> & {
+  emit: (name: string, payload: unknown) => void;
+};
+
+type FakeAppMetrics = MockOf<Pick<ExpoAppMetricsModuleType, 'logEvent'>>;
+
+type FakeImageModule = MockOf<Pick<ImageNativeModule, 'addListener'>> & {
+  remove: jest.Mock;
+  emit: (name: string, payload: unknown) => void;
+};
+
+function makeObserve(integrations: Record<string, unknown>): FakeObserve {
+  const listeners: Record<string, ((payload: unknown) => void)[]> = {};
+  return {
+    getIntegrations: jest.fn(() => integrations),
+    addListener: jest.fn((name: string, cb: (payload: unknown) => void) => {
+      (listeners[name] ??= []).push(cb);
+      return { remove: jest.fn() };
+    }),
+    emit(name, payload) {
+      (listeners[name] ?? []).forEach((cb) => cb(payload));
+    },
+  };
+}
+
+function makeAppMetrics(): FakeAppMetrics {
+  return { logEvent: jest.fn() };
+}
+
+function makeImageModule(): FakeImageModule {
+  const listeners: Record<string, ((payload: unknown) => void)[]> = {};
+  const remove = jest.fn();
+  return {
+    remove,
+    addListener: jest.fn((name: string, cb: (payload: unknown) => void) => {
+      (listeners[name] ??= []).push(cb);
+      return { remove };
+    }),
+    emit(name, payload) {
+      (listeners[name] ?? []).forEach((cb) => cb(payload));
+    },
+  };
+}
+
+function mockNativeModules({
+  observe = null,
+  appMetrics = null,
+  imageModule = null,
+}: {
+  observe?: FakeObserve | null;
+  appMetrics?: FakeAppMetrics | null;
+  imageModule?: FakeImageModule | null;
+}) {
+  requireNativeModule.mockImplementation((name: string) =>
+    name === 'ExpoObserve' ? observe : name === 'ExpoImage' ? imageModule : appMetrics
+  );
+}
+
+beforeEach(() => {
+  getScreen = jest.spyOn(Dimensions, 'get').mockReturnValue(screenSize(100, 100));
+  getPixelRatio = jest.spyOn(PixelRatio, 'get').mockReturnValue(1);
+  requireNativeModule.mockReset();
+  requireNativeModule.mockReturnValue(null);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+function state(
+  over: Partial<{
+    enabled: boolean;
+    threshold: number;
+    reported: Set<string>;
+    subscription: { remove: () => void } | null;
+    appMetrics: FakeAppMetrics | null;
+    imageModule: FakeImageModule | null;
+  }> = {}
+): IntegrationState {
+  return {
+    enabled: true,
+    threshold: 2,
+    reported: new Set<string>(),
+    subscription: null,
+    appMetrics: makeAppMetrics(),
+    imageModule: makeImageModule(),
+    ...over,
+  } as unknown as IntegrationState;
+}
+
+function image(
+  width: number,
+  height = width,
+  url = 'https://example.com/a.png',
+  pixelRatio = 1
+): LoadedImage {
+  return { url, width, height, screenWidth: 100, screenHeight: 100, pixelRatio };
+}
+
+describe('reportIfOversized', () => {
+  it('logs a warning once when the image area exceeds the screen budget times the ratio', () => {
+    const appMetrics = makeAppMetrics();
+
+    // budget 10000 × ratio 3 = 30000; 200×200 = 40000 > 30000
+    reportIfOversized(
+      state({ threshold: 3, appMetrics }),
+      image(200, 200, 'https://example.com/a.png', 1)
+    );
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+    const [name, options] = appMetrics.logEvent.mock.calls[0];
+    expect(name).toBe('expo-image.oversized');
+    expect(options.displayName).toBe('Oversized image loaded');
+    expect(options.severity).toBe('warn');
+    expect(options.attributes).toMatchObject({
+      url: 'https://example.com/a.png',
+      imageWidth: 200,
+      imageHeight: 200,
+      screenWidth: 100,
+      screenHeight: 100,
+      pixelRatio: 1,
+    });
+  });
+
+  it('does not log when the image area is within the budget', () => {
+    const appMetrics = makeAppMetrics();
+
+    // budget 10000 × ratio 3 = 30000; 150×150 = 22500 < 30000
+    reportIfOversized(state({ threshold: 3, appMetrics }), image(150));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('squares the device pixel ratio in the budget', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ threshold: 2, appMetrics });
+
+    // screen 100×100 @3x → budget 100*100*3*3 = 90000; ratio 2 → 180000
+    reportIfOversized(s, image(400, 400, 'https://example.com/a.png', 3)); // 160000 < 180000
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+
+    reportIfOversized(s, image(450, 450, 'https://example.com/b.png', 3)); // 202500 > 180000
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log when the integration is not enabled', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(state({ enabled: false, appMetrics }), image(1000));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports each source url at most once', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ threshold: 2, appMetrics });
+
+    reportIfOversized(s, image(1000));
+    reportIfOversized(s, image(1000));
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports distinct oversized urls independently', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ threshold: 2, appMetrics });
+
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png'));
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/b.png'));
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not log when the area exactly equals the budget times the ratio', () => {
+    const appMetrics = makeAppMetrics();
+
+    // budget 10000 × ratio 2 = 20000; 200×100 = 20000 — strictly greater is required
+    reportIfOversized(state({ threshold: 2, appMetrics }), image(200, 100));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not log or throw when the image has no measurable size', () => {
+    const appMetrics = makeAppMetrics();
+
+    expect(() => reportIfOversized(state({ appMetrics }), image(0))).not.toThrow();
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when app-metrics is not installed', () => {
+    expect(() => reportIfOversized(state({ appMetrics: null }), image(1000))).not.toThrow();
+  });
+
+  it('does not throw when logEvent fails', () => {
+    const appMetrics: FakeAppMetrics = {
+      logEvent: jest.fn(() => {
+        throw new Error('logEvent failed');
+      }),
+    };
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => reportIfOversized(state({ appMetrics }), image(1000))).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('handleImageLoaded', () => {
+  it('pairs the loaded image with the current screen size and forwards it to report', () => {
+    getScreen.mockReturnValue(screenSize(120, 240));
+    getPixelRatio.mockReturnValue(3);
+    const report = jest.fn();
+    const s = state();
+
+    handleImageLoaded(s, { url: 'https://example.com/a.png', width: 300, height: 300 }, report);
+
+    expect(report).toHaveBeenCalledWith(s, {
+      url: 'https://example.com/a.png',
+      width: 300,
+      height: 300,
+      screenWidth: 120,
+      screenHeight: 240,
+      pixelRatio: 3,
+    });
+  });
+});
+
+describe('activate', () => {
+  it('enables and subscribes, reading the oversize threshold from an object config', () => {
+    const imageModule = makeImageModule();
+    const s = state({ enabled: false, imageModule });
+
+    activate(s, { 'expo-image': { oversizeThreshold: 3 } });
+
+    expect(s.enabled).toBe(true);
+    expect(s.threshold).toBe(3);
+    expect(s.subscription).not.toBeNull();
+    expect(imageModule.addListener).toHaveBeenCalledWith(IMAGE_LOADED, expect.any(Function));
+  });
+
+  it('uses the default oversize threshold of 1.5 when enabled with `true`', () => {
+    const s = state({ enabled: false });
+
+    activate(s, { 'expo-image': true });
+
+    expect(s.enabled).toBe(true);
+    expect(s.threshold).toBe(1.5);
+  });
+
+  it('does not enable or subscribe when the config is absent', () => {
+    const imageModule = makeImageModule();
+    const s = state({ enabled: false, imageModule });
+
+    activate(s, {});
+
+    expect(s.enabled).toBe(false);
+    expect(imageModule.addListener).not.toHaveBeenCalled();
+  });
+
+  it('does not enable when disabled with `false`', () => {
+    const s = state({ enabled: false });
+
+    activate(s, { 'expo-image': false });
+
+    expect(s.enabled).toBe(false);
+  });
+
+  it('resets the dedup set so a previously reported url can report again', () => {
+    const reported = new Set(['https://example.com/a.png']);
+    const s = state({ reported });
+
+    activate(s, { 'expo-image': true });
+
+    expect(s.reported.size).toBe(0);
+    expect(s.reported).not.toBe(reported);
+  });
+
+  it('subscribes only once across repeated enabling configures', () => {
+    const imageModule = makeImageModule();
+    const s = state({ enabled: false, imageModule });
+
+    activate(s, { 'expo-image': true });
+    activate(s, { 'expo-image': { oversizeThreshold: 4 } });
+
+    expect(imageModule.addListener).toHaveBeenCalledTimes(1);
+    expect(s.threshold).toBe(4);
+  });
+
+  it('unsubscribes when a later configure disables the integration', () => {
+    const remove = jest.fn();
+    const s = state({ enabled: true, subscription: { remove } });
+
+    activate(s, {});
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(s.subscription).toBeNull();
+  });
+
+  it('re-subscribes after being disabled and enabled again', () => {
+    const imageModule = makeImageModule();
+    const s = state({ enabled: false, imageModule });
+
+    activate(s, { 'expo-image': true });
+    activate(s, {});
+    activate(s, { 'expo-image': true });
+
+    expect(imageModule.addListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes a native imageLoaded event to the injected handler', () => {
+    const imageModule = makeImageModule();
+    const handle = jest.fn();
+    const s = state({ enabled: false, imageModule });
+
+    activate(s, { 'expo-image': true }, handle);
+    imageModule.emit(IMAGE_LOADED, { url: 'https://example.com/a.png', width: 1, height: 1 });
+
+    expect(handle).toHaveBeenCalledWith(s, {
+      url: 'https://example.com/a.png',
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it('routes a native imageLoaded event through the default handler to logEvent', () => {
+    // screen 100×100pt @1x → budget 10000; default ratio 1.5 → 15000
+    const appMetrics = makeAppMetrics();
+    const imageModule = makeImageModule();
+    const s = state({ enabled: false, appMetrics, imageModule });
+
+    activate(s, { 'expo-image': true });
+    imageModule.emit(IMAGE_LOADED, {
+      url: 'https://example.com/big.png',
+      width: 300,
+      height: 300,
+    });
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes).toMatchObject({
+      url: 'https://example.com/big.png',
+      imageWidth: 300,
+      imageHeight: 300,
+      screenWidth: 100,
+      screenHeight: 100,
+      pixelRatio: 1,
+    });
+  });
+});
+
+describe('initObserveIntegrationIfNeededImpl', () => {
+  it('activates with the current integrations on load', () => {
+    const observe = makeObserve({ 'expo-image': { oversizeThreshold: 3 } });
+    mockNativeModules({ observe });
+    const activateSpy = jest.fn();
+
+    initObserveIntegrationIfNeededImpl(activateSpy);
+
+    expect(activateSpy).toHaveBeenCalledTimes(1);
+    expect(activateSpy.mock.calls[0][1]).toEqual({ 'expo-image': { oversizeThreshold: 3 } });
+  });
+
+  it('re-activates on each later configure event', () => {
+    const observe = makeObserve({});
+    mockNativeModules({ observe });
+    const activateSpy = jest.fn();
+
+    initObserveIntegrationIfNeededImpl(activateSpy);
+    observe.emit(CONFIGURE, { integrations: { 'expo-image': { oversizeThreshold: 2 } } });
+
+    expect(activateSpy).toHaveBeenCalledTimes(2);
+    expect(activateSpy.mock.calls[1][1]).toEqual({ 'expo-image': { oversizeThreshold: 2 } });
+  });
+
+  it('passes the same state object to every activate call', () => {
+    const observe = makeObserve({});
+    mockNativeModules({ observe });
+    const activateSpy = jest.fn();
+
+    initObserveIntegrationIfNeededImpl(activateSpy);
+    observe.emit(CONFIGURE, { integrations: { 'expo-image': true } });
+
+    expect(activateSpy.mock.calls[1][0]).toBe(activateSpy.mock.calls[0][0]);
+  });
+
+  it('resolves and threads the native modules into state', () => {
+    const observe = makeObserve({ 'expo-image': true });
+    const appMetrics = makeAppMetrics();
+    const imageModule = makeImageModule();
+    mockNativeModules({ observe, appMetrics, imageModule });
+    const activateSpy = jest.fn();
+
+    initObserveIntegrationIfNeededImpl(activateSpy);
+
+    const passedState = activateSpy.mock.calls[0][0];
+    expect(passedState.appMetrics).toBe(appMetrics);
+    expect(passedState.imageModule).toBe(imageModule);
+  });
+
+  it('is a no-op when expo-observe is not installed', () => {
+    // `requireNativeModule` resolves to `null` by default (see `beforeEach`).
+    const activateSpy = jest.fn();
+
+    initObserveIntegrationIfNeededImpl(activateSpy);
+
+    expect(activateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('initObserveIntegrationIfNeeded', () => {
+  it('runs the impl at most once across repeated calls', () => {
+    const observe = makeObserve({ 'expo-image': true });
+    mockNativeModules({ observe, appMetrics: makeAppMetrics(), imageModule: makeImageModule() });
+
+    initObserveIntegrationIfNeeded();
+    initObserveIntegrationIfNeeded();
+
+    expect(observe.getIntegrations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/expo-image/src/index.ts
+++ b/packages/expo-image/src/index.ts
@@ -1,3 +1,11 @@
+import { initObserveIntegrationIfNeeded } from './observe';
+
+// `observe.ts` is a client module ('use client'); calling it from a React server component is
+// illegal.
+if (typeof window !== 'undefined') {
+  initObserveIntegrationIfNeeded();
+}
+
 export * from './Image.types';
 export { Image } from './Image';
 export { ImageBackground } from './ImageBackground';

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -1,0 +1,172 @@
+'use client';
+
+import { requireOptionalNativeModule } from 'expo';
+import type { ExpoAppMetricsModuleType } from 'expo-app-metrics';
+import type { ObserveIntegrationsConfig, ObserveModule } from 'expo-observe';
+import { Dimensions, PixelRatio } from 'react-native';
+
+import type { ImageNativeModule } from './Image.types';
+
+/**
+ * Configuration for the `expo-observe` integration, set through
+ * `Observe.configure({ integrations: { 'expo-image': ... } })`. Passing `true` enables it with
+ * defaults; the object form tunes the behavior.
+ *
+ * The `declare module 'expo-observe'` augmentation that registers the `'expo-image'` key lives in
+ * `Image.types.ts` (always in the package's public type graph via `export *`, so it is picked up
+ * whenever expo-image is imported). `Image.types.ts` `import type`s this from here. It is exported
+ * from this module but not from the package entry, so it is not part of the public API.
+ */
+export type ExpoImageIntegrationConfig = {
+  /**
+   * An image is reported as oversized when its decoded pixel area exceeds the screen's physical
+   * pixel count (its point area times the square of the device pixel ratio) by more than this
+   * factor. For example, `1.5` flags an image decoded at more than 1.5× the pixels the screen
+   * physically has — a full-screen image plus 50% headroom.
+   *
+   * @default 1.5
+   */
+  oversizeThreshold?: number;
+};
+
+const DEFAULT_OVERSIZE_THRESHOLD = 1.5;
+
+// Guards `initObserveIntegrationIfNeeded` so repeated calls wire up the integration only once.
+let initialized = false;
+
+// Exported for testing purposes only.
+export type IntegrationState = {
+  enabled: boolean;
+  threshold: number;
+  // URLs already reported under the current configuration. Only oversized images are added.
+  reported: Set<string>;
+  // Subscription to the native `imageLoaded` event, held only while the integration is enabled.
+  subscription: { remove: () => void } | null;
+  // Native modules resolved when the integration initializes; either may be absent.
+  appMetrics: ExpoAppMetricsModuleType | null;
+  imageModule: ImageNativeModule | null;
+};
+
+type Integrations = ObserveIntegrationsConfig & {
+  'expo-image'?: ExpoImageIntegrationConfig;
+};
+
+// Exported for testing purposes only.
+export type LoadedImage = {
+  url: string;
+  width: number;
+  height: number;
+  screenWidth: number;
+  screenHeight: number;
+  pixelRatio: number;
+};
+
+// Exported for testing purposes only.
+export function reportIfOversized(state: IntegrationState, image: LoadedImage): void {
+  if (!state.enabled || !state.appMetrics) {
+    return;
+  }
+  const { url, width, height, screenWidth, screenHeight, pixelRatio } = image;
+  if (!url || !(width > 0) || !(height > 0)) {
+    return;
+  }
+  if (state.reported.has(url)) {
+    return;
+  }
+  // Screen area is in points; the decoded image is in pixels, so convert with pixelRatio² to get
+  // the screen's physical pixel count.
+  const budget = screenWidth * screenHeight * pixelRatio * pixelRatio;
+  if (!(budget > 0) || width * height <= budget * state.threshold) {
+    return;
+  }
+  state.reported.add(url);
+  try {
+    state.appMetrics.logEvent('expo-image.oversized', {
+      displayName: 'Oversized image loaded',
+      severity: 'warn',
+      body: `Image loaded at ${width}×${height}px is far larger than this device's screen (${screenWidth}×${screenHeight}pt @${pixelRatio}x). Constrain it with the maxWidth/maxHeight load options.`,
+      attributes: {
+        url,
+        imageWidth: width,
+        imageHeight: height,
+        screenWidth,
+        screenHeight,
+        pixelRatio,
+      },
+    });
+  } catch {
+    console.warn('[expo-image] Failed to logEvent for oversized image.');
+    // Reporting is best-effort; a logging failure must not disrupt image loading.
+  }
+}
+
+// Exported for testing purposes only.
+export function handleImageLoaded(
+  state: IntegrationState,
+  image: { url: string; width: number; height: number },
+  report = reportIfOversized
+): void {
+  const screen = Dimensions.get('screen');
+  report(state, {
+    ...image,
+    screenWidth: screen.width,
+    screenHeight: screen.height,
+    pixelRatio: PixelRatio.get(),
+  });
+}
+
+// Exported for testing purposes only.
+export function activate(
+  state: IntegrationState,
+  integrations: Integrations,
+  handle = handleImageLoaded
+): void {
+  const config = integrations['expo-image'];
+  state.enabled = !!config;
+  state.threshold =
+    typeof config === 'object' && config !== null
+      ? (config.oversizeThreshold ?? DEFAULT_OVERSIZE_THRESHOLD)
+      : DEFAULT_OVERSIZE_THRESHOLD;
+  // A new configure may change the threshold (or enable the integration), so start a fresh dedup
+  // set: images already reported under the previous settings become eligible to report again.
+  state.reported = new Set<string>();
+  if (state.enabled && !state.subscription && state.imageModule) {
+    state.subscription = state.imageModule.addListener('imageLoaded', (image) =>
+      handle(state, image)
+    );
+  } else if (!state.enabled && state.subscription) {
+    state.subscription.remove();
+    state.subscription = null;
+  }
+}
+
+// Exported for testing purposes only.
+export function initObserveIntegrationIfNeededImpl(
+  activate: (state: IntegrationState, integrations: Integrations) => void
+): void {
+  const observe = requireOptionalNativeModule<ObserveModule>('ExpoObserve');
+  if (!observe) {
+    return;
+  }
+  const state: IntegrationState = {
+    enabled: false,
+    threshold: DEFAULT_OVERSIZE_THRESHOLD,
+    reported: new Set<string>(),
+    subscription: null,
+    appMetrics: requireOptionalNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics'),
+    imageModule: requireOptionalNativeModule<ImageNativeModule>('ExpoImage'),
+  };
+  activate(state, observe.getIntegrations());
+  observe.addListener('configure', ({ integrations }) => activate(state, integrations));
+}
+
+/**
+ * Wires the expo-observe oversized-image integration. Idempotent.
+ */
+export function initObserveIntegrationIfNeeded(): void {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+  initObserveIntegrationIfNeededImpl(activate);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4643,9 +4643,15 @@ importers:
       expo:
         specifier: workspace:*
         version: link:../expo
+      expo-app-metrics:
+        specifier: workspace:*
+        version: link:../expo-app-metrics
       expo-module-scripts:
         specifier: workspace:*
         version: link:../expo-module-scripts
+      expo-observe:
+        specifier: workspace:*
+        version: link:../expo-observe
 
   packages/expo-image-loader:
     devDependencies:


### PR DESCRIPTION
# Why

Using the image loaded event from previous PR, this PR logs event when image is too big

# How

1. Subscribe to image loaded
2. When `img.w * img.h > screen.w * screen.h * pixelRatio * userDefinedRation` log `expo-image.oversized` event (user defined ratio defaults to `2`)
3. Extend observe configuration in ts to include `expo-image` property

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
