### PR TITLE
[docs] Improve Tabs and left sidebar scroll container

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -151,7 +151,10 @@ export default function DocumentationNestedScrollLayout({
             'max-lg:overflow-auto',
             isMobileMenuVisible && 'hidden'
           )}>
-          <ScrollContainer ref={contentRef} scrollHandler={scrollHandler}>
+          <ScrollContainer
+            ref={contentRef}
+            scrollHandler={scrollHandler}
+            className="[scrollbar-gutter:stable]">
             <div
               className={mergeClasses(
                 'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out will-change-[padding,max-width,margin]',

--- a/docs/ui/components/Tabs/Tab.tsx
+++ b/docs/ui/components/Tabs/Tab.tsx
@@ -1,3 +1,5 @@
 import { TabPanel, TabPanelProps } from '@reach/tabs';
 
-export const Tab = (props: TabPanelProps) => <TabPanel {...props} />;
+export const Tab = ({ label: _label, ...props }: TabPanelProps & { label?: string }) => (
+  <TabPanel {...props} />
+);

--- a/docs/ui/components/Tabs/Tabs.test.tsx
+++ b/docs/ui/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { renderToStaticMarkup as toStaticMarkup } from 'react-dom/server.node';
+import { IntlProvider } from 'react-intl';
+
+import { Tab } from './Tab';
+import { Tabs } from './Tabs';
+
+function ssr(element: React.ReactElement) {
+  const markup = toStaticMarkup(<IntlProvider locale="en">{element}</IntlProvider>);
+  const doc = new DOMParser().parseFromString(markup, 'text/html');
+  return { markup, doc };
+}
+
+describe('Tabs server rendering', () => {
+  it('hides inactive panels on the server so there is no layout shift on hydration', () => {
+    const { doc } = ssr(
+      <Tabs>
+        <Tab label="One">PanelOne</Tab>
+        <Tab label="Two">PanelTwo</Tab>
+        <Tab label="Three">PanelThree</Tab>
+      </Tabs>
+    );
+
+    const panels = [...doc.querySelectorAll('[data-reach-tab-panel]')];
+    expect(panels).toHaveLength(3);
+
+    const byText = (text: string) => panels.find(p => p.textContent?.includes(text));
+    expect(byText('PanelOne')?.hasAttribute('hidden')).toBe(false);
+    expect(byText('PanelTwo')?.hasAttribute('hidden')).toBe(true);
+    expect(byText('PanelThree')?.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('keeps every panel in the server markup (preserves SEO/a11y)', () => {
+    const { markup } = ssr(
+      <Tabs>
+        <Tab label="One">PanelOne</Tab>
+        <Tab label="Two">PanelTwo</Tab>
+      </Tabs>
+    );
+    expect(markup).toContain('PanelOne');
+    expect(markup).toContain('PanelTwo');
+  });
+
+  it('gives each panel a unique id on the server', () => {
+    const { doc } = ssr(
+      <Tabs>
+        <Tab label="One">PanelOne</Tab>
+        <Tab label="Two">PanelTwo</Tab>
+      </Tabs>
+    );
+    const ids = [...doc.querySelectorAll('[data-reach-tab-panel]')].map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -1,14 +1,16 @@
 import { mergeClasses } from '@expo/styleguide';
-import { TabList, TabPanels, Tabs as ReachTabs, TabsProps } from '@reach/tabs';
+import { TabList, TabPanelProps, TabPanels, Tabs as ReachTabs, TabsProps } from '@reach/tabs';
 import {
   Children,
   Fragment,
   PropsWithChildren,
   ReactElement,
+  cloneElement,
   isValidElement,
   useState,
   useContext,
   ReactNode,
+  useId,
   useMemo,
 } from 'react';
 
@@ -21,7 +23,7 @@ type Props = PropsWithChildren<TabsProps> & {
   tabs?: string[];
 };
 
-type TabChild = ReactElement<{ label?: string }>;
+type TabChild = ReactElement<TabPanelProps & { label?: string; hidden?: boolean }>;
 
 const collectTabPanels = (nodes: ReactNode): TabChild[] => {
   const panels: TabChild[] = [];
@@ -67,10 +69,7 @@ const InnerTabs = ({
   const tabPanels = useMemo(() => collectTabPanels(children), [children]);
   const tabTitles = tabs?.length === tabPanels.length ? tabs : generateTabLabels(tabPanels);
 
-  const layoutId = useMemo(
-    () => tabTitles.reduce((acc, tab) => acc + tab, `${Math.random().toString(36).slice(5)}-`),
-    []
-  );
+  const layoutId = useId();
 
   return (
     <ReachTabs
@@ -90,7 +89,9 @@ const InnerTabs = ({
             '[&_figure:first-child]:mt-1 [&_pre:first-child]:mt-1',
             '[&>div>*:last-child]:mb-0!'
           )}>
-          {tabPanels}
+          {tabPanels.map((panel, index) =>
+            cloneElement(panel, { key: index, index, hidden: index !== tabIndex })
+          )}
         </TabPanels>
       </InsideTabsContext.Provider>
     </ReachTabs>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22029

# How

<!--
How did you build this feature or fix this bug and why?
-->

# How

- Collapse inactive `<Tabs>` panels at render instead of after hydration: `Tabs` clones each panel with an explicit `index` and `hidden={index !== tabIndex}` so `@reach/tabs` server-renders only the active panel, and it uses `useId()` for the framer-motion `layoutId` (replacing `Math.random()`, which also fixes a hydration mismatch and duplicate panel `id`s).
- Separately, the content scroll container in `DocumentationNestedScrollLayout` gets `scrollbar-gutter: stable` so the centered article stops shifting horizontally when the scrollbar appears. 
- Adds an SSR test (`Tabs.test.tsx`) asserting inactive panels render `hidden`, every panel's content stays in the server markup, and panel `id`s are unique.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


https://github.com/user-attachments/assets/3e121415-71a0-4fa7-9d2e-9eb7017e06cb


https://github.com/user-attachments/assets/46ea3204-8972-4240-a57f-212c256482a8



Otherwise, see preview. Use a page that uses Tabs heavily, like https://pr-47184.expo-docs.pages.dev/skills/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
