### PR TITLE
[docs] Replace deprecated bare/managed workflow terminology

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
-`expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates. This guide explains how to set up a bare React Native project for use with [EAS Update](/eas-update/introduction), a hosted remote update service that includes tools to simplify installation and configuration of the `expo-updates` library.
+`expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates. This guide explains how to set up an existing React Native project for use with [EAS Update](/eas-update/introduction), a hosted remote update service that includes tools to simplify installation and configuration of the `expo-updates` library.
 
 <Collapsible summary="Do you use Continuous Native Generation (CNG) in your project?">
 

--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -32,7 +32,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `npx expo-doctor` to diagnose potential issues with your project configuration.
-1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI.
+1. Additional step for projects that use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/): Run `npx expo prebuild` to generate **android** and **ios** directories. This step will use the versioned Expo CLI.
 1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Restore the keystore (if it was included in the build request).
@@ -52,7 +52,7 @@ Next, this is what happens when EAS Build picks up your request:
 
 ## Project auto-configuration
 
-Every time you want to build a new Android app binary, we validate that the project is set up correctly so we can seamlessly run the build process on our servers. This mainly applies to bare projects, but similar steps are run when building managed projects.
+Every time you want to build a new Android app binary, we validate that the project is set up correctly so we can seamlessly run the build process on our servers. This mainly applies to [existing React Native projects](/bare/overview/), but similar steps are run when building projects that use Continuous Native Generation (CNG).
 
 ### Android keystore
 

--- a/docs/pages/build-reference/app-extensions.mdx
+++ b/docs/pages/build-reference/app-extensions.mdx
@@ -3,11 +3,11 @@ title: iOS App Extensions
 description: Learn how to use app extensions with EAS Build to add custom functionality.
 ---
 
-App extensions let you extend custom functionality and content beyond your app and make it available to users while they're interacting with other apps or iOS system functionality. EAS Build provides affordances for including app extensions in both bare and managed projects.
+App extensions let you extend custom functionality and content beyond your app and make it available to users while they're interacting with other apps or iOS system functionality. EAS Build provides affordances for including app extensions in both [existing React Native projects](/bare/overview/) and projects that use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/).
 
-## Managed projects (experimental support)
+## CNG projects (experimental support)
 
-A typical, simple managed project we have a single application target and no app extensions. You can add an app extension to your project by writing a [config plugin](/config-plugins/introduction/) (or using a library that creates an extension with its own config plugin). Config plugins let you add targets to the Xcode project that is generated during the "Prebuild" phase of a build job.
+A typical, simple project that uses Continuous Native Generation (CNG) has a single application target and no app extensions. You can add an app extension to your project by writing a [config plugin](/config-plugins/introduction/) (or using a library that creates an extension with its own config plugin). Config plugins let you add targets to the Xcode project that is generated during the "Prebuild" phase of a build job.
 
 Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` in your app config makes it possible for EAS CLI to know what app extensions exist _before the build starts_ (before the Xcode project has been generated) to ensure that the required credentials are generated and validated. Config plugins are also able to modify the app config, and in most cases, if you are using a library that adds an extension then the config plugin will also add the required configuration to declare the extension in your app config. If you are writing a library, we recommend that you consider this. The following is an example of what this would look like if it were declared directly in **app.json**:
 
@@ -38,6 +38,6 @@ Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` i
 }
 ```
 
-## Bare projects
+## Existing React Native projects
 
-When you build a bare project, EAS CLI will automatically detect app extensions configured in your Xcode project and generate all necessary credentials for each target, or you can provide them in **credentials.json** For more information, see [Multi target project](/app-signing/local-credentials/#multi-target-project).
+When you build an existing React Native project, EAS CLI will automatically detect app extensions configured in your Xcode project and generate all necessary credentials for each target, or you can provide them in **credentials.json** For more information, see [Multi target project](/app-signing/local-credentials/#multi-target-project).

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -107,7 +107,7 @@ To build your project locally in Android Studio or Xcode using the same version 
 
 ### Limitations
 
-- `eas build:version:sync` command on Android does not support bare projects with multiple flavors. However, the rest of the remote versioning functionality should work with all projects.
+- `eas build:version:sync` command on Android does not support [existing React Native projects](/bare/overview/) with multiple flavors. However, the rest of the remote versioning functionality should work with all projects.
 - `autoIncrement` does not support the `version` option.
 - It's not supported if you are using EAS Update and runtime policy set to `"runtimeVersion": { "policy": "nativeVersion" }`. For similar behavior, use the `"appVersion"` policy instead.
 

--- a/docs/pages/build-reference/build-configuration.mdx
+++ b/docs/pages/build-reference/build-configuration.mdx
@@ -45,7 +45,7 @@ The command will create an **eas.json** file in the root directory with the defa
 }
 ```
 
