### PR TITLE
[file-system] Fix FileHandle security-scoped access / non-SAF support

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support.
+
 ### 💡 Others
 
 - Improve read/write performance on Android by applying `withContext(Dispatchers.IO)` when possible. ([#46376](https://github.com/expo/expo/pull/46376) by [@wh201906](https://github.com/wh201906))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support.
+- Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support. ([#47176](https://github.com/expo/expo/pull/47176) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
@@ -32,6 +32,13 @@ internal class UnableToReadHandleException(reason: String) :
 internal class UnableToWriteHandleException(reason: String) :
   CodedException("Unable to write to a file handle: '$reason'")
 
+internal class UnsupportedContentUriReadWriteException :
+  CodedException(
+    "READ_WRITE mode is not supported for content:// URIs. " +
+      "Content providers may not support simultaneous read and write access. " +
+      "Use READ or WRITE mode instead."
+  )
+
 internal class MissingAppContextException :
   CodedException("The app context is missing.")
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -73,15 +73,24 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
     return when (fileImpl) {
       is JavaFile -> FileSystemFileHandle.forJavaFile(fileImpl, resolvedMode)
       is SAFDocumentFile -> FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
-      is ContentProviderFile -> try {
-        FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
-      } catch (e: Exception) {
-        throw Exceptions.IllegalStateException(
-          "Failed to open file handle for content:// URI: ${fileImpl.uri}. " +
-            "The content provider may not support random access. " +
-            "Try reading the file using File.text() or File.bytes() instead. " +
-            "Cause: ${e.message}"
-        )
+      is ContentProviderFile -> {
+        if (resolvedMode == FileMode.READ_WRITE) {
+          throw Exceptions.IllegalArgument(
+            "READ_WRITE mode is not supported for content:// URIs. " +
+              "Content providers may not support simultaneous read and write access. " +
+              "Use READ or WRITE mode instead."
+          )
+        }
+        try {
+          FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
+        } catch (e: Exception) {
+          throw Exceptions.IllegalStateException(
+            "Failed to open file handle for content:// URI: ${fileImpl.uri}. " +
+              "The content provider may not support random access. " +
+              "Try reading the file using File.text() or File.bytes() instead.",
+            e
+          )
+        }
       }
       else -> throw Exceptions.IllegalStateException("File handle is not supported for ${file.uri}")
     }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem
 
 import android.net.Uri
 import android.util.Base64
+import expo.modules.filesystem.unifiedfile.ContentProviderFile
 import expo.modules.filesystem.unifiedfile.JavaFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.kotlin.exception.Exceptions
@@ -62,13 +63,26 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun openHandle(mode: FileMode?): FileSystemFileHandle {
     val fileImpl = file
-    val resolvedMode = mode ?: if (fileImpl is SAFDocumentFile) FileMode.READ else FileMode.READ_WRITE
+    val resolvedMode = mode ?: when (fileImpl) {
+      is SAFDocumentFile, is ContentProviderFile -> FileMode.READ
+      else -> FileMode.READ_WRITE
+    }
     for (permission in resolvedMode.requiredPermissions()) {
       validatePermission(permission)
     }
     return when (fileImpl) {
       is JavaFile -> FileSystemFileHandle.forJavaFile(fileImpl, resolvedMode)
       is SAFDocumentFile -> FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
+      is ContentProviderFile -> try {
+        FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
+      } catch (e: Exception) {
+        throw Exceptions.IllegalStateException(
+          "Failed to open file handle for content:// URI: ${fileImpl.uri}. " +
+            "The content provider may not support random access. " +
+            "Try reading the file using File.text() or File.bytes() instead. " +
+            "Cause: ${e.message}"
+        )
+      }
       else -> throw Exceptions.IllegalStateException("File handle is not supported for ${file.uri}")
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -75,11 +75,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
       is SAFDocumentFile -> FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
       is ContentProviderFile -> {
         if (resolvedMode == FileMode.READ_WRITE) {
-          throw Exceptions.IllegalArgument(
-            "READ_WRITE mode is not supported for content:// URIs. " +
-              "Content providers may not support simultaneous read and write access. " +
-              "Use READ or WRITE mode instead."
-          )
+          throw UnsupportedContentUriReadWriteException()
         }
         try {
           FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.Enumerable
@@ -51,7 +52,8 @@ enum class FileMode(val descriptor: String) : Enumerable {
 
 class FileSystemFileHandle private constructor(
   channel: FileChannel,
-  private val mode: FileMode
+  private val mode: FileMode,
+  private val parcelFileDescriptor: ParcelFileDescriptor? = null
 ) : SharedRef<FileChannel>(channel), AutoCloseable {
   companion object {
     fun forJavaFile(file: File, mode: FileMode): FileSystemFileHandle {
@@ -72,6 +74,14 @@ class FileSystemFileHandle private constructor(
     }
 
     fun forContentURI(uri: Uri, mode: FileMode, contentResolver: ContentResolver): FileSystemFileHandle {
+      if (mode == FileMode.READ_WRITE) {
+        throw Exceptions.IllegalArgument(
+          "READ_WRITE mode is not supported for content:// URIs. " +
+            "Content providers may not support simultaneous read and write access. " +
+            "Use READ or WRITE mode instead."
+        )
+      }
+
       val pfd = contentResolver.openFileDescriptor(uri, mode.descriptor)
         ?: throw Exceptions.IllegalStateException("Could not open file descriptor for uri: $uri")
 
@@ -81,7 +91,7 @@ class FileSystemFileHandle private constructor(
         else -> throw Exceptions.IllegalArgument("Unsupported file mode: '$mode'")
       }
 
-      return FileSystemFileHandle(channel, mode)
+      return FileSystemFileHandle(channel, mode, pfd)
     }
   }
 
@@ -99,6 +109,7 @@ class FileSystemFileHandle private constructor(
 
   override fun close() {
     fileChannel.close()
+    parcelFileDescriptor?.close()
   }
 
   fun read(length: Long): ByteArray {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -74,14 +74,6 @@ class FileSystemFileHandle private constructor(
     }
 
     fun forContentURI(uri: Uri, mode: FileMode, contentResolver: ContentResolver): FileSystemFileHandle {
-      if (mode == FileMode.READ_WRITE) {
-        throw Exceptions.IllegalArgument(
-          "READ_WRITE mode is not supported for content:// URIs. " +
-            "Content providers may not support simultaneous read and write access. " +
-            "Use READ or WRITE mode instead."
-        )
-      }
-
       val pfd = contentResolver.openFileDescriptor(uri, mode.descriptor)
         ?: throw Exceptions.IllegalStateException("Could not open file descriptor for uri: $uri")
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -108,8 +108,11 @@ class FileSystemFileHandle private constructor(
   }
 
   override fun close() {
-    fileChannel.close()
-    parcelFileDescriptor?.close()
+    try {
+      fileChannel.close()
+    } finally {
+      parcelFileDescriptor?.close()
+    }
   }
 
   fun read(length: Long): ByteArray {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -74,6 +74,10 @@ class FileSystemFileHandle private constructor(
     }
 
     fun forContentURI(uri: Uri, mode: FileMode, contentResolver: ContentResolver): FileSystemFileHandle {
+      if (mode == FileMode.READ_WRITE) {
+        throw UnsupportedContentUriReadWriteException()
+      }
+
       val pfd = contentResolver.openFileDescriptor(uri, mode.descriptor)
         ?: throw Exceptions.IllegalStateException("Could not open file descriptor for uri: $uri")
 

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -70,6 +70,30 @@ class FileSystemFileTest {
   }
 
   @Test
+  fun openHandleRejectsReadWriteForSAFContentUriBeforeOpeningProvider() {
+    val file = FileSystemFile(Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADownload"))
+      .withAppContext(permissionServiceReturning(EnumSet.allOf(FilePermissionService.Permission::class.java)))
+
+    val exception = assertThrows(UnsupportedContentUriReadWriteException::class.java) {
+      file.openHandle(FileMode.READ_WRITE)
+    }
+
+    assertTrue(exception.message?.contains("READ_WRITE mode is not supported for content:// URIs") == true)
+  }
+
+  @Test
+  fun openHandleRejectsReadWriteForGenericContentUriBeforeOpeningProvider() {
+    val file = FileSystemFile(Uri.parse("content://expo-file-system-test-provider/file.txt"))
+      .withAppContext(permissionServiceReturning(EnumSet.allOf(FilePermissionService.Permission::class.java)))
+
+    val exception = assertThrows(UnsupportedContentUriReadWriteException::class.java) {
+      file.openHandle(FileMode.READ_WRITE)
+    }
+
+    assertTrue(exception.message?.contains("READ_WRITE mode is not supported for content:// URIs") == true)
+  }
+
+  @Test
   fun deleteRequiresWritePermissionBeforeDeletingFile() {
     val source = temporaryFolder.newFile("delete-target.txt")
     val file = FileSystemFile(Uri.fromFile(source))

--- a/packages/expo-file-system/ios/FileSystemFileHandle.swift
+++ b/packages/expo-file-system/ios/FileSystemFileHandle.swift
@@ -28,6 +28,7 @@ internal final class FileSystemFileHandle: SharedRef<FileHandle> {
   let mode: FileMode
   let handle: FileHandle
   private let didAccessSecurityScope: Bool
+  private var isClosed = false
 
   init(file: FileSystemFile, mode: FileMode?) throws {
     self.file = file
@@ -82,6 +83,8 @@ internal final class FileSystemFileHandle: SharedRef<FileHandle> {
   }
 
   func close() throws {
+    guard !isClosed else { return }
+    isClosed = true
     defer {
       if didAccessSecurityScope {
         file.url.stopAccessingSecurityScopedResource()

--- a/packages/expo-file-system/ios/FileSystemFileHandle.swift
+++ b/packages/expo-file-system/ios/FileSystemFileHandle.swift
@@ -27,22 +27,32 @@ internal final class FileSystemFileHandle: SharedRef<FileHandle> {
   let file: FileSystemFile
   let mode: FileMode
   let handle: FileHandle
+  private let didAccessSecurityScope: Bool
 
   init(file: FileSystemFile, mode: FileMode?) throws {
     self.file = file
     self.mode = mode ?? FileMode.readWrite
-    if self.mode.readOnly {
-      handle = try FileHandle(forReadingFrom: file.url)
-    } else if self.mode.writeOnly {
-      handle = try FileHandle(forWritingTo: file.url)
-    } else {
-      handle = try FileHandle(forUpdating: file.url)
-    }
+    self.didAccessSecurityScope = file.url.startAccessingSecurityScopedResource()
 
-    if self.mode == FileMode.append {
-      _ = try handle.seekToEnd()
-    } else if self.mode == FileMode.truncate {
-      try handle.truncate(atOffset: 0)
+    do {
+      if self.mode.readOnly {
+        handle = try FileHandle(forReadingFrom: file.url)
+      } else if self.mode.writeOnly {
+        handle = try FileHandle(forWritingTo: file.url)
+      } else {
+        handle = try FileHandle(forUpdating: file.url)
+      }
+
+      if self.mode == FileMode.append {
+        _ = try handle.seekToEnd()
+      } else if self.mode == FileMode.truncate {
+        try handle.truncate(atOffset: 0)
+      }
+    } catch {
+      if self.didAccessSecurityScope {
+        file.url.stopAccessingSecurityScopedResource()
+      }
+      throw error
     }
 
     super.init(handle)
@@ -69,6 +79,9 @@ internal final class FileSystemFileHandle: SharedRef<FileHandle> {
 
   func close() throws {
     try handle.close()
+    if didAccessSecurityScope {
+      file.url.stopAccessingSecurityScopedResource()
+    }
   }
 
   var offset: UInt64? {

--- a/packages/expo-file-system/ios/FileSystemFileHandle.swift
+++ b/packages/expo-file-system/ios/FileSystemFileHandle.swift
@@ -77,11 +77,17 @@ internal final class FileSystemFileHandle: SharedRef<FileHandle> {
     try handle.write(contentsOf: bytes)
   }
 
+  override func sharedObjectDidRelease() {
+    try? close()
+  }
+
   func close() throws {
-    try handle.close()
-    if didAccessSecurityScope {
-      file.url.stopAccessingSecurityScopedResource()
+    defer {
+      if didAccessSecurityScope {
+        file.url.stopAccessingSecurityScopedResource()
+      }
     }
+    try handle.close()
   }
 
   var offset: UInt64? {


### PR DESCRIPTION
# Why

`FileSystemFileHandle` on iOS leaked security-scoped resource access by never calling `stopAccessingSecurityScopedResource()`, and Android leaked `ParcelFileDescriptor` instances when opening `content://` URIs. Additionally, `content://` URIs from non-SAF content providers could not be opened as file handles at all.

# How

- **iOS:** Track whether `startAccessingSecurityScopedResource()` succeeded, stop access when the handle is closed or released, and clean up on init failure before rethrowing. Make `close()` idempotent so release-time cleanup is safe.
- **Android:** Store the `ParcelFileDescriptor` and close it alongside the `FileChannel`. Default SAF and generic `content://` file handles to read-only mode when no mode is provided. Reject `READ_WRITE` mode for `content://` URIs via a dedicated `UnsupportedContentUriReadWriteException`, since content providers may not support simultaneous access. Add `ContentProviderFile` support to `openHandle()` with a helpful error if the provider does not support random access.
- **Tests:** Extend the existing `FileSystemFileTest` Robolectric suite to cover early `READ_WRITE` rejection for both SAF and generic `content://` URIs.

# Test Plan

- Android unit tests
- Manual checks:
    - On iOS, use `FileSystemFileHandle` to open a security-scoped file, for example from document picker, read/write, then close. Confirm no resource access leak via Instruments or debug logs.
    - On Android, open a `content://` URI file handle in READ mode, read contents, close. Verify no `ParcelFileDescriptor` leak warnings in logcat.
    - On Android, attempt `READ_WRITE` mode on a `content://` URI. Expect a clear unsupported-mode error.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)