### PR TITLE
[camera][Android] Replace deprecated `RuntimeContext` with `Runtime`

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -436,11 +436,11 @@ class CameraViewModule : Module() {
 
       AsyncFunction("takePicture") { view: ExpoCameraView, options: PictureOptions, promise: Promise ->
         if (!EmulatorUtilities.isRunningOnEmulator()) {
-          view.takePicture(options, promise, cacheDirectory, runtimeContext)
+          view.takePicture(options, promise, cacheDirectory, runtime)
         } else {
           val image = CameraViewHelper.generateSimulatorPhoto(view.width, view.height)
           moduleScope.launch {
-            ResolveTakenPicture(image, promise, options, false, runtimeContext, cacheDirectory) { response ->
+            ResolveTakenPicture(image, promise, options, false, runtime, cacheDirectory) { response ->
               view.onPictureSaved(response)
             }.resolve()
           }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -74,8 +74,8 @@ import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import kotlinx.coroutines.CoroutineScope
@@ -272,7 +272,7 @@ class ExpoCameraView(
     addView(previewView, 0)
   }
 
-  fun takePicture(options: PictureOptions, promise: Promise, cacheDirectory: File, runtimeContext: RuntimeContext) {
+  fun takePicture(options: PictureOptions, promise: Promise, cacheDirectory: File, runtime: Runtime) {
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     val volume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
     val hasShutterSound = options.shutterSound
@@ -306,7 +306,7 @@ class ExpoCameraView(
           cacheDirectory.let {
             scope.launch {
               val shouldMirror = mirror && lensFacing == CameraType.FRONT
-              ResolveTakenPicture(data, promise, options, shouldMirror, runtimeContext, it) { response: Bundle ->
+              ResolveTakenPicture(data, promise, options, shouldMirror, runtime, it) { response: Bundle ->
                 if (!options.pictureRef) {
                   onPictureSaved(response)
                 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -17,7 +17,7 @@ import expo.modules.camera.utils.CameraViewHelper.getExifData
 import expo.modules.camera.utils.CameraViewHelper.setExifData
 import expo.modules.camera.utils.FileSystemUtils
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.RuntimeContext
+import expo.modules.kotlin.runtime.Runtime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
@@ -62,7 +62,7 @@ class ResolveTakenPicture(
   private var promise: Promise,
   private var options: PictureOptions,
   private var mirror: Boolean,
-  private val runtimeContext: RuntimeContext,
+  private val runtime: Runtime,
   private val directory: File,
   private var pictureSavedDelegate: PictureSavedDelegate
 ) {
@@ -140,7 +140,7 @@ class ResolveTakenPicture(
         }
 
         if (options.pictureRef) {
-          promise.resolve(PictureRef(bitmap, runtimeContext))
+          promise.resolve(PictureRef(bitmap, runtime))
           return response
         }
 


### PR DESCRIPTION
# Why
This PR is part of a series aimed at removing compilation warnings.

It removes the following warnings:
```gradle
`packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt:439:62` - 'val runtimeContext: Runtime' is deprecated. Use 'runtime' property instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt:443:65` - 'val runtimeContext: Runtime' is deprecated. Use 'runtime' property instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt:77:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt:275:100` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt:4:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt:7:50` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt:20:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt:65:31` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.

```

# How

Replaces deprecated `RuntimeContext` with `Runtime`.

# Test Plan

Green CI