-If you have a bare project, it will look a bit different.
+If you have an [existing React Native project](/bare/overview/), it will look a bit different.
 
 This is your EAS Build configuration. It defines three build profiles named `"development"`, `"preview"`, and `"production"` (you can have multiple build profiles like `"production"`, `"debug"`, `"testing"`, and so on) for each platform. If you want to learn more about **eas.json** see the [Configuration with **eas.json**](/build/eas-json) page.
 
@@ -90,9 +90,9 @@ In the example above, the `eas build --platform android` command prompts to set 
 
 <Step label="3.3">
 
-### Bare React Native project
+### Existing React Native project
 
-There are no additional steps for bare projects.
+There are no additional steps for existing React Native projects.
 
 </Step>
 

--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -8,7 +8,7 @@ To set up EAS Build with a monorepo, you need to follow the standard process as 
 
 - Run all EAS CLI commands from the root of the app directory. For example, if your project exists inside your git repository at **apps/my-app**, then run `eas build` from there.
 - All files related to EAS Build, such as **eas.json** and **credentials.json**, should be in the root of the app directory. If you have multiple apps that use EAS Build in your monorepo, each app directory will have its own copy of these files.
-- **If you are building a managed project in a monorepo**, see [Working with Monorepos](/guides/monorepos) guide.
+- **If you are building a project that uses [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) in a monorepo**, see [Working with Monorepos](/guides/monorepos) guide.
 - If your project needs additional setup beyond what is provided, add a `postinstall` step to **package.json** in your project that builds all necessary dependencies in other workspaces. For example:
 
 ```json package.json

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -13,7 +13,7 @@ When you make a change to your iOS entitlements, this change needs to be updated
 
 In an Expo app, the entitlements are read from the introspected app config. To edit them, see the [`ios.entitlements`](/versions/latest/config/app/#entitlements) field in your app config file. You can see your introspected config by running `npx expo config --type introspect` in your project and then look for the `ios.entitlements` object for the results.
 
-In a bare React Native app, the entitlements are read from your **ios/\*\*/\*.entitlements** file.
+In an [existing React Native project](/bare/overview/), the entitlements are read from your **ios/\*\*/\*.entitlements** file.
 
 ## Enabling
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -46,7 +46,7 @@ For example, you might see something like this on your Android builds:
   ]}
 />
 
-While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building a bare project, you will already be good at this. If you are building a [managed project](/workflow/overview/), it may be tricky because you don't directly interact with the native code, only write JavaScript.
+While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building an [existing React Native project](/bare/overview/), you will already be good at this. If you are building a project that uses [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), it may be tricky because you don't directly interact with the native code, only write JavaScript.
 
 A good path forward is to **determine if the build failed due to a native or JavaScript error**. When your build fails due to a JavaScript build error, you will usually see something like this:
 
@@ -63,7 +63,7 @@ It's important to note that with iOS builds the build details page only displays
 
 {/* TODO: native and js build phases should be separate in eas build logs, this is too much work for people to figure out */}
 
-If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you have added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
+If you are working on a project that uses Continuous Native Generation (CNG) and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you have added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
 Armed with your error logs, you can often start to fix your build or search the [forums](https://chat.expo.dev/) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -239,7 +239,7 @@ If you are building an app with Expo, EAS Build will pick the appropriate image 
 
 > You can specify [common properties](/eas/json/##common-properties-for-native-platforms) both in the platform-specific configuration object or at the profile's root. The platform-specific options take precedence over globally-defined ones.
 
-<Collapsible summary="A managed project with several profiles">
+<Collapsible summary="A Continuous Native Generation (CNG) project with several profiles">
 
 ```json eas.json
 {
@@ -299,7 +299,7 @@ If you are building an app with Expo, EAS Build will pick the appropriate image 
 
 </Collapsible>
 
-<Collapsible summary="A bare project with several profiles">
+<Collapsible summary="An existing React Native project with several profiles">
 
 ```json eas.json
 {

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -31,7 +31,7 @@ The following example demonstrates how you might use the `"production"` channel 
 
 Your native runtime may change on each build, depending on whether you modify the code in a way that changes the API contract with JavaScript. If you publish a JavaScript bundle to a binary with an incompatible native runtime (for example, a function that the JavaScript bundle expects to exist does not exist) then your app may not work as expected, or it may crash.
 
-We recommend using a different [runtime version](/eas-update/runtime-versions/) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
+We recommend using a different [runtime version](/eas-update/runtime-versions/) for each binary version of your app. Any time you change the native runtime (in projects that use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
 
 ## Previewing updates in development builds
 

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -302,7 +302,7 @@ We must define default **string.xml** values which the user will overwrite local
 </resources>
 ```
 
-At this point, bare users can configure this value by creating a string in their local **strings.xml** file (assuming they also have `expo-modules-core` support setup):
+At this point, users with [existing React Native projects](/bare/overview/) can configure this value by creating a string in their local **strings.xml** file (assuming they also have `expo-modules-core` support setup):
 
 ```xml ./android/app/src/main/res/values/strings.xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -311,7 +311,7 @@ At this point, bare users can configure this value by creating a string in their
 </resources>
 ```
 
-For managed users, we can expose this functionality (safely!) via an Expo config plugin:
+With [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), we can expose this functionality (safely!) via an Expo config plugin:
 
 ```js expo-custom/app.plugin.js
 const { AndroidConfig, withStringsXml } = require('expo/config-plugins');
@@ -336,7 +336,7 @@ function setStrings(strings, value) {
 }
 ```
 
-Managed Expo users can now interact with this API like so:
+Developers using CNG can now interact with this API like so:
 
 ```json app.json
 {
@@ -346,7 +346,7 @@ Managed Expo users can now interact with this API like so:
 }
 ```
 
-By re-running `npx expo prebuild -p` (`eas build -p android`, or `npx expo run:ios`) the user can now see the changes, safely applied in their managed project!
+By re-running `npx expo prebuild -p` (`eas build -p android`, or `npx expo run:ios`) the user can now see the changes, safely applied in their CNG project!
 
 As you can see from the example, we rely heavily on application code (expo-modules-core) to interact with application code (the native project). This ensures that our config plugins are safe and reliable, hopefully for a very long time!
 
@@ -387,7 +387,7 @@ Introspection works by creating custom base mods that work like the default base
 Instead of persisting, they save the results to the app config under `_internal.modResults`, followed by the name of the mod
 such as the `ios.infoPlist` mod saves to `_internal.modResults.ios.infoPlist: {}`.
 
-As a real-world example, introspection is used by `eas-cli` to determine what the final iOS entitlements will be in a managed app, so it can sync them with the Apple Developer Portal before building. Introspection can also be used as a handy debugging and development tool.
+As a real-world example, introspection is used by `eas-cli` to determine what the final iOS entitlements will be in a CNG project, so it can sync them with the Apple Developer Portal before building. Introspection can also be used as a handy debugging and development tool.
 
 {/* TODO: Link to VS Code extension after preview feature lands */}
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -90,9 +90,9 @@ For detailed, step-by-step instructions, see our [EAS Tutorial](/tutorial/eas/in
   }}
 />
 
