### PR TITLE
[expo-modules-jsi] Fix Xcode 26 / Swift 6.2 build (weak let → nonisolated(unsafe) weak var)

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -1,6 +1,6 @@
 /// Context that captures Swift values to pass them to JSI host function as an unmanaged pointer for interoperability with C++.
 internal final class HostFunctionContext: Sendable {
-  weak let runtime: JavaScriptRuntime?
+  nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   let name: String?
   let call: JavaScriptRuntime.SyncFunctionClosure
 
@@ -14,7 +14,7 @@ internal final class HostFunctionContext: Sendable {
 /// Counterpart to ``HostFunctionContext`` for host functions whose closure receives `this` as a
 /// borrowed ``JavaScriptUnownedValue`` (see ``JavaScriptRuntime/UnownedThisSyncFunctionClosure``).
 internal final class UnownedThisHostFunctionContext: Sendable {
-  weak let runtime: JavaScriptRuntime?
+  nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   let name: String?
   let call: JavaScriptRuntime.UnownedThisSyncFunctionClosure
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
@@ -5,7 +5,7 @@ internal final class HostObjectContext: Sendable {
   typealias PropertyNamesGetter = @JavaScriptActor () -> [String]
   typealias Deallocator = @JavaScriptActor () -> Void
 
-  weak let runtime: JavaScriptRuntime?
+  nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   let get: Getter
   let set: Setter?
   let getPropertyNames: PropertyNamesGetter

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -76,7 +76,7 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
 
 /// An actor that is dedicated for the specific runtime.
 internal actor JavaScriptRuntimeActor {
-  private weak let runtime: JavaScriptRuntime?
+  private nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   nonisolated private let executor: JavaScriptExecutor
 
   init(runtime: JavaScriptRuntime) {
@@ -95,7 +95,7 @@ internal actor JavaScriptRuntimeActor {
 
 /// Serial executor dedicated for the specific runtime.
 internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, @unchecked Sendable {
-  private weak let runtime: JavaScriptRuntime?
+  private nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
 
   init(runtime: JavaScriptRuntime) {
     self.runtime = runtime

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
@@ -2,7 +2,7 @@ internal import jsi
 
 /// Represents something that can be a JS property key.
 public final class JavaScriptPropNameID: JavaScriptType {
-  private weak let runtime: JavaScriptRuntime?
+  private nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.PropNameID
 
   /// Creates a PropNameID from existing `facebook.jsi.PropNameID`.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -5,7 +5,7 @@ internal import jsi
 /// and Swift, allowing you to access and manipulate JavaScript array elements from Swift code. It maintains a reference
 /// to the underlying JavaScript array and provides Swift-friendly APIs for common array operations.
 public struct JavaScriptArray: JavaScriptType, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Array
 
   /// Creates a new JavaScript array with the specified length.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
@@ -6,7 +6,7 @@ internal import jsi
 /// A Swift representation of a JavaScript array buffer. Provides access to the
 /// underlying raw data pointer and size of the buffer.
 public struct JavaScriptArrayBuffer: ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.ArrayBuffer
 
   internal init(_ runtime: JavaScriptRuntime, _ arrayBuffer: consuming facebook.jsi.ArrayBuffer) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
@@ -37,7 +37,7 @@ internal import jsi
 /// - Note: BigInt values cannot be mixed with Number values in arithmetic operations in JavaScript.
 /// You must explicitly convert between them.
 public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal var pointee: facebook.jsi.BigInt
 
   /// Creates a BigInt from an existing JSI BigInt.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
@@ -2,7 +2,7 @@ internal import ExpoModulesJSI_Cxx
 internal import jsi
 
 public struct JavaScriptError: JavaScriptType, ~Copyable {
-  private weak let runtime: JavaScriptRuntime?
+  private nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   nonisolated(unsafe) private let pointee: facebook.jsi.JSError
 
   internal init(_ runtime: JavaScriptRuntime, _ error: facebook.jsi.JSError) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
@@ -4,7 +4,7 @@ internal import ExpoModulesJSI_Cxx
 internal import jsi
 
 public struct JavaScriptFunction: JavaScriptType, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Function
 
   internal init(_ runtime: JavaScriptRuntime, _ pointee: consuming facebook.jsi.Function) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -6,7 +6,7 @@ internal import jsi
 /// A Swift representation of a JavaScript object. Provides access to JavaScript object properties and methods,
 /// supporting property access, modification, enumeration, prototype manipulation, and function calling.
 public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal var pointee: facebook.jsi.Object
 
   /// Creates a new object in the given runtime.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -10,7 +10,7 @@ internal import jsi
 public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
-  private weak let runtime: JavaScriptRuntime?
+  private nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   private var object: JavaScriptObject
   private let deferredPromise = DeferredPromise()
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -8,7 +8,7 @@ internal import ExpoModulesJSI_Cxx
 internal import jsi
 
 public struct JavaScriptTypedArray: ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Object
 
   /// The underlying `ArrayBuffer` backing this typed array. Stored alongside `pointee`

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -7,7 +7,7 @@ internal import jsi
 /// this one is a reference type so can be safely captured in closures, passed to other isolation context,
 /// and stored in containers that don't support non-copyable types etc.
 public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Value
 
   /// Initializer from the existing JSI value.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptWeakObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptWeakObject.swift
@@ -5,7 +5,7 @@ internal import jsi
 /// Represents a weak reference to an object. If the only references to an object are these,
 /// the object is eligible for GC. Method names are inspired by C++ `std::weak_ptr`.
 public struct JavaScriptWeakObject: JavaScriptType, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  internal nonisolated(unsafe) weak var runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.WeakObject
 
   /// Initializes a weak object with the underlying JSI weak object.


### PR DESCRIPTION
# Why

`expo-modules-jsi` fails to compile with **Xcode 26 / Swift 6.2** (tracked in #46242). Two stricter Swift 6.2 rules, stacked:

1. `weak let` is no longer allowed — a `weak` reference may become `nil` at runtime, so it must be a `var`.
2. After switching to `weak var`, the **Sendable** types (`HostFunctionContext`, `HostObjectContext`, `JavaScriptPropNameID`, `JavaScriptValue`) fail: a mutable stored property isn't allowed in a `Sendable`-conforming type.

This blocks `expo run:ios` / building from source on the current toolchain for SDK 56 (and `main`).

# How

Prefix every `weak let runtime` with `nonisolated(unsafe)` and make it `weak var` — i.e. `nonisolated(unsafe) weak var runtime: JavaScriptRuntime?`. `nonisolated(unsafe)` (Swift 5.10+) is the sanctioned escape hatch for storage mutated outside any concurrency domain. It resolves **both** rules uniformly for the class and struct cases, with **no public API change** and no behavior change (the references were already effectively single-assignment).

16 sites across 14 files in `packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/`.

# Test Plan

- Building `expo-modules-jsi` with Xcode 26.0.1 / Swift 6.2 succeeds (previously 15–16 compile errors: `'weak' must be a mutable variable` and `stored property 'runtime' of 'Sendable'-conforming class … is mutable`).
- Verified end-to-end: a dev build (`expo run:ios`) on an SDK 56 app compiles, installs, and runs on the iOS Simulator with the equivalent patch applied.

Refs #46242.