### PR TITLE
[ios][modules-core] Add JavaScriptCodable conformance for typed arrays

### DIFF
--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+TypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+TypedArray.swift
@@ -1,0 +1,17 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `JavaScriptCodable` conformance for `TypedArray`. Only the conformance declaration and `encode` live
+// here; the `decode` witness is a `class func` in the class body (extension methods can't be
+// overridden), and the concrete subclasses inherit the conformance and override `decode`. See
+// `TypedArray.swift` / `ConcreteTypedArrays.swift`.
+
+extension TypedArray: JavaScriptDecodable, JavaScriptEncodable {
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: TypedArray, in runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    // No byte copy: the wrapper already owns the JS typed array, so hand the same object back.
+    return value.jsTypedArray.asValue()
+  }
+}

--- a/packages/expo-modules-core/ios/Core/TypedArrays/ConcreteTypedArrays.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/ConcreteTypedArrays.swift
@@ -1,56 +1,128 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-/**
- Native equivalent of `Int8Array` in JavaScript, an array of two's-complement 8-bit signed integers.
- */
-public final class Int8Array: GenericTypedArray<Int8> {}
+import ExpoModulesJSI
 
-/**
- Native equivalent of `Int16Array` in JavaScript, an array of two's-complement 16-bit signed integers.
- */
-public final class Int16Array: GenericTypedArray<Int16> {}
+// Each concrete typed array overrides `decode` to return its own `Self` and reject a mismatched kind,
+// delegating to the shared `decode(_:expectingKind:)` on the base. See `TypedArray.swift` for why the
+// witness is an overridable `class func` rather than living in the conformance extension.
 
-/**
- Native equivalent of `Int32Array` in JavaScript, an array of two's-complement 32-bit signed integers.
- */
-public final class Int32Array: GenericTypedArray<Int32> {}
+/// Native equivalent of `Int8Array` in JavaScript, an array of two's-complement 8-bit signed integers.
+public final class Int8Array: GenericTypedArray<Int8> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Int8Array
+  {
+    return try decode(value, expectingKind: .Int8Array)
+  }
+}
 
-/**
- Native equivalent of `Uint8Array` in JavaScript, an array of 8-bit unsigned integers.
- */
-public final class Uint8Array: GenericTypedArray<UInt8> {}
+/// Native equivalent of `Int16Array` in JavaScript, an array of two's-complement 16-bit signed integers.
+public final class Int16Array: GenericTypedArray<Int16> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Int16Array
+  {
+    return try decode(value, expectingKind: .Int16Array)
+  }
+}
 
-/**
- Native equivalent of `Uint8ClampedArray` in JavaScript, an array of 8-bit unsigned integers clamped to 0-255.
- */
-public final class Uint8ClampedArray: GenericTypedArray<UInt8> {}
+/// Native equivalent of `Int32Array` in JavaScript, an array of two's-complement 32-bit signed integers.
+public final class Int32Array: GenericTypedArray<Int32> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Int32Array
+  {
+    return try decode(value, expectingKind: .Int32Array)
+  }
+}
 
-/**
- Native equivalent of `Uint16Array` in JavaScript, an array of 16-bit unsigned integers.
- */
-public final class Uint16Array: GenericTypedArray<UInt16> {}
+/// Native equivalent of `Uint8Array` in JavaScript, an array of 8-bit unsigned integers.
+public final class Uint8Array: GenericTypedArray<UInt8> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Uint8Array
+  {
+    return try decode(value, expectingKind: .Uint8Array)
+  }
+}
 
-/**
- Native equivalent of `Uint32Array` in JavaScript, an array of 32-bit unsigned integers.
- */
-public final class Uint32Array: GenericTypedArray<UInt32> {}
+/// Native equivalent of `Uint8ClampedArray` in JavaScript, an array of 8-bit unsigned integers clamped to 0-255.
+public final class Uint8ClampedArray: GenericTypedArray<UInt8> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Uint8ClampedArray
+  {
+    return try decode(value, expectingKind: .Uint8ClampedArray)
+  }
+}
 