-<Collapsible summary="Are you using this library in an existing (bare) React Native app?">
+<Collapsible summary="Are you using this library in an existing React Native project?">
 
-Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native app](/bare/install-dev-builds-in-bare/).
+Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 </Collapsible>
 

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -61,7 +61,7 @@ You can also use the following command to check if the project is misconfigured:
   }}
 />
 
-<Collapsible summary="Using bare React Native app?">
+<Collapsible summary="Using an existing React Native project?">
 
 #### Android
 

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -226,7 +226,7 @@ For iOS, your app's icon should follow the [Apple Human Interface Guidelines](ht
 Alternatively, the previous approach of providing an image is still supported. You should:
 
 - Use a **.png** file.
-- 1024x1024 is a good size. If you have an Expo project created using `npx create-expo-app`, [EAS Build](/build/setup/) will generate the other sizes for you. In case of a bare React Native project, generate the icons on your own. The largest size EAS Build generates is 1024x1024.
+- 1024x1024 is a good size. If you have an Expo project created using `npx create-expo-app`, [EAS Build](/build/setup/) will generate the other sizes for you. In case of an [existing React Native project](/bare/overview/), generate the icons on your own. The largest size EAS Build generates is 1024x1024.
 - The icon must be exactly square. For example, a 1023x1024 icon is not valid.
 - Make sure the icon fills the whole square, with no rounded corners or other transparent pixels. The operating system will mask your icon when appropriate.
 - Use `ios.icon` to specify different icons for various system appearances (for example, dark and tinted) can be provided. If specified, this overrides the top-level icon key in the app config file. See the example below:

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -92,7 +92,7 @@ To allow updates to apply to builds built with EAS, update your EAS Build profil
 
 <Step label="4">
 
