### PR TITLE
[cellular][Android] Remove deprecated `allowsVoipAsync`

### DIFF
--- a/apps/native-component-list/src/screens/CellularScreen.tsx
+++ b/apps/native-component-list/src/screens/CellularScreen.tsx
@@ -8,7 +8,6 @@ import Button from '../components/Button';
 import MonoText from '../components/MonoText';
 
 type CellularInfo = {
-  allowsVoip: boolean | null;
   carrier: string | null;
   isoCountryCode: string | null;
   mobileCountryCode: string | null;
@@ -29,7 +28,6 @@ export default function CellularScreen() {
       }
       const generation = await Cellular.getCellularGenerationAsync();
       setCellularInfo({
-        allowsVoip: await Cellular.allowsVoipAsync(),
         carrier: await Cellular.getCarrierNameAsync(),
         isoCountryCode: await Cellular.getIsoCountryCodeAsync(),
         mobileCountryCode: await Cellular.getMobileCountryCodeAsync(),

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [Android] Remove deprecated allowsVoipAsync ([#47148](https://github.com/expo/expo/pull/47148) by [@Wenszel](https://github.com/Wenszel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -3,7 +3,6 @@ package expo.modules.cellular
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
-import android.net.sip.SipManager
 import android.os.Build
 import android.telephony.TelephonyManager
 import android.util.Log
@@ -26,10 +25,6 @@ class CellularModule : Module() {
         Log.w(moduleName, "READ_PHONE_STATE permission is required to acquire network type", e)
         CellularGeneration.UNKNOWN.value
       }
-    }
-
-    AsyncFunction<Boolean>("allowsVoipAsync") {
-      SipManager.isVoipSupported(context)
     }
 
     AsyncFunction<String?>("getIsoCountryCodeAsync") {

--- a/packages/expo-cellular/src/Cellular.ts
+++ b/packages/expo-cellular/src/Cellular.ts
@@ -33,35 +33,6 @@ export async function getCellularGenerationAsync(): Promise<CellularGeneration> 
 }
 
 /**
- * @return Returns if the carrier allows making VoIP calls on its network. On Android, this checks whether
- * the system supports SIP-based VoIP API. See [here](https://developer.android.com/reference/android/net/sip/SipManager.html#isVoipSupported(android.content.Context))
- * to view more information.
- *
- * On iOS, if you configure a device for a carrier and then remove the SIM card, this property
- * retains the `boolean` value indicating the carrier’s policy regarding VoIP. If you then install
- * a new SIM card, its VoIP policy `boolean` replaces the previous value of this property.
- *
- * On iOS and web, this returns `null`.
- *
- * @platform android
- *
- * @example
- * ```ts
- * await Cellular.allowsVoipAsync(); // true or false
- * ```
- * @deprecated Voip technology is not widely used and Google is removing it from the Android platform. This method will be removed in a future release.
- */
-export async function allowsVoipAsync(): Promise<boolean | null> {
-  if (Platform.OS === 'ios') {
-    return null;
-  }
-  if (!ExpoCellular.allowsVoipAsync) {
-    throw new UnavailabilityError('expo-cellular', 'allowsVoipAsync');
-  }
-  return await ExpoCellular.allowsVoipAsync();
-}
-
-/**
  * @return Returns the ISO country code for the user’s cellular service provider.
  *
  * On iOS, the value is `null` if any of the following apply:

--- a/packages/expo-cellular/src/ExpoCellular.web.ts
+++ b/packages/expo-cellular/src/ExpoCellular.web.ts
@@ -1,9 +1,6 @@
 import { CellularGeneration } from './Cellular.types';
 
 export default {
-  get allowsVoip(): null {
-    return null;
-  },
   get carrier(): null {
     return null;
   },
@@ -37,9 +34,6 @@ export default {
     }
   },
 
-  async allowsVoipAsync(): Promise<boolean | null> {
-    return null;
-  },
   async getIsoCountryCodeAsync(): Promise<string | null> {
     return null;
   },


### PR DESCRIPTION
# Why

`allowsVoipAsync` was deprecated in SDK 56 because `SipManager` has been deprecated since API level 31. It can now be removed.

# How

Removes the `allowsVoipAsync` function.

# Test Plan

BareExpo