### PR TITLE
[expo] Add @expo/dom-webview to bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,4 +1,5 @@
 {
+  "@expo/dom-webview": "~56.0.5",
   "@expo/fingerprint": "~0.19.3",
   "@expo/metro-runtime": "~56.0.13",
   "@expo/vector-icons": "^15.0.2",


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/47076 

# How

Now that @expo/dom-webview is the default lib for DOM components, we should list it in bundledNativeModules to ensure the correct version is installed 

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
