### PR TITLE
[observe][ios] Correct OTLP retry behavior for dispatches

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Classify OTLP dispatch responses per the OTLP retry spec. Non-retryable responses (400, 401, 403, 404, other non-listed codes, and `partial_success` with rejected records) now drop the batch and advance the cursor instead of looping forever; retryable responses (408, 429, 502, 503, 504, and transport errors) gate subsequent dispatches with the server-supplied `Retry-After` header or a jittered exponential backoff. ([@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Remove the legacy non-OpenTelemetry dispatch path; metrics and logs are now always sent in the OTLP wire format. ([#47030](https://github.com/expo/expo/pull/47030) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Classify OTLP dispatch responses per the OTLP retry spec. Non-retryable responses (400, 401, 403, 404, other non-listed codes, and `partial_success` with rejected records) now drop the batch and advance the cursor instead of looping forever; retryable responses (408, 429, 502, 503, 504, and transport errors) gate subsequent dispatches with the server-supplied `Retry-After` header or a jittered exponential backoff. ([@douglowder](https://github.com/douglowder))
+- [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -1,0 +1,170 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+/// Outcome of a single dispatch attempt to the OTLP endpoint. Modeled after the OTLP retry
+/// guidance: a 3-way classification distinguishes transient failures (retry the same batch)
+/// from permanent ones (drop the batch and advance the cursor so it can't wedge the loop).
+///
+/// `retryable.retryAfter` carries the parsed `Retry-After` header value in seconds (or `nil`
+/// when the server didn't supply one). `nonRetryable.reason` carries a short diagnostic string
+/// for the `warn`-level log line.
+internal enum DispatchResult: Equatable, Sendable {
+  case success
+  case retryable(retryAfter: TimeInterval?)
+  case nonRetryable(reason: String)
+}
+
+extension Data {
+  /// First ~512 bytes of the response body as UTF-8, for inclusion in error log lines. Bounded
+  /// so a giant HTML error page doesn't flood the log; truncated mid-codepoint is acceptable
+  /// for a diagnostic excerpt.
+  fileprivate func bodyExcerpt(limit: Int = 512) -> String {
+    let slice = self.prefix(limit)
+    return String(data: slice, encoding: .utf8) ?? "<unreadable>"
+  }
+}
+
+/// HTTP transport + response classification for `ObservabilityManager`. Lives in its own file
+/// to keep `Observability.swift` focused on the dispatch lifecycle (cursors, batching, decide
+/// whether to dispatch at all). All functions are pure / `nonisolated` so they can be
+/// unit-tested without instantiating the manager or hitting the network.
+internal enum DispatchUtils {
+  /// POSTs the encoded `body` to `endpointUrl` and classifies the response. Catches both local
+  /// encoding errors (non-retryable — same bytes will fail again) and transport errors (DNS,
+  /// TLS, timeout, connection reset — retryable per OTLP).
+  internal static func sendRequest(
+    to endpointUrl: URL,
+    body: any Encodable
+  ) async -> DispatchResult {
+    var request = URLRequest(url: endpointUrl)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = [
+      "Content-Type": "application/json",
+      // Tells `NetworkRequestURLProtocol` to skip observation so our own telemetry uploads don't
+      // get logged back into the network-request stream. The header reaches o.expo.dev unchanged
+      // (we control that endpoint, so the harmless overhead is fine). The name is duplicated here
+      // rather than imported: expo-observe must not depend on expo-app-metrics internals. Keep it
+      // in sync with `NetworkRequestURLProtocol.internalHeaderName` in expo-app-metrics.
+      "Expo-AppMetrics-Skip": "1",
+    ]
+    do {
+      request.httpBody = try body.toJSONData([])
+    } catch {
+      return .nonRetryable(reason: "encoding error: \(error.localizedDescription)")
+    }
+
+    #if DEBUG
+    observeLogger.debug("[EAS Observe] Sending the request to \(endpointUrl) with body:")
+    // Use `print` so the JSON can be copied without including the log level emojis. Wrapped in
+    // `#if DEBUG` so release builds don't pay for a second pretty-printed encode of the payload.
+    if let prettyBody = try? body.toJSONString(.prettyPrinted) {
+      print(prettyBody)
+    }
+    #endif
+
+    let responseData: Data
+    let urlResponse: URLResponse
+    do {
+      (responseData, urlResponse) = try await URLSession.shared.data(for: request)
+    } catch {
+      observeLogger.warn(
+        "[EAS Observe] Transport error talking to \(endpointUrl): \(error.localizedDescription)"
+      )
+      return .retryable(retryAfter: nil)
+    }
+
+    guard let urlResponse = urlResponse as? HTTPURLResponse else {
+      // Non-HTTP response — exotic but not impossible (proxies). Treat as transient.
+      return .retryable(retryAfter: nil)
+    }
+
+    let retryAfterHeader = urlResponse.value(forHTTPHeaderField: "Retry-After")
+    let partialSuccess = try? JSONDecoder().decode(OTServiceResponse.self, from: responseData)
+      .partialSuccess
+    let result = classifyResponse(
+      statusCode: urlResponse.statusCode,
+      retryAfterHeader: retryAfterHeader,
+      partialSuccess: partialSuccess,
+      bodyExcerpt: { responseData.bodyExcerpt() }
+    )
+
+    switch result {
+    case .success:
+      observeLogger.debug(
+        "[EAS Observe] Server responded successfully with \(urlResponse.statusCode) and data: "
+          + "\(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
+      )
+    case .retryable:
+      observeLogger.warn(
+        "[EAS Observe] Server responded with \(urlResponse.statusCode) (retryable) and data: "
+          + "\(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
+      )
+    case .nonRetryable(let reason):
+      observeLogger.warn(
+        "[EAS Observe] Server responded with \(urlResponse.statusCode) (non-retryable, "
+          + "\(reason)) and data: \(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
+      )
+    }
+    return result
+  }
+
+  /// Pure classifier that maps an HTTP response into one of three retry outcomes. Extracted
+  /// from `sendRequest` so the OTLP-spec rules can be unit-tested without a real network call.
+  ///
+  /// `bodyExcerpt` is invoked lazily, only when the result is `.nonRetryable` and the reason
+  /// string benefits from including a peek at the response body. Lets the caller bound how much
+  /// data we slurp into the log line.
+  internal static func classifyResponse(
+    statusCode: Int,
+    retryAfterHeader: String?,
+    partialSuccess: OTPartialSuccess?,
+    bodyExcerpt: () -> String = { "" }
+  ) -> DispatchResult {
+    let retryAfter = parseRetryAfter(retryAfterHeader)
+
+    if (200...299).contains(statusCode) {
+      // The OTLP spec also allows `partial_success` to carry a warning-only payload — rejected=0
+      // with a non-empty `errorMessage`. Treat that as a successful send (the records DID land)
+      // so we don't double-drop. The dispatch caller may still want to log the warning.
+      if let partial = partialSuccess, partial.rejectedCount > 0 {
+        let detail = partial.errorMessage ?? "no error message"
+        return .nonRetryable(
+          reason: "partial_success: rejected \(partial.rejectedCount) (\(detail))"
+        )
+      }
+      return .success
+    }
+
+    // Retryable per OTLP. `408` lacks a real-world Retry-After in practice but the spec admits
+    // it; carry the header through unchanged so server can override us.
+    switch statusCode {
+    case 408, 429, 502, 503, 504:
+      return .retryable(retryAfter: retryAfter)
+    default:
+      let excerpt = bodyExcerpt()
+      let suffix = excerpt.isEmpty ? "" : ": \(excerpt)"
+      return .nonRetryable(reason: "HTTP \(statusCode)\(suffix)")
+    }
+  }
+
+  /// Parses an HTTP `Retry-After` header into a delay in seconds from now. Accepts both
+  /// formats permitted by RFC 7231: an integer delta-seconds, or an HTTP-date.
+  /// Returns `nil` if the header is absent or unparseable.
+  internal static func parseRetryAfter(_ header: String?) -> TimeInterval? {
+    guard let raw = header?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+      return nil
+    }
+    if let seconds = TimeInterval(raw) {
+      return max(seconds, 0)
+    }
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    if let date = formatter.date(from: raw) {
+      return max(date.timeIntervalSinceNow, 0)
+    }
+    return nil
+  }
+}

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -153,10 +153,9 @@ internal enum DispatchUtils {
       return .success
     }
 
-    // Retryable per OTLP. `408` lacks a real-world Retry-After in practice but the spec admits
-    // it; carry the header through unchanged so server can override us.
+    // Retryable per OTLP.
     switch statusCode {
-    case 408, 429, 502, 503, 504:
+    case 429, 502, 503, 504:
       return .retryableFailure(retryAfter: retryAfter)
     default:
       let excerpt = bodyExcerpt()
@@ -187,15 +186,26 @@ internal enum DispatchUtils {
       guard seconds.isFinite else { return nil }
       return clampToBounds(seconds, base: base, cap: cap)
     }
+
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.timeZone = TimeZone(identifier: "GMT")
+    // IMF-fixdate only; others fall through to backoff
     formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
-    if let date = formatter.date(from: raw) {
+
+    if let date = cachedFormatter.date(from: raw) {
       return clampToBounds(date.timeIntervalSinceNow, base: base, cap: cap)
     }
     return nil
   }
+
+  static let cachedFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    return formatter
+  }()
 
   /// Clamps a server-supplied retry delay into the client's `[base, cap]` window. Used by
   /// `parseRetryAfter` so the gate is bounded regardless of what the server sent.

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -167,4 +167,26 @@ internal enum DispatchUtils {
     }
     return nil
   }
+
+  /// Computes the cursor value the dispatch loop should persist after a single dispatch attempt.
+  ///
+  /// - `.success` advances to `highestId` — the rows have been accepted by the server.
+  /// - `.nonRetryable` ALSO advances to `highestId` — the server has refused these rows
+  ///   permanently, so retrying would just produce the same answer; advancing the cursor drops
+  ///   the batch so it can't wedge subsequent rounds. This is the acceptance-criterion behavior:
+  ///   a 400/403 must not be re-sent on the next cycle.
+  /// - `.retryable` leaves the cursor at its current value so the next dispatch attempt picks
+  ///   the same rows up again.
+  internal static func nextCursor(
+    for result: DispatchResult,
+    currentCursor: Int64,
+    highestId: Int64
+  ) -> Int64 {
+    switch result {
+    case .success, .nonRetryable:
+      return highestId
+    case .retryable:
+      return currentCursor
+    }
+  }
 }

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -150,22 +150,44 @@ internal enum DispatchUtils {
 
   /// Parses an HTTP `Retry-After` header into a delay in seconds from now. Accepts both
   /// formats permitted by RFC 7231: an integer delta-seconds, or an HTTP-date.
-  /// Returns `nil` if the header is absent or unparseable.
-  internal static func parseRetryAfter(_ header: String?) -> TimeInterval? {
+  /// Returns `nil` if the header is absent or unparseable, so the caller can fall through to
+  /// `computeBackoffDelay` for a client-driven delay.
+  ///
+  /// A successfully parsed value is clamped to `[base, cap]` so a misbehaving server can't
+  /// drive us to either extreme: a value below `base` (including `0`, negatives, or HTTP-dates
+  /// in the past) floors to `base` so we don't hammer; a value above `cap` (or a date far in
+  /// the future) ceilings to `cap` so we don't snooze for hours. Non-finite floating-point
+  /// values (`inf`, `NaN`) are treated as garbage and return `nil`.
+  internal static func parseRetryAfter(
+    _ header: String?,
+    base: TimeInterval = backoffBaseSeconds,
+    cap: TimeInterval = backoffCapSeconds
+  ) -> TimeInterval? {
     guard let raw = header?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
       return nil
     }
     if let seconds = TimeInterval(raw) {
-      return max(seconds, 0)
+      guard seconds.isFinite else { return nil }
+      return clampToBounds(seconds, base: base, cap: cap)
     }
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.timeZone = TimeZone(identifier: "GMT")
     formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
     if let date = formatter.date(from: raw) {
-      return max(date.timeIntervalSinceNow, 0)
+      return clampToBounds(date.timeIntervalSinceNow, base: base, cap: cap)
     }
     return nil
+  }
+
+  /// Clamps a server-supplied retry delay into the client's `[base, cap]` window. Used by
+  /// `parseRetryAfter` so the gate is bounded regardless of what the server sent.
+  private static func clampToBounds(
+    _ seconds: TimeInterval,
+    base: TimeInterval,
+    cap: TimeInterval
+  ) -> TimeInterval {
+    return min(max(seconds, base), cap)
   }
 
   /// Computes the cursor value the dispatch loop should persist after a single dispatch attempt.

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 
 /// Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
-/// OTLP retry guidance:
+/// OTLP retry guidance (see https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
 ///
 /// - `.success` — server accepted the batch without rejections.
 /// - `.partialSuccess` — server accepted the batch but rejected some records (the OTLP
@@ -243,6 +243,8 @@ internal enum DispatchUtils {
   /// `Retry-After`. Exponential growth (base × 2^(attempt-1)), capped, with full jitter so a
   /// fleet of devices recovering from the same transient backend outage doesn't thunder-herd
   /// the recovery.
+  ///
+  /// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
   ///
   /// `attempt` is 1-based; the helper is defensive for `0` / negative inputs and returns 0
   /// rather than producing a negative exponent.

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -189,4 +189,75 @@ internal enum DispatchUtils {
       return currentCursor
     }
   }
+
+  // MARK: - Retry gate + exponential backoff
+
+  /// Base delay for the exponential backoff when the server doesn't supply a `Retry-After`.
+  /// The cap (`backoffCapSeconds`) bounds the worst-case wait so we don't end up snoozing for
+  /// hours after a long string of failures.
+  internal static let backoffBaseSeconds: TimeInterval = 60
+  internal static let backoffCapSeconds: TimeInterval = 900
+
+  /// Computes a backoff delay for the next dispatch attempt when the server didn't supply
+  /// `Retry-After`. Exponential growth (base × 2^(attempt-1)), capped, with full jitter so a
+  /// fleet of devices recovering from the same transient backend outage doesn't thunder-herd
+  /// the recovery.
+  ///
+  /// `attempt` is 1-based; the helper is defensive for `0` / negative inputs and returns 0
+  /// rather than producing a negative exponent.
+  internal static func computeBackoffDelay(
+    attempt: Int,
+    base: TimeInterval = backoffBaseSeconds,
+    cap: TimeInterval = backoffCapSeconds,
+    random: () -> Double = { Double.random(in: 0..<1) }
+  ) -> TimeInterval {
+    guard attempt >= 1 else { return 0 }
+    let exponential = min(base * pow(2, Double(attempt - 1)), cap)
+    return exponential * random()
+  }
+
+  /// Snapshot of the retry-gate state carried across dispatch rounds. `dispatchAfterDate` is the
+  /// wall-clock deadline before which the dispatch entry point should short-circuit (set by a
+  /// retryable response, naturally expires); `consecutiveRetryableFailures` is the counter that
+  /// drives `computeBackoffDelay` when the server didn't supply a `Retry-After`.
+  internal struct RetryGateState: Equatable {
+    let dispatchAfterDate: Date?
+    let consecutiveRetryableFailures: Int
+
+    static let initial = RetryGateState(dispatchAfterDate: nil, consecutiveRetryableFailures: 0)
+  }
+
+  /// Pure helper that computes the next `RetryGateState` after a single dispatch result.
+  ///
+  /// - `.success` resets the counter to 0 and leaves the gate alone. The gate either already
+  ///   expired (we wouldn't have dispatched otherwise) or was never set — either way, success
+  ///   doesn't introduce a new pause.
+  /// - `.nonRetryable` also resets the counter. A permanent drop isn't a sign that the server
+  ///   is unhealthy and shouldn't pause subsequent rounds.
+  /// - `.retryable` increments the counter and sets the gate to `now + delay`, where `delay`
+  ///   is the server-supplied `Retry-After` if present, otherwise `backoff(nextCount)`.
+  ///
+  /// `backoff` is injected so tests can drive it deterministically without going through
+  /// `computeBackoffDelay`'s `Double.random` source.
+  internal static func nextRetryGateState(
+    result: DispatchResult,
+    currentState: RetryGateState,
+    now: Date,
+    backoff: (Int) -> TimeInterval
+  ) -> RetryGateState {
+    switch result {
+    case .success, .nonRetryable:
+      return RetryGateState(
+        dispatchAfterDate: currentState.dispatchAfterDate,
+        consecutiveRetryableFailures: 0
+      )
+    case .retryable(let retryAfter):
+      let nextCount = currentState.consecutiveRetryableFailures + 1
+      let delay = retryAfter ?? backoff(nextCount)
+      return RetryGateState(
+        dispatchAfterDate: now.addingTimeInterval(delay),
+        consecutiveRetryableFailures: nextCount
+      )
+    }
+  }
 }

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -2,17 +2,28 @@
 
 import ExpoModulesCore
 
-/// Outcome of a single dispatch attempt to the OTLP endpoint. Modeled after the OTLP retry
-/// guidance: a 3-way classification distinguishes transient failures (retry the same batch)
-/// from permanent ones (drop the batch and advance the cursor so it can't wedge the loop).
+/// Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
+/// OTLP retry guidance:
 ///
-/// `retryable.retryAfter` carries the parsed `Retry-After` header value in seconds (or `nil`
-/// when the server didn't supply one). `nonRetryable.reason` carries a short diagnostic string
-/// for the `warn`-level log line.
+/// - `.success` — server accepted the batch without rejections.
+/// - `.partialSuccess` — server accepted the batch but rejected some records (the OTLP
+///   `partial_success` body with `rejectedCount > 0`). The rows DID land on the server, so
+///   cursor advance and counter reset match `.success`; the case stays distinct so the call
+///   site can log the rejected count and `errorMessage` clearly rather than describing it as
+///   a drop.
+/// - `.retryableFailure` — transient failure (408/429/502/503/504 or transport error); retry the
+///   same batch after `retryAfter` seconds or a client-computed backoff.
+/// - `.nonRetryableFailure` — permanent failure (4xx/5xx outside the retryable set, encoding error);
+///   drop the batch so it can't wedge the loop.
+///
+/// `retryableFailure.retryAfter` carries the parsed `Retry-After` header value in seconds
+/// (or `nil` when the server didn't supply one). `nonRetryableFailure.reason` carries a short
+/// diagnostic string for the warn log.
 internal enum DispatchResult: Equatable, Sendable {
   case success
-  case retryable(retryAfter: TimeInterval?)
-  case nonRetryable(reason: String)
+  case partialSuccess(OTPartialSuccess)
+  case retryableFailure(retryAfter: TimeInterval?)
+  case nonRetryableFailure(reason: String)
 }
 
 extension Data {
@@ -51,7 +62,7 @@ internal enum DispatchUtils {
     do {
       request.httpBody = try body.toJSONData([])
     } catch {
-      return .nonRetryable(reason: "encoding error: \(error.localizedDescription)")
+      return .nonRetryableFailure(reason: "encoding error: \(error.localizedDescription)")
     }
 
     #if DEBUG
@@ -71,12 +82,12 @@ internal enum DispatchUtils {
       observeLogger.warn(
         "[EAS Observe] Transport error talking to \(endpointUrl): \(error.localizedDescription)"
       )
-      return .retryable(retryAfter: nil)
+      return .retryableFailure(retryAfter: nil)
     }
 
     guard let urlResponse = urlResponse as? HTTPURLResponse else {
       // Non-HTTP response — exotic but not impossible (proxies). Treat as transient.
-      return .retryable(retryAfter: nil)
+      return .retryableFailure(retryAfter: nil)
     }
 
     let retryAfterHeader = urlResponse.value(forHTTPHeaderField: "Retry-After")
@@ -95,12 +106,18 @@ internal enum DispatchUtils {
         "[EAS Observe] Server responded successfully with \(urlResponse.statusCode) and data: "
           + "\(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
       )
-    case .retryable:
+    case .partialSuccess(let partial):
+      observeLogger.warn(
+        "[EAS Observe] Server responded with \(urlResponse.statusCode) (partial success, "
+          + "rejected \(partial.rejectedCount): \(partial.errorMessage ?? "no error message")) "
+          + "and data: \(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
+      )
+    case .retryableFailure:
       observeLogger.warn(
         "[EAS Observe] Server responded with \(urlResponse.statusCode) (retryable) and data: "
           + "\(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
       )
-    case .nonRetryable(let reason):
+    case .nonRetryableFailure(let reason):
       observeLogger.warn(
         "[EAS Observe] Server responded with \(urlResponse.statusCode) (non-retryable, "
           + "\(reason)) and data: \(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
@@ -112,7 +129,7 @@ internal enum DispatchUtils {
   /// Pure classifier that maps an HTTP response into one of three retry outcomes. Extracted
   /// from `sendRequest` so the OTLP-spec rules can be unit-tested without a real network call.
   ///
-  /// `bodyExcerpt` is invoked lazily, only when the result is `.nonRetryable` and the reason
+  /// `bodyExcerpt` is invoked lazily, only when the result is `.nonRetryableFailure` and the reason
   /// string benefits from including a peek at the response body. Lets the caller bound how much
   /// data we slurp into the log line.
   internal static func classifyResponse(
@@ -124,14 +141,14 @@ internal enum DispatchUtils {
     let retryAfter = parseRetryAfter(retryAfterHeader)
 
     if (200...299).contains(statusCode) {
-      // The OTLP spec also allows `partial_success` to carry a warning-only payload — rejected=0
-      // with a non-empty `errorMessage`. Treat that as a successful send (the records DID land)
-      // so we don't double-drop. The dispatch caller may still want to log the warning.
+      // The OTLP spec allows `partial_success` to carry a warning-only payload — rejected=0
+      // with a non-empty `errorMessage`. Treat that as a successful send (the records DID
+      // land) so we don't double-drop. When `rejectedCount > 0`, the records still landed
+      // server-side but a subset was rejected; surface that as `.partialSuccess` so the
+      // caller can log the count and message clearly. Cursor advance and gate behavior for
+      // `.partialSuccess` match `.success`.
       if let partial = partialSuccess, partial.rejectedCount > 0 {
-        let detail = partial.errorMessage ?? "no error message"
-        return .nonRetryable(
-          reason: "partial_success: rejected \(partial.rejectedCount) (\(detail))"
-        )
+        return .partialSuccess(partial)
       }
       return .success
     }
@@ -140,11 +157,11 @@ internal enum DispatchUtils {
     // it; carry the header through unchanged so server can override us.
     switch statusCode {
     case 408, 429, 502, 503, 504:
-      return .retryable(retryAfter: retryAfter)
+      return .retryableFailure(retryAfter: retryAfter)
     default:
       let excerpt = bodyExcerpt()
       let suffix = excerpt.isEmpty ? "" : ": \(excerpt)"
-      return .nonRetryable(reason: "HTTP \(statusCode)\(suffix)")
+      return .nonRetryableFailure(reason: "HTTP \(statusCode)\(suffix)")
     }
   }
 
@@ -192,12 +209,14 @@ internal enum DispatchUtils {
 
   /// Computes the cursor value the dispatch loop should persist after a single dispatch attempt.
   ///
-  /// - `.success` advances to `highestId` — the rows have been accepted by the server.
-  /// - `.nonRetryable` ALSO advances to `highestId` — the server has refused these rows
-  ///   permanently, so retrying would just produce the same answer; advancing the cursor drops
-  ///   the batch so it can't wedge subsequent rounds. This is the acceptance-criterion behavior:
-  ///   a 400/403 must not be re-sent on the next cycle.
-  /// - `.retryable` leaves the cursor at its current value so the next dispatch attempt picks
+  /// - `.success` and `.partialSuccess` advance to `highestId` — the rows have been accepted
+  ///   by the server (partial success rejects a subset server-side, but the bytes still
+  ///   landed; re-sending them would just re-trip the same rejection).
+  /// - `.nonRetryableFailure` ALSO advances to `highestId` — the server has refused these rows
+  ///   permanently, so retrying would just produce the same answer; advancing the cursor
+  ///   drops the batch so it can't wedge subsequent rounds. This is the acceptance-criterion
+  ///   behavior: a 400/403 must not be re-sent on the next cycle.
+  /// - `.retryableFailure` leaves the cursor at its current value so the next dispatch attempt picks
   ///   the same rows up again.
   internal static func nextCursor(
     for result: DispatchResult,
@@ -205,9 +224,9 @@ internal enum DispatchUtils {
     highestId: Int64
   ) -> Int64 {
     switch result {
-    case .success, .nonRetryable:
+    case .success, .partialSuccess, .nonRetryableFailure:
       return highestId
-    case .retryable:
+    case .retryableFailure:
       return currentCursor
     }
   }
@@ -251,12 +270,13 @@ internal enum DispatchUtils {
 
   /// Pure helper that computes the next `RetryGateState` after a single dispatch result.
   ///
-  /// - `.success` resets the counter to 0 and leaves the gate alone. The gate either already
-  ///   expired (we wouldn't have dispatched otherwise) or was never set — either way, success
-  ///   doesn't introduce a new pause.
-  /// - `.nonRetryable` also resets the counter. A permanent drop isn't a sign that the server
-  ///   is unhealthy and shouldn't pause subsequent rounds.
-  /// - `.retryable` increments the counter and sets the gate to `now + delay`, where `delay`
+  /// - `.success` and `.partialSuccess` reset the counter to 0 and leave the gate alone. The
+  ///   gate either already expired (we wouldn't have dispatched otherwise) or was never set
+  ///   — either way, a server response that ACCEPTED the bytes (even if it rejected a subset
+  ///   server-side) doesn't introduce a new pause.
+  /// - `.nonRetryableFailure` also resets the counter. A permanent drop isn't a sign that the
+  ///   server is unhealthy and shouldn't pause subsequent rounds.
+  /// - `.retryableFailure` increments the counter and sets the gate to `now + delay`, where `delay`
   ///   is the server-supplied `Retry-After` if present, otherwise `backoff(nextCount)`.
   ///
   /// `backoff` is injected so tests can drive it deterministically without going through
@@ -268,12 +288,12 @@ internal enum DispatchUtils {
     backoff: (Int) -> TimeInterval
   ) -> RetryGateState {
     switch result {
-    case .success, .nonRetryable:
+    case .success, .partialSuccess, .nonRetryableFailure:
       return RetryGateState(
         dispatchAfterDate: currentState.dispatchAfterDate,
         consecutiveRetryableFailures: 0
       )
-    case .retryable(let retryAfter):
+    case .retryableFailure(let retryAfter):
       let nextCount = currentState.consecutiveRetryableFailures + 1
       let delay = retryAfter ?? backoff(nextCount)
       return RetryGateState(

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -9,45 +9,62 @@ internal struct ObservabilityManager {
   private static var logsEndpointUrl: URL? = nil
   private static var projectId: String? = nil
 
-  /// In-memory retry-gate state. Reset implicitly when the process restarts — a relaunch
-  /// usually means enough time passed that the transient cause has cleared anyway, and
-  /// persisting the gate would mean an extra UserDefaults write on every retryable response.
-  private static var retryGateState: DispatchUtils.RetryGateState = .initial
+  /// In-memory retry-gate state, kept independently per OTLP endpoint. The `/v1/metrics` and
+  /// `/v1/logs` endpoints fail independently in practice (e.g., one schema validation
+  /// disagreement on the metrics side shouldn't suppress a healthy logs stream), so each
+  /// signal carries its own consecutive-failure counter and dispatch-after deadline. A single
+  /// shared field would conflate the two: a recovering signal would reset the other's
+  /// counter on success, and a server's `Retry-After` on one endpoint would silently
+  /// overwrite a longer backoff computed for the other.
+  ///
+  /// State is reset implicitly when the process restarts — a relaunch usually means enough
+  /// time passed that the transient cause has cleared anyway, and persisting the gates would
+  /// mean a UserDefaults write per retryable response.
+  private static var metricsRetryGate: DispatchUtils.RetryGateState = .initial
+  private static var logsRetryGate: DispatchUtils.RetryGateState = .initial
 
   internal static func dispatch() async {
-    // Honor the retry gate first: if a previous round told us to back off (server-supplied
-    // `Retry-After` or computed exponential backoff after a transient failure), short-circuit
-    // until the deadline elapses. Skips both signals together so we don't hammer the same
-    // server endpoint with logs traffic while it's asking us to slow down metrics.
-    if let until = retryGateState.dispatchAfterDate, until > Date() {
-      observeLogger.debug(
-        "[EAS Observe] Dispatch suppressed by retry gate until \(until)"
-      )
-      return
-    }
-
-    // Compute once and reuse for both signals — `shouldDispatch()` reads the persisted config, the
-    // bundle defaults, and computes a sample-rate hash. Both halves of dispatch want the same answer.
+    // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` rather than
+    // here, so a backoff on one endpoint doesn't suppress the other's traffic.
     let shouldDispatch = Self.shouldDispatch()
 
     await dispatchMetrics(shouldDispatch: shouldDispatch)
     await dispatchLogs(shouldDispatch: shouldDispatch)
   }
 
-  /// Applies a per-signal dispatch outcome to the shared retry-gate state. Mirrors the pure
-  /// `DispatchUtils.nextRetryGateState(...)` but reads/writes the manager's static field so the
-  /// call sites stay concise. Called from both `dispatchMetrics` and `dispatchLogs` after each
-  /// `DispatchUtils.sendRequest(...)` call so the gate reflects the latest signal's response.
-  private static func applyRetryOutcome(_ result: DispatchResult) {
-    retryGateState = DispatchUtils.nextRetryGateState(
+  /// Whether a per-signal retry gate currently blocks dispatch on that signal. Logs a debug
+  /// line at the dispatch entry point if so, mirroring the previous top-of-dispatch check.
+  private static func retryGateBlocks(_ state: DispatchUtils.RetryGateState, signal: String) -> Bool {
+    guard let until = state.dispatchAfterDate, until > Date() else {
+      return false
+    }
+    observeLogger.debug(
+      "[EAS Observe] \(signal) dispatch suppressed by retry gate until \(until)"
+    )
+    return true
+  }
+
+  /// Applies a per-signal dispatch outcome to one of the retry-gate fields. The `inout`
+  /// parameter binding keeps the metrics and logs paths from accidentally sharing state.
+  /// Mirrors the pure `DispatchUtils.nextRetryGateState(...)` and is called from both
+  /// `dispatchMetrics` and `dispatchLogs` after each `DispatchUtils.sendRequest(...)` call.
+  private static func applyRetryOutcome(
+    _ result: DispatchResult,
+    to state: inout DispatchUtils.RetryGateState
+  ) {
+    state = DispatchUtils.nextRetryGateState(
       result: result,
-      currentState: retryGateState,
+      currentState: state,
       now: Date(),
       backoff: { DispatchUtils.computeBackoffDelay(attempt: $0) }
     )
   }
 
   private static func dispatchMetrics(shouldDispatch: Bool) async {
+    if retryGateBlocks(metricsRetryGate, signal: "metrics") {
+      return
+    }
+
     repairMetricCursorIfStale()
 
     let cursor = ObserveUserDefaults.lastDispatchedMetricId
@@ -80,7 +97,7 @@ internal struct ObservabilityManager {
     }
     let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    applyRetryOutcome(result)
+    applyRetryOutcome(result, to: &metricsRetryGate)
     ObserveUserDefaults.lastDispatchedMetricId = DispatchUtils.nextCursor(
       for: result,
       currentCursor: cursor,
@@ -100,6 +117,10 @@ internal struct ObservabilityManager {
   }
 
   private static func dispatchLogs(shouldDispatch: Bool) async {
+    if retryGateBlocks(logsRetryGate, signal: "logs") {
+      return
+    }
+
     repairLogCursorIfStale()
 
     let cursor = ObserveUserDefaults.lastDispatchedLogId
@@ -138,7 +159,7 @@ internal struct ObservabilityManager {
     }
     let body = OTLogsRequestBody(resourceLogs: resourceLogs)
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    applyRetryOutcome(result)
+    applyRetryOutcome(result, to: &logsRetryGate)
     ObserveUserDefaults.lastDispatchedLogId = DispatchUtils.nextCursor(
       for: result,
       currentCursor: cursor,

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -51,16 +51,21 @@ internal struct ObservabilityManager {
     }
     let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    // Commit A1 wiring: the classifier already returns a 3-way result, but the cursor still
-    // moves only on `.success`. `.retryable` and `.nonRetryable` are both treated as "retain",
-    // matching the pre-classifier behavior. The `.nonRetryable` branch lands its drop semantics
-    // (advance the cursor) in commit B1.
+    ObserveUserDefaults.lastDispatchedMetricId = DispatchUtils.nextCursor(
+      for: result,
+      currentCursor: cursor,
+      highestId: highestId
+    )
     switch result {
     case .success:
       ObserveUserDefaults.lastDispatchDate = Date.now
-      ObserveUserDefaults.lastDispatchedMetricId = highestId
-    case .retryable, .nonRetryable:
+    case .retryable:
       break
+    case .nonRetryable(let reason):
+      observeLogger.warn(
+        "[EAS Observe] Dropping batch of \(events.count) metric event(s) past id "
+          + "\(highestId): \(reason)"
+      )
     }
   }
 
@@ -103,12 +108,19 @@ internal struct ObservabilityManager {
     }
     let body = OTLogsRequestBody(resourceLogs: resourceLogs)
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    // Same pre-B1 behavior as `dispatchMetrics`: only `.success` advances the cursor.
+    ObserveUserDefaults.lastDispatchedLogId = DispatchUtils.nextCursor(
+      for: result,
+      currentCursor: cursor,
+      highestId: highestId
+    )
     switch result {
-    case .success:
-      ObserveUserDefaults.lastDispatchedLogId = highestId
-    case .retryable, .nonRetryable:
+    case .success, .retryable:
       break
+    case .nonRetryable(let reason):
+      observeLogger.warn(
+        "[EAS Observe] Dropping batch of \(resourceLogs.count) log event(s) past id "
+          + "\(highestId): \(reason)"
+      )
     }
   }
 

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -9,13 +9,42 @@ internal struct ObservabilityManager {
   private static var logsEndpointUrl: URL? = nil
   private static var projectId: String? = nil
 
+  /// In-memory retry-gate state. Reset implicitly when the process restarts — a relaunch
+  /// usually means enough time passed that the transient cause has cleared anyway, and
+  /// persisting the gate would mean an extra UserDefaults write on every retryable response.
+  private static var retryGateState: DispatchUtils.RetryGateState = .initial
+
   internal static func dispatch() async {
+    // Honor the retry gate first: if a previous round told us to back off (server-supplied
+    // `Retry-After` or computed exponential backoff after a transient failure), short-circuit
+    // until the deadline elapses. Skips both signals together so we don't hammer the same
+    // server endpoint with logs traffic while it's asking us to slow down metrics.
+    if let until = retryGateState.dispatchAfterDate, until > Date() {
+      observeLogger.debug(
+        "[EAS Observe] Dispatch suppressed by retry gate until \(until)"
+      )
+      return
+    }
+
     // Compute once and reuse for both signals — `shouldDispatch()` reads the persisted config, the
     // bundle defaults, and computes a sample-rate hash. Both halves of dispatch want the same answer.
     let shouldDispatch = Self.shouldDispatch()
 
     await dispatchMetrics(shouldDispatch: shouldDispatch)
     await dispatchLogs(shouldDispatch: shouldDispatch)
+  }
+
+  /// Applies a per-signal dispatch outcome to the shared retry-gate state. Mirrors the pure
+  /// `DispatchUtils.nextRetryGateState(...)` but reads/writes the manager's static field so the
+  /// call sites stay concise. Called from both `dispatchMetrics` and `dispatchLogs` after each
+  /// `DispatchUtils.sendRequest(...)` call so the gate reflects the latest signal's response.
+  private static func applyRetryOutcome(_ result: DispatchResult) {
+    retryGateState = DispatchUtils.nextRetryGateState(
+      result: result,
+      currentState: retryGateState,
+      now: Date(),
+      backoff: { DispatchUtils.computeBackoffDelay(attempt: $0) }
+    )
   }
 
   private static func dispatchMetrics(shouldDispatch: Bool) async {
@@ -51,6 +80,7 @@ internal struct ObservabilityManager {
     }
     let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+    applyRetryOutcome(result)
     ObserveUserDefaults.lastDispatchedMetricId = DispatchUtils.nextCursor(
       for: result,
       currentCursor: cursor,
@@ -108,6 +138,7 @@ internal struct ObservabilityManager {
     }
     let body = OTLogsRequestBody(resourceLogs: resourceLogs)
     let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+    applyRetryOutcome(result)
     ObserveUserDefaults.lastDispatchedLogId = DispatchUtils.nextCursor(
       for: result,
       currentCursor: cursor,

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -106,9 +106,19 @@ internal struct ObservabilityManager {
     switch result {
     case .success:
       ObserveUserDefaults.lastDispatchDate = Date.now
-    case .retryable:
+    case .partialSuccess(let partial):
+      // The batch reached the server; bump `lastDispatchDate` so stale-cursor repair
+      // doesn't trip. Surface the per-record rejection count and any server message at
+      // warn level so the loss is visible without conflating it with a wholesale drop.
+      ObserveUserDefaults.lastDispatchDate = Date.now
+      observeLogger.warn(
+        "[EAS Observe] Partial success on batch of \(events.count) metric event(s) past "
+          + "id \(highestId): server rejected \(partial.rejectedCount) "
+          + "(\(partial.errorMessage ?? "no error message"))"
+      )
+    case .retryableFailure:
       break
-    case .nonRetryable(let reason):
+    case .nonRetryableFailure(let reason):
       observeLogger.warn(
         "[EAS Observe] Dropping batch of \(events.count) metric event(s) past id "
           + "\(highestId): \(reason)"
@@ -166,9 +176,15 @@ internal struct ObservabilityManager {
       highestId: highestId
     )
     switch result {
-    case .success, .retryable:
+    case .success, .retryableFailure:
       break
-    case .nonRetryable(let reason):
+    case .partialSuccess(let partial):
+      observeLogger.warn(
+        "[EAS Observe] Partial success on batch of \(resourceLogs.count) log event(s) past "
+          + "id \(highestId): server rejected \(partial.rejectedCount) "
+          + "(\(partial.errorMessage ?? "no error message"))"
+      )
+    case .nonRetryableFailure(let reason):
       observeLogger.warn(
         "[EAS Observe] Dropping batch of \(resourceLogs.count) log event(s) past id "
           + "\(highestId): \(reason)"

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -49,15 +49,18 @@ internal struct ObservabilityManager {
       ObserveUserDefaults.lastDispatchedMetricId = highestId
       return
     }
-    do {
-      let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
-      let success = try await sendRequest(to: endpointUrl, body: body)
-      if success {
-        ObserveUserDefaults.lastDispatchDate = Date.now
-        ObserveUserDefaults.lastDispatchedMetricId = highestId
-      }
-    } catch {
-      observeLogger.warn("[EAS Observe] Dispatching the metrics has thrown an error: \(error)")
+    let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
+    let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+    // Commit A1 wiring: the classifier already returns a 3-way result, but the cursor still
+    // moves only on `.success`. `.retryable` and `.nonRetryable` are both treated as "retain",
+    // matching the pre-classifier behavior. The `.nonRetryable` branch lands its drop semantics
+    // (advance the cursor) in commit B1.
+    switch result {
+    case .success:
+      ObserveUserDefaults.lastDispatchDate = Date.now
+      ObserveUserDefaults.lastDispatchedMetricId = highestId
+    case .retryable, .nonRetryable:
+      break
     }
   }
 
@@ -98,14 +101,14 @@ internal struct ObservabilityManager {
       ObserveUserDefaults.lastDispatchedLogId = highestId
       return
     }
-    do {
-      let body = OTLogsRequestBody(resourceLogs: resourceLogs)
-      let success = try await sendRequest(to: endpointUrl, body: body)
-      if success {
-        ObserveUserDefaults.lastDispatchedLogId = highestId
-      }
-    } catch {
-      observeLogger.warn("[EAS Observe] Dispatching the logs has thrown an error: \(error)")
+    let body = OTLogsRequestBody(resourceLogs: resourceLogs)
+    let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+    // Same pre-B1 behavior as `dispatchMetrics`: only `.success` advances the cursor.
+    switch result {
+    case .success:
+      ObserveUserDefaults.lastDispatchedLogId = highestId
+    case .retryable, .nonRetryable:
+      break
     }
   }
 
@@ -134,44 +137,6 @@ internal struct ObservabilityManager {
       }
       return Event.from(session: session, metrics: [], logs: sessionLogs)
     }
-  }
-
-  private static func sendRequest(to endpointUrl: URL, body: any Encodable) async throws -> Bool {
-    var request = URLRequest(url: endpointUrl)
-    request.httpMethod = "POST"
-    request.allHTTPHeaderFields = [
-      "Content-Type": "application/json",
-      // Tells `NetworkRequestURLProtocol` to skip observation so our own telemetry uploads don't
-      // get logged back into the network-request stream. The header reaches o.expo.dev unchanged
-      // (we control that endpoint, so the harmless overhead is fine). The name is duplicated here
-      // rather than imported: expo-observe must not depend on expo-app-metrics internals. Keep it
-      // in sync with `NetworkRequestURLProtocol.internalHeaderName` in expo-app-metrics.
-      "Expo-AppMetrics-Skip": "1",
-    ]
-    request.httpBody = try body.toJSONData([])
-
-    #if DEBUG
-    observeLogger.debug("[EAS Observe] Sending the request to \(endpointUrl) with body:")
-    // Use `print` so the JSON can be copied without including the log level emojis. Wrapped in
-    // `#if DEBUG` so release builds don't pay for a second pretty-printed encode of the payload.
-    print(try body.toJSONString(.prettyPrinted))
-    #endif
-
-    let (responseData, urlResponse) = try await URLSession.shared.data(for: request)
-
-    guard let urlResponse = urlResponse as? HTTPURLResponse else {
-      return false
-    }
-    guard (200...299).contains(urlResponse.statusCode) else {
-      observeLogger.warn(
-        "[EAS Observe] Server responded with \(urlResponse.statusCode) status code and data: \(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
-      )
-      return false
-    }
-    observeLogger.debug(
-      "[EAS Observe] Server responded successfully with \(urlResponse.statusCode) status code and data: \(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
-    )
-    return true
   }
 
   internal nonisolated static func setEndpointUrl(_ urlString: String?, projectId: String) {

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -107,9 +107,6 @@ internal struct ObservabilityManager {
     case .success:
       ObserveUserDefaults.lastDispatchDate = Date.now
     case .partialSuccess(let partial):
-      // The batch reached the server; bump `lastDispatchDate` so stale-cursor repair
-      // doesn't trip. Surface the per-record rejection count and any server message at
-      // warn level so the loss is visible without conflating it with a wholesale drop.
       ObserveUserDefaults.lastDispatchDate = Date.now
       observeLogger.warn(
         "[EAS Observe] Partial success on batch of \(events.count) metric event(s) past "
@@ -177,8 +174,9 @@ internal struct ObservabilityManager {
     )
     switch result {
     case .success, .retryableFailure:
-      break
+      ObserveUserDefaults.lastDispatchDate = Date.now
     case .partialSuccess(let partial):
+      ObserveUserDefaults.lastDispatchDate = Date.now
       observeLogger.warn(
         "[EAS Observe] Partial success on batch of \(resourceLogs.count) log event(s) past "
           + "id \(highestId): server rejected \(partial.rejectedCount) "

--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -429,3 +429,31 @@ internal struct OTRequestBody: Codable, Sendable {
 internal struct OTLogsRequestBody: Codable, Sendable {
   let resourceLogs: [OTResourceLogs]
 }
+
+// MARK: -- Response shapes for Open Telemetry endpoints
+
+/// Per OTLP/HTTP, both `/v1/metrics` and `/v1/logs` return an `ExportXServiceResponse` with an
+/// optional `partial_success` object. Our server emits it (with camelCase JSON keys — no
+/// snake_case translation) only when there were actual rejections, e.g.
+/// `{ "partialSuccess": { "rejectedDataPoints": 3, "errorMessage": "..." } }`. We model the
+/// union — `rejectedDataPoints` for metrics responses, `rejectedLogRecords` for logs responses
+/// — so a single decoder works for either endpoint.
+///
+/// Spec: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
+internal struct OTPartialSuccess: Codable, Equatable, Sendable {
+  let rejectedDataPoints: Int64?
+  let rejectedLogRecords: Int64?
+  let errorMessage: String?
+
+  /// Count of records the server says it rejected from this batch. The OTLP spec also allows
+  /// `partial_success` to carry a warning-only payload (`rejectedCount == 0` with a non-empty
+  /// `errorMessage`); the dispatch classifier treats that as a successful send with a logged
+  /// warning rather than a batch drop.
+  var rejectedCount: Int64 {
+    (rejectedDataPoints ?? 0) + (rejectedLogRecords ?? 0)
+  }
+}
+
+internal struct OTServiceResponse: Codable, Sendable {
+  let partialSuccess: OTPartialSuccess?
+}

--- a/packages/expo-observe/ios/Tests/DispatchUtilsBackoffTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsBackoffTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+@Suite("DispatchUtils.computeBackoffDelay")
+struct DispatchUtilsBackoffTests {
+  private let base: TimeInterval = 60
+  private let cap: TimeInterval = 900
+
+  /// Attempt 1 with no jitter (random=0) is the zero floor of the exponential schedule.
+  /// Attempt 1 with full jitter (random near 1.0) is the unjittered base interval. Together
+  /// these prove the jitter range is `[0, base * 2^(attempt-1))`.
+  @Test
+  func `attempt one jitter zero is zero`() {
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: 1,
+      base: base,
+      cap: cap,
+      random: { 0 }
+    )
+    #expect(delay == 0)
+  }
+
+  @Test
+  func `attempt one jitter near max approaches base`() {
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: 1,
+      base: base,
+      cap: cap,
+      random: { 0.999 }
+    )
+    #expect(delay > base * 0.99)
+    #expect(delay < base)  // strict — `random(in: 0..<1)` excludes 1
+  }
+
+  /// The exponential schedule doubles between attempts: attempt 2 reaches 2 × base, attempt
+  /// 3 reaches 4 × base, …, all multiplied by the jitter draw.
+  @Test
+  func `attempts two through four double the unjittered ceiling`() {
+    let r: () -> Double = { 0.5 }  // pin jitter to exactly half
+    let two = DispatchUtils.computeBackoffDelay(attempt: 2, base: base, cap: cap, random: r)
+    let three = DispatchUtils.computeBackoffDelay(attempt: 3, base: base, cap: cap, random: r)
+    let four = DispatchUtils.computeBackoffDelay(attempt: 4, base: base, cap: cap, random: r)
+    #expect(two == base * 2 * 0.5)  //  60
+    #expect(three == base * 4 * 0.5)  // 120
+    #expect(four == base * 8 * 0.5)  // 240
+  }
+
+  /// Once `base * 2^(attempt-1)` would exceed `cap`, the unjittered ceiling clamps to `cap`.
+  /// Verified with attempt 5 (would be 16 × 60 = 960 > 900) and a very large attempt count.
+  @Test
+  func `attempt above cap threshold clamps to cap times jitter`() {
+    // attempt 5 → 60 × 16 = 960; cap = 900 → ceiling clamps to 900, jitter 0.5 → 450.
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: 5,
+      base: base,
+      cap: cap,
+      random: { 0.5 }
+    )
+    #expect(delay == cap * 0.5)
+  }
+
+  @Test
+  func `very large attempt count still respects cap`() {
+    // 2^29 × 60 is astronomical; the cap must clamp it before the jitter draw.
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: 30,
+      base: base,
+      cap: cap,
+      random: { 1.0 }
+    )
+    #expect(delay <= cap)
+  }
+
+  @Test
+  func `attempt zero returns zero defensively`() {
+    // 1-based attempt counter; attempt 0 would be a logic error elsewhere. Don't produce a
+    // negative exponent — just return 0 so the caller's gate is set to "now" and the next
+    // round can dispatch immediately.
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: 0,
+      base: base,
+      cap: cap,
+      random: { 1.0 }
+    )
+    #expect(delay == 0)
+  }
+
+  @Test
+  func `negative attempt returns zero defensively`() {
+    let delay = DispatchUtils.computeBackoffDelay(
+      attempt: -5,
+      base: base,
+      cap: cap,
+      random: { 1.0 }
+    )
+    #expect(delay == 0)
+  }
+}

--- a/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
@@ -18,12 +18,12 @@ struct DispatchUtilsNextCursorTests {
     #expect(next == 20)
   }
 
-  /// `.retryable` is the "leave it alone" case — the next dispatch round picks the same rows
+  /// `.retryableFailure` is the "leave it alone" case — the next dispatch round picks the same rows
   /// up again. This is what keeps an in-flight outage from losing telemetry.
   @Test
   func `retryable retains current cursor`() {
     let next = DispatchUtils.nextCursor(
-      for: .retryable(retryAfter: nil),
+      for: .retryableFailure(retryAfter: nil),
       currentCursor: 10,
       highestId: 20
     )
@@ -35,11 +35,25 @@ struct DispatchUtilsNextCursorTests {
   @Test
   func `retryable with Retry-After still retains current cursor`() {
     let next = DispatchUtils.nextCursor(
-      for: .retryable(retryAfter: 30),
+      for: .retryableFailure(retryAfter: 30),
       currentCursor: 10,
       highestId: 20
     )
     #expect(next == 10)
+  }
+
+  /// `.partialSuccess` advances the cursor like `.success` does: the bytes landed on the
+  /// server (a subset was rejected server-side, but the batch as a whole was accepted), so
+  /// re-sending the same rows would just trip the same rejection.
+  @Test
+  func `partialSuccess advances cursor to highestId`() {
+    let partial = OTPartialSuccess(rejectedDataPoints: 1, rejectedLogRecords: nil, errorMessage: "x")
+    let next = DispatchUtils.nextCursor(
+      for: .partialSuccess(partial),
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 20)
   }
 
   /// The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) advances the
@@ -48,7 +62,7 @@ struct DispatchUtilsNextCursorTests {
   @Test
   func `nonRetryable advances cursor to highestId`() {
     let next = DispatchUtils.nextCursor(
-      for: .nonRetryable(reason: "HTTP 400"),
+      for: .nonRetryableFailure(reason: "HTTP 400"),
       currentCursor: 10,
       highestId: 20
     )
@@ -56,11 +70,11 @@ struct DispatchUtilsNextCursorTests {
   }
 
   /// Edge case: a single-row batch where `currentCursor + 1 == highestId`. The cursor still
-  /// advances exactly once on `.nonRetryable` so the bad row is consumed.
+  /// advances exactly once on `.nonRetryableFailure` so the bad row is consumed.
   @Test
   func `nonRetryable on single-row batch advances by one`() {
     let next = DispatchUtils.nextCursor(
-      for: .nonRetryable(reason: "HTTP 400"),
+      for: .nonRetryableFailure(reason: "HTTP 400"),
       currentCursor: 41,
       highestId: 42
     )

--- a/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+@Suite("DispatchUtils.nextCursor")
+struct DispatchUtilsNextCursorTests {
+  /// On `.success`, the cursor must advance past the dispatched batch so the next round reads
+  /// only newer rows. This is unchanged from the pre-OTLP-spec behavior; covered here to lock
+  /// the contract for the table-driven `nonRetryable` case.
+  @Test
+  func `success advances cursor to highestId`() {
+    let next = DispatchUtils.nextCursor(
+      for: .success,
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 20)
+  }
+
+  /// `.retryable` is the "leave it alone" case — the next dispatch round picks the same rows
+  /// up again. This is what keeps an in-flight outage from losing telemetry.
+  @Test
+  func `retryable retains current cursor`() {
+    let next = DispatchUtils.nextCursor(
+      for: .retryable(retryAfter: nil),
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 10)
+  }
+
+  /// Retry-After value doesn't change the cursor decision — it only influences WHEN the next
+  /// attempt happens (gate logic lands in commit C1), not WHICH rows it covers.
+  @Test
+  func `retryable with Retry-After still retains current cursor`() {
+    let next = DispatchUtils.nextCursor(
+      for: .retryable(retryAfter: 30),
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 10)
+  }
+
+  /// The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) advances the
+  /// cursor past the offending batch. Without this, the next round would re-send the same rows
+  /// and the server would refuse them again, wedging the loop indefinitely.
+  @Test
+  func `nonRetryable advances cursor to highestId`() {
+    let next = DispatchUtils.nextCursor(
+      for: .nonRetryable(reason: "HTTP 400"),
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 20)
+  }
+
+  /// Edge case: a single-row batch where `currentCursor + 1 == highestId`. The cursor still
+  /// advances exactly once on `.nonRetryable` so the bad row is consumed.
+  @Test
+  func `nonRetryable on single-row batch advances by one`() {
+    let next = DispatchUtils.nextCursor(
+      for: .nonRetryable(reason: "HTTP 400"),
+      currentCursor: 41,
+      highestId: 42
+    )
+    #expect(next == 42)
+  }
+
+  /// Sanity check: `.success` on an empty-batch reply (highestId == currentCursor) is a no-op
+  /// move. We don't filter this case out at the cursor layer — the dispatch site already
+  /// short-circuits empty batches before calling `nextCursor`.
+  @Test
+  func `success with highestId equal to currentCursor leaves cursor unchanged`() {
+    let next = DispatchUtils.nextCursor(
+      for: .success,
+      currentCursor: 10,
+      highestId: 10
+    )
+    #expect(next == 10)
+  }
+}

--- a/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
@@ -32,7 +32,26 @@ struct DispatchUtilsRetryGateTests {
     #expect(next.dispatchAfterDate == state.dispatchAfterDate)  // untouched
   }
 
-  /// `.nonRetryable` is treated the same as success for gate purposes: a permanent drop
+  /// `.partialSuccess` is treated the same as success for gate purposes: the bytes landed on
+  /// the server, so the gate stays where it is and the counter resets.
+  @Test
+  func `partialSuccess resets the counter and leaves the gate alone`() {
+    let state = DispatchUtils.RetryGateState(
+      dispatchAfterDate: now.addingTimeInterval(60),
+      consecutiveRetryableFailures: 4
+    )
+    let partial = OTPartialSuccess(rejectedDataPoints: 2, rejectedLogRecords: nil, errorMessage: nil)
+    let next = DispatchUtils.nextRetryGateState(
+      result: .partialSuccess(partial),
+      currentState: state,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 0)
+    #expect(next.dispatchAfterDate == state.dispatchAfterDate)
+  }
+
+  /// `.nonRetryableFailure` is treated the same as success for gate purposes: a permanent drop
   /// doesn't suggest the server is unhealthy, so the counter resets and we don't introduce a
   /// new pause for subsequent batches.
   @Test
@@ -42,7 +61,7 @@ struct DispatchUtilsRetryGateTests {
       consecutiveRetryableFailures: 2
     )
     let next = DispatchUtils.nextRetryGateState(
-      result: .nonRetryable(reason: "HTTP 400"),
+      result: .nonRetryableFailure(reason: "HTTP 400"),
       currentState: state,
       now: now,
       backoff: stubbedBackoff
@@ -57,7 +76,7 @@ struct DispatchUtilsRetryGateTests {
   @Test
   func `first retryable with no Retry-After uses computed backoff`() {
     let next = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: nil),
+      result: .retryableFailure(retryAfter: nil),
       currentState: .initial,
       now: now,
       backoff: stubbedBackoff
@@ -76,7 +95,7 @@ struct DispatchUtilsRetryGateTests {
       consecutiveRetryableFailures: 2
     )
     let next = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: nil),
+      result: .retryableFailure(retryAfter: nil),
       currentState: state,
       now: now,
       backoff: stubbedBackoff
@@ -90,7 +109,7 @@ struct DispatchUtilsRetryGateTests {
   @Test
   func `retryable with server Retry-After uses the server delay`() {
     let next = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: 90),
+      result: .retryableFailure(retryAfter: 90),
       currentState: .initial,
       now: now,
       backoff: stubbedBackoff
@@ -106,7 +125,7 @@ struct DispatchUtilsRetryGateTests {
   @Test
   func `retryable with zero Retry-After still increments counter`() {
     let next = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: 0),
+      result: .retryableFailure(retryAfter: 0),
       currentState: .initial,
       now: now,
       backoff: stubbedBackoff
@@ -122,7 +141,7 @@ struct DispatchUtilsRetryGateTests {
   func `retryable with server Retry-After does not invoke the backoff function`() {
     var backoffCalled = false
     _ = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: 5),
+      result: .retryableFailure(retryAfter: 5),
       currentState: .initial,
       now: now,
       backoff: { _ in
@@ -139,13 +158,13 @@ struct DispatchUtilsRetryGateTests {
   @Test
   func `retryable then retryable then success drives counter back to zero`() {
     let after1 = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: nil),
+      result: .retryableFailure(retryAfter: nil),
       currentState: .initial,
       now: now,
       backoff: stubbedBackoff
     )
     let after2 = DispatchUtils.nextRetryGateState(
-      result: .retryable(retryAfter: nil),
+      result: .retryableFailure(retryAfter: nil),
       currentState: after1,
       now: now,
       backoff: stubbedBackoff

--- a/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+@Suite("DispatchUtils.nextRetryGateState")
+struct DispatchUtilsRetryGateTests {
+  /// Fixed "now" so the expected `dispatchAfterDate` is exact rather than approximate. The
+  /// helper itself never reads the system clock — `now` is always injected.
+  private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+  /// Backoff stub that returns `attempt * 10` so each test can pick the expected delay by
+  /// counting from `consecutiveRetryableFailures + 1`. Avoids the random source in
+  /// `computeBackoffDelay` and lets us assert exact deadlines.
+  private let stubbedBackoff: (Int) -> TimeInterval = { Double($0) * 10 }
+
+  /// `.success` is the all-clear: counter resets to 0, gate is left alone so any active
+  /// gate (which shouldn't exist if we got this far, but defensively) keeps its semantics.
+  @Test
+  func `success resets the counter and leaves the gate alone`() {
+    let state = DispatchUtils.RetryGateState(
+      dispatchAfterDate: now.addingTimeInterval(60),
+      consecutiveRetryableFailures: 3
+    )
+    let next = DispatchUtils.nextRetryGateState(
+      result: .success,
+      currentState: state,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 0)
+    #expect(next.dispatchAfterDate == state.dispatchAfterDate)  // untouched
+  }
+
+  /// `.nonRetryable` is treated the same as success for gate purposes: a permanent drop
+  /// doesn't suggest the server is unhealthy, so the counter resets and we don't introduce a
+  /// new pause for subsequent batches.
+  @Test
+  func `nonRetryable resets the counter and leaves the gate alone`() {
+    let state = DispatchUtils.RetryGateState(
+      dispatchAfterDate: now.addingTimeInterval(60),
+      consecutiveRetryableFailures: 2
+    )
+    let next = DispatchUtils.nextRetryGateState(
+      result: .nonRetryable(reason: "HTTP 400"),
+      currentState: state,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 0)
+    #expect(next.dispatchAfterDate == state.dispatchAfterDate)
+  }
+
+  /// First retryable failure (from .initial): counter goes to 1, gate is now + backoff(1).
+  /// `Retry-After` is `nil`, so we fall through to `computeBackoffDelay` (the stubbed value
+  /// of 10 s here).
+  @Test
+  func `first retryable with no Retry-After uses computed backoff`() {
+    let next = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: nil),
+      currentState: .initial,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 1)
+    #expect(next.dispatchAfterDate == now.addingTimeInterval(10))
+  }
+
+  /// Subsequent retryable failures: counter increments before the backoff lookup so the
+  /// helper passes `nextCount` (not `currentCount`) into the backoff function. Verifies that
+  /// 3rd failure → backoff(3) (= 30 s with the stub), not backoff(2).
+  @Test
+  func `nth retryable passes nextCount into backoff function`() {
+    let state = DispatchUtils.RetryGateState(
+      dispatchAfterDate: nil,
+      consecutiveRetryableFailures: 2
+    )
+    let next = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: nil),
+      currentState: state,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 3)
+    #expect(next.dispatchAfterDate == now.addingTimeInterval(30))
+  }
+
+  /// Server-supplied `Retry-After` wins over the computed backoff. The backoff stub here
+  /// returns 10 s for any attempt, but the explicit 90 s value should be honored.
+  @Test
+  func `retryable with server Retry-After uses the server delay`() {
+    let next = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: 90),
+      currentState: .initial,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 1)
+    #expect(next.dispatchAfterDate == now.addingTimeInterval(90))
+  }
+
+  /// `Retry-After: 0` is valid and means "try again immediately." Still counts as a
+  /// failure for the counter (so a misbehaving server can't suppress the exponential
+  /// backoff by always responding 429 with `Retry-After: 0`) but the gate deadline equals
+  /// `now`, so the next dispatch round runs without waiting.
+  @Test
+  func `retryable with zero Retry-After still increments counter`() {
+    let next = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: 0),
+      currentState: .initial,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 1)
+    #expect(next.dispatchAfterDate == now)
+  }
+
+  /// Backoff function is never consulted when the server sends `Retry-After`. Verifies the
+  /// server-delay branch doesn't accidentally also call into `backoff`, which would defeat
+  /// the purpose of letting the server steer.
+  @Test
+  func `retryable with server Retry-After does not invoke the backoff function`() {
+    var backoffCalled = false
+    _ = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: 5),
+      currentState: .initial,
+      now: now,
+      backoff: { _ in
+        backoffCalled = true
+        return 999
+      }
+    )
+    #expect(backoffCalled == false)
+  }
+
+  /// Sequence test: 2 retryable failures then a success returns to `.initial`-equivalent
+  /// state for the counter (gate is left alone, but the next attempt won't be blocked by
+  /// it because the deadline is in the past by the time the next round runs).
+  @Test
+  func `retryable then retryable then success drives counter back to zero`() {
+    let after1 = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: nil),
+      currentState: .initial,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    let after2 = DispatchUtils.nextRetryGateState(
+      result: .retryable(retryAfter: nil),
+      currentState: after1,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(after2.consecutiveRetryableFailures == 2)
+
+    let after3 = DispatchUtils.nextRetryGateState(
+      result: .success,
+      currentState: after2,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(after3.consecutiveRetryableFailures == 0)
+  }
+}

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -112,12 +112,12 @@ struct ObservabilityClassifyResponseTests {
   }
 
   @Test
-  func `408 502 504 are retryable`() {
+  func `429 502 504 are retryable`() {
     // 429 and 503 have their own dedicated tests above (with and without Retry-After);
     // this loop covers the remaining retryable codes in OTLP's set. 412 (Precondition
     // Failed) is intentionally NOT here — it's not in OTLP's retryable set and would
     // correctly fall through to .nonRetryableFailure.
-    for code in [408, 502, 504] {
+    for code in [429, 502, 504] {
       let result = DispatchUtils.classifyResponse(
         statusCode: code,
         retryAfterHeader: nil,

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+@Suite("DispatchUtils.classifyResponse")
+struct ObservabilityClassifyResponseTests {
+  // MARK: - 2xx
+
+  @Test
+  func `2xx with no partial_success returns success`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 200,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    #expect(result == .success)
+  }
+
+  @Test
+  func `2xx with partial_success rejected count returns nonRetryable`() {
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 3,
+      rejectedLogRecords: nil,
+      errorMessage: "metric_kind_mismatch"
+    )
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 200,
+      retryAfterHeader: nil,
+      partialSuccess: partial
+    )
+    guard case .nonRetryable(let reason) = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+    #expect(reason.contains("rejected 3"))
+    #expect(reason.contains("metric_kind_mismatch"))
+  }
+
+  @Test
+  func `2xx with partial_success rejected logs returns nonRetryable`() {
+    // The same response struct serves both metrics and logs endpoints; the logs response uses
+    // `rejectedLogRecords` instead of `rejectedDataPoints`.
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: nil,
+      rejectedLogRecords: 1,
+      errorMessage: "log_too_large"
+    )
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 200,
+      retryAfterHeader: nil,
+      partialSuccess: partial
+    )
+    guard case .nonRetryable(let reason) = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+    #expect(reason.contains("rejected 1"))
+    #expect(reason.contains("log_too_large"))
+  }
+
+  @Test
+  func `2xx with partial_success warning only (rejected zero) returns success`() {
+    // Per OTLP spec, a `partial_success` with `rejectedCount == 0` plus a non-empty
+    // `errorMessage` is a warning — the records DID land, so don't double-drop them.
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 0,
+      rejectedLogRecords: 0,
+      errorMessage: "deprecation_warning"
+    )
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 200,
+      retryAfterHeader: nil,
+      partialSuccess: partial
+    )
+    #expect(result == .success)
+  }
+
+  @Test
+  func `204 no content with no partial_success returns success`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 204,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    #expect(result == .success)
+  }
+
+  // MARK: - Retryable status codes per OTLP spec (408, 429, 502, 503, 504)
+
+  @Test
+  func `429 returns retryable`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 429,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    #expect(result == .retryable(retryAfter: nil))
+  }
+
+  @Test
+  func `429 with Retry-After seconds is parsed`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 429,
+      retryAfterHeader: "30",
+      partialSuccess: nil
+    )
+    #expect(result == .retryable(retryAfter: 30))
+  }
+
+  @Test
+  func `503 returns retryable and propagates Retry-After`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 503,
+      retryAfterHeader: "5",
+      partialSuccess: nil
+    )
+    #expect(result == .retryable(retryAfter: 5))
+  }
+
+  @Test
+  func `408 412 502 504 are retryable`() {
+    for code in [408, 502, 504] {
+      let result = DispatchUtils.classifyResponse(
+        statusCode: code,
+        retryAfterHeader: nil,
+        partialSuccess: nil
+      )
+      #expect(result == .retryable(retryAfter: nil), "status \(code) should be retryable")
+    }
+  }
+
+  // MARK: - Non-retryable 4xx / other 5xx
+
+  @Test
+  func `400 returns nonRetryable`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 400,
+      retryAfterHeader: nil,
+      partialSuccess: nil,
+      bodyExcerpt: { "bad request" }
+    )
+    guard case .nonRetryable(let reason) = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+    #expect(reason.contains("400"))
+    #expect(reason.contains("bad request"))
+  }
+
+  @Test
+  func `401 returns nonRetryable`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 401,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    guard case .nonRetryable = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+  }
+
+  @Test
+  func `403 returns nonRetryable`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 403,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    guard case .nonRetryable = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+  }
+
+  @Test
+  func `404 returns nonRetryable`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 404,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    guard case .nonRetryable = result else {
+      Issue.record("expected .nonRetryable, got \(result)")
+      return
+    }
+  }
+
+  @Test
+  func `other 5xx returns nonRetryable`() {
+    // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are NOT in OTLP's retry list;
+    // they describe persistent server-side mismatches. Retrying doesn't fix them.
+    for code in [501, 505] {
+      let result = DispatchUtils.classifyResponse(
+        statusCode: code,
+        retryAfterHeader: nil,
+        partialSuccess: nil
+      )
+      guard case .nonRetryable = result else {
+        Issue.record("status \(code) should be .nonRetryable, got \(result)")
+        continue
+      }
+    }
+  }
+
+  @Test
+  func `nonRetryable reason omits body excerpt when not requested`() {
+    // The excerpt closure is only invoked for non-retryable results that benefit from it.
+    // Retryable codes shouldn't pay the cost — verify the closure isn't called on 429.
+    var bodyClosureCalled = false
+    _ = DispatchUtils.classifyResponse(
+      statusCode: 429,
+      retryAfterHeader: nil,
+      partialSuccess: nil,
+      bodyExcerpt: {
+        bodyClosureCalled = true
+        return ""
+      }
+    )
+    #expect(bodyClosureCalled == false)
+  }
+}
+
+@Suite("DispatchUtils.parseRetryAfter")
+struct ObservabilityParseRetryAfterTests {
+  @Test
+  func `nil header returns nil`() {
+    #expect(DispatchUtils.parseRetryAfter(nil) == nil)
+  }
+
+  @Test
+  func `empty or whitespace header returns nil`() {
+    #expect(DispatchUtils.parseRetryAfter("") == nil)
+    #expect(DispatchUtils.parseRetryAfter("   ") == nil)
+  }
+
+  @Test
+  func `integer seconds parses to TimeInterval`() {
+    #expect(DispatchUtils.parseRetryAfter("0") == 0)
+    #expect(DispatchUtils.parseRetryAfter("30") == 30)
+    #expect(DispatchUtils.parseRetryAfter("3600") == 3600)
+  }
+
+  @Test
+  func `negative seconds clamps to zero`() {
+    // Defensive: a misbehaving server shouldn't be able to make us schedule the next dispatch
+    // in the past (or, worse, give us a negative sleep).
+    #expect(DispatchUtils.parseRetryAfter("-1") == 0)
+  }
+
+  @Test
+  func `fractional seconds parse`() {
+    // `TimeInterval` is `Double`; the RFC technically requires an integer but real servers
+    // sometimes emit `Retry-After: 0.5` and there's no harm in honoring it.
+    #expect(DispatchUtils.parseRetryAfter("0.5") == 0.5)
+  }
+
+  @Test
+  func `HTTP-date header parses to delta from now`() {
+    // Build a header that points 60 seconds in the future and verify the parsed delta is in
+    // the [55, 65] range (allowing for clock drift / test latency).
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    let future = Date().addingTimeInterval(60)
+    let header = formatter.string(from: future)
+
+    let parsed = DispatchUtils.parseRetryAfter(header)
+    #expect(parsed != nil)
+    if let parsed {
+      #expect(parsed >= 55 && parsed <= 65, "expected ~60 s, got \(parsed)")
+    }
+  }
+
+  @Test
+  func `HTTP-date in the past clamps to zero`() {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    let past = Date().addingTimeInterval(-3600)
+    #expect(DispatchUtils.parseRetryAfter(formatter.string(from: past)) == 0)
+  }
+
+  @Test
+  func `garbage header returns nil`() {
+    #expect(DispatchUtils.parseRetryAfter("tomorrow morning") == nil)
+    #expect(DispatchUtils.parseRetryAfter("Mon Jun 16") == nil)
+  }
+}

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -18,7 +18,7 @@ struct ObservabilityClassifyResponseTests {
   }
 
   @Test
-  func `2xx with partial_success rejected count returns nonRetryable`() {
+  func `2xx with partial_success rejected data points returns partialSuccess`() {
     let partial = OTPartialSuccess(
       rejectedDataPoints: 3,
       rejectedLogRecords: nil,
@@ -29,16 +29,11 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: partial
     )
-    guard case .nonRetryable(let reason) = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
-      return
-    }
-    #expect(reason.contains("rejected 3"))
-    #expect(reason.contains("metric_kind_mismatch"))
+    #expect(result == .partialSuccess(partial))
   }
 
   @Test
-  func `2xx with partial_success rejected logs returns nonRetryable`() {
+  func `2xx with partial_success rejected log records returns partialSuccess`() {
     // The same response struct serves both metrics and logs endpoints; the logs response uses
     // `rejectedLogRecords` instead of `rejectedDataPoints`.
     let partial = OTPartialSuccess(
@@ -51,12 +46,7 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: partial
     )
-    guard case .nonRetryable(let reason) = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
-      return
-    }
-    #expect(reason.contains("rejected 1"))
-    #expect(reason.contains("log_too_large"))
+    #expect(result == .partialSuccess(partial))
   }
 
   @Test
@@ -95,7 +85,7 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: nil
     )
-    #expect(result == .retryable(retryAfter: nil))
+    #expect(result == .retryableFailure(retryAfter: nil))
   }
 
   @Test
@@ -106,7 +96,7 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: "120",
       partialSuccess: nil
     )
-    #expect(result == .retryable(retryAfter: 120))
+    #expect(result == .retryableFailure(retryAfter: 120))
   }
 
   @Test
@@ -118,7 +108,7 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: "5",
       partialSuccess: nil
     )
-    #expect(result == .retryable(retryAfter: DispatchUtils.backoffBaseSeconds))
+    #expect(result == .retryableFailure(retryAfter: DispatchUtils.backoffBaseSeconds))
   }
 
   @Test
@@ -129,7 +119,7 @@ struct ObservabilityClassifyResponseTests {
         retryAfterHeader: nil,
         partialSuccess: nil
       )
-      #expect(result == .retryable(retryAfter: nil), "status \(code) should be retryable")
+      #expect(result == .retryableFailure(retryAfter: nil), "status \(code) should be retryable")
     }
   }
 
@@ -143,8 +133,8 @@ struct ObservabilityClassifyResponseTests {
       partialSuccess: nil,
       bodyExcerpt: { "bad request" }
     )
-    guard case .nonRetryable(let reason) = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
+    guard case .nonRetryableFailure(let reason) = result else {
+      Issue.record("expected .nonRetryableFailure, got \(result)")
       return
     }
     #expect(reason.contains("400"))
@@ -158,8 +148,8 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: nil
     )
-    guard case .nonRetryable = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
+    guard case .nonRetryableFailure = result else {
+      Issue.record("expected .nonRetryableFailure, got \(result)")
       return
     }
   }
@@ -171,8 +161,8 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: nil
     )
-    guard case .nonRetryable = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
+    guard case .nonRetryableFailure = result else {
+      Issue.record("expected .nonRetryableFailure, got \(result)")
       return
     }
   }
@@ -184,8 +174,8 @@ struct ObservabilityClassifyResponseTests {
       retryAfterHeader: nil,
       partialSuccess: nil
     )
-    guard case .nonRetryable = result else {
-      Issue.record("expected .nonRetryable, got \(result)")
+    guard case .nonRetryableFailure = result else {
+      Issue.record("expected .nonRetryableFailure, got \(result)")
       return
     }
   }
@@ -200,8 +190,8 @@ struct ObservabilityClassifyResponseTests {
         retryAfterHeader: nil,
         partialSuccess: nil
       )
-      guard case .nonRetryable = result else {
-        Issue.record("status \(code) should be .nonRetryable, got \(result)")
+      guard case .nonRetryableFailure = result else {
+        Issue.record("status \(code) should be .nonRetryableFailure, got \(result)")
         continue
       }
     }

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -112,7 +112,11 @@ struct ObservabilityClassifyResponseTests {
   }
 
   @Test
-  func `408 412 502 504 are retryable`() {
+  func `408 502 504 are retryable`() {
+    // 429 and 503 have their own dedicated tests above (with and without Retry-After);
+    // this loop covers the remaining retryable codes in OTLP's set. 412 (Precondition
+    // Failed) is intentionally NOT here — it's not in OTLP's retryable set and would
+    // correctly fall through to .nonRetryableFailure.
     for code in [408, 502, 504] {
       let result = DispatchUtils.classifyResponse(
         statusCode: code,

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -99,23 +99,26 @@ struct ObservabilityClassifyResponseTests {
   }
 
   @Test
-  func `429 with Retry-After seconds is parsed`() {
+  func `429 with Retry-After inside client bounds is parsed as-is`() {
+    // 120 s sits between base (60) and cap (900), so it propagates unchanged.
     let result = DispatchUtils.classifyResponse(
       statusCode: 429,
-      retryAfterHeader: "30",
+      retryAfterHeader: "120",
       partialSuccess: nil
     )
-    #expect(result == .retryable(retryAfter: 30))
+    #expect(result == .retryable(retryAfter: 120))
   }
 
   @Test
-  func `503 returns retryable and propagates Retry-After`() {
+  func `503 Retry-After below base clamps up to base`() {
+    // 5 s is below the 60 s floor — the client wouldn't dispatch faster than that anyway, so
+    // honor the server's intent to slow down by snapping up to base.
     let result = DispatchUtils.classifyResponse(
       statusCode: 503,
       retryAfterHeader: "5",
       partialSuccess: nil
     )
-    #expect(result == .retryable(retryAfter: 5))
+    #expect(result == .retryable(retryAfter: DispatchUtils.backoffBaseSeconds))
   }
 
   @Test
@@ -224,69 +227,149 @@ struct ObservabilityClassifyResponseTests {
 
 @Suite("DispatchUtils.parseRetryAfter")
 struct ObservabilityParseRetryAfterTests {
+  /// Test-local bounds passed explicitly to every call so the suite is independent of the
+  /// production constants. Tests using the default-argument values are listed separately.
+  private let base: TimeInterval = 60
+  private let cap: TimeInterval = 900
+
+  // MARK: - Missing / unparseable inputs return nil (caller falls through to backoff)
+
   @Test
   func `nil header returns nil`() {
-    #expect(DispatchUtils.parseRetryAfter(nil) == nil)
+    #expect(DispatchUtils.parseRetryAfter(nil, base: base, cap: cap) == nil)
   }
 
   @Test
   func `empty or whitespace header returns nil`() {
-    #expect(DispatchUtils.parseRetryAfter("") == nil)
-    #expect(DispatchUtils.parseRetryAfter("   ") == nil)
+    #expect(DispatchUtils.parseRetryAfter("", base: base, cap: cap) == nil)
+    #expect(DispatchUtils.parseRetryAfter("   ", base: base, cap: cap) == nil)
+    #expect(DispatchUtils.parseRetryAfter("\t\n", base: base, cap: cap) == nil)
   }
 
   @Test
-  func `integer seconds parses to TimeInterval`() {
-    #expect(DispatchUtils.parseRetryAfter("0") == 0)
-    #expect(DispatchUtils.parseRetryAfter("30") == 30)
-    #expect(DispatchUtils.parseRetryAfter("3600") == 3600)
-  }
-
-  @Test
-  func `negative seconds clamps to zero`() {
-    // Defensive: a misbehaving server shouldn't be able to make us schedule the next dispatch
-    // in the past (or, worse, give us a negative sleep).
-    #expect(DispatchUtils.parseRetryAfter("-1") == 0)
-  }
-
-  @Test
-  func `fractional seconds parse`() {
-    // `TimeInterval` is `Double`; the RFC technically requires an integer but real servers
-    // sometimes emit `Retry-After: 0.5` and there's no harm in honoring it.
-    #expect(DispatchUtils.parseRetryAfter("0.5") == 0.5)
-  }
-
-  @Test
-  func `HTTP-date header parses to delta from now`() {
-    // Build a header that points 60 seconds in the future and verify the parsed delta is in
-    // the [55, 65] range (allowing for clock drift / test latency).
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(identifier: "GMT")
-    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
-    let future = Date().addingTimeInterval(60)
-    let header = formatter.string(from: future)
-
-    let parsed = DispatchUtils.parseRetryAfter(header)
-    #expect(parsed != nil)
-    if let parsed {
-      #expect(parsed >= 55 && parsed <= 65, "expected ~60 s, got \(parsed)")
+  func `garbage header returns nil`() {
+    // Neither a Double nor an RFC 7231 HTTP-date — caller should fall through to backoff.
+    let cases = [
+      "tomorrow morning",
+      "Mon Jun 16",  // partial date, missing time + year + zone
+      "30 minutes",  // delta-seconds doesn't accept units
+      "30s",
+      "abc",
+      "300/600",
+      ", 30",
+      "30,",
+    ]
+    for header in cases {
+      #expect(
+        DispatchUtils.parseRetryAfter(header, base: base, cap: cap) == nil,
+        "expected nil for garbage header \"\(header)\""
+      )
     }
   }
 
   @Test
-  func `HTTP-date in the past clamps to zero`() {
+  func `non-finite numeric tokens return nil`() {
+    // `Double(_:)` happily parses `inf`, `-inf`, `nan`, `infinity` — but feeding any of those
+    // into the gate deadline is a bug. Reject them as garbage so the caller falls through to
+    // `computeBackoffDelay`, which is bounded by construction.
+    for header in ["inf", "Inf", "infinity", "Infinity", "-inf", "nan", "NaN"] {
+      #expect(
+        DispatchUtils.parseRetryAfter(header, base: base, cap: cap) == nil,
+        "expected nil for non-finite numeric \"\(header)\""
+      )
+    }
+  }
+
+  // MARK: - delta-seconds (numeric)
+
+  @Test
+  func `delta-seconds inside [base, cap] returns the parsed value unchanged`() {
+    #expect(DispatchUtils.parseRetryAfter("60", base: base, cap: cap) == 60)
+    #expect(DispatchUtils.parseRetryAfter("120", base: base, cap: cap) == 120)
+    #expect(DispatchUtils.parseRetryAfter("900", base: base, cap: cap) == 900)
+  }
+
+  @Test
+  func `delta-seconds below base clamps up to base`() {
+    // `Retry-After: 0` is the most common misbehavior — a server that wants us to retry
+    // immediately. Snap to base so we don't hammer the recovering endpoint.
+    #expect(DispatchUtils.parseRetryAfter("0", base: base, cap: cap) == base)
+    #expect(DispatchUtils.parseRetryAfter("1", base: base, cap: cap) == base)
+    #expect(DispatchUtils.parseRetryAfter("30", base: base, cap: cap) == base)
+    #expect(DispatchUtils.parseRetryAfter("0.5", base: base, cap: cap) == base)
+  }
+
+  @Test
+  func `delta-seconds above cap clamps down to cap`() {
+    // A pathological server response shouldn't be able to wedge us in a multi-hour snooze.
+    #expect(DispatchUtils.parseRetryAfter("901", base: base, cap: cap) == cap)
+    #expect(DispatchUtils.parseRetryAfter("3600", base: base, cap: cap) == cap)
+    #expect(DispatchUtils.parseRetryAfter("86400", base: base, cap: cap) == cap)
+    #expect(DispatchUtils.parseRetryAfter("1e9", base: base, cap: cap) == cap)
+  }
+
+  @Test
+  func `negative delta-seconds clamps up to base`() {
+    // A negative delta would otherwise schedule the next dispatch in the past — bounce it
+    // to the floor so the gate is still a real pause.
+    #expect(DispatchUtils.parseRetryAfter("-1", base: base, cap: cap) == base)
+    #expect(DispatchUtils.parseRetryAfter("-3600", base: base, cap: cap) == base)
+  }
+
+  @Test
+  func `leading and trailing whitespace is trimmed before parsing`() {
+    #expect(DispatchUtils.parseRetryAfter("  120  ", base: base, cap: cap) == 120)
+    #expect(DispatchUtils.parseRetryAfter("\n120\t", base: base, cap: cap) == 120)
+  }
+
+  // MARK: - HTTP-date
+
+  @Test
+  func `HTTP-date inside bounds parses to a delta near the actual offset`() {
+    // Build a header 5 minutes (300 s) in the future — comfortably inside [60, 900].
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    let future = Date().addingTimeInterval(300)
+    let header = formatter.string(from: future)
+
+    let parsed = DispatchUtils.parseRetryAfter(header, base: base, cap: cap)
+    #expect(parsed != nil)
+    if let parsed {
+      #expect(parsed >= 295 && parsed <= 305, "expected ~300 s, got \(parsed)")
+    }
+  }
+
+  @Test
+  func `HTTP-date in the past clamps up to base`() {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.timeZone = TimeZone(identifier: "GMT")
     formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
     let past = Date().addingTimeInterval(-3600)
-    #expect(DispatchUtils.parseRetryAfter(formatter.string(from: past)) == 0)
+    #expect(DispatchUtils.parseRetryAfter(formatter.string(from: past), base: base, cap: cap) == base)
   }
 
   @Test
-  func `garbage header returns nil`() {
-    #expect(DispatchUtils.parseRetryAfter("tomorrow morning") == nil)
-    #expect(DispatchUtils.parseRetryAfter("Mon Jun 16") == nil)
+  func `HTTP-date far in the future clamps down to cap`() {
+    // Two hours from now is well past the 15-minute cap.
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    let farFuture = Date().addingTimeInterval(7200)
+    #expect(DispatchUtils.parseRetryAfter(formatter.string(from: farFuture), base: base, cap: cap) == cap)
+  }
+
+  // MARK: - Custom client bounds
+
+  @Test
+  func `custom base and cap override the defaults`() {
+    // The same input ("100") clamps differently depending on the bounds passed in: with the
+    // default [60, 900] it sits inside, but a stricter [120, 600] window snaps it up to 120.
+    #expect(DispatchUtils.parseRetryAfter("100") == 100)
+    #expect(DispatchUtils.parseRetryAfter("100", base: 120, cap: 600) == 120)
+    #expect(DispatchUtils.parseRetryAfter("100", base: 10, cap: 50) == 50)
   }
 }


### PR DESCRIPTION
# Why

Our client side code in expo-observe does not comply with the Open Telemetry spec for retrying requests that fail. This PR fixes that for iOS (Android changes will be in a separate PR).

# How

Classify responses into successful, retryable, and failed types, and handle them as appropriate. Non-retryable errors are handled by moving the cursor, to prevent the request being retried, which means that those metrics or logs will be dropped. In this PR, dropped requests are logged as warnings.

# Test Plan

- Testing with a real Expo app against a local server to send back different responses
- New iOS unit tests added.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)