### PR TITLE
chore: Drop Git LFS

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -33,9 +33,6 @@ inputs:
   ccache:
     description: 'Restore ccache'
     required: false
-  git-lfs:
-    description: 'Restore Git LFS cache'
-    required: false
   react-native-gradle-downloads:
     description: 'Restore Gradle downloads cache for React Native libraries'
     required: false
@@ -59,9 +56,6 @@ outputs:
   native-tests-pods-hit:
     description: 'Returns true, if /apps/native-tests/ios pods cache is up-to-date'
     value: ${{ steps.native-tests-pods-cache.outputs.cache-hit }}
-  git-lfs-hit:
-    description: 'Returns true, if Git LFS cache is up-to-date'
-    value: ${{ steps.git-lfs-cache.outputs.cache-hit }}
 
 runs:
   using: 'composite'
@@ -179,19 +173,6 @@ runs:
         # - Gradle files: see https://github.com/expo/expo/pull/44884
         key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle', 'apps/bare-expo/android/app/src/main/jni/pch.h') }}
         restore-keys: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}
-
-    - name: 🔍️ Get cache key of Git LFS files
-      if: inputs.git-lfs == 'true'
-      id: git-lfs
-      run: echo "sha256=$(git lfs ls-files | openssl dgst -sha256)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: ♻️ Restore Git LFS cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      id: git-lfs-cache
-      if: inputs.git-lfs == 'true'
-      with:
-        path: .git/lfs
-        key: ${{ steps.git-lfs.outputs.sha256 }}
 
     - name: 🛠 Setup "REACT_NATIVE_DOWNLOADS_DIR" environment variable
       if: inputs.react-native-gradle-downloads == 'true'

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,0 @@
-[lfs]
-	fetchexclude = ios/Pods*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,8 @@ Manual smoke tests are included in `apps/native-component-list`, which is a good
 1. If you are an Expo team member, clone the repository. If you are an external contributor, [fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device. (`git remote add upstream git@github.com:expo/expo.git` 😉). You can use `git clone --depth 1 --single-branch --branch main git@github.com:expo/expo.git`, skipping most of the branches and history to clone it faster.
 2. Install [direnv](https://direnv.net/). On macOS: `brew install direnv`. Don't forget to install the [shell hook](https://direnv.net/docs/hook.html) to your shell profile.
 3. Install Ruby 3.3 or later. On macOS: `brew install ruby@3.3`
-4. Install [git-lfs](https://git-lfs.github.com/). On macOS: `brew install git-lfs`.
-5. Install [Node LTS](https://nodejs.org/).
-6. Some of the scripts in this repository require Bun. You won't need it for most tasks, but can install it via [these options](https://bun.com/docs/installation).
+4. Install [Node LTS](https://nodejs.org/).
+5. Some of the scripts in this repository require Bun. You won't need it for most tasks, but can install it via [these options](https://bun.com/docs/installation).
 
 ### Set up documentation
 

--- a/scripts/check-cocoapods-lockfiles.sh
+++ b/scripts/check-cocoapods-lockfiles.sh
@@ -5,12 +5,24 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   exit 0
 fi
 
+pathsToCheck=("ios" "apps/bare-expo/ios")
+
+# Hooks pass a commit range; skip when no Podfile.lock changed within it.
+if [[ -n "$1" && -n "$2" ]]; then
+  lockfiles=()
+  for path in "${pathsToCheck[@]}"; do
+    lockfiles+=("$path/Podfile.lock")
+  done
+  if git diff --quiet "$1" "$2" -- "${lockfiles[@]}" 2>/dev/null; then
+    exit 0
+  fi
+fi
+
 green="tput setaf 2"
 yellow="tput setaf 3"
 blue="tput setaf 4"
 reset="tput sgr0"
 
-pathsToCheck=("ios" "apps/bare-expo/ios")
 pathsToUpdate=()
 
 for path in ${pathsToCheck[@]}; do

--- a/scripts/download-dependencies.sh
+++ b/scripts/download-dependencies.sh
@@ -9,15 +9,11 @@ require() {
 
 require node
 require npm
-require git-lfs
 require direnv
 
 # Set up submodules
 git submodule update --init
 git submodule foreach --recursive git checkout .
-
-# Pull the large git files
-git lfs pull
 
 if [[ "$1" == "--native" ]]; then
   # We can install pnpm because `npm install` is cross-platform

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,5 +1,2 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\n"; exit 2; }
-git lfs post-checkout "$@"
-
 ./scripts/check-cocoapods-lockfiles.sh

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,2 +1,4 @@
 #!/bin/sh
-./scripts/check-cocoapods-lockfiles.sh
+# $3 is 1 only for branch checkouts, not file checkouts.
+[ "$3" = "1" ] || exit 0
+./scripts/check-cocoapods-lockfiles.sh "$1" "$2"

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,5 +1,2 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\n"; exit 2; }
-git lfs post-merge "$@"
-
 ./scripts/check-cocoapods-lockfiles.sh

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,2 +1,3 @@
 #!/bin/sh
-./scripts/check-cocoapods-lockfiles.sh
+# ORIG_HEAD is the pre-merge commit.
+./scripts/check-cocoapods-lockfiles.sh ORIG_HEAD HEAD


### PR DESCRIPTION
## Summary

Unless I'm mistaken, we don't use Git LFS anymore. There's no Git LFS tracked files, and the setup is likely unused right now.

## Set of changes

- Delete `.lfsconfig`
- Delete from `download-dependencies.sh`
- Delete from cache workflow
- Remove from git hooks
- Remove from contributing guide
- Ensure post-merge/checkout git hooks don't slow down shell