### PR TITLE
[docs] Observe is not supported in Expo Go

### DIFF
--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -12,7 +12,7 @@ import { Step } from '~/ui/components/Step';
 
 EAS Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
 
-> **important** EAS Observe is not available in Expo Go because it relies on the `expo-observe` native module. To use it, create a [development build](/develop/development-builds/introduction/) or a production build.
+> **important** EAS Observe is not available in Expo Go because it relies on the `expo-observe` native library. To use it, create a [development build](/develop/development-builds/introduction/) or a production build.
 
 ## Prerequisites
 

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -12,6 +12,8 @@ import { Step } from '~/ui/components/Step';
 
 EAS Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
 
+> **important** EAS Observe is not available in Expo Go because it relies on the `expo-observe` native module. To use it, create a [development build](/develop/development-builds/introduction/) or a production build.
+
 ## Prerequisites
 
 <Prerequisites>

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -92,6 +92,12 @@ EAS Observe supports Android and iOS. Metrics are collected from production buil
 
 </Collapsible>
 
+<Collapsible summary="Is EAS Observe available in Expo Go?">
+
+No. EAS Observe relies on the `expo-observe` native module, which is not included in Expo Go. To use it, create a [development build](/develop/development-builds/introduction/) or a production build.
+
+</Collapsible>
+
 <Collapsible summary="Does EAS Observe collect personally identifiable information?">
 
 No. Users are identified by an anonymous ID that is unique per app installation. This ID is not personally identifiable and is reset if the user uninstalls and reinstalls the app. See [Metrics reference: User](/eas/observe/reference/metrics/#user) for more details.


### PR DESCRIPTION
# Why

We had a report of the app crashing when the user was running Expo Go which made me realise we don't explicitly mention that Expo Go is not supported in the docs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Explicitly document that Observe is not included in Expo Go.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

👀 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
