### PR TITLE
test(module-scripts): Narrow transforms to speed up tests

### DIFF
--- a/packages/expo-module-scripts/createJestPreset.cjs
+++ b/packages/expo-module-scripts/createJestPreset.cjs
@@ -1,5 +1,33 @@
 'use strict';
 
+const { createModulesTransform } = require('./jest-modules-transform.cjs');
+
+// NOTE: Many modules ship as ESM-only but are otherwise ready to be used directly
+// We can manually list them here to extend support to them and only transpile to CJS with SWC
+const cjsTransformIncludeNames = [
+  '@react-navigation',
+  'standard-navigation',
+];
+
+// WARN: Packages here ship Flow/untranspiled source or ESM and assume a transforming bundler
+// Anything not listed (e.g. plain-CommonJS deps) runs as-is to keep test transforms fast
+const baseTransformIncludeNames = [
+  // negative lookahead skip the virtual-store segment
+  '\\.pnpm',
+  // React Native packages are shipped with Flow source and/or ESM
+  'react-native',
+  '@react-native/assets-registry',
+  '@react-native/js-polyfills',
+  '@react-native/normalize-colors',
+  '@react-native/virtualized-lists',
+  '@react-native/jest-preset',
+  '@react-native-masked-view',
+  // Google Fonts packages ship ESM
+  '@expo-google-fonts',
+  // We need to include the above packages that need to be transformed by SWC
+  ...cjsTransformIncludeNames,
+];
+
 module.exports = function createJestPreset(basePreset) {
   // Explicitly catch and log errors since Jest sometimes suppresses error messages
   try {
@@ -21,6 +49,16 @@ function _createJestPreset(basePreset) {
     ...basePreset,
     clearMocks: true,
     roots: ['<rootDir>/src'],
+    transform: {
+      // NOTE: Many modules ship as ESM-only but are otherwise ready to be used directly
+      // We can manually list them here to extend support to them and only transpile to CJS with SWC
+      ...createModulesTransform(cjsTransformIncludeNames),
+      ...basePreset.transform,
+    },
+    transformIgnorePatterns: [
+      ...(basePreset.transformIgnorePatterns ?? []),
+      `/node_modules/(?!(?:${baseTransformIncludeNames.join('|')}))`,
+    ],
     testEnvironmentOptions: {
       ...basePreset.testEnvironmentOptions,
       customExportConditions,

--- a/packages/expo-module-scripts/jest-modules-transform.cjs
+++ b/packages/expo-module-scripts/jest-modules-transform.cjs
@@ -1,0 +1,30 @@
+// NOTE(@kitten): Similar to `./jest-swc-transform.cjs` but for node_modules
+const SWC_ESM_TRANSFORM = [
+  require.resolve('@swc/jest'),
+  {
+    jsc: {
+      parser: { syntax: 'ecmascript', jsx: true },
+      target: 'es2022',
+      transform: { react: { runtime: 'automatic' } },
+      // Emit configurable/writable CommonJS exports so `jest.spyOn`/reassignment of module
+      // members works (SWC's default getter-only exports are not mockable).
+      experimental: {
+        plugins: [[require.resolve('@swc-contrib/mut-cjs-exports'), {}]],
+      },
+    },
+    module: { type: 'commonjs' },
+  },
+];
+
+/**
+ * Builds a mergeable Jest `transform` map that routes the given node_modules through SWC.
+ *
+ * @param {string[]} moduleNames Package names or scopes to match. Defaults to `DEFAULT_SWC_MODULES`.
+ * @returns {import('jest').Config['transform']}
+ */
+function createModulesTransform(moduleNames = DEFAULT_SWC_MODULES) {
+  const pattern = `/node_modules/(?:${moduleNames.join('|')})/.+\\.[cm]?jsx?$`;
+  return { [pattern]: SWC_ESM_TRANSFORM };
+}
+
+module.exports = { createModulesTransform };


### PR DESCRIPTION
# Why

The recent Jest changes (#47034) should make Node / non-module/RN tests faster via an SWC transform. However, we still apply the Babel transforms pretty aggressively and have not necessarily kept the excludes up-to-date to ensure that we don't over-transform with Babel.

Since `babel-jest` is a large and slow part of running Jest in CI, tightening this should speed up the test runs in CI.

# How

- Add ESM-only SWC transform for ESM-only packages (for now `@react-navigation` and `standard-navigation`)
- Add overridden selectively include list for applying transforms to `node_modules` (mostly needed for react-native packages and `@expo-google-fonts`), but we merge with `jest-expo`'s list

# Test Plan

- [Check CI run of `check-packages` and compare to prior runs](https://github.com/expo/expo/pull/47210#issuecomment-4789345066)
