### PR TITLE
chore: Update markdown files for Turborepo

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,10 +40,9 @@ one package with `--packages <name>` (e.g. `et native-unit-tests -p ios --packag
 
 ## Committing
 
-Before committing, run `et check-packages <...packages>` with the names of the packages that changed. It runs the unit tests **and** builds the package's
-JS files. The build output is committed alongside your source changes, so a commit that skips
-this step will be missing its built files. Stage both your source edits and the regenerated
-build output.
+Before committing, you may use `turbo run <task>` to run an npm script for a given task on all dependents, for example `build`, `typecheck`, `depscheck`, `test`, and `lint`. This may also be run via `et check-packages <...packages>` with the names of the packages that changed. This matches how CI checks packages.
+
+The compiled `build/` output is gitignored and is **not** committed. Turborepo regenerates and caches it on demand. Stage only your source edits (and other source files); do not stage `build/`.
 
 ## Creating PRs
 
@@ -57,11 +56,11 @@ Follow the contribution guide: https://github.com/expo/expo/blob/main/CONTRIBUTI
 - **How:** how you built the feature or fixed the bug, and why you took that approach.
 - **Test Plan:** how you tested the change and how a reviewer can reproduce it — include terminal
   output or screenshots when there are no automated tests.
-- **Checklist:** added a `CHANGELOG.md` entry and rebuilt the package sources; confirmed the change
-  works with `npx expo prebuild` & EAS Build if relevant; follows the documentation style guide.
-
-**Before submitting:** run `et check-packages` (builds, lints, and tests), commit the `build/`
-output, and remove stray `console.log`s or commented-out code.
+- **Checklist:** added a `CHANGELOG.md` entry and verified the change builds, type-checks, lints,
+  and tests via `et check-packages`; confirmed the change works with `npx expo prebuild` & EAS Build
+  if relevant; follows the documentation style guide.
+**Before submitting:** run `et check-packages` (builds, type-checks, lints, and tests), remove stray
+`console.log`s or commented-out code, and do not stage the gitignored `build/` output.
 
 **See also:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ If you will be working with the iOS project, ensure **ruby 3.3** is installed on
 All Expo SDK packages can be found in the `packages/` directory. These packages are automatically linked to the projects in the `apps/` directory, so you can edit them in-place and see the changes in the running app.
 
 1. Navigate to a package you want to edit. Ex: `cd packages/expo-constants`
-2. Start the TypeScript build in watch mode: `pnpm build` (skip this if such script is not present)
+2. Compile the package's TypeScript after editing: `pnpm build` (skip this if such script is not present)
 3. Edit code in that package's `src/` directory
 4. Play with your changes on a simulator or device through `bare-expo`:
    - Add or modify a file named after the API you're working on. Ex: `apps/test-suite/tests/Constants.js`
@@ -115,6 +115,25 @@ All Expo SDK packages can be found in the `packages/` directory. These packages 
    - Xcode: `pnpm edit:ios`
    - Remember to **rebuild** the native project whenever you make a native change
 6. (optional) Package docs are partially generated from sources. Run `et generate-docs-api-data -p <package-name>` to generate the package docs [read more](#-updating-documentation).
+
+### Common package scripts
+
+Almost every package in `packages/` exposes the same set of npm scripts, orchestrated across the monorepo by [Turborepo](https://turborepo.com/). The compiled `build/` output is not committed to Git (it is in `.gitignore`); Turborepo builds it on demand and caches the result, locally and in a shared remote cache, so a `git pull` or `git checkout` doesn't force you to rebuild every package.
+
+| Script | What it does |
+| --- | --- |
+| `build` | Compiles `src/` → `build/`. |
+| `typecheck` | Type-checks the package with `tsc`. |
+| `test` | Runs the package's Jest unit tests. |
+| `lint` | Lints the package. Pass `--fix` to autofix. |
+| `depscheck` | Verifies the package's declared dependencies match what it imports. |
+
+Run them two ways:
+
+- **From the repo root** with `pnpm <script>` (e.g. `pnpm build`, `pnpm test`, `pnpm lint`, `pnpm typecheck`). This invokes `turbo <task>` and runs the script across every workspace package — respecting the cache and dependency graph 
+- **From a single package directory** with `pnpm run <script>` (e.g. `cd packages/expo-constants && pnpm run test`) to run just that package's script.
+
+For a one-shot "did my change build, typecheck, lint, and pass tests?" check across the packages you touched, use `et check-packages <...packages>`, which runs the same Turborepo task graph as CI.
 
 ### Finding a task to work on
 
@@ -135,7 +154,6 @@ All modules should adhere to the style guides which can be found here:
 
 - The React Native dev tools are currently disabled in our fork [#5602](https://github.com/expo/expo/issues/5602). You can hack around this by cloning React Native outside this repo, then copying the contents `react-native/React/DevSupport` into `expo/react-native-lab/react-native/React/DevSupport` (this will only enable the shake gesture, CMD+R won't work yet).
 - We use a fork of `react-native` in this repo; this fork is located at `react-native-lab/react-native` (you can make changes or cherry-picks from here if you want). It diverges the minimal amount necessary from the `react-native` version in its `package.json`.
-- All of the package's `build/` code should be committed. This is because it is simpler to reproduce issues if all contributors are running the same code and so we don't need to rebuild dozens of packages locally on every `git pull` or `git checkout` operation.
 - We use a unified set of basic Bash scripts and configs called `expo-module-scripts` to ensure everything runs smoothly (TypeScript, Babel, Jest, etc...).
 
 ## ⏱ Testing Your Changes
@@ -191,9 +209,8 @@ To keep CI green, please make sure of the following:
 
 ### If you modified anything in `packages/`:
 
-  - You transpiled the TypeScript with `pnpm build` in the directory of whichever package you modified.
+  - Run `et check-packages <...packages>` (or `pnpm build`, `pnpm typecheck`, `pnpm test`, and `pnpm lint`) for the packages you changed. See [Common package scripts](#common-package-scripts).
   - Run `pnpm lint --fix` to fix the formatting of the code. Ensure that `pnpm lint` succeeds without errors or warnings.
-  - Run `pnpm test` to ensure all existing tests pass for that package, along with any new tests you would've written.
   - (optional) Package docs are partially generated from sources. Run `et generate-docs-api-data -p <package-name>` to generate the package docs [read more](#-updating-documentation).
   - All `console.log`s or commented out code blocks are removed!
 

--- a/guides/Expo Module Infrastructure.md
+++ b/guides/Expo Module Infrastructure.md
@@ -24,7 +24,7 @@ Run:
 
 # The Standard Configuration
 
-We use a shared set of configuration files and tools like TypeScript across modules. The `expo-module-scripts` package is the source of truth for much of the configuration. With Yarn workspaces, all modules use the same version of `expo-module-scripts`, helping us structurally ensure we use the same configuration across modules and uniformly use the same versions of Babel, TypeScript, Jest, and other tools.
+We use a shared set of configuration files and tools like TypeScript across modules. The `expo-module-scripts` package is the source of truth for much of the configuration. With pnpm workspaces, all modules use the in-repo version of `expo-module-scripts`, helping us structurally ensure we use the same configuration across modules and uniformly use the same versions of Babel, TypeScript, Jest, and other tools.
 
 In a module, include `expo-module-scripts` as a development dependency in package.json:
 
@@ -55,7 +55,7 @@ In a module, include `expo-module-scripts` as a development dependency in packag
 }
 ```
 
-The `expo-module` program is provided by `expo-module-scripts`. You can run `yarn expo-module --help` to see all of the commands. Several of the scripts are interactive and start file watchers as they are intended for human developers rather than CI. To run the commands in non-interactive mode, set the environment variable `EXPO_NONINTERACTIVE=1`.
+The `expo-module` program is provided by `expo-module-scripts`. You can run `pnpm expo-module --help` to see all of the commands. Several of the scripts are interactive and start file watchers as they are intended for human developers rather than CI. To run the commands in non-interactive mode, set the environment variable `EXPO_NONINTERACTIVE=1`.
 
 ## Auto-generated Configuration Files
 
@@ -73,11 +73,11 @@ In package.json, define the main module of the package to be the compiled entry 
 }
 ```
 
-Running `yarn clean` will delete the `build` directory.
+Running `pnpm clean` will delete the `build` directory.
 
 ## Compiling TypeScript
 
-Run `yarn build` to compile the source code from `src` to `build`. Run `yarn typecheck` to type-check the package with `tsc` without emitting output. When working across the monorepo, prefer running these through Turborepo from the repo root (`pnpm build`, `pnpm typecheck`) so only affected packages are rebuilt and results are cached.
+Run `pnpm build` to compile the source code from `src` to `build`. Run `pnpm typecheck` to type-check the package with `tsc` without emitting output. When working across the monorepo, prefer running these through Turborepo from the repo root (`pnpm build`, `pnpm typecheck`) so only affected packages are rebuilt and results are cached.
 
 The `postinstall` script generates a small tsconfig.json file that extends the main configuration file inside of `expo-module-scripts`.
 
@@ -95,7 +95,7 @@ The `postinstall` script generates a small tsconfig.json file that extends the m
 
 This preset enables TypeScript support with `ts-jest`. It creates a custom tsconfig.json file for Jest tests and configures Jest to run both TypeScript and Babel with `babel-preset-expo` so we more accurately transform the code as if it were part of an app.
 
-Run `yarn test` to run Jest in watcher mode. By default, Jest will run tests affected by changed files and re-run tests when files are edited and saved. Since the unit tests run every time a file changes, we need to keep these tests fast and deterministic.
+Run `pnpm test` to run Jest in watcher mode. By default, Jest will run tests affected by changed files and re-run tests when files are edited and saved. Since the unit tests run every time a file changes, we need to keep these tests fast and deterministic.
 
 # package.json Fields
 

--- a/guides/Expo Module Infrastructure.md
+++ b/guides/Expo Module Infrastructure.md
@@ -63,7 +63,7 @@ The `postinstall` script auto-generates configuration files in the package when 
 
 ## Directory Structure
 
-`expo-module-scripts` expects modules to be written in TypeScript under a directory named `src` and will compile the modules to a directory named `build`. **In a module package, commit the `build` directory to Git.** Only the people working on a module need to compile it instead of everyone needing to run `tsc` in each package whenever their local Git repository changes.
+`expo-module-scripts` expects modules to be written in TypeScript under a directory named `src` and will compile the modules to a directory named `build`. **The `build` directory is not committed to Git** — it is in `.gitignore`. [Turborepo](https://turborepo.com/) compiles packages on demand and caches the output (locally and via a shared remote cache), so contributors don't need to rebuild every package whenever their local Git repository changes.
 
 In package.json, define the main module of the package to be the compiled entry point under `build`:
 
@@ -77,7 +77,7 @@ Running `yarn clean` will delete the `build` directory.
 
 ## Compiling TypeScript
 
-Run `yarn build` to compile the source code. This command starts a file watcher and compiles source files as they are edited and saved. You can also run `yarn expo-module tsc` to run `tsc` directly.
+Run `yarn build` to compile the source code from `src` to `build`. Run `yarn typecheck` to type-check the package with `tsc` without emitting output. When working across the monorepo, prefer running these through Turborepo from the repo root (`pnpm build`, `pnpm typecheck`) so only affected packages are rebuilt and results are cached.
 
 The `postinstall` script generates a small tsconfig.json file that extends the main configuration file inside of `expo-module-scripts`.
 

--- a/guides/releasing/Quality Assurance.md
+++ b/guides/releasing/Quality Assurance.md
@@ -4,7 +4,7 @@
 
 ### 1. Checking packages
 
-- Run `et check-packages` to make sure every package build successfully, `build` folder is up to date and all unit tests pass.
+- Run `et check-packages` to make sure every package builds, type-checks, and passes its unit tests. This runs the Turborepo task graph (build, typecheck, depscheck, test, lint); the `build/` output is generated and cached on demand rather than committed.
 
 ### 2. React Native dev tools
 

--- a/packages/expo-ui/CLAUDE.md
+++ b/packages/expo-ui/CLAUDE.md
@@ -47,7 +47,7 @@ For every component added, create example screens in NCL (native-component-list)
 
 ## Before committing
 
-1. Run `pnpm build` in the package directory — the `build/` output must be committed alongside source changes. CI will fail otherwise.
+1. Run `pnpm build` in the package directory (or `et check-packages @expo/ui`) to confirm it compiles. The `build/` output is gitignored.
 2. Run `pnpm lint --max-warnings 0`.
 3. Add a changelog entry to `CHANGELOG.md` under the "Unpublished" section.
 4. When adding a new component, add documentation for it. When adding a new feature to an existing component, update its documentation accordingly. Docs are MDX files in `docs/pages/versions/unversioned/sdk/ui/swift-ui/` and `docs/pages/versions/unversioned/sdk/ui/jetpack-compose/`.

--- a/packages/expo-ui/CONTRIBUTING.md
+++ b/packages/expo-ui/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## Before opening a PR
 
-- [ ] Verified the package builds and passes checks: `et check-packages @expo/ui` (or `yarn build && yarn typecheck && yarn test` from `packages/expo-ui/`)
+- [ ] Verified the package builds and passes checks: `et check-packages @expo/ui` (or `pnpm build && pnpm typecheck && pnpm test` from `packages/expo-ui/`)
 
 ### When adding or updating a component
 

--- a/packages/expo-ui/CONTRIBUTING.md
+++ b/packages/expo-ui/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## Before opening a PR
 
-- [ ] Rebuilt JS output: `yarn build` (from `packages/expo-ui/`) and committed the `build/` output.
+- [ ] Verified the package builds and passes checks: `et check-packages @expo/ui` (or `yarn build && yarn typecheck && yarn test` from `packages/expo-ui/`)
 
 ### When adding or updating a component
 


### PR DESCRIPTION
This comes down to three main changes:
- the npm scripts are more unified and can be documented
- the `build/` outputs aren't committed anymore
- there's a few ways users may validate changes, e.g. with `et check-packages`