### PR TITLE
[ios][modules-core] Add JavaScriptCodable conformance for SharedObject

### DIFF
--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+SharedObject.swift
@@ -1,0 +1,44 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `SharedObject` is `JavaScriptCodable`. A shared object is represented in JS by the object the
+// `SharedObjectRegistry` pairs with it, so the conversion wraps that pairing rather than encoding the
+// object's structure like `Record`.
+
+extension SharedObject: JavaScriptDecodable, JavaScriptEncodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws -> Self
+  {
+    // Reads the native object off the JS object's `SharedObjectNativeState` (no app context needed).
+    // Throws `NotFoundException` for a foreign object and `TypeMismatchException` when the paired
+    // object isn't `Self`.
+    return try native(from: value.asObject(), as: Self.self)
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptUnownedValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Self
+  {
+    // Overrides the defaulted overload to stay zero-copy: `asObject(in:)` reads the object straight off
+    // the borrowed value, skipping the owning `JavaScriptValue` the default would materialize before
+    // discarding it. The argument-decode fast path the macro emits goes through here.
+    return try native(from: value.asObject(in: runtime), as: Self.self)
+  }
+
+  @JavaScriptActor
+  public static func encode(_ value: SharedObject, in runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    // Delegates to `DynamicSharedObjectType.castToJS`, which returns the already-paired JS object or
+    // creates and registers a new one. That needs the registry on the app context, recovered from the
+    // runtime; an unprepared runtime throws `Exceptions.AppContextNotFound`.
+    //
+    // TODO: creating the object isn't `encode`'s job. Once creation/pairing moves elsewhere, `encode`
+    // would only read the native state, dropping the app-context lookup and becoming `@inlinable` too.
+    guard let appContext = AppContext.from(runtime: runtime) else {
+      throw Exceptions.AppContextNotFound()
+    }
+    return try DynamicSharedObjectType(innerType: Self.self).castToJS(value, appContext: appContext)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableSharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableSharedObjectTests.swift
@@ -1,0 +1,154 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Testing
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+SharedObject")
+@JavaScriptActor
+struct JavaScriptCodableSharedObjectTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - encode
+
+  @Test
+  func `encodes a native shared object to a registered JS object`() throws {
+    let runtime = try runtime
+    let registrySizeBefore = appContext.sharedObjectRegistry.size
+    let native = CodableSharedObject()
+
+    let encoded = try CodableSharedObject.encode(native, in: runtime)
+
+    #expect(encoded.kind == .object)
+    #expect(appContext.sharedObjectRegistry.size == registrySizeBefore + 1)
+    // The native object is now paired with the JS object it encoded to. The nil check runs outside
+    // `#expect` because `getJavaScriptObject()` returns a `~Copyable` optional the macro can't capture.
+    let isPaired = native.getJavaScriptObject() != nil
+    #expect(isPaired)
+  }
+
+  @Test
+  func `encoding the same object twice returns the existing JS object`() throws {
+    let runtime = try runtime
+    let native = CodableSharedObject()
+
+    let first = try CodableSharedObject.encode(native, in: runtime)
+    let registrySizeAfterFirst = appContext.sharedObjectRegistry.size
+    let second = try CodableSharedObject.encode(native, in: runtime)
+
+    // The second encode reuses the already-paired JS object rather than registering a new one.
+    // `JavaScriptValue` equality is JS strict equality, so two values wrapping the same object are equal.
+    #expect(first == second)
+    #expect(appContext.sharedObjectRegistry.size == registrySizeAfterFirst)
+  }
+
+  // MARK: - decode
+
+  @Test
+  func `round-trips a shared object through its JS object`() throws {
+    let runtime = try runtime
+    let native = CodableSharedObject()
+    let encoded = try CodableSharedObject.encode(native, in: runtime)
+
+    let decoded = try CodableSharedObject.decode(encoded, in: runtime)
+
+    #expect(decoded === native)
+  }
+
+  @Test
+  func `decode throws a type mismatch when the native object is a different subclass`() throws {
+    let runtime = try runtime
+    let native = CodableSharedObject()
+    let encoded = try CodableSharedObject.encode(native, in: runtime)
+
+    // The JS object is paired with a `CodableSharedObject`, so decoding it as a different subclass mismatches.
+    #expect(throws: SharedObject.TypeMismatchException.self) {
+      _ = try OtherCodableSharedObject.decode(encoded, in: runtime)
+    }
+  }
+
+  @Test
+  func `decode throws not-found for a foreign object`() throws {
+    let runtime = try runtime
+    // A plain object carries no paired native shared object.
+    let foreign = try runtime.eval("({})")
+
+    #expect(throws: SharedObject.NotFoundException.self) {
+      _ = try CodableSharedObject.decode(foreign, in: runtime)
+    }
+  }
+
+  @Test
+  func `decodes from a borrowed argument buffer`() throws {
+    // `decode` resolves to the defaulted borrowing `JavaScriptUnownedValue` overload (the fast path the
+    // macro emits for arguments), which materializes an owning value and forwards to the requirement.
+    let runtime = try runtime
+    let native = CodableSharedObject()
+    let encoded = try CodableSharedObject.encode(native, in: runtime)
+    let buffer = JavaScriptValuesBuffer.copying(in: runtime, values: [encoded])
+
+    let decoded = try CodableSharedObject.decode(buffer.unownedValue(at: 0), in: runtime)
+
+    #expect(decoded === native)
+  }
+
+  @Test
+  func `decode does not need an app context`() throws {
+    // `decode` reads the native object off the JS object's native state, so it works even on a runtime
+    // the app context never prepared. The object is encoded (and so paired) with the prepared runtime,
+    // then decoded with a bare one to prove the decode path itself never touches the app context.
+    let native = CodableSharedObject()
+    let encoded = try CodableSharedObject.encode(native, in: runtime)
+
+    let decoded = try CodableSharedObject.decode(encoded, in: JavaScriptRuntime())
+
+    #expect(decoded === native)
+  }
+
+  // MARK: - SharedRef
+
+  @Test
+  func `round-trips a shared ref`() throws {
+    let runtime = try runtime
+    let native = CodableSharedRef(42)
+
+    let encoded = try CodableSharedRef.encode(native, in: runtime)
+    let decoded = try CodableSharedRef.decode(encoded, in: runtime)
+
+    #expect(decoded === native)
+    #expect(decoded.ref == 42)
+  }
+
+  // MARK: - Missing app context
+
+  @Test
+  func `encode throws when the runtime has no app context`() throws {
+    let bareRuntime = JavaScriptRuntime()
+    let native = CodableSharedObject()
+
+    #expect(throws: Exceptions.AppContextNotFound.self) {
+      _ = try CodableSharedObject.encode(native, in: bareRuntime)
+    }
+  }
+}
+
+// MARK: - Test Helpers
+
+private final class CodableSharedObject: SharedObject {}
+
+/// A second, unrelated subclass used to exercise the type-mismatch path of `decode`.
+private final class OtherCodableSharedObject: SharedObject {}
+
+/// A `SharedRef` subclass used to exercise the `AnySharedRef` branch of the encode path.
+private final class CodableSharedRef: SharedRef<Int> {
+  override var nativeRefType: String {
+    "codable-test"
+  }
+}


