### PR TITLE
[fingerprint] Extend SourceSkips.ExpoConfigVersions to ios.version/android.version

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added `SourceSkips.ExpoConfigPlatformVersions` to exclude `ios.version` and `android.version` from the fingerprint, so per-platform version bumps do not invalidate the fingerprint.
+
 ### 🐛 Bug fixes
 
 - Fixed unstable fingerprint for iOS precompiled modules. ([#46466](https://github.com/expo/expo/pull/46466) by [@kudo](https://github.com/kudo))

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### 🛠 Breaking changes
 
-### 🎉 New features
+- Extended `SourceSkips.ExpoConfigVersions` to also strip the platform-specific version overrides `ios.version` and `android.version` (which take precedence over the top-level `version`). Projects already setting this flag will see their fingerprint hash change after upgrading.
 
-- Added `SourceSkips.ExpoConfigPlatformVersions` to exclude `ios.version` and `android.version` from the fingerprint, so per-platform version bumps do not invalidate the fingerprint.
+### 🎉 New features
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -135,12 +135,9 @@ function normalizeExpoConfig(
   if (sourceSkips & SourceSkips.ExpoConfigVersions) {
     delete normalizedConfig.version;
     delete normalizedConfig.android?.versionCode;
-    delete normalizedConfig.ios?.buildNumber;
-  }
-
-  if (sourceSkips & SourceSkips.ExpoConfigPlatformVersions) {
-    delete normalizedConfig.ios?.version;
     delete normalizedConfig.android?.version;
+    delete normalizedConfig.ios?.buildNumber;
+    delete normalizedConfig.ios?.version;
   }
 
   if (sourceSkips & SourceSkips.ExpoConfigRuntimeVersionIfString) {

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -138,6 +138,11 @@ function normalizeExpoConfig(
     delete normalizedConfig.ios?.buildNumber;
   }
 
+  if (sourceSkips & SourceSkips.ExpoConfigPlatformVersions) {
+    delete normalizedConfig.ios?.version;
+    delete normalizedConfig.android?.version;
+  }
+
   if (sourceSkips & SourceSkips.ExpoConfigRuntimeVersionIfString) {
     if (typeof normalizedConfig.runtimeVersion === 'string') {
       delete normalizedConfig.runtimeVersion;

--- a/packages/@expo/fingerprint/src/sourcer/SourceSkips.ts
+++ b/packages/@expo/fingerprint/src/sourcer/SourceSkips.ts
@@ -7,7 +7,11 @@ export enum SourceSkips {
 
   //#region - ExpoConfig source (e.g., app.json, app.config.js, etc.)
 
-  /** Versions in app.json, including `version`, `android.versionCode`, and `ios.buildNumber`. */
+  /**
+   * Versions in app.json, including `version`, `android.versionCode`, `ios.buildNumber`, and the
+   * platform-specific overrides `ios.version` and `android.version` (which take precedence over
+   * the top-level `version`).
+   */
   ExpoConfigVersions = 1 << 0,
 
   /** `runtimeVersion` in app.json if it is a string. */
@@ -60,12 +64,4 @@ export enum SourceSkips {
 
   /** The [extra](https://docs.expo.dev/versions/latest/config/app/#extra) section in app.json */
   ExpoConfigExtraSection = 1 << 12,
-
-  /**
-   * Platform-specific version overrides in app.json, including `ios.version` and `android.version`.
-   * These take precedence over the top-level `version`. Use this when versioning each platform
-   * independently, so a version bump on one platform does not invalidate the other platform's
-   * fingerprint.
-   */
-  ExpoConfigPlatformVersions = 1 << 13,
 }

--- a/packages/@expo/fingerprint/src/sourcer/SourceSkips.ts
+++ b/packages/@expo/fingerprint/src/sourcer/SourceSkips.ts
@@ -60,4 +60,12 @@ export enum SourceSkips {
 
   /** The [extra](https://docs.expo.dev/versions/latest/config/app/#extra) section in app.json */
   ExpoConfigExtraSection = 1 << 12,
+
+  /**
+   * Platform-specific version overrides in app.json, including `ios.version` and `android.version`.
+   * These take precedence over the top-level `version`. Use this when versioning each platform
+   * independently, so a version bump on one platform does not invalidate the other platform's
+   * fingerprint.
+   */
+  ExpoConfigPlatformVersions = 1 << 13,
 }

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
@@ -538,8 +538,8 @@ describe(`getExpoConfigSourcesAsync - sourceSkips`, () => {
       vol.fromJSON(require('./fixtures/ExpoManaged47Project.json'));
       mockConfigFile('/app/app.config.js', () => ({
         default: ({ config }: any) => {
-          config.android = { versionCode: 1 };
-          config.ios = { buildNumber: '1' };
+          config.android = { versionCode: 1, version: '1.2.3' };
+          config.ios = { buildNumber: '1', version: '4.5.6' };
           return config;
         },
       }));
@@ -557,34 +557,9 @@ describe(`getExpoConfigSourcesAsync - sourceSkips`, () => {
       expect(expoConfig).not.toBeNull();
       expect(expoConfig.version).toBeUndefined();
       expect(expoConfig.android.versionCode).toBeUndefined();
-      expect(expoConfig.ios.buildNumber).toBeUndefined();
-    });
-  });
-
-  it('should remove ios.version and android.version when SourceSkips.ExpoConfigPlatformVersions', async () => {
-    await jest.isolateModulesAsync(async () => {
-      vol.fromJSON(require('./fixtures/ExpoManaged47Project.json'));
-      mockConfigFile('/app/app.config.js', () => ({
-        default: ({ config }: any) => {
-          config.android = { version: '1.2.3' };
-          config.ios = { version: '4.5.6' };
-          return config;
-        },
-      }));
-
-      const options = await normalizeOptionsAsync('/app', {
-        sourceSkips: SourceSkips.ExpoConfigPlatformVersions,
-      });
-      const { config, loadedModules } = await getExpoConfigAsync('/app', options);
-      const sources = await getExpoConfigSourcesAsync('/app', config, loadedModules, options);
-      const expoConfigSource = sources.find<HashSourceContents>(
-        (source): source is HashSourceContents =>
-          source.type === 'contents' && source.id === 'expoConfig'
-      );
-      const expoConfig = JSON.parse(expoConfigSource?.contents?.toString() ?? 'null');
-      expect(expoConfig).not.toBeNull();
-      expect(expoConfig.ios.version).toBeUndefined();
       expect(expoConfig.android.version).toBeUndefined();
+      expect(expoConfig.ios.buildNumber).toBeUndefined();
+      expect(expoConfig.ios.version).toBeUndefined();
     });
   });
 

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
@@ -561,6 +561,33 @@ describe(`getExpoConfigSourcesAsync - sourceSkips`, () => {
     });
   });
 
+  it('should remove ios.version and android.version when SourceSkips.ExpoConfigPlatformVersions', async () => {
+    await jest.isolateModulesAsync(async () => {
+      vol.fromJSON(require('./fixtures/ExpoManaged47Project.json'));
+      mockConfigFile('/app/app.config.js', () => ({
+        default: ({ config }: any) => {
+          config.android = { version: '1.2.3' };
+          config.ios = { version: '4.5.6' };
+          return config;
+        },
+      }));
+
+      const options = await normalizeOptionsAsync('/app', {
+        sourceSkips: SourceSkips.ExpoConfigPlatformVersions,
+      });
+      const { config, loadedModules } = await getExpoConfigAsync('/app', options);
+      const sources = await getExpoConfigSourcesAsync('/app', config, loadedModules, options);
+      const expoConfigSource = sources.find<HashSourceContents>(
+        (source): source is HashSourceContents =>
+          source.type === 'contents' && source.id === 'expoConfig'
+      );
+      const expoConfig = JSON.parse(expoConfigSource?.contents?.toString() ?? 'null');
+      expect(expoConfig).not.toBeNull();
+      expect(expoConfig.ios.version).toBeUndefined();
+      expect(expoConfig.android.version).toBeUndefined();
+    });
+  });
+
   it('should support sourceSkips from config', async () => {
     await jest.isolateModulesAsync(async () => {
       vol.fromJSON(require('./fixtures/ExpoManaged47Project.json'));


### PR DESCRIPTION
# Why

When versioning iOS and Android independently via `ios.version` / `android.version` (which take precedence over the top-level `version`), a bump on one platform currently invalidates the fingerprint on the other.

The existing `SourceSkips.ExpoConfigVersions` flag is named for "versions in app.json" and already strips the top-level `version`, `ios.buildNumber`, and `android.versionCode`. The platform-specific `version` overrides predate the flag and were never added to it — this PR closes that gap so the flag's coverage matches its name.

# How

Extended `normalizeExpoConfig` in `@expo/fingerprint` so that the existing `ExpoConfigVersions` branch also deletes `ios.version` and `android.version` from the cloned ExpoConfig before hashing. Updated the flag's docstring to enumerate the new fields, and updated the existing unit test to seed and assert all five version-related fields are stripped.

I initially considered adding a separate `ExpoConfigPlatformVersions` flag (visible in the first commit on this branch) but folding into the existing flag is cleaner: a static `fingerprint.config.js` can't branch per-platform, so the only useful surface for either flag is "strip all of them together" — which is what `ExpoConfigVersions` is already shaped to express.

# Test Plan

- Updated the existing `should not container version when SourceSkips.ExpoConfigVersions` test in `Expo-test.ts` to also seed `ios.version` / `android.version` and assert both are stripped from the hashed ExpoConfig contents.
- I was unable to run `et check-packages @expo/fingerprint` locally (no bootstrapped `node_modules` in this worktree); CI will validate build, type-check, lint, and the new assertions.

# Note on breaking change

Projects already opting into `SourceSkips.ExpoConfigVersions` and setting `ios.version` / `android.version` will see their fingerprint hash shift after upgrading, because those fields are now stripped before hashing. Called out under 🛠 Breaking changes in the CHANGELOG entry.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). _Not applicable — change is internal to `@expo/fingerprint`._
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)