### PR TITLE
[ui][android] Fix date picker year range ignoring min/maximumDate

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix the `community/datetime-picker` dialog ignoring `minimumDate`/`maximumDate` for its year range, so the calendar and year picker no longer always span 1900–2100. ([#47206](https://github.com/expo/expo/issues/47206) by [@vioodle](https://github.com/vioodle)) ([#47213](https://github.com/expo/expo/pull/47213) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][Android] Fix a scrollable (e.g. `FlatList`) inside `@expo/ui/community/bottom-sheet` not scrolling when the `<BottomSheet>` is mounted inside another same-orientation list (such as a `FlatList` header). ([#47197](https://github.com/expo/expo/pull/47197) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix Mac Catalyst build failure with `activityBackgroundTint` ([#46929](https://github.com/expo/expo/pull/46929) by [@theeket](https://github.com/theeket))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix the `community/datetime-picker` dialog ignoring `minimumDate`/`maximumDate` for its year range, so the calendar and year picker no longer always span 1900–2100. ([#47206](https://github.com/expo/expo/issues/47206) by [@vioodle](https://github.com/vioodle)) ([#47213](https://github.com/expo/expo/pull/47213) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix the `@expo-ui/community/datetime-picker` dialog ignoring `minimumDate`/`maximumDate` for its year range, so the calendar and year picker no longer always span 1900–2100. ([#47206](https://github.com/expo/expo/issues/47206) by [@vioodle](https://github.com/vioodle)) ([#47213](https://github.com/expo/expo/pull/47213) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][Android] Fix a scrollable (e.g. `FlatList`) inside `@expo/ui/community/bottom-sheet` not scrolling when the `<BottomSheet>` is mounted inside another same-orientation list (such as a `FlatList` header). ([#47197](https://github.com/expo/expo/pull/47197) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix Mac Catalyst build failure with `activityBackgroundTint` ([#46929](https://github.com/expo/expo/pull/46929) by [@theeket](https://github.com/theeket))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -226,6 +226,29 @@ fun rememberSelectableDates(selectableDatesRecord: SelectableDatesRecord?): Sele
   }
 }
 
+// `selectableDates` only greys out unselectable cells; the calendar's actual extent (months list,
+// year grid, range content description) comes from `yearRange`. Derive it from min/max so the
+// picker reflects the constraints instead of always spanning the 1900..2100 default.
+// https://github.com/expo/expo/issues/47206
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun rememberDatePickerYearRange(selectableDatesRecord: SelectableDatesRecord?, initialDateMillis: Long): IntRange {
+  val start = selectableDatesRecord?.start
+  val end = selectableDatesRecord?.end
+  return remember(start, end, initialDateMillis) {
+    val defaults = DatePickerDefaults.YearRange
+    val yearOf = { millis: Long ->
+      Calendar.getInstance().apply { timeInMillis = millis }.get(Calendar.YEAR)
+    }
+    val startYear = start?.let(yearOf) ?: defaults.first
+    val endYear = end?.let(yearOf) ?: defaults.last
+    // Keep the initially selected/displayed year inside the range so Material3 doesn't discard the
+    // selection
+    val initialYear = yearOf(initialDateMillis)
+    minOf(startYear, initialYear)..maxOf(endYear, initialYear)
+  }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun buildDatePickerColors(
@@ -294,14 +317,15 @@ fun ExpoDatePickerDialogContent(props: DatePickerDialogProps, onDateSelected: (D
   val selectableDates = rememberSelectableDates(props.selectableDates)
   val fallbackDate = remember { Date().time }
   val initialDate = props.initialDate ?: fallbackDate
+  val yearRange = rememberDatePickerYearRange(props.selectableDates, initialDate)
 
-  val state = remember(variant, initialDate, selectableDates) {
+  val state = remember(variant, initialDate, selectableDates, yearRange) {
     DatePickerState(
       initialDisplayMode = variant,
       locale = locale,
       initialSelectedDateMillis = initialDate,
       initialDisplayedMonthMillis = initialDate,
-      yearRange = DatePickerDefaults.YearRange,
+      yearRange = yearRange,
       selectableDates = selectableDates
     )
   }
@@ -399,17 +423,18 @@ fun FunctionalComposableScope.DateTimePickerContent(props: DateTimePickerProps, 
 fun ExpoDatePicker(modifier: Modifier = Modifier, props: DateTimePickerProps, onDateSelected: (DatePickerResult) -> Unit) {
   val locale = LocalConfiguration.current.locales[0]
   val variant = props.variant.toDisplayMode()
-  val initialDate = props.initialDate
+  val fallbackDate = remember { Date().time }
+  val initialDate = props.initialDate ?: fallbackDate
   val selectableDates = rememberSelectableDates(props.selectableDates)
+  val yearRange = rememberDatePickerYearRange(props.selectableDates, initialDate)
 
-  val state = remember(variant, initialDate, selectableDates) {
-    val fallbackDate = Date().time
+  val state = remember(variant, initialDate, selectableDates, yearRange) {
     DatePickerState(
       initialDisplayMode = variant,
       locale = locale,
-      initialSelectedDateMillis = initialDate ?: fallbackDate,
-      initialDisplayedMonthMillis = initialDate ?: fallbackDate,
-      yearRange = DatePickerDefaults.YearRange,
+      initialSelectedDateMillis = initialDate,
+      initialDisplayedMonthMillis = initialDate,
+      yearRange = yearRange,
       selectableDates = selectableDates
     )
   }


### PR DESCRIPTION
# Why

Fixes #47206
On Android, the `@expo-ui/community/datetime-picker` dialog always showed years 1900–2100 regardless of `minimumDate`/`maximumDate`. 

# How

The min/max dates were only wired into Material3's `selectableDates`, which greys out cells but doesn't change the calendar's extent, `yearRange` also needs to be made into range.

# Test Plan

Tested the repro