### PR TITLE
fix(cli): Fix `LogStream#destroy` racing close with pending writes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))
 - Remove `@expo/metro-config` install from `expo customize metro.config.js` ([#46600](https://github.com/expo/expo/pull/46600) by [@kitten](https://github.com/kitten))
 - Place static entries last in serialized HTML output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
+- [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/events/__tests__/stream-test.ts
+++ b/packages/@expo/cli/src/events/__tests__/stream-test.ts
@@ -46,6 +46,51 @@ describe('basic write operations', () => {
     expect(await fs.promises.readFile(destFile, 'utf8')).toBe('hello world\n');
   });
 
+  it('flushes an in-flight write before destroying', async () => {
+    const realWrite = fs.write.bind(fs);
+    const spy = jest.spyOn(fs, 'write').mockImplementation((...args: any[]) => {
+      setTimeout(() => (realWrite as any)(...args), 50);
+    });
+
+    try {
+      const stream = new LogStream(destFD);
+      const _close = new Promise((resolve) => stream.on('close', resolve));
+
+      stream.write('hello world\n');
+      stream.destroy();
+
+      await _close;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(await fs.promises.readFile(destFile, 'utf8')).toBe('hello world\n');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('drops queued lines when destroying mid-write', async () => {
+    const realWrite = fs.write.bind(fs);
+    const spy = jest.spyOn(fs, 'write').mockImplementation((...args: any[]) => {
+      setTimeout(() => (realWrite as any)(...args), 50);
+    });
+
+    try {
+      const stream = new LogStream(destFD);
+      const _close = new Promise((resolve) => stream.on('close', resolve));
+
+      // The first write goes in-flight; the rest queue behind it under backpressure.
+      stream.write('first\n');
+      stream.write('second\n');
+      stream.write('third\n');
+      stream.destroy();
+
+      await _close;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(await fs.promises.readFile(destFile, 'utf8')).toBe('first\n');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('writes twice then ends a stream', async () => {
     const stream = new LogStream(destFD);
     const _close = new Promise((resolve) => stream.on('close', resolve));

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -22,6 +22,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
   #writing = false;
   #ending = false;
+  #closing = false;
   #flushPending = false;
   #destroyed = false;
   #opening = false;
@@ -76,7 +77,11 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         this.#len -= this.#output.length;
         this.#output = '';
 
-        if (this.#lines.length - this.#head > this.#partialLine) {
+        if (this.#closing && !this.#ending) {
+          // destroy(): the in-flight write has landed, drop any queued lines and close
+          this.#writing = false;
+          this.#close();
+        } else if (this.#lines.length - this.#head > this.#partialLine) {
           this.#writeLine();
         } else if (this.#ending) {
           this.#writing = false;
@@ -99,7 +104,12 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
           this.#output = '';
         }
 
-        if (this.#output || this.#lines.length - this.#head > this.#partialLine) {
+        if (this.#output) {
+          this.#writeLine();
+        } else if (this.#closing && !this.#ending) {
+          this.#writing = false;
+          this.#close();
+        } else if (this.#lines.length - this.#head > this.#partialLine) {
           this.#writeLine();
         } else if (this.#ending) {
           this.#writing = false;
@@ -131,6 +141,8 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         this.emit('ready');
         if (this.#destroyed) {
           // do nothing when we're already closing the file
+        } else if (this.#closing) {
+          this.#close();
         } else if (
           (!this.writing && this.#lines.length - this.#head > this.#partialLine) ||
           this.#flushPending
@@ -235,7 +247,12 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
   }
 
   destroy() {
-    if (!this.#destroyed) this.#close();
+    if (this.#destroyed || this.#closing) {
+    } else if (this.#writing || this.#opening) {
+      this.#closing = true;
+    } else {
+      this.#close();
+    }
   }
 
   flush(cb?: (error?: Error | null) => void) {

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -78,7 +78,6 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         this.#output = '';
 
         if (this.#closing && !this.#ending) {
-          // destroy(): the in-flight write has landed, drop any queued lines and close
           this.#writing = false;
           this.#close();
         } else if (this.#lines.length - this.#head > this.#partialLine) {
@@ -248,6 +247,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
   destroy() {
     if (this.#destroyed || this.#closing) {
+      // already closing/destroyed
     } else if (this.#writing || this.#opening) {
       this.#closing = true;
     } else {


### PR DESCRIPTION
## Summary

On CI, there's occasional failures from the test that exercises `LogStream#destroy`. Since this doesn't wait for pending writes to be flushed, we could get into syscall races, where the `close` would be flushed from the event loop before a pending write. This then fails the write with `EBADF`.

The test checks whether the last write flushed, but when the data race case happens, it won't be written or flushed to disk.

> [!NOTE]
> There's no need to backport this since our code doesn't use `LogStream#destroy` yet and it's just there for completeness.

## Set of changes

- Delay `destroy` for pending writes