### PR TITLE
[ios][camera] Try to improve startup performance

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Host the iOS camera preview on the view's backing layer so it no longer zooms into place on launch. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 - Replace the deprecated `videoOrientation` API with `AVCaptureDevice.RotationCoordinator` for the iOS camera preview. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix dark frames and the preview rotating into place on iOS launch by fully configuring the camera session before it starts running. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
+- Default the iOS camera `pictureSize` to `photo` instead of `high`. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -73,6 +73,10 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     View(CameraView.self) {
       Events(cameraEvents)
 
+      OnViewDidUpdateProps { (view: CameraView) in
+        view.startSessionIfNeeded()
+      }
+
       Prop("facing") { (view, type: CameraType?) in
         if let type, view.presetCamera != type.toPosition() {
           view.presetCamera = type.toPosition()
@@ -117,8 +121,8 @@ public final class CameraViewModule: Module, ScannerResultHandler {
           view.pictureSize = pictureSize
           return
         }
-        if pictureSize == nil && view.pictureSize != .high {
-          view.pictureSize = .high
+        if pictureSize == nil && view.pictureSize != .photo {
+          view.pictureSize = .photo
         }
       }
 

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -332,6 +332,10 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
       return
     }
 
+    if captureDeviceInput?.device.uniqueID == device.uniqueID {
+      return
+    }
+
     session.beginConfiguration()
     defer {
       session.commitConfiguration()
@@ -410,10 +414,6 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     addErrorNotification()
     delegate.configurePreviewRotation()
     delegate.barcodeScanner?.maybeStartBarcodeScanning()
-    updateCameraIsActive()
-    DispatchQueue.main.async { [weak delegate] in
-      delegate?.onCameraReady()
-    }
     enableTorch()
   }
 }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -31,6 +31,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   // Typed as Any? because AVCaptureDevice.RotationCoordinator is iOS 17+.
   private var rotationCoordinator: Any?
   private var previewRotationObservation: NSKeyValueObservation?
+  private var didStartSession = false
   private var motionManager: CMMotionManager = {
     let mm = CMMotionManager()
     mm.accelerometerUpdateInterval = 0.2
@@ -97,7 +98,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     }
   }
 
-  var pictureSize = PictureSize.high {
+  var pictureSize = PictureSize.photo {
     didSet {
       updatePictureSize()
     }
@@ -187,7 +188,22 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     previewLayer.session = sessionManager.session
     previewLayer.videoGravity = .resizeAspectFill
     previewLayer.needsDisplayOnBoundsChange = true
-    // backgroundColor = .black
+  }
+
+  func startSessionIfNeeded() {
+    guard !didStartSession else {
+      return
+    }
+    didStartSession = true
+    sessionQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+      self.sessionManager.updateCameraIsActive()
+      DispatchQueue.main.async {
+        self.onCameraReady()
+      }
+    }
   }
 
   public func onAppForegrounded() {
@@ -304,6 +320,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     super.didMoveToWindow()
     if window != nil {
       configurePreviewRotation()
+      startSessionIfNeeded()
     }
   }
 


### PR DESCRIPTION
# Why

On launch the camera showed dark frames and the preview visibly rotated into its final position. The root cause was a capture session reconfiguration on a running session during launch. The session was configured and started in init, and the iOS default pictureSize was high while the value the JS applies maps to photo. So every launch the session preset was reconfigured from high to photo after the session had already started running. Reconfiguring a running session tears down and rebuilds the capture pipeline, which both blanked the preview for a moment (the dark frames) and re-established it (the rotate into place).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Default the iOS pictureSize to photo so it matches the value the JS layer applies. The preset is now correct at initial configuration and the prop becomes a no op, so the session is no longer reconfigured while running. As supporting cleanups, the session is now started once after the first batch of props is applied rather than in init, so any remaining launch configuration happens while the session is stopped, and the capture device is no longer re-added when it has not actually changed.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare expo