### PR TITLE
[docs][widgets] Expand widgets docs and add missing APIs

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -314,6 +314,8 @@ exceptions:
   - Live Activity
   - 'Prerequisite: Creating widget'
   - 'Prerequisite: Creating Live Activity'
+  - 'Prerequisite: Creating a widget'
+  - 'Prerequisite: Creating a Live Activity'
   - Hiding the Tab bar
   - Integrated vs Isolated
   - Expo Skills

--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -14,6 +14,11 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 `expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating a widget's timeline, as well as starting and managing Live Activities. You can build the layout using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
 
+## Known limitations
+
+- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
+- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
+
 ## Installation
 
 <APIInstallSection />
@@ -702,11 +707,6 @@ To end a Live Activity remotely, send an `end` event with the final content stat
 ```
 
 For the exact payload shape and headers, follow Apple's [Starting and updating Live Activities with ActivityKit push notifications](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications).
-
-## Known limitations
-
-- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
-- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -12,7 +12,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 > **important** This library is not available in the Expo Go app — use [development builds](/develop/development-builds/introduction) to try it out.
 
-`expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating widgets timeline, as well as starting and managing Live Activities. Layout can be built using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
+`expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating a widget's timeline, as well as starting and managing Live Activities. You can build the layout using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
 
 ## Installation
 
@@ -36,7 +36,9 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
               "name": "MyWidget",
               "displayName": "My Widget",
               "description": "A sample home screen widget",
-              "supportedFamilies": ["systemSmall", "systemMedium", "systemLarge"]
+              "ios": {
+                "supportedFamilies": ["systemSmall", "systemMedium", "systemLarge"]
+              }
             }
           ]
         }
@@ -59,7 +61,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
     {
       name: 'groupIdentifier',
       description:
-        'The app group identifier used for communication and data sharing between the main app and widgets. This is required for widgets to work properly. If not specified, defaults to `group.<main app bundle identifier>`.',
+        'The app group identifier used for communication and data sharing between the main app and widgets, which widgets require to work. If not specified, it defaults to `group.<main app bundle identifier>`. If `ios.bundleIdentifier` is also unset, prebuild fails because the bundle identifier is required to derive this value.',
       default: '"group.<app bundle identifier>"',
     },
     {
@@ -76,7 +78,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
     {
       name: 'widgets[].name',
       description:
-        'The internal name (identifier) of the widget. This is used as the Swift struct name and should be a valid Swift identifier (no spaces or special characters).',
+        'The internal name (identifier) of the widget. This is used as the Swift struct name and should be a valid Swift identifier (no spaces or special characters). It must match the `name` passed to `createWidget`.',
     },
     {
       name: 'widgets[].displayName',
@@ -89,13 +91,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
         "A brief description of what the widget does. This appears in the widget gallery to help users understand the widget's purpose.",
     },
     {
-      name: 'widgets[].contentMarginsDisabled',
-      description:
-        "When you disable content margins for a widget, the system doesn't automatically add margins around the widget's content, and you are responsible for specifying margins and padding around your widget content for each context.",
-      default: 'false',
-    },
-    {
-      name: 'widgets[].supportedFamilies',
+      name: 'widgets[].ios.supportedFamilies',
       description: [
         'An array of widget sizes that this widget supports. Available options:',
         '* `systemSmall` - Small square widget (2x2 grid)',
@@ -108,12 +104,29 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
       ].join('\n'),
     },
     {
+      name: 'widgets[].ios.contentMarginsDisabled',
+      description:
+        "When you disable content margins for a widget, the system doesn't automatically add margins around the widget's content, and you are responsible for specifying margins and padding around your widget content for each context.",
+      default: 'false',
+    },
+    {
       name: 'widgets[].ios.initialLayout',
       description:
         'A path to the file that registers this widget with `createWidget`. The path is relative to the project root. Set this so the widget appears in the widget gallery before the app is open for the first time.',
     },
+    {
+      name: 'widgets[].ios.configuration',
+      description: [
+        'Makes the widget [configurable](#configurable-widgets). The values the user picks are passed to your widget at runtime through `environment.configuration`. An object with:',
+        '* `title` - The title shown when the user edits the widget.',
+        '* `description` - An optional description shown when the user edits the widget.',
+        '* `parameters` - A map of parameter keys to parameter definitions. Each parameter has a `title`, a `type` (`string`, `number`, `boolean`, or `enum`), and a `default`. An `enum` parameter additionally takes a `values` array of `{ name, value }` options.',
+      ].join('\n'),
+    },
   ]}
 />
+
+> **info** The top-level `supportedFamilies` and `contentMarginsDisabled` options are deprecated aliases for `ios.supportedFamilies` and `ios.contentMarginsDisabled`. Prefer the nested `ios` form shown above.
 
 ### Full example with all options
 
@@ -132,20 +145,45 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
               "name": "StatusWidget",
               "displayName": "Status",
               "description": "Shows your current status at a glance",
-              "contentMarginsDisabled": true,
-              "supportedFamilies": ["systemSmall", "systemMedium"]
+              "ios": {
+                "contentMarginsDisabled": true,
+                "supportedFamilies": ["systemSmall", "systemMedium"]
+              }
             },
             {
-              "name": "DetailWidget",
-              "displayName": "Details",
-              "description": "Shows detailed information",
-              "supportedFamilies": ["systemMedium", "systemLarge"]
+              "name": "WeatherWidget",
+              "displayName": "Weather",
+              "description": "Shows the weather for a city you choose",
+              "ios": {
+                "supportedFamilies": ["systemSmall", "systemMedium"],
+                "configuration": {
+                  "title": "Choose a city",
+                  "description": "Pick which city to show the weather for",
+                  "parameters": {
+                    "city": {
+                      "title": "City",
+                      "type": "enum",
+                      "default": "sf",
+                      "values": [
+                        { "name": "San Francisco", "value": "sf" },
+                        { "name": "New York", "value": "nyc" }
+                      ]
+                    }
+                  }
+                }
+              }
             },
             {
               "name": "LockScreenWidget",
               "displayName": "Quick View",
               "description": "View info on your Lock Screen",
-              "supportedFamilies": ["accessoryCircular", "accessoryRectangular", "accessoryInline"]
+              "ios": {
+                "supportedFamilies": [
+                  "accessoryCircular",
+                  "accessoryRectangular",
+                  "accessoryInline"
+                ]
+              }
             }
           ]
         }
