### PR TITLE
[vscode] Add defaultFormatter `oxc` to .vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "eslint.workingDirectories": [{ "pattern": "*" }],
   "search.exclude": {


### PR DESCRIPTION
# Why

It might be useful to tell vscode to use oxc instead of eslint formatter after migration to `oxc` #47096

# How

Added `"editor.defaultFormatter": "oxc.oxc-vscode",` to `settings.json`