### PR TITLE
[cellular][Android] Remove legacy networkType path and suppress warnings

### DIFF
--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -3,7 +3,6 @@ package expo.modules.cellular
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
 import android.telephony.TelephonyManager
 import android.util.Log
 import expo.modules.interfaces.permissions.Permissions
@@ -75,13 +74,8 @@ class CellularModule : Module() {
   private fun getCurrentGeneration(): Int {
     val telephonyManager = telephonyManager()
       ?: return CellularGeneration.UNKNOWN.value
-    val networkType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      telephonyManager.dataNetworkType
-    } else {
-      @Suppress("DEPRECATION")
-      telephonyManager.networkType
-    }
-    return when (networkType) {
+    @Suppress("DEPRECATION") // Legacy CDMA constants are deprecated, but can still be returned on older devices, so we keep mapping them instead of returning UNKNOWN
+    return when (telephonyManager.dataNetworkType) {
       TelephonyManager.NETWORK_TYPE_GPRS,
       TelephonyManager.NETWORK_TYPE_EDGE,
       TelephonyManager.NETWORK_TYPE_CDMA,


### PR DESCRIPTION
# Why

This PR is part of a series aimed at removing compilation warnings.

It removes the following warnings:
```gradle 
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:92:24` - 'static field NETWORK_TYPE_CDMA: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:93:24` - 'static field NETWORK_TYPE_1xRTT: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:94:24` - 'static field NETWORK_TYPE_IDEN: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:98:24` - 'static field NETWORK_TYPE_EVDO_0: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:99:24` - 'static field NETWORK_TYPE_EVDO_A: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:103:24` - 'static field NETWORK_TYPE_EVDO_B: Int' is deprecated. Deprecated in Java.
`packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt:104:24` - 'static field NETWORK_TYPE_EHRPD: Int' is deprecated. Deprecated in Java.
```
# How

- Suppressed deprecation warnings for deprecated network types. If these types are returned on older devices, they will still be mapped to the correct cellular generation instead of `UNKNOWN`.
- Removed the `Build.VERSION.SDK_INT < Build.VERSION_CODES.N` `networkType` path, since minSdk is 24.

# Test Plan

BareExpo