@@ -157,11 +195,42 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
 
 ## Usage
 
+### The `'widget'` directive
+
+Components passed to `createWidget` and `createLiveActivity` must start with the `'widget'` directive. The directive tells the bundler to compile that component into a separate JavaScript bundle that runs in an isolated runtime inside the widget extension, not in your app's React Native runtime.
+
+Because of this isolation, code inside a `'widget'`-marked component is limited:
+
+- It can only render [`@expo/ui/swift-ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers. Standard React Native components (such as `View` and `Text` from `react-native`) are not available.
+- It cannot use React hooks (`useState`, `useEffect`, and others), component state, or context. The function must be pure and return its layout synchronously.
+- It cannot perform asynchronous work, import other modules, or access your app's runtime or in-memory state.
+- It cannot reference anything declared outside the component function, including plain top-level `const`s in the **same file**. The bundler serializes only the function body, so module-scope values are not present at runtime. Declare every constant and helper **inside** the widget function, or pass it in through props.
+
+All data a widget needs must come in through its props (set with `updateSnapshot`, `updateTimeline`, or a Live Activity's `start` and `update`) and the `environment` argument. To use images, write them to [`widgetsDirectory`](#sharing-images-with-widgetsdirectory) from your app and reference them by path.
+
+```tsx
+import { Text } from '@expo/ui/swift-ui';
+import { createWidget, type WidgetEnvironment } from 'expo-widgets';
+
+// Declared at module scope — not included in the widget bundle.
+const CITY_NAMES: Record<string, string> = { sf: 'San Francisco' };
+
+const CityWidget = (props: object, environment: WidgetEnvironment<{ city: string }>) => {
+  'widget';
+  // Throws at runtime: Can't find variable: CITY_NAMES
+  return <Text>{CITY_NAMES[environment.configuration.city]}</Text>;
+};
+
+export default createWidget('CityWidget', CityWidget);
+```
+
+Move `CITY_NAMES` inside `CityWidget` (or pass the resolved value through props) to fix it.
+
 ### Widgets
 
-#### Prerequisite: Creating widget
+#### Prerequisite: Creating a widget
 
-Start by creating a Widget using the `createWidget` function and pass the widget component marked with the `'widget'` directive. The component receives your widget props as the first argument and a `WidgetEnvironment` object as the second.
+Start by creating a widget using the `createWidget` function and pass the widget component marked with the `'widget'` directive. The component receives your widget props as the first argument and a `WidgetEnvironment` object as the second.
 
 ```tsx
 import { Text, VStack } from '@expo/ui/swift-ui';
@@ -194,7 +263,7 @@ The optional third argument provides the initial props used before the widget ti
 
 An effective way to update a widget is to use the `updateSnapshot` method. This creates a widget timeline with a single entry that displays immediately.
 
-The example below continues from [Creating widget](#prerequisite-creating-widget).
+The example below continues from [Creating a widget](#prerequisite-creating-a-widget).
 
 ```tsx
 import MyWidget from './MyWidget';
@@ -205,9 +274,9 @@ MyWidget.updateSnapshot({ count: 5 });
 
 #### Timeline widget
 
-Use `updateTimeline` method to schedule widget updates at specific time. System will automatically update the widget based on the timeline.
+Use the `updateTimeline` method to schedule widget updates at a specific time. The system automatically updates the widget based on the timeline.
 
-The example below continues from [Creating widget](#prerequisite-creating-widget).
+The example below continues from [Creating a widget](#prerequisite-creating-a-widget).
 
 ```tsx
 import MyWidget from './MyWidget';
@@ -218,6 +287,27 @@ MyWidget.updateTimeline([
   { date: new Date(Date.now() + 7200000), props: { count: 3 } }, // 2 hours from now
   { date: new Date(Date.now() + 10800000), props: { count: 4 } }, // 3 hours from now
 ]);
+```
+
+#### Reading the current timeline
+
+Use `getTimeline` to read the entries currently scheduled for a widget, including past and future entries.
+
+```tsx
+import MyWidget from './MyWidget';
+
+const entries = await MyWidget.getTimeline();
+// [{ date: Date, props: { count: number } }, ...]
+```
+
+#### Reloading a widget
+
+Use `reload` to force the system to refresh a widget's content and timeline immediately, for example after the underlying data changes.
+
+```tsx
+import MyWidget from './MyWidget';
+
+MyWidget.reload();
 ```
 
 #### Responsive widget
@@ -272,13 +362,111 @@ Widget.updateSnapshot({
 });
 ```
 
+#### Adapting to the rendering environment
+
+Beyond `widgetFamily` and `date`, the `environment` object describes how and where the system is drawing the widget so you can adapt the layout:
+
+- `colorScheme`: `'light'` or `'dark'`.
+- `widgetRenderingMode`: `'fullColor'` for home screen widgets, `'vibrant'` for Lock Screen widgets (the system desaturates them into an adaptive monochrome look), and `'accented'` for tinted widgets on iOS 18 and later. Use this to choose colors that read well in each mode.
+- `isLuminanceReduced`: `true` when the display requires reduced brightness (such as Always-On). Lower the overall brightness of your content, for example by using stroked rather than filled shapes.
+- `widgetContentMargins`: The system-suggested margins (`top`, `bottom`, `leading`, `trailing`) when content margins are not disabled.
+- `showsWidgetLabel`: For accessory widgets, whether an accessory label can be displayed.
+
+#### Interactive widgets
+
+Widgets can include interactive controls such as `Button`. The value a button's `onPress` callback returns becomes the widget's new props. The runtime persists it and reloads the widget on device, with no running app process required. This is the primary way to make a widget update itself in response to a tap. Interactive widgets require iOS 17 or later.
+
+```tsx CounterWidget.tsx
+import { Button, Text, VStack } from '@expo/ui/swift-ui';
+import { createWidget } from 'expo-widgets';
+
+type CounterProps = {
+  count: number;
+};
+
+const CounterWidget = (props: CounterProps) => {
+  'widget';
+  return (
+    <VStack>
+      <Text>Count: {props.count}</Text>
+      <Button label="Increment" target="increment" onPress={() => ({ count: props.count + 1 })} />
+    </VStack>
+  );
+};
+
+export default createWidget('CounterWidget', CounterWidget, { count: 0 });
+```
+
+To also keep your running app in sync with widget interactions, give the control a `target` identifier (as above) and listen for taps with `addUserInteractionListener`. The listener receives the widget's `name` as `source` and the control's `target`. Unlike `onPress`, it only fires while the app process is alive, so use it to mirror interactions into app state, not as the widget's update mechanism.
+
+```tsx App.tsx
+import { addUserInteractionListener } from 'expo-widgets';
+
+const subscription = addUserInteractionListener(event => {
+  if (event.source === 'CounterWidget' && event.target === 'increment') {
+    // The widget already updated itself via onPress; mirror the change in app state here.
+    console.log('Counter incremented from the widget');
+  }
+});
+
+// Later, when you no longer need updates:
+subscription.remove();
+```
+
+#### Sharing images with `widgetsDirectory`
+
+A widget can't access files inside your app's sandbox, so to display an image in a widget you must place it in the shared app group container. `widgetsDirectory` is a `file://` URL string pointing to a directory that both your app and its widgets can read. Write the image there from your app, then reference it by path in the widget.
+
+```tsx
+import { widgetsDirectory } from 'expo-widgets';
+
+// `widgetsDirectory` is a file:// URL to a directory shared with your widgets.
+console.log(widgetsDirectory);
+```
+
+> **info** `widgetsDirectory` is `null` only when no app group is configured. The `groupIdentifier` config plugin option sets one up automatically (falling back to `group.<bundle identifier>`), so it is available in normal use.
+
+#### Configurable widgets
+
+When you add an [`ios.configuration`](#configuration-in-app-config) to a widget, users can long-press the widget and edit its parameters. The values they choose are delivered to your widget through `environment.configuration`. Type the configuration by passing a second type argument to `createWidget` (and `WidgetEnvironment`). Configurable widgets require iOS 17 or later.
+
+```tsx
+import { Text, VStack } from '@expo/ui/swift-ui';
+import { createWidget, type WidgetEnvironment } from 'expo-widgets';
+
+type WeatherProps = {
+  temperature: number;
+};
+
+type WeatherConfiguration = {
+  city: string;
+};
+
+const WeatherWidget = (
+  props: WeatherProps,
+  environment: WidgetEnvironment<WeatherConfiguration>
+) => {
+  'widget';
+  return (
+    <VStack>
+      <Text>{environment.configuration.city}</Text>
+      <Text>{props.temperature}°</Text>
+    </VStack>
+  );
+};
+
+export default createWidget<WeatherProps, WeatherConfiguration>('WeatherWidget', WeatherWidget);
+```
+
 ### Live Activities
 
 Live Activities display real-time information on the Lock Screen and in the Dynamic Island on supported devices.
 
-#### Prerequisite: Creating Live Activity
+#### Prerequisite: Creating a Live Activity
 
-Live Activity layouts must be created once using `createLiveActivity` and marked with the `'widget'` directive. The component receives your props as the first argument and a `LiveActivityEnvironment` object as the second.
+Live Activity layouts must be created once using `createLiveActivity` and marked with the `'widget'` directive. The component receives your props as the first argument and a `LiveActivityEnvironment` object as the second. It returns an object describing the layout for each presentation: the Lock Screen `banner`, the compact and minimal Dynamic Island states, and the expanded Dynamic Island regions.
+
+> **important** `createLiveActivity` registers a Live Activity entirely at runtime, and the library's built-in Live Activity target renders it. Do **not** add a `widgets[]` entry for it in the [app config](#configuration-in-app-config). The `widgets[]` array is only for home screen and Lock Screen widgets, and an entry without `supportedFamilies` generates an invalid widget target that fails to build. The `name` you pass to `createLiveActivity` only has to match this `createLiveActivity` call, not an app-config widget.
 
 ```tsx
 import { Image, Text, VStack } from '@expo/ui/swift-ui';
@@ -292,7 +480,7 @@ type DeliveryActivityProps = {
 
 const DeliveryActivity = (props: DeliveryActivityProps, environment: LiveActivityEnvironment) => {
   'widget';
-  const accentColor = environment.colorScheme === 'dark' ? '#FFFFFF' : '#007AFF';
+  const accentColor = environment.isLuminanceReduced ? '#FFFFFF' : '#007AFF';
 
   return {
     banner: (
@@ -330,9 +518,18 @@ const DeliveryActivity = (props: DeliveryActivityProps, environment: LiveActivit
 export default createLiveActivity('DeliveryActivity', DeliveryActivity);
 ```
 
+The layout object supports these regions:
+
+- `banner`: The main Lock Screen presentation.
+- `bannerSmall`: A compact Lock Screen presentation used on CarPlay and watchOS. Falls back to `banner` when omitted.
+- `compactLeading`, `compactTrailing`, `minimal`: The compact and minimal Dynamic Island states.
+- `expandedLeading`, `expandedTrailing`, `expandedCenter`, `expandedBottom`: The regions of the expanded Dynamic Island.
+
+The `environment` object also exposes `isLuminanceReduced`, `isActivityFullscreen`, `isActivityUpdateReduced`, and `activityFamily` so you can adapt the layout to the current presentation.
+
 #### Starting a Live Activity
 
-The example below continues from [Creating Live Activity](#prerequisite-creating-live-activity).
+The example below continues from [Creating a Live Activity](#prerequisite-creating-a-live-activity).
 
 ```tsx
 import { Button, View } from 'react-native';
@@ -360,6 +557,8 @@ function App() {
 export default App;
 ```
 
+The optional second argument is a URL associated with the Live Activity. When the user taps the activity, the system opens your app with that URL, so you can route to the relevant screen using [linking](/linking/into-your-app/) (for example with Expo Router's deep linking).
+
 #### Updating a Live Activity
 
 The example below continues from [Starting a Live Activity](#starting-a-live-activity).
@@ -372,6 +571,20 @@ function updateDelivery(instance: LiveActivity<DeliveryActivityProps>) {
     etaMinutes: 2,
     status: 'Delivery arriving soon!',
   });
+}
+```
+
+#### Recovering active Live Activities
+
+A Live Activity can outlive the app process that started it. Use `getInstances` on the factory to retrieve the activities of that type that are currently active, for example to update or end them after your app relaunches.
+
+```tsx
+import DeliveryActivity from './DeliveryActivity';
+
+const activeInstances = DeliveryActivity.getInstances();
+
+for (const instance of activeInstances) {
+  await instance.update({ etaMinutes: 5, status: 'Almost there' });
 }
 ```
 
@@ -396,9 +609,12 @@ async function completeDelivery(instance: LiveActivity<DeliveryActivityProps>) {
 
 You can also pass `'default'` or `'immediate'` instead of `after(date)` for the dismissal policy.
 
-#### Push tokens for remote updates
+#### Remote updates with push notifications
 
-When `enablePushNotifications` is `true`, use `addPushToStartTokenListener` to receive the app-wide push-to-start token and `instance.getPushToken()` or `instance.addPushTokenListener()` to work with a specific Live Activity instance.
+When `enablePushNotifications` is `true`, you can update Live Activities remotely from your server through Apple Push Notification service (APNs).
+
+- Use `addPushToStartTokenListener` to receive the app-wide push-to-start token, which lets your server start a Live Activity remotely (requires iOS 17.2 or later).
+- Use `instance.getPushToken()` or `instance.addPushTokenListener()` to obtain the token for a specific running Live Activity, which lets your server send updates to that activity.
 
 ```tsx
 import { addPushToStartTokenListener } from 'expo-widgets';
@@ -428,6 +644,69 @@ async function startDeliveryTracking() {
 // Later, when you no longer need updates:
 pushToStartSubscription.remove();
 ```
+
+Send the token to your server and use it to push updates. The notification must use the `liveactivity` push type (the `apns-push-type` header) and an `apns-topic` of `<your bundle identifier>.push-type.liveactivity`. Its `aps` payload carries an `event` (`start`, `update`, or `end`), a `timestamp`, and a `content-state` that matches your activity's props. The `content-state` must match the internal content state used by `expo-widgets`: set `name` to the name you passed to `createLiveActivity`, and set `props` to a JSON string of that activity's props. Use `apns-priority: 10` for immediate updates and `apns-priority: 5` for lower-priority updates. The `timestamp`, `dismissal-date`, and other APNs date fields are Unix timestamps in seconds.
+
+To start a Live Activity remotely, send a `start` event to the push-to-start token:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832000,
+    "event": "start",
+    "attributes-type": "LiveActivityAttributes",
+    "attributes": {},
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":15,\"status\":\"Your delivery is on the way\"}"
+    },
+    "alert": {
+      "title": "Delivery started",
+      "body": "Your delivery is on the way"
+    }
+  }
+}
+```
+
+Remote start requires iOS 17.2 or later. Include `input-push-token: 1` in the `aps` payload on iOS 18 or later if you want APNs to provide a new per-activity token for future updates.
+
+To update a Live Activity remotely, send an `update` event to that activity's per-activity token:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832300,
+    "event": "update",
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":2,\"status\":\"Delivery arriving soon!\"}"
+    }
+  }
+}
+```
+
+To end a Live Activity remotely, send an `end` event with the final content state:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832600,
+    "event": "end",
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":0,\"status\":\"Delivered\"}"
+    },
+    "dismissal-date": 1778833200
+  }
+}
+```
+
+For the exact payload shape and headers, follow Apple's [Starting and updating Live Activities with ActivityKit push notifications](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications).
+
+## Known limitations
+
+- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
+- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
 
 ## API
 

--- a/docs/pages/versions/v56.0.0/sdk/widgets.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/widgets.mdx
@@ -12,7 +12,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 > **important** This library is not available in the Expo Go app — use [development builds](/develop/development-builds/introduction) to try it out.
 
-`expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating widgets timeline, as well as starting and managing Live Activities. Layout can be built using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
+`expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating a widget's timeline, as well as starting and managing Live Activities. You can build the layout using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
 
 ## Installation
 
@@ -36,7 +36,9 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
               "name": "MyWidget",
               "displayName": "My Widget",
               "description": "A sample home screen widget",
-              "supportedFamilies": ["systemSmall", "systemMedium", "systemLarge"]
+              "ios": {
+                "supportedFamilies": ["systemSmall", "systemMedium", "systemLarge"]
+              }
             }
           ]
         }
@@ -59,7 +61,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
     {
       name: 'groupIdentifier',
       description:
-        'The app group identifier used for communication and data sharing between the main app and widgets. This is required for widgets to work properly. If not specified, defaults to `group.<main app bundle identifier>`.',
+        'The app group identifier used for communication and data sharing between the main app and widgets, which widgets require to work. If not specified, it defaults to `group.<main app bundle identifier>`. If `ios.bundleIdentifier` is also unset, prebuild fails because the bundle identifier is required to derive this value.',
       default: '"group.<app bundle identifier>"',
     },
     {
@@ -76,7 +78,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
     {
       name: 'widgets[].name',
       description:
-        'The internal name (identifier) of the widget. This is used as the Swift struct name and should be a valid Swift identifier (no spaces or special characters).',
+        'The internal name (identifier) of the widget. This is used as the Swift struct name and should be a valid Swift identifier (no spaces or special characters). It must match the `name` passed to `createWidget`.',
     },
     {
       name: 'widgets[].displayName',
@@ -89,13 +91,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
         "A brief description of what the widget does. This appears in the widget gallery to help users understand the widget's purpose.",
     },
     {
-      name: 'widgets[].contentMarginsDisabled',
-      description:
-        "When you disable content margins for a widget, the system doesn't automatically add margins around the widget's content, and you are responsible for specifying margins and padding around your widget content for each context.",
-      default: 'false',
-    },
-    {
-      name: 'widgets[].supportedFamilies',
+      name: 'widgets[].ios.supportedFamilies',
       description: [
         'An array of widget sizes that this widget supports. Available options:',
         '* `systemSmall` - Small square widget (2x2 grid)',
@@ -107,8 +103,25 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
         '* `accessoryInline` - Inline text widget for Lock Screen',
       ].join('\n'),
     },
+    {
+      name: 'widgets[].ios.contentMarginsDisabled',
+      description:
+        "When you disable content margins for a widget, the system doesn't automatically add margins around the widget's content, and you are responsible for specifying margins and padding around your widget content for each context.",
+      default: 'false',
+    },
+    {
+      name: 'widgets[].ios.configuration',
+      description: [
+        'Makes the widget [configurable](#configurable-widgets). The values the user picks are passed to your widget at runtime through `environment.configuration`. An object with:',
+        '* `title` - The title shown when the user edits the widget.',
+        '* `description` - An optional description shown when the user edits the widget.',
+        '* `parameters` - A map of parameter keys to parameter definitions. Each parameter has a `title`, a `type` (`string`, `number`, `boolean`, or `enum`), and a `default`. An `enum` parameter additionally takes a `values` array of `{ name, value }` options.',
+      ].join('\n'),
+    },
   ]}
 />
