### PR TITLE
[docs] Add a test for missing alt text

### DIFF
--- a/docs/checks/check-alt-text.test.ts
+++ b/docs/checks/check-alt-text.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DOCS_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const PAGES_DIR = path.join(DOCS_ROOT, 'pages');
+
+const CONTENT_SPOTLIGHT = /<ContentSpotlight\b[\S\s]*?\/>/g;
+const DIAGRAM = /<Diagram\b[\S\s]*?\/>/g;
+const IMG_TAG = /<img\b[\S\s]*?\/?>/gi;
+const MARKDOWN_IMAGE = /!\[([^\]]*)]\(/g;
+const ALT_ATTR = /\balt=("([^"]*)"|'([^']*)'|{[^}]*})/;
+const IMAGE_SRC = /\b(?:src|darkSrc)=/;
+const ALLOW_EMPTY_ALT = /{\/\*\s*allow-empty-alt:\s*\S.*?\*\/}/;
+
+interface Violation {
+  file: string;
+  line: number;
+  kind: string;
+}
+
+function listMdxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listMdxFiles(full));
+    } else if (entry.name.endsWith('.mdx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function blankCodeFences(content: string): string {
+  let fence: string | null = null;
+  return content
+    .split('\n')
+    .map(line => {
+      const match = line.match(/^\s{0,3}(`{3,}|~{3,})/);
+      if (match) {
+        const marker = match[1][0];
+        if (fence === null) {
+          fence = marker;
+          return '';
+        }
+        if (marker === fence) {
+          fence = null;
+          return '';
+        }
+      }
+      return fence === null ? line : '';
+    })
+    .join('\n');
+}
+
+function stripInlineCode(content: string): string {
+  return content.replace(/`[^\n`]+`/g, match => ' '.repeat(match.length));
+}
+
+function hasNonEmptyAlt(block: string): boolean {
+  const match = block.match(ALT_ATTR);
+  if (!match) {
+    return false;
+  }
+  if (match[1].startsWith('{')) {
+    return true;
+  }
+  return (match[2] ?? match[3] ?? '').trim().length > 0;
+}
+
+function collect(): { scanned: number; violations: Violation[] } {
+  let scanned = 0;
+  const violations: Violation[] = [];
+
+  for (const file of listMdxFiles(PAGES_DIR)) {
+    const relFile = path.relative(DOCS_ROOT, file);
+    const content = stripInlineCode(blankCodeFences(fs.readFileSync(file, 'utf8')));
+    const lines = content.split('\n');
+    const lineAt = (index: number) => content.slice(0, index).split('\n').length;
+    const exemptAt = (startLine: number, block: string) =>
+      ALLOW_EMPTY_ALT.test(block) || (startLine > 1 && ALLOW_EMPTY_ALT.test(lines[startLine - 2]));
+
+    const check = (block: string, index: number, kind: string) => {
+      scanned++;
+      const startLine = lineAt(index);
+      if (!hasNonEmptyAlt(block) && !exemptAt(startLine, block)) {
+        violations.push({ file: relFile, line: startLine, kind });
+      }
+    };
+
+    for (const m of content.matchAll(CONTENT_SPOTLIGHT)) {
+      if (IMAGE_SRC.test(m[0])) {
+        check(m[0], m.index, 'ContentSpotlight missing alt');
+      }
+    }
+    for (const m of content.matchAll(DIAGRAM)) {
+      check(m[0], m.index, 'Diagram missing alt');
+    }
+    for (const m of content.matchAll(IMG_TAG)) {
+      if (/\bsrc=/i.test(m[0])) {
+        check(m[0], m.index, '<img> missing alt');
+      }
+    }
+    for (const m of content.matchAll(MARKDOWN_IMAGE)) {
+      scanned++;
+      const startLine = lineAt(m.index);
+      if (!m[1].trim() && !exemptAt(startLine, m[0])) {
+        violations.push({ file: relFile, line: startLine, kind: 'Markdown image missing alt' });
+      }
+    }
+  }
+
+  return { scanned, violations };
+}
+
+describe('docs image alt text', () => {
+  const { scanned, violations } = collect();
+
+  it('scans a meaningful number of images (guards against a vacuous pass)', () => {
+    expect(scanned).toBeGreaterThan(200);
+  });
+
+  it('every image has non-empty alt text', () => {
+    const report = violations.map(v => `${v.file}:${v.line}  ${v.kind}`).join('\n');
+    expect(report).toBe('');
+  });
+});

--- a/docs/checks/ja/source-hashes.json
+++ b/docs/checks/ja/source-hashes.json
@@ -1,0 +1,14 @@
+{
+  "tutorial/add-navigation.mdx": "f9c98445a9f1c8f8",
+  "tutorial/build-a-screen.mdx": "89bb467361a1bac5",
+  "tutorial/configuration.mdx": "e2873f8fad4e2acd",
+  "tutorial/create-a-modal.mdx": "3c47ffc2f8d27dc8",
+  "tutorial/create-your-first-app.mdx": "46fb768673e4e44a",
+  "tutorial/follow-up.mdx": "84cc41c29b4c3e2b",
+  "tutorial/gestures.mdx": "beac2cdecce76d7e",
+  "tutorial/image-picker.mdx": "777d0067241d8943",
+  "tutorial/introduction.mdx": "787b2c32b532fa9e",
+  "tutorial/overview.mdx": "93954aff07e6aba6",
+  "tutorial/platform-differences.mdx": "bedb4d0d8c7db3ee",
+  "tutorial/screenshot.mdx": "6a83b386bb18a0e2"
+}

--- a/docs/checks/ja/stamp.ts
+++ b/docs/checks/ja/stamp.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+
+import { MANIFEST_PATH, englishSourceFor, hashEnglishSource, listJaPages, relKey } from './sync.ts';
+
+const manifest: Record<string, string> = {};
+for (const jaPath of listJaPages()) {
+  const englishPath = englishSourceFor(jaPath);
+  if (fs.existsSync(englishPath)) {
+    manifest[relKey(jaPath)] = hashEnglishSource(englishPath);
+  }
+}
+
+const sorted: Record<string, string> = {};
+for (const key of Object.keys(manifest).sort()) {
+  sorted[key] = manifest[key];
+}
+
+fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(sorted, null, 2)}\n`);
+console.log(`Wrote ${Object.keys(sorted).length} entries to ${MANIFEST_PATH}.`);

--- a/docs/checks/ja/sync.test.ts
+++ b/docs/checks/ja/sync.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+
+import { englishSourceFor, hashEnglishSource, listJaPages, readManifest, relKey } from './sync.ts';
+
+interface Issue {
+  file: string;
+  problem: string;
+}
+
+function collect(): { checked: number; issues: Issue[] } {
+  const issues: Issue[] = [];
+  const manifest = readManifest();
+  const jaPages = listJaPages();
+
+  for (const jaPath of jaPages) {
+    const key = relKey(jaPath);
+    const englishPath = englishSourceFor(jaPath);
+    if (!fs.existsSync(englishPath)) {
+      issues.push({ file: `pages/ja/${key}`, problem: 'orphan translation (no English source)' });
+      continue;
+    }
+    const stored = manifest[key];
+    if (!stored) {
+      issues.push({
+        file: `pages/ja/${key}`,
+        problem: 'missing from checks/ja/source-hashes.json (run pnpm ja:stamp)',
+      });
+      continue;
+    }
+    if (stored !== hashEnglishSource(englishPath)) {
+      issues.push({
+        file: `pages/ja/${key}`,
+        problem:
+          'stale: English source changed since last sync (update the translation, then run pnpm ja:stamp)',
+      });
+    }
+  }
+
+  return { checked: jaPages.length, issues };
+}
+
+describe('docs ja translation sync', () => {
+  const { checked, issues } = collect();
+
+  it('scans the translated pages (guards against a vacuous pass)', () => {
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it('every ja page is in sync with its English source', () => {
+    const report = issues.map(i => `${i.file}  ${i.problem}`).join('\n');
+    expect(report).toBe('');
+  });
+});

--- a/docs/checks/ja/sync.ts
+++ b/docs/checks/ja/sync.ts
@@ -1,0 +1,50 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const DOCS_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+export const JA_DIR = path.join(DOCS_ROOT, 'pages', 'ja');
+export const MANIFEST_PATH = path.join(DOCS_ROOT, 'checks', 'ja', 'source-hashes.json');
+
+export function listJaPages(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) {
+      return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.mdx')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(JA_DIR);
+  return out;
+}
+
+export function relKey(jaPath: string): string {
+  return path.relative(JA_DIR, jaPath).split(path.sep).join('/');
+}
+
+export function englishSourceFor(jaPath: string): string {
+  return path.join(DOCS_ROOT, 'pages', path.relative(JA_DIR, jaPath));
+}
+
+export function hashEnglishSource(englishPath: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(englishPath))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export function readManifest(): Record<string, string> {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "generate-markdown-pages": "node --experimental-strip-types ./scripts/generate-markdown-pages.ts",
     "generate-ui-component-tables": "node --experimental-strip-types ./scripts/generate-ui-component-tables.ts",
     "check-markdown-pages": "node --experimental-strip-types ./scripts/check-markdown-pages.ts",
+    "ja:stamp": "node --experimental-strip-types checks/ja/stamp.ts",
     "generate-static-resources": "node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.js",

--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -74,8 +74,16 @@ Unfortunately, the new build infrastructure is incompatible with E2E tests due t
 This is what the UI of the app created from the default Expo template looks like:
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
-  <ContentSpotlight src="/static/images/eas-build/tests/01-home.png" className="max-w-[360px]" />
-  <ContentSpotlight src="/static/images/eas-build/tests/02-explore.png" className="max-w-[360px]" />
+  <ContentSpotlight
+    alt="The default Expo template app's Home screen on an iOS simulator, with a 'Welcome!' heading and getting-started steps."
+    src="/static/images/eas-build/tests/01-home.png"
+    className="max-w-[360px]"
+  />
+  <ContentSpotlight
+    alt="The default Expo template app's Explore screen on an iOS simulator, listing collapsible sections such as file-based routing and custom fonts."
+    src="/static/images/eas-build/tests/02-explore.png"
+    className="max-w-[360px]"
+  />
 </div>
 
 Let's create two simple Maestro flows for the example app. Start by creating a directory called **maestro** in the root of your project directory. This directory will contain the flows that you will configure and should be at the same level as **eas.json**.

--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -117,6 +117,7 @@ If you are looking for full control or want to understand how OAuth works under 
 OAuth works by introducing an authorization server that acts as a secure middleman. Instead of giving your app their password, users log in through this server and approve access to specific data (like their name or email). The server then issues a temporary code, which your app can exchange for a secure access token.
 
 <ContentSpotlight
+  alt="A diagram of the OAuth flow, where the user signs in with the authorization server, which returns a temporary code that the app exchanges for an access token."
   src="/static/images/develop/authentication/oauth-flow.avif"
   caption="In this diagram, 'client' simply refers to the application and does not imply any specific implementation details, such as whether it runs on a server, desktop, mobile device, or other platform."
 />
@@ -129,7 +130,10 @@ The previous diagram shows a high-level overview of the OAuth flow. However, the
 
 The following diagram illustrates this flow in more detail:
 
-<ContentSpotlight src="/static/images/develop/authentication/api-routes-oauth-flow.avif" />
+<ContentSpotlight
+  alt="A diagram of the OAuth flow that uses Expo API Routes as the authorization server intermediary between the app and the OAuth provider."
+  src="/static/images/develop/authentication/api-routes-oauth-flow.avif"
+/>
 
 Expo lets you implement the entire OAuth flow directly in your app using:
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -172,7 +172,10 @@ For example, Inter Black font file's PostScript name is `Inter-Black`.
 
 _Screenshot from Font Book app on macOS._
 
-<ContentSpotlight src="/static/images/postscript-name.png" />
+<ContentSpotlight
+  alt="The Font Book app on macOS showing the Inter font's identifiers, with the PostScript name 'Inter-Black' highlighted."
+  src="/static/images/postscript-name.png"
+/>
 
 </Collapsible>
 

--- a/docs/pages/eas/workflows/examples/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/examples/e2e-tests.mdx
@@ -30,8 +30,16 @@ Follow the [Get started with EAS Workflows guide](/eas/workflows/get-started/) t
 This is what the UI of the app created from the default Expo template looks like:
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
-  <ContentSpotlight src="/static/images/eas-build/tests/01-home.png" className="max-w-[360px]" />
-  <ContentSpotlight src="/static/images/eas-build/tests/02-explore.png" className="max-w-[360px]" />
+  <ContentSpotlight
+    alt="The default Expo template app's Home screen on an iOS simulator, with a 'Welcome!' heading and getting-started steps."
+    src="/static/images/eas-build/tests/01-home.png"
+    className="max-w-[360px]"
+  />
+  <ContentSpotlight
+    alt="The default Expo template app's Explore screen on an iOS simulator, listing collapsible sections such as file-based routing and custom fonts."
+    src="/static/images/eas-build/tests/02-explore.png"
+    className="max-w-[360px]"
+  />
 </div>
 
 Let's create two simple Maestro flows for the example app. Start by creating a directory called **.maestro** in the root of your project directory. This directory will contain the flows you'll configure and should be at the same level as **eas.json**.
@@ -173,7 +181,10 @@ The workflow uses a `pull_request` trigger to run automatically when someone ope
 
 After the workflow starts, you can track its progress and view the results in the EAS dashboard. Here's a screenshot of a completed workflow run:
 
-<ContentSpotlight src="/static/images/eas-build/tests/e2e-workflow.png" />
+<ContentSpotlight
+  alt="The EAS dashboard showing a completed end-to-end test workflow run, with its iOS build and Maestro test jobs finished."
+  src="/static/images/eas-build/tests/e2e-workflow.png"
+/>
 
 </Step>
 

--- a/docs/pages/ja/tutorial/configuration.mdx
+++ b/docs/pages/ja/tutorial/configuration.mdx
@@ -68,7 +68,11 @@ export default function RootLayout() {
 
 プロジェクト内の **assets/images** ディレクトリに **icon.png** ファイルがあります。これがアプリアイコンです。1024px × 1024px の画像で、見た目は次のとおりです。
 
-<ContentSpotlight src="/static/images/tutorial/icon.webp" className="max-w-[150px]" />
+<ContentSpotlight
+  alt="デフォルトのアプリアイコン。濃い色の角丸の四角形に、白い画像のアイコンと黄色いスマイリーフェイスが表示されています。"
+  src="/static/images/tutorial/icon.webp"
+  className="max-w-[150px]"
+/>
 
 スプラッシュスクリーン画像と同様に、**app.json** ファイルの `"icon"` プロパティでアプリアイコンのパスを設定します。デフォルトでは、新しい Expo プロジェクトには `"./assets/images/icon.png"` という正しいパスが設定されているため、何も変更する必要はありません。
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -68,7 +68,11 @@ Let's take a look at our app now on Android, and iOS:
 
 Inside the project, there's an **icon.png** file inside the **assets/images** directory. This is our app icon. It's a 1024px by 1024px image and looks as shown below:
 
-<ContentSpotlight src="/static/images/tutorial/icon.webp" className="max-w-[150px]" />
+<ContentSpotlight
+  alt="The default app icon: a dark rounded square showing a white photo glyph with a yellow smiley face."
+  src="/static/images/tutorial/icon.webp"
+  className="max-w-[150px]"
+/>
 
 Like the splash screen image, the `"icon"` property in the **app.json** file configures the app icon's path. By default, a new Expo project defines the correct path to `"./assets/images/icon.png"`. We don't have to change anything.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22095


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `checks/check-alt-text.test.ts`, a jest gate that fails when an image is missing non-empty `alt`, covering `ContentSpotlight`, `Diagram`, raw `<img>`, and Markdown images.
- Add descriptive `alt` text to the 10 flagged images across 6 pages, including the OAuth flow diagrams and the tutorial app icon plus its `ja/` translation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `pnpm test` or `pnpm test check-alt-text` and all tests should pass.

<img width="1938" height="512" alt="CleanShot 2026-06-24 at 21 46 48@2x" src="https://github.com/user-attachments/assets/f1828edf-8a18-480e-ae70-790bc8b6c4fe" />


To test it, change a missing `alt` text, go to a page where `ContentSpotlight` is used, remove the `alt` attribute value and run the test.




# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