-/**
- Native equivalent of `Float32Array` in JavaScript, an array of 32-bit floating point numbers.
- */
-public final class Float32Array: GenericTypedArray<Float32> {}
+/// Native equivalent of `Uint16Array` in JavaScript, an array of 16-bit unsigned integers.
+public final class Uint16Array: GenericTypedArray<UInt16> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Uint16Array
+  {
+    return try decode(value, expectingKind: .Uint16Array)
+  }
+}
 
-/**
- Native equivalent of `Float64Array` in JavaScript, an array of 64-bit floating point numbers.
- */
-public final class Float64Array: GenericTypedArray<Float64> {}
+/// Native equivalent of `Uint32Array` in JavaScript, an array of 32-bit unsigned integers.
+public final class Uint32Array: GenericTypedArray<UInt32> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Uint32Array
+  {
+    return try decode(value, expectingKind: .Uint32Array)
+  }
+}
 
-/**
- Native equivalent of `BigInt64Array` in JavaScript, an array of 64-bit signed integers.
- */
-public final class BigInt64Array: GenericTypedArray<Int64> {}
+/// Native equivalent of `Float32Array` in JavaScript, an array of 32-bit floating point numbers.
+public final class Float32Array: GenericTypedArray<Float32> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Float32Array
+  {
+    return try decode(value, expectingKind: .Float32Array)
+  }
+}
 
