### PR TITLE
chore(cli): Bump to `dnssd-advertise@^1.1.6`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Internal] Update logbox imports ([#46640](https://github.com/expo/expo/pull/46640) by [@kitten](https://github.com/kitten))
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
 - [Internal] Unify the sync realpath helper and make fallback handling explicit. ([#47175](https://github.com/expo/expo/pull/47175) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Bump to `dnssd-advertise@^1.1.6` ([#47183](https://github.com/expo/expo/pull/47183) by [@kitten](https://github.com/kitten))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -86,7 +86,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
-    "dnssd-advertise": "^1.1.4",
+    "dnssd-advertise": "^1.1.6",
     "expo-server": "workspace:^56.0.4",
     "fetch-nodeshim": "^0.4.10",
     "getenv": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1915,8 +1915,8 @@ importers:
         specifier: ^4.3.4
         version: 4.4.3
       dnssd-advertise:
-        specifier: ^1.1.4
-        version: 1.1.4
+        specifier: ^1.1.6
+        version: 1.1.6
       expo:
         specifier: '*'
         version: link:../../expo
@@ -10735,8 +10735,8 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  dnssd-advertise@1.1.4:
-    resolution: {integrity: sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==}
+  dnssd-advertise@1.1.6:
+    resolution: {integrity: sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -19685,7 +19685,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dnssd-advertise@1.1.4: {}
+  dnssd-advertise@1.1.6: {}
 
   doctrine@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

This force-bumps all users, mainly to resolve two issues with network device changes, in case users haven't manually updated transitive deps.
- https://github.com/kitten/dnssd-advertise/releases/tag/v1.1.5
- https://github.com/kitten/dnssd-advertise/releases/tag/v1.1.6

## Set of changes

- Bump to `dnssd-advertise@^1.1.6`