### PR TITLE
[expo-type-information] Add support for Int backed enums

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -176,8 +176,17 @@ class TestRecordClass: Record {
   var field2: String
 }
 
-enum TestEnum {
+enum TestEnum: String {
   case simpleCase
   case multipleCases1, multipleCases2
   case caseWithArgs1(Int, Double, String), caseWithArgs2(Double, String, Either<Int, String>)
+}
+
+enum IntBackedEnum1: Int {
+  case simpleCase
+  case multipleCases1, multipleCases2
+}
+
+enum IntBackedEnum2: Something, Int, SomethingElse {
+  case simpleCase
 }

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -40,6 +40,14 @@ export enum TestEnum {
   caseWithArgs1 = 'caseWithArgs1',
   caseWithArgs2 = 'caseWithArgs2'
 }
+export enum IntBackedEnum1 {
+  simpleCase,
+  multipleCases1,
+  multipleCases2
+}
+export enum IntBackedEnum2 {
+  simpleCase
+}
 
 export declare class TestClassWithConstructor {
   constructor(a: number);
@@ -220,6 +228,8 @@ import { requireNativeModule, NativeModule } from 'expo';
 
 import {
   TestEnum,
+  IntBackedEnum1,
+  IntBackedEnum2,
   TestRecord,
   TestRecord2,
   TestRecordClass,
@@ -318,6 +328,14 @@ export enum TestEnum {
   caseWithArgs1 = 'caseWithArgs1',
   caseWithArgs2 = 'caseWithArgs2'
 }
+export enum IntBackedEnum1 {
+  simpleCase,
+  multipleCases1,
+  multipleCases2
+}
+export enum IntBackedEnum2 {
+  simpleCase
+}
 
 export declare class TestClassWithConstructor {
   constructor(a: number);
@@ -414,6 +432,14 @@ export enum TestEnum {
     caseWithArgs1 = "caseWithArgs1",
     caseWithArgs2 = "caseWithArgs2"
 }
+export enum IntBackedEnum1 {
+    simpleCase,
+    multipleCases1,
+    multipleCases2
+}
+export enum IntBackedEnum2 {
+    simpleCase
+}
 
 
 export function SimpleFunction(a: number, b: number): number { return 0; }
@@ -482,6 +508,16 @@ export var TestEnum;
     TestEnum["caseWithArgs1"] = "caseWithArgs1";
     TestEnum["caseWithArgs2"] = "caseWithArgs2";
 })(TestEnum || (TestEnum = {}));
+export var IntBackedEnum1;
+(function (IntBackedEnum1) {
+    IntBackedEnum1[IntBackedEnum1["simpleCase"] = 0] = "simpleCase";
+    IntBackedEnum1[IntBackedEnum1["multipleCases1"] = 1] = "multipleCases1";
+    IntBackedEnum1[IntBackedEnum1["multipleCases2"] = 2] = "multipleCases2";
+})(IntBackedEnum1 || (IntBackedEnum1 = {}));
+export var IntBackedEnum2;
+(function (IntBackedEnum2) {
+    IntBackedEnum2[IntBackedEnum2["simpleCase"] = 0] = "simpleCase";
+})(IntBackedEnum2 || (IntBackedEnum2 = {}));
 export function SimpleFunction(a, b) { return 0; }
 export function TestUntypedFunction() { return ""; }
 export function TestUnicodeCharacters() { return; }
@@ -545,6 +581,14 @@ export enum TestEnum {
   multipleCases2 = 'multipleCases2',
   caseWithArgs1 = 'caseWithArgs1',
   caseWithArgs2 = 'caseWithArgs2'
+}
+export enum IntBackedEnum1 {
+  simpleCase,
+  multipleCases1,
+  multipleCases2
+}
+export enum IntBackedEnum2 {
+  simpleCase
 }
 
 export declare class TestClassWithConstructor {
@@ -642,6 +686,8 @@ export default _default;
 exports[`Same type information 1`] = `
 {
   "declaredTypeIdentifiersList": [
+    "IntBackedEnum1",
+    "IntBackedEnum2",
     "TestBasicClass",
     "TestClassWithConstructor",
     "TestEmptyClass",
@@ -660,6 +706,23 @@ exports[`Same type information 1`] = `
         "caseWithArgs2",
       ],
       "name": "TestEnum",
+      "stringBacked": true,
+    },
+    {
+      "cases": [
+        "simpleCase",
+        "multipleCases1",
+        "multipleCases2",
+      ],
+      "name": "IntBackedEnum1",
+      "stringBacked": false,
+    },
+    {
+      "cases": [
+        "simpleCase",
+      ],
+      "name": "IntBackedEnum2",
+      "stringBacked": false,
     },
   ],
   "inferredTypeParametersCountList": [
@@ -1458,6 +1521,34 @@ exports[`Same type information 1`] = `
   ],
   "typeIdentifierDefinitionList": [
     [
+      "IntBackedEnum1",
+      {
+        "definition": {
+          "cases": [
+            "simpleCase",
+            "multipleCases1",
+            "multipleCases2",
+          ],
+          "name": "IntBackedEnum1",
+          "stringBacked": false,
+        },
+        "kind": 1,
+      },
+    ],
+    [
+      "IntBackedEnum2",
+      {
+        "definition": {
+          "cases": [
+            "simpleCase",
+          ],
+          "name": "IntBackedEnum2",
+          "stringBacked": false,
+        },
+        "kind": 1,
+      },
+    ],
+    [
       "TestEnum",
       {
         "definition": {
@@ -1469,6 +1560,7 @@ exports[`Same type information 1`] = `
             "caseWithArgs2",
           ],
           "name": "TestEnum",
+          "stringBacked": true,
         },
         "kind": 1,
       },

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -694,10 +694,12 @@ function parseEnumStructure(enumStructure: Structure): EnumType {
     .flatMap((sub) => sub['key.substructure'])
     .map((sub) => sub['key.name'].split('(', 1)[0])
     .filter((enumcase) => enumcase !== undefined);
+  const stringBacked = !enumStructure['key.inheritedtypes']?.find((v) => v['key.name'] === 'Int');
 
   return {
     name: enumStructure['key.name'],
     cases: enumcases,
+    stringBacked,
   };
 }
 

--- a/packages/expo-type-information/src/typeInformation.ts
+++ b/packages/expo-type-information/src/typeInformation.ts
@@ -54,6 +54,7 @@ export type EnumCase = string;
  */
 export type EnumType = {
   name: string;
+  stringBacked: boolean;
   cases: EnumCase[];
 };
 

--- a/packages/expo-type-information/src/typescriptGeneration.ts
+++ b/packages/expo-type-information/src/typescriptGeneration.ts
@@ -735,7 +735,10 @@ export function buildEnumTypeDeclaration(
     constructModifiersArray({ exported, declare: declared }),
     enumType.name,
     enumType.cases.map((enumcase) =>
-      ts.factory.createEnumMember(enumcase, ts.factory.createStringLiteral(enumcase))
+      ts.factory.createEnumMember(
+        enumcase,
+        enumType.stringBacked ? ts.factory.createStringLiteral(enumcase) : undefined
+      )
     )
   );
 }


### PR DESCRIPTION
# Why

Currently for enums we always generate string cases that match the case name, which is incorrect as:
- somtimes enums are Int backed
- sometimes there are explicit initializers of enum cases

# How
Added support for int backed enums, the check is based on whether the enum inherits from Int or not. Changed the TypeScript generation code to emit cases without initializers then.

# Test Plan
- [x] Added new tests, updated snapshots
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
