### PR TITLE
[cli] ref: maybeRealpathSync helper

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bump to `@expo/ws-tunnel@^2.0.0` ([#46696](https://github.com/expo/expo/pull/46696) by [@kitten](https://github.com/kitten))
 - [Internal] Update logbox imports ([#46640](https://github.com/expo/expo/pull/46640) by [@kitten](https://github.com/kitten))
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
+- [Internal] Unify the sync realpath helper and make fallback handling explicit. ([#47175](https://github.com/expo/expo/pull/47175) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/src/export/publicFolder.ts
+++ b/packages/@expo/cli/src/export/publicFolder.ts
@@ -1,19 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 
-import { copyAsync, isPathInside } from '../utils/dir';
+import { copyAsync, isPathInside, maybeRealpathSync } from '../utils/dir';
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 
 const debug = require('debug')('expo:public-folder') as typeof console.log;
-
-const maybeRealpath = (target: string) => {
-  try {
-    return fs.realpathSync(target);
-  } catch {
-    return target;
-  }
-};
 
 /**
  * Resolve `EXPO_PUBLIC_FOLDER` against the project root and ensure the result
@@ -23,7 +15,8 @@ const maybeRealpath = (target: string) => {
  * that serves or copies the public folder.
  */
 export function getPublicFolderPath(projectRoot: string): string {
-  const publicPath = maybeRealpath(path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER));
+  const unresolvedPublicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  const publicPath = maybeRealpathSync(unresolvedPublicPath) ?? unresolvedPublicPath;
   if (!isPathInside(publicPath, projectRoot)) {
     throw new CommandError(
       'EXPO_PUBLIC_FOLDER',

--- a/packages/@expo/cli/src/start/server/DevToolsPlugin.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPlugin.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import type { WebSocketServer } from 'ws';
 
 import type { DevToolsPluginInfo } from './DevToolsPlugin.schema';
@@ -10,15 +9,7 @@ import {
   loadRequestHandlerAsync,
   loadWebSocketServerAsync,
 } from './DevToolsPluginServerHelpers';
-import { isPathInside } from '../../utils/dir';
-
-const maybeRealpath = (target: string): string => {
-  try {
-    return fs.realpathSync(target);
-  } catch {
-    return target;
-  }
-};
+import { isPathInside, maybeRealpathSync } from '../../utils/dir';
 
 export type { DevToolsPluginRequestHandler } from './DevToolsPluginServerHelpers';
 
@@ -46,7 +37,7 @@ export class DevToolsPlugin {
     }
 
     if (plugin.webpageRoot != null) {
-      const webpageRoot = maybeRealpath(plugin.webpageRoot);
+      const webpageRoot = maybeRealpathSync(plugin.webpageRoot) ?? plugin.webpageRoot;
       if (!isPathInside(webpageRoot, plugin.packageRoot)) {
         throw new Error(
           `webpageRoot (${plugin.webpageRoot}) is not inside packageRoot (${plugin.packageRoot}).`
@@ -55,7 +46,8 @@ export class DevToolsPlugin {
     }
 
     if (plugin.serverEntryPoint != null) {
-      const serverEntryPoint = maybeRealpath(plugin.serverEntryPoint);
+      const serverEntryPoint =
+        maybeRealpathSync(plugin.serverEntryPoint) ?? plugin.serverEntryPoint;
       if (!isPathInside(serverEntryPoint, plugin.packageRoot)) {
         throw new Error(
           `serverEntryPoint (${plugin.serverEntryPoint}) is not inside packageRoot (${plugin.packageRoot}).`

--- a/packages/@expo/cli/src/utils/dir.ts
+++ b/packages/@expo/cli/src/utils/dir.ts
@@ -60,6 +60,14 @@ export const removeAsync = (path: string): Promise<void> => {
   });
 };
 
+export function maybeRealpathSync(target: string): string | null {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return null;
+  }
+}
+
 export function isPathInside(child: string, parent: string): boolean {
   const relative = path.relative(parent, child);
   return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);


### PR DESCRIPTION
Unifies the sync realpath helper implementation in utils and aligns the name with the actual implementation. Fallback behavior is now explicit via null handling.