### PR TITLE
fix(expo-module-scripts): Add `ignoreDynamic` to ignore `import()` statements

### DIFF
--- a/packages/expo-module-scripts/bin/expo-build
+++ b/packages/expo-module-scripts/bin/expo-build
@@ -108,9 +108,9 @@ function createBuildHost(baseDir, inputDir, outDir, typecheck) {
 async function transformSources(files, srcDir, outDir, format, writeFileIfChanged, opts) {
   const moduleConfig =
     format === 'cjs'
-      ? { type: 'commonjs', lazy: true, importInterop: 'swc', exportInteropAnnotation: true }
+      ? { type: 'commonjs', lazy: true, ignoreDynamic: true, importInterop: 'swc', exportInteropAnnotation: true }
       : format === 'script'
-        ? { type: 'commonjs', strict: true, strictMode: false, noInterop: true }
+        ? { type: 'commonjs', strict: true, ignoreDynamic: true, strictMode: false, noInterop: true }
         : { type: 'es6' };
 
   await Promise.all(


### PR DESCRIPTION
Follow-up to #46801

The `import()` downleveling is a regression and not desirable. `import()` is usually used in CLI/Node code for us, and also has special semantics in Metro. Neither require this to be transpiled/downleveled to `require` in CommonJS and is well supported in Node, and has special semantics.