### PR TITLE
[docs] Add test to flag stale Japanese translations

### DIFF
--- a/docs/checks/ja/source-hashes.json
+++ b/docs/checks/ja/source-hashes.json
@@ -1,0 +1,14 @@
+{
+  "tutorial/add-navigation.mdx": "f9c98445a9f1c8f8",
+  "tutorial/build-a-screen.mdx": "89bb467361a1bac5",
+  "tutorial/configuration.mdx": "e2873f8fad4e2acd",
+  "tutorial/create-a-modal.mdx": "3c47ffc2f8d27dc8",
+  "tutorial/create-your-first-app.mdx": "46fb768673e4e44a",
+  "tutorial/follow-up.mdx": "84cc41c29b4c3e2b",
+  "tutorial/gestures.mdx": "beac2cdecce76d7e",
+  "tutorial/image-picker.mdx": "777d0067241d8943",
+  "tutorial/introduction.mdx": "787b2c32b532fa9e",
+  "tutorial/overview.mdx": "93954aff07e6aba6",
+  "tutorial/platform-differences.mdx": "bedb4d0d8c7db3ee",
+  "tutorial/screenshot.mdx": "6a83b386bb18a0e2"
+}

--- a/docs/checks/ja/stamp.ts
+++ b/docs/checks/ja/stamp.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+
+import { MANIFEST_PATH, englishSourceFor, hashEnglishSource, listJaPages, relKey } from './sync.ts';
+
+const manifest: Record<string, string> = {};
+for (const jaPath of listJaPages()) {
+  const englishPath = englishSourceFor(jaPath);
+  if (fs.existsSync(englishPath)) {
+    manifest[relKey(jaPath)] = hashEnglishSource(englishPath);
+  }
+}
+
+const sorted: Record<string, string> = {};
+for (const key of Object.keys(manifest).sort()) {
+  sorted[key] = manifest[key];
+}
+
+fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(sorted, null, 2)}\n`);
+console.log(`Wrote ${Object.keys(sorted).length} entries to ${MANIFEST_PATH}.`);

--- a/docs/checks/ja/sync.test.ts
+++ b/docs/checks/ja/sync.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+
+import { englishSourceFor, hashEnglishSource, listJaPages, readManifest, relKey } from './sync.ts';
+
+interface Issue {
+  file: string;
+  problem: string;
+}
+
+function collect(): { checked: number; issues: Issue[] } {
+  const issues: Issue[] = [];
+  const manifest = readManifest();
+  const jaPages = listJaPages();
+
+  for (const jaPath of jaPages) {
+    const key = relKey(jaPath);
+    const englishPath = englishSourceFor(jaPath);
+    if (!fs.existsSync(englishPath)) {
+      issues.push({ file: `pages/ja/${key}`, problem: 'orphan translation (no English source)' });
+      continue;
+    }
+    const stored = manifest[key];
+    if (!stored) {
+      issues.push({
+        file: `pages/ja/${key}`,
+        problem: 'missing from checks/ja/source-hashes.json (run pnpm ja:stamp)',
+      });
+      continue;
+    }
+    if (stored !== hashEnglishSource(englishPath)) {
+      issues.push({
+        file: `pages/ja/${key}`,
+        problem:
+          'stale: English source changed since last sync (update the translation, then run pnpm ja:stamp)',
+      });
+    }
+  }
+
+  return { checked: jaPages.length, issues };
+}
+
+describe('docs ja translation sync', () => {
+  const { checked, issues } = collect();
+
+  it('scans the translated pages (guards against a vacuous pass)', () => {
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it('every ja page is in sync with its English source', () => {
+    const report = issues.map(i => `${i.file}  ${i.problem}`).join('\n');
+    expect(report).toBe('');
+  });
+});

--- a/docs/checks/ja/sync.ts
+++ b/docs/checks/ja/sync.ts
@@ -1,0 +1,50 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const DOCS_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+export const JA_DIR = path.join(DOCS_ROOT, 'pages', 'ja');
+export const MANIFEST_PATH = path.join(DOCS_ROOT, 'checks', 'ja', 'source-hashes.json');
+
+export function listJaPages(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) {
+      return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.mdx')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(JA_DIR);
+  return out;
+}
+
+export function relKey(jaPath: string): string {
+  return path.relative(JA_DIR, jaPath).split(path.sep).join('/');
+}
+
+export function englishSourceFor(jaPath: string): string {
+  return path.join(DOCS_ROOT, 'pages', path.relative(JA_DIR, jaPath));
+}
+
+export function hashEnglishSource(englishPath: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(englishPath))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export function readManifest(): Record<string, string> {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "generate-markdown-pages": "node --experimental-strip-types ./scripts/generate-markdown-pages.ts",
     "generate-ui-component-tables": "node --experimental-strip-types ./scripts/generate-ui-component-tables.ts",
     "check-markdown-pages": "node --experimental-strip-types ./scripts/check-markdown-pages.ts",
+    "ja:stamp": "node --experimental-strip-types checks/ja/stamp.ts",
     "generate-static-resources": "node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.js",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22096

# How

- Add `checks/ja/sync.test.ts`, a jest gate (runs in `pnpm test`) that fails when a `/ja` page is stale (its English source changed since last sync) or orphaned (no English source).
- Track sync state in a content-hash manifest at `checks/ja/source-hashes.json`, keeping `/ja` frontmatter clean, and regenerate it with the new `pnpm ja:stamp`.
- Add the `ja:stamp` script plus shared helpers in `checks/ja/sync.ts` and `checks/ja/stamp.ts`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `pnpm test` or `pnpm test ja/sync` and all tests should pass.

<img width="1908" height="514" alt="CleanShot 2026-06-24 at 22 52 58@2x" src="https://github.com/user-attachments/assets/7594f6e8-722c-42d5-bf7a-39dc81dcbbe4" />

To test it, change text in one of the chapters in `/tutoria/`'s English language page, and then run `pnpm test ja/sync`.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
