### PR TITLE
[gh][docs] Add docs upstream script

### DIFF
--- a/.github/workflows/docs-upstream-sync.yml
+++ b/.github/workflows/docs-upstream-sync.yml
@@ -1,0 +1,63 @@
+name: Docs Upstream Sync
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 8 * * *' # 8:00 AM UTC daily
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    if: github.repository == 'expo/expo'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: 🏗️ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - name: 📦 Install workspace deps
+        run: pnpm install --ignore-scripts --frozen-lockfile
+      - name: 🔄 Run upstream sync
+        id: sync
+        working-directory: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          result="$(pnpm --silent upstream-sync | tail -n1)"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+      - name: 📝 Create Pull Request
+        if: ${{ fromJSON(steps.sync.outputs.result).hasChanged }}
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          branch: bot/docs-upstream-sync
+          base: main
+          commit-message: ${{ fromJSON(steps.sync.outputs.result).commitMessage }}
+          title: ${{ fromJSON(steps.sync.outputs.result).title }}
+          body: ${{ fromJSON(steps.sync.outputs.result).body }}
+          labels: docs
+          delete-branch: true
+          committer: Expo Bot <expo-bot@users.noreply.github.com>
+          author: Expo Bot <expo-bot@users.noreply.github.com>
+          reviewers: amandeepmittal
+      - name: 🔔 Notify on Slack
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.slack_webhook_docs }}
+          channel: '#docs'
+          author_name: Docs upstream sync

--- a/docs/.oxfmtrc.json
+++ b/docs/.oxfmtrc.json
@@ -28,6 +28,7 @@
     "public",
     "pages/versions/latest",
     "next-env.d.ts",
-    "ui/components/EASCLIReference/data/eas-cli-commands.json"
+    "ui/components/EASCLIReference/data/eas-cli-commands.json",
+    "components/plugins/permissions/data/android.json"
   ]
 }

--- a/docs/.oxlintrc.json
+++ b/docs/.oxlintrc.json
@@ -22,6 +22,7 @@
     "**/out",
     "**/public",
     "pages/versions/latest",
+    "components/plugins/permissions/data/android.json",
     "scripts/generate-llms/talks.js",
     "types/global.d.ts",
     "README.md",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,8 @@
     "expo-skills-sync": "node --experimental-strip-types ./ui/components/ExpoSkillsTable/sync-expo-skills.js",
     "expo-mcp-sync": "node --experimental-strip-types ./ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js",
     "install-vale": "node --experimental-strip-types scripts/install-vale.ts",
-    "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale"
+    "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale",
+    "upstream-sync": "node --experimental-strip-types ./scripts/upstream-sync.ts"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/docs/scripts/upstream-sync.ts
+++ b/docs/scripts/upstream-sync.ts
@@ -47,12 +47,14 @@ for (const { label, script } of SYNCS) {
   }
 }
 
+const TIMESTAMP_FIELDS = ['fetchedAt', 'scrapedAt'];
+
 const changed: string[] = [];
 for (const { code, file } of status()) {
   const realDiff = git('diff', '--', file)
     .split('\n')
     .filter(line => /^[+-]/.test(line) && !/^(\+{3}|-{3})/.test(line))
-    .some(line => !line.includes('fetchedAt'));
+    .some(line => !TIMESTAMP_FIELDS.some(field => line.includes(field)));
   if (code.includes('?') || realDiff) {
     changed.push(file);
   } else {

--- a/docs/scripts/upstream-sync.ts
+++ b/docs/scripts/upstream-sync.ts
@@ -1,0 +1,78 @@
+// Runs the CI-safe upstream-sync generators, drops timestamp-only noise, and prints a JSON
+// summary the docs-upstream-sync workflow uses to raise a PR. Run: pnpm upstream-sync
+
+import { execFileSync, execSync } from 'node:child_process';
+import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SYNCS = [
+  { label: '@expo/ui component tables', script: 'generate-ui-component-tables', match: 'ExpoUI' },
+  { label: 'App config schema', script: 'schema-sync', match: 'schemas/' },
+  { label: 'Expo Skills', script: 'expo-skills-sync', match: 'ExpoSkillsTable' },
+  { label: 'EAS CLI reference', script: 'eas-cli-sync', match: 'EASCLIReference' },
+  { label: 'Android permissions', script: 'permissions-sync-android', match: 'permissions' },
+];
+
+const docsDir = process.cwd();
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  cwd: docsDir,
+  encoding: 'utf8',
+}).trim();
+const self = relative(root, fileURLToPath(import.meta.url));
+
+const git = (...args: string[]) =>
+  execFileSync('git', args, { cwd: root, encoding: 'utf8' }).replace(/\n+$/, '');
+
+const status = () =>
+  git('status', '--porcelain')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => ({ code: line.slice(0, 2), file: line.slice(3) }))
+    .filter(entry => entry.file !== self);
+
+if (status().length) {
+  console.error(
+    'Working tree is not clean; commit or stash first so changes can be attributed to a sync.'
+  );
+  process.exit(1);
+}
+
+const failed: string[] = [];
+for (const { label, script } of SYNCS) {
+  console.error(`Running ${script}`);
+  try {
+    execSync(`pnpm ${script}`, { cwd: docsDir, stdio: 'pipe' });
+  } catch {
+    failed.push(label);
+  }
+}
+
+const changed: string[] = [];
+for (const { code, file } of status()) {
+  const realDiff = git('diff', '--', file)
+    .split('\n')
+    .filter(line => /^[+-]/.test(line) && !/^(\+{3}|-{3})/.test(line))
+    .some(line => !line.includes('fetchedAt'));
+  if (code.includes('?') || realDiff) {
+    changed.push(file);
+  } else {
+    git('checkout', '--', file);
+  }
+}
+
+const sources = [
+  ...new Set(changed.map(f => SYNCS.find(s => f.includes(s.match))?.label ?? 'other')),
+].sort();
+const title = sources.length
+  ? `[docs] Sync upstream reference content (${sources.join(', ')})`
+  : '[docs] Sync upstream reference content';
+const body = [
+  'Automated upstream sync of generated reference content.',
+  ...(sources.length ? ['', '## Synced', ...sources.map(s => `- ${s}`)] : []),
+  ...(changed.length ? ['', '## Files', ...changed.map(f => `- \`${f}\``)] : []),
+  ...(failed.length ? ['', '## Generators that failed', ...failed.map(f => `- ${f}`)] : []),
+].join('\n');
+
+process.stdout.write(
+  JSON.stringify({ hasChanged: changed.length > 0, title, commitMessage: title, body })
+);


### PR DESCRIPTION
# Why

Fix ENG-22049

# How

- Adds a scheduled `Docs Upstream Sync` GitHub Action that runs the CI-safe generators daily through a new `pnpm upstream-sync` script (`docs/scripts/upstream-sync.ts`), which reverts `fetchedAt`-only timestamp noise and prints a JSON summary.

- The `expo-mcp-sync` generator is excluded since it needs an interactive OAuth flow. 

- The generated `permissions/data/android.json` is added to the `oxfmt`/`oxlint` ignore lists.

# Test Plan

N/A

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).