### PR TITLE
Update popover.mdx

### DIFF
--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/popover.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/popover.mdx
@@ -40,7 +40,7 @@ export default function BasicPopoverExample() {
     <Host matchContents>
       <Popover
         isPresented={isPresented}
-        onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
+        onIsPresentedChange={(isPresented) => setIsPresented(isPresented)}>
         <Popover.Trigger>
           <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
@@ -71,7 +71,7 @@ export default function AttachmentAnchorExample() {
     <Host matchContents>
       <Popover
         isPresented={isPresented}
-        onStateChange={({ isPresented }) => setIsPresented(isPresented)}
+        onIsPresentedChange={(isPresented) => setIsPresented(isPresented)}
         attachmentAnchor="trailing">
         <Popover.Trigger>
           <Button label="Show Popover" onPress={() => setIsPresented(true)} />
@@ -103,7 +103,7 @@ export default function ArrowEdgeExample() {
     <Host matchContents>
       <Popover
         isPresented={isPresented}
-        onStateChange={({ isPresented }) => setIsPresented(isPresented)}
+        onIsPresentedChange={(isPresented) => setIsPresented(isPresented)}
         arrowEdge="top">
         <Popover.Trigger>
           <Button label="Show Popover" onPress={() => setIsPresented(true)} />
@@ -136,7 +136,7 @@ export default function RNContentPopoverExample() {
     <Host matchContents>
       <Popover
         isPresented={isPresented}
-        onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
+        onIsPresentedChange={(isPresented) => setIsPresented(isPresented)}>
         <Popover.Trigger>
           <Button label="Show RN Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>


### PR DESCRIPTION
# Why

The Popover documentation example uses `onStateChange` which does not exist as a prop on the `Popover` component. The correct prop is `onIsPresentedChange`. This causes a runtime warning (or silent failure) for anyone copy-pasting the example code directly.

Fixes the mismatch between the code example and the props table on the same documentation page.

# How

Updated the code snippet in the Popover documentation from:

```tsx
onStateChange={({ isPresented }) => setIsPresented(isPresented)}
```

to:

```tsx
onIsPresentedChange={(isPresented) => setIsPresented(isPresented)}
```

No logic changes — this is a documentation-only fix to align the example with the correct prop signature already documented in the props table.

# Test Plan

1. Navigate to the Expo `expo-ui` Popover documentation page.
2. Copy the example snippet and run it in an Expo project with `@expo/ui` installed.
3. Before fix: `onStateChange` has no effect / triggers a prop warning.
4. After fix: `onIsPresentedChange` fires correctly when the Popover is presented or dismissed, and `isPresented` state updates as expected.

Tested locally on:
- iOS Simulator (iPhone 15, iOS 17)
- Android Emulator (Pixel 7, API 34)

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to this short guide
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the Documentation Writing Style Guide