### PR TITLE
[image] Fix ThumbHash crashing on images with extreme aspect ratios

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed image staying blank when its `source` changes while a `transition` cross-fade is still running. ([#46752](https://github.com/expo/expo/pull/46752) by [@zoontek](https://github.com/zoontek))
+- [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/Utils/Thumbhash.swift
+++ b/packages/expo-image/ios/Utils/Thumbhash.swift
@@ -461,8 +461,9 @@ import UIKit
 
 func thumbHash(fromImage: UIImage) -> Data {
   let size = fromImage.size
-  let w = Int(round(100 * size.width / max(size.width, size.height)))
-  let h = Int(round(100 * size.height / max(size.width, size.height)))
+  // Extreme aspect ratios can lead to dimension of 0 after rounding
+  let w = max(1, Int(round(100 * size.width / max(size.width, size.height))))
+  let h = max(1, Int(round(100 * size.height / max(size.width, size.height))))
   var rgba = Data(count: w * h * 4)
   rgba.withUnsafeMutableBytes { rgba in
     if


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/47153

# How

Update ThumbHash logic to clamp both dimensions to a minimum of 1px 

# Test Plan

```
import { Image } from 'expo-image';

...

Image.generateThumbhashAsync("https://placehold.co/1x2001.png");
```
 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
