### PR TITLE
[sqlite] Use new ArrayBuffer type in native APIs

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Changed native implementation to use the unified `ArrayBuffer` type.
+- Changed native implementation to use the unified `ArrayBuffer` type. ([#47168](https://github.com/expo/expo/pull/47168) by [@barthap](https://github.com/barthap))
 
 ## 56.0.4 — 2026-05-21
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Changed native implementation to use the unified `ArrayBuffer` type.
+
 ## 56.0.4 — 2026-05-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
@@ -2,7 +2,7 @@
 
 package expo.modules.sqlite
 
-import expo.modules.kotlin.jni.NativeArrayBuffer
+import expo.modules.kotlin.jni.ArrayBuffer
 import expo.modules.kotlin.sharedobjects.SharedRef
 import java.nio.ByteBuffer
 
@@ -25,7 +25,7 @@ internal class NativeStatement : SharedRef<NativeStatementBinding>(NativeStateme
   fun getTransformedColumnValues(): SQLiteColumnValues {
     val columnValueList = ref.getColumnValues().map {
       when (it) {
-        is ByteBuffer -> NativeArrayBuffer(it)
+        is ByteBuffer -> ArrayBuffer(it)
         else -> it
       }
     }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -8,8 +8,6 @@ import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.jni.ArrayBuffer
-import expo.modules.kotlin.jni.JavaScriptArrayBuffer
-import expo.modules.kotlin.jni.NativeArrayBuffer
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.CoroutineScope
@@ -219,10 +217,10 @@ class SQLiteModule : Module() {
         return@Constructor NativeStatement()
       }
 
-      AsyncFunction("runAsync") { statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any?>, bindBlobParams: Map<String, NativeArrayBuffer>, shouldPassAsArray: Boolean ->
+      AsyncFunction("runAsync") { statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any?>, bindBlobParams: Map<String, ArrayBuffer>, shouldPassAsArray: Boolean ->
         return@AsyncFunction run(statement, database, bindParams, bindBlobParams, shouldPassAsArray)
       }.runOnQueue(moduleCoroutineScope)
-      Function("runSync") { statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any?>, bindBlobParams: Map<String, JavaScriptArrayBuffer>, shouldPassAsArray: Boolean ->
+      Function("runSync") { statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any?>, bindBlobParams: Map<String, ArrayBuffer>, shouldPassAsArray: Boolean ->
         return@Function run(statement, database, bindParams, bindBlobParams, shouldPassAsArray)
       }
 
@@ -308,17 +306,17 @@ class SQLiteModule : Module() {
         return@Function sessionCreateInvertedChangeset(database, session)
       }
 
-      AsyncFunction("applyChangesetAsync") { session: NativeSession, database: NativeDatabase, changeset: NativeArrayBuffer ->
+      AsyncFunction("applyChangesetAsync") { session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer ->
         sessionApplyChangeset(database, session, changeset)
       }.runOnQueue(moduleCoroutineScope)
-      Function("applyChangesetSync") { session: NativeSession, database: NativeDatabase, changeset: JavaScriptArrayBuffer ->
+      Function("applyChangesetSync") { session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer ->
         sessionApplyChangeset(database, session, changeset)
       }
 
-      AsyncFunction("invertChangesetAsync") { session: NativeSession, database: NativeDatabase, changeset: NativeArrayBuffer ->
+      AsyncFunction("invertChangesetAsync") { session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer ->
         return@AsyncFunction sessionInvertChangeset(database, session, changeset)
       }.runOnQueue(moduleCoroutineScope)
-      Function("invertChangesetSync") { session: NativeSession, database: NativeDatabase, changeset: JavaScriptArrayBuffer ->
+      Function("invertChangesetSync") { session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer ->
         return@Function sessionInvertChangeset(database, session, changeset)
       }
     }
@@ -646,21 +644,21 @@ class SQLiteModule : Module() {
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)
-  private fun sessionCreateChangeset(database: NativeDatabase, session: NativeSession): NativeArrayBuffer {
+  private fun sessionCreateChangeset(database: NativeDatabase, session: NativeSession): ArrayBuffer {
     maybeThrowForClosedDatabase(database)
     val byteBuffer = session.ref.sqlite3session_changeset()
       ?: throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
 
-    return NativeArrayBuffer(byteBuffer)
+    return ArrayBuffer(byteBuffer)
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)
-  private fun sessionCreateInvertedChangeset(database: NativeDatabase, session: NativeSession): NativeArrayBuffer {
+  private fun sessionCreateInvertedChangeset(database: NativeDatabase, session: NativeSession): ArrayBuffer {
     maybeThrowForClosedDatabase(database)
     val byteBuffer = session.ref.sqlite3session_changeset_inverted()
       ?: throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
 
-    return NativeArrayBuffer(byteBuffer)
+    return ArrayBuffer(byteBuffer)
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)
@@ -672,12 +670,12 @@ class SQLiteModule : Module() {
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)
-  private fun sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: ArrayBuffer): NativeArrayBuffer {
+  private fun sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: ArrayBuffer): ArrayBuffer {
     maybeThrowForClosedDatabase(database)
     val byteBuffer = session.ref.sqlite3changeset_invert(changeset.toDirectBuffer())
       ?: throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
 
-    return NativeArrayBuffer(byteBuffer)
+    return ArrayBuffer(byteBuffer)
   }
 
   // endregion

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -615,7 +615,7 @@ public final class SQLiteModule: Module {
       return String(cString: text)
     case SQLITE_BLOB:
       guard let blob = exsqlite3_column_blob(instance, index) else {
-        return ArrayBuffer.allocate(size: 0)
+        return ArrayBuffer(size: 0)
       }
       let size = exsqlite3_column_bytes(instance, index)
       return ArrayBuffer.copy(of: blob, count: Int(size))
@@ -770,7 +770,7 @@ public final class SQLiteModule: Module {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     guard let buffer else {
-      return ArrayBuffer.allocate(size: 0)
+      return ArrayBuffer(size: 0)
     }
     defer { exsqlite3_free(buffer) }
     return ArrayBuffer.copy(of: buffer, count: Int(size))
@@ -815,7 +815,7 @@ public final class SQLiteModule: Module {
         throw SQLiteErrorException(convertSqlLiteErrorToString(database))
       }
       guard let outBuffer else {
-        return ArrayBuffer.allocate(size: 0)
+        return ArrayBuffer(size: 0)
       }
       defer { exsqlite3_free(outBuffer) }
       return ArrayBuffer.copy(of: outBuffer, count: Int(outSize))

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -196,7 +196,7 @@ public final class SQLiteModule: Module {
 
       // swiftlint:disable line_length
 
-      AsyncFunction("runAsync") { (statement: NativeStatement, database: NativeDatabase, bindParams: [String: Any], bindBlobParams: [String: NativeArrayBuffer], shouldPassAsArray: Bool) -> [String: Any] in
+      AsyncFunction("runAsync") { (statement: NativeStatement, database: NativeDatabase, bindParams: [String: Any], bindBlobParams: [String: ArrayBuffer], shouldPassAsArray: Bool) -> [String: Any] in
         return try run(statement: statement, database: database, bindParams: bindParams, bindBlobParams: bindBlobParams, shouldPassAsArray: shouldPassAsArray)
       }.runOnQueue(moduleQueue)
       Function("runSync") { (statement: NativeStatement, database: NativeDatabase, bindParams: [String: Any], bindBlobParams: [String: ArrayBuffer], shouldPassAsArray: Bool) -> [String: Any] in
@@ -270,31 +270,31 @@ public final class SQLiteModule: Module {
         try sessionClose(database: database, session: session)
       }
 
-      AsyncFunction("createChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> NativeArrayBuffer in
+      AsyncFunction("createChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> ArrayBuffer in
         return try sessionCreateChangeset(database: database, session: session)
       }.runOnQueue(moduleQueue)
-      Function("createChangesetSync") { (session: NativeSession, database: NativeDatabase) -> NativeArrayBuffer in
+      Function("createChangesetSync") { (session: NativeSession, database: NativeDatabase) -> ArrayBuffer in
         return try sessionCreateChangeset(database: database, session: session)
       }
 
-      AsyncFunction("createInvertedChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> NativeArrayBuffer in
+      AsyncFunction("createInvertedChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> ArrayBuffer in
         return try sessionCreateInvertedChangeset(database: database, session: session)
       }.runOnQueue(moduleQueue)
-      Function("createInvertedChangesetSync") { (session: NativeSession, database: NativeDatabase) -> NativeArrayBuffer in
+      Function("createInvertedChangesetSync") { (session: NativeSession, database: NativeDatabase) -> ArrayBuffer in
         return try sessionCreateInvertedChangeset(database: database, session: session)
       }
 
-      AsyncFunction("applyChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: NativeArrayBuffer) in
+      AsyncFunction("applyChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer) in
         try sessionApplyChangeset(database: database, session: session, changeset: changeset)
       }.runOnQueue(moduleQueue)
       Function("applyChangesetSync") { (session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer) in
         try sessionApplyChangeset(database: database, session: session, changeset: changeset)
       }
 
-      AsyncFunction("invertChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: NativeArrayBuffer) -> NativeArrayBuffer in
+      AsyncFunction("invertChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer) -> ArrayBuffer in
         return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
       }.runOnQueue(moduleQueue)
-      Function("invertChangesetSync") { (session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer) -> NativeArrayBuffer in
+      Function("invertChangesetSync") { (session: NativeSession, database: NativeDatabase, changeset: ArrayBuffer) -> ArrayBuffer in
         return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
       }
     }
@@ -615,10 +615,10 @@ public final class SQLiteModule: Module {
       return String(cString: text)
     case SQLITE_BLOB:
       guard let blob = exsqlite3_column_blob(instance, index) else {
-        return NativeArrayBuffer.allocate(size: 0)
+        return ArrayBuffer.allocate(size: 0)
       }
       let size = exsqlite3_column_bytes(instance, index)
-      return NativeArrayBuffer.copy(of: blob, count: Int(size))
+      return ArrayBuffer.copy(of: blob, count: Int(size))
     case SQLITE_NULL:
       return NSNull()
     default:
@@ -762,7 +762,7 @@ public final class SQLiteModule: Module {
     exsqlite3session_delete(session.pointer)
   }
 
-  private func sessionCreateChangeset(database: NativeDatabase, session: NativeSession) throws -> NativeArrayBuffer {
+  private func sessionCreateChangeset(database: NativeDatabase, session: NativeSession) throws -> ArrayBuffer {
     try maybeThrowForClosedDatabase(database)
     var size: Int32 = 0
     var buffer: UnsafeMutableRawPointer?
@@ -770,13 +770,13 @@ public final class SQLiteModule: Module {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     guard let buffer else {
-      return NativeArrayBuffer.allocate(size: 0)
+      return ArrayBuffer.allocate(size: 0)
     }
     defer { exsqlite3_free(buffer) }
-    return NativeArrayBuffer.copy(of: buffer, count: Int(size))
+    return ArrayBuffer.copy(of: buffer, count: Int(size))
   }
 
-  private func sessionCreateInvertedChangeset(database: NativeDatabase, session: NativeSession) throws -> NativeArrayBuffer {
+  private func sessionCreateInvertedChangeset(database: NativeDatabase, session: NativeSession) throws -> ArrayBuffer {
     do {
       let changeset = try sessionCreateChangeset(database: database, session: session)
       return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
@@ -804,7 +804,7 @@ public final class SQLiteModule: Module {
     }
   }
 
-  private func sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: some AnyArrayBuffer) throws -> NativeArrayBuffer {
+  private func sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: some AnyArrayBuffer) throws -> ArrayBuffer {
     try maybeThrowForClosedDatabase(database)
     return try changeset.withUnsafeBytes {
       let inBuffer = UnsafeMutableRawPointer(mutating: $0.baseAddress)
@@ -815,10 +815,10 @@ public final class SQLiteModule: Module {
         throw SQLiteErrorException(convertSqlLiteErrorToString(database))
       }
       guard let outBuffer else {
-        return NativeArrayBuffer.allocate(size: 0)
+        return ArrayBuffer.allocate(size: 0)
       }
       defer { exsqlite3_free(outBuffer) }
-      return NativeArrayBuffer.copy(of: outBuffer, count: Int(outSize))
+      return ArrayBuffer.copy(of: outBuffer, count: Int(outSize))
     }
   }
 }


### PR DESCRIPTION
# Why

The new unified `ArrayBuffer` type in expo-modules-core (from the parent PR #47106 ) replaces the old `ArrayBuffer` Kotlin interface with a concrete class. expo-sqlite used the old interface as a parameter type in internal helpers and used `NativeArrayBuffer`/`JavaScriptArrayBuffer` directly in module definitions - these no longer compile against the new type hierarchy.

# How

- Replace dall `NativeArrayBuffer` and `JavaScriptArrayBuffer` parameter types in module definitions with the unified `ArrayBuffer` type (Android and iOS).
- Updated private helper return types and constructors from `NativeArrayBuffer` to `ArrayBuffer`.
- On iOS this is just a rename (`NativeArrayBuffer` is a typealias), to keep naming consistent.

# Test Plan

- Run test-suite - both iOS and Android (CRUD, blob read/write, changeset apply/invert).
- Verify blob columns are returned correctly as `ArrayBuffer` instances.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)