### PR TITLE
[ios][camera] Use AVCaptureDevice.RotationCoordinator

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 🐛 Bug fixes
 
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
+- Host the iOS camera preview on the view's backing layer so it no longer zooms into place on launch. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
+- Replace the deprecated `videoOrientation` API with `AVCaptureDevice.RotationCoordinator` for the iOS camera preview. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -21,7 +21,7 @@ protocol CameraSessionManagerDelegate: AnyObject {
   var barcodeScanner: BarcodeScanner? { get }
 
   func emitAvailableLenses()
-  func changePreviewOrientation()
+  func configurePreviewRotation()
 }
 
 class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
@@ -336,6 +336,7 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     defer {
       session.commitConfiguration()
       delegate.emitAvailableLenses()
+      delegate.configurePreviewRotation()
     }
     if let captureDeviceInput {
       session.removeInput(captureDeviceInput)
@@ -407,7 +408,7 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
 
     session.commitConfiguration()
     addErrorNotification()
-    delegate.changePreviewOrientation()
+    delegate.configurePreviewRotation()
     delegate.barcodeScanner?.maybeStartBarcodeScanning()
     updateCameraIsActive()
     DispatchQueue.main.async { [weak delegate] in

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -17,9 +17,20 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   internal var permissionsManager: EXPermissionsInterface?
 
   internal var barcodeScanner: BarcodeScanner?
-  internal lazy var previewLayer = AVCaptureVideoPreviewLayer(session: self.session)
+
+  public override class var layerClass: AnyClass {
+    AVCaptureVideoPreviewLayer.self
+  }
+
+  internal var previewLayer: AVCaptureVideoPreviewLayer {
+    // swiftlint:disable:next force_cast
+    layer as! AVCaptureVideoPreviewLayer
+  }
 
   internal var physicalOrientation: UIDeviceOrientation = .unknown
+  // Typed as Any? because AVCaptureDevice.RotationCoordinator is iOS 17+.
+  private var rotationCoordinator: Any?
+  private var previewRotationObservation: NSKeyValueObservation?
   private var motionManager: CMMotionManager = {
     let mm = CMMotionManager()
     mm.accelerometerUpdateInterval = 0.2
@@ -173,9 +184,10 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   }
 
   private func setupPreview() {
-    previewLayer = AVCaptureVideoPreviewLayer(session: sessionManager.session)
+    previewLayer.session = sessionManager.session
     previewLayer.videoGravity = .resizeAspectFill
     previewLayer.needsDisplayOnBoundsChange = true
+    // backgroundColor = .black
   }
 
   public func onAppForegrounded() {
@@ -288,15 +300,10 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     videoRecording.toggleRecording(videoFileOutput: videoFileOutput)
   }
 
-  public override func layoutSubviews() {
-    super.layoutSubviews()
-    self.backgroundColor = .black
-    previewLayer.frame = self.bounds
-    if previewLayer.superlayer == nil {
-      self.layer.insertSublayer(previewLayer, at: 0)
-    } else if previewLayer.superlayer !== self.layer {
-      previewLayer.removeFromSuperlayer()
-      self.layer.insertSublayer(previewLayer, at: 0)
+  public override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      configurePreviewRotation()
     }
   }
 
@@ -309,6 +316,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     lifecycleManager?.unregisterAppLifecycleListener(self)
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+    previewRotationObservation?.invalidate()
+    previewRotationObservation = nil
+    rotationCoordinator = nil
   }
 
   func stopRecording() {
@@ -324,10 +334,58 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   }
 
   @objc func orientationChanged() {
-    changePreviewOrientation()
+    // On iOS 17+ the RotationCoordinator's KVO drives preview rotation; the legacy
+    // notification path is only needed on iOS 16.
+    if #available(iOS 17.0, *) {
+      return
+    }
+    applyLegacyPreviewOrientation()
   }
 
-  func changePreviewOrientation() {
+  func configurePreviewRotation() {
+    if #available(iOS 17.0, *) {
+      Task { @MainActor in
+        self.setUpRotationCoordinator()
+      }
+    } else {
+      applyLegacyPreviewOrientation()
+    }
+  }
+
+  @available(iOS 17.0, *)
+  private func setUpRotationCoordinator() {
+    previewRotationObservation?.invalidate()
+    previewRotationObservation = nil
+
+    guard let device = sessionManager.currentDevice else {
+      rotationCoordinator = nil
+      return
+    }
+
+    let coordinator = AVCaptureDevice.RotationCoordinator(device: device, previewLayer: previewLayer)
+    rotationCoordinator = coordinator
+    applyPreviewRotationAngle(from: coordinator)
+
+    previewRotationObservation = coordinator.observe(
+      \.videoRotationAngleForHorizonLevelPreview,
+      options: [.new]
+    ) { [weak self] coordinator, _ in
+      self?.applyPreviewRotationAngle(from: coordinator)
+    }
+  }
+
+  @available(iOS 17.0, *)
+  private func applyPreviewRotationAngle(from coordinator: AVCaptureDevice.RotationCoordinator) {
+    guard let connection = previewLayer.connection else {
+      return
+    }
+    let angle = coordinator.videoRotationAngleForHorizonLevelPreview
+    if connection.isVideoRotationAngleSupported(angle) {
+      connection.videoRotationAngle = angle
+    }
+  }
+
+  private func applyLegacyPreviewOrientation() {
     // We shouldn't access the device orientation anywhere but on the main thread
     Task { @MainActor in
       let videoOrientation = ExpoCameraUtils.videoOrientation(for: deviceOrientation)
@@ -355,6 +413,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   }
 
   deinit {
+    previewRotationObservation?.invalidate()
     motionManager.stopAccelerometerUpdates()
     photoCapture.cleanup()
     videoRecording.cleanup()


### PR DESCRIPTION
# Why

Two preview correctness issues. The preview was hosted by inserting an AVCaptureVideoPreviewLayer as a manually managed sublayer and syncing its frame in layoutSubviews, which was a workaround for an older new-arch crash. That manual frame handling caused the preview to scale into place on launch and is not the recommended way to host a preview. Separately, the orientation code relied on videoOrientation, which is deprecated as of iOS 17.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Override layerClass on CameraView so the view's own backing layer is the AVCaptureVideoPreviewLayer, matching the pattern already used by ExpoBlurView and GLView. This removes the manually inserted sublayer and the layoutSubviews frame syncing, so the preview no longer zooms into place and React Native overlays render correctly on top. The original crash was caused by adding a child view, not by overriding layerClass.

Drive the preview connection's rotation with AVCaptureDevice.RotationCoordinator on iOS 17 and later, reading videoRotationAngleForHorizonLevelPreview and updating it through a key value observation. The existing videoOrientation path remains as the iOS 16 fallback. The coordinator is rebuilt when the device changes and when the view enters a window.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare expo