### PR TITLE
[cli] Guard DevTools plugin request error handler against started responses

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Avoid writing a 500 response when a DevTools plugin server request has already started or aborted. ([#47192](https://github.com/expo/expo/pull/47192) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Use `loadModule` for MCP and DevTools plugin server module loading. ([#47139](https://github.com/expo/expo/pull/47139) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Focus the booted device in Device Hub using its `devices://` deep link instead of only bringing the app forward. ([#46809](https://github.com/expo/expo/pull/46809) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Symbolicate web error stacks in the dev server console. ([#46584](https://github.com/expo/expo/pull/46584) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/src/start/server/middleware/DevToolsPluginMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DevToolsPluginMiddleware.ts
@@ -77,9 +77,10 @@ export class DevToolsPluginMiddleware extends ExpoMiddleware {
     urlInPluginRoot: string
   ): Promise<boolean> {
     const originalUrl = req.url;
+    let request: Request | undefined;
     try {
       req.url = urlInPluginRoot;
-      const request = convertRequest(req as http.IncomingMessage, res as http.ServerResponse);
+      request = convertRequest(req as http.IncomingMessage, res as http.ServerResponse);
       const handler = await plugin.getRequestHandlerAsync();
       const response = await handler?.(request);
       if (response == null) {
@@ -89,6 +90,9 @@ export class DevToolsPluginMiddleware extends ExpoMiddleware {
       return true;
     } catch (error: any) {
       debug('DevTools plugin server request failed: %O', error);
+      if (res.headersSent || res.writableEnded || res.destroyed || request?.signal.aborted) {
+        return true;
+      }
       res.statusCode = 500;
       res.setHeader('Content-Type', 'text/plain');
       res.end(

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
@@ -310,6 +310,30 @@ describe(DevToolsPluginMiddleware, () => {
       expect(response.statusCode).toBe(500);
       expect(response.body()).toContain('boom');
     });
+
+    it('should not write a 500 when the response has already started', async () => {
+      const middleware = createMiddleware(
+        createPluginManager({
+          packageName: 'hello-plugin',
+          packageRoot: '/root/packages/hello-plugin',
+          serverEntryPoint: '/root/packages/hello-plugin/dist/server.js',
+          getRequestHandlerAsync: async () =>
+            jest.fn(async () => {
+              throw new Error('stream aborted');
+            }),
+        })
+      );
+
+      const response = Object.assign(createMockResponse(), { headersSent: true });
+      await middleware.handleRequestAsync(
+        createServerRequest('http://localhost:8081/_expo/plugins/hello-plugin/api/hello'),
+        response
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.setHeader).not.toHaveBeenCalled();
+      expect(response.end).not.toHaveBeenCalled();
+    });
   });
 
   it('handleRequestAsync should throw from invalid request', async () => {


### PR DESCRIPTION
# Why

When a DevTools plugin's fetch `requestHandler` threw *after* the response had already started streaming (headers sent, stream ended/destroyed, or the request aborted), the error handler tried to write a 500 fallback onto an already-committed response, throwing a secondary error.

# How

Before writing the 500 fallback, the error handler now checks `res.headersSent`, `res.writableEnded`, `res.destroyed`, and `request?.signal.aborted`. If any of those hold, the response is already committed/gone and the handler returns without touching it.