### PR TITLE
[ios][modules-jsi] Check isNumber first when decoding a wide integer

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Primitives.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Primitives.swift
@@ -422,21 +422,28 @@ func decodeInteger<T: FixedWidthInteger>(_ number: Double, as type: T.Type) thro
   return result
 }
 
-/// Decodes a 64-bit-wide integer that may arrive as either a JS `number` or a JS `bigint`. A `bigint`
-/// is read losslessly through its 64-bit accessor; anything else falls back to the `Double` path so a
-/// plain number still decodes (and rounds) exactly as the narrow integer types do.
+/// Decodes a 64-bit-wide integer that may arrive as either a JS `number` or a JS `bigint`. The `number`
+/// case is checked first since it's the common one: a single `isNumber()` tag check, then the
+/// assert-only `getDouble()` reads the value without re-checking the tag. A `bigint` is read losslessly
+/// through its 64-bit accessor; anything else throws the same `TypeError` the `number` read would.
 @usableFromInline
 @JavaScriptActor
 func decodeWideInteger<T: FixedWidthInteger>(_ value: borrowing JavaScriptValue, as type: T.Type) throws -> T {
-  guard value.isBigInt() else {
-    return try decodeInteger(value.asDouble(), as: T.self)
+  guard value.isNumber() else {
+    guard value.isBigInt() else {
+      // Neither a number nor a bigint: `asDouble()` throws the canonical `TypeError`. Throwing it
+      // through the accessor (rather than constructing it here) keeps this inlinable helper from
+      // referencing `TypeError`'s internal memberwise initializer.
+      return try decodeInteger(value.asDouble(), as: T.self)
+    }
+    return try decodeBigInt(value.getBigInt(), as: T.self)
   }
-  return try decodeBigInt(value.getBigInt(), as: T.self)
+  return try decodeInteger(value.getDouble(), as: T.self)
 }
 
-/// `JavaScriptUnownedValue` overload of `decodeWideInteger`. The common `number` path stays zero-copy;
-/// only a `bigint` materializes an owning value (the borrowed value exposes no BigInt accessor), which
-/// is acceptable on this rare branch.
+/// `JavaScriptUnownedValue` overload of `decodeWideInteger`. The common `number` path stays zero-copy
+/// and pays a single tag check (see the owning overload); only a `bigint` materializes an owning value
+/// (the borrowed value exposes no BigInt accessor), which is acceptable on this rare branch.
 @usableFromInline
 @JavaScriptActor
 func decodeWideInteger<T: FixedWidthInteger>(
@@ -444,10 +451,15 @@ func decodeWideInteger<T: FixedWidthInteger>(
   as type: T.Type,
   runtime: borrowing JavaScriptRuntime
 ) throws -> T {
-  guard value.isBigInt() else {
-    return try decodeInteger(value.asDouble(), as: T.self)
+  guard value.isNumber() else {
+    guard value.isBigInt() else {
+      // See the owning overload: route the not-a-number throw through `asDouble()` rather than
+      // constructing `TypeError` here, which this inlinable helper can't reference.
+      return try decodeInteger(value.asDouble(), as: T.self)
+    }
+    return try decodeBigInt(value.copied(in: copy runtime).getBigInt(), as: T.self)
   }
-  return try decodeBigInt(value.copied(in: copy runtime).getBigInt(), as: T.self)
+  return try decodeInteger(value.getDouble(), as: T.self)
 }
 
 /// Narrows a `JavaScriptBigInt` to `T`, reading it through the signed or unsigned 64-bit accessor to

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodablePrimitivesTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodablePrimitivesTests.swift
@@ -212,5 +212,10 @@ struct JavaScriptCodablePrimitivesTests {
     #expect(throws: JavaScriptValue.TypeError.self) {
       _ = try Bool.decode(runtime.eval("'true'"), in: runtime)
     }
+    // A wide integer decodes from either a number or a bigint; a value that is neither still throws a
+    // TypeError rather than falling through.
+    #expect(throws: JavaScriptValue.TypeError.self) {
+      _ = try Int.decode(runtime.eval("'not a number'"), in: runtime)
+    }
   }
 }


### PR DESCRIPTION
## Why

`decodeWideInteger` (the `Int`/`UInt`/`Int64`/`UInt64` decode path) read the jsi value's type tag twice for every plain number: it checked `isBigInt()` first, then took the number path through `asDouble()`, which re-checks `isNumber()` internally. Decoding integer arguments is a hot path, so the redundant tag check is worth removing.

## How

Reorder to check `isNumber()` first (the common case) and read the value through the assert-only `getDouble()`, which doesn't re-check the tag. The number path now does a single tag check; the rare `bigint` branch and the not-a-number throw move into the `else`. Behavior is identical: still rounds, still range-checks, and still throws the same `TypeError` on a value that is neither a number nor a `bigint`. Both `decodeWideInteger` overloads (owning and zero-copy unowned) are updated the same way.

No CHANGELOG entry: this is an internal `@usableFromInline` refactor with no observable behavior change.

## Test Plan

`packages/expo-modules-jsi` integration tests (`pnpm test:integration`). Added a case to `decode throws on a wrong-typed primitive` covering `Int.decode` of a non-number value (the rerouted throw branch); the existing number, rounding, bigint, and out-of-range cases cover the other branches.
