### PR TITLE
[camera][image-picker][media-library] Add TAG_PHOTOGRAPHIC_SENSITIVITY to Android EXIF tags

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Enabled responsive capture and fast capture prioritization on iOS for lower shutter lag and faster successive photo captures.
+- [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/ExifTags.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/ExifTags.kt
@@ -62,7 +62,9 @@ val exifTags = arrayOf(
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION),
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION),
   arrayOf("int", ExifInterface.TAG_GAIN_CONTROL),
+  @Suppress("DEPRECATION") // Deprecated, but we keep it as it can still be present in EXIF data.
   arrayOf("int", ExifInterface.TAG_ISO_SPEED_RATINGS),
+  arrayOf("int", ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY),
   arrayOf("string", ExifInterface.TAG_IMAGE_UNIQUE_ID),
   arrayOf("int", ExifInterface.TAG_LIGHT_SOURCE),
   arrayOf("string", ExifInterface.TAG_MAKER_NOTE),

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Allow `launchCameraAsync` to be invoked on the simulator. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -120,7 +120,9 @@ object ImagePickerConstants {
         ExifInterface.TAG_GPS_DIFFERENTIAL,
         ExifInterface.TAG_IMAGE_LENGTH,
         ExifInterface.TAG_IMAGE_WIDTH,
+        @Suppress("DEPRECATION") // Deprecated, but we keep it as it can still be present in EXIF data.
         ExifInterface.TAG_ISO_SPEED_RATINGS,
+        ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY,
         ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT,
         ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT_LENGTH,
         ExifInterface.TAG_LIGHT_SOURCE,

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 - Add filtering by `isFavorite` to `Query` ([#45769](https://github.com/expo/expo/pull/45769) by [@Wenszel](https://github.com/Wenszel))
 - Add `Query.exeForMetadata()` for cheap bulk fetch ([#46485](https://github.com/expo/expo/pull/46485) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.kt
@@ -93,7 +93,9 @@ val EXIF_TAGS = arrayOf(
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION),
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION),
   arrayOf("int", ExifInterface.TAG_GAIN_CONTROL),
+  @Suppress("DEPRECATION") // Deprecated, but we keep it as it can still be present in EXIF data.
   arrayOf("int", ExifInterface.TAG_ISO_SPEED_RATINGS),
+  arrayOf("int", ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY),
   arrayOf("string", ExifInterface.TAG_IMAGE_UNIQUE_ID),
   arrayOf("int", ExifInterface.TAG_LIGHT_SOURCE),
   arrayOf("string", ExifInterface.TAG_MAKER_NOTE),

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/ExifTags.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/ExifTags.kt
@@ -62,7 +62,9 @@ val EXIF_TAGS = arrayOf(
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION),
   arrayOf("double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION),
   arrayOf("int", ExifInterface.TAG_GAIN_CONTROL),
+  @Suppress("DEPRECATION") // Deprecated, but we keep it as it can still be present in EXIF data.
   arrayOf("int", ExifInterface.TAG_ISO_SPEED_RATINGS),
+  arrayOf("int", ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY),
   arrayOf("string", ExifInterface.TAG_IMAGE_UNIQUE_ID),
   arrayOf("int", ExifInterface.TAG_LIGHT_SOURCE),
   arrayOf("string", ExifInterface.TAG_MAKER_NOTE),


### PR DESCRIPTION
# Why

`ExifInterface.TAG_ISO_SPEED_RATINGS` was deprecated.

```gradle
packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/ExifTags.kt:65:32 - 'static field TAG_ISO_SPEED_RATINGS: String' is deprecated. Deprecated in Java.
```

# How

- Keep `TAG_ISO_SPEED_RATINGS`, as it still might be present in old EXIF metadata
- Add `TAG_PHOTOGRAPHIC_SENSITIVITY`, which is the recommended replacement

# Test Plan

BareExpo