-**Optional**: If your project is a bare React Native project, see [Use EAS Update in an existing project](/eas-update/getting-started/) for the extra configuration you may need.
+**Optional**: If your project is an [existing React Native project](/bare/overview/), see [Use EAS Update in an existing project](/eas-update/getting-started/) for the extra configuration you may need.
 
 </Step>
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -312,7 +312,7 @@ jobs:
 
 Calculates a fingerprint of your project.
 
-> **Note:** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
+> **Note:** This job type only supports [CNG](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
 > **Note:** To ensure fingerprints match your builds, use the same `environment` setting as your build profile. For environment variables, we recommend using [EAS environment variables](/eas/environment-variables/) rather than the [`env`](/eas/workflows/syntax/#jobsjob_idenv) field for better consistency.
 

--- a/docs/pages/guides/apple-privacy.mdx
+++ b/docs/pages/guides/apple-privacy.mdx
@@ -45,7 +45,7 @@ Make sure you have updated your Expo SDK libraries to the latest versions for yo
 
 <ConfigReactNative>
 
-You can include an iOS privacy manifest in a bare Expo app by creating a **PrivacyInfo.xcprivacy** file using Xcode and adding it to your iOS app target.
+You can include an iOS privacy manifest in an [existing React Native project](/bare/overview/) by creating a **PrivacyInfo.xcprivacy** file using Xcode and adding it to your iOS app target.
 Follow [Apple's Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) guide to create a **PrivacyInfo.xcprivacy** file.
 
 </ConfigReactNative>

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -208,7 +208,7 @@ In the future, this will work universally across platforms with EAS Update hosti
 
 Expo's Metro config supports the `compilerOptions.paths` and `compilerOptions.baseUrl` fields in the project's **tsconfig.json** (or **jsconfig.json**) file. This enables absolute imports and aliases in the project. See [TypeScript](/guides/typescript) guide for more information.
 
-This feature requires additional setup in bare projects. See the [Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+This feature requires additional setup in [existing React Native projects](/bare/overview/). See the [Metro setup guide](/versions/latest/config/metro#existing-react-native-apps) for more information.
 
 ## CSS
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -212,7 +212,7 @@ You can configure the React Native Directory check in your **package.json** file
   </Tab>
 </Tabs>
 
-<Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
+<Collapsible summary="Are you enabling the New Architecture in an existing React Native project?">
 
 If you are using Expo SDK 53 or later, the New Architecture is enabled by default. For SDK 55 and later, the New Architecture is always enabled and cannot be disabled. The following instructions apply to SDK 52 and earlier projects.
 
@@ -237,7 +237,7 @@ On **SDK 54 and earlier**, you can opt out of the New Architecture by setting th
 }
 ```
 
-<Collapsible summary="Are you disabling the New Architecture in a bare React Native app (SDK 54 and earlier)?">
+<Collapsible summary="Are you disabling the New Architecture in an existing React Native project (SDK 54 and earlier)?">
 
 - **Android**: Set `newArchEnabled=false` in the **gradle.properties** file.
 - **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can disable the New Architecture by setting the `newArchEnabled` property to `"false"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -176,7 +176,7 @@ When using path aliases, consider the following:
 - If not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
 - Path aliases add additional resolution time when defined.
 - Path aliases are only supported by Metro (including Metro web) and not by the deprecated `@expo/webpack-config`.
-- Bare projects require additional setup for this feature. See the [Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+- [Existing React Native projects](/bare/overview/) require additional setup for this feature. See the [Metro setup guide](/versions/latest/config/metro#existing-react-native-apps) for more information.
 
 </Step>
 
@@ -210,7 +210,7 @@ When using absolute imports, consider the following:
 - Restarting Expo CLI is necessary to update [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) after modifying the **tsconfig.json**.
 - If you're not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
 - Absolute imports are only supported by Metro (including Metro web) and not by `@expo/webpack-config`.
-- Bare projects require additional setup for this feature. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+- Existing React Native projects require additional setup for this feature. See the [versioned Metro setup guide](/versions/latest/config/metro#existing-react-native-apps) for more information.
 
 </Step>
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -171,7 +171,7 @@ You can consider using React Native Firebase when:
 - Your app requires access to Firebase services not supported by the Firebase JS SDK, such as Dynamic Links, [Crashlytics](https://rnfirebase.io/crashlytics/usage), and so on.
   For more information on the additional capabilities offered by the native SDK's, see [React Native Firebase documentation](https://rnfirebase.io/faqs-and-tips#why-react-native-firebase-over-firebase-js-sdk).
 - You want to use native SDKs in your app.
-- You have a bare React Native app with React Native Firebase already configured but are migrating to use Expo SDK.
+- You have an [existing React Native project](/bare/overview/) with React Native Firebase already configured but are migrating to use Expo SDK.
 - You want to use [Firebase Analytics](https://rnfirebase.io/analytics/usage) in your app.
 
 <Collapsible summary="Migrating from Expo Firebase packages?">
@@ -219,7 +219,7 @@ It also adds custom native code in your project using a config plugin. You can i
   }}
 />
 
-**At this point, you must follow the instructions from [React Native Firebase documentation](https://rnfirebase.io/#managed-workflow)** as it covers all the steps required to configure your project with the library.
+**At this point, you must follow the instructions from [React Native Firebase documentation](https://rnfirebase.io/#installation-for-expo-projects)** as it covers all the steps required to configure your project with the library.
 
 Once you have configured the React Native Firebase library in your project, come back to this guide to learn how to run your project in the next step.
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -53,7 +53,7 @@ Expo CLI is included in the `expo` package. You can install it with npm or yarn:
 
 <Terminal cmd={['$ yarn add expo']} />
 
-> Projects that are not using [Expo Prebuild](#prebuild) will need to perform additional setup to ensure all custom Expo bundling features work: [Metro: Bare workflow setup](/versions/latest/config/metro/#existing-react-native-apps).
+> Projects that are not using [Expo Prebuild](#prebuild) will need to perform additional setup to ensure all custom Expo bundling features work: [Metro setup for existing React Native apps](/versions/latest/config/metro/#existing-react-native-apps).
 
 ## Develop
 

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -135,7 +135,7 @@ Here are some ways our community members have resolved this issue:
 Read Apple's [Technical Note on troubleshooting push notifications](https://developer.apple.com/library/archive/technotes/tn2265/_index.html)! This is the single most reliable source of information on this problem. To help you grasp what they're suggesting:
 
 - Make sure the device has a reliable connection to the Internet (try turning off Wi-Fi or switching to another network, and disabling the firewall block on port 5223, as suggested in [this SO answer](https://stackoverflow.com/a/34332047/1123156)).
-- **Bare React Native apps** must [manually enable the **Push Notifications** capability](/build-reference/ios-capabilities#manual-setup). If you have trouble setting this up, refer to [this Stack Overflow answer](https://stackoverflow.com/a/10791240/1123156). You may also want to try to debug this even further by logging persistent connection debug information as outlined by [this Stack Overflow answer](https://stackoverflow.com/a/8036052/1123156).
+- **[Existing React Native projects](/bare/overview/)** must [manually enable the **Push Notifications** capability](/build-reference/ios-capabilities#manual-setup). If you have trouble setting this up, refer to [this Stack Overflow answer](https://stackoverflow.com/a/10791240/1123156). You may also want to try to debug this even further by logging persistent connection debug information as outlined by [this Stack Overflow answer](https://stackoverflow.com/a/8036052/1123156).
 
 </Collapsible>
 

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -34,7 +34,7 @@ Look at your logs before this error message to see what may have caused it. A fr
 
 Another possibility is that there is a mismatch between the `AppKey` being provided to [`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent), and the `AppKey` being registered on the native iOS or Android side.
 
-In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, see [registerRootComponent](/versions/latest/sdk/expo/#registerrootcomponentcomponent) API reference.
+In projects that use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, see [registerRootComponent](/versions/latest/sdk/expo/#registerrootcomponentcomponent) API reference.
 
 In projects with native code, you will see something like this in your **index.js** by default:
 

--- a/docs/pages/troubleshooting/react-native-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.mdx
@@ -30,10 +30,10 @@ The bundler that you're running in your terminal (using `npx expo start`) is usi
 
 - If this is a Expo project, you should make sure your `react-native` version is correct. Run `npx expo-doctor` will show a warning where the `react-native` version you should install. If you did upgrade to a newer SDK, make sure to run `npx expo install --fix` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
 
-- If this is a bare React Native project, and this error is occurring right after upgrading your React Native version, you should double-check that you have performed each of the upgrade steps correctly.
+- If this is an [existing React Native project](/bare/overview/), and this error is occurring right after upgrading your React Native version, you should double-check that you have performed each of the upgrade steps correctly.
 
 - Finally:
   - Clear your bundler caches by running `rm -rf node_modules && npm cache clean --force && npm install && watchman watch-del-all && rm -rf $TMPDIR/haste-map-* && rm -rf $TMPDIR/metro-cache && npx expo start --clear`
     - Commands if you are using npm can be found [here.](clear-cache-macos-linux)
     - Commands if you are using Windows can be found [here.](clear-cache-windows)
-  - If this is a bare React Native project, run `npx pod-install`, then rebuild your native projects (run `yarn android` to rebuild for Android, and `yarn ios` to rebuild iOS)
+  - If this is an existing React Native project, run `npx pod-install`, then rebuild your native projects (run `yarn android` to rebuild for Android, and `yarn ios` to rebuild iOS)

--- a/docs/pages/tutorial/eas/introduction.mdx
+++ b/docs/pages/tutorial/eas/introduction.mdx
@@ -33,7 +33,7 @@ This tutorial is hands-on and designed to be completed in about two hours.
 
     - Continue with the Sticker Smash app from the previous tutorial. If new, download it from [GitHub](https://github.com/expo/examples/tree/master/stickersmash).
     - Start a new project with [`npx create-expo-app`](/get-started/create-a-project/).
-    - Use a bare React Native project. Ensure the `expo` package is installed, which you can do [automatically](/bare/installing-expo-modules/) or [manually](/bare/installing-expo-modules/#manual-installation).
+    - Use an [existing React Native project](/bare/overview/). Ensure the `expo` package is installed, which you can do [automatically](/bare/installing-expo-modules/) or [manually](/bare/installing-expo-modules/#manual-installation).
 
   </Requirement>
 </Prerequisites>

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -705,7 +705,7 @@ Alternatively, in the Xcode project, select the **"Bundle React Native code and 
 
 ### Custom entry file
 
-By default, React Native only supports using a root `index.js` file as the entry file (or platform-specific variation like `index.ios.js`). Expo projects allow using any entry file, but this requires addition bare setup.
+By default, React Native only supports using a root `index.js` file as the entry file (or platform-specific variation like `index.ios.js`). Expo projects allow using any entry file, but this requires additional setup in existing React Native projects.
 
 #### Development
 

--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -15,7 +15,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
 > **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
-> and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
+> and therefore cannot be used with projects that don't run `npx expo prebuild` (existing React Native projects).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -29,7 +29,7 @@ Alternatively, it is also possible to configure the `expo-updates` library manua
 
 <APIInstallSection hideBareInstructions />
 
-If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
+If you're installing this library in an [existing React Native project](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
 If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
 
@@ -277,11 +277,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                              | Description                                                                                                                                                                                                                                                        |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                              |
-| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare React Native apps, double-check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                                   |
-| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                      |
-| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                        |
-| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                                 |
+| Code                              | Description                                                                                                                                                                                                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                                      |
+| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For existing React Native projects, double-check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                                           |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                              |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                                |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                                         |

--- a/docs/pages/versions/v56.0.0/config/metro.mdx
+++ b/docs/pages/versions/v56.0.0/config/metro.mdx
@@ -705,7 +705,7 @@ Alternatively, in the Xcode project, select the **"Bundle React Native code and 
 
 ### Custom entry file
 
-By default, React Native only supports using a root `index.js` file as the entry file (or platform-specific variation like `index.ios.js`). Expo projects allow using any entry file, but this requires addition bare setup.
+By default, React Native only supports using a root `index.js` file as the entry file (or platform-specific variation like `index.ios.js`). Expo projects allow using any entry file, but this requires additional setup in existing React Native projects.
 
 #### Development
 

--- a/docs/pages/versions/v56.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/build-properties.mdx
@@ -15,7 +15,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
 > **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
-> and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
+> and therefore cannot be used with projects that don't run `npx expo prebuild` (existing React Native projects).
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/updates.mdx
@@ -29,7 +29,7 @@ Alternatively, it is also possible to configure the `expo-updates` library manua
 
 <APIInstallSection hideBareInstructions />
 
-If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
+If you're installing this library in an [existing React Native project](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
 If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
 
@@ -277,11 +277,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                              | Description                                                                                                                                                                                                                                                        |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                              |
-| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare React Native apps, double-check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                                   |
-| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                      |
-| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                        |
-| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                                 |
+| Code                              | Description                                                                                                                                                                                                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                                      |
+| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For existing React Native projects, double-check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                                           |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                              |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                                |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                                         |

--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -170,9 +170,9 @@ The convenience change to the `scripts` field is the only side effect that alter
 
 ## Optionality
 
-Prebuild is optional and works seamlessly with all Expo tools and services. For existing React Native projects, where the native projects are managed manually, do not use `npx expo prebuild`, as that may overwrite any manual customizations. Developers can continue to make ([direct changes to their native projects](/more/glossary-of-terms/#bare-workflow)) while adopting other Expo tools and workflows. Later on, they can move their manual customizations to app config and/or config plugins, and then adopt CNG.
+Prebuild is optional and works seamlessly with all Expo tools and services. For [existing React Native projects](/bare/overview/), where the native projects are managed manually, do not use `npx expo prebuild`, as that may overwrite any manual customizations. Developers can continue to make ([direct changes to their native projects](/more/glossary-of-terms/#bare-workflow)) while adopting other Expo tools and workflows. Later on, they can move their manual customizations to app config and/or config plugins, and then adopt CNG.
 
-Everything offered by Expo including [EAS](/eas/), Expo CLI, and the libraries in the Expo SDK are built to **fully support** bare React Native projects as this is a minimum requirement for supporting projects using `npx expo prebuild`. The only exception is the [Expo Go](https://expo.dev/go) app, which can load arbitrary React Native projects only if they include JavaScript fallbacks for native code absent in the Expo Go runtime.
+Everything offered by Expo including [EAS](/eas/), Expo CLI, and the libraries in the Expo SDK are built to **fully support** existing React Native projects as this is a minimum requirement for supporting projects using `npx expo prebuild`. The only exception is the [Expo Go](https://expo.dev/go) app, which can load arbitrary React Native projects only if they include JavaScript fallbacks for native code absent in the Expo Go runtime.
 
 ## Common questions
 
@@ -200,7 +200,7 @@ React Native library authors can adopt CNG in several ways. It depends on the co
 
 - **Libraries Dependent on Native Runtime Hooks**: Libraries that depend on specific native runtime hooks, such as intercepting the initial launch URL via the `AppDelegate`, `MainActivity`, `MainApplication`, and so on, can utilize [**Lifecycle listeners**](/modules/android-lifecycle-listeners/) in the Expo Modules API. These lifecycle listeners allow these runtime hooks to be applied via Expo Autolinking instead of by modifying these standard native project files, eliminating the need for a config plugin.
 
-Many complex libraries and services already support CNG via Expo Prebuild such as, [MapBox](https://github.com/rnmapbox/maps), [Sentry](https://github.com/getsentry/sentry-react-native), [Stripe](https://github.com/stripe/stripe-react-native), and [React Native Firebase](https://rnfirebase.io/#expo).
+Many complex libraries and services already support CNG via Expo Prebuild such as, [MapBox](https://github.com/rnmapbox/maps), [Sentry](https://github.com/getsentry/sentry-react-native), [Stripe](https://github.com/stripe/stripe-react-native), and [React Native Firebase](https://rnfirebase.io/#installation-for-expo-projects).
 
 Adopting CNG by library authors is not a preqrequisite for using `npx expo prebuild`. If a library author has not adopted CNG, developers can still use `npx expo prebuild` by creating local [Config Plugins](https://github.com/expo/config-plugins/) to modify the native generation pipeline. This flexibility makes CNG accessible and beneficial to all developers within the React Native community.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22071 ENG-22073

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Replace the deprecated "bare" workflow terminology with "existing React Native project(s)", linked to `/bare/overview/` on first mention.
- Replace "managed" workflow terminology with "Continuous Native Generation (CNG)", linked to `/workflow/continuous-native-generation/`.
- Apply both across the guide pages and the `v56.0.0` and `unversioned` SDK reference prose.
- Leave the glossary's deprecated-term definition, the `/bare/` section URLs, and `expo-template-bare-minimum` names in place.
- Repair the stale Metro anchor (`#bare-workflow-setup` to `#existing-react-native-apps`), linked from `customizing-metro.mdx` and `typescript.mdx`.
- Fix the broken `rnfirebase.io/#managed-workflow` link (now `#installation-for-expo-projects`).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff and proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