+
+> **info** The top-level `supportedFamilies` and `contentMarginsDisabled` options are deprecated aliases for `ios.supportedFamilies` and `ios.contentMarginsDisabled`. Prefer the nested `ios` form shown above.
 
 ### Full example with all options
 
@@ -127,20 +140,45 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
               "name": "StatusWidget",
               "displayName": "Status",
               "description": "Shows your current status at a glance",
-              "contentMarginsDisabled": true,
-              "supportedFamilies": ["systemSmall", "systemMedium"]
+              "ios": {
+                "contentMarginsDisabled": true,
+                "supportedFamilies": ["systemSmall", "systemMedium"]
+              }
             },
             {
-              "name": "DetailWidget",
-              "displayName": "Details",
-              "description": "Shows detailed information",
-              "supportedFamilies": ["systemMedium", "systemLarge"]
+              "name": "WeatherWidget",
+              "displayName": "Weather",
+              "description": "Shows the weather for a city you choose",
+              "ios": {
+                "supportedFamilies": ["systemSmall", "systemMedium"],
+                "configuration": {
+                  "title": "Choose a city",
+                  "description": "Pick which city to show the weather for",
+                  "parameters": {
+                    "city": {
+                      "title": "City",
+                      "type": "enum",
+                      "default": "sf",
+                      "values": [
+                        { "name": "San Francisco", "value": "sf" },
+                        { "name": "New York", "value": "nyc" }
+                      ]
+                    }
+                  }
+                }
+              }
             },
             {
               "name": "LockScreenWidget",
               "displayName": "Quick View",
               "description": "View info on your Lock Screen",
-              "supportedFamilies": ["accessoryCircular", "accessoryRectangular", "accessoryInline"]
+              "ios": {
+                "supportedFamilies": [
+                  "accessoryCircular",
+                  "accessoryRectangular",
+                  "accessoryInline"
+                ]
+              }
             }
           ]
         }