-/**
- Native equivalent of `BigUint64Array` in JavaScript, an array of 64-bit unsigned integers.
- */
-public final class BigUint64Array: GenericTypedArray<UInt64> {}
+/// Native equivalent of `Float64Array` in JavaScript, an array of 64-bit floating point numbers.
+public final class Float64Array: GenericTypedArray<Float64> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> Float64Array
+  {
+    return try decode(value, expectingKind: .Float64Array)
+  }
+}
+
+/// Native equivalent of `BigInt64Array` in JavaScript, an array of 64-bit signed integers.
+public final class BigInt64Array: GenericTypedArray<Int64> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> BigInt64Array
+  {
+    return try decode(value, expectingKind: .BigInt64Array)
+  }
+}
+
+/// Native equivalent of `BigUint64Array` in JavaScript, an array of 64-bit unsigned integers.
+public final class BigUint64Array: GenericTypedArray<UInt64> {
+  @JavaScriptActor
+  @inlinable
+  public override class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> BigUint64Array
+  {
+    return try decode(value, expectingKind: .BigUint64Array)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
@@ -9,6 +9,7 @@ public class TypedArray: AnyTypedArray {
   /**
    Creates a concrete TypedArray from the given JavaScriptTypedArray
    */
+  @usableFromInline
   internal static func create(from jsTypedArray: consuming JavaScriptTypedArray) -> TypedArray {
     switch jsTypedArray.kind {
     case .Int8Array:
@@ -41,7 +42,8 @@ public class TypedArray: AnyTypedArray {
   /**
    A JavaScript object of the underlying typed array.
    */
-  let jsTypedArray: JavaScriptTypedArray
+  @usableFromInline
+  internal let jsTypedArray: JavaScriptTypedArray
 
   /**
    The length in bytes from the start of the underlying ArrayBuffer.
@@ -87,7 +89,93 @@ public class TypedArray: AnyTypedArray {
   /**
    Initializes the typed array with the given JS typed array.
    */
+  // `@usableFromInline internal`, not `public`: the `@inlinable` decode bodies need to call it, but it
+  // must not be public API. A concrete subclass binds the buffer to its `ContentType`, so wrapping a
+  // mismatched-kind JS typed array (e.g. `Int32Array(someUint8Array)`) would reinterpret memory. The
+  // `decode` paths only call it after checking the kind.
+  @usableFromInline
   required init(_ jsTypedArray: consuming JavaScriptTypedArray) {
     self.jsTypedArray = jsTypedArray
+  }
+
+  /// `JavaScriptDecodable` witness. It's a `class func` in the class body, not in the conformance
+  /// extension, so the concrete subclasses can override it (extension methods can't be overridden).
+  /// The base accepts any kind and resolves the concrete subclass via `create(from:)`.
+  @JavaScriptActor
+  @inlinable
+  public class func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws -> Self {
+    guard value.isTypedArray() else {
+      throw NotATypedArrayException()
+    }
+    // `create(from:)` returns the concrete subclass for the JS kind. For the base `TypedArray` the cast
+    // to `Self` always holds; it only fails when this inherited witness runs for a narrower `Self` (a
+    // `GenericTypedArray<T>` specialization) whose element type doesn't match the JS kind. Guard rather
+    // than force-cast so that surfaces as a thrown error instead of a trap.
+    let typedArray = create(from: value.getTypedArray())
+    guard let typed = typedArray as? Self else {
+      throw KindMismatchException(expected: nil, received: typedArray.kind)
+    }
+    return typed
+  }
+
+  /// Shared body for the concrete subclasses' `decode` overrides: constructs `Self` directly for a
+  /// matching `kind`, skipping `create(from:)`'s dispatch and a downcast.
+  @JavaScriptActor
+  @inlinable
+  internal static func decode(
+    _ value: borrowing JavaScriptValue,
+    expectingKind kind: JavaScriptTypedArray.Kind
+  ) throws -> Self {
+    guard value.isTypedArray() else {
+      throw NotATypedArrayException()
+    }
+    let jsTypedArray = value.getTypedArray()
+    guard jsTypedArray.kind == kind else {
+      throw KindMismatchException(expected: kind, received: jsTypedArray.kind)
+    }
+    return Self(jsTypedArray)
+  }
+}
+
+// MARK: - Decoding exceptions
+
+extension TypedArray {
+  /// Thrown when decoding a typed array from a JavaScript value that is not a typed array.
+  public struct NotATypedArrayException: JavaScriptThrowable {
+    // An explicit initializer because a struct's synthesized init is internal and so can't be called
+    // from the `@inlinable` decode bodies.
+    public init() {}
+
+    public var code: String {
+      "ERR_NOT_TYPED_ARRAY"
+    }
+    public var message: String {
+      "Expected a JavaScript typed array, but received a value of another type"
+    }
+  }
+
+  /// Thrown when a typed array is the wrong kind for the concrete type being decoded, e.g. decoding a
+  /// `Uint8Array` from a JavaScript `Int16Array`. `expected` is `nil` when the decoded type is a
+  /// `GenericTypedArray<T>` specialization that has no single expected kind.
+  public struct KindMismatchException: JavaScriptThrowable {
+    public let expected: JavaScriptTypedArray.Kind?
+    public let received: JavaScriptTypedArray.Kind
+
+    // An explicit initializer because a struct's synthesized memberwise init is internal even with
+    // public fields, so it can't be called from the `@inlinable` decode bodies.
+    public init(expected: JavaScriptTypedArray.Kind?, received: JavaScriptTypedArray.Kind) {
+      self.expected = expected
+      self.received = received
+    }
+
+    public var code: String {
+      "ERR_TYPED_ARRAY_KIND_MISMATCH"
+    }
+    public var message: String {
+      if let expected {
+        return "Expected a typed array of kind \(expected), but received \(received)"
+      }
+      return "A typed array of kind \(received) cannot be decoded as the expected typed array type"
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableTypedArrayTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableTypedArrayTests.swift
@@ -1,0 +1,142 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Testing
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+TypedArray")
+@JavaScriptActor
+struct JavaScriptCodableTypedArrayTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - Concrete types
+
+  @Test
+  func `decodes a Uint8Array`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("new Uint8Array([10, 20, 30])")
+
+    let decoded = try Uint8Array.decode(value, in: runtime)
+
+    #expect(decoded.kind == .Uint8Array)
+    #expect(decoded.length == 3)
+    #expect(decoded[0] == 10)
+    #expect(decoded[2] == 30)
+  }
+
+  @Test
+  func `decodes the integer and float concrete kinds`() throws {
+    let runtime = try runtime
+    #expect(try Int16Array.decode(runtime.eval("new Int16Array([1, 2])"), in: runtime).kind == .Int16Array)
+    #expect(try Int32Array.decode(runtime.eval("new Int32Array([1])"), in: runtime).kind == .Int32Array)
+    #expect(try Float32Array.decode(runtime.eval("new Float32Array([1.5])"), in: runtime).kind == .Float32Array)
+    #expect(try Float64Array.decode(runtime.eval("new Float64Array([2.5])"), in: runtime).kind == .Float64Array)
+    #expect(try BigInt64Array.decode(runtime.eval("new BigInt64Array([1n])"), in: runtime).kind == .BigInt64Array)
+  }
+
+  @Test
+  func `concrete decode throws on a kind mismatch`() throws {
+    let runtime = try runtime
+    // A `Uint8Array` decode given a JS `Int16Array` mismatches rather than silently accepting it, and
+    // the thrown error carries the expected and received kinds.
+    let error = try #require(throws: TypedArray.KindMismatchException.self) {
+      _ = try Uint8Array.decode(runtime.eval("new Int16Array([1, 2])"), in: runtime)
+    }
+    #expect(error.expected == .Uint8Array)
+    #expect(error.received == .Int16Array)
+  }
+
+  @Test
+  func `concrete decode throws when the value is not a typed array`() throws {
+    let runtime = try runtime
+    #expect(throws: TypedArray.NotATypedArrayException.self) {
+      _ = try Uint8Array.decode(runtime.eval("[1, 2, 3]"), in: runtime)
+    }
+  }
+
+  // MARK: - Base TypedArray
+
+  @Test
+  func `base TypedArray decodes any kind into the matching concrete subclass`() throws {
+    let runtime = try runtime
+    let decodedUint8 = try TypedArray.decode(runtime.eval("new Uint8Array([1])"), in: runtime)
+    #expect(decodedUint8 is Uint8Array)
+    #expect(decodedUint8.kind == .Uint8Array)
+
+    let decodedFloat64 = try TypedArray.decode(runtime.eval("new Float64Array([1.5])"), in: runtime)
+    #expect(decodedFloat64 is Float64Array)
+    #expect(decodedFloat64.kind == .Float64Array)
+  }
+
+  @Test
+  func `base TypedArray decode throws when the value is not a typed array`() throws {
+    let runtime = try runtime
+    #expect(throws: TypedArray.NotATypedArrayException.self) {
+      _ = try TypedArray.decode(runtime.eval("({})"), in: runtime)
+    }
+  }
+
+  // MARK: - Encode
+
+  @Test
+  func `encodes a typed array back to the same JS object`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("globalThis.original = new Uint8Array([7, 8, 9]); original")
+    let decoded = try Uint8Array.decode(value, in: runtime)
+
+    let encoded = try Uint8Array.encode(decoded, in: runtime)
+
+    // The conversion preserves identity: re-encoding hands back the original JS object, not a copy.
+    let isSame = try runtime.eval("v => v === globalThis.original").getFunction().call(arguments: encoded)
+    #expect(try isSame.asBool() == true)
+  }
+
+  @Test
+  func `round-trips a non-Uint8 typed array through the inherited encode`() throws {
+    let runtime = try runtime
+    // Concrete subclasses inherit `encode` from the base `TypedArray`; round-tripping a `Float64Array`
+    // confirms the inherited witness works, not just `Uint8Array`.
+    let value = try runtime.eval("new Float64Array([1.5, 2.5])")
+    let decoded = try Float64Array.decode(value, in: runtime)
+
+    let encoded = try Float64Array.encode(decoded, in: runtime)
+    let reDecoded = try Float64Array.decode(encoded, in: runtime)
+
+    #expect(reDecoded.kind == .Float64Array)
+    #expect(reDecoded[0] == 1.5)
+    #expect(reDecoded[1] == 2.5)
+  }
+
+  @Test
+  func `mutations through the decoded array are visible in JS`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("globalThis.buf = new Uint8Array([0, 0, 0]); buf")
+    let decoded = try Uint8Array.decode(value, in: runtime)
+
+    // No byte copy: writing through the native wrapper mutates the backing JS buffer in place.
+    decoded[1] = 42
+
+    #expect(try runtime.eval("globalThis.buf[1]").asInt() == 42)
+  }
+
+  // MARK: - Zero-copy borrowed-value overload
+
+  @Test
+  func `decodes from a borrowed argument buffer`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("new Uint8Array([5, 6])")
+    let buffer = JavaScriptValuesBuffer.copying(in: runtime, values: [value])
+
+    let decoded = try Uint8Array.decode(buffer.unownedValue(at: 0), in: runtime)
+
+    #expect(decoded.kind == .Uint8Array)
+    #expect(decoded[0] == 5)
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -72,7 +72,7 @@ public struct JavaScriptTypedArray: ~Copyable {
 
   // We need to redefine the C++ enum (see TypedArray.h) to expose it to Swift
   // without leaking the C++ type into the public API. Please keep them in-sync!
-  public enum Kind: Int {
+  public enum Kind: Int, Sendable {
     case Int8Array = 1
     case Int16Array = 2
     case Int32Array = 3


### PR DESCRIPTION
# Why

Continues migrating the legacy `AnyDynamicType` conversions to the typed `JavaScriptCodable` path. `TypedArray` and its concrete subclasses (`Uint8Array`, `Int16Array`, …) had no conformance; this adds it so typed arrays convert without type erasure, mirroring `Data` and the other conformances.

Note: like the other conformances, this isn't wired into the runtime yet. The live argument/return-value path still goes through `AnyDynamicType`, so this is groundwork, not a behavior change.

# How

`TypedArray` and all 11 concrete subclasses conform to `JavaScriptDecodable`/`JavaScriptEncodable`. Like the dynamic-type path, the conversion copies no bytes: the native wrapper holds the JS typed array, so `decode` wraps the incoming object and `encode` (`value.jsTypedArray.asValue()`) hands the same object back.

`decode` returns `Self`, so each concrete type needs its own kind-checked implementation. A conformance method declared in an extension can't be overridden, so the witness is an overridable `class func decode` in the class **body**:

- The base `TypedArray.decode` accepts any kind and resolves the concrete subclass through `create(from:)`.
- Each concrete subclass overrides `decode` to construct directly (`Uint8Array(jsTypedArray)`) and throw `TypedArray.KindMismatchException` on a mismatched kind, or `TypedArray.NotATypedArrayException` when the value isn't a typed array.
- The bare conformance declaration and the shared `encode` live in `JavaScriptCodable+TypedArray.swift`; the subclasses inherit the conformance and only override the witness. The exceptions live in `TypedArray.swift`, next to where they're thrown.

The conformances are `@inlinable` so they specialize into the caller's module instead of dispatching through the prebuilt binary. That required widening visibility on the touched internals: `TypedArray.init(_ jsTypedArray:)` is now `public` (a legitimately useful initializer), and `jsTypedArray` / `create(from:)` are `@usableFromInline`. `JavaScriptTypedArray.Kind` is now `Sendable` so the mismatch error can store it.

Internal-only change (`expo` and `expo-modules-core` ship paired, the surface stays visible via re-export), so no CHANGELOG entry.

# Test Plan

Added `JavaScriptCodableTypedArrayTests` covering: concrete decode for several kinds, kind-mismatch rejection (asserting the error's `expected`/`received` kinds), not-a-typed-array rejection, the base `TypedArray` decoding any kind into the matching subclass, encode preserving JS-object identity, a non-`Uint8Array` round-trip through the inherited `encode`, in-place mutation visibility (proving no byte copy), and the unowned/borrowed-argument decode fast path. All pass via `et native-unit-tests -p ios --packages expo-modules-core`:

```
✔ Suite "JavaScriptCodable+TypedArray" passed (12 tests)
```
