### PR TITLE
[expo-video] override getAllocator(PlayerId) for media3 1.8.0 compatibility

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerLoadControl.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerLoadControl.kt
@@ -54,4 +54,8 @@ class VideoPlayerLoadControl : DefaultLoadControl() {
 
     updateAllocator()
   }
+
+  override fun getAllocator(playerId: androidx.media3.exoplayer.analytics.PlayerId): androidx.media3.exoplayer.upstream.Allocator {
+    return super.getAllocator()
+  }
 }


### PR DESCRIPTION
Starting from media3 1.8.0, `LoadControl` gains an overloaded `getAllocator(PlayerId)` method that ExoPlayer calls instead of the no-arg `getAllocator()`. Any subclass that only overrides the no-arg form causes an `AbstractMethodError` at runtime because the new overload remains abstract.

`VideoPlayerLoadControl` overrides `getAllocator()` but not `getAllocator(PlayerId)`, so apps built against media3 1.8.0+ crash on playback initialisation. This commit adds the missing override, delegating to `super.getAllocator()` to preserve the existing allocator selection logic.

Fixes #47043