### PR TITLE
[expo-type-information] Add static method handling

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -105,6 +105,12 @@ public class TestModule: Module {
       AsyncFunction("TestAsyncFunction") { (a: Int) async -> String in 
         "string"
       }
+
+      StaticAsyncFunction("TestStaticAsyncFunction") { (a: String) async -> Void in }
+
+      StaticFunction("TestStaticFunction") { () async -> String in 
+        "string"
+      }
     }
 
     Class(TestEmptyClass.self) {

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -45,7 +45,9 @@ export declare class TestClassWithConstructor {
   constructor(a: number);
 }
 export declare class TestBasicClass {
+  static TestStaticFunction(): string;
   TestAsyncFunction(a: number): Promise<string>;
+  static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
   readonly TestEnumProperty: TestEnum;
@@ -323,7 +325,9 @@ export declare class TestClassWithConstructor {
   constructor(a: number);
 }
 export declare class TestBasicClass {
+  static TestStaticFunction(): string;
   TestAsyncFunction(a: number): Promise<string>;
+  static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
   readonly TestEnumProperty: TestEnum;
@@ -445,7 +449,9 @@ export class TestClassWithConstructor {
     constructor(a: number) { }
 }
 export class TestBasicClass {
+    static TestStaticFunction(): string { return ""; }
     async TestAsyncFunction(a: number): Promise<string> { return ""; }
+    async static TestStaticAsyncFunction(a: string): Promise<void> { }
     constructor(a: number, b: string, c: string | TestRecord) { }
 }
 export class TestEmptyClass {
@@ -499,7 +505,9 @@ export class TestClassWithConstructor {
     constructor(a) { }
 }
 export class TestBasicClass {
+    static TestStaticFunction() { return ""; }
     async TestAsyncFunction(a) { return ""; }
+    async static TestStaticAsyncFunction(a) { }
     constructor(a, b, c) { }
 }
 export class TestEmptyClass {
@@ -551,7 +559,9 @@ export declare class TestClassWithConstructor {
   constructor(a: number);
 }
 export declare class TestBasicClass {
+  static TestStaticFunction(): string;
   TestAsyncFunction(a: number): Promise<string>;
+  static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
   readonly TestEnumProperty: TestEnum;
@@ -697,6 +707,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 2481,
+          "isStatic": false,
           "name": "TestSimpleAsyncFunction",
           "parameters": [],
           "returnType": {
@@ -725,6 +736,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 2672,
+          "isStatic": false,
           "name": "TestUnderscore",
           "parameters": [],
           "returnType": {
@@ -766,11 +778,31 @@ exports[`Same type information 1`] = `
                 },
               ],
               "definitionOffset": 3340,
+              "isStatic": false,
               "name": "TestAsyncFunction",
               "parameters": [],
               "returnType": {
                 "kind": 0,
                 "type": 1,
+              },
+            },
+            {
+              "arguments": [
+                {
+                  "name": "a",
+                  "type": {
+                    "kind": 0,
+                    "type": 1,
+                  },
+                },
+              ],
+              "definitionOffset": 3438,
+              "isStatic": true,
+              "name": "TestStaticAsyncFunction",
+              "parameters": [],
+              "returnType": {
+                "kind": 0,
+                "type": 4,
               },
             },
           ],
@@ -813,7 +845,19 @@ exports[`Same type information 1`] = `
             "definitionOffset": 2900,
           },
           "definitionOffset": 2864,
-          "methods": [],
+          "methods": [
+            {
+              "arguments": [],
+              "definitionOffset": 3525,
+              "isStatic": true,
+              "name": "TestStaticFunction",
+              "parameters": [],
+              "returnType": {
+                "kind": 0,
+                "type": 1,
+              },
+            },
+          ],
           "name": "TestBasicClass",
           "properties": [
             {
@@ -865,7 +909,7 @@ exports[`Same type information 1`] = `
         {
           "asyncMethods": [],
           "constructor": null,
-          "definitionOffset": 3442,
+          "definitionOffset": 3623,
           "methods": [],
           "name": "TestEmptyClass",
           "properties": [],
@@ -923,6 +967,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 510,
+          "isStatic": false,
           "name": "SimpleFunction",
           "parameters": [],
           "returnType": {
@@ -933,6 +978,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 674,
+          "isStatic": false,
           "name": "TestUntypedFunction",
           "parameters": [],
           "returnType": {
@@ -943,6 +989,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 818,
+          "isStatic": false,
           "name": "TestUnicodeCharacters",
           "parameters": [],
           "returnType": {
@@ -953,6 +1000,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 1008,
+          "isStatic": false,
           "name": "TestUntypedFunction2",
           "parameters": [],
           "returnType": {
@@ -963,6 +1011,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 1172,
+          "isStatic": false,
           "name": "TestUntypedFunction3",
           "parameters": [],
           "returnType": {
@@ -984,6 +1033,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 1338,
+          "isStatic": false,
           "name": "TestArrays",
           "parameters": [],
           "returnType": {
@@ -1042,6 +1092,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 1497,
+          "isStatic": false,
           "name": "TestDictionaries",
           "parameters": [],
           "returnType": {
@@ -1132,6 +1183,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 1694,
+          "isStatic": false,
           "name": "TestParametrizedTypes",
           "parameters": [],
           "returnType": {
@@ -1159,6 +1211,7 @@ exports[`Same type information 1`] = `
             },
           ],
           "definitionOffset": 1938,
+          "isStatic": false,
           "name": "TestTypeCombinations",
           "parameters": [],
           "returnType": {
@@ -1196,6 +1249,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 2139,
+          "isStatic": false,
           "name": "TestFunctionReturningRecord",
           "parameters": [],
           "returnType": {
@@ -1206,6 +1260,7 @@ exports[`Same type information 1`] = `
         {
           "arguments": [],
           "definitionOffset": 2304,
+          "isStatic": false,
           "name": "TestFunctionReturningEnum",
           "parameters": [],
           "returnType": {
@@ -1223,7 +1278,7 @@ exports[`Same type information 1`] = `
           "classes": [],
           "constants": [],
           "constructor": null,
-          "definitionOffset": 3505,
+          "definitionOffset": 3686,
           "events": [
             "onEvent1",
             "onEvent2",
@@ -1249,7 +1304,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3551,
+              "definitionOffset": 3732,
               "name": "url",
             },
             {
@@ -1269,7 +1324,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3735,
+              "definitionOffset": 3916,
               "name": "testRecord",
             },
             {
@@ -1289,7 +1344,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3806,
+              "definitionOffset": 3987,
               "name": "testRecord2",
             },
             {
@@ -1309,7 +1364,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3880,
+              "definitionOffset": 4061,
               "name": "testRecordClass",
             },
             {
@@ -1329,7 +1384,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3966,
+              "definitionOffset": 4147,
               "name": "testEnum",
             },
           ],

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -560,7 +560,8 @@ async function parseModuleClassStructure(
 async function parseModuleFunctionSubstructure(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  options: SwiftFileTypeInformationOptions,
+  isStatic: boolean
 ): Promise<FunctionDeclaration> {
   const definitionParams = substructure['key.substructure'];
   const nameSubstrucutre = definitionParams[0];
@@ -582,6 +583,7 @@ async function parseModuleFunctionSubstructure(
     parameters: [], // TODO(@HubertBer): Module function is not generic. I think so. Check it
     arguments: types?.parameters?.map(mapSourcekittenParameterToType) ?? [],
     definitionOffset: substructure['key.offset'],
+    isStatic,
   };
 }
 
@@ -780,7 +782,7 @@ async function parseModuleStructure(
       }
       case 'Function': {
         moduleClassDeclaration.functions.push(
-          await parseModuleFunctionSubstructure(structure, file, options)
+          await parseModuleFunctionSubstructure(structure, file, options, false)
         );
         break;
       }
@@ -805,7 +807,17 @@ async function parseModuleStructure(
       }
       case 'AsyncFunction':
         moduleClassDeclaration.asyncFunctions.push(
-          await parseModuleFunctionSubstructure(structure, file, options)
+          await parseModuleFunctionSubstructure(structure, file, options, false)
+        );
+        break;
+      case 'StaticAsyncFunction':
+        moduleClassDeclaration.asyncFunctions.push(
+          await parseModuleFunctionSubstructure(structure, file, options, true)
+        );
+        break;
+      case 'StaticFunction':
+        moduleClassDeclaration.functions.push(
+          await parseModuleFunctionSubstructure(structure, file, options, true)
         );
         break;
       case 'Constructor':

--- a/packages/expo-type-information/src/typeInformation.ts
+++ b/packages/expo-type-information/src/typeInformation.ts
@@ -171,6 +171,7 @@ export type FunctionDeclaration = {
   returnType: Type;
   arguments: Argument[];
   parameters: Type[];
+  isStatic: boolean;
 } & DefinitionOffset;
 
 /**

--- a/packages/expo-type-information/src/typescriptGeneration.ts
+++ b/packages/expo-type-information/src/typescriptGeneration.ts
@@ -31,6 +31,7 @@ const exportModifier = () => ts.factory.createModifier(ts.SyntaxKind.ExportKeywo
 const declareModifier = () => ts.factory.createModifier(ts.SyntaxKind.DeclareKeyword);
 const asyncModifier = () => ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword);
 const readonlyModifier = () => ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword);
+const staticModifier = () => ts.factory.createModifier(ts.SyntaxKind.StaticKeyword);
 const constModifier = () => ts.factory.createModifier(ts.SyntaxKind.ConstKeyword);
 const defaultModifier = () => ts.factory.createModifier(ts.SyntaxKind.DefaultKeyword);
 
@@ -108,12 +109,14 @@ function constructModifiersArray(modifiers: {
   declare?: boolean;
   async?: boolean;
   readonly?: boolean;
+  isStatic?: boolean;
 }): ts.Modifier[] {
   const modifiersArray: ts.Modifier[] = [];
   if (modifiers.exported) modifiersArray.push(exportModifier());
   if (modifiers.declare) modifiersArray.push(declareModifier());
   if (modifiers.async) modifiersArray.push(asyncModifier());
   if (modifiers.readonly) modifiersArray.push(readonlyModifier());
+  if (modifiers.isStatic) modifiersArray.push(staticModifier());
   return modifiersArray;
 }
 
@@ -579,7 +582,11 @@ export function buildFunction({
   overrideArgumentDeclarations,
   omitReturnType,
 }: buildFunctionOptions): ts.FunctionDeclaration | ts.MethodDeclaration {
-  const functionModifiers = constructModifiersArray({ exported, async: async && !declaration });
+  const functionModifiers = constructModifiersArray({
+    exported,
+    async: async && !declaration,
+    isStatic: functionDeclaration.isStatic,
+  });
   const customReturn = !!returnStatement;
   const bareReturnTypeNode = mapTypeToTsTypeNode(functionDeclaration.returnType);
 


### PR DESCRIPTION
# Why
`StaticAsyncFunction` and `StaticFunction` weren't supported by the `expo-type-information` package.
# How
Added `isStatic` field to FunctionDeclaration type. Now parsing Swift `StaticAsyncFunction` and `StaticFunction`, and emmiting TypeScript for them.
# Test Plan
- [x] Tested manually on contacts/next package
- [x] updated tests and regenerated snapshots
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