@@ -152,11 +190,42 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
 
 ## Usage
 
+### The `'widget'` directive
+
+Components passed to `createWidget` and `createLiveActivity` must start with the `'widget'` directive. The directive tells the bundler to compile that component into a separate JavaScript bundle that runs in an isolated runtime inside the widget extension, not in your app's React Native runtime.
+
+Because of this isolation, code inside a `'widget'`-marked component is limited:
+
+- It can only render [`@expo/ui/swift-ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers. Standard React Native components (such as `View` and `Text` from `react-native`) are not available.
+- It cannot use React hooks (`useState`, `useEffect`, and others), component state, or context. The function must be pure and return its layout synchronously.
+- It cannot perform asynchronous work, import other modules, or access your app's runtime or in-memory state.
+- It cannot reference anything declared outside the component function, including plain top-level `const`s in the **same file**. The bundler serializes only the function body, so module-scope values are not present at runtime. Declare every constant and helper **inside** the widget function, or pass it in through props.
+
+All data a widget needs must come in through its props (set with `updateSnapshot`, `updateTimeline`, or a Live Activity's `start` and `update`) and the `environment` argument. To use images, write them to [`widgetsDirectory`](#sharing-images-with-widgetsdirectory) from your app and reference them by path.
+
+```tsx
+import { Text } from '@expo/ui/swift-ui';
+import { createWidget, type WidgetEnvironment } from 'expo-widgets';
+
+// Declared at module scope — not included in the widget bundle.
+const CITY_NAMES: Record<string, string> = { sf: 'San Francisco' };
+
+const CityWidget = (props: object, environment: WidgetEnvironment<{ city: string }>) => {
+  'widget';
+  // Throws at runtime: Can't find variable: CITY_NAMES
+  return <Text>{CITY_NAMES[environment.configuration.city]}</Text>;
+};
+
+export default createWidget('CityWidget', CityWidget);
+```
+
+Move `CITY_NAMES` inside `CityWidget` (or pass the resolved value through props) to fix it.
+
 ### Widgets
 
-#### Prerequisite: Creating widget
+#### Prerequisite: Creating a widget
 
-Start by creating a Widget using the `createWidget` function and pass the widget component marked with the `'widget'` directive. The component receives your widget props as the first argument and a `WidgetEnvironment` object as the second.
+Start by creating a widget using the `createWidget` function and pass the widget component marked with the `'widget'` directive. The component receives your widget props as the first argument and a `WidgetEnvironment` object as the second.
 
 ```tsx
 import { Text, VStack } from '@expo/ui/swift-ui';
@@ -188,7 +257,7 @@ The widget name (`'MyWidget'`) must match the `name` field in your widget config
 
 An effective way to update a widget is to use the `updateSnapshot` method. This creates a widget timeline with a single entry that displays immediately.
 
-The example below continues from [Creating widget](#prerequisite-creating-widget).
+The example below continues from [Creating a widget](#prerequisite-creating-a-widget).
 
 ```tsx
 import MyWidget from './MyWidget';
@@ -199,9 +268,9 @@ MyWidget.updateSnapshot({ count: 5 });
 
 #### Timeline widget
 
-Use `updateTimeline` method to schedule widget updates at specific time. System will automatically update the widget based on the timeline.
+Use the `updateTimeline` method to schedule widget updates at a specific time. The system automatically updates the widget based on the timeline.
 
-The example below continues from [Creating widget](#prerequisite-creating-widget).
+The example below continues from [Creating a widget](#prerequisite-creating-a-widget).
 
 ```tsx
 import MyWidget from './MyWidget';
@@ -212,6 +281,27 @@ MyWidget.updateTimeline([
   { date: new Date(Date.now() + 7200000), props: { count: 3 } }, // 2 hours from now
   { date: new Date(Date.now() + 10800000), props: { count: 4 } }, // 3 hours from now
 ]);
+```
+
+#### Reading the current timeline
+
+Use `getTimeline` to read the entries currently scheduled for a widget, including past and future entries.
+
+```tsx
+import MyWidget from './MyWidget';
+
+const entries = await MyWidget.getTimeline();
+// [{ date: Date, props: { count: number } }, ...]
+```
+
+#### Reloading a widget
+
+Use `reload` to force the system to refresh a widget's content and timeline immediately, for example after the underlying data changes.
+
+```tsx
+import MyWidget from './MyWidget';
+
+MyWidget.reload();
 ```
 
 #### Responsive widget
@@ -266,13 +356,111 @@ Widget.updateSnapshot({
 });
 ```
 
+#### Adapting to the rendering environment
+
+Beyond `widgetFamily` and `date`, the `environment` object describes how and where the system is drawing the widget so you can adapt the layout:
+
+- `colorScheme`: `'light'` or `'dark'`.
+- `widgetRenderingMode`: `'fullColor'` for home screen widgets, `'vibrant'` for Lock Screen widgets (the system desaturates them into an adaptive monochrome look), and `'accented'` for tinted widgets on iOS 18 and later. Use this to choose colors that read well in each mode.
+- `isLuminanceReduced`: `true` when the display requires reduced brightness (such as Always-On). Lower the overall brightness of your content, for example by using stroked rather than filled shapes.
+- `widgetContentMargins`: The system-suggested margins (`top`, `bottom`, `leading`, `trailing`) when content margins are not disabled.
+- `showsWidgetLabel`: For accessory widgets, whether an accessory label can be displayed.
+
+#### Interactive widgets
+
+Widgets can include interactive controls such as `Button`. The value a button's `onPress` callback returns becomes the widget's new props. The runtime persists it and reloads the widget on device, with no running app process required. This is the primary way to make a widget update itself in response to a tap. Interactive widgets require iOS 17 or later.
+
+```tsx CounterWidget.tsx
+import { Button, Text, VStack } from '@expo/ui/swift-ui';
+import { createWidget } from 'expo-widgets';
+
+type CounterProps = {
+  count: number;
+};
+
+const CounterWidget = (props: CounterProps) => {
+  'widget';
+  return (
+    <VStack>
+      <Text>Count: {props.count}</Text>
+      <Button label="Increment" target="increment" onPress={() => ({ count: props.count + 1 })} />
+    </VStack>
+  );
+};
+
+export default createWidget('CounterWidget', CounterWidget);
+```
+
+To also keep your running app in sync with widget interactions, give the control a `target` identifier (as above) and listen for taps with `addUserInteractionListener`. The listener receives the widget's `name` as `source` and the control's `target`. Unlike `onPress`, it only fires while the app process is alive, so use it to mirror interactions into app state, not as the widget's update mechanism.
+
+```tsx App.tsx
+import { addUserInteractionListener } from 'expo-widgets';
+
+const subscription = addUserInteractionListener(event => {
+  if (event.source === 'CounterWidget' && event.target === 'increment') {
+    // The widget already updated itself via onPress; mirror the change in app state here.
+    console.log('Counter incremented from the widget');
+  }
+});
+
+// Later, when you no longer need updates:
+subscription.remove();
+```
+
+#### Sharing images with `widgetsDirectory`
+
+A widget can't access files inside your app's sandbox, so to display an image in a widget you must place it in the shared app group container. `widgetsDirectory` is a `file://` URL string pointing to a directory that both your app and its widgets can read. Write the image there from your app, then reference it by path in the widget.
+
+```tsx
+import { widgetsDirectory } from 'expo-widgets';
+
+// `widgetsDirectory` is a file:// URL to a directory shared with your widgets.
+console.log(widgetsDirectory);
+```
+
+> **info** `widgetsDirectory` is `null` only when no app group is configured. The `groupIdentifier` config plugin option sets one up automatically (falling back to `group.<bundle identifier>`), so it is available in normal use.
+
+#### Configurable widgets
+
+When you add an [`ios.configuration`](#configuration-in-app-config) to a widget, users can long-press the widget and edit its parameters. The values they choose are delivered to your widget through `environment.configuration`. Type the configuration by passing a second type argument to `createWidget` (and `WidgetEnvironment`). Configurable widgets require iOS 17 or later.
+
+```tsx
+import { Text, VStack } from '@expo/ui/swift-ui';
+import { createWidget, type WidgetEnvironment } from 'expo-widgets';
+
+type WeatherProps = {
+  temperature: number;
+};
+
+type WeatherConfiguration = {
+  city: string;
+};
+
+const WeatherWidget = (
+  props: WeatherProps,
+  environment: WidgetEnvironment<WeatherConfiguration>
+) => {
+  'widget';
+  return (
+    <VStack>
+      <Text>{environment.configuration.city}</Text>
+      <Text>{props.temperature}°</Text>
+    </VStack>
+  );
+};
+
+export default createWidget<WeatherProps, WeatherConfiguration>('WeatherWidget', WeatherWidget);
+```
+
 ### Live Activities
 
 Live Activities display real-time information on the Lock Screen and in the Dynamic Island on supported devices.
 
-#### Prerequisite: Creating Live Activity
+#### Prerequisite: Creating a Live Activity
 
-Live Activity layouts must be created once using `createLiveActivity` and marked with the `'widget'` directive. The component receives your props as the first argument and a `LiveActivityEnvironment` object as the second.
+Live Activity layouts must be created once using `createLiveActivity` and marked with the `'widget'` directive. The component receives your props as the first argument and a `LiveActivityEnvironment` object as the second. It returns an object describing the layout for each presentation: the Lock Screen `banner`, the compact and minimal Dynamic Island states, and the expanded Dynamic Island regions.
+
+> **important** `createLiveActivity` registers a Live Activity entirely at runtime, and the library's built-in Live Activity target renders it. Do **not** add a `widgets[]` entry for it in the [app config](#configuration-in-app-config). The `widgets[]` array is only for home screen and Lock Screen widgets, and an entry without `supportedFamilies` generates an invalid widget target that fails to build. The `name` you pass to `createLiveActivity` only has to match this `createLiveActivity` call, not an app-config widget.
 
 ```tsx
 import { Image, Text, VStack } from '@expo/ui/swift-ui';
@@ -286,7 +474,7 @@ type DeliveryActivityProps = {
 
 const DeliveryActivity = (props: DeliveryActivityProps, environment: LiveActivityEnvironment) => {
   'widget';
-  const accentColor = environment.colorScheme === 'dark' ? '#FFFFFF' : '#007AFF';
+  const accentColor = environment.isLuminanceReduced ? '#FFFFFF' : '#007AFF';
 
   return {
     banner: (
@@ -324,9 +512,18 @@ const DeliveryActivity = (props: DeliveryActivityProps, environment: LiveActivit
 export default createLiveActivity('DeliveryActivity', DeliveryActivity);
 ```
 
+The layout object supports these regions:
+
+- `banner`: The main Lock Screen presentation.
+- `bannerSmall`: A compact Lock Screen presentation used on CarPlay and watchOS. Falls back to `banner` when omitted.
+- `compactLeading`, `compactTrailing`, `minimal`: The compact and minimal Dynamic Island states.
+- `expandedLeading`, `expandedTrailing`, `expandedCenter`, `expandedBottom`: The regions of the expanded Dynamic Island.
+
+The `environment` object also exposes `isLuminanceReduced`, `isActivityFullscreen`, `isActivityUpdateReduced`, and `activityFamily` so you can adapt the layout to the current presentation.
+
 #### Starting a Live Activity
 
-The example below continues from [Creating Live Activity](#prerequisite-creating-live-activity).
+The example below continues from [Creating a Live Activity](#prerequisite-creating-a-live-activity).
 
 ```tsx
 import { Button, View } from 'react-native';
@@ -354,6 +551,8 @@ function App() {
 export default App;
 ```
 
+The optional second argument is a URL associated with the Live Activity. When the user taps the activity, the system opens your app with that URL, so you can route to the relevant screen using [linking](/linking/into-your-app/) (for example with Expo Router's deep linking).
+
 #### Updating a Live Activity
 
 The example below continues from [Starting a Live Activity](#starting-a-live-activity).
@@ -366,6 +565,20 @@ function updateDelivery(instance: LiveActivity<DeliveryActivityProps>) {
     etaMinutes: 2,
     status: 'Delivery arriving soon!',
   });
+}
+```
+
+#### Recovering active Live Activities
+
+A Live Activity can outlive the app process that started it. Use `getInstances` on the factory to retrieve the activities of that type that are currently active, for example to update or end them after your app relaunches.
+
+```tsx
+import DeliveryActivity from './DeliveryActivity';
+
+const activeInstances = DeliveryActivity.getInstances();
+
+for (const instance of activeInstances) {
+  await instance.update({ etaMinutes: 5, status: 'Almost there' });
 }
 ```
 
@@ -390,9 +603,12 @@ async function completeDelivery(instance: LiveActivity<DeliveryActivityProps>) {
 
 You can also pass `'default'` or `'immediate'` instead of `after(date)` for the dismissal policy.
 
-#### Push tokens for remote updates
+#### Remote updates with push notifications
 
-When `enablePushNotifications` is `true`, use `addPushToStartTokenListener` to receive the app-wide push-to-start token and `instance.getPushToken()` or `instance.addPushTokenListener()` to work with a specific Live Activity instance.
+When `enablePushNotifications` is `true`, you can update Live Activities remotely from your server through Apple Push Notification service (APNs).
+
+- Use `addPushToStartTokenListener` to receive the app-wide push-to-start token, which lets your server start a Live Activity remotely (requires iOS 17.2 or later).
+- Use `instance.getPushToken()` or `instance.addPushTokenListener()` to obtain the token for a specific running Live Activity, which lets your server send updates to that activity.
 
 ```tsx
 import { addPushToStartTokenListener } from 'expo-widgets';
@@ -422,6 +638,69 @@ async function startDeliveryTracking() {
 // Later, when you no longer need updates:
 pushToStartSubscription.remove();
 ```
+
+Send the token to your server and use it to push updates. The notification must use the `liveactivity` push type (the `apns-push-type` header) and an `apns-topic` of `<your bundle identifier>.push-type.liveactivity`. Its `aps` payload carries an `event` (`start`, `update`, or `end`), a `timestamp`, and a `content-state` that matches your activity's props. The `content-state` must match the internal content state used by `expo-widgets`: set `name` to the name you passed to `createLiveActivity`, and set `props` to a JSON string of that activity's props. Use `apns-priority: 10` for immediate updates and `apns-priority: 5` for lower-priority updates. The `timestamp`, `dismissal-date`, and other APNs date fields are Unix timestamps in seconds.
+
+To start a Live Activity remotely, send a `start` event to the push-to-start token:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832000,
+    "event": "start",
+    "attributes-type": "LiveActivityAttributes",
+    "attributes": {},
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":15,\"status\":\"Your delivery is on the way\"}"
+    },
+    "alert": {
+      "title": "Delivery started",
+      "body": "Your delivery is on the way"
+    }
+  }
+}
+```
+
+Remote start requires iOS 17.2 or later. Include `input-push-token: 1` in the `aps` payload on iOS 18 or later if you want APNs to provide a new per-activity token for future updates.
+
+To update a Live Activity remotely, send an `update` event to that activity's per-activity token:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832300,
+    "event": "update",
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":2,\"status\":\"Delivery arriving soon!\"}"
+    }
+  }
+}
+```
+
+To end a Live Activity remotely, send an `end` event with the final content state:
+
+```json
+{
+  "aps": {
+    "timestamp": 1778832600,
+    "event": "end",
+    "content-state": {
+      "name": "DeliveryActivity",
+      "props": "{\"etaMinutes\":0,\"status\":\"Delivered\"}"
+    },
+    "dismissal-date": 1778833200
+  }
+}
+```
+
+For the exact payload shape and headers, follow Apple's [Starting and updating Live Activities with ActivityKit push notifications](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications).
+
+## Known limitations
+
+- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
+- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
 
 ## API
 

--- a/docs/pages/versions/v56.0.0/sdk/widgets.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/widgets.mdx
@@ -14,6 +14,11 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 `expo-widgets` enables the creation of iOS home screen widgets and Live Activities using Expo UI components, without writing native code. It provides a simple API for creating and updating a widget's timeline, as well as starting and managing Live Activities. You can build the layout using [`expo/ui`](/versions/latest/sdk/ui/swift-ui/) components and modifiers.
 
+## Known limitations
+
+- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
+- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
+
 ## Installation
 
 <APIInstallSection />
@@ -696,11 +701,6 @@ To end a Live Activity remotely, send an `end` event with the final content stat
 ```
 
 For the exact payload shape and headers, follow Apple's [Starting and updating Live Activities with ActivityKit push notifications](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications).
-
-## Known limitations
-
-- **Frequent Live Activity updates.** To raise the budget for frequent push updates, set `NSSupportsLiveActivitiesFrequentUpdates` to `true` in your **Info.plist**. The system may still throttle updates, and the user can disable frequent updates in Settings.
-- **Widget runtime.** Code inside a `'widget'`-marked component runs in an isolated runtime and can only use `@expo/ui/swift-ui` components, with no React hooks, app state, or asynchronous work. See [The `'widget'` directive](#the-widget-directive).
 
 ## API
 


### PR DESCRIPTION
# Why

Expands the `expo-widgets` SDK reference docs to cover the full API surface and fixes documentation style issues flagged by the docs writing style guide and Vale.

The previous page documented only a subset of the API and the prose had several deviations from the [Expo Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (passive voice, emphasis-capitalized words, missing articles, and headings that weren't sentence case).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Expanded `sdk/widgets.mdx` to document the missing APIs (reading/reloading timelines, interactive widgets, configurable widgets, `widgetsDirectory`, recovering active Live Activities, push-based remote updates, and the rendering environment), applied identically to both the `v56.0.0` and `unversioned` copies per the [docs contribution rule](https://github.com/expo/expo/blob/main/CONTRIBUTING.md).
- Applied style-guide fixes: rewrote passive sentences in the active voice, lowercased a word that was capitalized for emphasis, added missing articles, and switched to present tense.
- Renamed the `Prerequisite: Creating a widget` / `Prerequisite: Creating a Live Activity` headings and updated their cross-reference anchors to match.
- Added the new heading text to the `expo-docs.HeadingCase` Vale exceptions list (keeping the old entries so the frozen `v55.0.0` docs still pass).
- Ran `oxfmt` to format the changed files.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `pnpm format` (oxfmt) — passes; both files report correct formatting.
- `pnpm run lint-prose` (Vale) — passes: `0 errors, 0 warnings, and 0 suggestions in 1280 files`.
- Verified the renamed headings and their in-page anchor links (`#prerequisite-creating-a-widget`, `#prerequisite-creating-a-live-activity`) resolve correctly.
- Confirmed the `v56.0.0` and `unversioned` copies are in sync.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)