### PR TITLE
[docs] Document workflows Testflight pre-packaged job with non-fastlane approach

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -639,7 +639,7 @@ jobs:
 
 Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
-The job supports two approaches. With `build_id`, you upload an EAS iOS build and distribute it to TestFlight. With `asc_build_id`, you operate on a build that is already in App Store Connect and handle TestFlight beta distribution. This adds the build to groups, sets "What to Test" notes, and submits for Beta App Review. Provide exactly one of `build_id` or `asc_build_id`.
+The job supports two approaches: upload a build and submit it to TestFlight (`build_id`), or submit an already uploaded build (`asc_build_id`). In both cases, you can add the build to groups, set "What to Test" notes, and submit for Beta App Review. Provide exactly one of `build_id` or `asc_build_id`.
 
 <Prerequisites>
   <Requirement title="TestFlight test information for external distribution">
@@ -653,7 +653,7 @@ The job supports two approaches. With `build_id`, you upload an EAS iOS build an
 
 ### Shared parameters
 
-Both paths accept the following parameters in `params`:
+Both approaches accept the following parameters in `params`:
 
 | Parameter          | Type     | Description                                                                                                                                                                                                                                                             |
 | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -662,9 +662,9 @@ Both paths accept the following parameters in `params`:
 | changelog          | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                                                                                                                                                           |
 | submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when `external_groups` are provided, `false` otherwise. Set to `false` to update the changelog or groups on an already-submitted build without re-submitting for Beta App Review. |
 
-### Fastlane approach
+### Upload build and submit to TestFlight
 
-Upload an EAS iOS build to App Store Connect and distribute it to TestFlight using fastlane, all in the same workflow job.
+Upload an EAS iOS build and submit it to TestFlight in a single workflow job.
 
 <Prerequisites>
   <Requirement title="An iOS store build and Apple Developer account">
@@ -766,9 +766,9 @@ jobs:
 
 </Collapsible>
 
-### Direct App Store Connect approach
+### Submit an already uploaded build
 
-Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review. Beta App Review submission is optional. Set `submit_beta_review: false` to update the changelog or groups on an existing build without re-submitting it for review.
+Submit a build that is already in App Store Connect to TestFlight groups, set "What to Test" notes, and submit for Beta App Review. Beta App Review submission is optional. Set `submit_beta_review: false` to update the changelog or groups on an existing build without re-submitting it for review.
 
 <Prerequisites>
   <Requirement title="App Store Connect integration">

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -810,7 +810,7 @@ You can also pass any of the [shared parameters](#shared-parameters).
 
 <Collapsible summary="Auto-distribute to TestFlight after App Store Connect upload">
 
-When a build is uploaded to App Store Connect outside EAS Workflows, this workflow automatically adds the build to TestFlight groups, sets "What to Test" notes, and submits for Beta App Review. Configure your App Store Connect connection before using this trigger. See [Trigger workflows from App Store Connect events](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events).
+When a build is uploaded to App Store Connect, this workflow automatically adds the build to TestFlight groups, sets "What to Test" notes, and submits for Beta App Review. Configure your App Store Connect connection before using this trigger. See [Trigger workflows from App Store Connect events](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events).
 
 `${{ app_store_connect.build_upload.build.id }}` is only available when the workflow is triggered by a `build_upload` event and App Store Connect has associated a build with the upload. `build_upload.state: complete` means the upload finished, not that App Store Connect finished processing the build. When using `external_groups`, complete the required TestFlight test information in App Store Connect first.
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -639,7 +639,7 @@ jobs:
 
 Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
-The job supports two approaches. With `build_id`, you upload an EAS iOS build and distribute it to TestFlight. With `asc_build_id`, you operate on a build that is already in App Store Connect and handle TestFlight beta distribution — adding the build to groups, setting "What to Test" notes, and submitting for Beta App Review. Provide exactly one of `build_id` or `asc_build_id`.
+The job supports two approaches. With `build_id`, you upload an EAS iOS build and distribute it to TestFlight. With `asc_build_id`, you operate on a build that is already in App Store Connect and handle TestFlight beta distribution. This adds the build to groups, sets "What to Test" notes, and submits for Beta App Review. Provide exactly one of `build_id` or `asc_build_id`.
 
 <Prerequisites>
   <Requirement title="TestFlight test information for external distribution">
@@ -768,11 +768,11 @@ jobs:
 
 ### Direct App Store Connect approach
 
-Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review. Beta App Review submission is optional — set `submit_beta_review: false` to update the changelog or groups on an existing build without re-submitting it for review.
+Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review. Beta App Review submission is optional. Set `submit_beta_review: false` to update the changelog or groups on an existing build without re-submitting it for review.
 
 <Prerequisites>
   <Requirement title="App Store Connect integration">
-    Configure your App Store Connect connection in [Project settings >
+    Configure your App Store Connect connection in [Project settings > General >
     Connections](https://expo.dev/accounts/[account]/projects/[project]/settings). The build must
     already exist in App Store Connect and be ready for submission.
   </Requirement>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -768,7 +768,7 @@ jobs:
 
 ### Direct App Store Connect approach
 
-Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review.
+Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review. Beta App Review submission is optional — set `submit_beta_review: false` to update the changelog or groups on an existing build without re-submitting it for review.
 
 <Prerequisites>
   <Requirement title="App Store Connect integration">
@@ -835,6 +835,39 @@ jobs:
         - Public Beta
       changelog: Build from CI
       submit_beta_review: true
+```
+
+</Collapsible>
+
+<Collapsible summary="Update the changelog without re-submitting for Beta App Review">
+
+For a build that already exists in App Store Connect, you can update the "What to Test" notes or group membership without triggering Beta App Review. Set `submit_beta_review: false` to apply the changes while leaving the build's existing review status untouched.
+
+This workflow takes the build ID and new changelog as [manual inputs](/eas/workflows/syntax/#onworkflow_dispatchinputs), so you can run it on demand with `eas workflow:run`.
+
+```yaml .eas/workflows/testflight-update-changelog.yml
+name: Update TestFlight changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      asc_build_id:
+        type: string
+        required: true
+        description: The App Store Connect build ID to update.
+      changelog:
+        type: string
+        required: true
+        description: The new "What to Test" notes.
+
+jobs:
+  update_changelog:
+    name: Update changelog
+    type: testflight
+    params:
+      asc_build_id: ${{ inputs.asc_build_id }}
+      changelog: ${{ inputs.changelog }}
+      submit_beta_review: false
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -639,6 +639,33 @@ jobs:
 
 Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
+The job supports two approaches. With `build_id`, you upload an EAS iOS build and distribute it to TestFlight. With `asc_build_id`, you operate on a build that is already in App Store Connect and handle TestFlight beta distribution — adding the build to groups, setting "What to Test" notes, and submitting for Beta App Review. Provide exactly one of `build_id` or `asc_build_id`.
+
+<Prerequisites>
+  <Requirement title="TestFlight test information for external distribution">
+    When distributing to external groups or submitting for Beta App Review (`external_groups` and/or
+    `submit_beta_review: true`), the build must have the required TestFlight test information
+    completed in App Store Connect before the job can succeed. See [Provide test
+    information](https://developer.apple.com/help/app-store-connect/test-a-beta-version/provide-test-information/)
+    in Apple's documentation.
+  </Requirement>
+</Prerequisites>
+
+### Shared parameters
+
+Both paths accept the following parameters in `params`:
+
+| Parameter          | Type     | Description                                                                                                                                                                                                                                                             |
+| ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.                                                                                                                                  |
+| external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                                                                                                                                              |
+| changelog          | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                                                                                                                                                           |
+| submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when `external_groups` are provided, `false` otherwise. Set to `false` to update the changelog or groups on an already-submitted build without re-submitting for Beta App Review. |
+
+### Fastlane approach
+
+Upload an EAS iOS build to App Store Connect and distribute it to TestFlight using fastlane, all in the same workflow job.
+
 <Prerequisites>
   <Requirement title="An iOS store build and Apple Developer account">
     TestFlight jobs require an iOS build created with `distribution: store` and an Apple Developer
@@ -647,7 +674,7 @@ Distribute iOS builds to TestFlight internal and external testing groups. This i
   </Requirement>
 </Prerequisites>
 
-### Syntax
+#### Syntax
 
 ```yaml
 jobs:
@@ -668,15 +695,13 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter                       | Type     | Description                                                                                                                                 |
-| ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| build_id                        | string   | Required. The ID of the iOS build to distribute.                                                                                            |
-| profile                         | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
-| internal_groups                 | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
-| external_groups                 | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
-| changelog                       | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
-| submit_beta_review              | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
-| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds to wait for App Store Connect build processing. Defaults to `1800` (30 minutes).                               |
+| Parameter                       | Type   | Description                                                                                                                                                           |
+| ------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| build_id                        | string | Required. The ID of the iOS EAS Build to distribute.                                                                                                                  |
+| profile                         | string | Optional. The submit profile to use. Defaults to `production`.                                                                                                        |
+| wait_processing_timeout_seconds | number | Optional. Timeout in seconds to wait for App Store Connect build processing. Defaults to `1800` (30 minutes). Only applies when distributing via groups or changelog. |
+
+You can also pass any of the [shared parameters](#shared-parameters).
 
 #### Outputs
 
@@ -687,7 +712,7 @@ You can reference the following outputs in subsequent jobs:
 | apple_app_id          | string | The Apple App ID of the submitted build.          |
 | ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
 
-### Examples
+#### Examples
 
 Here are some practical examples of using the TestFlight job:
 
@@ -737,6 +762,79 @@ jobs:
       build_id: ${{ needs.build_ios.outputs.build_id }}
       changelog: "${{ github.commit_message || 'Bug fixes' }}"
       # github.commit_message only available in push & schedule events.
+```
+
+</Collapsible>
+
+### Direct App Store Connect approach
+
+Distribute an already uploaded build to TestFlight groups, set "What to Test" notes, and submit for Beta App Review.
+
+<Prerequisites>
+  <Requirement title="App Store Connect integration">
+    Configure your App Store Connect connection in [Project settings >
+    Connections](https://expo.dev/accounts/[account]/projects/[project]/settings). The build must
+    already exist in App Store Connect and be ready for submission.
+  </Requirement>
+</Prerequisites>
+
+#### Syntax
+
+```yaml
+jobs:
+  testflight_distribution:
+    type: testflight
+    params:
+      asc_build_id: string # required
+      internal_groups: string[]
+      external_groups: string[]
+      changelog: string
+      submit_beta_review: boolean
+```
+
+#### Parameters
+
+| Parameter    | Type   | Description                                                           |
+| ------------ | ------ | --------------------------------------------------------------------- |
+| asc_build_id | string | Required. The ID of a build that already exists in App Store Connect. |
+
+You can also pass any of the [shared parameters](#shared-parameters).
+
+#### Outputs
+
+| Output       | Type   | Description                     |
+| ------------ | ------ | ------------------------------- |
+| asc_build_id | string | The App Store Connect build ID. |
+
+#### Examples
+
+<Collapsible summary="Auto-distribute to TestFlight after App Store Connect upload">
+
+When a build is uploaded to App Store Connect outside EAS Workflows, this workflow automatically adds the build to TestFlight groups, sets "What to Test" notes, and submits for Beta App Review. Configure your App Store Connect connection before using this trigger. See [Trigger workflows from App Store Connect events](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events).
+
+`${{ app_store_connect.build_upload.build.id }}` is only available when the workflow is triggered by a `build_upload` event and App Store Connect has associated a build with the upload. `build_upload.state: complete` means the upload finished, not that App Store Connect finished processing the build. When using `external_groups`, complete the required TestFlight test information in App Store Connect first.
+
+```yaml .eas/workflows/testflight-after-asc-upload.yml
+name: Distribute to TestFlight after ASC upload
+
+on:
+  app_store_connect:
+    build_upload:
+      states:
+        - complete
+
+jobs:
+  distribute_to_testflight:
+    name: Distribute to TestFlight
+    type: testflight
+    params:
+      asc_build_id: ${{ app_store_connect.build_upload.build.id }}
+      internal_groups:
+        - QA Team
+      external_groups:
+        - Public Beta
+      changelog: Build from CI
+      submit_beta_review: true
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1295,7 +1295,7 @@ When using the `asc_build_id` path, this job outputs the following properties:
 
 ```json
 {
-  "asc_build_id": string | null, // App Store Connect build ID
+  "asc_build_id": string | null // App Store Connect build ID
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -854,6 +854,23 @@ type AppStoreConnectContext = {
   build_upload?: {
     id: string;
     state: 'awaiting_upload' | 'processing' | 'failed' | 'complete';
+    cf_bundle_version?: string;
+    build?: {
+      id: string;
+    };
+  };
+  app_version?: {
+    id: string;
+    state: string;
+  };
+  external_beta?: {
+    id: string;
+    state: string;
+  };
+  beta_feedback?: {
+    id: string;
+    type: 'crash' | 'screenshot';
+    url: string;
   };
 };
 ```
@@ -878,6 +895,32 @@ jobs:
         Upload complete for App Store Connect app: ${{ app_store_connect.app.id }}
         Upload ID: ${{ app_store_connect.build_upload.id }}
         Upload state: ${{ app_store_connect.build_upload.state }}
+```
+
+Use `build_upload.build.id` as the `asc_build_id` for a `testflight` job:
+
+```yaml .eas/workflows/testflight-after-asc-upload.yml
+name: Distribute to TestFlight after ASC upload
+
+on:
+  app_store_connect:
+    build_upload:
+      states:
+        - complete
+
+jobs:
+  distribute_to_testflight:
+    name: Distribute to TestFlight
+    type: testflight
+    params:
+      asc_build_id: ${{ app_store_connect.build_upload.build.id }}
+      internal_groups:
+        - QA Team
+      external_groups:
+        - Public Beta
+      changelog: |
+        Build ${{ app_store_connect.build_upload.cf_bundle_version }} is ready for testing.
+      submit_beta_review: true
 ```
 
 #### `env`
@@ -1220,7 +1263,7 @@ This job outputs the following properties:
 
 #### `testflight`
 
-Distributes iOS builds to TestFlight internal and external testing groups. See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
+Distributes iOS builds to TestFlight internal and external testing groups. Provide exactly one of `build_id` (EAS Build + fastlane path) or `asc_build_id` (App Store Connect API path). See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -1229,21 +1272,30 @@ jobs:
     type: testflight
     # @end #
     params:
-      build_id: string # required
-      profile: string # optional, default: production
+      build_id: string # required for fastlane path, mutually exclusive with asc_build_id
+      profile: string # optional, default: production; fastlane path only
+      wait_processing_timeout_seconds: number # optional, default: 1800 (30 minutes); fastlane path only
+      asc_build_id: string # required for App Store Connect API path, mutually exclusive with build_id
       internal_groups: string[] # optional
       external_groups: string[] # optional
       changelog: string # optional
       submit_beta_review: boolean # optional
-      wait_processing_timeout_seconds: number # optional, default: 1800 (30 minutes)
 ```
 
-This job outputs the following properties:
+When using the `build_id` path, this job outputs the following properties:
 
 ```json
 {
   "apple_app_id": string | null, // Apple App ID. https://expo.fyi/asc-app-id
   "ios_bundle_identifier": string | null // iOS bundle identifier of the submitted build. https://expo.fyi/bundle-identifier
+}
+```
+
+When using the `asc_build_id` path, this job outputs the following properties:
+
+```json
+{
+  "asc_build_id": string | null, // App Store Connect build ID
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1263,7 +1263,7 @@ This job outputs the following properties:
 
 #### `testflight`
 
-Distributes iOS builds to TestFlight internal and external testing groups. Provide exactly one of `build_id` (EAS Build + fastlane path) or `asc_build_id` (App Store Connect API path). See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
+Distributes iOS builds to TestFlight internal and external testing groups. Provide exactly one of `build_id` (EAS Build and fastlane path) or `asc_build_id` (App Store Connect API path). See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1263,7 +1263,7 @@ This job outputs the following properties:
 
 #### `testflight`
 
-Distributes iOS builds to TestFlight internal and external testing groups. Provide exactly one of `build_id` (EAS Build and fastlane path) or `asc_build_id` (App Store Connect API path). See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
+Distributes iOS builds to TestFlight internal and external testing groups. Provide exactly one of `build_id` (upload a build and submit to TestFlight) or `asc_build_id` (submit an already uploaded build). See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -1272,17 +1272,17 @@ jobs:
     type: testflight
     # @end #
     params:
-      build_id: string # required for fastlane path, mutually exclusive with asc_build_id
-      profile: string # optional, default: production; fastlane path only
-      wait_processing_timeout_seconds: number # optional, default: 1800 (30 minutes); fastlane path only
-      asc_build_id: string # required for App Store Connect API path, mutually exclusive with build_id
+      build_id: string # required to upload and submit to TestFlight; mutually exclusive with asc_build_id
+      profile: string # optional, default: production; only when uploading and submitting
+      wait_processing_timeout_seconds: number # optional, default: 1800 (30 minutes); only when uploading and submitting in one job
+      asc_build_id: string # required to submit an already uploaded build; mutually exclusive with build_id
       internal_groups: string[] # optional
       external_groups: string[] # optional
       changelog: string # optional
       submit_beta_review: boolean # optional
 ```
 
-When using the `build_id` path, this job outputs the following properties:
+When uploading and submitting with `build_id`, this job outputs the following properties:
 
 ```json
 {
@@ -1291,7 +1291,7 @@ When using the `build_id` path, this job outputs the following properties:
 }
 ```
 
-When using the `asc_build_id` path, this job outputs the following properties:
+When submitting an already uploaded build with `asc_build_id`, this job outputs the following properties:
 
 ```json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `testflight` pre-packaged workflow job now supports a second, non-fastlane approach. In addition to the existing `build_id` path (upload an EAS iOS build and distribute via fastlane), you can now pass `asc_build_id` to operate on a build that already exists in App Store Connect and handle TestFlight beta distribution through the App Store Connect API.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Documented the two `testflight` approaches in `pre-packaged-jobs.mdx`:
  - Added a shared-parameters section  used by both paths.
  - Split the job into a "Fastlane approach" (`build_id`) and a "Direct App Store Connect approach" (`asc_build_id`), each with its own syntax, parameters, outputs, and examples.
  - Added a prerequisite callout about completing TestFlight test information for external distribution / Beta App Review.
  - Added an example workflow that auto-distributes to TestFlight on an `app_store_connect` `build_upload` event.
- Updated `syntax.mdx`:
  - Expanded the `AppStoreConnectContext` type with `build_upload.build.id`, `build_upload.cf_bundle_version`, `app_version`, `external_beta`, and `beta_feedback` (this was missing from the interpolation context docs).
  - Documented using `build_upload.build.id` as `asc_build_id`, and clarified the `testflight` job now accepts exactly one of `build_id` or `asc_build_id`, with path-specific params and outputs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="1188" height="1194" alt="Screenshot 2026-06-23 at 15 09 25" src="https://github.com/user-attachments/assets/1abded25-2747-413b-a8cc-10814f48ed3a" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
