### PR TITLE
[ios][media-library] Fix permission guards for limited and write-only access

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Add `accessPrivileges` to `PermissionResponse` type ([#47177](https://github.com/expo/expo/pull/47177) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] Fix permission guards for limited and write-only photo library access. ([#47216](https://github.com/expo/expo/pull/47216) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
@@ -5,6 +5,7 @@ import PhotosUI
 public final class MediaLibraryNextModule: Module {
   private static let libraryDidChangeEvent = "mediaLibraryDidChange"
   private let assetMapper = AssetMapper()
+  private lazy var permissionDelegate = MediaLibraryNextPermissionDelegate(appContext: appContext)
   private lazy var observerManager = PhotoLibraryObserverManager(onChange: { [weak self] body in
     guard let self = self else {
       return
@@ -16,6 +17,10 @@ public final class MediaLibraryNextModule: Module {
     Name("ExpoMediaLibraryNext")
 
     Events(MediaLibraryNextModule.libraryDidChangeEvent)
+
+    OnCreate {
+      permissionDelegate.registerPermissionRequesters()
+    }
 
     OnStartObserving(MediaLibraryNextModule.libraryDidChangeEvent) {
       observerManager.startObserving()
@@ -116,7 +121,7 @@ public final class MediaLibraryNextModule: Module {
       }
 
       StaticAsyncFunction("create") { (filePath: URL, album: Album?) async throws in
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfWritePermissionGranted()
         let newAssetId = try await AssetRepository.shared.add(from: filePath)
         if let guardedAlbum = album {
           guard let asset = AssetRepository.shared.get(by: [newAssetId]).first else {
@@ -128,7 +133,7 @@ public final class MediaLibraryNextModule: Module {
       }
 
       StaticAsyncFunction("delete") { (assets: [Asset]) async throws in
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfReadWritePermissionGranted()
         let assetIds = assets.map { $0.localIdentifier }
         try await AssetRepository.shared.delete(by: assetIds)
       }
@@ -225,12 +230,12 @@ public final class MediaLibraryNextModule: Module {
       }
 
       StaticAsyncFunction("getAll") {
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfFullAccessGranted()
         return try await Album.getAll(assetMapper: assetMapper)
       }
 
       StaticAsyncFunction("get") { (title: String) -> Album? in
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfFullAccessGranted()
         guard let collection = AssetCollectionRepository.shared.get(byTitle: title) else {
           return nil
         }
@@ -238,13 +243,13 @@ public final class MediaLibraryNextModule: Module {
       }
 
       StaticAsyncFunction("delete") { (albums: [Album], deleteAssets: Bool?) async throws in
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfFullAccessGranted()
         let albumsIds = albums.map { $0.id }
         try await AssetCollectionRepository.shared.delete(by: albumsIds, deleteAssets: deleteAssets ?? false)
       }
 
       StaticAsyncFunction("create") { (name: String, assetRefs: Either<[Asset], [URL]>, moveAssets: Bool?) async throws -> Album in
-        try await checkIfPermissionGranted()
+        try await permissionDelegate.checkIfFullAccessGranted()
         let assetIds = try await getAssetIdsFromAssetRefs(from: assetRefs)
         let newCollectionId = try await AssetCollectionRepository.shared.add(name: name)
         let phAssetsToAdd = AssetRepository.shared.get(by: assetIds)
@@ -254,23 +259,11 @@ public final class MediaLibraryNextModule: Module {
     }
 
     AsyncFunction("getPermissionsAsync") { (writeOnly: Bool?, promise: Promise) in
-      appContext?
-        .permissions?
-        .getPermissionUsingRequesterClass(
-          requesterClass(writeOnly ?? false),
-          resolve: promise.legacyResolver,
-          reject: promise.legacyRejecter
-        )
+      try permissionDelegate.getPermissions(writeOnly: writeOnly ?? false, promise: promise)
     }
 
     AsyncFunction("requestPermissionsAsync") { (writeOnly: Bool?, promise: Promise) in
-      appContext?
-        .permissions?
-        .askForPermission(
-          usingRequesterClass: requesterClass(writeOnly ?? false),
-          resolve: promise.legacyResolver,
-          reject: promise.legacyRejecter
-        )
+      try permissionDelegate.requestPermissions(writeOnly: writeOnly ?? false, promise: promise)
     }
 
     AsyncFunction("presentPermissionsPicker") { (_ mediaTypes: [String]?) in
@@ -296,32 +289,5 @@ public final class MediaLibraryNextModule: Module {
       return localIdentifiers
     }
     throw FailedToCreateAlbumException("Unsupported assetRefs type")
-  }
-
-  private func checkIfPermissionGranted() async throws {
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-      appContext?.permissions?.getPermissionUsingRequesterClass(
-        MediaLibraryPermissionRequester.self,
-        resolve: { result in
-          if let permissions = result as? [String: Any] {
-            if permissions["status"] as? String != "granted" ||
-              permissions["accessPrivileges"] as? String != "all" {
-              continuation.resume(throwing: FailedToGrantPermissions())
-              return
-            }
-            continuation.resume(returning: ())
-            return
-          }
-          continuation.resume(throwing: FailedToGrantPermissions())
-        },
-        reject: { _, _, error in
-          if let error = error {
-            continuation.resume(throwing: error)
-          } else {
-            continuation.resume(throwing: FailedToGrantPermissions())
-          }
-        }
-      )
-    }
   }
 }

--- a/packages/expo-media-library/ios/next/MediaLibraryNextPermissionDelegate.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextPermissionDelegate.swift
@@ -1,0 +1,106 @@
+import ExpoModulesCore
+
+final class MediaLibraryNextPermissionDelegate {
+  private weak var appContext: AppContext?
+
+  init(appContext: AppContext?) {
+    self.appContext = appContext
+  }
+
+  func registerPermissionRequesters() {
+    appContext?.permissions?.register([
+      MediaLibraryPermissionRequester(),
+      MediaLibraryWriteOnlyPermissionRequester()
+    ])
+  }
+
+  func getPermissions(writeOnly: Bool, promise: Promise) throws {
+    let permissionsManager = try permissionsManager()
+    permissionsManager.getPermissionUsingRequesterClass(
+      requesterClass(writeOnly),
+      resolve: promise.legacyResolver,
+      reject: promise.legacyRejecter
+    )
+  }
+
+  func requestPermissions(writeOnly: Bool, promise: Promise) throws {
+    let permissionsManager = try permissionsManager()
+    permissionsManager.askForPermission(
+      usingRequesterClass: requesterClass(writeOnly),
+      resolve: promise.legacyResolver,
+      reject: promise.legacyRejecter
+    )
+  }
+
+  func checkIfReadWritePermissionGranted() async throws {
+    let permissions = try await getPermissions(using: MediaLibraryPermissionRequester.self)
+    guard hasGrantedPermission(permissions) else {
+      throw FailedToGrantPermissions()
+    }
+  }
+
+  func checkIfWritePermissionGranted() async throws {
+    let writeOnlyPermissions = try await getPermissions(using: MediaLibraryWriteOnlyPermissionRequester.self)
+    if hasGrantedPermission(writeOnlyPermissions) {
+      return
+    }
+
+    let readWritePermissions = try await getPermissions(using: MediaLibraryPermissionRequester.self)
+    guard hasWritePermission(
+      writeOnlyPermissions: writeOnlyPermissions,
+      readWritePermissions: readWritePermissions
+    ) else {
+      throw FailedToGrantPermissions()
+    }
+  }
+
+  func checkIfFullAccessGranted() async throws {
+    let permissions = try await getPermissions(using: MediaLibraryPermissionRequester.self)
+    guard hasFullAccess(permissions) else {
+      throw FailedToGrantPermissions()
+    }
+  }
+
+  private func getPermissions(using requesterClass: EXPermissionsRequester.Type) async throws -> [String: Any] {
+    let permissionsManager = try permissionsManager()
+
+    return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String: Any], Error>) in
+      permissionsManager.getPermissionUsingRequesterClass(
+        requesterClass,
+        resolve: { result in
+          guard let permissions = result as? [String: Any] else {
+            continuation.resume(throwing: FailedToGrantPermissions())
+            return
+          }
+
+          continuation.resume(returning: permissions)
+        },
+        reject: { _, _, error in
+          continuation.resume(throwing: error ?? FailedToGrantPermissions())
+        }
+      )
+    }
+  }
+
+  private func permissionsManager() throws -> EXPermissionsInterface {
+    guard let permissionsManager = appContext?.permissions else {
+      throw FailedToGrantPermissions()
+    }
+    return permissionsManager
+  }
+
+  private func hasGrantedPermission(_ permissions: [String: Any]) -> Bool {
+    permissions["status"] as? String == "granted"
+  }
+
+  private func hasFullAccess(_ permissions: [String: Any]) -> Bool {
+    hasGrantedPermission(permissions) && permissions["accessPrivileges"] as? String == "all"
+  }
+
+  private func hasWritePermission(
+    writeOnlyPermissions: [String: Any],
+    readWritePermissions: [String: Any]
+  ) -> Bool {
+    hasGrantedPermission(writeOnlyPermissions) || hasGrantedPermission(readWritePermissions)
+  }
+}


### PR DESCRIPTION
# Why

follow up to: https://github.com/expo/expo/pull/47177
Fixes limited and write-only permissions, all operations incorrectly required full access.
# How

- Creates `MediaLibraryNextPermissionDelegate` to encapsulate permission logic
- Changes required permissions per operation:
	- Asset.create - write-only or read-write
	- Asset.delete - read-write
	- Album operations - full access

# Test Plan
BareExpo ✅