### PR TITLE
[observe][android] Correct OTLP retry behavior for dispatches

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
@@ -10,6 +10,14 @@ import java.util.TimeZone
 object TimeUtils {
   fun getCurrentTimeInMillis(): Long = SystemClock.uptimeMillis()
 
+  /**
+   * Wall-clock time in milliseconds since the Unix epoch. Use this when comparing against
+   * another wall-clock timestamp — HTTP `Retry-After` deadlines, server-supplied dates, file
+   * modification times. For measuring elapsed intervals within the process, prefer
+   * [getCurrentTimeInMillis], which is monotonic and immune to wall-clock adjustments.
+   */
+  fun getWallClockMillis(): Long = System.currentTimeMillis()
+
   fun getProcessStartTimeInMillis(): Long = Process.getStartUptimeMillis()
 
   fun getProcessStartTimestamp(): String {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
@@ -18,6 +18,14 @@ object TimeUtils {
    */
   fun getWallClockMillis(): Long = System.currentTimeMillis()
 
+  /**
+   * Wall-clock delta in milliseconds from `from` to `to` (positive if `to` is in the future
+   * relative to `from`, negative if it's in the past). Defaults `from` to now. Used by
+   * `expo-observe`'s `Retry-After` parser to compute how long the server wants us to wait.
+   * Centralized here so tests can stub the time read via `mockkObject(TimeUtils)`.
+   */
+  fun millisUntil(to: Date, from: Date = Date()): Long = to.time - from.time
+
   fun getProcessStartTimeInMillis(): Long = Process.getStartUptimeMillis()
 
   fun getProcessStartTimestamp(): String {

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
+- [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
-- [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder))
+- [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder)) ([#47160](https://github.com/expo/expo/pull/47160) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -20,7 +20,7 @@ import kotlin.random.Random
  *   pending-ID removal and counter reset match `Success`; the case stays distinct so the
  *   call site can log the rejected count and `errorMessage` clearly rather than describing
  *   it as a drop.
- * - `RetryableFailure` — transient failure (408/429/502/503/504 or transport error); retry
+ * - `RetryableFailure` — transient failure (429/502/503/504 or transport error); retry
  *   the same batch after `retryAfterMs` or a client-computed backoff.
  * - `NonRetryableFailure` — permanent failure (4xx/5xx outside the retryable set, encoding
  *   error); drop the batch so it can't wedge the queue.
@@ -74,7 +74,7 @@ object DispatchUtils {
     }
 
     return when (statusCode) {
-      408, 429, 502, 503, 504 -> DispatchResult.RetryableFailure(retryAfter)
+      429, 502, 503, 504 -> DispatchResult.RetryableFailure(retryAfter)
       else -> {
         val excerpt = bodyExcerpt()
         val suffix = if (excerpt.isEmpty()) "" else ": $excerpt"

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -117,8 +117,7 @@ object DispatchUtils {
   fun parseRetryAfter(
     header: String?,
     base: Long = backoffBaseMs,
-    cap: Long = backoffCapMs,
-    now: Long = TimeUtils.getWallClockMillis()
+    cap: Long = backoffCapMs
   ): Long? {
     val raw = header?.trim() ?: return null
     if (raw.isEmpty()) return null
@@ -133,7 +132,7 @@ object DispatchUtils {
     formatter.timeZone = TimeZone.getTimeZone("GMT")
     val parsed = runCatching { formatter.parse(raw) }.getOrNull()
     if (parsed != null) {
-      return clampToBounds(parsed.time - now, base, cap)
+      return clampToBounds(TimeUtils.millisUntil(parsed), base, cap)
     }
     return null
   }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -132,6 +132,8 @@ object DispatchUtils {
       return clampToBounds((it * 1000L).toLong(), base, cap)
     }
 
+    // IMF-fixdate only; others fall through to backoff
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Date#syntax
     val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
     formatter.timeZone = TimeZone.getTimeZone("GMT")
     val parsed = runCatching { formatter.parse(raw) }.getOrNull()

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.json.Json
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
+import kotlin.math.pow
+import kotlin.random.Random
 
 /**
  * Outcome of a single dispatch attempt to the OTLP endpoint. Modeled after the OTLP retry
@@ -124,5 +126,83 @@ object DispatchUtils {
     return runCatching {
       responseJson.decodeFromString(OTServiceResponse.serializer(), body).partialSuccess
     }.getOrNull()
+  }
+
+  // MARK: -- Retry gate + exponential backoff
+
+  /**
+   * Base delay (in ms) for the exponential backoff when the server doesn't supply a
+   * `Retry-After`. The cap (`backoffCapMs`) bounds the worst-case wait so we don't end up
+   * snoozing for hours after a long string of failures.
+   */
+  const val backoffBaseMs: Long = 60_000L
+  const val backoffCapMs: Long = 900_000L
+
+  /**
+   * Computes a backoff delay (in ms) for the next dispatch attempt when the server didn't
+   * supply `Retry-After`. Exponential growth (base × 2^(attempt-1)), capped, with full jitter
+   * so a fleet of devices recovering from the same transient backend outage doesn't
+   * thunder-herd the recovery.
+   *
+   * `attempt` is 1-based; the helper is defensive for `0` / negative inputs and returns 0
+   * rather than producing a negative exponent.
+   */
+  fun computeBackoffDelay(
+    attempt: Int,
+    base: Long = backoffBaseMs,
+    cap: Long = backoffCapMs,
+    random: () -> Double = { Random.nextDouble() }
+  ): Long {
+    if (attempt < 1) return 0L
+    val unjittered = minOf((base.toDouble() * 2.0.pow(attempt - 1)).toLong(), cap)
+    return (unjittered.toDouble() * random()).toLong()
+  }
+
+  /**
+   * Snapshot of the retry-gate state carried across dispatch rounds. `dispatchAfterMs` is the
+   * wall-clock deadline (ms since epoch) before which the dispatch entry point should
+   * short-circuit (set by a retryable response, naturally expires); `consecutiveRetryableFailures`
+   * is the counter that drives `computeBackoffDelay` when the server didn't supply a
+   * `Retry-After`.
+   */
+  data class RetryGateState(
+    val dispatchAfterMs: Long?,
+    val consecutiveRetryableFailures: Int
+  ) {
+    companion object {
+      val initial = RetryGateState(dispatchAfterMs = null, consecutiveRetryableFailures = 0)
+    }
+  }
+
+  /**
+   * Pure helper that computes the next `RetryGateState` after a single dispatch result.
+   *
+   * - `Success` resets the counter to 0 and leaves the gate alone. The gate either already
+   *   expired (we wouldn't have dispatched otherwise) or was never set — either way, success
+   *   doesn't introduce a new pause.
+   * - `NonRetryable` also resets the counter. A permanent drop isn't a sign that the server
+   *   is unhealthy and shouldn't pause subsequent rounds.
+   * - `Retryable` increments the counter and sets the gate to `now + delay`, where `delay`
+   *   is the server-supplied `retryAfterMs` if present, otherwise `backoff(nextCount)`.
+   *
+   * `backoff` is injected so tests can drive it deterministically without going through
+   * `computeBackoffDelay`'s random source.
+   */
+  fun nextRetryGateState(
+    result: DispatchResult,
+    currentState: RetryGateState,
+    now: Long,
+    backoff: (Int) -> Long
+  ): RetryGateState = when (result) {
+    is DispatchResult.Success, is DispatchResult.NonRetryable ->
+      currentState.copy(consecutiveRetryableFailures = 0)
+    is DispatchResult.Retryable -> {
+      val nextCount = currentState.consecutiveRetryableFailures + 1
+      val delay = result.retryAfterMs ?: backoff(nextCount)
+      RetryGateState(
+        dispatchAfterMs = now + delay,
+        consecutiveRetryableFailures = nextCount
+      )
+    }
   }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -71,6 +71,21 @@ object DispatchUtils {
   }
 
   /**
+   * Whether the dispatch caller should remove the just-sent pending IDs from the queue.
+   *
+   * - `Success` removes them — the rows have been accepted by the server.
+   * - `NonRetryable` ALSO removes them — the server has refused these rows permanently, so
+   *   retrying would produce the same answer; removing them drops the batch so it can't
+   *   wedge subsequent rounds. This is the acceptance-criterion behavior: a 400/403 must
+   *   not be re-sent on the next cycle.
+   * - `Retryable` keeps them so the next dispatch round picks the same rows up again.
+   */
+  fun shouldRemovePending(result: DispatchResult): Boolean = when (result) {
+    is DispatchResult.Success, is DispatchResult.NonRetryable -> true
+    is DispatchResult.Retryable -> false
+  }
+
+  /**
    * Parses an HTTP `Retry-After` header into a delay in milliseconds from now. Accepts both
    * formats permitted by RFC 7231: an integer delta-seconds, or an HTTP-date.
    * Returns `null` if the header is absent or unparseable. Clamps negative / past values to 0

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -2,6 +2,7 @@
 
 package expo.modules.observe
 
+import expo.modules.appmetrics.utils.TimeUtils
 import kotlinx.serialization.json.Json
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -90,24 +91,44 @@ object DispatchUtils {
   /**
    * Parses an HTTP `Retry-After` header into a delay in milliseconds from now. Accepts both
    * formats permitted by RFC 7231: an integer delta-seconds, or an HTTP-date.
-   * Returns `null` if the header is absent or unparseable. Clamps negative / past values to 0
-   * so a misbehaving server can't make us schedule the next dispatch in the past.
+   * Returns `null` if the header is absent or unparseable, so the caller can fall through to
+   * `computeBackoffDelay` for a client-driven delay.
+   *
+   * A successfully parsed value is clamped to `[base, cap]` so a misbehaving server can't
+   * drive us to either extreme: a value below `base` (including `0`, negatives, or HTTP-dates
+   * in the past) floors to `base` so we don't hammer; a value above `cap` (or a date far in
+   * the future) ceilings to `cap` so we don't snooze for hours. Non-finite floating-point
+   * values (`Infinity`, `NaN`) are treated as garbage and return `null`.
    */
-  fun parseRetryAfter(header: String?, now: Long = System.currentTimeMillis()): Long? {
+  fun parseRetryAfter(
+    header: String?,
+    base: Long = backoffBaseMs,
+    cap: Long = backoffCapMs,
+    now: Long = TimeUtils.getWallClockMillis()
+  ): Long? {
     val raw = header?.trim() ?: return null
     if (raw.isEmpty()) return null
 
-    raw.toLongOrNull()?.let { return maxOf(it * 1000L, 0L) }
-    raw.toDoubleOrNull()?.let { return maxOf((it * 1000L).toLong(), 0L) }
+    raw.toLongOrNull()?.let { return clampToBounds(it * 1000L, base, cap) }
+    raw.toDoubleOrNull()?.let {
+      if (!it.isFinite()) return null
+      return clampToBounds((it * 1000L).toLong(), base, cap)
+    }
 
     val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
     formatter.timeZone = TimeZone.getTimeZone("GMT")
     val parsed = runCatching { formatter.parse(raw) }.getOrNull()
     if (parsed != null) {
-      return maxOf(parsed.time - now, 0L)
+      return clampToBounds(parsed.time - now, base, cap)
     }
     return null
   }
+
+  /**
+   * Clamps a server-supplied retry delay into the client's `[base, cap]` window. Used by
+   * `parseRetryAfter` so the gate is bounded regardless of what the server sent.
+   */
+  private fun clampToBounds(ms: Long, base: Long, cap: Long): Long = ms.coerceIn(base, cap)
 
   /**
    * First `limit` bytes of the response body, for inclusion in error log lines. Bounded so a

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -12,7 +12,7 @@ import kotlin.random.Random
 
 /**
  * Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
- * OTLP retry guidance:
+ * OTLP retry guidance (see https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
  *
  * - `Success` — server accepted the batch without rejections.
  * - `PartialSuccess` — server accepted the batch but rejected some records (the OTLP
@@ -178,6 +178,8 @@ object DispatchUtils {
    * supply `Retry-After`. Exponential growth (base × 2^(attempt-1)), capped, with full jitter
    * so a fleet of devices recovering from the same transient backend outage doesn't
    * thunder-herd the recovery.
+   *
+   * https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
    *
    * `attempt` is 1-based; the helper is defensive for `0` / negative inputs and returns 0
    * rather than producing a negative exponent.

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -66,7 +66,11 @@ object DispatchUtils {
       // still landed server-side but a subset was rejected; surface that as `PartialSuccess`
       // so the caller can log the count and message clearly. Pending-ID removal and gate
       // behavior for `PartialSuccess` match `Success`.
-      val partial = responseBody?.let { parsePartialSuccess(it) }
+      val partial = responseBody?.takeIf { it.isNotBlank() }?.let { body ->
+        runCatching {
+          responseJson.decodeFromString(OTServiceResponse.serializer(), body).partialSuccess
+        }.getOrNull()
+      }
       if (partial != null && partial.rejectedCount > 0) {
         return DispatchResult.PartialSuccess(partial)
       }
@@ -154,13 +158,6 @@ object DispatchUtils {
   }
 
   private val responseJson = Json { ignoreUnknownKeys = true }
-
-  private fun parsePartialSuccess(body: String): OTPartialSuccess? {
-    if (body.isBlank()) return null
-    return runCatching {
-      responseJson.decodeFromString(OTServiceResponse.serializer(), body).partialSuccess
-    }.getOrNull()
-  }
 
   // MARK: -- Retry gate + exponential backoff
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -1,0 +1,113 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.observe
+
+import kotlinx.serialization.json.Json
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Outcome of a single dispatch attempt to the OTLP endpoint. Modeled after the OTLP retry
+ * guidance: a 3-way classification distinguishes transient failures (retry the same batch)
+ * from permanent ones (drop the batch so it can't wedge the queue).
+ *
+ * `Retryable.retryAfterMs` carries the parsed `Retry-After` header value in milliseconds (or
+ * `null` when the server didn't supply one). `NonRetryable.reason` carries a short diagnostic
+ * string for the `warn`-level log line.
+ */
+sealed class DispatchResult {
+  object Success : DispatchResult()
+  data class Retryable(val retryAfterMs: Long? = null) : DispatchResult()
+  data class NonRetryable(val reason: String) : DispatchResult()
+}
+
+/**
+ * HTTP response classification + Retry-After parsing for `EventDispatcher`. Lives in its own
+ * file mirroring `DispatchUtils.swift` on the iOS side. All functions are pure so they can be
+ * unit-tested without instantiating the dispatcher or hitting the network.
+ */
+object DispatchUtils {
+  /**
+   * Pure classifier that maps an HTTP response into one of three retry outcomes. Extracted
+   * from the dispatch call site so the OTLP-spec rules can be unit-tested without a real
+   * network call.
+   *
+   * `bodyExcerpt` is invoked lazily, only when the result is `NonRetryable` and the reason
+   * string benefits from including a peek at the response body. Lets the caller bound how
+   * much data we slurp into the log line.
+   */
+  fun classifyResponse(
+    statusCode: Int,
+    retryAfterHeader: String?,
+    responseBody: String?,
+    bodyExcerpt: () -> String = { "" }
+  ): DispatchResult {
+    val retryAfter = parseRetryAfter(retryAfterHeader)
+
+    if (statusCode in 200..299) {
+      // The OTLP spec also allows `partial_success` to carry a warning-only payload —
+      // `rejectedCount == 0` with a non-empty `errorMessage`. Treat that as a successful send
+      // (the records DID land) so we don't double-drop. The caller may still want to log the
+      // warning.
+      val partial = responseBody?.let { parsePartialSuccess(it) }
+      if (partial != null && partial.rejectedCount > 0) {
+        val detail = partial.errorMessage ?: "no error message"
+        return DispatchResult.NonRetryable(
+          reason = "partial_success: rejected ${partial.rejectedCount} ($detail)"
+        )
+      }
+      return DispatchResult.Success
+    }
+
+    return when (statusCode) {
+      408, 429, 502, 503, 504 -> DispatchResult.Retryable(retryAfter)
+      else -> {
+        val excerpt = bodyExcerpt()
+        val suffix = if (excerpt.isEmpty()) "" else ": $excerpt"
+        DispatchResult.NonRetryable(reason = "HTTP $statusCode$suffix")
+      }
+    }
+  }
+
+  /**
+   * Parses an HTTP `Retry-After` header into a delay in milliseconds from now. Accepts both
+   * formats permitted by RFC 7231: an integer delta-seconds, or an HTTP-date.
+   * Returns `null` if the header is absent or unparseable. Clamps negative / past values to 0
+   * so a misbehaving server can't make us schedule the next dispatch in the past.
+   */
+  fun parseRetryAfter(header: String?, now: Long = System.currentTimeMillis()): Long? {
+    val raw = header?.trim() ?: return null
+    if (raw.isEmpty()) return null
+
+    raw.toLongOrNull()?.let { return maxOf(it * 1000L, 0L) }
+    raw.toDoubleOrNull()?.let { return maxOf((it * 1000L).toLong(), 0L) }
+
+    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+    formatter.timeZone = TimeZone.getTimeZone("GMT")
+    val parsed = runCatching { formatter.parse(raw) }.getOrNull()
+    if (parsed != null) {
+      return maxOf(parsed.time - now, 0L)
+    }
+    return null
+  }
+
+  /**
+   * First `limit` bytes of the response body, for inclusion in error log lines. Bounded so a
+   * giant HTML error page doesn't flood the log; truncated mid-codepoint is acceptable for a
+   * diagnostic excerpt.
+   */
+  internal fun bodyExcerpt(body: String?, limit: Int = 512): String {
+    if (body.isNullOrEmpty()) return ""
+    return if (body.length <= limit) body else body.substring(0, limit)
+  }
+
+  private val responseJson = Json { ignoreUnknownKeys = true }
+
+  private fun parsePartialSuccess(body: String): OTPartialSuccess? {
+    if (body.isBlank()) return null
+    return runCatching {
+      responseJson.decodeFromString(OTServiceResponse.serializer(), body).partialSuccess
+    }.getOrNull()
+  }
+}

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -11,18 +11,29 @@ import kotlin.math.pow
 import kotlin.random.Random
 
 /**
- * Outcome of a single dispatch attempt to the OTLP endpoint. Modeled after the OTLP retry
- * guidance: a 3-way classification distinguishes transient failures (retry the same batch)
- * from permanent ones (drop the batch so it can't wedge the queue).
+ * Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
+ * OTLP retry guidance:
  *
- * `Retryable.retryAfterMs` carries the parsed `Retry-After` header value in milliseconds (or
- * `null` when the server didn't supply one). `NonRetryable.reason` carries a short diagnostic
- * string for the `warn`-level log line.
+ * - `Success` — server accepted the batch without rejections.
+ * - `PartialSuccess` — server accepted the batch but rejected some records (the OTLP
+ *   `partial_success` body with `rejectedCount > 0`). The rows DID land on the server, so
+ *   pending-ID removal and counter reset match `Success`; the case stays distinct so the
+ *   call site can log the rejected count and `errorMessage` clearly rather than describing
+ *   it as a drop.
+ * - `RetryableFailure` — transient failure (408/429/502/503/504 or transport error); retry
+ *   the same batch after `retryAfterMs` or a client-computed backoff.
+ * - `NonRetryableFailure` — permanent failure (4xx/5xx outside the retryable set, encoding
+ *   error); drop the batch so it can't wedge the queue.
+ *
+ * `RetryableFailure.retryAfterMs` carries the parsed `Retry-After` header value in
+ * milliseconds (or `null` when the server didn't supply one). `NonRetryableFailure.reason`
+ * carries a short diagnostic string for the warn log.
  */
 sealed class DispatchResult {
   object Success : DispatchResult()
-  data class Retryable(val retryAfterMs: Long? = null) : DispatchResult()
-  data class NonRetryable(val reason: String) : DispatchResult()
+  data class PartialSuccess(val partial: OTPartialSuccess) : DispatchResult()
+  data class RetryableFailure(val retryAfterMs: Long? = null) : DispatchResult()
+  data class NonRetryableFailure(val reason: String) : DispatchResult()
 }
 
 /**
@@ -49,26 +60,25 @@ object DispatchUtils {
     val retryAfter = parseRetryAfter(retryAfterHeader)
 
     if (statusCode in 200..299) {
-      // The OTLP spec also allows `partial_success` to carry a warning-only payload —
+      // The OTLP spec allows `partial_success` to carry a warning-only payload —
       // `rejectedCount == 0` with a non-empty `errorMessage`. Treat that as a successful send
-      // (the records DID land) so we don't double-drop. The caller may still want to log the
-      // warning.
+      // (the records DID land) so we don't double-drop. When `rejectedCount > 0`, the records
+      // still landed server-side but a subset was rejected; surface that as `PartialSuccess`
+      // so the caller can log the count and message clearly. Pending-ID removal and gate
+      // behavior for `PartialSuccess` match `Success`.
       val partial = responseBody?.let { parsePartialSuccess(it) }
       if (partial != null && partial.rejectedCount > 0) {
-        val detail = partial.errorMessage ?: "no error message"
-        return DispatchResult.NonRetryable(
-          reason = "partial_success: rejected ${partial.rejectedCount} ($detail)"
-        )
+        return DispatchResult.PartialSuccess(partial)
       }
       return DispatchResult.Success
     }
 
     return when (statusCode) {
-      408, 429, 502, 503, 504 -> DispatchResult.Retryable(retryAfter)
+      408, 429, 502, 503, 504 -> DispatchResult.RetryableFailure(retryAfter)
       else -> {
         val excerpt = bodyExcerpt()
         val suffix = if (excerpt.isEmpty()) "" else ": $excerpt"
-        DispatchResult.NonRetryable(reason = "HTTP $statusCode$suffix")
+        DispatchResult.NonRetryableFailure(reason = "HTTP $statusCode$suffix")
       }
     }
   }
@@ -76,16 +86,20 @@ object DispatchUtils {
   /**
    * Whether the dispatch caller should remove the just-sent pending IDs from the queue.
    *
-   * - `Success` removes them — the rows have been accepted by the server.
-   * - `NonRetryable` ALSO removes them — the server has refused these rows permanently, so
-   *   retrying would produce the same answer; removing them drops the batch so it can't
-   *   wedge subsequent rounds. This is the acceptance-criterion behavior: a 400/403 must
-   *   not be re-sent on the next cycle.
-   * - `Retryable` keeps them so the next dispatch round picks the same rows up again.
+   * - `Success` and `PartialSuccess` remove them — the rows have been accepted by the server
+   *   (partial success rejects a subset server-side, but the bytes still landed; re-sending
+   *   them would just re-trip the same rejection).
+   * - `NonRetryableFailure` ALSO removes them — the server has refused these rows
+   *   permanently, so retrying would produce the same answer; removing them drops the batch
+   *   so it can't wedge subsequent rounds. This is the acceptance-criterion behavior: a
+   *   400/403 must not be re-sent on the next cycle.
+   * - `RetryableFailure` keeps them so the next dispatch round picks the same rows up again.
    */
   fun shouldRemovePending(result: DispatchResult): Boolean = when (result) {
-    is DispatchResult.Success, is DispatchResult.NonRetryable -> true
-    is DispatchResult.Retryable -> false
+    is DispatchResult.Success,
+    is DispatchResult.PartialSuccess,
+    is DispatchResult.NonRetryableFailure -> true
+    is DispatchResult.RetryableFailure -> false
   }
 
   /**
@@ -198,13 +212,14 @@ object DispatchUtils {
   /**
    * Pure helper that computes the next `RetryGateState` after a single dispatch result.
    *
-   * - `Success` resets the counter to 0 and leaves the gate alone. The gate either already
-   *   expired (we wouldn't have dispatched otherwise) or was never set — either way, success
-   *   doesn't introduce a new pause.
-   * - `NonRetryable` also resets the counter. A permanent drop isn't a sign that the server
-   *   is unhealthy and shouldn't pause subsequent rounds.
-   * - `Retryable` increments the counter and sets the gate to `now + delay`, where `delay`
-   *   is the server-supplied `retryAfterMs` if present, otherwise `backoff(nextCount)`.
+   * - `Success` and `PartialSuccess` reset the counter to 0 and leave the gate alone. The
+   *   gate either already expired (we wouldn't have dispatched otherwise) or was never set
+   *   — either way, a server response that ACCEPTED the bytes (even if it rejected a subset
+   *   server-side) doesn't introduce a new pause.
+   * - `NonRetryableFailure` also resets the counter. A permanent drop isn't a sign that the
+   *   server is unhealthy and shouldn't pause subsequent rounds.
+   * - `RetryableFailure` increments the counter and sets the gate to `now + delay`, where
+   *   `delay` is the server-supplied `retryAfterMs` if present, otherwise `backoff(nextCount)`.
    *
    * `backoff` is injected so tests can drive it deterministically without going through
    * `computeBackoffDelay`'s random source.
@@ -215,9 +230,11 @@ object DispatchUtils {
     now: Long,
     backoff: (Int) -> Long
   ): RetryGateState = when (result) {
-    is DispatchResult.Success, is DispatchResult.NonRetryable ->
+    is DispatchResult.Success,
+    is DispatchResult.PartialSuccess,
+    is DispatchResult.NonRetryableFailure ->
       currentState.copy(consecutiveRetryableFailures = 0)
-    is DispatchResult.Retryable -> {
+    is DispatchResult.RetryableFailure -> {
       val nextCount = currentState.consecutiveRetryableFailures + 1
       val delay = result.retryAfterMs ?: backoff(nextCount)
       RetryGateState(

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -47,7 +47,7 @@ class EventDispatcher(
         ).toJson(prettyPrint = true)
       } catch (e: Exception) {
         Log.w(OBSERVE_TAG, "Encoding metrics request body failed: ${e.message}")
-        continuation.resume(DispatchResult.NonRetryable("encoding error: ${e.message}"))
+        continuation.resume(DispatchResult.NonRetryableFailure("encoding error: ${e.message}"))
         return@suspendCancellableCoroutine Unit
       }
       executePost(continuation, metricsEndpointUrl(), body)
@@ -71,7 +71,7 @@ class EventDispatcher(
         OTLogsRequestBody(resourceLogs = resourceLogs).toJson(prettyPrint = true)
       } catch (e: Exception) {
         Log.w(OBSERVE_TAG, "Encoding logs request body failed: ${e.message}")
-        continuation.resume(DispatchResult.NonRetryable("encoding error: ${e.message}"))
+        continuation.resume(DispatchResult.NonRetryableFailure("encoding error: ${e.message}"))
         return@suspendCancellableCoroutine Unit
       }
       executePost(continuation, logsEndpointUrl(), body)
@@ -109,7 +109,7 @@ class EventDispatcher(
       call.execute()
     } catch (e: Exception) {
       Log.w(OBSERVE_TAG, "Transport error talking to $endpointUrl: ${e.message}")
-      continuation.resume(DispatchResult.Retryable(retryAfterMs = null))
+      continuation.resume(DispatchResult.RetryableFailure(retryAfterMs = null))
       return
     }
 
@@ -125,9 +125,16 @@ class EventDispatcher(
     when (result) {
       is DispatchResult.Success ->
         Log.d(OBSERVE_TAG, "Server responded successfully with ${response.code} and data: $responseBody")
-      is DispatchResult.Retryable ->
+      is DispatchResult.PartialSuccess ->
+        Log.w(
+          OBSERVE_TAG,
+          "Server responded with ${response.code} (partial success, rejected " +
+            "${result.partial.rejectedCount}: ${result.partial.errorMessage ?: "no error message"}) " +
+            "and data: $responseBody"
+        )
+      is DispatchResult.RetryableFailure ->
         Log.w(OBSERVE_TAG, "Server responded with ${response.code} (retryable) and data: $responseBody")
-      is DispatchResult.NonRetryable ->
+      is DispatchResult.NonRetryableFailure ->
         Log.w(
           OBSERVE_TAG,
           "Server responded with ${response.code} (non-retryable, ${result.reason}) and data: $responseBody"

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -9,7 +9,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 // TODO: Make this safe for concurrent usage
 class EventDispatcher(
@@ -28,60 +27,62 @@ class EventDispatcher(
 
   private fun logsEndpointUrl(): String = "$baseProjectUrl/v1/logs"
 
-  suspend fun dispatch(events: List<Event>): Boolean =
+  /**
+   * POSTs `events` to the metrics endpoint and classifies the response per the OTLP retry
+   * spec. Non-throwing: payload-encoding errors collapse to `NonRetryable` (same bytes will
+   * fail again), transport errors collapse to `Retryable(null)` (transient by definition).
+   */
+  suspend fun dispatch(events: List<Event>): DispatchResult =
     suspendCancellableCoroutine { continuation ->
       if (events.isEmpty()) {
-        continuation.resume(false)
+        // Empty input isn't a server response — keep the old "nothing to do" semantics by
+        // signaling success so the call site removes (nothing) and moves on.
+        continuation.resume(DispatchResult.Success)
         return@suspendCancellableCoroutine Unit
       }
       val easId = EASClientID(context).uuid.toString()
-      try {
-        val body = OTRequestBody(
+      val body = try {
+        OTRequestBody(
           resourceMetrics = events.map { it.toOTEvent(easId) }
         ).toJson(prettyPrint = true)
-
-        executePost(continuation, metricsEndpointUrl(), body)
       } catch (e: Exception) {
-        Log.w(
-          TAG,
-          "Dispatching the events has thrown an error: ${e.message}"
-        )
-        continuation.resumeWithException(e)
+        Log.w(OBSERVE_TAG, "Encoding metrics request body failed: ${e.message}")
+        continuation.resume(DispatchResult.NonRetryable("encoding error: ${e.message}"))
+        return@suspendCancellableCoroutine Unit
       }
+      executePost(continuation, metricsEndpointUrl(), body)
     }
 
   /**
    * Dispatches log records to `{baseUrl}/{projectId}/v1/logs`. Always uses the
    * OTLP wire shape — there is no legacy logs endpoint.
    */
-  suspend fun dispatchLogs(events: List<Event>): Boolean =
+  suspend fun dispatchLogs(events: List<Event>): DispatchResult =
     suspendCancellableCoroutine { continuation ->
       val easId = EASClientID(context).uuid.toString()
       val resourceLogs = events
         .filter { it.logs.isNotEmpty() }
         .map { it.toOTResourceLogs(easId) }
       if (resourceLogs.isEmpty()) {
-        continuation.resume(false)
+        continuation.resume(DispatchResult.Success)
         return@suspendCancellableCoroutine Unit
       }
-      try {
-        val body = OTLogsRequestBody(resourceLogs = resourceLogs).toJson(prettyPrint = true)
-        executePost(continuation, logsEndpointUrl(), body)
+      val body = try {
+        OTLogsRequestBody(resourceLogs = resourceLogs).toJson(prettyPrint = true)
       } catch (e: Exception) {
-        Log.w(
-          TAG,
-          "Dispatching the logs has thrown an error: ${e.message}"
-        )
-        continuation.resumeWithException(e)
+        Log.w(OBSERVE_TAG, "Encoding logs request body failed: ${e.message}")
+        continuation.resume(DispatchResult.NonRetryable("encoding error: ${e.message}"))
+        return@suspendCancellableCoroutine Unit
       }
+      executePost(continuation, logsEndpointUrl(), body)
     }
 
   private fun executePost(
-    continuation: kotlinx.coroutines.CancellableContinuation<Boolean>,
+    continuation: kotlinx.coroutines.CancellableContinuation<DispatchResult>,
     endpointUrl: String,
     body: String
   ) {
-    Log.d(TAG, "Sending events to $endpointUrl")
+    Log.d(OBSERVE_TAG, "Sending events to $endpointUrl")
 
     val request = Request
       .Builder()
@@ -96,7 +97,7 @@ class EventDispatcher(
       .post(body.toRequestBody("application/json".toMediaType()))
       .build()
 
-    Log.d(TAG, body)
+    Log.d(OBSERVE_TAG, body)
 
     val call = httpClient.newCall(request)
 
@@ -104,13 +105,35 @@ class EventDispatcher(
       call.cancel()
     }
 
-    val response = call.execute()
-    Log.d(TAG, "Server responded with: ${response.body?.string()}")
+    val response = try {
+      call.execute()
+    } catch (e: Exception) {
+      Log.w(OBSERVE_TAG, "Transport error talking to $endpointUrl: ${e.message}")
+      continuation.resume(DispatchResult.Retryable(retryAfterMs = null))
+      return
+    }
 
-    continuation.resume(response.code in 200..299)
-  }
+    val responseBody = response.body?.string()
+    val retryAfterHeader = response.header("Retry-After")
+    val result = DispatchUtils.classifyResponse(
+      statusCode = response.code,
+      retryAfterHeader = retryAfterHeader,
+      responseBody = responseBody,
+      bodyExcerpt = { DispatchUtils.bodyExcerpt(responseBody) }
+    )
 
-  companion object {
-    private const val TAG = "EasObserve"
+    when (result) {
+      is DispatchResult.Success ->
+        Log.d(OBSERVE_TAG, "Server responded successfully with ${response.code} and data: $responseBody")
+      is DispatchResult.Retryable ->
+        Log.w(OBSERVE_TAG, "Server responded with ${response.code} (retryable) and data: $responseBody")
+      is DispatchResult.NonRetryable ->
+        Log.w(
+          OBSERVE_TAG,
+          "Server responded with ${response.code} (non-retryable, ${result.reason}) and data: $responseBody"
+        )
+    }
+
+    continuation.resume(result)
   }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -128,8 +128,7 @@ class EventDispatcher(
         Log.w(
           OBSERVE_TAG,
           "Server responded with ${response.code} (partial success, rejected " +
-            "${result.partial.rejectedCount}: ${result.partial.errorMessage ?: "no error message"}) " +
-            "and data: $responseBody"
+            "${result.partial.rejectedCount}: ${result.partial.errorMessage ?: "no error message"}) "
         )
       is DispatchResult.RetryableFailure ->
         Log.w(OBSERVE_TAG, "Server responded with ${response.code} (retryable) and data: $responseBody")

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -35,8 +35,7 @@ class EventDispatcher(
   suspend fun dispatch(events: List<Event>): DispatchResult =
     suspendCancellableCoroutine { continuation ->
       if (events.isEmpty()) {
-        // Empty input isn't a server response — keep the old "nothing to do" semantics by
-        // signaling success so the call site removes (nothing) and moves on.
+        // Empty input isn't a server response - signal success.
         continuation.resume(DispatchResult.Success)
         return@suspendCancellableCoroutine Unit
       }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -173,11 +173,20 @@ class BaseObservabilityManager(
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
     }
-    if (result is DispatchResult.NonRetryable) {
-      Log.w(
-        OBSERVE_TAG,
-        "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
-      )
+    when (result) {
+      is DispatchResult.PartialSuccess ->
+        Log.w(
+          OBSERVE_TAG,
+          "Partial success on batch of ${dispatchedMetricIds.size} metric event(s): " +
+            "server rejected ${result.partial.rejectedCount} " +
+            "(${result.partial.errorMessage ?: "no error message"})"
+        )
+      is DispatchResult.NonRetryableFailure ->
+        Log.w(
+          OBSERVE_TAG,
+          "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
+        )
+      is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
     }
   }
 
@@ -228,11 +237,20 @@ class BaseObservabilityManager(
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingLogsManager.removePendingLogs(dispatchedLogIds)
     }
-    if (result is DispatchResult.NonRetryable) {
-      Log.w(
-        OBSERVE_TAG,
-        "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
-      )
+    when (result) {
+      is DispatchResult.PartialSuccess ->
+        Log.w(
+          OBSERVE_TAG,
+          "Partial success on batch of ${dispatchedLogIds.size} log event(s): " +
+            "server rejected ${result.partial.rejectedCount} " +
+            "(${result.partial.errorMessage ?: "no error message"})"
+        )
+      is DispatchResult.NonRetryableFailure ->
+        Log.w(
+          OBSERVE_TAG,
+          "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
+        )
+      is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
     }
   }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -88,40 +88,49 @@ class BaseObservabilityManager(
   )
 
   /**
-   * In-memory retry-gate state. Reset implicitly when the process restarts — a relaunch
-   * usually means enough time passed that the transient cause has cleared anyway, and
-   * persisting the gate would mean an extra disk write on every retryable response. The gate
-   * is shared between the metrics and logs paths so when the server asks us to slow down on
-   * one signal, the other one waits too.
+   * In-memory retry-gate state, kept independently per OTLP endpoint. The `/v1/metrics` and
+   * `/v1/logs` endpoints fail independently in practice (one schema validation disagreement
+   * on the metrics side shouldn't suppress a healthy logs stream), so each signal carries
+   * its own consecutive-failure counter and dispatch-after deadline. A single shared field
+   * would conflate the two: a recovering signal would reset the other's counter on success,
+   * and a server's `Retry-After` on one endpoint would silently overwrite a longer backoff
+   * computed for the other.
+   *
+   * State is reset implicitly when the process restarts — a relaunch usually means enough
+   * time passed that the transient cause has cleared anyway, and persisting the gates would
+   * mean a disk write per retryable response.
    */
-  private var retryGateState: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
+  private var metricsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
+  private var logsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
 
   /**
-   * Returns true and logs when an active retry gate suppresses this dispatch round. Mirrors
-   * the `dispatch()` entry-point gate check on the iOS side.
+   * Returns true and logs when an active retry gate suppresses this dispatch round. Called
+   * inside each per-signal dispatch method rather than at a shared entry point, so a backoff
+   * on one endpoint doesn't suppress traffic on the other.
    */
-  private fun retryGateBlocks(): Boolean {
-    val until = retryGateState.dispatchAfterMs ?: return false
+  private fun retryGateBlocks(state: DispatchUtils.RetryGateState, signal: String): Boolean {
+    val until = state.dispatchAfterMs ?: return false
     val now = currentTimeMs()
     if (until <= now) return false
-    Log.d(OBSERVE_TAG, "Dispatch suppressed by retry gate until $until (now $now)")
+    Log.d(OBSERVE_TAG, "$signal dispatch suppressed by retry gate until $until (now $now)")
     return true
   }
 
   /**
-   * Applies a per-signal dispatch outcome to the shared retry-gate state. Reads/writes the
-   * manager's `retryGateState` field so call sites stay concise. Called from both
-   * `dispatchUnsentMetrics` and `dispatchUnsentLogs` after each `eventDispatcher.dispatch*`
-   * call so the gate reflects the latest signal's response.
+   * Computes the next gate state for a given current state and dispatch result. Each per-
+   * signal call site assigns the return value back to its own field — the manager doesn't
+   * share a single mutable state across signals, so the metrics and logs gates can't drift
+   * out of sync from cross-signal updates.
    */
-  private fun applyRetryOutcome(result: DispatchResult) {
-    retryGateState = DispatchUtils.nextRetryGateState(
-      result = result,
-      currentState = retryGateState,
-      now = currentTimeMs(),
-      backoff = { DispatchUtils.computeBackoffDelay(it) }
-    )
-  }
+  private fun nextGate(
+    current: DispatchUtils.RetryGateState,
+    result: DispatchResult
+  ): DispatchUtils.RetryGateState = DispatchUtils.nextRetryGateState(
+    result = result,
+    currentState = current,
+    now = currentTimeMs(),
+    backoff = { DispatchUtils.computeBackoffDelay(it) }
+  )
 
   suspend fun dispatchUnsentMetrics() {
     val pendingIds = pendingMetricsManager.getAllPendingMetricIds()
@@ -129,7 +138,7 @@ class BaseObservabilityManager(
       return
     }
 
-    if (retryGateBlocks()) {
+    if (retryGateBlocks(metricsRetryGate, "metrics")) {
       return
     }
 
@@ -159,7 +168,7 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatch(events)
-    applyRetryOutcome(result)
+    metricsRetryGate = nextGate(metricsRetryGate, result)
     val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
@@ -182,7 +191,7 @@ class BaseObservabilityManager(
       return
     }
 
-    if (retryGateBlocks()) {
+    if (retryGateBlocks(logsRetryGate, "logs")) {
       return
     }
 
@@ -214,7 +223,7 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatchLogs(events)
-    applyRetryOutcome(result)
+    logsRetryGate = nextGate(logsRetryGate, result)
     val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingLogsManager.removePendingLogs(dispatchedLogIds)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -1,6 +1,7 @@
 package expo.modules.observe
 
 import android.content.Context
+import android.util.Log
 import expo.modules.easclient.EASClientID
 import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
@@ -116,9 +117,15 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatch(events)
-    if (result is DispatchResult.Success) {
-      val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
+    val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
+    if (DispatchUtils.shouldRemovePending(result)) {
       pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+    }
+    if (result is DispatchResult.NonRetryable) {
+      Log.w(
+        OBSERVE_TAG,
+        "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
+      )
     }
   }
 
@@ -160,9 +167,15 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatchLogs(events)
-    if (result is DispatchResult.Success) {
-      val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
+    val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
+    if (DispatchUtils.shouldRemovePending(result)) {
       pendingLogsManager.removePendingLogs(dispatchedLogIds)
+    }
+    if (result is DispatchResult.NonRetryable) {
+      Log.w(
+        OBSERVE_TAG,
+        "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
+      )
     }
   }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -6,6 +6,7 @@ import expo.modules.easclient.EASClientID
 import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.interfaces.constants.ConstantsInterface
 
 class ObservabilityManager(
@@ -78,7 +79,7 @@ class BaseObservabilityManager(
   private val deterministicUniformValueProvider: () -> Double = {
     EASClientID.deterministicUniformValue(EASClientID(context).uuid)
   },
-  private val currentTimeMs: () -> Long = { System.currentTimeMillis() }
+  private val currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() }
 ) {
   private val eventDispatcher = EventDispatcher(
     context = context,

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -115,7 +115,8 @@ class BaseObservabilityManager(
       )
     }
 
-    if (eventDispatcher.dispatch(events)) {
+    val result = eventDispatcher.dispatch(events)
+    if (result is DispatchResult.Success) {
       val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
       pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
     }
@@ -158,7 +159,8 @@ class BaseObservabilityManager(
       )
     }
 
-    if (eventDispatcher.dispatchLogs(events)) {
+    val result = eventDispatcher.dispatchLogs(events)
+    if (result is DispatchResult.Success) {
       val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
       pendingLogsManager.removePendingLogs(dispatchedLogIds)
     }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -77,7 +77,8 @@ class BaseObservabilityManager(
   private val isDebugBuild: Boolean = false,
   private val deterministicUniformValueProvider: () -> Double = {
     EASClientID.deterministicUniformValue(EASClientID(context).uuid)
-  }
+  },
+  private val currentTimeMs: () -> Long = { System.currentTimeMillis() }
 ) {
   private val eventDispatcher = EventDispatcher(
     context = context,
@@ -85,9 +86,49 @@ class BaseObservabilityManager(
     baseUrl = baseUrl
   )
 
+  /**
+   * In-memory retry-gate state. Reset implicitly when the process restarts — a relaunch
+   * usually means enough time passed that the transient cause has cleared anyway, and
+   * persisting the gate would mean an extra disk write on every retryable response. The gate
+   * is shared between the metrics and logs paths so when the server asks us to slow down on
+   * one signal, the other one waits too.
+   */
+  private var retryGateState: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
+
+  /**
+   * Returns true and logs when an active retry gate suppresses this dispatch round. Mirrors
+   * the `dispatch()` entry-point gate check on the iOS side.
+   */
+  private fun retryGateBlocks(): Boolean {
+    val until = retryGateState.dispatchAfterMs ?: return false
+    val now = currentTimeMs()
+    if (until <= now) return false
+    Log.d(OBSERVE_TAG, "Dispatch suppressed by retry gate until $until (now $now)")
+    return true
+  }
+
+  /**
+   * Applies a per-signal dispatch outcome to the shared retry-gate state. Reads/writes the
+   * manager's `retryGateState` field so call sites stay concise. Called from both
+   * `dispatchUnsentMetrics` and `dispatchUnsentLogs` after each `eventDispatcher.dispatch*`
+   * call so the gate reflects the latest signal's response.
+   */
+  private fun applyRetryOutcome(result: DispatchResult) {
+    retryGateState = DispatchUtils.nextRetryGateState(
+      result = result,
+      currentState = retryGateState,
+      now = currentTimeMs(),
+      backoff = { DispatchUtils.computeBackoffDelay(it) }
+    )
+  }
+
   suspend fun dispatchUnsentMetrics() {
     val pendingIds = pendingMetricsManager.getAllPendingMetricIds()
     if (pendingIds.isEmpty()) {
+      return
+    }
+
+    if (retryGateBlocks()) {
       return
     }
 
@@ -117,6 +158,7 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatch(events)
+    applyRetryOutcome(result)
     val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
@@ -136,6 +178,10 @@ class BaseObservabilityManager(
   suspend fun dispatchUnsentLogs() {
     val pendingIds = pendingLogsManager.getAllPendingLogIds()
     if (pendingIds.isEmpty()) {
+      return
+    }
+
+    if (retryGateBlocks()) {
       return
     }
 
@@ -167,6 +213,7 @@ class BaseObservabilityManager(
     }
 
     val result = eventDispatcher.dispatchLogs(events)
+    applyRetryOutcome(result)
     val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
     if (DispatchUtils.shouldRemovePending(result)) {
       pendingLogsManager.removePendingLogs(dispatchedLogIds)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -8,6 +8,8 @@ import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.interfaces.constants.ConstantsInterface
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class ObservabilityManager(
   // TODO(@lukmccall): Consider saving context as weak reference to avoid potential memory leaks
@@ -104,6 +106,20 @@ class BaseObservabilityManager(
   private var logsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
 
   /**
+   * Per-signal mutexes that serialize same-signal dispatch calls. Two `dispatchEvents`
+   * invocations from JS can otherwise land on the same `BaseObservabilityManager` instance
+   * concurrently and race on the gate's read-modify-write (and double-POST the same pending
+   * rows). The metrics and logs paths take separate mutexes so they can still run in
+   * parallel — only same-signal calls serialize.
+   *
+   * Worst case without these would be benign (a dropped gate update or a duplicate dispatch),
+   * since the pending-ID stores are already DB-backed and telemetry is best-effort — but the
+   * gate is in-memory state with no other synchronization, so close the race explicitly.
+   */
+  private val metricsDispatchMutex = Mutex()
+  private val logsDispatchMutex = Mutex()
+
+  /**
    * Returns true and logs when an active retry gate suppresses this dispatch round. Called
    * inside each per-signal dispatch method rather than at a shared entry point, so a backoff
    * on one endpoint doesn't suppress traffic on the other.
@@ -132,7 +148,7 @@ class BaseObservabilityManager(
     backoff = { DispatchUtils.computeBackoffDelay(it) }
   )
 
-  suspend fun dispatchUnsentMetrics() {
+  suspend fun dispatchUnsentMetrics(): Unit = metricsDispatchMutex.withLock {
     val pendingIds = pendingMetricsManager.getAllPendingMetricIds()
     if (pendingIds.isEmpty()) {
       return
@@ -194,7 +210,7 @@ class BaseObservabilityManager(
    * Dispatches log events to `/v1/logs`. Independent from the metrics path —
    * a logs failure doesn't affect the metrics pending table and vice versa.
    */
-  suspend fun dispatchUnsentLogs() {
+  suspend fun dispatchUnsentLogs(): Unit = logsDispatchMutex.withLock {
     val pendingIds = pendingLogsManager.getAllPendingLogIds()
     if (pendingIds.isEmpty()) {
       return

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -160,6 +160,34 @@ data class OTLogsRequestBody(
   }
 }
 
+// MARK: -- Response shapes
+
+/**
+ * `partial_success` body emitted by the collector when records were accepted but some were
+ * rejected. Mirrors the wire shape the server actually sends (camelCase keys; the metrics
+ * endpoint populates `rejectedDataPoints`, the logs endpoint populates `rejectedLogRecords`).
+ * The server only emits this block when at least one record was rejected — a fully successful
+ * dispatch returns no body.
+ *
+ * The OTLP spec also allows a warning-only variant where `rejectedCount == 0` and
+ * `errorMessage` carries an advisory note (e.g. deprecation warnings). The classifier handles
+ * that case as a success since the records did land.
+ */
+@Serializable
+data class OTPartialSuccess(
+  val rejectedDataPoints: Int? = null,
+  val rejectedLogRecords: Int? = null,
+  val errorMessage: String? = null
+) {
+  val rejectedCount: Int
+    get() = (rejectedDataPoints ?: 0) + (rejectedLogRecords ?: 0)
+}
+
+@Serializable
+data class OTServiceResponse(
+  val partialSuccess: OTPartialSuccess? = null
+)
+
 /**
  * OpenTelemetry Semantic Conventions schema URL referenced by the resource on
  * every dispatched payload. Bumping this constant signals that our attribute

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.Session
+import expo.modules.appmetrics.storage.LogRecord
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.storage.SessionWithLogs
 import expo.modules.appmetrics.storage.SessionWithMetrics
 import expo.modules.appmetrics.utils.TimeUtils
 import io.mockk.*
@@ -1068,23 +1070,33 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
-  fun `dispatchUnsentLogs is suppressed when retry gate is active (shared with metrics)`() =
+  fun `metrics Retryable does not gate logs (per-signal gates are independent)`() =
     runTest {
-      // The gate is shared between metrics and logs: a Retryable response to a metrics
-      // dispatch must defer the next logs dispatch too. Otherwise we'd hammer the same
-      // server endpoint with the logs side while it's asking us to slow down.
+      // The metrics and logs endpoints fail independently in practice — one schema
+      // disagreement on the metrics side shouldn't suppress a healthy logs stream. After a
+      // metrics dispatch sets its own gate, a logs dispatch must still proceed (and reach
+      // the dispatcher).
       val metric = createMetric("metric1", metricId = "id1")
       val metricSession = createSessionWithMetrics(
         sessionId = "session-1",
         environment = "production",
         metrics = listOf(metric)
       )
+      val logRecord = createLog("log1", logId = "log-1")
+      val logSession = createSessionWithLogs(
+        sessionId = "session-2",
+        environment = "production",
+        logs = listOf(logRecord)
+      )
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns
         DispatchResult.Retryable(retryAfterMs = 60_000L)
+
       coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
 
       val fixedNow = 1_700_000_000_000L
       val manager = createManager(currentTimeMs = { fixedNow })
@@ -1092,7 +1104,43 @@ class BaseObservabilityManagerTest {
       manager.dispatchUnsentMetrics()
       manager.dispatchUnsentLogs()
 
-      coVerify(exactly = 0) { mockEventDispatcher.dispatchLogs(any()) }
+      // Logs MUST reach the dispatcher; the metrics gate doesn't suppress it.
+      coVerify(exactly = 1) { mockEventDispatcher.dispatchLogs(any()) }
+    }
+
+  @Test
+  fun `logs Retryable does not gate metrics (per-signal gates are independent)`() =
+    runTest {
+      // Symmetric test: a logs failure doesn't suppress metrics.
+      val metric = createMetric("metric1", metricId = "id1")
+      val metricSession = createSessionWithMetrics(
+        sessionId = "session-1",
+        environment = "production",
+        metrics = listOf(metric)
+      )
+      val logRecord = createLog("log1", logId = "log-1")
+      val logSession = createSessionWithLogs(
+        sessionId = "session-2",
+        environment = "production",
+        logs = listOf(logRecord)
+      )
+
+      coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns
+        DispatchResult.Retryable(retryAfterMs = 60_000L)
+
+      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
+
+      val fixedNow = 1_700_000_000_000L
+      val manager = createManager(currentTimeMs = { fixedNow })
+
+      manager.dispatchUnsentLogs()
+      manager.dispatchUnsentMetrics()
+
+      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
     }
 
   @Test
@@ -1198,6 +1246,53 @@ class BaseObservabilityManagerTest {
       value = value,
       routeName = null,
       params = null
+    )
+
+  private fun createSessionWithLogs(
+    sessionId: String,
+    environment: String?,
+    logs: List<LogRecord>,
+    appName: String = "TestApp",
+    appVersion: String = "1.0.0"
+  ): SessionWithLogs {
+    val session = Session(
+      id = sessionId,
+      startTimestamp = "2025-01-01T00:00:00.000Z",
+      isActive = true,
+      environment = environment,
+      appName = appName,
+      appIdentifier = "com.test.app",
+      appVersion = appVersion,
+      appBuildNumber = "1",
+      appUpdateId = null,
+      deviceOs = "Android",
+      deviceOsVersion = "14",
+      deviceModel = "Test Device",
+      deviceName = "test",
+      expoSdkVersion = "52.0.0",
+      reactNativeVersion = "0.76.0",
+      clientVersion = null,
+      languageTag = "en-US"
+    )
+    return SessionWithLogs(
+      session = session,
+      logs = logs.map { it.copy(sessionId = sessionId) }
+    )
+  }
+
+  private fun createLog(
+    name: String,
+    logId: String = "log-${System.nanoTime()}",
+    body: String = "test log body",
+    severity: String = "info"
+  ): LogRecord =
+    LogRecord(
+      logId = logId,
+      sessionId = "",
+      timestamp = "2025-01-01T00:00:00.000Z",
+      name = name,
+      body = body,
+      severity = severity
     )
 
   // endregion

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -1166,7 +1166,7 @@ class BaseObservabilityManagerTest {
       val manager = createManager(currentTimeMs = { nowMs })
 
       manager.dispatchUnsentMetrics()
-      nowMs += 120_000L  // jump past the 60-second gate
+      nowMs += 120_000L // jump past the 60-second gate
       manager.dispatchUnsentMetrics()
 
       coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -726,6 +726,37 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
+  fun `dispatchUnsentMetrics removes metric IDs from pending on NonRetryable result`() =
+    runTest {
+      // OTLP non-retryable responses (e.g. 400, 403, 404) drop the batch: the pending IDs
+      // are removed so the same rows don't keep getting refused on every dispatch round.
+      val metric1 = createMetric("metric1", metricId = "id1")
+      val metric2 = createMetric("metric2", metricId = "id2")
+      val session = createSessionWithMetrics(
+        sessionId = "session-1",
+        environment = "production",
+        metrics = listOf(metric1, metric2)
+      )
+
+      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.NonRetryable("HTTP 400")
+
+      val removedIds = mutableListOf<String>()
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedIds.addAll(firstArg<List<String>>())
+      }
+
+      val manager = createManager()
+
+      manager.dispatchUnsentMetrics()
+
+      assertEquals(2, removedIds.size)
+      assertTrue(removedIds.contains("id1"))
+      assertTrue(removedIds.contains("id2"))
+    }
+
+  @Test
   fun `dispatchUnsentMetrics does not remove metric IDs from pending on Retryable result`() =
     runTest {
       // A retryable response (e.g. 503, transport error) should leave the pending IDs alone

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -1035,11 +1035,102 @@ class BaseObservabilityManagerTest {
 
   // endregion
 
+  // region Retry-gate tests
+
+  @Test
+  fun `dispatchUnsentMetrics is suppressed when retry gate is active`() =
+    runTest {
+      // First dispatch returns Retryable with Retry-After=60s; that sets the gate. Second
+      // dispatch (same simulated clock) should short-circuit before calling the dispatcher
+      // again. Verifies the C2 acceptance criterion: a Retryable response must defer the
+      // next round, not just leave the rows pending.
+      val metric = createMetric("metric1", metricId = "id1")
+      val session = createSessionWithMetrics(
+        sessionId = "session-1",
+        environment = "production",
+        metrics = listOf(metric)
+      )
+
+      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
+      coEvery { mockEventDispatcher.dispatch(any()) } returns
+        DispatchResult.Retryable(retryAfterMs = 60_000L)
+
+      val fixedNow = 1_700_000_000_000L
+      val manager = createManager(currentTimeMs = { fixedNow })
+
+      manager.dispatchUnsentMetrics()
+      manager.dispatchUnsentMetrics()
+
+      // The second call must NOT reach the dispatcher — only one call total.
+      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs is suppressed when retry gate is active (shared with metrics)`() =
+    runTest {
+      // The gate is shared between metrics and logs: a Retryable response to a metrics
+      // dispatch must defer the next logs dispatch too. Otherwise we'd hammer the same
+      // server endpoint with the logs side while it's asking us to slow down.
+      val metric = createMetric("metric1", metricId = "id1")
+      val metricSession = createSessionWithMetrics(
+        sessionId = "session-1",
+        environment = "production",
+        metrics = listOf(metric)
+      )
+
+      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
+      coEvery { mockEventDispatcher.dispatch(any()) } returns
+        DispatchResult.Retryable(retryAfterMs = 60_000L)
+      coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
+
+      val fixedNow = 1_700_000_000_000L
+      val manager = createManager(currentTimeMs = { fixedNow })
+
+      manager.dispatchUnsentMetrics()
+      manager.dispatchUnsentLogs()
+
+      coVerify(exactly = 0) { mockEventDispatcher.dispatchLogs(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics resumes after the retry gate expires`() =
+    runTest {
+      // First dispatch sets a gate at now+60s. We then advance the simulated clock past the
+      // gate; the second dispatch should proceed.
+      val metric = createMetric("metric1", metricId = "id1")
+      val session = createSessionWithMetrics(
+        sessionId = "session-1",
+        environment = "production",
+        metrics = listOf(metric)
+      )
+
+      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.Retryable(retryAfterMs = 60_000L),
+        DispatchResult.Success
+      )
+
+      var nowMs = 1_700_000_000_000L
+      val manager = createManager(currentTimeMs = { nowMs })
+
+      manager.dispatchUnsentMetrics()
+      nowMs += 120_000L  // jump past the 60-second gate
+      manager.dispatchUnsentMetrics()
+
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  // endregion
+
   // region Helper methods
 
   private fun createManager(
     isDebugBuild: Boolean = false,
-    deterministicUniformValue: Double = 0.0
+    deterministicUniformValue: Double = 0.0,
+    currentTimeMs: () -> Long = { System.currentTimeMillis() }
   ): BaseObservabilityManager {
     val manager = BaseObservabilityManager(
       context = mockContext,
@@ -1049,7 +1140,8 @@ class BaseObservabilityManagerTest {
       projectId = testProjectId,
       baseUrl = testBaseUrl,
       isDebugBuild = isDebugBuild,
-      deterministicUniformValueProvider = { deterministicUniformValue }
+      deterministicUniformValueProvider = { deterministicUniformValue },
+      currentTimeMs = currentTimeMs
     )
     // Replace the internal EventDispatcher with our mock
     val field = BaseObservabilityManager::class.java.getDeclaredField("eventDispatcher")

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -6,6 +6,7 @@ import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.Session
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.storage.SessionWithMetrics
+import expo.modules.appmetrics.utils.TimeUtils
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
@@ -1130,7 +1131,7 @@ class BaseObservabilityManagerTest {
   private fun createManager(
     isDebugBuild: Boolean = false,
     deterministicUniformValue: Double = 0.0,
-    currentTimeMs: () -> Long = { System.currentTimeMillis() }
+    currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() }
   ): BaseObservabilityManager {
     val manager = BaseObservabilityManager(
       context = mockContext,

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -94,7 +94,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -132,7 +132,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -170,7 +170,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager(isDebugBuild = false)
 
@@ -205,7 +205,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -260,7 +260,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager(isDebugBuild = false)
 
@@ -332,7 +332,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
 
       val manager = createManager(isDebugBuild = true)
@@ -360,7 +360,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
 
       val manager = createManager(isDebugBuild = false)
@@ -408,7 +408,7 @@ class BaseObservabilityManagerTest {
       )
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       // `deterministicUniformValue` must not matter when sampleRate is null.
       val manager = createManager(deterministicUniformValue = 0.999)
@@ -433,7 +433,7 @@ class BaseObservabilityManagerTest {
       )
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager(deterministicUniformValue = 0.2)
 
@@ -521,7 +521,7 @@ class BaseObservabilityManagerTest {
       )
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager(deterministicUniformValue = 0.9999999)
 
@@ -545,7 +545,7 @@ class BaseObservabilityManagerTest {
       )
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager(deterministicUniformValue = 0.95)
 
@@ -644,7 +644,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "orphaned-id")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIdBatches = mutableListOf<List<String>>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -706,7 +706,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2", "id3")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session1, session2)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -726,9 +726,10 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
-  fun `dispatchUnsentMetrics does not remove metric IDs from pending when dispatch fails`() =
+  fun `dispatchUnsentMetrics does not remove metric IDs from pending on Retryable result`() =
     runTest {
-      // Arrange
+      // A retryable response (e.g. 503, transport error) should leave the pending IDs alone
+      // so the next dispatch round picks the same rows up again.
       val metric1 = createMetric("metric1", metricId = "id1")
       val metric2 = createMetric("metric2", metricId = "id2")
       val session = createSessionWithMetrics(
@@ -739,14 +740,14 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns false
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Retryable()
 
       val manager = createManager()
 
       // Act
       manager.dispatchUnsentMetrics()
 
-      // Assert - NO metric IDs should be removed from pending when dispatch fails
+      // Assert
       coVerify(exactly = 0) { mockPendingMetricsManager.removePendingMetrics(any()) }
     }
 
@@ -928,7 +929,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("m1", "m2")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val manager = createManager()
 
@@ -972,7 +973,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("metric-id-1", "metric-id-2")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session1, session2)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns true
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -743,7 +743,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.NonRetryable("HTTP 400")
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.NonRetryableFailure("HTTP 400")
 
       val removedIds = mutableListOf<String>()
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
@@ -774,7 +774,7 @@ class BaseObservabilityManagerTest {
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
-      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Retryable()
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.RetryableFailure()
 
       val manager = createManager()
 
@@ -1057,7 +1057,7 @@ class BaseObservabilityManagerTest {
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns
-        DispatchResult.Retryable(retryAfterMs = 60_000L)
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
 
       val fixedNow = 1_700_000_000_000L
       val manager = createManager(currentTimeMs = { fixedNow })
@@ -1092,7 +1092,7 @@ class BaseObservabilityManagerTest {
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns
-        DispatchResult.Retryable(retryAfterMs = 60_000L)
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
 
       coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
       coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
@@ -1128,7 +1128,7 @@ class BaseObservabilityManagerTest {
       coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
       coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
       coEvery { mockEventDispatcher.dispatchLogs(any()) } returns
-        DispatchResult.Retryable(retryAfterMs = 60_000L)
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
 
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
@@ -1158,7 +1158,7 @@ class BaseObservabilityManagerTest {
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
-        DispatchResult.Retryable(retryAfterMs = 60_000L),
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L),
         DispatchResult.Success
       )
 

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsBackoffTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsBackoffTest.kt
@@ -12,9 +12,9 @@ class DispatchUtilsBackoffTest {
   private val base: Long = 60_000L
   private val cap: Long = 900_000L
 
-  /// Attempt 1 with no jitter (random=0) is the zero floor of the exponential schedule.
-  /// Attempt 1 with full jitter (random near 1.0) approaches the unjittered base interval.
-  /// Together these prove the jitter range is `[0, base * 2^(attempt-1))`.
+  // Attempt 1 with no jitter (random=0) is the zero floor of the exponential schedule.
+  // Attempt 1 with full jitter (random near 1.0) approaches the unjittered base interval.
+  // Together these prove the jitter range is `[0, base * 2^(attempt-1))`.
   @Test
   fun `attempt one jitter zero is zero`() {
     val delay = DispatchUtils.computeBackoffDelay(
@@ -39,21 +39,21 @@ class DispatchUtilsBackoffTest {
     assertTrue("expected delay < base, got $delay", delay < base)
   }
 
-  /// The exponential schedule doubles between attempts: attempt 2 reaches 2 × base,
-  /// attempt 3 reaches 4 × base, …, all multiplied by the jitter draw.
+  // The exponential schedule doubles between attempts: attempt 2 reaches 2 × base,
+  // attempt 3 reaches 4 × base, …, all multiplied by the jitter draw.
   @Test
   fun `attempts two through four double the unjittered ceiling`() {
-    val r: () -> Double = { 0.5 }  // pin jitter to exactly half
+    val r: () -> Double = { 0.5 } // pin jitter to exactly half
     val two = DispatchUtils.computeBackoffDelay(attempt = 2, base = base, cap = cap, random = r)
     val three = DispatchUtils.computeBackoffDelay(attempt = 3, base = base, cap = cap, random = r)
     val four = DispatchUtils.computeBackoffDelay(attempt = 4, base = base, cap = cap, random = r)
-    assertEquals(base * 2 / 2, two)   // 60_000
-    assertEquals(base * 4 / 2, three)  // 120_000
-    assertEquals(base * 8 / 2, four)   // 240_000
+    assertEquals(base * 2 / 2, two) // 60_000
+    assertEquals(base * 4 / 2, three) // 120_000
+    assertEquals(base * 8 / 2, four) // 240_000
   }
 
-  /// Once `base * 2^(attempt-1)` would exceed `cap`, the unjittered ceiling clamps to `cap`.
-  /// Verified with attempt 5 (would be 16 × 60_000 = 960_000 > 900_000).
+  // Once `base * 2^(attempt-1)` would exceed `cap`, the unjittered ceiling clamps to `cap`.
+  // Verified with attempt 5 (would be 16 × 60_000 = 960_000 > 900_000).
   @Test
   fun `attempt above cap threshold clamps to cap times jitter`() {
     // attempt 5 → 60_000 × 16 = 960_000; cap = 900_000 → clamps to 900_000, jitter 0.5 → 450_000.

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsBackoffTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsBackoffTest.kt
@@ -1,0 +1,105 @@
+package expo.modules.observe
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for `DispatchUtils.computeBackoffDelay`. The random source is injected so
+ * jitter draws are deterministic; this lets us assert exact wall-clock delays.
+ */
+class DispatchUtilsBackoffTest {
+  private val base: Long = 60_000L
+  private val cap: Long = 900_000L
+
+  /// Attempt 1 with no jitter (random=0) is the zero floor of the exponential schedule.
+  /// Attempt 1 with full jitter (random near 1.0) approaches the unjittered base interval.
+  /// Together these prove the jitter range is `[0, base * 2^(attempt-1))`.
+  @Test
+  fun `attempt one jitter zero is zero`() {
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = 1,
+      base = base,
+      cap = cap,
+      random = { 0.0 }
+    )
+    assertEquals(0L, delay)
+  }
+
+  @Test
+  fun `attempt one jitter near max approaches base`() {
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = 1,
+      base = base,
+      cap = cap,
+      random = { 0.999 }
+    )
+    assertTrue("expected delay > 0.99 * base, got $delay", delay > (base * 0.99).toLong())
+    // Strict — `Random.nextDouble()` excludes 1.0, and 0.999 < 1 so delay < base.
+    assertTrue("expected delay < base, got $delay", delay < base)
+  }
+
+  /// The exponential schedule doubles between attempts: attempt 2 reaches 2 × base,
+  /// attempt 3 reaches 4 × base, …, all multiplied by the jitter draw.
+  @Test
+  fun `attempts two through four double the unjittered ceiling`() {
+    val r: () -> Double = { 0.5 }  // pin jitter to exactly half
+    val two = DispatchUtils.computeBackoffDelay(attempt = 2, base = base, cap = cap, random = r)
+    val three = DispatchUtils.computeBackoffDelay(attempt = 3, base = base, cap = cap, random = r)
+    val four = DispatchUtils.computeBackoffDelay(attempt = 4, base = base, cap = cap, random = r)
+    assertEquals(base * 2 / 2, two)   // 60_000
+    assertEquals(base * 4 / 2, three)  // 120_000
+    assertEquals(base * 8 / 2, four)   // 240_000
+  }
+
+  /// Once `base * 2^(attempt-1)` would exceed `cap`, the unjittered ceiling clamps to `cap`.
+  /// Verified with attempt 5 (would be 16 × 60_000 = 960_000 > 900_000).
+  @Test
+  fun `attempt above cap threshold clamps to cap times jitter`() {
+    // attempt 5 → 60_000 × 16 = 960_000; cap = 900_000 → clamps to 900_000, jitter 0.5 → 450_000.
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = 5,
+      base = base,
+      cap = cap,
+      random = { 0.5 }
+    )
+    assertEquals(cap / 2, delay)
+  }
+
+  @Test
+  fun `very large attempt count still respects cap`() {
+    // 2^29 × 60_000 would overflow Long; the cap must clamp it before the jitter draw.
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = 30,
+      base = base,
+      cap = cap,
+      random = { 1.0 }
+    )
+    assertTrue("expected delay <= cap, got $delay", delay <= cap)
+  }
+
+  @Test
+  fun `attempt zero returns zero defensively`() {
+    // 1-based attempt counter; attempt 0 would be a logic error elsewhere. Don't produce a
+    // negative exponent — just return 0 so the caller's gate is set to "now" and the next
+    // round can dispatch immediately.
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = 0,
+      base = base,
+      cap = cap,
+      random = { 1.0 }
+    )
+    assertEquals(0L, delay)
+  }
+
+  @Test
+  fun `negative attempt returns zero defensively`() {
+    val delay = DispatchUtils.computeBackoffDelay(
+      attempt = -5,
+      base = base,
+      cap = cap,
+      random = { 1.0 }
+    )
+    assertEquals(0L, delay)
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
@@ -1,0 +1,167 @@
+package expo.modules.observe
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Unit tests for `DispatchUtils.nextRetryGateState`. The transition function is pure — `now`
+ * is injected so the expected `dispatchAfterMs` is exact rather than approximate, and the
+ * backoff function is stubbed so we can pick the expected delay by counting from the
+ * pre-transition counter.
+ */
+class DispatchUtilsRetryGateTest {
+  private val now: Long = 1_700_000_000_000L
+
+  /// Backoff stub that returns `attempt * 10` so each test can pick the expected delay by
+  /// counting from `consecutiveRetryableFailures + 1`. Avoids the random source in
+  /// `computeBackoffDelay` and lets us assert exact deadlines.
+  private val stubbedBackoff: (Int) -> Long = { (it * 10).toLong() }
+
+  /// `Success` is the all-clear: counter resets to 0, gate is left alone so any active gate
+  /// (which shouldn't exist if we got this far, but defensively) keeps its semantics.
+  @Test
+  fun `Success resets the counter and leaves the gate alone`() {
+    val state = DispatchUtils.RetryGateState(
+      dispatchAfterMs = now + 60_000L,
+      consecutiveRetryableFailures = 3
+    )
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Success,
+      currentState = state,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(0, next.consecutiveRetryableFailures)
+    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)  // untouched
+  }
+
+  /// `NonRetryable` is treated the same as success for gate purposes: a permanent drop
+  /// doesn't suggest the server is unhealthy, so the counter resets and we don't introduce a
+  /// new pause for subsequent batches.
+  @Test
+  fun `NonRetryable resets the counter and leaves the gate alone`() {
+    val state = DispatchUtils.RetryGateState(
+      dispatchAfterMs = now + 60_000L,
+      consecutiveRetryableFailures = 2
+    )
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.NonRetryable("HTTP 400"),
+      currentState = state,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(0, next.consecutiveRetryableFailures)
+    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
+  }
+
+  /// First retryable failure (from `.initial`): counter goes to 1, gate is `now + backoff(1)`.
+  /// `retryAfterMs` is `null`, so we fall through to `computeBackoffDelay` (the stubbed value
+  /// of 10 here).
+  @Test
+  fun `first retryable with no Retry-After uses computed backoff`() {
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(),
+      currentState = DispatchUtils.RetryGateState.initial,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(1, next.consecutiveRetryableFailures)
+    assertEquals(now + 10L, next.dispatchAfterMs)
+  }
+
+  /// Subsequent retryable failures: counter increments before the backoff lookup so the
+  /// helper passes `nextCount` (not `currentCount`) into the backoff function. Verifies that
+  /// 3rd failure → backoff(3) (= 30 with the stub), not backoff(2).
+  @Test
+  fun `nth retryable passes nextCount into backoff function`() {
+    val state = DispatchUtils.RetryGateState(
+      dispatchAfterMs = null,
+      consecutiveRetryableFailures = 2
+    )
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(),
+      currentState = state,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(3, next.consecutiveRetryableFailures)
+    assertEquals(now + 30L, next.dispatchAfterMs)
+  }
+
+  /// Server-supplied `retryAfterMs` wins over the computed backoff. The backoff stub here
+  /// returns small values, but the explicit 90_000 ms value should be honored.
+  @Test
+  fun `retryable with server Retry-After uses the server delay`() {
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(retryAfterMs = 90_000L),
+      currentState = DispatchUtils.RetryGateState.initial,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(1, next.consecutiveRetryableFailures)
+    assertEquals(now + 90_000L, next.dispatchAfterMs)
+  }
+
+  /// `retryAfterMs: 0L` is valid and means "try again immediately." Still counts as a
+  /// failure for the counter (so a misbehaving server can't suppress the exponential backoff
+  /// by always responding 429 with `Retry-After: 0`) but the gate deadline equals `now`, so
+  /// the next dispatch round runs without waiting.
+  @Test
+  fun `retryable with zero Retry-After still increments counter`() {
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(retryAfterMs = 0L),
+      currentState = DispatchUtils.RetryGateState.initial,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(1, next.consecutiveRetryableFailures)
+    assertEquals(now, next.dispatchAfterMs)
+  }
+
+  /// Backoff function is never consulted when the server sends `Retry-After`. Verifies the
+  /// server-delay branch doesn't accidentally also call into `backoff`, which would defeat
+  /// the purpose of letting the server steer.
+  @Test
+  fun `retryable with server Retry-After does not invoke the backoff function`() {
+    var backoffCalled = false
+    DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(retryAfterMs = 5_000L),
+      currentState = DispatchUtils.RetryGateState.initial,
+      now = now,
+      backoff = {
+        backoffCalled = true
+        999L
+      }
+    )
+    assertFalse(backoffCalled)
+  }
+
+  /// Sequence test: 2 retryable failures then a success returns the counter to zero. The
+  /// gate from the second failure is left in place (it will naturally expire by the time the
+  /// next dispatch round happens).
+  @Test
+  fun `retryable then retryable then success drives counter back to zero`() {
+    val after1 = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(),
+      currentState = DispatchUtils.RetryGateState.initial,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    val after2 = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Retryable(),
+      currentState = after1,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(2, after2.consecutiveRetryableFailures)
+
+    val after3 = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.Success,
+      currentState = after2,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(0, after3.consecutiveRetryableFailures)
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
@@ -36,9 +36,28 @@ class DispatchUtilsRetryGateTest {
     assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)  // untouched
   }
 
-  /// `NonRetryable` is treated the same as success for gate purposes: a permanent drop
-  /// doesn't suggest the server is unhealthy, so the counter resets and we don't introduce a
-  /// new pause for subsequent batches.
+  /// `PartialSuccess` is treated the same as success for gate purposes: the bytes landed on
+  /// the server, so the gate stays where it is and the counter resets.
+  @Test
+  fun `PartialSuccess resets the counter and leaves the gate alone`() {
+    val state = DispatchUtils.RetryGateState(
+      dispatchAfterMs = now + 60_000L,
+      consecutiveRetryableFailures = 4
+    )
+    val partial = OTPartialSuccess(rejectedDataPoints = 2)
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.PartialSuccess(partial),
+      currentState = state,
+      now = now,
+      backoff = stubbedBackoff
+    )
+    assertEquals(0, next.consecutiveRetryableFailures)
+    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
+  }
+
+  /// `NonRetryableFailure` is treated the same as success for gate purposes: a permanent
+  /// drop doesn't suggest the server is unhealthy, so the counter resets and we don't
+  /// introduce a new pause for subsequent batches.
   @Test
   fun `NonRetryable resets the counter and leaves the gate alone`() {
     val state = DispatchUtils.RetryGateState(
@@ -46,7 +65,7 @@ class DispatchUtilsRetryGateTest {
       consecutiveRetryableFailures = 2
     )
     val next = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.NonRetryable("HTTP 400"),
+      result = DispatchResult.NonRetryableFailure("HTTP 400"),
       currentState = state,
       now = now,
       backoff = stubbedBackoff
@@ -61,7 +80,7 @@ class DispatchUtilsRetryGateTest {
   @Test
   fun `first retryable with no Retry-After uses computed backoff`() {
     val next = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(),
+      result = DispatchResult.RetryableFailure(),
       currentState = DispatchUtils.RetryGateState.initial,
       now = now,
       backoff = stubbedBackoff
@@ -80,7 +99,7 @@ class DispatchUtilsRetryGateTest {
       consecutiveRetryableFailures = 2
     )
     val next = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(),
+      result = DispatchResult.RetryableFailure(),
       currentState = state,
       now = now,
       backoff = stubbedBackoff
@@ -94,7 +113,7 @@ class DispatchUtilsRetryGateTest {
   @Test
   fun `retryable with server Retry-After uses the server delay`() {
     val next = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(retryAfterMs = 90_000L),
+      result = DispatchResult.RetryableFailure(retryAfterMs = 90_000L),
       currentState = DispatchUtils.RetryGateState.initial,
       now = now,
       backoff = stubbedBackoff
@@ -110,7 +129,7 @@ class DispatchUtilsRetryGateTest {
   @Test
   fun `retryable with zero Retry-After still increments counter`() {
     val next = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(retryAfterMs = 0L),
+      result = DispatchResult.RetryableFailure(retryAfterMs = 0L),
       currentState = DispatchUtils.RetryGateState.initial,
       now = now,
       backoff = stubbedBackoff
@@ -126,7 +145,7 @@ class DispatchUtilsRetryGateTest {
   fun `retryable with server Retry-After does not invoke the backoff function`() {
     var backoffCalled = false
     DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(retryAfterMs = 5_000L),
+      result = DispatchResult.RetryableFailure(retryAfterMs = 5_000L),
       currentState = DispatchUtils.RetryGateState.initial,
       now = now,
       backoff = {
@@ -143,13 +162,13 @@ class DispatchUtilsRetryGateTest {
   @Test
   fun `retryable then retryable then success drives counter back to zero`() {
     val after1 = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(),
+      result = DispatchResult.RetryableFailure(),
       currentState = DispatchUtils.RetryGateState.initial,
       now = now,
       backoff = stubbedBackoff
     )
     val after2 = DispatchUtils.nextRetryGateState(
-      result = DispatchResult.Retryable(),
+      result = DispatchResult.RetryableFailure(),
       currentState = after1,
       now = now,
       backoff = stubbedBackoff

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
@@ -13,13 +13,13 @@ import org.junit.Test
 class DispatchUtilsRetryGateTest {
   private val now: Long = 1_700_000_000_000L
 
-  /// Backoff stub that returns `attempt * 10` so each test can pick the expected delay by
-  /// counting from `consecutiveRetryableFailures + 1`. Avoids the random source in
-  /// `computeBackoffDelay` and lets us assert exact deadlines.
+  // Backoff stub that returns `attempt * 10` so each test can pick the expected delay by
+  // counting from `consecutiveRetryableFailures + 1`. Avoids the random source in
+  // `computeBackoffDelay` and lets us assert exact deadlines.
   private val stubbedBackoff: (Int) -> Long = { (it * 10).toLong() }
 
-  /// `Success` is the all-clear: counter resets to 0, gate is left alone so any active gate
-  /// (which shouldn't exist if we got this far, but defensively) keeps its semantics.
+  // `Success` is the all-clear: counter resets to 0, gate is left alone so any active gate
+  // (which shouldn't exist if we got this far, but defensively) keeps its semantics.
   @Test
   fun `Success resets the counter and leaves the gate alone`() {
     val state = DispatchUtils.RetryGateState(
@@ -33,11 +33,11 @@ class DispatchUtilsRetryGateTest {
       backoff = stubbedBackoff
     )
     assertEquals(0, next.consecutiveRetryableFailures)
-    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)  // untouched
+    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs) // untouched
   }
 
-  /// `PartialSuccess` is treated the same as success for gate purposes: the bytes landed on
-  /// the server, so the gate stays where it is and the counter resets.
+  // `PartialSuccess` is treated the same as success for gate purposes: the bytes landed on
+  // the server, so the gate stays where it is and the counter resets.
   @Test
   fun `PartialSuccess resets the counter and leaves the gate alone`() {
     val state = DispatchUtils.RetryGateState(
@@ -55,9 +55,9 @@ class DispatchUtilsRetryGateTest {
     assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
   }
 
-  /// `NonRetryableFailure` is treated the same as success for gate purposes: a permanent
-  /// drop doesn't suggest the server is unhealthy, so the counter resets and we don't
-  /// introduce a new pause for subsequent batches.
+  // `NonRetryableFailure` is treated the same as success for gate purposes: a permanent
+  // drop doesn't suggest the server is unhealthy, so the counter resets and we don't
+  // introduce a new pause for subsequent batches.
   @Test
   fun `NonRetryable resets the counter and leaves the gate alone`() {
     val state = DispatchUtils.RetryGateState(
@@ -74,9 +74,9 @@ class DispatchUtilsRetryGateTest {
     assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
   }
 
-  /// First retryable failure (from `.initial`): counter goes to 1, gate is `now + backoff(1)`.
-  /// `retryAfterMs` is `null`, so we fall through to `computeBackoffDelay` (the stubbed value
-  /// of 10 here).
+  // First retryable failure (from `.initial`): counter goes to 1, gate is `now + backoff(1)`.
+  // `retryAfterMs` is `null`, so we fall through to `computeBackoffDelay` (the stubbed value
+  // of 10 here).
   @Test
   fun `first retryable with no Retry-After uses computed backoff`() {
     val next = DispatchUtils.nextRetryGateState(
@@ -89,9 +89,9 @@ class DispatchUtilsRetryGateTest {
     assertEquals(now + 10L, next.dispatchAfterMs)
   }
 
-  /// Subsequent retryable failures: counter increments before the backoff lookup so the
-  /// helper passes `nextCount` (not `currentCount`) into the backoff function. Verifies that
-  /// 3rd failure → backoff(3) (= 30 with the stub), not backoff(2).
+  // Subsequent retryable failures: counter increments before the backoff lookup so the
+  // helper passes `nextCount` (not `currentCount`) into the backoff function. Verifies that
+  // 3rd failure → backoff(3) (= 30 with the stub), not backoff(2).
   @Test
   fun `nth retryable passes nextCount into backoff function`() {
     val state = DispatchUtils.RetryGateState(
@@ -108,8 +108,8 @@ class DispatchUtilsRetryGateTest {
     assertEquals(now + 30L, next.dispatchAfterMs)
   }
 
-  /// Server-supplied `retryAfterMs` wins over the computed backoff. The backoff stub here
-  /// returns small values, but the explicit 90_000 ms value should be honored.
+  // Server-supplied `retryAfterMs` wins over the computed backoff. The backoff stub here
+  // returns small values, but the explicit 90_000 ms value should be honored.
   @Test
   fun `retryable with server Retry-After uses the server delay`() {
     val next = DispatchUtils.nextRetryGateState(
@@ -122,10 +122,10 @@ class DispatchUtilsRetryGateTest {
     assertEquals(now + 90_000L, next.dispatchAfterMs)
   }
 
-  /// `retryAfterMs: 0L` is valid and means "try again immediately." Still counts as a
-  /// failure for the counter (so a misbehaving server can't suppress the exponential backoff
-  /// by always responding 429 with `Retry-After: 0`) but the gate deadline equals `now`, so
-  /// the next dispatch round runs without waiting.
+  // `retryAfterMs: 0L` is valid and means "try again immediately." Still counts as a
+  // failure for the counter (so a misbehaving server can't suppress the exponential backoff
+  // by always responding 429 with `Retry-After: 0`) but the gate deadline equals `now`, so
+  // the next dispatch round runs without waiting.
   @Test
   fun `retryable with zero Retry-After still increments counter`() {
     val next = DispatchUtils.nextRetryGateState(
@@ -138,9 +138,9 @@ class DispatchUtilsRetryGateTest {
     assertEquals(now, next.dispatchAfterMs)
   }
 
-  /// Backoff function is never consulted when the server sends `Retry-After`. Verifies the
-  /// server-delay branch doesn't accidentally also call into `backoff`, which would defeat
-  /// the purpose of letting the server steer.
+  // Backoff function is never consulted when the server sends `Retry-After`. Verifies the
+  // server-delay branch doesn't accidentally also call into `backoff`, which would defeat
+  // the purpose of letting the server steer.
   @Test
   fun `retryable with server Retry-After does not invoke the backoff function`() {
     var backoffCalled = false
@@ -156,9 +156,9 @@ class DispatchUtilsRetryGateTest {
     assertFalse(backoffCalled)
   }
 
-  /// Sequence test: 2 retryable failures then a success returns the counter to zero. The
-  /// gate from the second failure is left in place (it will naturally expire by the time the
-  /// next dispatch round happens).
+  // Sequence test: 2 retryable failures then a success returns the counter to zero. The
+  // gate from the second failure is left in place (it will naturally expire by the time the
+  // next dispatch round happens).
   @Test
   fun `retryable then retryable then success drives counter back to zero`() {
     val after1 = DispatchUtils.nextRetryGateState(

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -1,5 +1,11 @@
 package expo.modules.observe
 
+import expo.modules.appmetrics.utils.TimeUtils
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -373,39 +379,65 @@ class DispatchUtilsParseRetryAfterTest {
 
   @Test
   fun `HTTP-date inside bounds parses to a delta near the actual offset`() {
-    // Build a header 5 minutes (300 s) in the future — comfortably inside [60, 900].
-    val now = 1_700_000_000_000L
-    val futureMs = now + 300_000L
-    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
-    formatter.timeZone = TimeZone.getTimeZone("GMT")
-    val header = formatter.format(Date(futureMs))
+    // The header is parsed into a Date and handed to TimeUtils.millisUntil along with "now";
+    // we mock millisUntil to return a known delta (5 min, comfortably inside [60, 900]) and
+    // also verify the parser routed the parsed Date through the helper.
+    mockkObject(TimeUtils)
+    try {
+      val capturedTo = slot<Date>()
+      every { TimeUtils.millisUntil(capture(capturedTo), any()) } returns 300_000L
 
-    val parsed = DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now)
-    assertNotNull(parsed)
-    assertTrue("expected ~300_000 ms, got $parsed", parsed!! in 295_000L..305_000L)
+      val headerInstant = 1_700_000_300_000L
+      val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+      formatter.timeZone = TimeZone.getTimeZone("GMT")
+      val header = formatter.format(Date(headerInstant))
+
+      val parsed = DispatchUtils.parseRetryAfter(header, base = base, cap = cap)
+      assertEquals(300_000L, parsed)
+
+      verify { TimeUtils.millisUntil(any(), any()) }
+      // SimpleDateFormat with second precision drops sub-second portions, but the captured
+      // Date should match the header instant within ±1 s.
+      assertTrue(
+        "expected captured Date near $headerInstant, got ${capturedTo.captured.time}",
+        capturedTo.captured.time in (headerInstant - 1000L)..(headerInstant + 1000L)
+      )
+    } finally {
+      unmockkObject(TimeUtils)
+    }
   }
 
   @Test
   fun `HTTP-date in the past clamps up to base`() {
-    val now = 1_700_000_000_000L
-    val pastMs = now - 3_600_000L
-    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
-    formatter.timeZone = TimeZone.getTimeZone("GMT")
-    val header = formatter.format(Date(pastMs))
+    mockkObject(TimeUtils)
+    try {
+      every { TimeUtils.millisUntil(any(), any()) } returns -3_600_000L
 
-    assertEquals(base, DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now))
+      val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+      formatter.timeZone = TimeZone.getTimeZone("GMT")
+      val header = formatter.format(Date(1_699_996_400_000L))
+
+      assertEquals(base, DispatchUtils.parseRetryAfter(header, base = base, cap = cap))
+    } finally {
+      unmockkObject(TimeUtils)
+    }
   }
 
   @Test
   fun `HTTP-date far in the future clamps down to cap`() {
-    // Two hours from now is well past the 15-minute cap.
-    val now = 1_700_000_000_000L
-    val farFutureMs = now + 7_200_000L
-    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
-    formatter.timeZone = TimeZone.getTimeZone("GMT")
-    val header = formatter.format(Date(farFutureMs))
+    // Two hours ahead is well past the 15-minute cap.
+    mockkObject(TimeUtils)
+    try {
+      every { TimeUtils.millisUntil(any(), any()) } returns 7_200_000L
 
-    assertEquals(cap, DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now))
+      val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+      formatter.timeZone = TimeZone.getTimeZone("GMT")
+      val header = formatter.format(Date(1_700_007_200_000L))
+
+      assertEquals(cap, DispatchUtils.parseRetryAfter(header, base = base, cap = cap))
+    } finally {
+      unmockkObject(TimeUtils)
+    }
   }
 
   // MARK: -- Custom client bounds

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -232,6 +232,31 @@ class DispatchUtilsClassifyResponseTest {
   }
 }
 
+class DispatchUtilsShouldRemovePendingTest {
+  /// On `Success`, the queue moves past the dispatched batch so the next round reads only
+  /// newer rows. Unchanged from the pre-OTLP behavior; locked here for the table.
+  @Test
+  fun `Success removes pending IDs`() {
+    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.Success))
+  }
+
+  /// `Retryable` is the "leave them alone" case — the next dispatch round picks the same
+  /// rows up again. This is what keeps an in-flight outage from losing telemetry.
+  @Test
+  fun `Retryable keeps pending IDs`() {
+    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.Retryable()))
+    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.Retryable(retryAfterMs = 30_000L)))
+  }
+
+  /// The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) drops the
+  /// offending batch. Without this, the next round would re-send the same rows and the
+  /// server would refuse them again, wedging the queue indefinitely.
+  @Test
+  fun `NonRetryable removes pending IDs`() {
+    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.NonRetryable("HTTP 400")))
+  }
+}
+
 class DispatchUtilsParseRetryAfterTest {
   @Test
   fun `null header returns null`() {

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -107,7 +107,7 @@ class DispatchUtilsClassifyResponseTest {
     assertEquals(DispatchResult.Success, result)
   }
 
-  // MARK: -- Retryable per OTLP (408, 429, 502, 503, 504)
+  // MARK: -- Retryable per OTLP (429, 502, 503, 504)
 
   @Test
   fun `429 returns Retryable with null retryAfter when no header`() {
@@ -143,8 +143,8 @@ class DispatchUtilsClassifyResponseTest {
   }
 
   @Test
-  fun `408 502 504 are all Retryable`() {
-    for (code in intArrayOf(408, 502, 504)) {
+  fun `429 502 504 are all Retryable`() {
+    for (code in intArrayOf(429, 502, 504)) {
       val result = DispatchUtils.classifyResponse(
         statusCode = code,
         retryAfterHeader = null,

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -39,21 +39,23 @@ class DispatchUtilsClassifyResponseTest {
   }
 
   @Test
-  fun `2xx with partialSuccess rejectedDataPoints returns NonRetryable`() {
+  fun `2xx with partialSuccess rejectedDataPoints returns PartialSuccess`() {
     val body = """{"partialSuccess":{"rejectedDataPoints":3,"errorMessage":"metric_kind_mismatch"}}"""
     val result = DispatchUtils.classifyResponse(
       statusCode = 200,
       retryAfterHeader = null,
       responseBody = body
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
-    val reason = (result as DispatchResult.NonRetryable).reason
-    assertTrue(reason.contains("rejected 3"))
-    assertTrue(reason.contains("metric_kind_mismatch"))
+    assertEquals(
+      DispatchResult.PartialSuccess(
+        OTPartialSuccess(rejectedDataPoints = 3, errorMessage = "metric_kind_mismatch")
+      ),
+      result
+    )
   }
 
   @Test
-  fun `2xx with partialSuccess rejectedLogRecords returns NonRetryable`() {
+  fun `2xx with partialSuccess rejectedLogRecords returns PartialSuccess`() {
     // The same response struct serves both metrics and logs endpoints; the logs response uses
     // `rejectedLogRecords` instead of `rejectedDataPoints`.
     val body = """{"partialSuccess":{"rejectedLogRecords":1,"errorMessage":"log_too_large"}}"""
@@ -62,10 +64,12 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = null,
       responseBody = body
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
-    val reason = (result as DispatchResult.NonRetryable).reason
-    assertTrue(reason.contains("rejected 1"))
-    assertTrue(reason.contains("log_too_large"))
+    assertEquals(
+      DispatchResult.PartialSuccess(
+        OTPartialSuccess(rejectedLogRecords = 1, errorMessage = "log_too_large")
+      ),
+      result
+    )
   }
 
   @Test
@@ -112,7 +116,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = null,
       responseBody = null
     )
-    assertEquals(DispatchResult.Retryable(retryAfterMs = null), result)
+    assertEquals(DispatchResult.RetryableFailure(retryAfterMs = null), result)
   }
 
   @Test
@@ -123,7 +127,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = "120",
       responseBody = null
     )
-    assertEquals(DispatchResult.Retryable(retryAfterMs = 120_000L), result)
+    assertEquals(DispatchResult.RetryableFailure(retryAfterMs = 120_000L), result)
   }
 
   @Test
@@ -135,7 +139,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = "5",
       responseBody = null
     )
-    assertEquals(DispatchResult.Retryable(retryAfterMs = DispatchUtils.backoffBaseMs), result)
+    assertEquals(DispatchResult.RetryableFailure(retryAfterMs = DispatchUtils.backoffBaseMs), result)
   }
 
   @Test
@@ -148,7 +152,7 @@ class DispatchUtilsClassifyResponseTest {
       )
       assertTrue(
         "status $code should be Retryable, got $result",
-        result is DispatchResult.Retryable
+        result is DispatchResult.RetryableFailure
       )
     }
   }
@@ -163,8 +167,8 @@ class DispatchUtilsClassifyResponseTest {
       responseBody = "bad request",
       bodyExcerpt = { "bad request" }
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
-    val reason = (result as DispatchResult.NonRetryable).reason
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
+    val reason = (result as DispatchResult.NonRetryableFailure).reason
     assertTrue(reason.contains("400"))
     assertTrue(reason.contains("bad request"))
   }
@@ -176,7 +180,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = null,
       responseBody = null
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
   }
 
   @Test
@@ -186,7 +190,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = null,
       responseBody = null
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
   }
 
   @Test
@@ -196,7 +200,7 @@ class DispatchUtilsClassifyResponseTest {
       retryAfterHeader = null,
       responseBody = null
     )
-    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
   }
 
   @Test
@@ -211,7 +215,7 @@ class DispatchUtilsClassifyResponseTest {
       )
       assertTrue(
         "status $code should be NonRetryable, got $result",
-        result is DispatchResult.NonRetryable
+        result is DispatchResult.NonRetryableFailure
       )
     }
   }
@@ -247,8 +251,17 @@ class DispatchUtilsShouldRemovePendingTest {
   /// rows up again. This is what keeps an in-flight outage from losing telemetry.
   @Test
   fun `Retryable keeps pending IDs`() {
-    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.Retryable()))
-    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.Retryable(retryAfterMs = 30_000L)))
+    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure()))
+    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure(retryAfterMs = 30_000L)))
+  }
+
+  /// `PartialSuccess` removes pending IDs like `Success` does: the bytes landed on the
+  /// server (a subset was rejected server-side, but the batch as a whole was accepted), so
+  /// re-sending the same rows would just trip the same rejection.
+  @Test
+  fun `PartialSuccess removes pending IDs`() {
+    val partial = OTPartialSuccess(rejectedDataPoints = 1, errorMessage = "x")
+    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.PartialSuccess(partial)))
   }
 
   /// The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) drops the
@@ -256,7 +269,7 @@ class DispatchUtilsShouldRemovePendingTest {
   /// server would refuse them again, wedging the queue indefinitely.
   @Test
   fun `NonRetryable removes pending IDs`() {
-    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.NonRetryable("HTTP 400")))
+    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.NonRetryableFailure("HTTP 400")))
   }
 }
 

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -7,7 +7,6 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -246,33 +245,33 @@ class DispatchUtilsClassifyResponseTest {
 }
 
 class DispatchUtilsShouldRemovePendingTest {
-  /// On `Success`, the queue moves past the dispatched batch so the next round reads only
-  /// newer rows. Unchanged from the pre-OTLP behavior; locked here for the table.
+  // On `Success`, the queue moves past the dispatched batch so the next round reads only
+  // newer rows. Unchanged from the pre-OTLP behavior; locked here for the table.
   @Test
   fun `Success removes pending IDs`() {
     assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.Success))
   }
 
-  /// `Retryable` is the "leave them alone" case — the next dispatch round picks the same
-  /// rows up again. This is what keeps an in-flight outage from losing telemetry.
+  // `Retryable` is the "leave them alone" case — the next dispatch round picks the same
+  // rows up again. This is what keeps an in-flight outage from losing telemetry.
   @Test
   fun `Retryable keeps pending IDs`() {
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure()))
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure(retryAfterMs = 30_000L)))
   }
 
-  /// `PartialSuccess` removes pending IDs like `Success` does: the bytes landed on the
-  /// server (a subset was rejected server-side, but the batch as a whole was accepted), so
-  /// re-sending the same rows would just trip the same rejection.
+  // `PartialSuccess` removes pending IDs like `Success` does: the bytes landed on the
+  // server (a subset was rejected server-side, but the batch as a whole was accepted), so
+  // re-sending the same rows would just trip the same rejection.
   @Test
   fun `PartialSuccess removes pending IDs`() {
     val partial = OTPartialSuccess(rejectedDataPoints = 1, errorMessage = "x")
     assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.PartialSuccess(partial)))
   }
 
-  /// The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) drops the
-  /// offending batch. Without this, the next round would re-send the same rows and the
-  /// server would refuse them again, wedging the queue indefinitely.
+  // The acceptance-criterion behavior: a non-retryable response (e.g. 400, 403) drops the
+  // offending batch. Without this, the next round would re-send the same rows and the
+  // server would refuse them again, wedging the queue indefinitely.
   @Test
   fun `NonRetryable removes pending IDs`() {
     assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.NonRetryableFailure("HTTP 400")))
@@ -304,8 +303,8 @@ class DispatchUtilsParseRetryAfterTest {
     // Neither a Long/Double nor an RFC 7231 HTTP-date — caller should fall through to backoff.
     val cases = listOf(
       "tomorrow morning",
-      "Mon Jun 16",  // partial date, missing time + year + zone
-      "30 minutes",  // delta-seconds doesn't accept units
+      "Mon Jun 16", // partial date, missing time + year + zone
+      "30 minutes", // delta-seconds doesn't accept units
       "30s",
       "abc",
       "300/600",

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -116,23 +116,26 @@ class DispatchUtilsClassifyResponseTest {
   }
 
   @Test
-  fun `429 with Retry-After seconds parses to milliseconds`() {
+  fun `429 with Retry-After inside client bounds is parsed as-is`() {
+    // 120 s sits between base (60) and cap (900), so it propagates unchanged.
     val result = DispatchUtils.classifyResponse(
       statusCode = 429,
-      retryAfterHeader = "30",
+      retryAfterHeader = "120",
       responseBody = null
     )
-    assertEquals(DispatchResult.Retryable(retryAfterMs = 30_000L), result)
+    assertEquals(DispatchResult.Retryable(retryAfterMs = 120_000L), result)
   }
 
   @Test
-  fun `503 propagates Retry-After`() {
+  fun `503 Retry-After below base clamps up to base`() {
+    // 5 s is below the 60 s floor — the client wouldn't dispatch faster than that anyway, so
+    // honor the server's intent to slow down by snapping up to base.
     val result = DispatchUtils.classifyResponse(
       statusCode = 503,
       retryAfterHeader = "5",
       responseBody = null
     )
-    assertEquals(DispatchResult.Retryable(retryAfterMs = 5_000L), result)
+    assertEquals(DispatchResult.Retryable(retryAfterMs = DispatchUtils.backoffBaseMs), result)
   }
 
   @Test
@@ -258,66 +261,149 @@ class DispatchUtilsShouldRemovePendingTest {
 }
 
 class DispatchUtilsParseRetryAfterTest {
+  // Test-local bounds passed explicitly to every call so the suite is independent of the
+  // production constants. A separate test verifies the default-argument path.
+  private val base: Long = 60_000L
+  private val cap: Long = 900_000L
+
+  // MARK: -- Missing / unparseable inputs return null (caller falls through to backoff)
+
   @Test
   fun `null header returns null`() {
-    assertNull(DispatchUtils.parseRetryAfter(null))
+    assertNull(DispatchUtils.parseRetryAfter(null, base = base, cap = cap))
   }
 
   @Test
   fun `empty or whitespace header returns null`() {
-    assertNull(DispatchUtils.parseRetryAfter(""))
-    assertNull(DispatchUtils.parseRetryAfter("   "))
+    assertNull(DispatchUtils.parseRetryAfter("", base = base, cap = cap))
+    assertNull(DispatchUtils.parseRetryAfter("   ", base = base, cap = cap))
+    assertNull(DispatchUtils.parseRetryAfter("\t\n", base = base, cap = cap))
   }
 
   @Test
-  fun `integer seconds parses to milliseconds`() {
-    assertEquals(0L, DispatchUtils.parseRetryAfter("0"))
-    assertEquals(30_000L, DispatchUtils.parseRetryAfter("30"))
-    assertEquals(3_600_000L, DispatchUtils.parseRetryAfter("3600"))
+  fun `garbage header returns null`() {
+    // Neither a Long/Double nor an RFC 7231 HTTP-date — caller should fall through to backoff.
+    val cases = listOf(
+      "tomorrow morning",
+      "Mon Jun 16",  // partial date, missing time + year + zone
+      "30 minutes",  // delta-seconds doesn't accept units
+      "30s",
+      "abc",
+      "300/600",
+      ", 30",
+      "30,"
+    )
+    for (header in cases) {
+      assertNull(
+        "expected null for garbage header \"$header\"",
+        DispatchUtils.parseRetryAfter(header, base = base, cap = cap)
+      )
+    }
   }
 
   @Test
-  fun `negative seconds clamps to zero`() {
-    // Defensive: a misbehaving server shouldn't be able to schedule the next dispatch in the
-    // past (or, worse, give us a negative sleep).
-    assertEquals(0L, DispatchUtils.parseRetryAfter("-1"))
+  fun `non-finite numeric tokens return null`() {
+    // `toDoubleOrNull` accepts `Infinity` / `NaN` strings — but feeding either into the gate
+    // deadline is a bug. Reject as garbage so the caller falls through to `computeBackoffDelay`,
+    // which is bounded by construction.
+    for (header in listOf("Infinity", "-Infinity", "NaN")) {
+      assertNull(
+        "expected null for non-finite numeric \"$header\"",
+        DispatchUtils.parseRetryAfter(header, base = base, cap = cap)
+      )
+    }
+  }
+
+  // MARK: -- delta-seconds (numeric)
+
+  @Test
+  fun `delta-seconds inside base and cap returns the parsed value unchanged`() {
+    assertEquals(60_000L, DispatchUtils.parseRetryAfter("60", base = base, cap = cap))
+    assertEquals(120_000L, DispatchUtils.parseRetryAfter("120", base = base, cap = cap))
+    assertEquals(900_000L, DispatchUtils.parseRetryAfter("900", base = base, cap = cap))
   }
 
   @Test
-  fun `fractional seconds parse`() {
-    // RFC 7231 mandates integer delta-seconds; real servers sometimes emit decimals and
-    // there's no harm in honoring them. 0.5 s → 500 ms.
-    assertEquals(500L, DispatchUtils.parseRetryAfter("0.5"))
+  fun `delta-seconds below base clamps up to base`() {
+    // `Retry-After: 0` is the most common misbehavior — a server that wants us to retry
+    // immediately. Snap to base so we don't hammer the recovering endpoint.
+    assertEquals(base, DispatchUtils.parseRetryAfter("0", base = base, cap = cap))
+    assertEquals(base, DispatchUtils.parseRetryAfter("1", base = base, cap = cap))
+    assertEquals(base, DispatchUtils.parseRetryAfter("30", base = base, cap = cap))
+    assertEquals(base, DispatchUtils.parseRetryAfter("0.5", base = base, cap = cap))
   }
 
   @Test
-  fun `HTTP-date header parses to delta from injected now`() {
-    val now = 1_700_000_000_000L  // fixed wall-clock for repeatability
-    val futureMs = now + 60_000L
+  fun `delta-seconds above cap clamps down to cap`() {
+    // A pathological server response shouldn't be able to wedge us in a multi-hour snooze.
+    assertEquals(cap, DispatchUtils.parseRetryAfter("901", base = base, cap = cap))
+    assertEquals(cap, DispatchUtils.parseRetryAfter("3600", base = base, cap = cap))
+    assertEquals(cap, DispatchUtils.parseRetryAfter("86400", base = base, cap = cap))
+    assertEquals(cap, DispatchUtils.parseRetryAfter("1e9", base = base, cap = cap))
+  }
+
+  @Test
+  fun `negative delta-seconds clamps up to base`() {
+    // A negative delta would otherwise schedule the next dispatch in the past — bounce it to
+    // the floor so the gate is still a real pause.
+    assertEquals(base, DispatchUtils.parseRetryAfter("-1", base = base, cap = cap))
+    assertEquals(base, DispatchUtils.parseRetryAfter("-3600", base = base, cap = cap))
+  }
+
+  @Test
+  fun `leading and trailing whitespace is trimmed before parsing`() {
+    assertEquals(120_000L, DispatchUtils.parseRetryAfter("  120  ", base = base, cap = cap))
+    assertEquals(120_000L, DispatchUtils.parseRetryAfter("\n120\t", base = base, cap = cap))
+  }
+
+  // MARK: -- HTTP-date
+
+  @Test
+  fun `HTTP-date inside bounds parses to a delta near the actual offset`() {
+    // Build a header 5 minutes (300 s) in the future — comfortably inside [60, 900].
+    val now = 1_700_000_000_000L
+    val futureMs = now + 300_000L
     val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
     formatter.timeZone = TimeZone.getTimeZone("GMT")
     val header = formatter.format(Date(futureMs))
 
-    val parsed = DispatchUtils.parseRetryAfter(header, now = now)
+    val parsed = DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now)
     assertNotNull(parsed)
-    // SimpleDateFormat with second precision drops sub-second portions; allow ±1 s slop.
-    assertTrue("expected ~60_000 ms, got $parsed", parsed!! in 59_000L..61_000L)
+    assertTrue("expected ~300_000 ms, got $parsed", parsed!! in 295_000L..305_000L)
   }
 
   @Test
-  fun `HTTP-date in the past clamps to zero`() {
+  fun `HTTP-date in the past clamps up to base`() {
     val now = 1_700_000_000_000L
     val pastMs = now - 3_600_000L
     val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
     formatter.timeZone = TimeZone.getTimeZone("GMT")
     val header = formatter.format(Date(pastMs))
 
-    assertEquals(0L, DispatchUtils.parseRetryAfter(header, now = now))
+    assertEquals(base, DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now))
   }
 
   @Test
-  fun `garbage header returns null`() {
-    assertNull(DispatchUtils.parseRetryAfter("tomorrow morning"))
-    assertNull(DispatchUtils.parseRetryAfter("Mon Jun 16"))
+  fun `HTTP-date far in the future clamps down to cap`() {
+    // Two hours from now is well past the 15-minute cap.
+    val now = 1_700_000_000_000L
+    val farFutureMs = now + 7_200_000L
+    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+    formatter.timeZone = TimeZone.getTimeZone("GMT")
+    val header = formatter.format(Date(farFutureMs))
+
+    assertEquals(cap, DispatchUtils.parseRetryAfter(header, base = base, cap = cap, now = now))
+  }
+
+  // MARK: -- Custom client bounds
+
+  @Test
+  fun `custom base and cap override the defaults`() {
+    // The same input ("100") clamps differently depending on the bounds passed in: with the
+    // default [60 s, 900 s] it sits inside, but a stricter [120 s, 600 s] window snaps it up
+    // to 120 s.
+    assertEquals(100_000L, DispatchUtils.parseRetryAfter("100"))
+    assertEquals(120_000L, DispatchUtils.parseRetryAfter("100", base = 120_000L, cap = 600_000L))
+    assertEquals(50_000L, DispatchUtils.parseRetryAfter("100", base = 10_000L, cap = 50_000L))
   }
 }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -1,0 +1,298 @@
+package expo.modules.observe
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Unit tests for the pure classification + Retry-After parsing helpers. No network, no
+ * coroutines — these are the building blocks `EventDispatcher` calls into. Network behavior
+ * is covered separately in `EventDispatcherTest` against a MockWebServer.
+ */
+class DispatchUtilsClassifyResponseTest {
+  // MARK: -- 2xx
+
+  @Test
+  fun `2xx with no body returns Success`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertEquals(DispatchResult.Success, result)
+  }
+
+  @Test
+  fun `2xx with empty body returns Success`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = ""
+    )
+    assertEquals(DispatchResult.Success, result)
+  }
+
+  @Test
+  fun `2xx with partialSuccess rejectedDataPoints returns NonRetryable`() {
+    val body = """{"partialSuccess":{"rejectedDataPoints":3,"errorMessage":"metric_kind_mismatch"}}"""
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = body
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    val reason = (result as DispatchResult.NonRetryable).reason
+    assertTrue(reason.contains("rejected 3"))
+    assertTrue(reason.contains("metric_kind_mismatch"))
+  }
+
+  @Test
+  fun `2xx with partialSuccess rejectedLogRecords returns NonRetryable`() {
+    // The same response struct serves both metrics and logs endpoints; the logs response uses
+    // `rejectedLogRecords` instead of `rejectedDataPoints`.
+    val body = """{"partialSuccess":{"rejectedLogRecords":1,"errorMessage":"log_too_large"}}"""
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = body
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    val reason = (result as DispatchResult.NonRetryable).reason
+    assertTrue(reason.contains("rejected 1"))
+    assertTrue(reason.contains("log_too_large"))
+  }
+
+  @Test
+  fun `2xx with partialSuccess warning only (rejected zero) returns Success`() {
+    // Per OTLP spec, a `partial_success` with `rejectedCount == 0` plus a non-empty
+    // `errorMessage` is a warning — the records DID land, so don't double-drop them.
+    val body = """{"partialSuccess":{"rejectedDataPoints":0,"errorMessage":"deprecation_warning"}}"""
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = body
+    )
+    assertEquals(DispatchResult.Success, result)
+  }
+
+  @Test
+  fun `2xx with unparseable JSON body returns Success`() {
+    // A garbage body on a 2xx response is not the server saying "rejected." Treat as success
+    // — the bytes were accepted, the response is just non-conforming.
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 200,
+      retryAfterHeader = null,
+      responseBody = "not even close to JSON"
+    )
+    assertEquals(DispatchResult.Success, result)
+  }
+
+  @Test
+  fun `204 no content returns Success`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 204,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertEquals(DispatchResult.Success, result)
+  }
+
+  // MARK: -- Retryable per OTLP (408, 429, 502, 503, 504)
+
+  @Test
+  fun `429 returns Retryable with null retryAfter when no header`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 429,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertEquals(DispatchResult.Retryable(retryAfterMs = null), result)
+  }
+
+  @Test
+  fun `429 with Retry-After seconds parses to milliseconds`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 429,
+      retryAfterHeader = "30",
+      responseBody = null
+    )
+    assertEquals(DispatchResult.Retryable(retryAfterMs = 30_000L), result)
+  }
+
+  @Test
+  fun `503 propagates Retry-After`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 503,
+      retryAfterHeader = "5",
+      responseBody = null
+    )
+    assertEquals(DispatchResult.Retryable(retryAfterMs = 5_000L), result)
+  }
+
+  @Test
+  fun `408 502 504 are all Retryable`() {
+    for (code in intArrayOf(408, 502, 504)) {
+      val result = DispatchUtils.classifyResponse(
+        statusCode = code,
+        retryAfterHeader = null,
+        responseBody = null
+      )
+      assertTrue(
+        "status $code should be Retryable, got $result",
+        result is DispatchResult.Retryable
+      )
+    }
+  }
+
+  // MARK: -- Non-retryable 4xx / other 5xx
+
+  @Test
+  fun `400 returns NonRetryable with status and body excerpt`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 400,
+      retryAfterHeader = null,
+      responseBody = "bad request",
+      bodyExcerpt = { "bad request" }
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+    val reason = (result as DispatchResult.NonRetryable).reason
+    assertTrue(reason.contains("400"))
+    assertTrue(reason.contains("bad request"))
+  }
+
+  @Test
+  fun `401 returns NonRetryable`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 401,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+  }
+
+  @Test
+  fun `403 returns NonRetryable`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 403,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+  }
+
+  @Test
+  fun `404 returns NonRetryable`() {
+    val result = DispatchUtils.classifyResponse(
+      statusCode = 404,
+      retryAfterHeader = null,
+      responseBody = null
+    )
+    assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+  }
+
+  @Test
+  fun `500 is NonRetryable (not in OTLP retryable set)`() {
+    // Only 502/503/504 are retryable in the 5xx range per the OTLP spec. 500 (and exotics
+    // like 501, 505) describe a state we can't reason about without retrying ad infinitum.
+    for (code in intArrayOf(500, 501, 505)) {
+      val result = DispatchUtils.classifyResponse(
+        statusCode = code,
+        retryAfterHeader = null,
+        responseBody = null
+      )
+      assertTrue(
+        "status $code should be NonRetryable, got $result",
+        result is DispatchResult.NonRetryable
+      )
+    }
+  }
+
+  @Test
+  fun `bodyExcerpt closure is not invoked on Retryable status`() {
+    // The excerpt closure is only useful for the NonRetryable log line. Verify the closure
+    // isn't called on a 429 — we don't want to pay the cost of building a body excerpt for
+    // every transient failure.
+    var bodyClosureCalled = false
+    DispatchUtils.classifyResponse(
+      statusCode = 429,
+      retryAfterHeader = null,
+      responseBody = "ignored",
+      bodyExcerpt = {
+        bodyClosureCalled = true
+        ""
+      }
+    )
+    assertTrue("bodyExcerpt closure should not be called on 429", !bodyClosureCalled)
+  }
+}
+
+class DispatchUtilsParseRetryAfterTest {
+  @Test
+  fun `null header returns null`() {
+    assertNull(DispatchUtils.parseRetryAfter(null))
+  }
+
+  @Test
+  fun `empty or whitespace header returns null`() {
+    assertNull(DispatchUtils.parseRetryAfter(""))
+    assertNull(DispatchUtils.parseRetryAfter("   "))
+  }
+
+  @Test
+  fun `integer seconds parses to milliseconds`() {
+    assertEquals(0L, DispatchUtils.parseRetryAfter("0"))
+    assertEquals(30_000L, DispatchUtils.parseRetryAfter("30"))
+    assertEquals(3_600_000L, DispatchUtils.parseRetryAfter("3600"))
+  }
+
+  @Test
+  fun `negative seconds clamps to zero`() {
+    // Defensive: a misbehaving server shouldn't be able to schedule the next dispatch in the
+    // past (or, worse, give us a negative sleep).
+    assertEquals(0L, DispatchUtils.parseRetryAfter("-1"))
+  }
+
+  @Test
+  fun `fractional seconds parse`() {
+    // RFC 7231 mandates integer delta-seconds; real servers sometimes emit decimals and
+    // there's no harm in honoring them. 0.5 s → 500 ms.
+    assertEquals(500L, DispatchUtils.parseRetryAfter("0.5"))
+  }
+
+  @Test
+  fun `HTTP-date header parses to delta from injected now`() {
+    val now = 1_700_000_000_000L  // fixed wall-clock for repeatability
+    val futureMs = now + 60_000L
+    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+    formatter.timeZone = TimeZone.getTimeZone("GMT")
+    val header = formatter.format(Date(futureMs))
+
+    val parsed = DispatchUtils.parseRetryAfter(header, now = now)
+    assertNotNull(parsed)
+    // SimpleDateFormat with second precision drops sub-second portions; allow ±1 s slop.
+    assertTrue("expected ~60_000 ms, got $parsed", parsed!! in 59_000L..61_000L)
+  }
+
+  @Test
+  fun `HTTP-date in the past clamps to zero`() {
+    val now = 1_700_000_000_000L
+    val pastMs = now - 3_600_000L
+    val formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+    formatter.timeZone = TimeZone.getTimeZone("GMT")
+    val header = formatter.format(Date(pastMs))
+
+    assertEquals(0L, DispatchUtils.parseRetryAfter(header, now = now))
+  }
+
+  @Test
+  fun `garbage header returns null`() {
+    assertNull(DispatchUtils.parseRetryAfter("tomorrow morning"))
+    assertNull(DispatchUtils.parseRetryAfter("Mon Jun 16"))
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -163,6 +163,8 @@ class EventDispatcherTest {
   @Test
   fun `dispatch returns Retryable on 503 with Retry-After header`() =
     runTest {
+      // Server says 5 s; that's below the client's 60 s base, so `parseRetryAfter` clamps
+      // up to base — the client wouldn't dispatch faster than that anyway.
       mockServer.enqueue(
         MockResponse()
           .setResponseCode(503)
@@ -175,7 +177,10 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
-      assertEquals(5_000L, (result as DispatchResult.Retryable).retryAfterMs)
+      assertEquals(
+        DispatchUtils.backoffBaseMs,
+        (result as DispatchResult.Retryable).retryAfterMs
+      )
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -134,8 +134,8 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
-      assertTrue((result as DispatchResult.NonRetryable).reason.contains("400"))
+      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
+      assertTrue((result as DispatchResult.NonRetryableFailure).reason.contains("400"))
       assertEquals(1, mockServer.requestCount)
     }
 
@@ -156,7 +156,7 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryableFailure)
       assertEquals(1, mockServer.requestCount)
     }
 
@@ -176,10 +176,10 @@ class EventDispatcherTest {
 
       val result = eventDispatcher.dispatch(events)
 
-      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
+      assertTrue("expected Retryable, got $result", result is DispatchResult.RetryableFailure)
       assertEquals(
         DispatchUtils.backoffBaseMs,
-        (result as DispatchResult.Retryable).retryAfterMs
+        (result as DispatchResult.RetryableFailure).retryAfterMs
       )
     }
 
@@ -194,8 +194,8 @@ class EventDispatcherTest {
 
       val result = eventDispatcher.dispatch(listOf(createTestEvent()))
 
-      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
-      assertEquals(null, (result as DispatchResult.Retryable).retryAfterMs)
+      assertTrue("expected Retryable, got $result", result is DispatchResult.RetryableFailure)
+      assertEquals(null, (result as DispatchResult.RetryableFailure).retryAfterMs)
     }
 
   @Test
@@ -292,8 +292,8 @@ class EventDispatcherTest {
 
       val result = eventDispatcher.dispatch(events)
 
-      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
-      assertEquals(null, (result as DispatchResult.Retryable).retryAfterMs)
+      assertTrue("expected Retryable, got $result", result is DispatchResult.RetryableFailure)
+      assertEquals(null, (result as DispatchResult.RetryableFailure).retryAfterMs)
     }
 
   @Test
@@ -381,11 +381,12 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch returns NonRetryable on 200 with partial_success that rejected records`() =
+  fun `dispatch returns PartialSuccess on 200 with partial_success that rejected records`() =
     runTest {
       // A 2xx body that includes `partialSuccess` with rejectedDataPoints > 0 means the
-      // collector permanently refused those rows. Treat as NonRetryable so the caller drops
-      // them instead of looping.
+      // collector accepted the batch but rejected those rows server-side. Surface as
+      // `PartialSuccess` so the caller logs the per-record rejection without describing it
+      // as a wholesale drop.
       mockServer.enqueue(
         MockResponse()
           .setResponseCode(200)
@@ -394,9 +395,12 @@ class EventDispatcherTest {
 
       val result = eventDispatcher.dispatch(listOf(createTestEvent()))
 
-      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
-      assertTrue((result as DispatchResult.NonRetryable).reason.contains("rejected 3"))
-      assertTrue(result.reason.contains("metric_kind_mismatch"))
+      assertEquals(
+        DispatchResult.PartialSuccess(
+          OTPartialSuccess(rejectedDataPoints = 3, errorMessage = "metric_kind_mismatch")
+        ),
+        result
+      )
     }
 
   // Helper function to create test events

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -142,7 +142,7 @@ class EventDispatcherTest {
   @Test
   fun `dispatch returns NonRetryable on 500 server error`() =
     runTest {
-      // 500 is NOT in OTLP's retryable list — only 408/429/502/503/504 are. 500 means an
+      // 500 is NOT in OTLP's retryable list — only 429/502/503/504 are. 500 means an
       // internal server error we can't reason about, so we drop the batch.
       mockServer.enqueue(
         MockResponse()

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -59,7 +59,7 @@ class EventDispatcherTest {
   }
 
   @Test
-  fun `dispatch returns true on successful 200 response`() =
+  fun `dispatch returns Success on 200 response`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -74,7 +74,7 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue(result)
+      assertEquals(DispatchResult.Success, result)
       assertEquals(1, mockServer.requestCount)
 
       val request = mockServer.takeRequest()
@@ -85,7 +85,7 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch returns true on successful 201 response`() =
+  fun `dispatch returns Success on 201 response`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -100,25 +100,26 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue(result)
+      assertEquals(DispatchResult.Success, result)
     }
 
   @Test
-  fun `dispatch returns false when empty event list is provided`() =
+  fun `dispatch returns Success on empty event list without hitting the network`() =
     runTest {
-      // Arrange
+      // Empty input is a no-op; we still report Success so the caller treats it as "nothing
+      // to do" rather than as a transient failure to retry.
       val emptyEvents = emptyList<Event>()
 
       // Act
       val result = eventDispatcher.dispatch(emptyEvents)
 
       // Assert
-      assertFalse(result)
+      assertEquals(DispatchResult.Success, result)
       assertEquals(0, mockServer.requestCount)
     }
 
   @Test
-  fun `dispatch returns false on 400 error response`() =
+  fun `dispatch returns NonRetryable on 400 error response`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -133,14 +134,16 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertFalse(result)
+      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+      assertTrue((result as DispatchResult.NonRetryable).reason.contains("400"))
       assertEquals(1, mockServer.requestCount)
     }
 
   @Test
-  fun `dispatch returns false on 500 server error`() =
+  fun `dispatch returns NonRetryable on 500 server error`() =
     runTest {
-      // Arrange
+      // 500 is NOT in OTLP's retryable list — only 408/429/502/503/504 are. 500 means an
+      // internal server error we can't reason about, so we drop the batch.
       mockServer.enqueue(
         MockResponse()
           .setResponseCode(500)
@@ -153,8 +156,41 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertFalse(result)
+      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
       assertEquals(1, mockServer.requestCount)
+    }
+
+  @Test
+  fun `dispatch returns Retryable on 503 with Retry-After header`() =
+    runTest {
+      mockServer.enqueue(
+        MockResponse()
+          .setResponseCode(503)
+          .setHeader("Retry-After", "5")
+          .setBody("""{"error": "Service Unavailable"}""")
+      )
+
+      val events = listOf(createTestEvent())
+
+      val result = eventDispatcher.dispatch(events)
+
+      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
+      assertEquals(5_000L, (result as DispatchResult.Retryable).retryAfterMs)
+    }
+
+  @Test
+  fun `dispatch returns Retryable on 429 without Retry-After`() =
+    runTest {
+      mockServer.enqueue(
+        MockResponse()
+          .setResponseCode(429)
+          .setBody("""{"error": "Too Many Requests"}""")
+      )
+
+      val result = eventDispatcher.dispatch(listOf(createTestEvent()))
+
+      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
+      assertEquals(null, (result as DispatchResult.Retryable).retryAfterMs)
     }
 
   @Test
@@ -208,7 +244,7 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue(result)
+      assertEquals(DispatchResult.Success, result)
       assertEquals(1, mockServer.requestCount)
 
       val request = mockServer.takeRequest()
@@ -240,21 +276,19 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch throws exception on network failure`() =
+  fun `dispatch returns Retryable on network failure`() =
     runTest {
-      // Arrange
+      // Transport-level errors (DNS, TLS, timeouts, connection reset) are transient by
+      // definition — fold them into Retryable(null) so the next dispatch round picks the
+      // batch up again instead of crashing the WorkManager job.
       mockServer.shutdown() // Shutdown server to simulate network failure
 
       val events = listOf(createTestEvent())
 
-      // Act & Assert
-      try {
-        eventDispatcher.dispatch(events)
-        fail("Expected exception to be thrown")
-      } catch (e: Exception) {
-        // Expected behavior
-        assertNotNull(e)
-      }
+      val result = eventDispatcher.dispatch(events)
+
+      assertTrue("expected Retryable, got $result", result is DispatchResult.Retryable)
+      assertEquals(null, (result as DispatchResult.Retryable).retryAfterMs)
     }
 
   @Test
@@ -323,7 +357,7 @@ class EventDispatcherTest {
     }
 
   @Test
-  fun `dispatch handles 299 response as success`() =
+  fun `dispatch handles 299 response as Success`() =
     runTest {
       // Arrange
       mockServer.enqueue(
@@ -338,7 +372,26 @@ class EventDispatcherTest {
       val result = eventDispatcher.dispatch(events)
 
       // Assert
-      assertTrue(result)
+      assertEquals(DispatchResult.Success, result)
+    }
+
+  @Test
+  fun `dispatch returns NonRetryable on 200 with partial_success that rejected records`() =
+    runTest {
+      // A 2xx body that includes `partialSuccess` with rejectedDataPoints > 0 means the
+      // collector permanently refused those rows. Treat as NonRetryable so the caller drops
+      // them instead of looping.
+      mockServer.enqueue(
+        MockResponse()
+          .setResponseCode(200)
+          .setBody("""{"partialSuccess":{"rejectedDataPoints":3,"errorMessage":"metric_kind_mismatch"}}""")
+      )
+
+      val result = eventDispatcher.dispatch(listOf(createTestEvent()))
+
+      assertTrue("expected NonRetryable, got $result", result is DispatchResult.NonRetryable)
+      assertTrue((result as DispatchResult.NonRetryable).reason.contains("rejected 3"))
+      assertTrue(result.reason.contains("metric_kind_mismatch"))
     }
 
   // Helper function to create test events


### PR DESCRIPTION
# Why

Our client side code in expo-observe does not comply with the Open Telemetry spec for retrying requests that fail. This PR fixes that for Android (iOS changes are in the downstack PR).

# How

Classify responses into successful, retryable, and failed types, and handle them as appropriate. Non-retryable errors are handled by moving the cursor, to prevent the request being retried, which means that those metrics or logs will be dropped. In this PR, dropped requests are logged as warnings.

# Test Plan

- Testing with a real Expo app against a local server to send back different responses
- New Android unit tests added.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)