### PR TITLE
[dev-launcher][dev-menu] Migrate off deprecated Compose Unstyled API

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -131,7 +131,7 @@ dependencies {
 
   debugOnly("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
 
-  debugOnly("com.composables:core:1.43.1")
+  debugOnly("com.composables:core:1.49.9")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'androidx.test:core-ktx:1.7.0'

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devlauncher.compose.Update
 import expo.modules.devlauncher.compose.models.BranchAction
 import expo.modules.devlauncher.compose.primitives.CircularProgressBar
@@ -56,7 +56,7 @@ fun BranchScreen(
         color = Color.Transparent,
         modifier = Modifier.align(Alignment.CenterStart)
       ) {
-        Button(
+        UnstyledButton(
           onClick = goBack
         ) {
           LauncherIcons.Chevron(
@@ -110,7 +110,7 @@ fun BranchScreen(
           itemsIndexed(items = updates) { index, update ->
             val formatedTime = DateFormat.formatUpdateDate(update.createdAt)
 
-            Button(
+            UnstyledButton(
               modifier = Modifier
                 .background(
                   NewAppTheme.colors.background.subtle,

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composeunstyled.Icon
+import com.composeunstyled.UnstyledIcon
 import expo.modules.devlauncher.R
 import expo.modules.devlauncher.compose.Branch
 import expo.modules.devlauncher.compose.Update
@@ -91,7 +91,7 @@ private fun NeedToSignInComponent(
       horizontalAlignment = Alignment.CenterHorizontally,
       modifier = Modifier.fillMaxWidth()
     ) {
-      Icon(
+      UnstyledIcon(
         painter = painterResource(R.drawable.log_in),
         contentDescription = "Log in icon",
         tint = NewAppTheme.colors.icon.info

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devlauncher.compose.models.HomeState
 import expo.modules.devlauncher.compose.primitives.Accordion
@@ -50,7 +50,7 @@ private fun CrashReport(
   }
 
   Row(modifier = Modifier.padding(top = NewAppTheme.spacing.`6` - NewAppTheme.spacing.`4`)) {
-    Button(onClick = {
+    UnstyledButton(onClick = {
       onClick(crashReport)
     }) {
       Warning(

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composeunstyled.TextField
 import com.composeunstyled.TextInput
+import com.composeunstyled.UnstyledTextField
 import expo.modules.devlauncher.compose.models.SettingsAction
 import expo.modules.devlauncher.compose.models.SettingsState
 import expo.modules.devlauncher.compose.ui.DefaultScreenContainer
@@ -342,7 +342,7 @@ private fun NSDSection(state: SettingsState, onAction: (SettingsAction) -> Unit)
             )
           }
 
-          TextField(
+          UnstyledTextField(
             value = state.filterBySlug,
             onValueChange = { newSlug ->
               onAction(SettingsAction.UpdateFilterBySlug(newSlug))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ActionButton.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ActionButton.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
 import expo.modules.devmenu.compose.ripple.ripple
@@ -29,7 +29,7 @@ fun ActionButton(
   enabled: Boolean = true,
   onClick: () -> Unit = {}
 ) {
-  Button(
+  UnstyledButton(
     onClick = onClick,
     enabled = enabled,
     shape = RoundedCornerShape(borderRadius),

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppHeader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppHeader.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devlauncher.compose.primitives.AsyncImage
 import expo.modules.devlauncher.services.AppService
 import expo.modules.devlauncher.services.SessionService
@@ -95,7 +95,7 @@ fun AppHeader(
       borderRadius = NewAppTheme.borderRadius.full,
       color = NewAppTheme.colors.background.element
     ) {
-      Button(onClick = onProfileClick) {
+      UnstyledButton(onClick = onProfileClick) {
         Box(
           modifier = Modifier.size(44.dp),
           contentAlignment = Alignment.Center

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppLoadingErrorDialog.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppLoadingErrorDialog.kt
@@ -17,12 +17,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composables.core.Dialog
-import com.composables.core.DialogPanel
-import com.composables.core.DialogState
-import com.composables.core.Scrim
-import com.composables.core.rememberDialogState
-import com.composeunstyled.Button
+import com.composeunstyled.DialogState
+import com.composeunstyled.UnstyledDialog
+import com.composeunstyled.UnstyledDialogPanel
+import com.composeunstyled.UnstyledScrim
+import com.composeunstyled.UnstyledButton
+import com.composeunstyled.rememberDialogState
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devlauncher.compose.models.HomeState
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -52,10 +52,10 @@ fun AppLoadingErrorDialog(
   dialogState: DialogState,
   currentError: String?
 ) {
-  Dialog(state = dialogState) {
-    Scrim()
+  UnstyledDialog(state = dialogState) {
+    UnstyledScrim()
 
-    DialogPanel(
+    UnstyledDialogPanel(
       modifier = Modifier
         .displayCutoutPadding()
         .systemBarsPadding()
@@ -78,7 +78,7 @@ fun AppLoadingErrorDialog(
             )
           )
 
-          Button(onClick = {
+          UnstyledButton(onClick = {
             dialogState.visible = false
           }) {
             MenuIcons.Close(

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -128,7 +128,7 @@ fun EmbeddedBundleButton(
     color = NewAppTheme.colors.background.element,
     borderRadius = NewAppTheme.borderRadius.xl
   ) {
-    Button(
+    UnstyledButton(
       onClick = {
         onAction(HomeAction.LoadEmbeddedBundle)
       }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/FetchDevelopmentServersButton.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/FetchDevelopmentServersButton.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devlauncher.compose.primitives.CircularProgressBar
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -24,7 +24,7 @@ fun FetchDevelopmentServersButton(
     color = NewAppTheme.colors.background.element,
     borderRadius = NewAppTheme.borderRadius.xl
   ) {
-    Button(
+    UnstyledButton(
       onClick = {
         onAction(HomeAction.RefreshServers)
       },

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/LauncherIcons.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/LauncherIcons.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
-import com.composeunstyled.Icon
+import com.composeunstyled.UnstyledIcon
 import expo.modules.devlauncher.R
 
 object LauncherIcons {
@@ -16,7 +16,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.plus),
       contentDescription = "Plus",
       tint = tint,
@@ -32,7 +32,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.expo_logo),
       contentDescription = "Expo Logo",
       tint = tint,
@@ -48,7 +48,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.show_at_launch),
       contentDescription = "Show at launch",
       tint = tint,
@@ -64,7 +64,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.settings),
       contentDescription = "Settings",
       tint = tint,
@@ -80,7 +80,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.user),
       contentDescription = "User",
       tint = tint,
@@ -96,7 +96,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.check_circle),
       contentDescription = "Check",
       tint = tint,
@@ -112,7 +112,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.updates_nav),
       contentDescription = "Updates",
       tint = tint,
@@ -128,7 +128,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.update_icon),
       contentDescription = "Updates",
       tint = tint,
@@ -144,7 +144,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.home),
       contentDescription = "Home",
       tint = tint,
@@ -160,7 +160,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.download),
       contentDescription = "Download",
       tint = tint,
@@ -176,7 +176,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.scan),
       contentDescription = "Scan",
       tint = tint,
@@ -192,7 +192,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.chevron_right),
       contentDescription = "Chevron",
       tint = tint,
@@ -208,7 +208,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.branch_icon),
       contentDescription = "Branch",
       tint = tint,
@@ -224,7 +224,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.package_search),
       contentDescription = "Branch",
       tint = tint,
@@ -240,7 +240,7 @@ object LauncherIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.link),
       contentDescription = "Branch",
       tint = tint,

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/RunningAppCard.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/RunningAppCard.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.fromHex
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
@@ -40,7 +40,7 @@ fun RunningAppCard(
     borderRadius = NewAppTheme.borderRadius.xl,
     color = NewAppTheme.colors.background.subtle
   ) {
-    Button(
+    UnstyledButton(
       onClick = { onClick(appIp) }
     ) {
       Row(

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ScanQRCodeButton.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ScanQRCodeButton.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
@@ -23,7 +23,7 @@ fun ScanQRCodeButton(
     color = NewAppTheme.colors.background.element,
     borderRadius = NewAppTheme.borderRadius.xl
   ) {
-    Button(
+    UnstyledButton(
       onClick = {
         onAction(HomeAction.ScanQRCode)
       }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.TextField
 import com.composeunstyled.TextInput
+import com.composeunstyled.UnstyledTextField
 import expo.modules.devlauncher.compose.utils.sanitizeUrlString
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
@@ -59,7 +59,7 @@ fun ServerUrlInput(
   Column(
     verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
   ) {
-    TextField(
+    UnstyledTextField(
       value = url,
       onValueChange = { newUrl ->
         url = newUrl

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   debugOnly "androidx.compose.ui:ui:$composeVersion"
   debugOnly "androidx.compose.ui:ui-tooling:$composeVersion"
 
-  debugOnly("com.composables:core:1.49.6")
+  debugOnly("com.composables:core:1.49.9")
 
   debugOnlyApi 'io.github.lukmccall:radix-ui-colors:1.0.1'
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/primitives/ToggleSwitch.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/primitives/ToggleSwitch.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.ToggleSwitch
+import com.composeunstyled.UnstyledToggleSwitch
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 
 @Composable
@@ -34,7 +34,7 @@ fun ToggleSwitch(
     }
   )
 
-  ToggleSwitch(
+  UnstyledToggleSwitch(
     toggled = isToggled,
     onToggled = onToggled,
     shape = RoundedCornerShape(NewAppTheme.borderRadius.full),

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/AppInfo.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/AppInfo.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.compose.DevMenuActionHandler
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -61,7 +61,7 @@ fun AppInfo(
 
     Spacer(modifier = Modifier.weight(1f))
 
-    Button(
+    UnstyledButton(
       onClick = {
         onAction(DevMenuAction.Close)
       },

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ComponentsSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ComponentsSection.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.compose.DevMenuActionHandler
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -33,7 +33,7 @@ fun ComponentsScreen(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
     ) {
-      Button(
+      UnstyledButton(
         onClick = { onAction(DevMenuAction.CloseSubScreen) },
         shape = RoundedCornerShape(NewAppTheme.borderRadius.full),
         backgroundColor = NewAppTheme.colors.background.element,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuButton.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.RoundedSurface
 import expo.modules.devmenu.compose.primitives.Spacer
@@ -30,7 +30,7 @@ fun NewMenuButton(
   onClick: () -> Unit = {}
 ) {
   val contentComponent = @Composable {
-    Button(onClick = onClick, enabled = enabled) {
+    UnstyledButton(onClick = onClick, enabled = enabled) {
       Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(spacedBy),

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuIcons.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/MenuIcons.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
-import com.composeunstyled.Icon
+import com.composeunstyled.UnstyledIcon
 import expo.modules.devmenu.R
 
 object MenuIcons {
@@ -16,7 +16,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.x_close),
       contentDescription = "Close",
       tint = tint,
@@ -32,7 +32,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.check),
       contentDescription = "Selected",
       tint = tint,
@@ -48,7 +48,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.arrow_back),
       contentDescription = "Back",
       tint = tint,
@@ -64,7 +64,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.layers),
       contentDescription = "Components",
       tint = tint,
@@ -80,7 +80,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.chevron_right),
       contentDescription = "Open",
       tint = tint,
@@ -96,7 +96,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.copy),
       contentDescription = "Copy",
       tint = tint,
@@ -112,7 +112,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.refresh),
       contentDescription = "Reload",
       tint = tint,
@@ -128,7 +128,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.home),
       contentDescription = "Home",
       tint = tint,
@@ -144,7 +144,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.performance),
       contentDescription = "Performance monitor",
       tint = tint,
@@ -160,7 +160,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.inspect),
       contentDescription = "Element inspector",
       tint = tint,
@@ -176,7 +176,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.code_brackets),
       contentDescription = "DevTools",
       tint = tint,
@@ -192,7 +192,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.gear_fill),
       contentDescription = "React Native dev menu",
       tint = tint,
@@ -208,7 +208,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.fast_refresh),
       contentDescription = "Fast Refresh",
       tint = tint,
@@ -224,7 +224,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.dev_menu_fab_icon),
       contentDescription = "Toggle Dev Menu",
       tint = tint,
@@ -240,7 +240,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.alert),
       contentDescription = "Warning",
       tint = tint,
@@ -256,7 +256,7 @@ object MenuIcons {
     tint: Color,
     modifier: Modifier = Modifier
   ) {
-    Icon(
+    UnstyledIcon(
       painter = painterResource(R.drawable.lightbulb),
       contentDescription = "Lightbulb",
       tint = tint,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/Onboarding.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/Onboarding.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
@@ -67,7 +67,7 @@ fun Onboarding(onOnboardingFinished: () -> Unit = {}) {
 
     Spacer(NewAppTheme.spacing.`3`)
 
-    Button(
+    UnstyledButton(
       onClick = onOnboardingFinished,
       shape = RoundedCornerShape(NewAppTheme.borderRadius.md),
       backgroundColor = NewAppTheme.colors.buttons.primary.background,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/SystemSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/SystemSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Button
+import com.composeunstyled.UnstyledButton
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.Divider
 import expo.modules.devmenu.compose.primitives.NewText
@@ -49,7 +49,7 @@ fun SystemSection(
 @Composable
 private fun CopyButton(fullDataProvider: () -> String) {
   val context = LocalContext.current
-  Button(
+  UnstyledButton(
     onClick = {
       copyToClipboard(
         context,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composeunstyled.Icon
-import com.composeunstyled.Text
+import com.composeunstyled.UnstyledIcon
+import com.composeunstyled.UnstyledText
 import expo.modules.devmenu.R
 
 private val FabBlue = Color(0xFF007AFF)
@@ -88,7 +88,7 @@ fun FloatingActionButtonContent(
         .padding(4.dp)
         .background(FabBlue, CircleShape)
     ) {
-      Icon(
+      UnstyledIcon(
         painter = painterResource(R.drawable.gear_fill),
         contentDescription = "Tools",
         tint = Color.White,
@@ -107,7 +107,7 @@ fun FloatingActionButtonContent(
           .background(Color.White, RoundedCornerShape(percent = 50))
           .padding(horizontal = 10.dp, vertical = 4.dp)
       ) {
-        Text(
+        UnstyledText(
           text = "Tools",
           color = Color.Black,
           fontSize = 11.sp,


### PR DESCRIPTION
# Why

Fixes Android compilation warnings caused by usage of the deprecated Unstyled API.

# How

- Bumped `com.composables:core` from `1.49.6` to `1.49.9`
- Replaced deprecated component class references, e.g. `Button` -> `UnstyledButton`

# Test Plan

- BareExpo ✅