### PR TITLE
[ios][camera] Use isFastCapturePrioritizationEnabled if available

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Enabled responsive capture and fast capture prioritization on iOS for lower shutter lag and faster successive photo captures.
+
 ### 🐛 Bug fixes
 
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -132,6 +132,9 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     } else {
       self.cleanupMovieFileCapture(withSessionConfiguration: false)
       self.updateSessionPreset(preset: delegate.pictureSize.toCapturePreset(), withSessionConfiguration: false)
+      if let photoOutput {
+        self.configureResponsiveCapture(photoOutput)
+      }
     }
   }
 
@@ -360,6 +363,16 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     return AVCaptureDevice.default(for: .video) != nil
   }
 
+  private func configureResponsiveCapture(_ photoOutput: AVCapturePhotoOutput) {
+    guard #available(iOS 17.0, *), photoOutput.isResponsiveCaptureSupported else {
+      return
+    }
+    photoOutput.isResponsiveCaptureEnabled = true
+    if photoOutput.isFastCapturePrioritizationSupported {
+      photoOutput.isFastCapturePrioritizationEnabled = true
+    }
+  }
+
   private func startSession() {
     guard hasAvailableCameraDevice else {
       return
@@ -389,6 +402,8 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     ? delegate.videoQuality.toPreset()
     : delegate.pictureSize.toCapturePreset()
     updateSessionPreset(preset: preset, withSessionConfiguration: false)
+
+    configureResponsiveCapture(photoOutput)
 
     session.commitConfiguration()
     addErrorNotification()


### PR DESCRIPTION
# Why

On iOS 17 and later, AVCapturePhotoOutput can reduce shutter lag and sustain higher capture rates by enabling responsive capture and fast capture prioritization. expo-camera was not opting into either, so rapid successive captures could lag or drop quality.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

After creating the photo output in CameraSessionManager, enable responsive capture when the active configuration supports it, and then fast capture prioritization on top of it. Zero shutter lag is already enabled automatically for apps linked against iOS 17, so responsive capture is the actual new lever here. Gated to iOS 17, and applied during session configuration.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare expo