### PR TITLE
[ui] Fix scrollable inside community BottomSheet not scrolling when nested in a list

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS][android] Fix a scrollable (e.g. `FlatList`) inside `community/bottom-sheet` not scrolling when the `<BottomSheet>` is mounted inside another same-orientation list (such as a `FlatList` header). ([#47197](https://github.com/expo/expo/pull/47197) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix Mac Catalyst build failure with `activityBackgroundTint` ([#46929](https://github.com/expo/expo/pull/46929) by [@theeket](https://github.com/theeket))
 - [iOS] Fix the SwiftUI `listRowInsets` modifier being ignored when every edge is set to `0`, so a row can now reset all of its insets. ([#47000](https://github.com/expo/expo/pull/47000) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS][android] Fix a scrollable (e.g. `FlatList`) inside `community/bottom-sheet` not scrolling when the `<BottomSheet>` is mounted inside another same-orientation list (such as a `FlatList` header). ([#47197](https://github.com/expo/expo/pull/47197) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS][Android] Fix a scrollable (e.g. `FlatList`) inside `@expo/ui/community/bottom-sheet` not scrolling when the `<BottomSheet>` is mounted inside another same-orientation list (such as a `FlatList` header). ([#47197](https://github.com/expo/expo/pull/47197) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix Mac Catalyst build failure with `activityBackgroundTint` ([#46929](https://github.com/expo/expo/pull/46929) by [@theeket](https://github.com/theeket))
 - [iOS] Fix the SwiftUI `listRowInsets` modifier being ignored when every edge is set to `0`, so a row can now reset all of its insets. ([#47000](https://github.com/expo/expo/pull/47000) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState 
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 
 import { BottomSheetContext, BottomSheetInternalContext } from './context';
+import { SheetScrollContextReset } from './scrollContextReset';
 import type { BottomSheetMethods, BottomSheetProps } from './types';
 import { parseSnapPoint } from './types';
 import { Host } from '../../jetpack-compose/Host';
@@ -199,7 +200,9 @@ export function BottomSheet(props: BottomSheetProps) {
               shouldDismissOnClickOutside: enablePanDownToClose,
             }}>
             <RNHostView matchContents={fitToContents}>
-              <View style={fitToContents ? undefined : { flex: 1 }}>{children}</View>
+              <View style={fitToContents ? undefined : { flex: 1 }}>
+                <SheetScrollContextReset>{children}</SheetScrollContextReset>
+              </View>
             </RNHostView>
           </ModalBottomSheet>
         </Host>

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
@@ -3,6 +3,7 @@ import { useWindowDimensions, View, StyleSheet } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 import { BottomSheetContext, BottomSheetInternalContext } from './context';
+import { SheetScrollContextReset } from './scrollContextReset';
 import type { BottomSheetMethods, BottomSheetProps } from './types';
 import { parseSnapPoint } from './types';
 import { BottomSheet as NativeBottomSheet } from '../../swift-ui/BottomSheet';
@@ -248,7 +249,7 @@ export function BottomSheet(props: BottomSheetProps) {
                       ? { paddingTop: handleComponent !== null ? 16 : 0 }
                       : { flex: 1, paddingTop: handleComponent !== null ? 16 : 0 }
                   }>
-                  {children}
+                  <SheetScrollContextReset>{children}</SheetScrollContextReset>
                 </View>
               </RNHostView>
             </Group>

--- a/packages/expo-ui/src/community/bottom-sheet/scrollContextReset.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/scrollContextReset.tsx
@@ -1,24 +1,24 @@
-import type { ComponentType, Context, ReactNode } from 'react';
-import { Modal, ScrollView } from 'react-native';
+import type { Context, ReactNode } from 'react';
+import { ScrollView, VirtualizedList } from 'react-native';
 
-const VirtualizedListContextResetter = (
-  Modal as unknown as { Context?: ComponentType<{ children: ReactNode }> }
-).Context;
-const ScrollViewContext = (
-  ScrollView as unknown as { Context: Context<{ horizontal: boolean } | null> }
-).Context;
+const VirtualizedListContext = (VirtualizedList as unknown as { contextType?: Context<unknown> })
+  .contextType;
+const ScrollViewContext = (ScrollView as unknown as { Context?: Context<unknown> }).Context;
 
-// When virtualised list (RN Flatlist) is nested within another Flatlist,
+// When a virtualised list (RN Flatlist) is nested within another Flatlist,
 // it renders a regular View as Scroll component https://github.com/react/react-native/blob/5c197fb303ed0d975482757fefb7ed38349601b6/packages/virtualized-lists/Lists/VirtualizedList.js#L1291
 // which breaks scrolling.
 // Nested same direction FlatLists are generally considered bad
 // but the react context check it is doing to identify nesting can break some genuine cases
-// e.g. User has a FlatList with a button child that opens bottomsheet with a Flatlist
+// e.g. User has a FlatList with a button child that opens bottomsheet with a Flatlist.
+// RN Modal uses similar pattern as below
 export function SheetScrollContextReset({ children }: { children: ReactNode }) {
-  const content = <ScrollViewContext.Provider value={null}>{children}</ScrollViewContext.Provider>;
-  return VirtualizedListContextResetter ? (
-    <VirtualizedListContextResetter>{content}</VirtualizedListContextResetter>
-  ) : (
-    content
-  );
+  let node: ReactNode = children;
+  if (ScrollViewContext) {
+    node = <ScrollViewContext.Provider value={null}>{node}</ScrollViewContext.Provider>;
+  }
+  if (VirtualizedListContext) {
+    node = <VirtualizedListContext.Provider value={null}>{node}</VirtualizedListContext.Provider>;
+  }
+  return <>{node}</>;
 }

--- a/packages/expo-ui/src/community/bottom-sheet/scrollContextReset.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/scrollContextReset.tsx
@@ -1,0 +1,24 @@
+import type { ComponentType, Context, ReactNode } from 'react';
+import { Modal, ScrollView } from 'react-native';
+
+const VirtualizedListContextResetter = (
+  Modal as unknown as { Context?: ComponentType<{ children: ReactNode }> }
+).Context;
+const ScrollViewContext = (
+  ScrollView as unknown as { Context: Context<{ horizontal: boolean } | null> }
+).Context;
+
+// When virtualised list (RN Flatlist) is nested within another Flatlist,
+// it renders a regular View as Scroll component https://github.com/react/react-native/blob/5c197fb303ed0d975482757fefb7ed38349601b6/packages/virtualized-lists/Lists/VirtualizedList.js#L1291
+// which breaks scrolling.
+// Nested same direction FlatLists are generally considered bad
+// but the react context check it is doing to identify nesting can break some genuine cases
+// e.g. User has a FlatList with a button child that opens bottomsheet with a Flatlist
+export function SheetScrollContextReset({ children }: { children: ReactNode }) {
+  const content = <ScrollViewContext.Provider value={null}>{children}</ScrollViewContext.Provider>;
+  return VirtualizedListContextResetter ? (
+    <VirtualizedListContextResetter>{content}</VirtualizedListContextResetter>
+  ) : (
+    content
+  );
+}


### PR DESCRIPTION
# Why?

Reported on slack - https://exponent-internal.slack.com/archives/C01D24DMP98/p1782232486941459?thread_ts=1782162662.014889&cid=C01D24DMP98

Nesting a BottomSheet inside a FlatList breaks scroll view scrolling.


# How?

When virtualised list (RN Flatlist) is nested within another FlatList, it [renders](https://github.com/react/react-native/blob/5c197fb303ed0d975482757fefb7ed38349601b6/packages/virtualized-lists/Lists/VirtualizedList.js#L1291) a regular View as Scroll component which breaks scrolling. Nested same direction FlatLists are considered bad as it can break virtualisation but the react context check that RN is doing to identify nesting can break some genuine cases. e.g. User has a FlatList with a button child that opens BottomSheet with a FlatList. In such cases, FlatList is not exactly nested inside a FlatList as natively sheets are mounted in a separate window but the JS context check makes it false positive.

# Test

Tested the repro shared in the report.