### PR DESCRIPTION
# Why

The `JavaScriptCodable` protocols (added in #47178) let native types convert to and from a JS value without type erasure. `Record` and `Enumerable` already conform; `SharedObject` didn't. This adds the conformance so `SharedObject` keeps parity as the codable surface grows.

Note: these conformances aren't wired into the runtime yet. The live argument/return-value path still goes through the legacy `AnyDynamicType` converters, so this is groundwork ahead of that switch, not a behavior change.

# How

`SharedObject` conforms to `JavaScriptDecodable`/`JavaScriptEncodable` in a new `JavaScriptCodable+SharedObject.swift`:

- **`decode`** recovers the native object straight off the JS object's `SharedObjectNativeState` via `SharedObject.native(from:as:)`, which throws `NotFoundException` for a foreign object and `TypeMismatchException` when the paired object isn't the requested subclass. It needs no app context and is `@inlinable` (the checked cast specializes in the conformer's module, like `native(from:as:)` itself).
- **`encode`** delegates to `DynamicSharedObjectType.castToJS`, the existing source of truth that returns the already-paired JS object or creates and registers a new one. That registry lives on the app context, which `encode` recovers from the runtime via `AppContext.from(runtime:)`. It's left non-`@inlinable` because it routes through internal registry machinery, and carries a `TODO`: object creation isn't `encode`'s responsibility and should move elsewhere so `encode` only reads the native state and returns the object for the runtime (which would let it drop the app-context lookup and become `@inlinable` too).

Internal-only change (`expo` and `expo-modules-core` ship paired, the surface stays visible via re-export), so no CHANGELOG entry.

# Test Plan

Added `JavaScriptCodableSharedObjectTests` covering encode→registered object, encode reuse (same object, no double-registration), encode/decode round-trip, the unowned/borrowed-argument decode fast path, decode without an app context, a `SharedRef` round-trip, type-mismatch, not-found, and encode-without-app-context. All pass via `et native-unit-tests -p ios --packages expo-modules-core`:

```
✔ Suite "JavaScriptCodable+SharedObject" passed (11 tests)
```
