### PR TITLE
chore: use `styleText()` from `node:util` to replace `chalk`

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -81,7 +81,6 @@
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",
-    "chalk": "^4.0.0",
     "ci-info": "^3.3.0",
     "compression": "^1.7.4",
     "connect": "^3.7.0",

--- a/packages/@expo/cli/src/api/settings.ts
+++ b/packages/@expo/cli/src/api/settings.ts
@@ -1,6 +1,6 @@
 // This file represents temporary globals for the CLI when using the API.
 // Settings should be as minimal as possible since they are globals.
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../log';
 import { env } from '../utils/env';
@@ -8,5 +8,5 @@ import { env } from '../utils/env';
 export function disableNetwork() {
   if (env.EXPO_OFFLINE) return;
   process.env.EXPO_OFFLINE = '1';
-  Log.log(chalk.gray('Networking has been disabled'));
+  Log.log(styleText('gray', 'Networking has been disabled'));
 }

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 import { env } from '../../utils/env';
@@ -123,9 +123,7 @@ export async function tryGetUserAsync(): Promise<Actor | null> {
   ];
 
   const value = await selectAsync(
-    chalk`\n\nIt is recommended to log in with your Expo account before proceeding. \n{dim ${learnMore(
-      'https://expo.fyi/unverified-app-expo-go'
-    )}}\n`,
+    `\n\nIt is recommended to log in with your Expo account before proceeding. \n${styleText('dim', learnMore('https://expo.fyi/unverified-app-expo-go'))}\n`,
     choices,
     {
       nonInteractiveHelp: `Use the EXPO_TOKEN environment variable to authenticate in CI (${learnMore(

--- a/packages/@expo/cli/src/api/user/otp.ts
+++ b/packages/@expo/cli/src/api/user/otp.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 import { AbortCommandError } from '../../utils/errors';
@@ -14,7 +14,7 @@ const nonInteractiveHelp = `Use the EXPO_TOKEN environment variable to authentic
  * Prompt for an OTP with the option to cancel the question by answering empty (pressing return key).
  */
 async function promptForOTPAsync(): Promise<string | null> {
-  const enterMessage = chalk`press {bold Enter} to cancel`;
+  const enterMessage = `press ${styleText('bold', `Enter`)} to cancel`;
   const { otp } = await promptAsync(
     {
       type: 'text',

--- a/packages/@expo/cli/src/config/index.ts
+++ b/packages/@expo/cli/src/config/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
@@ -22,9 +23,9 @@ export const expoConfig: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Show the project config`,
-      chalk`npx expo config {dim <dir>}`,
+      `npx expo config ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                                    Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                                    Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `--full                                   Include all project config data`,
         `--json                                   Output in JSON format`,
         `-t, --type <public|prebuild|introspect>  Type of config to show`,

--- a/packages/@expo/cli/src/customize/index.ts
+++ b/packages/@expo/cli/src/customize/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
@@ -22,10 +23,10 @@ export const expoCustomize: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Generate static project files`,
-      chalk`npx expo customize {dim [files...] -- [options]}`,
+      `npx expo customize ${styleText('dim', `[files...] -- [options]`)}`,
       [
-        chalk`[files...]  List of files to generate`,
-        chalk`[options]   Options to pass to the install command`,
+        `[files...]  List of files to generate`,
+        `[options]   Options to pass to the install command`,
         `-h, --help  Usage info`,
       ].join('\n')
     );

--- a/packages/@expo/cli/src/customize/templates.ts
+++ b/packages/@expo/cli/src/customize/templates.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -153,7 +153,7 @@ function createChoices(
     return {
       title: destination,
       value: index,
-      description: exists ? chalk.red('This will overwrite the existing file') : undefined,
+      description: exists ? styleText('red', 'This will overwrite the existing file') : undefined,
     };
   });
 }

--- a/packages/@expo/cli/src/export/embed/exportServer.ts
+++ b/packages/@expo/cli/src/export/embed/exportServer.ts
@@ -7,9 +7,9 @@
 import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import { modifyConfigAsync } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs';
 import { execSync } from 'node:child_process';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { disableNetwork } from '../../api/settings';
@@ -193,7 +193,10 @@ async function runServerDeployCommandAsync(
 
     logMetroErrorInXcode(
       projectRoot,
-      chalk.red`Running CLI in offline mode, skipping server deployment. Deploy manually with: ${manualScript}`
+      styleText(
+        'red',
+        `Running CLI in offline mode, skipping server deployment. Deploy manually with: ${manualScript}`
+      )
     );
   };
   if (env.EXPO_OFFLINE) {
@@ -280,7 +283,8 @@ async function runServerDeployCommandAsync(
     if (isSpawnResultError(error)) {
       const output = error.output.join('\n').trim() || error.toString();
       Log.log(
-        chalk.dim(
+        styleText(
+          'dim',
           'An error occurred while deploying server. Logs stored at: ' +
             (await dumpDeploymentLogs(projectRoot, output, 'deploy-error'))
         )
@@ -290,7 +294,7 @@ async function runServerDeployCommandAsync(
       if (output.match(/ENOTFOUND/)) {
         logOfflineError();
         // Print the raw error message to help provide more context.
-        Log.log(chalk.dim(output));
+        Log.log(styleText('dim', output));
         // Prevent any other network requests (unlikely for this command).
         disableNetwork();
         return false;

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import type arg from 'arg';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import type { Command } from '../../index';
@@ -54,9 +54,9 @@ export const expoExportEmbed: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `(Internal) Export the JavaScript bundle during a native build script for embedding in a native binary`,
-      chalk`npx expo export:embed {dim <dir>}`,
+      `npx expo export:embed ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                                  Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                                  Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `--entry-file <path>                    Path to the root JS file, either absolute or relative to current working directory`,
         `--platform <string>                    Either "ios" or "android" (default: "ios")`,
         `--transformer <string>                 Specify a custom transformer to be used`,

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -3,10 +3,10 @@ import type { Platform } from '@expo/config';
 import { resolveRelativeEntryPoint } from '@expo/config/paths';
 import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import { createFaviconAsString } from '@expo/router-server/build/utils/html';
-import chalk from 'chalk';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { WebSupportProjectPrerequisite } from '../start/doctor/web/WebSupportProjectPrerequisite';
@@ -101,11 +101,14 @@ export async function exportAppAsync(
   // Print out logs
   if (baseUrl) {
     Log.log();
-    Log.log(chalk.gray`Using (experimental) base path: ${baseUrl}`);
+    Log.log(styleText('gray', `Using (experimental) base path: ${baseUrl}`));
     // Warn if not using an absolute path.
     if (!baseUrl.startsWith('/')) {
       Log.log(
-        chalk.yellow`  Base path does not start with a slash. Requests will not be absolute.`
+        styleText(
+          'yellow',
+          `  Base path does not start with a slash. Requests will not be absolute.`
+        )
       );
     }
   }

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Log from '../log';
@@ -34,7 +34,7 @@ export async function exportAsync(projectRoot: string, options: Options) {
   await waitUntilAtlasExportIsReadyAsync(projectRoot);
 
   // Final notes
-  Log.log(chalk.greenBright`Exported: ${options.outputDir}`);
+  Log.log(styleText('greenBright', `Exported: ${options.outputDir}`));
 
   // Exit the process to stop any hanging processes from reading the app.config.js or server rendering.
   ensureProcessExitsAfterDelay();

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -7,11 +7,11 @@
 import type { ExpoConfig } from '@expo/config';
 import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import type { GetStaticContentOptions } from '@expo/router-server/build/static/renderStaticContent';
-import chalk from 'chalk';
 import type { RouteNode } from 'expo-router/build/Route';
 import { getContextKey, stripGroupSegmentsFromPath } from 'expo-router/build/matchers';
 import { shouldLinkExternally } from 'expo-router/build/utils/url';
 import type { RoutesManifest } from 'expo-server/private';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import { inspect } from 'util';
@@ -681,16 +681,22 @@ function warnPossibleInvalidExportType(appDir: string) {
   if (apiRoutes.length) {
     // TODO: Allow API Routes for native-only.
     Log.warn(
-      chalk.yellow`Skipping export for API routes because \`web.output\` is not "server". You may want to remove the routes: ${apiRoutes
-        .map((v) => path.relative(appDir, v))
-        .join(', ')}`
+      styleText(
+        'yellow',
+        `Skipping export for API routes because \`web.output\` is not "server". You may want to remove the routes: ${apiRoutes
+          .map((v) => path.relative(appDir, v))
+          .join(', ')}`
+      )
     );
   }
 
   const middlewareFile = getMiddlewareForDirectory(appDir);
   if (middlewareFile) {
     Log.warn(
-      chalk.yellow`Skipping export for middleware because \`web.output\` is not "server". You may want to remove ${path.relative(appDir, middlewareFile)}`
+      styleText(
+        'yellow',
+        `Skipping export for middleware because \`web.output\` is not "server". You may want to remove ${path.relative(appDir, middlewareFile)}`
+      )
     );
   }
 }

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import type arg from 'arg';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import type { Command } from '../index';
@@ -45,18 +45,18 @@ export const expoExport: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Export the static files of the app for hosting it on a web server`,
-      chalk`npx expo export {dim <dir>}`,
+      `npx expo export ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                      Directory of the Expo project. {dim Default: Current working directory}`,
-        chalk`--output-dir <dir>         The directory to export the static files to. {dim Default: dist}`,
+        `<dir>                      Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
+        `--output-dir <dir>         The directory to export the static files to. ${styleText('dim', `Default: dist`)}`,
         `--dev                      Configure static files for developing locally using a non-https server`,
         `--no-minify                Prevent minifying source`,
         `--no-bytecode              Prevent generating Hermes bytecode`,
         `--max-workers <number>     Maximum number of tasks to allow the bundler to spawn`,
         `--dump-assetmap            Emit an asset map for further processing`,
         `--no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web`,
-        chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
-        chalk`-s, --source-maps [mode]   Emit JavaScript source maps. {dim Options: true, false, inline, external. Default: false}`,
+        `-p, --platform <platform>  Options: android, ios, web, all. ${styleText('dim', `Default: all`)}`,
+        `-s, --source-maps [mode]   Emit JavaScript source maps. ${styleText('dim', `Options: true, false, inline, external. Default: false`)}`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/export/saveAssets.ts
+++ b/packages/@expo/cli/src/export/saveAssets.ts
@@ -7,8 +7,8 @@
 import type { Platform } from '@expo/config';
 import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import type { AssetData } from '@expo/metro/metro';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { Log } from '../log';
@@ -131,7 +131,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   const sizeStr = (contents: string | Buffer) => {
     const length = contentSize(contents);
-    const size = chalk.gray`(${prettyBytes(length)})`;
+    const size = styleText('gray', `(${prettyBytes(length)})`);
     return size;
   };
 
@@ -156,14 +156,15 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
       const totalAssets = assetGroups.reduce((sum, [, assets]) => sum + assets.length, 0);
 
       Log.log('');
-      Log.log(chalk.bold`${BLT} Assets (${totalAssets}):`);
+      Log.log(styleText('bold', `${BLT} Assets (${totalAssets}):`));
 
       for (const [assetId, assets] of assetGroups) {
         const averageContentSize =
           assets.reduce((sum, [, { contents }]) => sum + contentSize(contents), 0) / assets.length;
         Log.log(
           assetId,
-          chalk.gray(
+          styleText(
+            'gray',
             `(${[
               assets.length > 1 ? `${assets.length} variations` : '',
               `${prettyBytes(averageContentSize)}`,
@@ -192,7 +193,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   [...bundles.entries()].forEach(([platform, assets]) => {
     Log.log('');
-    Log.log(chalk.bold`${BLT} ${platform} bundles (${assets.length}):`);
+    Log.log(styleText('bold', `${BLT} ${platform} bundles (${assets.length}):`));
 
     const allAssets = assets.sort((a, b) => a[0].localeCompare(b[0]));
     while (allAssets.length) {
@@ -203,7 +204,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
         const sourceMapIndex = allAssets.findIndex(([fp]) => fp === filePath + '.map');
         if (sourceMapIndex !== -1) {
           const [sourceMapFilePath, sourceMapAsset] = allAssets.splice(sourceMapIndex, 1)[0]!;
-          Log.log(chalk.gray(sourceMapFilePath), sizeStr(sourceMapAsset.contents));
+          Log.log(styleText('gray', sourceMapFilePath), sizeStr(sourceMapAsset.contents));
         }
       }
     }
@@ -211,7 +212,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   if (showAdditionalInfo && other.length) {
     Log.log('');
-    Log.log(chalk.bold`${BLT} Files (${other.length}):`);
+    Log.log(styleText('bold', `${BLT} Files (${other.length}):`));
 
     for (const [filePath, asset] of other.sort((a, b) => a[0].localeCompare(b[0]))) {
       Log.log(filePath, sizeStr(asset.contents));
@@ -220,25 +221,25 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   if (rscEntries.length) {
     Log.log('');
-    Log.log(chalk.bold`${BLT} React Server Components (${rscEntries.length}):`);
+    Log.log(styleText('bold', `${BLT} React Server Components (${rscEntries.length}):`));
 
     for (const [filePath, assets] of rscEntries.sort((a, b) => a[0].length - b[0].length)) {
       const id = assets.rscId!;
       Log.log(
-        '/' + (id === '' ? chalk.gray(' (index)') : id),
+        '/' + (id === '' ? styleText('gray', ' (index)') : id),
         sizeStr(assets.contents),
-        chalk.gray(filePath)
+        styleText('gray', filePath)
       );
     }
   }
 
   if (routeEntries.length) {
     Log.log('');
-    Log.log(chalk.bold`${BLT} Static routes (${routeEntries.length}):`);
+    Log.log(styleText('bold', `${BLT} Static routes (${routeEntries.length}):`));
 
     for (const [, assets] of routeEntries.sort((a, b) => a[0].length - b[0].length)) {
       const id = assets.routeId!;
-      Log.log('/' + (id === '' ? chalk.gray(' (index)') : id), sizeStr(assets.contents));
+      Log.log('/' + (id === '' ? styleText('gray', ' (index)') : id), sizeStr(assets.contents));
     }
   }
 
@@ -247,7 +248,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
       (route) => !route[0].endsWith('.map')
     );
     Log.log('');
-    Log.log(chalk.bold`${BLT} API routes (${apiRoutesWithoutSourcemaps.length}):`);
+    Log.log(styleText('bold', `${BLT} API routes (${apiRoutesWithoutSourcemaps.length}):`));
 
     for (const [apiRouteFilename, assets] of apiRoutesWithoutSourcemaps.sort(
       (a, b) => a[0].length - b[0].length
@@ -260,9 +261,9 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
           filename.endsWith('.map')
       );
       Log.log(
-        id === '' ? chalk.gray(' (index)') : id,
+        id === '' ? styleText('gray', ' (index)') : id,
         sizeStr(assets.contents),
-        hasSourceMap ? chalk.gray(`(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
+        hasSourceMap ? styleText('gray', `(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
       );
     }
   }
@@ -272,7 +273,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
       (route) => !route[0].endsWith('.map')
     );
     Log.log('');
-    Log.log(chalk.bold`${BLT} Middleware:`);
+    Log.log(styleText('bold', `${BLT} Middleware:`));
 
     for (const [middlewareFilename, assets] of middlewareWithoutSourcemaps.sort(
       (a, b) => a[0].length - b[0].length
@@ -287,7 +288,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
       Log.log(
         id,
         sizeStr(assets.contents),
-        hasSourceMap ? chalk.gray(`(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
+        hasSourceMap ? styleText('gray', `(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
       );
     }
   }
@@ -295,7 +296,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
   if (loaderEntries.length) {
     const loadersWithoutSourcemaps = loaderEntries.filter((entry) => !entry[0].endsWith('.map'));
     Log.log('');
-    Log.log(chalk.bold`${BLT} Loaders (${loadersWithoutSourcemaps.length}):`);
+    Log.log(styleText('bold', `${BLT} Loaders (${loadersWithoutSourcemaps.length}):`));
 
     for (const [loaderFilename, assets] of loadersWithoutSourcemaps.sort(
       (a, b) => a[0].length - b[0].length
@@ -308,9 +309,9 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
           filename.endsWith('.map')
       );
       Log.log(
-        id === '/' ? '/ ' + chalk.gray('(index)') : id,
+        id === '/' ? '/ ' + styleText('gray', '(index)') : id,
         sizeStr(assets.contents),
-        hasSourceMap ? chalk.gray(`(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
+        hasSourceMap ? styleText('gray', `(source map ${sizeStr(hasSourceMap[1].contents)})`) : ''
       );
     }
   }

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../../log';
 import { WebSupportProjectPrerequisite } from '../../start/doctor/web/WebSupportProjectPrerequisite';
@@ -24,7 +24,7 @@ export async function exportWebAsync(projectRoot: string, options: Options) {
   // If the user set `web.bundler: 'metro'` then they should use `expo export` instead.
   if (!bundler.isTargetingWeb()) {
     throw new CommandError(
-      chalk`{bold expo export:web} can only be used with Webpack. Use {bold expo export} for other bundlers.`
+      `${styleText('bold', `expo export:web`)} can only be used with Webpack. Use ${styleText('bold', `expo export`)} for other bundlers.`
     );
   }
 

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../../index';
 import { assertArgs, getProjectRoot, printHelp } from '../../utils/args';
@@ -22,9 +23,9 @@ export const expoExportWeb: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `(Deprecated) Bundle the static files of the web app with Webpack for hosting on a web server`,
-      chalk`npx expo export:web {dim <dir>}`,
+      `npx expo export:web ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                         Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                         Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `--dev                         Bundle in development mode`,
         `-c, --clear                   Clear the bundler cache`,
         `-h, --help                    Usage info`,

--- a/packages/@expo/cli/src/index.ts
+++ b/packages/@expo/cli/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import arg from 'arg';
-import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 
 import { installEventLogger } from '../src/events';
 
@@ -20,9 +20,12 @@ if (
   (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1]! < NODE_MIN[1])
 ) {
   console.error(
-    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}` +
-      chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n` +
-      chalk.red`Go to: https://nodejs.org/en/download\n`
+    styleText(['bold', 'red'], `Node.js (${process.version}) is outdated and unsupported.`) +
+      styleText(
+        'red',
+        ` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`
+      ) +
+      styleText('red', `Go to: https://nodejs.org/en/download\n`)
   );
 }
 
@@ -90,7 +93,12 @@ if (args['--version']) {
 }
 
 if (args['--non-interactive']) {
-  console.warn(chalk.yellow`  {bold --non-interactive} is not supported, use {bold $CI=1} instead`);
+  console.warn(
+    styleText(
+      'yellow',
+      `  ${styleText('bold', `--non-interactive`)} is not supported, use ${styleText('bold', `$CI=1`)} instead`
+    )
+  );
 }
 
 // Check if we are running `npx expo <subcommand>` or `npx expo`
@@ -127,22 +135,22 @@ if (!isSubcommand && args['--help']) {
     ...others
   } = commands;
 
-  console.log(chalk`
-  {bold Usage}
-    {dim $} npx expo <command>
+  console.log(`
+  ${styleText('bold', `Usage`)}
+    ${styleText('dim', `$`)} npx expo <command>
 
-  {bold Commands}
+  ${styleText('bold', `Commands`)}
     ${Object.keys({ start, export: _export, ...others }).join(', ')}
     ${Object.keys({ 'run:ios': runIos, 'run:android': runAndroid, prebuild }).join(', ')}
     ${Object.keys({ install, customize, config, serve }).join(', ')}
-    {dim ${Object.keys({ login, logout, whoami, register }).join(', ')}}
+    ${styleText('dim', Object.keys({ login, logout, whoami, register }).join(', '))}
 
-  {bold Options}
+  ${styleText('bold', `Options`)}
     --version, -v   Version number
     --help, -h      Usage info
 
-  For more info run a command with the {bold --help} flag
-    {dim $} npx expo start --help
+  For more info run a command with the ${styleText('bold', `--help`)} flag
+    ${styleText('dim', `$`)} npx expo start --help
 `);
 
   process.exit(0);
@@ -200,7 +208,10 @@ if (!isSubcommand) {
     console.log();
     const instruction = subcommand === 'upgrade' ? 'follow this guide' : 'use';
     console.log(
-      chalk.yellow`  {gray $} {bold expo ${subcommand}} is not supported in the local CLI, please ${instruction} {bold ${replacement}} instead`
+      styleText(
+        'yellow',
+        `  ${styleText('gray', `$`)} ${styleText('bold', `expo ${subcommand}`)} is not supported in the local CLI, please ${instruction} ${styleText('bold', replacement!)} instead`
+      )
     );
     console.log();
     process.exit(1);
@@ -208,7 +219,12 @@ if (!isSubcommand) {
   const deprecated = ['send', 'client:ios'];
   if (subcommand && deprecated.includes(subcommand)) {
     console.log();
-    console.log(chalk.yellow`  {gray $} {bold expo ${subcommand}} is deprecated`);
+    console.log(
+      styleText(
+        'yellow',
+        `  ${styleText('gray', `$`)} ${styleText('bold', `expo ${subcommand}`)} is deprecated`
+      )
+    );
     console.log();
     process.exit(1);
   }

--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@expo/config';
 import type * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import {
@@ -56,9 +56,9 @@ export async function checkPackagesAsync(
 
   if (pkg.expo?.install?.exclude?.length && !json) {
     Log.log(
-      chalk`Skipped ${fix ? 'fixing' : 'checking'} dependencies: ${joinWithCommasAnd(
+      `Skipped ${fix ? 'fixing' : 'checking'} dependencies: ${joinWithCommasAnd(
         pkg.expo.install.exclude
-      )}. These dependencies are listed in {bold expo.install.exclude} in package.json. ${learnMore(
+      )}. These dependencies are listed in ${styleText('bold', `expo.install.exclude`)} in package.json. ${learnMore(
         'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
       )}`
     );
@@ -70,7 +70,7 @@ export async function checkPackagesAsync(
     if (json) {
       console.log(JSON.stringify({ dependencies: [], upToDate: true }));
     } else {
-      Log.exit(chalk.greenBright('Dependencies are up to date'), 0);
+      Log.exit(styleText('greenBright', 'Dependencies are up to date'), 0);
     }
     return;
   }
@@ -101,5 +101,5 @@ export async function checkPackagesAsync(
   }
 
   // Exit with non-zero exit code if any of the dependencies are out of date.
-  Log.exit(chalk.red('Found outdated dependencies'), 1);
+  Log.exit(styleText('red', 'Found outdated dependencies'), 1);
 }

--- a/packages/@expo/cli/src/install/fixPackages.ts
+++ b/packages/@expo/cli/src/install/fixPackages.ts
@@ -1,5 +1,5 @@
 import type * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { getOperationLog } from '../start/doctor/dependencies/getVersionedPackages';
@@ -47,9 +47,9 @@ export async function fixPackagesAsync(
 
   // display all packages to update, including expo package
   Log.log(
-    chalk`\u203A Installing ${
+    `\u203A Installing ${
       versioningMessages.length ? versioningMessages.join(' and ') + ' ' : ''
-    }using {bold ${packageManager.name}}`
+    }using ${styleText('bold', packageManager.name)}`
   );
 
   // if updating expo package, install this first, then run expo install --fix again under new version

--- a/packages/@expo/cli/src/install/index.ts
+++ b/packages/@expo/cli/src/install/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
@@ -28,18 +29,18 @@ export const expoInstall: Command = async (argv) => {
         `--check     Check which installed packages need to be updated`,
         '--dev       Save the dependencies as devDependencies',
         `--fix       Automatically update any invalid package versions`,
-        chalk`--npm       Use npm to install dependencies. {dim Default when package-lock.json exists}`,
-        chalk`--yarn      Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
-        chalk`--bun       Use bun to install dependencies. {dim Default when bun.lock or bun.lockb exists}`,
-        chalk`--pnpm      Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
+        `--npm       Use npm to install dependencies. ${styleText('dim', `Default when package-lock.json exists`)}`,
+        `--yarn      Use Yarn to install dependencies. ${styleText('dim', `Default when yarn.lock exists`)}`,
+        `--bun       Use bun to install dependencies. ${styleText('dim', `Default when bun.lock or bun.lockb exists`)}`,
+        `--pnpm      Use pnpm to install dependencies. ${styleText('dim', `Default when pnpm-lock.yaml exists`)}`,
         `-h, --help  Usage info`,
         `--json      Output dependency information in JSON format with --check flag`,
       ].join('\n'),
       [
         '',
-        chalk`  Additional options can be passed to the underlying install command by using {bold --}`,
-        chalk`    {dim $} npx expo install react -- --verbose`,
-        chalk`    {dim >} yarn add react --verbose`,
+        `  Additional options can be passed to the underlying install command by using ${styleText('bold', `--`)}`,
+        `    ${styleText('dim', `$`)} npx expo install react -- --verbose`,
+        `    ${styleText('dim', `>`)} yarn add react --verbose`,
         '',
       ].join('\n')
     );

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -1,6 +1,6 @@
 import { getConfig, getPackageJson } from '@expo/config';
 import * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { getVersionedPackagesAsync } from '../start/doctor/dependencies/getVersionedPackages';
@@ -133,9 +133,9 @@ export async function installPackagesAsync(
   });
 
   Log.log(
-    chalk`\u203A Installing ${
+    `\u203A Installing ${
       versioning.messages.length ? versioning.messages.join(' and ') + ' ' : ''
-    }using {bold ${packageManager.name}}`
+    }using ${styleText('bold', packageManager.name)}`
   );
 
   if (versioning.excludedNativeModules.length) {
@@ -148,14 +148,14 @@ export async function installPackagesAsync(
 
     if (alreadyExcluded.length) {
       Log.log(
-        chalk`\u203A Using ${joinWithCommasAnd(
+        `\u203A Using ${joinWithCommasAnd(
           alreadyExcluded.map(
             ({ bundledNativeVersion, name, specifiedVersion }) =>
               `${specifiedVersion || 'latest'} instead of  ${bundledNativeVersion} for ${name}`
           )
         )} because ${
           alreadyExcluded.length > 1 ? 'they are' : 'it is'
-        } listed in {bold expo.install.exclude} in package.json. ${learnMore(
+        } listed in ${styleText('bold', `expo.install.exclude`)} in package.json. ${learnMore(
           'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
         )}`
       );
@@ -163,14 +163,14 @@ export async function installPackagesAsync(
 
     if (specifiedExactVersion.length) {
       Log.log(
-        chalk`\u203A Using ${joinWithCommasAnd(
+        `\u203A Using ${joinWithCommasAnd(
           specifiedExactVersion.map(
             ({ bundledNativeVersion, name, specifiedVersion }) =>
               `${specifiedVersion} instead of ${bundledNativeVersion} for ${name}`
           )
         )} because ${
           specifiedExactVersion.length > 1 ? 'these versions' : 'this version'
-        } was explicitly provided. Packages excluded from dependency validation should be listed in {bold expo.install.exclude} in package.json. ${learnMore(
+        } was explicitly provided. Packages excluded from dependency validation should be listed in ${styleText('bold', `expo.install.exclude`)} in package.json. ${learnMore(
           'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
         )}`
       );

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -1,6 +1,6 @@
 import type * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { getRunningProcess } from '../utils/getRunningProcess';
@@ -49,7 +49,7 @@ export async function installExpoPackageAsync(
     }
   } catch (error) {
     Log.error(
-      chalk`Cannot install the latest Expo package. Install {bold expo@latest} with ${packageManager.name} and then run {bold npx expo install} again.`
+      `Cannot install the latest Expo package. Install ${styleText('bold', `expo@latest`)} with ${packageManager.name} and then run ${styleText('bold', `npx expo install`)} again.`
     );
     throw error;
   }
@@ -63,7 +63,9 @@ export async function installExpoPackageAsync(
       commandSegments = [...commandSegments, '--', ...packageManagerArguments];
     }
 
-    Log.log(chalk`\u203A Running {bold npx expo install} under the updated expo version`);
+    Log.log(
+      `\u203A Running ${styleText('bold', `npx expo install`)} under the updated expo version`
+    );
     Log.log('> ' + commandSegments.join(' '));
 
     await spawnAsync('npx', commandSegments, {

--- a/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
+++ b/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
@@ -1,5 +1,5 @@
 // note(Simek): reference https://github.com/react-native-community/directory/blob/main/pages/api/libraries/check.ts
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../../log';
 import { chunk } from '../../utils/array';
@@ -47,7 +47,7 @@ export async function checkPackagesCompatibility(packages: string[]) {
       if (result.status === 'fulfilled') {
         return { ...acc, ...result.value };
       }
-      Log.log(chalk.gray(ERROR_MESSAGE));
+      Log.log(styleText('gray', ERROR_MESSAGE));
       return acc;
     }, {});
 
@@ -57,13 +57,14 @@ export async function checkPackagesCompatibility(packages: string[]) {
 
     if (incompatiblePackages.length) {
       Log.warn(
-        chalk.yellow(
-          `${chalk.bold('Warning')}: ${formatPackageNames(incompatiblePackages)} do${incompatiblePackages.length > 1 ? '' : 'es'} not support the New Architecture. ${learnMore('https://docs.expo.dev/guides/new-architecture/')}`
+        styleText(
+          'yellow',
+          `${styleText('bold', 'Warning')}: ${formatPackageNames(incompatiblePackages)} do${incompatiblePackages.length > 1 ? '' : 'es'} not support the New Architecture. ${learnMore('https://docs.expo.dev/guides/new-architecture/')}`
         )
       );
     }
   } catch {
-    Log.log(chalk.gray(ERROR_MESSAGE));
+    Log.log(styleText('gray', ERROR_MESSAGE));
   }
 }
 

--- a/packages/@expo/cli/src/lint/index.ts
+++ b/packages/@expo/cli/src/lint/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
@@ -25,27 +25,27 @@ export const expoLint: Command = async (argv) => {
 
   if (args['--help']) {
     printHelp(
-      chalk`Lint all files in {bold /src}, {bold /app}, {bold /components} directories with ESLint`,
-      chalk`npx expo lint {dim [path...] -- [eslint options]}`,
+      `Lint all files in ${styleText('bold', `/src`)}, ${styleText('bold', `/app`)}, ${styleText('bold', `/components`)} directories with ESLint`,
+      `npx expo lint ${styleText('dim', `[path...] -- [eslint options]`)}`,
 
       [
-        chalk`[path...]                  List of files and directories to lint`,
-        chalk`--ext {dim <string>}             Additional file extensions to lint. {dim Default: .js, .jsx, .ts, .tsx, .mjs, .cjs}`,
-        chalk`--config {dim <path>}            Custom ESLint config file`,
+        `[path...]                  List of files and directories to lint`,
+        `--ext ${styleText('dim', `<string>`)}             Additional file extensions to lint. ${styleText('dim', `Default: .js, .jsx, .ts, .tsx, .mjs, .cjs`)}`,
+        `--config ${styleText('dim', `<path>`)}            Custom ESLint config file`,
         `--no-cache                 Check all files, instead of changes between runs`,
         `--fix                      Automatically fix problems`,
-        chalk`--fix-type {dim <string>}        Specify the types of fixes to apply. {dim Example: problem, suggestion, layout}`,
+        `--fix-type ${styleText('dim', `<string>`)}        Specify the types of fixes to apply. ${styleText('dim', `Example: problem, suggestion, layout`)}`,
         `--no-ignore                Disable use of ignore files and patterns`,
-        chalk`--ignore-pattern {dim <string>}  Patterns of files to ignore`,
+        `--ignore-pattern ${styleText('dim', `<string>`)}  Patterns of files to ignore`,
         `--quiet                    Only report errors`,
-        chalk`--max-warnings {dim <number>}    Number of warnings to trigger nonzero exit code`,
+        `--max-warnings ${styleText('dim', `<number>`)}    Number of warnings to trigger nonzero exit code`,
         `-h, --help                 Usage info`,
       ].join('\n'),
       [
         '',
-        chalk`  Additional options can be passed to {bold npx eslint} by using {bold --}`,
-        chalk`    {dim $} npx expo lint -- --no-error-on-unmatched-pattern`,
-        chalk`    {dim >} npx eslint --no-error-on-unmatched-pattern {dim ...}`,
+        `  Additional options can be passed to ${styleText('bold', `npx eslint`)} by using ${styleText('bold', `--`)}`,
+        `    ${styleText('dim', `$`)} npx expo lint -- --no-error-on-unmatched-pattern`,
+        `    ${styleText('dim', `>`)} npx eslint --no-error-on-unmatched-pattern ${styleText('dim', `...`)}`,
         '',
       ].join('\n')
     );

--- a/packages/@expo/cli/src/log.ts
+++ b/packages/@expo/cli/src/log.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 // NOTE(@kitten): LogRespectingTerminal in instantiateMetro regressed on fatal errors and
 // logs may be swallowed before exiting. We redirect them to a direct write when we're about to exit
@@ -27,15 +27,17 @@ export function error(...message: string[]): void {
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
   const { env } = require('./utils/env');
-  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(
+    styleText('red', e.toString()) + (env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : '')
+  );
 }
 
 export function warn(...message: string[]): void {
   if (isExiting) {
-    process.stderr.write(message.map((value) => chalk.yellow(value)).join(' ') + '\n');
+    process.stderr.write(message.map((value) => styleText('yellow', value)).join(' ') + '\n');
     return;
   }
-  console.warn(...message.map((value) => chalk.yellow(value)));
+  console.warn(...message.map((value) => styleText('yellow', value)));
 }
 
 export function log(...message: string[]): void {

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import { vol } from 'memfs';
 
 import * as Log from '../../log';
@@ -269,11 +269,11 @@ describe(updatePkgDependencies, () => {
       expo: 'version-from-project',
     });
     expect(Log.warn).toHaveBeenCalledWith(
-      expect.stringContaining(`instead of recommended ${chalk.bold('expo@version-from-template')}`)
+      expect.stringContaining(`instead of recommended ${styleText("bold", 'expo@version-from-template')}`)
     );
     expect(Log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        `instead of recommended ${chalk.bold('react-native@version-from-template-required-1')}`
+        `instead of recommended ${styleText("bold", 'react-native@version-from-template-required-1')}`
       )
     );
   });

--- a/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
+++ b/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
@@ -1,8 +1,8 @@
 import type { ModPlatform } from '@expo/config-plugins';
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
-import chalk from 'chalk';
 import { isNativeModuleAsync } from 'expo/internal/unstable-autolinking-exports';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Log from '../log';
@@ -127,7 +127,7 @@ export async function promptToClearMalformedNativeProjectsAsync(
     return;
   }
 
-  const displayPlatforms = platforms.map((platform) => chalk.cyan(platform));
+  const displayPlatforms = platforms.map((platform) => styleText('cyan', platform));
   // Prompt which platforms to reset.
   const message =
     platforms.length > 1

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -1,7 +1,7 @@
 import type { ModPlatform } from '@expo/config-plugins';
 import type { MergeResults } from '@expo/config-plugins/build/utils/generateCode';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { copySync } from '../utils/dir';
@@ -40,17 +40,18 @@ export function createCopyFilesSuccessMessage(
   let message = `Created native ${pluralized}`;
 
   if (skippedPaths.length) {
-    message += chalk.dim(
-      ` | reusing ${skippedPaths.map((path) => chalk.bold(`/${path}`)).join(', ')}`
+    message += styleText(
+      'dim',
+      ` | reusing ${skippedPaths.map((path) => styleText('bold', `/${path}`)).join(', ')}`
     );
   }
   if (!gitignore) {
     // Add no additional message...
   } else if (!gitignore.didMerge) {
-    message += chalk.dim(` | reusing gitignore`);
+    message += styleText('dim', ` | reusing gitignore`);
   } else if (gitignore.didMerge && gitignore.didClear) {
     // This is legacy and for non-standard templates. The Expo template adds gitignores to the platform folders.
-    message += chalk.dim(` | updated gitignore`);
+    message += styleText('dim', ` | updated gitignore`);
   }
   return message;
 }

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
@@ -30,17 +31,17 @@ export const expoPrebuild: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Create native iOS and Android project files for building natively`,
-      chalk`npx expo prebuild {dim <dir>}`,
+      `npx expo prebuild ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                                    Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                                    Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `--no-install                             Skip installing npm packages and CocoaPods`,
         `--no-clean                               Apply changes to the existing native folders instead of recreating them`,
-        chalk`--npm                                    Use npm to install dependencies. {dim Default when package-lock.json exists}`,
-        chalk`--yarn                                   Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
-        chalk`--bun                                    Use bun to install dependencies. {dim Default when bun.lock or bun.lockb exists}`,
-        chalk`--pnpm                                   Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
+        `--npm                                    Use npm to install dependencies. ${styleText('dim', `Default when package-lock.json exists`)}`,
+        `--yarn                                   Use Yarn to install dependencies. ${styleText('dim', `Default when yarn.lock exists`)}`,
+        `--bun                                    Use bun to install dependencies. ${styleText('dim', `Default when bun.lock or bun.lockb exists`)}`,
+        `--pnpm                                   Use pnpm to install dependencies. ${styleText('dim', `Default when pnpm-lock.yaml exists`)}`,
         `--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo`,
-        chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
+        `-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. ${styleText('dim', `Default: all`)}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
         `-h, --help                               Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import type { ModPlatform } from '@expo/config-plugins';
 import { updateXcodeProject } from '@expo/inline-modules';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { installAsync } from '../install/installAsync';
 import { Log } from '../log';
@@ -81,7 +81,7 @@ export async function prebuildAsync(
     } else {
       const requestedPlatforms = options.platforms.join(', ');
       Log.warn(
-        chalk`⚠️  Requested prebuild for "${requestedPlatforms}", but only "${platforms.join(', ')}" is present in app config ("expo.platforms" entry). Continuing with "${requestedPlatforms}".`
+        `⚠️  Requested prebuild for "${requestedPlatforms}", but only "${platforms.join(', ')}" is present in app config ("expo.platforms" entry). Continuing with "${requestedPlatforms}".`
       );
     }
   }
@@ -132,8 +132,10 @@ export async function prebuildAsync(
         await clearNodeModulesAsync(projectRoot);
       }
 
-      Log.log(chalk.gray(chalk`Dependencies in the {bold package.json} changed:`));
-      Log.log(chalk.gray('  ' + changedDependencies.join(', ')));
+      Log.log(
+        styleText('gray', `Dependencies in the ${styleText('bold', `package.json`)} changed:`)
+      );
+      Log.log(styleText('gray', '  ' + changedDependencies.join(', ')));
 
       // Installing dependencies is a legacy feature from the unversioned
       // command. We know opt to not change dependencies unless a template

--- a/packages/@expo/cli/src/prebuild/resolveOptions.ts
+++ b/packages/@expo/cli/src/prebuild/resolveOptions.ts
@@ -1,7 +1,7 @@
 import type { ModPlatform } from '@expo/config-plugins';
 import assert from 'assert';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Log from '../log';
@@ -127,7 +127,7 @@ export function ensureValidPlatforms(platforms: ModPlatform[]): ModPlatform[] {
   // Skip prebuild for iOS on Windows
   if (process.platform === 'win32' && platforms.includes('ios')) {
     Log.warn(
-      chalk`⚠️  Skipping generating the iOS native project files. Run {bold npx expo prebuild} again from macOS or Linux to generate the iOS project.\n`
+      `⚠️  Skipping generating the iOS native project files. Run ${styleText('bold', `npx expo prebuild`)} again from macOS or Linux to generate the iOS project.\n`
     );
     return platforms.filter((platform) => platform !== 'ios');
   }

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -1,5 +1,5 @@
 import type { ExpoConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import type { Ora } from 'ora';
 import semver from 'semver';
 
@@ -165,15 +165,15 @@ async function resolveAndDownloadRepoTemplateAsync(
     }
   }
   if (!repoUrl) {
-    oraInstance.fail(`Invalid URL: ${chalk.red(`"${template}"`)}. Try again with a valid URL.`);
+    oraInstance.fail(
+      `Invalid URL: ${styleText('red', `"${template}"`)}. Try again with a valid URL.`
+    );
     throw new AbortCommandError();
   }
 
   if (repoUrl.origin !== 'https://github.com') {
     oraInstance.fail(
-      `Invalid URL: ${chalk.red(
-        `"${template}"`
-      )}. Only GitHub repositories are supported. Try again with a valid GitHub URL.`
+      `Invalid URL: ${styleText('red', `"${template}"`)}. Only GitHub repositories are supported. Try again with a valid GitHub URL.`
     );
     throw new AbortCommandError();
   }
@@ -182,7 +182,7 @@ async function resolveAndDownloadRepoTemplateAsync(
 
   if (!repoInfo) {
     oraInstance.fail(
-      `Found invalid GitHub URL: ${chalk.red(`"${template}"`)}. Fix the URL and try again.`
+      `Found invalid GitHub URL: ${styleText('red', `"${template}"`)}. Fix the URL and try again.`
     );
     throw new AbortCommandError();
   }
@@ -191,15 +191,14 @@ async function resolveAndDownloadRepoTemplateAsync(
 
   if (!found) {
     oraInstance.fail(
-      `Could not locate the repository for ${chalk.red(
-        `"${template}"`
-      )}. Check that the repository exists and try again.`
+      `Could not locate the repository for ${styleText('red', `"${template}"`)}. Check that the repository exists and try again.`
     );
     throw new AbortCommandError();
   }
 
-  oraInstance.text = chalk.bold(
-    `Downloading files from repo ${chalk.cyan(template)}. This might take a moment.`
+  oraInstance.text = styleText(
+    'bold',
+    `Downloading files from repo ${styleText('cyan', template)}. This might take a moment.`
   );
 
   return await downloadAndExtractRepoAsync(repoInfo, templateDirectory, { expName });

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import type { ModPlatform } from '@expo/config-plugins';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { createTempDirectoryPath } from '../utils/createTempPath';
@@ -145,8 +145,9 @@ export async function cloneTemplateAndCopyToProjectAsync({
     }
     ora.fail(`Failed to create the native ${pluralized}`);
     Log.log(
-      chalk.yellow(
-        chalk`You may want to delete the {bold ./ios} and/or {bold ./android} directories before trying again.`
+      styleText(
+        'yellow',
+        `You may want to delete the ${styleText('bold', `./ios`)} and/or ${styleText('bold', `./android`)} directories before trying again.`
       )
     );
     throw new SilentError(e);

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -1,8 +1,8 @@
 import type { PackageJSONConfig } from '@expo/config';
 import { getPackageJson } from '@expo/config';
-import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 import type { Range as SemverRange } from 'semver';
 import { intersects as semverIntersects } from 'semver';
@@ -54,7 +54,7 @@ export async function updatePackageJSONAsync(
   }
 
   updatingPackageJsonStep.succeed(
-    'Updated package.json' + (hasChanges ? '' : chalk.dim(` | no changes`))
+    'Updated package.json' + (hasChanges ? '' : styleText('dim', ` | no changes`))
   );
 
   return results;
@@ -185,7 +185,7 @@ export function updatePkgDependencies(
   if (symlinkedPackages.length) {
     symlinkedPackages.forEach(([current, recommended]) => {
       Log.log(
-        `\u203A Using symlinked ${chalk.bold(current)} instead of recommended ${chalk.bold(recommended)}.`
+        `\u203A Using symlinked ${styleText('bold', current)} instead of recommended ${styleText('bold', recommended)}.`
       );
     });
   }
@@ -193,7 +193,7 @@ export function updatePkgDependencies(
   if (nonRecommendedPackages.length) {
     nonRecommendedPackages.forEach(([current, recommended]) => {
       Log.warn(
-        `\u203A Using ${chalk.bold(current)} instead of recommended ${chalk.bold(recommended)}.`
+        `\u203A Using ${styleText('bold', current)} instead of recommended ${styleText('bold', recommended)}.`
       );
     });
   }

--- a/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
+++ b/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
@@ -1,5 +1,4 @@
 import type { ModPlatform } from '@expo/config-plugins';
-import chalk from 'chalk';
 import path from 'path';
 
 import * as Log from '../log';
@@ -19,7 +18,7 @@ export function validateTemplatePlatforms({
       existingPlatforms.push(platform);
     } else {
       Log.warn(
-        chalk`⚠️  Skipping platform ${platform}. Use a template that contains native files for ${platform} (./${platform}).`
+        `⚠️  Skipping platform ${platform}. Use a template that contains native files for ${platform} (./${platform}).`
       );
     }
   }

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import type arg from 'arg';
-import chalk from 'chalk';
 import path from 'path';
 
 import type { Command } from '../../index';
 import * as Log from '../../log';
 import { assertWithOptionsArgs } from '../../utils/args';
 import { logCmdError } from '../../utils/errors';
+import { styleText } from 'node:util';
 
 export const expoRunAndroid: Command = async (argv) => {
   const rawArgsMap: arg.Spec = {
@@ -38,22 +38,22 @@ export const expoRunAndroid: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-  {bold Description}
+      `
+  ${styleText('bold', `Description`)}
     Run the native Android app locally
 
-  {bold Usage}
+  ${styleText('bold', `Usage`)}
     $ npx expo run:android <dir>
 
-  {bold Options} 
+  ${styleText('bold', `Options`)}
     --no-build-cache       Clear the native build cache
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
     --app-id <appId>       Custom Android application ID to launch.
-    --variant <name>       Build variant or product flavor and build variant. {dim Default: debug}
+    --variant <name>       Build variant or product flavor and build variant. ${styleText('dim', `Default: debug`)}
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
-    -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
+    -p, --port <port>      Port to start the dev server on. ${styleText('dim', `Default: 8081`)}
     -h, --help             Output usage information
 `,
       0

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import fs from 'fs';
 import path from 'path';
 
@@ -98,7 +98,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     if (!fs.existsSync(binaryPath)) {
       throw new CommandError(`The path to the custom Android binary does not exist: ${binaryPath}`);
     }
-    Log.log(chalk.gray`\u203A Installing ${binaryPath}`);
+    Log.log(styleText("gray", `\u203A Installing ${binaryPath}`));
     await props.device.installAppAsync(binaryPath);
   } else {
     await installAppAsync(androidProjectRoot, props);

--- a/packages/@expo/cli/src/run/hints.ts
+++ b/packages/@expo/cli/src/run/hints.ts
@@ -1,21 +1,21 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../log';
 import { isInteractive } from '../utils/interactive';
 
 /** Log the device argument to use for the next run: `Using --device foobar` */
 export function logDeviceArgument(id: string) {
-  Log.log(chalk.dim`› Using --device ${id}`);
+  Log.log(styleText('dim', `› Using --device ${id}`));
 }
 
 export function logPlatformRunCommand(platform: string, argv: string[] = []) {
-  Log.log(chalk.dim(`› Using expo run:${platform} ${argv.join(' ')}`));
+  Log.log(styleText('dim', `› Using expo run:${platform} ${argv.join(' ')}`));
 }
 
 export function logProjectLogsLocation() {
   Log.log(
-    chalk`\n› Logs for your project will appear below.${
-      isInteractive() ? chalk.dim(` Press Ctrl+C to exit.`) : ''
+    `\n› Logs for your project will appear below.${
+      isInteractive() ? styleText('dim', ` Press Ctrl+C to exit.`) : ''
     }`
   );
 }

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
@@ -37,7 +38,7 @@ export const expoRun: Command = async (argv) => {
       printHelp(
         'Run the native app locally',
         `npx expo run <android|ios>`,
-        chalk`{dim $} npx expo run <android|ios> --help  Output usage information`
+        `${styleText('dim', `$`)} npx expo run <android|ios> --help  Output usage information`
       );
     }
 

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import { ExpoRunFormatter } from '@expo/xcpretty';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import type { SpawnOptionsWithoutStdio } from 'child_process';
 import { spawn } from 'child_process';
 import fs from 'fs';
@@ -39,7 +39,7 @@ export function getGenericSimulatorDestination(osType: OSType): string {
   }
 }
 export function logPrettyItem(message: string) {
-  Log.log(chalk`{whiteBright \u203A} ${message}`);
+  Log.log(`${styleText('whiteBright', `\u203A`)} ${message}`);
 }
 
 export function matchEstimatedBinaryPath(buildOutput: string): string | null {
@@ -321,7 +321,7 @@ async function spawnXcodeBuildWithFormat(
 ): Promise<{ code: number | null; results: string; error: string; formatter: ExpoRunFormatter }> {
   Log.debug(`  xcodebuild ${args.join(' ')}`);
 
-  logPrettyItem(chalk.bold`Planning build`);
+  logPrettyItem(styleText("bold", `Planning build`));
 
   const formatter = ExpoRunFormatter.create(projectRoot, {
     xcodeProject,
@@ -443,14 +443,14 @@ export function _assertXcodeBuildResults(
     throw new CommandError(
       `${errorTitle}\nTo view more error logs, try building the app with Xcode directly, by opening ${xcodeProject.name}.\n\n` +
         message +
-        `Build logs written to ${chalk.underline(logFilePath)}`
+        `Build logs written to ${styleText("underline", logFilePath)}`
     );
   };
 
   const localizedError = error.match(/NSLocalizedFailure = "(.*)"/)?.[1];
 
   if (localizedError) {
-    throwWithMessage(chalk.bold(localizedError) + '\n\n');
+    throwWithMessage(styleText("bold", localizedError) + '\n\n');
   }
   // Show all the log info because often times the error is coming from a shell script,
   // that invoked a node script, that started metro, which threw an error.

--- a/packages/@expo/cli/src/run/ios/appleDevice/installOnDeviceAsync.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/installOnDeviceAsync.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import type { Ora } from 'ora';
 import os from 'os';
 import path from 'path';
@@ -54,7 +54,7 @@ export async function installOnDeviceAsync(props: {
         if (!indicator) {
           indicator = ora(status).start();
         }
-        indicator.text = `${chalk.bold(status)} ${progress}%`;
+        indicator.text = `${styleText("bold", status)} ${progress}%`;
         if (isComplete) {
           indicator.succeed();
         }

--- a/packages/@expo/cli/src/run/ios/codeSigning/__tests__/resolveCertificateSigningIdentity-test.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/__tests__/resolveCertificateSigningIdentity-test.ts
@@ -1,5 +1,5 @@
 import { getConfig, modifyConfigAsync } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import * as Log from '../../../../log';
 import { selectAsync } from '../../../../utils/prompts';
@@ -115,7 +115,7 @@ describe(resolveCertificateSigningIdentityAsync, () => {
     expect(selectAsync).toHaveBeenCalledWith(expect.any(String), [
       {
         // Formatted the preferred ID as bold and sorted it first.
-        title: chalk.bold(' (12345ABCD) - Apple Developer: Nave Nocab (YYY)'),
+        title: styleText("bold", ' (12345ABCD) - Apple Developer: Nave Nocab (YYY)'),
         value: 0,
       },
       expect.anything(),

--- a/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import * as Security from './Security';
 import { resolveCertificateSigningIdentityAsync } from './resolveCertificateSigningIdentity';
@@ -27,7 +27,7 @@ function isCodeSigningConfigured(projectRoot: string): boolean {
       const team = curr.developmentTeams[0];
       return team ? [...prev, team] : prev;
     }, []);
-    Log.log(chalk.dim`\u203A Auto signing app using team(s): ${teamList.join(', ')}`);
+    Log.log(styleText("dim", `\u203A Auto signing app using team(s): ${teamList.join(', ')}`));
     return true;
   }
 

--- a/packages/@expo/cli/src/run/ios/codeSigning/resolveCertificateSigningIdentity.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/resolveCertificateSigningIdentity.ts
@@ -1,5 +1,5 @@
 import { getConfig, modifyConfigAsync } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import * as Security from './Security';
 import { getLastDeveloperCodeSigningIdAsync, setLastDeveloperCodeSigningIdAsync } from './settings';
@@ -34,9 +34,7 @@ export async function sortDefaultIdToBeginningAsync(
 function assertCodeSigningSetup(): never {
   // TODO: We can probably do this too automatically.
   Log.log(
-    `\u203A Your computer requires some additional setup before you can build onto physical iOS devices.\n  ${chalk.bold(
-      learnMore('https://expo.fyi/setup-xcode-signing')
-    )}`
+    `\u203A Your computer requires some additional setup before you can build onto physical iOS devices.\n  ${styleText("bold", learnMore('https://expo.fyi/setup-xcode-signing'))}`
   );
 
   throw new CommandError('No code signing certificates are available to use.');
@@ -108,7 +106,7 @@ export async function selectDevelopmentTeamAsync(
     'Development team for signing the app',
     identities.map((value, i) => {
       const format =
-        value.signingCertificateId === preferredId ? chalk.bold : (message: string) => message;
+        value.signingCertificateId === preferredId ? (message: string) => styleText('bold', message) : (message: string) => message;
       return {
         // Formatted like: `650 Industries, Inc. (A1BCDEF234) - Apple Development: Evan Bacon (AA00AABB0A)`
         title: format(

--- a/packages/@expo/cli/src/run/ios/index.ts
+++ b/packages/@expo/cli/src/run/ios/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import type arg from 'arg';
-import chalk from 'chalk';
 import path from 'path';
 
 import type { XcodeConfiguration } from './XcodeBuild.types';
 import type { Command } from '../../index';
 import { assertWithOptionsArgs, printHelp } from '../../utils/args';
 import { logCmdError } from '../../utils/errors';
+import { styleText } from 'node:util';
 
 export const expoRunIos: Command = async (argv) => {
   const rawArgsMap: arg.Spec = {
@@ -49,19 +49,19 @@ export const expoRunIos: Command = async (argv) => {
         `--no-bundler                     Skip starting the Metro bundler`,
         `--scheme [scheme]                Scheme to build`,
         `--binary <path>                  Path to existing .app or .ipa to install.`,
-        chalk`--configuration <configuration>  Xcode configuration to use. Debug or Release. {dim Default: Debug}`,
-        chalk`-d, --device [device]            Device name, UDID, or "generic" for build-only`,
+        `--configuration <configuration>  Xcode configuration to use. Debug or Release. ${styleText('dim', `Default: Debug`)}`,
+        `-d, --device [device]            Device name, UDID, or "generic" for build-only`,
         `-o, --output <path>              Directory to output the built app binary`,
-        chalk`-p, --port <port>                Port to start the Metro bundler on. {dim Default: 8081}`,
+        `-p, --port <port>                Port to start the Metro bundler on. ${styleText('dim', `Default: 8081`)}`,
         `-h, --help                       Usage info`,
       ].join('\n'),
       [
         '',
-        chalk`  Build for production (unsigned) with the {bold Release} configuration:`,
-        chalk`    {dim $} npx expo run:ios --configuration Release`,
+        `  Build for production (unsigned) with the ${styleText('bold', `Release`)} configuration:`,
+        `    ${styleText('dim', `$`)} npx expo run:ios --configuration Release`,
         '',
-        chalk`  Build for simulator without installing (build-only):`,
-        chalk`    {dim $} npx expo run:ios --configuration Release --device generic --output ./build`,
+        `  Build for simulator without installing (build-only):`,
+        `    ${styleText('dim', `$`)} npx expo run:ios --configuration Release --device generic --output ./build`,
         '',
       ].join('\n')
     );

--- a/packages/@expo/cli/src/run/ios/launchApp.ts
+++ b/packages/@expo/cli/src/run/ios/launchApp.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import path from 'path';
 
 import * as XcodeBuild from './XcodeBuild';
@@ -30,7 +30,7 @@ export async function launchAppAsync(
 ) {
   appId ??= (await profile(getLaunchInfoForBinaryAsync)(binaryPath)).bundleId;
 
-  Log.log(chalk.gray`\u203A Installing ${binaryPath}`);
+  Log.log(styleText("gray", `\u203A Installing ${binaryPath}`));
   if (!props.isSimulator) {
     if (props.device.osType === 'macOS') {
       await launchBinaryOnMacAsync(appId, binaryPath);
@@ -47,12 +47,12 @@ export async function launchAppAsync(
     return;
   }
 
-  XcodeBuild.logPrettyItem(chalk`{bold Installing} on ${props.device.name}`);
+  XcodeBuild.logPrettyItem(`${styleText('bold', `Installing`)} on ${props.device.name}`);
 
   const device = await AppleDeviceManager.resolveAsync({ device: props.device });
   await device.installAppAsync(binaryPath);
 
-  XcodeBuild.logPrettyItem(chalk`{bold Opening} on ${device.name} {dim (${appId})}`);
+  XcodeBuild.logPrettyItem(`${styleText('bold', `Opening`)} on ${device.name} ${styleText('dim', `(${appId})`)}`);
 
   if (props.shouldStartBundler) {
     await SimulatorLogStreamer.getStreamer(device.device, {

--- a/packages/@expo/cli/src/run/ios/options/promptDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/promptDevice.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import type { OSType, Device } from '../../../start/platforms/ios/simctl';
 import prompt from '../../../utils/prompts';
@@ -32,10 +32,10 @@ export function formatDeviceChoice(item: AnyDevice): { title: string; value: str
           ? '🌐 '
           : '🔌 '
         : '';
-  const format = isActive ? chalk.bold : (text: string) => text;
+  const format = isActive ? (text: string) => styleText('bold', text) : (text: string) => text;
   return {
     title: `${symbol}${format(item.name)}${
-      item.osVersion ? chalk.dim(` (${item.osVersion})`) : ''
+      item.osVersion ? styleText("dim", ` (${item.osVersion})`) : ''
     }`,
     value: item.udid,
   };

--- a/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
@@ -1,5 +1,5 @@
 import { IOSConfig } from '@expo/config-plugins';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import path from 'path';
 
 import * as Log from '../../../log';
@@ -51,7 +51,7 @@ export async function promptOrQueryNativeSchemeAsync(
           value.type === IOSConfig.Target.TargetType.APPLICATION && value.osType === 'iOS';
         return {
           value: value.name,
-          title: isApp ? chalk.bold(value.name) + chalk.gray(' (app)') : value.name,
+          title: isApp ? styleText("bold", value.name) + styleText("gray", ' (app)') : value.name,
         };
       }),
       {

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -1,5 +1,4 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 
@@ -22,6 +21,7 @@ import { getSchemesForIosAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
 import { startBundlerAsync } from '../startBundler';
+import { styleText } from 'node:util';
 
 const debug = require('debug')('expo:run:ios');
 
@@ -151,8 +151,8 @@ export async function runIosAsync(projectRoot: string, options: Options) {
 
   // Generic build (--device generic) - skip install/launch, just output the binary path.
   if (!props.device) {
-    Log.log(chalk`\n{green ✓} Build complete`);
-    Log.log(chalk`{bold Binary:} ${binaryPath}`);
+    Log.log(`\n${styleText('green', `✓`)} Build complete`);
+    Log.log(`${styleText('bold', `Binary:`)} ${binaryPath}`);
 
     if (shouldUpdateBuildCache && props.buildCacheProvider) {
       await uploadBuildCache({
@@ -231,7 +231,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
 function assertPlatform() {
   if (process.platform !== 'darwin') {
     Log.exit(
-      chalk`iOS apps can only be built on macOS devices. Use {cyan eas build -p ios} to build in the cloud.`
+      `iOS apps can only be built on macOS devices. Use ${styleText('cyan', `eas build -p ios`)} to build in the cloud.`
     );
   }
 }
@@ -250,7 +250,7 @@ async function copyBinaryToOutputAsync(binaryPath: string, outputDir: string): P
   // Copy the .app bundle to the output directory.
   await fs.promises.cp(binaryPath, outputPath, { recursive: true });
 
-  Log.log(chalk`{dim Copied to} ${outputPath}`);
+  Log.log(`${styleText('dim', `Copied to`)} ${outputPath}`);
 
   return outputPath;
 }

--- a/packages/@expo/cli/src/run/startBundler.ts
+++ b/packages/@expo/cli/src/run/startBundler.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { getWellKnownTemporaryLogFile, installEventLogger } from '../events';
 import * as Log from '../log';
@@ -58,7 +58,7 @@ export async function startBundlerAsync(
         // Print the URL to stdout for tests
         console.info(`[__EXPO_E2E_TEST:server] ${JSON.stringify({ url })}`);
       }
-      Log.log(chalk`Waiting on {underline ${url}}`);
+      Log.log(`Waiting on ${styleText('underline', url)}`);
     }
   }
 

--- a/packages/@expo/cli/src/serve/index.ts
+++ b/packages/@expo/cli/src/serve/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
@@ -20,9 +21,9 @@ export const expoServe: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Host the production server locally`,
-      chalk`npx expo serve {dim <dir>}`,
+      `npx expo serve ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>            Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>            Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `--port <number>  Port to host the server on`,
         `-h, --help       Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -1,7 +1,7 @@
-import chalk from 'chalk';
 import connect from 'connect';
 import { createRequestHandler } from 'expo-server/adapter/http';
 import http from 'http';
+import { styleText } from 'node:util';
 import path from 'path';
 import send from 'send';
 
@@ -47,7 +47,7 @@ export async function serveAsync(inputDir: string, options: Options) {
 
   const isStatic = await isStaticExportAsync(serverDist);
 
-  Log.log(chalk.dim(`Starting ${isStatic ? 'static ' : ''}server in ${serverDist}`));
+  Log.log(styleText('dim', `Starting ${isStatic ? 'static ' : ''}server in ${serverDist}`));
 
   if (isStatic) {
     await startStaticServerAsync(serverDist, options);

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -1,5 +1,5 @@
 import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
@@ -76,12 +76,21 @@ export function getDependencyCheckMessage(
 ): string[] {
   if (result?.expo) {
     return [
-      chalk.yellow`An update for {bold expo} is available: {red ${result.expo.actualVersion}} {dim →} {green ${result.expo.expectedVersionOrRange}}`,
-      chalk.yellow`${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`,
+      styleText(
+        'yellow',
+        `An update for ${styleText('bold', `expo`)} is available: ${styleText('red', result.expo.actualVersion)} ${styleText('dim', `→`)} ${styleText('green', result.expo.expectedVersionOrRange)}`
+      ),
+      styleText(
+        'yellow',
+        `${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run ${styleText('bold', `npx expo install --check`)} for details.`
+      ),
     ];
   } else if (result?.otherCount) {
     return [
-      chalk.yellow`${result.otherCount} package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`,
+      styleText(
+        'yellow',
+        `${result.otherCount} package${result.otherCount === 1 ? '' : 's'} may need updating. Run ${styleText('bold', `npx expo install --check`)} for details.`
+      ),
     ];
   } else {
     return [];

--- a/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { execSync } from 'child_process';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import * as Log from '../../../log';
@@ -130,13 +130,16 @@ export class XcodePrerequisite extends Prerequisite {
           Log.error(
             [
               '',
-              chalk.bold('Xcode has not been fully setup for Apple development yet.'),
+              styleText('bold', 'Xcode has not been fully setup for Apple development yet.'),
               'Download at: https://developer.apple.com/xcode/',
               'or in the App Store.',
               '',
               'After downloading Xcode, run the following two commands in your terminal:',
-              chalk.cyan('  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer'),
-              chalk.cyan('  sudo xcodebuild -runFirstLaunch'),
+              styleText(
+                'cyan',
+                '  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer'
+              ),
+              styleText('cyan', '  sudo xcodebuild -runFirstLaunch'),
               '',
               'Then you can re-run Expo CLI. Alternatively, you can build apps in the cloud with EAS CLI, or preview using the Expo Go app on a physical device.',
               '',

--- a/packages/@expo/cli/src/start/doctor/apple/XcrunPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/XcrunPrerequisite.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { execSync } from 'child_process';
+import { styleText } from 'node:util';
 
 import { delayAsync } from '../../../utils/delay';
 import { AbortCommandError } from '../../../utils/errors';
@@ -38,7 +38,7 @@ export class XcrunPrerequisite extends Prerequisite {
     // This prompt serves no purpose accept informing the user what to do next, we could just open the App Store but it could be confusing if they don't know what's going on.
     const confirm = await confirmAsync({
       initial: true,
-      message: chalk`Xcode {bold Command Line Tools} needs to be installed (requires {bold sudo}), continue?`,
+      message: `Xcode ${styleText('bold', `Command Line Tools`)} needs to be installed (requires ${styleText('bold', `sudo`)}), continue?`,
     });
 
     if (confirm) {

--- a/packages/@expo/cli/src/start/doctor/dependencies/bundledNativeModules.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/bundledNativeModules.ts
@@ -1,5 +1,5 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import resolveFrom from 'resolve-from';
 
 import { getNativeModuleVersionsAsync } from '../../../api/getNativeModuleVersions';
@@ -34,7 +34,7 @@ export async function getVersionedNativeModulesAsync(
     } catch (error: any) {
       if (error instanceof CommandError && (error.code === 'OFFLINE' || error.code === 'API')) {
         Log.warn(
-          chalk`Unable to reach well-known versions endpoint. Using local dependency map {bold expo/bundledNativeModules.json} for version validation`
+          `Unable to reach well-known versions endpoint. Using local dependency map ${styleText('bold', `expo/bundledNativeModules.json`)} for version validation`
         );
       } else {
         throw error;
@@ -59,7 +59,7 @@ async function getBundledNativeModulesAsync(projectRoot: string): Promise<Bundle
   if (!bundledNativeModulesPath) {
     Log.log();
     throw new CommandError(
-      chalk`The dependency map {bold expo/bundledNativeModules.json} cannot be found, please ensure you have the package "{bold expo}" installed in your project.`
+      `The dependency map ${styleText('bold', `expo/bundledNativeModules.json`)} cannot be found, please ensure you have the package "${styleText('bold', `expo`)}" installed in your project.`
     );
   }
   return await JsonFile.readAsync<BundledNativeModules>(bundledNativeModulesPath);

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import wrapAnsi from 'wrap-ansi';
 
 import { installAsync } from '../../../install/installAsync';
@@ -60,11 +60,11 @@ export async function ensureDependenciesAsync(
     let confirm = skipPrompt;
     if (skipPrompt) {
       // Automatically install packages without prompting.
-      Log.log(wrapForTerminal(title + ` Installing ${chalk.cyan(readableMissingPackages)}`));
+      Log.log(wrapForTerminal(title + ` Installing ${styleText('cyan', readableMissingPackages)}`));
     } else {
       confirm = await confirmAsync({
         message: wrapForTerminal(
-          title + ` Would you like to install ${chalk.cyan(readableMissingPackages)}?`
+          title + ` Would you like to install ${styleText('cyan', readableMissingPackages)}?`
         ),
         initial: true,
       });
@@ -113,9 +113,7 @@ export async function ensureDependenciesAsync(
 
   const disableMessage = warningMessage;
 
-  const solution = `Install ${chalk.bold(
-    readableMissingPackages
-  )} by running:\n\n  ${chalk.reset.bold(installCommand)}\n\n`;
+  const solution = `Install ${styleText('bold', readableMissingPackages)} by running:\n\n  ${styleText(['reset', 'bold'], installCommand)}\n\n`;
 
   // This prevents users from starting a misconfigured JS or TS project by default.
   throw new CommandError(wrapForTerminal(title + solution + disableMessage + '\n'));
@@ -144,7 +142,7 @@ async function installPackagesAsync(
   projectRoot: string,
   { packages, dev }: { packages: string[]; dev?: boolean }
 ) {
-  const packagesStr = chalk.bold(packages.join(', '));
+  const packagesStr = styleText('bold', packages.join(', '));
   Log.log();
   const installingPackageStep = logNewSection(`Installing ${packagesStr}`);
   try {

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import npmPackageArg from 'npm-package-arg';
 import semver from 'semver';
 import semverRangeSubset from 'semver/ranges/subset';
@@ -61,7 +61,7 @@ function logInvalidDependency({
   actualVersion,
 }: IncorrectDependency) {
   Log.warn(
-    chalk`  {bold ${packageName}}{cyan @}{red ${actualVersion}} - expected version: {green ${expectedVersionOrRange}}`
+    `  ${styleText('bold', packageName)}${styleText('cyan', `@`)}${styleText('red', actualVersion)} - expected version: ${styleText('green', expectedVersionOrRange)}`
   );
 }
 
@@ -71,7 +71,7 @@ export function logIncorrectDependencies(incorrectDeps: IncorrectDependency[]) {
   }
 
   Log.warn(
-    chalk`The following packages should be updated for best compatibility with the installed {bold expo} version:`
+    `The following packages should be updated for best compatibility with the installed ${styleText('bold', `expo`)} version:`
   );
   incorrectDeps.forEach((dep) => logInvalidDependency(dep));
 

--- a/packages/@expo/cli/src/start/doctor/typescript/updateTSConfig.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/updateTSConfig.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 
 import * as Log from '../../../log';
 
@@ -48,10 +48,12 @@ export async function updateTSConfigAsync({
   Log.log();
 
   if (shouldGenerate) {
-    Log.log(chalk`{bold TypeScript}: A {cyan tsconfig.json} has been auto-generated`);
+    Log.log(
+      `${styleText('bold', `TypeScript`)}: A ${styleText('cyan', `tsconfig.json`)} has been auto-generated`
+    );
   } else {
     Log.log(
-      chalk`{bold TypeScript}: The {cyan tsconfig.json} has been updated {dim (Use EXPO_NO_TYPESCRIPT_SETUP to skip)}`
+      `${styleText('bold', `TypeScript`)}: The ${styleText('cyan', `tsconfig.json`)} has been updated ${styleText('dim', `(Use EXPO_NO_TYPESCRIPT_SETUP to skip)`)}`
     );
     logModifications(modifications);
   }
@@ -61,7 +63,9 @@ export async function updateTSConfigAsync({
 function logModifications(modifications: [string, string][]) {
   Log.log();
 
-  Log.log(chalk`\u203A {bold Required} modifications made to the {cyan tsconfig.json}:`);
+  Log.log(
+    `\u203A ${styleText('bold', `Required`)} modifications made to the ${styleText('cyan', `tsconfig.json`)}:`
+  );
 
   Log.log();
 
@@ -73,7 +77,7 @@ function logModifications(modifications: [string, string][]) {
 
 function printTable(items: [string, string][]) {
   const tableFormat = (name: string, msg: string) =>
-    `  ${chalk.bold`${name}`} is now ${chalk.cyan(msg)}`;
+    `  ${styleText('bold', name)} is now ${styleText('cyan', msg)}`;
   for (const [key, value] of items) {
     Log.log(tableFormat(key, value));
   }

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -1,6 +1,6 @@
 import type { AppJSONConfig, ExpoConfig, PackageJSONConfig, ProjectConfig } from '@expo/config';
 import { getConfig, getProjectConfigDescriptionWithPaths } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
@@ -37,7 +37,7 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
       const configName = getProjectConfigDescriptionWithPaths(this.projectRoot, config);
       throw new PrerequisiteCommandError(
         'WEB_SUPPORT',
-        chalk`Skipping web setup: {bold "web"} is not included in the project ${configName} {bold "platforms"} array.`
+        `Skipping web setup: ${styleText('bold', `"web"`)} is not included in the project ${configName} ${styleText('bold', `"platforms"`)} array.`
       );
     }
 
@@ -85,7 +85,7 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
         isProjectMutable: false,
         exp,
         installMessage: `It looks like you're trying to use web support but don't have the required dependencies installed.`,
-        warningMessage: chalk`If you're not using web, please ensure you remove the {bold "web"} string from the platforms array in the project Expo config.`,
+        warningMessage: `If you're not using web, please ensure you remove the ${styleText('bold', `"web"`)} string from the platforms array in the project Expo config.`,
         requiredPackages,
       });
     } catch (error) {
@@ -96,7 +96,7 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
       const hasReactDOM = !!(pkg.dependencies?.['react-dom'] || pkg.devDependencies?.['react-dom']);
       if (hasReactDOM) {
         Log.warn(
-          chalk`{bold react-native-web} is not installed. Some React Native components may not work on web without it. Install it with: {bold npx expo install react-native-web}`
+          `${styleText('bold', `react-native-web`)} is not installed. Some React Native components may not work on web without it. Install it with: ${styleText('bold', `npx expo install react-native-web`)}`
         );
         return false;
       }

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+
+import { styleText } from 'node:util';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
@@ -47,35 +48,35 @@ export const expoStart: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Start a local dev server for the app`,
-      chalk`npx expo start {dim <dir>}`,
+      `npx expo start ${styleText('dim', `<dir>`)}`,
       [
-        chalk`<dir>                           Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                           Directory of the Expo project. ${styleText('dim', `Default: Current working directory`)}`,
         `-a, --android                   Open on a connected Android device`,
         `-i, --ios                       Open in an iOS simulator`,
         `-w, --web                       Open in a web browser`,
         ``,
-        chalk`-d, --dev-client                Launch in a custom native app`,
-        chalk`-g, --go                        Launch in Expo Go`,
+        `-d, --dev-client                Launch in a custom native app`,
+        `-g, --go                        Launch in Expo Go`,
         ``,
         `-c, --clear                     Clear the bundler cache`,
         `--max-workers <number>          Maximum number of tasks to allow Metro to spawn`,
         `--no-dev                        Bundle in production mode`,
         `--minify                        Minify JavaScript`,
         ``,
-        chalk`-m, --host <string>             Dev server hosting type. {dim Default: lan}`,
-        chalk`                                {bold lan}: Use the local network`,
-        chalk`                                {bold tunnel}: Use any network by tunnel through ngrok`,
-        chalk`                                {bold localhost}: Connect to the dev server over localhost`,
+        `-m, --host <string>             Dev server hosting type. ${styleText('dim', `Default: lan`)}`,
+        `                                ${styleText('bold', `lan`)}: Use the local network`,
+        `                                ${styleText('bold', `tunnel`)}: Use any network by tunnel through ngrok`,
+        `                                ${styleText('bold', `localhost`)}: Connect to the dev server over localhost`,
         `--tunnel                        Same as --host tunnel`,
         `--lan                           Same as --host lan`,
         `--localhost                     Same as --host localhost`,
         ``,
         `--offline                       Skip network requests and use anonymous manifest signatures`,
-        chalk`--https                         Start the dev server with https protocol. {bold Deprecated in favor of --tunnel}`,
+        `--https                         Start the dev server with https protocol. ${styleText('bold', `Deprecated in favor of --tunnel`)}`,
         `--scheme <scheme>               Custom URI protocol to use when launching an app`,
-        chalk`-p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). {dim Default: 8081}`,
+        `-p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). ${styleText('dim', `Default: 8081`)}`,
         ``,
-        chalk`--private-key-path <path>       Path to private key for code signing. {dim Default: "private-key.pem" in the same directory as the certificate specified by the expo-updates configuration in app.json.}`,
+        `--private-key-path <path>       Path to private key for code signing. ${styleText('dim', `Default: "private-key.pem" in the same directory as the certificate specified by the expo-updates configuration in app.json.`)}`,
         `-h, --help                      Usage info`,
       ].join('\n')
     );

--- a/packages/@expo/cli/src/start/interface/__tests__/createDevToolsMenuItems-test.ts
+++ b/packages/@expo/cli/src/start/interface/__tests__/createDevToolsMenuItems-test.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { DevToolsPlugin } from '../../server/DevToolsPlugin';
 import { createDevToolsMenuItems } from '../createDevToolsMenuItems';
@@ -27,7 +26,7 @@ describe('createInteractiveMenuItems', () => {
       Promise.resolve()
     );
     expect(menuItems.length).toBe(1);
-    expect(menuItems[menuItems.length - 1]!.title).toBe(chalk`Open {bold test-plugin}`);
+    expect(menuItems[menuItems.length - 1]!.title).toBe(`Open ${styleText('bold', 'test-plugin')}`);
     expect(menuItems[menuItems.length - 1]!.children).toBeUndefined();
   });
 
@@ -56,7 +55,7 @@ describe('createInteractiveMenuItems', () => {
       Promise.resolve()
     );
     expect(menuItems.length).toBe(1);
-    expect(menuItems[menuItems.length - 1]!.title).toBe(chalk`{bold test-plugin}`);
+    expect(menuItems[menuItems.length - 1]!.title).toBe(styleText('bold', 'test-plugin'));
     expect(menuItems[menuItems.length - 1]!.children?.length).toBe(1);
     expect(menuItems[menuItems.length - 1]!.children![0]!.title).toBe('Test Command');
   });
@@ -92,7 +91,7 @@ describe('createInteractiveMenuItems', () => {
       Promise.resolve()
     );
     expect(menuItems.length).toBe(1);
-    expect(menuItems[menuItems.length - 1]!.title).toBe(chalk`{bold test-plugin}`);
+    expect(menuItems[menuItems.length - 1]!.title).toBe(styleText('bold', 'test-plugin'));
     expect(menuItems[menuItems.length - 1]!.children?.length).toBe(2);
     expect(menuItems[menuItems.length - 1]!.children![0]!.title).toBe('Test Command 1');
     expect(menuItems[menuItems.length - 1]!.children![1]!.title).toBe('Test Command 2');
@@ -124,10 +123,10 @@ describe('createInteractiveMenuItems', () => {
       Promise.resolve()
     );
     expect(menuItems.length).toBe(1);
-    expect(menuItems[menuItems.length - 1]!.title).toBe(chalk`{bold test-plugin}`);
+    expect(menuItems[menuItems.length - 1]!.title).toBe(styleText('bold', 'test-plugin'));
     expect(menuItems[menuItems.length - 1]!.children?.length).toBe(2);
     expect(menuItems[menuItems.length - 1]!.children![0]!.title).toBe(
-      chalk`Open {bold test-plugin}`
+      `Open ${styleText('bold', 'test-plugin')}`
     );
     expect(menuItems[menuItems.length - 1]!.children![1]!.title).toBe('Test Command 1');
   });

--- a/packages/@expo/cli/src/start/interface/cliExtensionMenuItemHandler.ts
+++ b/packages/@expo/cli/src/start/interface/cliExtensionMenuItemHandler.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import type { Ora } from 'ora';
 
 import * as Log from '../../log';
@@ -31,7 +31,7 @@ export const cliExtensionMenuItemHandler = async (
   }
 
   if (plugin.executor == null) {
-    Log.warn(chalk`{bold ${plugin.packageName}} does not support CLI commands.`);
+    Log.warn(`${styleText('bold', plugin.packageName)} does not support CLI commands.`);
     return;
   }
 
@@ -44,8 +44,8 @@ export const cliExtensionMenuItemHandler = async (
           name: param.name,
           type: param.type,
           message:
-            `${param.name}${param.description ? chalk` {dim ${param.description}}` : ''}` +
-            chalk` {dim (${param.type})}`,
+            `${param.name}${param.description ? ` ${styleText('dim', param.description)}` : ''}` +
+            ` ${styleText('dim', `(param.type)`)}`,
         });
         if (result[param.name] == null) {
           throw new Error('Input cancelled');
@@ -58,7 +58,7 @@ export const cliExtensionMenuItemHandler = async (
 
   // Confirm execution
   const { value } = await promptAsync({
-    message: chalk`{dim Execute command "${command.title}":} "${plugin.executor.getCommandString({ command: command.name, args })}"`,
+    message: `${styleText('dim', `Execute command "${command.title}":`)} "${plugin.executor.getCommandString({ command: command.name, args })}"`,
     initial: false,
     name: 'value',
     type: 'confirm',
@@ -92,9 +92,9 @@ export const cliExtensionMenuItemHandler = async (
 function normalizeText(text: string, level: 'info' | 'warning' | 'error') {
   const trimText = text.trim();
   if (level === 'error') {
-    return chalk.red(trimText);
+    return styleText('red', trimText);
   } else if (level === 'warning') {
-    return chalk.yellow(trimText);
+    return styleText('yellow', trimText);
   } else {
     return trimText;
   }

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -1,5 +1,5 @@
 import type { ExpoConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../log';
@@ -33,7 +33,7 @@ export const getTerminalColumns = () => process.stdout.columns || 80;
 export const printItem = (text: string, opts?: { dim: boolean }): string => {
   let output = `${BLT} ` + wrapAnsi(text, getTerminalColumns()).trimStart();
   if (opts?.dim) {
-    output = chalk`{dim ${output}}`;
+    output = `${styleText('dim', output)}`;
   }
   return output;
 };
@@ -55,9 +55,9 @@ export function printUsage(
 
   const printPrefix = ({ short }: { short: boolean }) => {
     Log.log();
-    let message = chalk`Using {cyan ${target}}`;
+    let message = `Using ${styleText('cyan', target)}`;
     if (!short) {
-      message += chalk` {dim (Press {bold s} to ${switchMsg})}`;
+      message += ` ${styleText('dim', `(Press ${styleText('bold', `s`)} to ${switchMsg})`)}`;
     }
     Log.log(printItem(message));
   };
@@ -117,13 +117,13 @@ function logCommandsTable(
       if (!key) return '';
       let view = `${BLT} `;
       if (key.length === 1) view += 'Press ';
-      view += chalk`{bold ${key}} {dim │} `;
+      view += `${styleText('bold', key)} ${styleText('dim', `│`)} `;
       view += msg;
       if (status) {
-        view += ` ${chalk.dim(`(${chalk.italic(status)})`)}`;
+        view += ` ${styleText('dim', `(${styleText('italic', status)})`)}`;
       }
       if (disabled) {
-        view = chalk.dim(view);
+        view = styleText('dim', view);
       }
       return view;
     });

--- a/packages/@expo/cli/src/start/interface/createDevToolsMenuItems.ts
+++ b/packages/@expo/cli/src/start/interface/createDevToolsMenuItems.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 import { openBrowserAsync } from '../../utils/open';
@@ -55,12 +55,12 @@ export const createDevToolsMenuItems = (
           })),
         ].filter((item) => item != null);
         return {
-          title: chalk`{bold ${plugin.packageName}}`,
+          title: `${styleText('bold', plugin.packageName)}`,
           value: '',
           children,
           action: async () => {
             try {
-              const value = await selectAsync(chalk`{dim Select command}`, children);
+              const value = await selectAsync(`${styleText('dim', `Select command`)}`, children);
               await children.find((item) => item.value === value)?.action?.();
             } catch (error: any) {
               // Handle aborting prompt
@@ -88,7 +88,7 @@ const devtoolFactory = (
   }
 
   return {
-    title: chalk`Open {bold ${plugin.packageName}}`,
+    title: `Open ${styleText('bold', plugin.packageName)}`,
     value: `devtoolsPlugin:${plugin.packageName}`,
     action: async () => {
       const url = new URL(plugin.webpageEndpoint!, defaultServerUrl);
@@ -121,12 +121,12 @@ const cliExtensionFactory = (
   }));
 
   return {
-    title: chalk`{bold ${plugin.packageName}}`,
+    title: `${styleText('bold', plugin.packageName)}`,
     value: `cliExtension:${plugin.packageName}`,
     children,
     action: async () => {
       try {
-        const value = await selectAsync(chalk`{dim Select command}`, children);
+        const value = await selectAsync(`${styleText('dim', `Select command`)}`, children);
         const cmd = commands.find((c) => c.name === value);
         if (cmd == null) {
           Log.warn(`No command found for ${plugin.packageName}`);

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 import { env } from '../../utils/env';
@@ -51,7 +51,7 @@ export async function printDevToolsPluginCliBannersAsync(
     );
 
     for (const { title, url } of bannerItems) {
-      Log.log(printItem(chalk`${title}: {underline ${url}}`));
+      Log.log(printItem(`${title}: ${styleText('underline', url)}`));
     }
 
     return bannerItems.length;
@@ -99,9 +99,9 @@ export class DevServerManagerActions {
 
           let qrMessage = '';
           if (!options.devClient) {
-            qrMessage = `Scan the QR code above to open in ${chalk`{bold Expo Go}`}.`;
+            qrMessage = `Scan the QR code above to open in ${styleText('bold', `Expo Go`)}.`;
           } else {
-            qrMessage = chalk`Scan the QR code above to open in a {bold development build}.`;
+            qrMessage = `Scan the QR code above to open in a ${styleText('bold', `development build`)}.`;
             qrMessage += ` (${learnMore('https://expo.fyi/start')})`;
           }
           rows--;
@@ -112,13 +112,13 @@ export class DevServerManagerActions {
           rows--;
           Log.log(
             printItem(
-              chalk`Choose an app to open your project at {underline ${interstitialPageUrl}}`
+              `Choose an app to open your project at ${styleText('underline', interstitialPageUrl)}`
             )
           );
         }
 
         rows--;
-        Log.log(printItem(chalk`Metro: {underline ${nativeRuntimeUrl}}`));
+        Log.log(printItem(`Metro: ${styleText('underline', nativeRuntimeUrl)}`));
       } catch (error) {
         console.log('err', error);
         // @ts-ignore: If there is no development build scheme, then skip the QR code.
@@ -126,7 +126,7 @@ export class DevServerManagerActions {
           throw error;
         } else {
           const serverUrl = devServer.getDevServerUrl();
-          Log.log(printItem(chalk`Metro: {underline ${serverUrl}}`));
+          Log.log(printItem(`Metro: ${styleText('underline', serverUrl!)}`));
           rows--;
           Log.log(printItem(`Linking is disabled because the client scheme cannot be resolved.`));
           rows--;
@@ -138,7 +138,7 @@ export class DevServerManagerActions {
       const webDevServer = this.devServerManager.getWebDevServer();
       const webUrl = webDevServer?.getDevServerUrl({ hostType: 'localhost' });
       if (webUrl) {
-        Log.log(printItem(chalk`Web: {underline ${webUrl}}`));
+        Log.log(printItem(`Web: ${styleText('underline', webUrl)}`));
         rows--;
       }
     }
@@ -163,7 +163,7 @@ export class DevServerManagerActions {
       const apps = await queryAllInspectorAppsAsync(metroServerOrigin);
       if (!apps.length) {
         return Log.warn(
-          chalk`{bold Debug:} No compatible apps connected, React Native DevTools can only be used with Hermes. ${learnMore(
+          `${styleText('bold', `Debug:`)} No compatible apps connected, React Native DevTools can only be used with Hermes. ${learnMore(
             'https://docs.expo.dev/guides/using-hermes/'
           )}`
         );
@@ -171,12 +171,12 @@ export class DevServerManagerActions {
 
       const app = await promptInspectorAppAsync(apps);
       if (!app) {
-        return Log.error(chalk`{bold Debug:} No inspectable device selected`);
+        return Log.error(`${styleText('bold', `Debug:`)} No inspectable device selected`);
       }
 
       if (!(await openJsInspector(metroServerOrigin, app))) {
         Log.warn(
-          chalk`{bold Debug:} Failed to open the React Native DevTools, see debug logs for more info.`
+          `${styleText('bold', `Debug:`)} Failed to open the React Native DevTools, see debug logs for more info.`
         );
       }
     } catch (error: any) {
@@ -218,7 +218,7 @@ export class DevServerManagerActions {
         ...createDevToolsMenuItems(plugins, defaultServerUrl, metroServerOrigin),
       ];
 
-      const value = await selectAsync(chalk`Dev tools {dim (native only)}`, menuItems);
+      const value = await selectAsync(`Dev tools ${styleText('dim', `(native only)`)}`, menuItems);
       const menuItem = menuItems.find((item) => item.value === value);
       if (menuItem?.action) {
         menuItem.action();

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 import { openInEditorAsync } from '../../utils/editor';
@@ -126,7 +126,7 @@ export async function startInterfaceAsync(
 
       if (server.isTargetingNative() && !platforms.includes(settings.key)) {
         Log.warn(
-          chalk`${settings.name} is disabled, enable it by adding {bold ${settings.key}} to the platforms array in your app.json or app.config.js`
+          `${settings.name} is disabled, enable it by adding ${styleText('bold', settings.key)} to the platforms array in your app.json or app.config.js`
         );
       } else {
         try {

--- a/packages/@expo/cli/src/start/platforms/DeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/DeviceManager.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../../log';
 
@@ -11,7 +11,7 @@ export abstract class DeviceManager<IDevice> {
   abstract get identifier(): string;
 
   logOpeningUrl(url: string) {
-    Log.log(chalk`\u203A Opening {underline ${url}} on {bold ${this.name}}`);
+    Log.log(`\u203A Opening ${styleText('underline', url)} on ${styleText('bold', this.name)}`);
   }
 
   abstract startAsync(): Promise<IDevice>;

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@expo/config';
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../../log';
 import { CommandError, UnimplementedError } from '../../utils/errors';
@@ -72,9 +72,9 @@ export class PlatformManager<
         applicationId = await this._getAppIdResolver().getAppIdAsync();
       } catch {
         Log.warn(
-          chalk`\u203A Launching in Expo Go. If you want to use a ` +
+          `\u203A Launching in Expo Go. If you want to use a ` +
             `development build, you need to create and install one first, or, if you already ` +
-            chalk`have a build, add {bold ios.bundleIdentifier} and {bold android.package} to ` +
+            `have a build, add ${styleText('bold', `ios.bundleIdentifier`)} and ${styleText('bold', `android.package`)} to ` +
             `this project's app config.\n${learnMore('https://docs.expo.dev/development/build/')}`
         );
       }
@@ -90,8 +90,8 @@ export class PlatformManager<
           // Log a warning if no development build is available on the device, but the
           // interstitial page would otherwise be opened.
           Log.warn(
-            chalk`\u203A The {bold expo-dev-client} package is installed, but a development build is not ` +
-              chalk`installed on {bold ${deviceManager.name}}.\nLaunching in Expo Go. If you want to use a ` +
+            `\u203A The ${styleText('bold', `expo-dev-client`)} package is installed, but a development build is not ` +
+              `installed on ${styleText('bold', deviceManager.name)}.\nLaunching in Expo Go. If you want to use a ` +
               `development build, you need to create and install one first.\n${learnMore(
                 'https://docs.expo.dev/development/build/'
               )}`

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import { activateWindowAsync } from './activateWindow';
 import * as AndroidDebugBridge from './adb';
@@ -118,11 +118,9 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     } catch (error: any) {
       let errorMessage = `Couldn't open Android app with activity "${launchActivity}" on device "${this.name}".`;
       if (error instanceof CommandError && error.code === 'APP_NOT_INSTALLED') {
-        errorMessage += `\nThe app might not be installed, try installing it with: ${chalk.bold(
-          `npx expo run:android -d ${this.name}`
-        )}`;
+        errorMessage += `\nThe app might not be installed, try installing it with: ${styleText("bold", `npx expo run:android -d ${this.name}`)}`;
       }
-      errorMessage += chalk.gray(`\n${error.message}`);
+      errorMessage += styleText("gray", `\n${error.message}`);
       error.message = errorMessage;
       throw error;
     }

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import os from 'os';
 
 import { ADBServer } from './ADBServer';
@@ -66,9 +66,7 @@ export function getServer() {
 /** Logs an FYI message about authorizing your device. */
 export function logUnauthorized(device: Device) {
   Log.warn(
-    `\nThis computer is not authorized for developing on ${chalk.bold(device.name)}. ${chalk.dim(
-      learnMore('https://expo.fyi/authorize-android-device')
-    )}`
+    `\nThis computer is not authorized for developing on ${styleText("bold", device.name)}. ${styleText("dim", learnMore('https://expo.fyi/authorize-android-device'))}`
   );
 }
 

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -1,5 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import { spawn } from 'child_process';
 import os from 'os';
 
@@ -58,7 +58,7 @@ export async function startDeviceAsync(
     interval?: number;
   } = {}
 ): Promise<Device> {
-  Log.log(`\u203A Opening emulator ${chalk.bold(device.name)}`);
+  Log.log(`\u203A Opening emulator ${styleText("bold", device.name)}`);
 
   // Start a process to open an emulator
   const emulatorProcess = spawn(

--- a/packages/@expo/cli/src/start/platforms/android/promptAndroidDevice.ts
+++ b/packages/@expo/cli/src/start/platforms/android/promptAndroidDevice.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import type { Device } from './adb';
 import { logUnauthorized } from './adb';
@@ -34,7 +34,7 @@ export async function promptForDeviceAsync(devices: Device[]): Promise<Device> {
 export function formatDeviceChoice(device: Device): { title: string; value: string } {
   const symbol = getDeviceChoiceSymbol(device);
   const name = getDeviceChoiceName(device);
-  const type = chalk.dim(device.isAuthorized ? device.type : 'unauthorized');
+  const type = styleText("dim", device.isAuthorized ? device.type : 'unauthorized');
 
   return {
     value: device.name,
@@ -64,9 +64,9 @@ function getDeviceChoiceName(device: Device) {
 
   // A device that is connected and ready to be used should be bolded to match iOS.
   if (device.isAuthorized) {
-    return chalk.bold(device.name);
+    return styleText("bold", device.name);
   }
 
   // Devices that are unauthorized and connected cannot be used, but they are connected so gray them out.
-  return chalk.bold(chalk.gray(device.name));
+  return styleText("bold", styleText('gray', device.name));
 }

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -1,6 +1,6 @@
 import { spawnAsync as spawnAppleScriptAsync } from '@expo/osascript';
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import fs from 'fs';
 import path from 'path';
 
@@ -128,15 +128,13 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
         if (appId === EXPO_GO_BUNDLE_IDENTIFIER) {
           errorMessage = `Couldn't open Expo Go app on device "${this.name}". Install it: https://expo.dev/go.`;
         } else {
-          errorMessage += `\nThe app might not be installed, try installing it with: ${chalk.bold(
-            `npx expo run:ios -d ${this.device.udid}`
-          )}`;
+          errorMessage += `\nThe app might not be installed, try installing it with: ${styleText("bold", `npx expo run:ios -d ${this.device.udid}`)}`;
         }
       }
       if (error.stderr) {
-        errorMessage += chalk.gray(`\n${error.stderr}`);
+        errorMessage += styleText("gray", `\n${error.stderr}`);
       } else if (error.message) {
-        errorMessage += chalk.gray(`\n${error.message}`);
+        errorMessage += styleText("gray", `\n${error.message}`);
       }
       throw new CommandError(errorMessage);
     }

--- a/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
@@ -8,7 +8,7 @@
 import JsonFile from '@expo/json-file';
 import type { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import { spawn, execSync } from 'child_process';
 import fs from 'fs';
 import assert from 'node:assert';
@@ -412,7 +412,7 @@ export async function installAndLaunchAppAsync(props: {
         if (!indicator) {
           indicator = ora(status).start();
         }
-        indicator.text = `${chalk.bold(status)} ${progress}%`;
+        indicator.text = `${styleText("bold", status)} ${progress}%`;
         if (isComplete) {
           indicator.succeed();
         }

--- a/packages/@expo/cli/src/start/platforms/ios/promptAppleDevice.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/promptAppleDevice.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import { getBestSimulatorAsync } from './getBestSimulator';
 import type { Device } from './simctl';
@@ -46,9 +46,9 @@ async function promptAppleDeviceInternalAsync(devices: Device[]): Promise<string
     message: 'Select a simulator',
     choices: devices.map((item) => {
       const isActive = item.state === 'Booted';
-      const format = isActive ? chalk.bold : (text: string) => text;
+      const format = isActive ? (text: string) => styleText('bold', text) : (text: string) => text;
       return {
-        title: `${format(item.name)} ${chalk.dim(`(${item.osVersion})`)}`,
+        title: `${format(item.name)} ${styleText("dim", `(${item.osVersion})`)}`,
         value: item.udid,
       };
     }),

--- a/packages/@expo/cli/src/start/platforms/ios/simctlLogging.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctlLogging.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { spawn } from 'child_process';
 import { EOL } from 'os';
@@ -239,7 +239,7 @@ function isRunningBoardServicesLog(simLog: SimControlLog): boolean {
 
 function formatMessage(simLog: SimControlLog): string {
   // TODO: Maybe change "TCC" to "Consent" or "System".
-  const category = chalk.gray(`[${simLog.source?.image ?? simLog.subsystem}]`);
+  const category = styleText("gray", `[${simLog.source?.image ?? simLog.subsystem}]`);
   const message = simLog.eventMessage;
   return wrapAnsi(category + ' ' + message, process.stdout.columns || 80);
 }

--- a/packages/@expo/cli/src/start/platforms/ios/xcrun.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/xcrun.ts
@@ -1,6 +1,6 @@
 import type { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 
 import { CommandError } from '../../../utils/errors';
 
@@ -34,9 +34,7 @@ function throwXcrunError(e: any): never {
   } else if (e.stderr?.includes('not a developer tool or in PATH')) {
     throw new CommandError(
       'SIMCTL_NOT_AVAILABLE',
-      `You may need to run ${chalk.bold(
-        'sudo xcode-select -s /Applications/Xcode.app'
-      )} and try again.`
+      `You may need to run ${styleText("bold", 'sudo xcode-select -s /Applications/Xcode.app')} and try again.`
     );
   }
   // Attempt to craft a better error message...

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../log';
 import { envIsWebcontainer } from '../utils/env';
@@ -38,7 +38,9 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
   });
 
   if (args['--https']) {
-    Log.warn(chalk`{bold --https} option is deprecated in favor of {bold --tunnel}`);
+    Log.warn(
+      `${styleText('bold', `--https`)} option is deprecated in favor of ${styleText('bold', `--tunnel`)}`
+    );
   }
 
   // User can force the default target by passing either `--dev-client` or `--go`. They can also
@@ -101,11 +103,11 @@ export async function resolveSchemeAsync(
         // This can happen if one of the native projects has no URI schemes defined in it.
         // Normally, this should never happen.
         Log.warn(
-          chalk`Could not find a shared URI scheme for the dev client between the local {bold /ios} and {bold /android} directories. App launches (QR code, interstitial, terminal keys) may not work as expected. You can configure a custom scheme using the {bold --scheme} option, or by running {bold npx expo prebuild} to regenerate the native directories with URI schemes.`
+          `Could not find a shared URI scheme for the dev client between the local ${styleText('bold', `/ios`)} and ${styleText('bold', `/android`)} directories. App launches (QR code, interstitial, terminal keys) may not work as expected. You can configure a custom scheme using the ${styleText('bold', `--scheme`)} option, or by running ${styleText('bold', `npx expo prebuild`)} to regenerate the native directories with URI schemes.`
         );
       } else if (['ios', 'android'].includes(resolvedScheme.resolution)) {
         Log.warn(
-          chalk`The {bold /${resolvedScheme.resolution}} project does not contain any URI schemes. Expo CLI will not be able to use links to launch the project. You can configure a custom URI scheme using the {bold --scheme} option.`
+          `The ${styleText('bold', `/${resolvedScheme.resolution}`)} project does not contain any URI schemes. Expo CLI will not be able to use links to launch the project. You can configure a custom URI scheme using the ${styleText('bold', `--scheme`)} option.`
         );
       }
     }

--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import crypto from 'crypto';
+import { styleText } from 'node:util';
 import * as path from 'path';
 import slugify from 'slugify';
 
@@ -170,9 +170,14 @@ export class AsyncNgrok {
         onStatusChange(status) {
           if (status === 'closed') {
             Log.error(
-              chalk.red(
+              styleText(
+                'red',
                 'Tunnel connection has been closed. This is often related to intermittent connection issues between the dev server and ngrok. Restart the dev server to try connecting to ngrok again.'
-              ) + chalk.gray('\nCheck the Ngrok status page for outages: https://status.ngrok.com/')
+              ) +
+                styleText(
+                  'gray',
+                  '\nCheck the Ngrok status page for outages: https://status.ngrok.com/'
+                )
             );
           } else if (status === 'connected') {
             Log.log('Tunnel connected.');
@@ -189,7 +194,10 @@ export class AsyncNgrok {
             [
               error.body.msg,
               error.body.details?.err,
-              chalk.gray('Check the Ngrok status page for outages: https://status.ngrok.com/'),
+              styleText(
+                'gray',
+                'Check the Ngrok status page for outages: https://status.ngrok.com/'
+              ),
             ]
               .filter(Boolean)
               .join('\n\n')
@@ -198,7 +206,10 @@ export class AsyncNgrok {
         throw new CommandError(
           'NGROK_CONNECT',
           error.toString() +
-            chalk.gray('\nCheck the Ngrok status page for outages: https://status.ngrok.com/')
+            styleText(
+              'gray',
+              '\nCheck the Ngrok status page for outages: https://status.ngrok.com/'
+            )
         );
       };
 

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -1,9 +1,9 @@
 import { getConfig } from '@expo/config';
 import * as tunnel from '@expo/ws-tunnel';
-import chalk from 'chalk';
 import * as fs from 'node:fs';
 import { tmpdir, hostname } from 'node:os';
 import * as path from 'node:path';
+import { styleText } from 'node:util';
 
 import { TunnelMutation } from '../../api/graphql/mutations/TunnelMutation';
 import { AppQuery } from '../../api/graphql/queries/AppQuery';
@@ -38,9 +38,14 @@ export class AsyncWsTunnel {
       onStatusChange(status) {
         if (status === 'disconnected') {
           Log.error(
-            chalk.red(
+            styleText(
+              'red',
               'Tunnel connection has been closed. This is often related to intermittent connection problems with the ws proxy servers. Restart the dev server to try connecting again.'
-            ) + chalk.gray('\nCheck the Expo status page for outages: https://status.expo.dev/')
+            ) +
+              styleText(
+                'gray',
+                '\nCheck the Expo status page for outages: https://status.expo.dev/'
+              )
           );
         }
       },

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -1,7 +1,7 @@
 import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../../log';
 import { FileNotifier } from '../../utils/FileNotifier';
@@ -74,7 +74,7 @@ export class DevServerManager {
         './.babelrc.js',
       ],
       {
-        additionalWarning: chalk` You may need to clear the bundler cache with the {bold --clear} flag for your changes to take effect.`,
+        additionalWarning: ` You may need to clear the bundler cache with the ${styleText('bold', `--clear`)} flag for your changes to take effect.`,
       }
     );
 
@@ -150,7 +150,7 @@ export class DevServerManager {
   /** Switch between Expo Go and Expo Dev Clients. */
   async toggleRuntimeMode(isUsingDevClient: boolean = !this.options.devClient): Promise<boolean> {
     const nextMode = isUsingDevClient ? '--dev-client' : '--go';
-    Log.log(printItem(`Switching to ${chalk`{bold ${nextMode}}`}`, { dim: true }));
+    Log.log(printItem(`Switching to ${`${styleText('bold', nextMode)}`}`, { dim: true }));
     Log.log();
 
     const nextScheme = await resolveSchemeAsync(this.projectRoot, {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -24,7 +24,6 @@ import getGraphId from '@expo/metro/metro/lib/getGraphId';
 import type { GetStreamingContentOptions } from '@expo/router-server/build/server/renderStreamingContent';
 import type { GetStaticContentOptions } from '@expo/router-server/build/static/renderStaticContent';
 import assert from 'assert';
-import chalk from 'chalk';
 import type { RouteNode } from 'expo-router/build/Route';
 import {
   type RouteInfo,
@@ -32,6 +31,7 @@ import {
   type ImmutableRequest,
   resolveLoaderContextKey,
 } from 'expo-server/private';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { events } from '../../../events';
@@ -1757,7 +1757,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
             // This could happen during the install.
             Log.log();
             Log.error(
-              chalk.red`Failed to automatically setup TypeScript for your project. Try restarting the dev server to fix.`
+              styleText(
+                'red',
+                `Failed to automatically setup TypeScript for your project. Try restarting the dev server to fix.`
+              )
             );
             Log.exception(error);
             resolve(false);
@@ -1808,7 +1811,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         // Wrap with command error for better error messages.
         const err = new CommandError(
           'API_ROUTE',
-          chalk`Failed to bundle API Route: {bold ${relativePath}}\n\n` + error.message
+          `Failed to bundle API Route: ${styleText('bold', relativePath)}\n\n` + error.message
         );
 
         for (const key in error) {
@@ -1965,7 +1968,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       debug('Failed to bundle loader:', filePath, ':', error.message);
       throw new CommandError(
         'LOADER_BUNDLE',
-        chalk`Failed to bundle loader: {bold ${filePath}}\n\n` + error.message
+        `Failed to bundle loader: ${styleText('bold', filePath)}\n\n` + error.message
       );
     }
   }

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@expo/metro/metro-core';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import { format as utilFormat, stripVTControlCharacters } from 'util';
 
@@ -178,7 +178,10 @@ export class MetroTerminalReporter extends TerminalReporter {
 
     if (!inProgress) {
       const status = phase === 'done' ? `Bundled ` : `Bundling failed `;
-      const color = phase === 'done' ? chalk.green : chalk.red;
+      const color =
+        phase === 'done'
+          ? (text: string) => styleText('green', text)
+          : (text: string) => styleText('red', text);
 
       const startTime = this._bundleTimers.get(progress.bundleDetails.buildID!);
 
@@ -193,9 +196,9 @@ export class MetroTerminalReporter extends TerminalReporter {
         if (ms <= 0.5) {
           const tenthFractionOfMicro = ((micro * 10) / 1000).toFixed(0);
           // Format as microseconds to nearest tenth
-          time = chalk.cyan.bold(`0.${tenthFractionOfMicro}ms`);
+          time = styleText(['cyan', 'bold'], `0.${tenthFractionOfMicro}ms`);
         } else {
-          time = chalk.dim(ms.toFixed(0) + 'ms');
+          time = styleText('dim', ms.toFixed(0) + 'ms');
         }
       }
 
@@ -212,7 +215,7 @@ export class MetroTerminalReporter extends TerminalReporter {
       return (
         color(platform + status) +
         time +
-        chalk.reset.dim(` ${localPath} (${progress.totalFileCount} module${plural})`)
+        styleText(['reset', 'dim'], ` ${localPath} (${progress.totalFileCount} module${plural})`)
       );
     }
 
@@ -228,10 +231,14 @@ export class MetroTerminalReporter extends TerminalReporter {
 
     const filledBar = Math.floor(progress.ratio * MAX_PROGRESS_BAR_CHAR_WIDTH);
     const _progress = inProgress
-      ? chalk.green.bgGreen(DARK_BLOCK_CHAR.repeat(filledBar)) +
-        chalk.bgWhite.white(LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar)) +
-        chalk.bold(` ${(100 * progress.ratio).toFixed(1).padStart(4)}% `) +
-        chalk.dim(
+      ? styleText(['green', 'bgGreen'], DARK_BLOCK_CHAR.repeat(filledBar)) +
+        styleText(
+          ['bgWhite', 'white'],
+          LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar)
+        ) +
+        styleText('bold', ` ${(100 * progress.ratio).toFixed(1).padStart(4)}% `) +
+        styleText(
+          'dim',
           `(${progress.transformedFileCount
             .toString()
             .padStart(progress.totalFileCount.toString().length)}/${progress.totalFileCount})`
@@ -239,8 +246,8 @@ export class MetroTerminalReporter extends TerminalReporter {
       : '';
     return (
       platform +
-      chalk.reset.dim(`${path.dirname(localPath)}${path.sep}`) +
-      chalk.bold(path.basename(localPath)) +
+      styleText(['reset', 'dim'], `${path.dirname(localPath)}${path.sep}`) +
+      styleText('bold', path.basename(localPath)) +
       ' ' +
       _progress
     );
@@ -249,7 +256,7 @@ export class MetroTerminalReporter extends TerminalReporter {
   _logInitializing(port: number, hasReducedPerformance: boolean): void {
     // Don't print a giant logo...
     if (!shouldReduceLogs()) {
-      this.terminal.log(chalk.dim('Starting Metro Bundler') + '\n');
+      this.terminal.log(styleText('dim', 'Starting Metro Bundler') + '\n');
     }
   }
 
@@ -265,7 +272,7 @@ export class MetroTerminalReporter extends TerminalReporter {
   transformCacheReset(): void {
     logWarning(
       this.terminal,
-      chalk`Bundler cache is empty, rebuilding {dim (this may take a minute)}`
+      `Bundler cache is empty, rebuilding ${styleText('dim', `(this may take a minute)`)}`
     );
   }
 
@@ -275,7 +282,8 @@ export class MetroTerminalReporter extends TerminalReporter {
     if (hasReducedPerformance) {
       // Extends https://github.com/facebook/metro/blob/347b1d7ed87995d7951aaa9fd597c04b06013dac/packages/metro/src/lib/TerminalReporter.js#L283-L290
       this.terminal.log(
-        chalk.red(
+        styleText(
+          'red',
           [
             'Metro is operating with reduced performance.',
             'Fix the problem above and restart Metro.',
@@ -488,19 +496,13 @@ export function formatUsingNodeStandardLibraryError(
   if (isNodeStdLibraryModule(targetModuleName)) {
     if (originModulePath.includes('node_modules')) {
       return [
-        `The package at "${chalk.bold(
-          relativePath
-        )}" attempted to import the Node standard library module "${chalk.bold(
-          targetModuleName
-        )}".`,
+        `The package at "${styleText('bold', relativePath)}" attempted to import the Node standard library module "${styleText('bold', targetModuleName)}".`,
         `It failed because the native React runtime does not include the Node standard library.`,
         learnMore(DOCS_PAGE_URL),
       ].join('\n');
     } else {
       return [
-        `You attempted to import the Node standard library module "${chalk.bold(
-          targetModuleName
-        )}" from "${chalk.bold(relativePath)}".`,
+        `You attempted to import the Node standard library module "${styleText('bold', targetModuleName)}" from "${styleText('bold', relativePath)}".`,
         `It failed because the native React runtime does not include the Node standard library.`,
         learnMore(DOCS_PAGE_URL),
       ].join('\n');
@@ -610,7 +612,7 @@ function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null): st
       default:
         formatted = platform;
     }
-    return `${chalk.bold(formatted)} `;
+    return `${styleText('bold', formatted)} `;
   }
 
   return '';
@@ -620,16 +622,16 @@ function getEnvironmentForBuildDetails(bundleDetails?: BundleDetails | null): st
   // Expo CLI will pass `customTransformOptions.environment = 'node'` when bundling for the server.
   const env = bundleDetails?.customTransformOptions?.environment ?? null;
   if (env === 'node') {
-    return chalk.bold('λ') + ' ';
+    return styleText('bold', 'λ') + ' ';
   } else if (env === 'react-server') {
-    return chalk.bold(`RSC(${getPlatformTagForBuildDetails(bundleDetails).trim()})`) + ' ';
+    return styleText('bold', `RSC(${getPlatformTagForBuildDetails(bundleDetails).trim()})`) + ' ';
   }
 
   if (
     bundleDetails?.customTransformOptions?.dom &&
     typeof bundleDetails?.customTransformOptions?.dom === 'string'
   ) {
-    return chalk.bold(`DOM`) + ' ';
+    return styleText('bold', `DOM`) + ' ';
   }
 
   return '';

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
@@ -3,7 +3,7 @@ import type { WatcherStatus } from '@expo/metro/metro-file-map';
 // This file represents an abstraction on the metro TerminalReporter.
 // We use this abstraction to safely extend the TerminalReporter for our own custom logging.
 import UpstreamTerminalReporter from '@expo/metro/metro/lib/TerminalReporter';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import util from 'util';
 
 import { stripAnsi } from '../../../utils/ansi';
@@ -24,7 +24,7 @@ const debug = require('debug')('expo:metro:logger') as typeof console.log;
  */
 export function logWarning(terminal: Terminal, format: string, ...args: any[]): void {
   const str = util.format(format, ...args);
-  terminal.log('%s: %s', chalk.yellow('warning'), str);
+  terminal.log('%s: %s', styleText('yellow', 'warning'), str);
 }
 
 /**
@@ -33,12 +33,12 @@ export function logWarning(terminal: Terminal, format: string, ...args: any[]): 
 export function logError(terminal: Terminal, format: string, ...args: any[]): void {
   terminal.log(
     '%s: %s',
-    chalk.red('error'),
+    styleText('red', 'error'),
     // Syntax errors may have colors applied for displaying code frames
     // in various places outside of where Metro is currently running.
     // If the current terminal does not support color, we'll strip the colors
     // here.
-    util.format(chalk.supportsColor ? format : stripAnsi(format), ...args)
+    util.format(process.stdout.hasColors() ? format : stripAnsi(format), ...args)
   );
 }
 
@@ -129,7 +129,7 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
       lines.splice(lines.length - 1, 1);
     }
 
-    const originTag = origin === 'stdout' ? chalk.dim('|') : chalk.yellow('|');
+    const originTag = origin === 'stdout' ? styleText('dim', '|') : styleText('yellow', '|');
     lines.forEach((line: string) => {
       this.terminal.log(originTag, line);
     });

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -14,8 +14,8 @@ import type MetroHmrServer from '@expo/metro/metro/HmrServer';
 import RevisionNotFoundError from '@expo/metro/metro/IncrementalBundler/RevisionNotFoundError';
 import type MetroServer from '@expo/metro/metro/Server';
 import formatBundlingError from '@expo/metro/metro/lib/formatBundlingError';
-import chalk from 'chalk';
 import type http from 'http';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { events, shouldReduceLogs } from '../../../events';
@@ -273,11 +273,16 @@ export async function loadMetroConfigAsync(
 
   const reactCompilerEnabled = !!exp.experiments?.reactCompiler;
   if (!reduceLogs && reactCompilerEnabled) {
-    Log.log(chalk.gray`React Compiler enabled`);
+    Log.log(
+      styleText(
+        'gray',
+        `));
   }
 
   if (!reduceLogs && autolinkingModuleResolutionEnabled) {
-    Log.log(chalk.gray`Expo Autolinking module resolution enabled`);
+    Log.log(styleText("gray", `
+      )
+    );
   }
 
   if (env.EXPO_UNSTABLE_TREE_SHAKING && !env.EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH) {
@@ -698,7 +703,7 @@ function pruneCustomTransformOptions(
 export function isWatchEnabled() {
   if (env.CI) {
     Log.log(
-      chalk`Metro is running in CI mode, reloads are disabled. Remove {bold CI=true} to enable watch mode.`
+      `Metro is running in CI mode, reloads are disabled. Remove ${styleText('bold', `CI=true`)} to enable watch mode.`
     );
   }
 

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -6,8 +6,7 @@
  */
 import { getMetroServerRoot } from '@expo/config/paths';
 import { parseWebBuildErrors } from '@expo/log-box-utils';
-import chalk from 'chalk';
-import { stripVTControlCharacters } from 'node:util';
+import { styleText, stripVTControlCharacters } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import type { StackFrame } from 'stacktrace-parser';
@@ -31,11 +30,11 @@ function fill(width: number): string {
 }
 
 function formatPaths(config: { filePath: string | null; line?: number; col?: number }) {
-  const filePath = chalk.reset(config.filePath);
+  const filePath = styleText('reset', config.filePath ?? '');
   return (
-    chalk.dim('(') +
+    styleText('dim', '(') +
     filePath +
-    chalk.dim(`:${[config.line, config.col].filter(Boolean).join(':')})`)
+    styleText('dim', `:${[config.line, config.col].filter(Boolean).join(':')})`)
   );
 }
 
@@ -59,7 +58,7 @@ export async function logMetroErrorWithStack(
   // process.stdout.write('\u001bc'); // Reset the terminal
 
   Log.log();
-  Log.log(chalk.red('Metro error: ') + error.message);
+  Log.log(styleText('red', 'Metro error: ') + error.message);
   Log.log();
 
   if (error instanceof CommandError) {
@@ -104,7 +103,7 @@ export function getStackAsFormattedLog(
     // ---- index.tsx ------------------------------------------------------
     //  32 |         This is example code which will be under the title.
     const title = path.basename(codeFrame.fileName);
-    logs.push(chalk.bold`Code: ${title}`);
+    logs.push(styleText('bold', `Code: ${title}`));
 
     const isPreviewTooLong = lines.some((line) => line.length > maxWarningLineLength);
     const column = codeFrame.location?.column;
@@ -135,16 +134,24 @@ export function getStackAsFormattedLog(
         if (minBounds > 0) {
           // Adjust the min bounds so the cursor is aligned after we add the "..."
           minBounds -= 3;
-          previewLine = chalk.dim('...') + previewLine;
+          previewLine = styleText('dim', '...') + previewLine;
         }
         if (maxBounds < lineText.length) {
-          previewLine += chalk.dim('...');
+          previewLine += styleText('dim', '...');
         }
 
         // If the column property could be found, then use that to fix the cursor location which is often broken in regex.
-        cursorLine = (column == null ? '' : fill(column) + chalk.reset('^')).slice(minBounds);
+        cursorLine = (column == null ? '' : fill(column) + styleText('reset', '^')).slice(
+          minBounds
+        );
 
-        logs.push(formattedPath, '', previewLine, cursorLine, chalk.dim('(error truncated)'));
+        logs.push(
+          formattedPath,
+          '',
+          previewLine,
+          cursorLine,
+          styleText('dim', '(error truncated)')
+        );
       }
     } else {
       logs.push(codeFrame.content);
@@ -170,10 +177,10 @@ export function getStackAsFormattedLog(
       const position = terminalLink.isSupported
         ? terminalLink(frame.subtitle, frame.subtitle)
         : frame.subtitle;
-      let lineItem = chalk.gray(`  ${frame.title} (${position})`);
+      let lineItem = styleText('gray', `  ${frame.title} (${position})`);
 
       if (frame.collapse) {
-        lineItem = chalk.dim(lineItem);
+        lineItem = styleText('dim', lineItem);
       }
       // Never show the internal module system.
       const isMetroRuntime =
@@ -187,10 +194,10 @@ export function getStackAsFormattedLog(
       }
     });
 
-    logs.push(chalk.bold`Call Stack`);
+    logs.push(styleText('bold', `Call Stack`));
 
     if (!backupStackLines.length) {
-      logs.push(chalk.gray('  No stack trace available.'));
+      logs.push(styleText('gray', '  No stack trace available.'));
     } else {
       isFallback = stackLines.length === 0;
       // If there are not stack lines then it means the error likely happened in the node modules, in this case we should fallback to showing all the
@@ -199,7 +206,7 @@ export function getStackAsFormattedLog(
       logs.push(displayStack.join('\n'));
     }
   } else if (error && error.stack) {
-    logs.push(chalk.gray(`  ${error.stack}`));
+    logs.push(styleText('gray', `  ${error.stack}`));
   }
 
   return {

--- a/packages/@expo/cli/src/start/server/metro/router.ts
+++ b/packages/@expo/cli/src/start/server/metro/router.ts
@@ -1,7 +1,7 @@
 import type { ExpoConfig } from '@expo/config';
-import chalk from 'chalk';
 import type { MiddlewareMatcher } from 'expo-server';
 import { sync as globSync } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -65,7 +65,7 @@ let hasWarnedAboutSrcDir = false;
 const logSrcDir = () => {
   if (hasWarnedAboutSrcDir) return;
   hasWarnedAboutSrcDir = true;
-  Log.log(chalk.gray('Using src/app as the root directory for Expo Router.'));
+  Log.log(styleText('gray', 'Using src/app as the root directory for Expo Router.'));
 };
 
 export function getRouterDirectory(projectRoot: string): string {
@@ -143,9 +143,12 @@ export function hasWarnedAboutMiddleware() {
 export function warnInvalidWebOutput() {
   if (!hasWarnedAboutApiRouteOutput) {
     Log.warn(
-      chalk.yellow`Using API routes requires the {bold web.output} to be set to {bold "server"} in the project {bold app.json}. ${learnMore(
-        'https://docs.expo.dev/router/reference/api-routes/'
-      )}`
+      styleText(
+        'yellow',
+        `Using API routes requires the ${styleText('bold', `web.output`)} to be set to ${styleText('bold', `"server"`)} in the project ${styleText('bold', `app.json`)}. ${learnMore(
+          'https://docs.expo.dev/router/reference/api-routes/'
+        )}`
+      )
     );
   }
 
@@ -155,9 +158,12 @@ export function warnInvalidWebOutput() {
 export function warnInvalidMiddlewareOutput() {
   if (!hasWarnedAboutMiddlewareOutput) {
     Log.warn(
-      chalk.yellow`Using middleware requires the {bold web.output} to be set to {bold "server"} in the project {bold app.json}. ${learnMore(
-        'https://docs.expo.dev/router/reference/api-routes/'
-      )}`
+      styleText(
+        'yellow',
+        `Using middleware requires the ${styleText('bold', `web.output`)} to be set to ${styleText('bold', `"server"`)} in the project ${styleText('bold', `app.json`)}. ${learnMore(
+          'https://docs.expo.dev/router/reference/api-routes/'
+        )}`
+      )
     );
   }
 
@@ -171,13 +177,19 @@ export function warnInvalidMiddlewareMatcherSettings(matcher: MiddlewareMatcher)
   if (matcher.methods) {
     if (!Array.isArray(matcher.methods)) {
       Log.error(
-        chalk.red`Middleware matcher methods must be an array of valid HTTP methods. Supported methods are: ${validMethods.join(', ')}`
+        styleText(
+          'red',
+          `Middleware matcher methods must be an array of valid HTTP methods. Supported methods are: ${validMethods.join(', ')}`
+        )
       );
     } else {
       for (const method of matcher.methods) {
         if (!validMethods.includes(method)) {
           Log.error(
-            chalk.red`Invalid middleware HTTP method: ${method}. Supported methods are: ${validMethods.join(', ')}`
+            styleText(
+              'red',
+              `Invalid middleware HTTP method: ${method}. Supported methods are: ${validMethods.join(', ')}`
+            )
           );
         }
       }
@@ -190,15 +202,21 @@ export function warnInvalidMiddlewareMatcherSettings(matcher: MiddlewareMatcher)
     for (const pattern of patterns) {
       if (typeof pattern !== 'string' && !(pattern instanceof RegExp)) {
         Log.error(
-          chalk.red`Middleware matcher patterns must be strings or regular expressions. Received: ${String(
-            pattern
-          )}`
+          styleText(
+            'red',
+            `Middleware matcher patterns must be strings or regular expressions. Received: ${String(
+              pattern
+            )}`
+          )
         );
       }
 
       if (typeof pattern === 'string' && !pattern.startsWith('/')) {
         Log.error(
-          chalk.red`String patterns in middleware matcher must start with '/'. Received: ${pattern}`
+          styleText(
+            'red',
+            `String patterns in middleware matcher must start with '/'. Received: ${pattern}`
+          )
         );
       }
     }

--- a/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
@@ -1,7 +1,7 @@
 import type { ConfigT as MetroConfig } from '@expo/metro/metro-config';
 import canonicalize from '@expo/metro/metro-core/canonicalize';
 import type { ResolutionContext } from '@expo/metro/metro-resolver';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import { stripVTControlCharacters } from 'util';
 
@@ -305,12 +305,13 @@ export const createMutateResolutionError =
     debug('Number of explored stacks:', stackCounter);
 
     if (inverseStack && inverseStack.frames.length > 0) {
-      const formattedImport = chalk`{gray  |} {cyan import} `;
+      const formattedImport = `${styleText('gray', ` |`)} ${styleText('cyan', `import`)} `;
       const importMessagePadding = ' '.repeat(stripVTControlCharacters(formattedImport).length + 1);
 
       debug('Found inverse graph:', JSON.stringify(inverseStack, null, 2));
 
-      let extraMessage = chalk.bold(
+      let extraMessage = styleText(
+        'bold',
         `Import stack${stackCounter >= stackCountLimit ? ` (${stackCounter})` : ''}:`
       );
 
@@ -319,9 +320,9 @@ export const createMutateResolutionError =
         let filename = path.relative(root, frame.origin);
 
         if (filename.match(/\?ctx=[\w\d]+$/)) {
-          filename = filename.replace(/\?ctx=[\w\d]+$/, chalk.dim(' (require.context)'));
+          filename = filename.replace(/\?ctx=[\w\d]+$/, styleText('dim', ' (require.context)'));
         } else {
-          let formattedRequest = chalk.green(`"${frame.request}"`);
+          let formattedRequest = styleText('green', `"${frame.request}"`);
 
           if (
             // If bundling for web and the import is pulling internals from outside of react-native
@@ -332,18 +333,19 @@ export const createMutateResolutionError =
           ) {
             formattedRequest =
               formattedRequest +
-              chalk`\n${importMessagePadding}{yellow ^ Importing react-native internals is not supported on web.}`;
+              `\n${importMessagePadding}${styleText('yellow', `^ Importing react-native internals is not supported on web.`)}`;
           }
 
-          filename = filename + chalk`\n${formattedImport}${formattedRequest}`;
+          filename = filename + `\n${formattedImport}${formattedRequest}`;
         }
 
-        let line = '\n' + chalk.gray(' ') + filename;
+        let line = '\n' + styleText('gray', ' ') + filename;
         if (filename.match(/node_modules/)) {
-          line = chalk.gray(
+          line = styleText(
+            'gray',
             // Bold the node module name
             line.replace(/node_modules\/([^/]+)/, (_match, p1) => {
-              return 'node_modules/' + chalk.bold(p1);
+              return `node_modules/${styleText('bold', p1)}`;
             })
           );
         }
@@ -352,11 +354,11 @@ export const createMutateResolutionError =
       }
 
       if (inverseStack.circular) {
-        extraMessage += chalk`\n${importMessagePadding}{yellow ^ The import above creates circular dependency.}`;
+        extraMessage += `\n${importMessagePadding}${styleText('yellow', `^ The import above creates circular dependency.`)}`;
       }
 
       if (inverseStack.limited) {
-        extraMessage += chalk`\n\n {bold {yellow Depth limit reached. The actual stack is longer than what you can see above.}}`;
+        extraMessage += `\n\n ${styleText(['bold', 'yellow'], `Depth limit reached. The actual stack is longer than what you can see above.`)}`;
       }
 
       extraMessage += '\n';

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -1,5 +1,5 @@
 import type { CustomMessageHandlerConnection } from '@react-native/dev-middleware';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { selectAsync } from '../../../../utils/prompts';
 import { pageIsSupported } from '../../metro/debugging/pageIsSupported';
@@ -108,13 +108,13 @@ export async function promptInspectorAppAsync(apps: MetroInspectorProxyApp[]) {
   const choices = apps.map((app) => {
     const name = app.deviceName ?? 'Unknown device';
     return {
-      title: hasDuplicateNames ? chalk`${name}{dim  - ${app.id}}` : name,
+      title: hasDuplicateNames ? `${name}${styleText('dim', ` - ${app.id}`)}` : name,
       value: app.id,
       app,
     };
   });
 
-  const value = await selectAsync(chalk`Debug target {dim (Hermes only)}`, choices);
+  const value = await selectAsync(`Debug target ${styleText('dim', `(Hermes only)`)}`, choices);
 
   return choices.find((item) => item.value === value)?.app;
 }

--- a/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import type { NextHandleFunction } from 'connect';
 import type { IncomingMessage, ServerResponse } from 'http';
+import { styleText } from 'node:util';
 import { URL } from 'url';
 
 import { isMatchingOrigin, shouldThrottleRemoteDevCall } from '../../../../utils/net';
@@ -35,7 +35,8 @@ export function createJsInspectorMiddleware({
     if (!app) {
       res.writeHead(404).end('Unable to find inspector target from @react-native/dev-middleware');
       console.warn(
-        chalk.yellow(
+        styleText(
+          'yellow',
           'No compatible apps connected. JavaScript Debugging can only be used with the Hermes engine.'
         )
       );
@@ -62,7 +63,10 @@ export function createJsInspectorMiddleware({
         // 15:50: execution error: Google Chrome got an error: Application isn’t running. (-600)
 
         console.error(
-          chalk.red('Error launching JS inspector: ' + (error?.message ?? 'Unknown error occurred'))
+          styleText(
+            'red',
+            'Error launching JS inspector: ' + (error?.message ?? 'Unknown error occurred')
+          )
         );
         res.writeHead(500);
         res.end();

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { INTERNAL_CALLSITES_REGEX } from '@expo/metro-config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import * as stackTraceParser from 'stacktrace-parser';
 
@@ -44,10 +44,10 @@ export function logLikeMetro(
   const logFunction = console[level] && level !== 'trace' ? level : 'log';
   const color =
     level === 'error'
-      ? chalk.inverse.red
+      ? (['inverse', 'red'] as const)
       : level === 'warn'
-        ? chalk.inverse.yellow
-        : chalk.inverse.white;
+        ? (['inverse', 'yellow'] as const)
+        : (['inverse', 'white'] as const);
 
   if (level === 'group') {
     groupStack.push(level);
@@ -58,7 +58,7 @@ export function logLikeMetro(
     collapsedGuardTimer = setTimeout(() => {
       if (groupStack.includes('groupCollapsed')) {
         originalLogFunction(
-          chalk.inverse.yellow.bold(' WARN '),
+          styleText(['inverse', 'yellow', 'bold'], ' WARN '),
           'Expected `console.groupEnd` to be called after `console.groupCollapsed`.'
         );
         groupStack.length = 0;
@@ -81,10 +81,12 @@ export function logLikeMetro(
     }
 
     const modePrefix =
-      platform && platform !== 'BRIDGE' && platform !== 'NOBRIDGE' ? chalk.bold`${platform} ` : '';
+      platform && platform !== 'BRIDGE' && platform !== 'NOBRIDGE'
+        ? styleText('bold', `${platform} `)
+        : '';
     originalLogFunction(
       modePrefix +
-        color.bold(` ${logFunction.toUpperCase()} `) +
+        styleText([...color, 'bold'], ` ${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),
       ...data
     );
@@ -251,7 +253,9 @@ function formatParsedStackLikeMetro(
         return null;
       }
       // If a file is collapsed, print it with dim styling.
-      const style = isCollapsed ? chalk.dim : chalk.gray;
+      const style = isCollapsed
+        ? (text: string) => styleText('dim', text)
+        : (text: string) => styleText('gray', text);
       // Use the `at` prefix to match Node.js
       let fileName = line.file!;
       if (fileName.startsWith(path.sep)) {

--- a/packages/@expo/cli/src/start/server/type-generation/tsconfig.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/tsconfig.ts
@@ -1,6 +1,6 @@
 import type { JSONObject } from '@expo/json-file';
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { Log } from '../../../log';
@@ -76,7 +76,7 @@ async function writeUpdates(tsConfigPath: string, tsConfig: JSONObject, updates:
     await JsonFile.writeAsync(tsConfigPath, tsConfig);
     for (const update of updates) {
       Log.log(
-        chalk`{bold TypeScript}: The {cyan tsconfig.json#${update}} property has been updated`
+        `${styleText('bold', `TypeScript`)}: The ${styleText('cyan', `tsconfig.json#${update}`)} property has been updated`
       );
     }
   }

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk';
 import type { Application } from 'express';
 import fs from 'node:fs';
 import type http from 'node:http';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import resolveFrom from 'resolve-from';
 import type webpack from 'webpack';
 import type WebpackDevServer from 'webpack-dev-server';
@@ -115,13 +115,16 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       config.plugins = [];
     }
 
-    const bar = createProgressBar(chalk`{bold Web} Bundling Javascript [:bar] :percent`, {
-      width: 64,
-      total: 100,
-      clear: true,
-      complete: '=',
-      incomplete: ' ',
-    });
+    const bar = createProgressBar(
+      `${styleText('bold', `Web`)} Bundling Javascript [:bar] :percent`,
+      {
+        width: 64,
+        total: 100,
+        clear: true,
+        complete: '=',
+        incomplete: ' ',
+      }
+    );
 
     // NOTE(EvanBacon): Add a progress bar to the webpack logger if defined (e.g. not in CI).
     if (bar != null) {
@@ -141,7 +144,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     try {
       await compileAsync(compiler);
     } catch (error: any) {
-      Log.error(chalk.red('Failed to compile'));
+      Log.error(styleText('red', 'Failed to compile'));
       throw error;
     } finally {
       bar?.terminate();
@@ -185,7 +188,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
 
     const config = await this.loadConfigAsync(options);
 
-    Log.log(chalk`Starting Webpack on port ${port} in {underline ${mode}} mode.`);
+    Log.log(`Starting Webpack on port ${port} in ${styleText('underline', mode!)} mode.`);
 
     // Create a webpack compiler that is configured with custom messages.
     const compiler = webpack(config);
@@ -290,7 +293,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     projectRoot: string,
     mode: string = 'development'
   ): Promise<void> {
-    Log.log(chalk.dim(`Clearing Webpack ${mode} cache directory...`));
+    Log.log(styleText('dim', `Clearing Webpack ${mode} cache directory...`));
 
     const dir = await ensureDotExpoProjectDirectoryInitialized(projectRoot);
     const cacheFolder = path.join(dir, 'web/cache', mode);

--- a/packages/@expo/cli/src/start/server/webpack/compile.ts
+++ b/packages/@expo/cli/src/start/server/webpack/compile.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { promisify } from 'util';
 import type webpack from 'webpack';
 
@@ -21,10 +21,10 @@ export async function compileAsync(compiler: webpack.Compiler) {
     throw new CommandError('WEBPACK_BUNDLE', errors.join('\n\n'));
   }
   if (warnings?.length) {
-    Log.warn(chalk.yellow('Compiled with warnings\n'));
+    Log.warn(styleText('yellow', 'Compiled with warnings\n'));
     Log.warn(warnings.join('\n\n'));
   } else {
-    Log.log(chalk.green('Compiled successfully'));
+    Log.log(styleText('green', 'Compiled successfully'));
   }
 
   return { errors, warnings };

--- a/packages/@expo/cli/src/start/server/webpack/tls.ts
+++ b/packages/@expo/cli/src/start/server/webpack/tls.ts
@@ -1,6 +1,6 @@
 import { certificateFor } from '@expo/devcert';
-import chalk from 'chalk';
 import fs from 'fs/promises';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Log from '../../../log';
@@ -25,7 +25,7 @@ export async function getTLSCertAsync(
   projectRoot: string
 ): Promise<{ keyPath: string; certPath: string } | false> {
   Log.log(
-    chalk`Creating TLS certificate for localhost. {dim This functionality may not work on all computers.}`
+    `Creating TLS certificate for localhost. ${styleText('dim', `This functionality may not work on all computers.`)}`
   );
 
   const name = 'localhost';

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { getLogFile, shouldReduceLogs } from '../events';
 import * as Log from '../log';
@@ -77,10 +77,10 @@ export async function startAsync(
   settings: { webOnly?: boolean }
 ) {
   if (!shouldReduceLogs()) {
-    Log.log(chalk.gray(`Starting project at ${projectRoot}`));
+    Log.log(styleText('gray', `Starting project at ${projectRoot}`));
     const logFile = getLogFile();
     if (!isInteractive() && logFile) {
-      Log.log(chalk.gray(`Logs: ${logFile}`));
+      Log.log(styleText('gray', `Logs: ${logFile}`));
     }
   }
 
@@ -153,7 +153,7 @@ export async function startAsync(
         // Print the URL to stdout for tests
         console.info(`[__EXPO_E2E_TEST:server] ${JSON.stringify({ url: defaultServerUrl })}`);
       }
-      Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
+      Log.log(`Waiting on ${styleText('underline', defaultServerUrl)}`);
       Log.log();
       await printDevToolsPluginCliBannersAsync(devServerManager);
     }
@@ -171,8 +171,8 @@ export async function startAsync(
   // Final note about closing the server.
   const logLocation = settings.webOnly ? 'in the browser console' : 'below';
   Log.log(
-    chalk`Logs for your project will appear ${logLocation}.${
-      isInteractive() ? chalk.dim(` Press Ctrl+C to exit.`) : ''
+    `Logs for your project will appear ${logLocation}.${
+      isInteractive() ? styleText('dim', ` Press Ctrl+C to exit.`) : ''
     }`
   );
 }

--- a/packages/@expo/cli/src/utils/FileNotifier.ts
+++ b/packages/@expo/cli/src/utils/FileNotifier.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { watchFile } from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -65,9 +65,8 @@ export class FileNotifier {
     const listener = (cur: any, prev: any) => {
       if (prev.size || cur.size) {
         Log.log(
-          `\u203A Detected a change in ${chalk.bold(
-            configName
-          )}. Restart the server to see the new results.` + (this.settings.additionalWarning || '')
+          `\u203A Detected a change in ${styleText('bold', configName)}. Restart the server to see the new results.` +
+            (this.settings.additionalWarning || '')
         );
       }
     };

--- a/packages/@expo/cli/src/utils/__tests__/ansi-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/ansi-test.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { stripAnsi } from '../ansi';
 
@@ -6,6 +6,8 @@ describe(stripAnsi, () => {
   it(`strips ansi`, () => {
     expect(stripAnsi()).toEqual(undefined);
     expect(stripAnsi(`\u001B[0m`)).toEqual('');
-    expect(stripAnsi(chalk`{bold hey} {underline you}`)).toEqual('hey you');
+    expect(stripAnsi(`${styleText('bold', 'hey')} ${styleText('underline', 'you')}`)).toEqual(
+      'hey you'
+    );
   });
 });

--- a/packages/@expo/cli/src/utils/args.ts
+++ b/packages/@expo/cli/src/utils/args.ts
@@ -1,8 +1,8 @@
 // Common utilities for interacting with `args` library.
 // These functions should be used by every command.
 import arg from 'arg';
-import chalk from 'chalk';
 import { existsSync } from 'fs';
+import { styleText } from 'node:util';
 import { resolve } from 'path';
 
 import * as Log from '../log';
@@ -53,14 +53,14 @@ export function assertWithOptionsArgs(
 
 export function printHelp(info: string, usage: string, options: string, extra: string = ''): never {
   Log.exit(
-    chalk`
-  {bold Info}
+    `
+  ${styleText('bold', `Info`)}
     ${info}
 
-  {bold Usage}
-    {dim $} ${usage}
+  ${styleText('bold', `Usage`)}
+    ${styleText('dim', `$`)} ${usage}
 
-  {bold Options}
+  ${styleText('bold', `Options`)}
     ${options.split('\n').join('\n    ')}
 ` + extra,
     0

--- a/packages/@expo/cli/src/utils/cocoapods.ts
+++ b/packages/@expo/cli/src/utils/cocoapods.ts
@@ -2,8 +2,8 @@ import type { PackageJSONConfig } from '@expo/config';
 import { getPackageJson } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Log from '../log';
@@ -99,7 +99,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
     } catch (error: any) {
       step.stopAndPersist({
         symbol: '⚠️ ',
-        text: chalk.red('Unable to install the CocoaPods CLI.'),
+        text: styleText('red', 'Unable to install the CocoaPods CLI.'),
       });
       if (error instanceof PackageManager.CocoaPodsError) {
         Log.log(error.message);
@@ -119,7 +119,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
   } catch (error: any) {
     step.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.red('Something went wrong running `pod install` in the `ios` directory.'),
+      text: styleText('red', 'Something went wrong running `pod install` in the `ios` directory.'),
     });
     if (error instanceof PackageManager.CocoaPodsError) {
       Log.log(error.message);
@@ -170,8 +170,8 @@ async function promptToInstallPodsAsync(projectRoot: string, missingPods?: strin
   if (missingPods?.length) {
     Log.log(
       `Could not find the following native modules: ${missingPods
-        .map((pod) => chalk.bold(pod))
-        .join(', ')}. Did you forget to run "${chalk.bold('pod install')}" ?`
+        .map((pod) => styleText('bold', pod))
+        .join(', ')}. Did you forget to run "${styleText('bold', 'pod install')}" ?`
     );
   }
 

--- a/packages/@expo/cli/src/utils/errors.ts
+++ b/packages/@expo/cli/src/utils/errors.ts
@@ -1,6 +1,6 @@
 import { AssertionError } from 'assert';
-import chalk from 'chalk';
 import { execSync } from 'child_process';
+import { styleText } from 'node:util';
 
 import { exit, exception, warn } from '../log';
 
@@ -69,9 +69,9 @@ export function logCmdError(error: any): never {
     exit(error);
   }
 
-  const errorDetails = error.stack ? '\n' + chalk.gray(error.stack) : '';
+  const errorDetails = error.stack ? '\n' + styleText('gray', error.stack) : '';
 
-  exit(chalk.red(error.toString()) + errorDetails);
+  exit(styleText('red', error.toString()) + errorDetails);
 }
 
 /** This should never be thrown in production. */

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { UnexpectedServerError, UnexpectedServerData } from '../api/graphql/client';
 import { AppQuery } from '../api/graphql/queries/AppQuery';
@@ -86,9 +86,10 @@ async function promptForBundleIdWithInitialAsync(
 ): Promise<string> {
   if (!bundleIdentifier) {
     memoLog(
-      chalk`\n{bold 📝  iOS Bundle Identifier} {dim ${learnMore(
-        'https://expo.fyi/bundle-identifier'
-      )}}\n`
+      `\n${styleText('bold', `📝  iOS Bundle Identifier`)} ${styleText(
+        'dim',
+        learnMore('https://expo.fyi/bundle-identifier')
+      )}\n`
     );
 
     // Prompt the user for the bundle ID.
@@ -126,7 +127,7 @@ async function promptForBundleIdWithInitialAsync(
       { ios: { bundleIdentifier } }
     )
   ) {
-    Log.log(chalk.gray`\u203A Apple bundle identifier: ${bundleIdentifier}`);
+    Log.log(styleText('gray', `\u203A Apple bundle identifier: ${bundleIdentifier}`));
   }
 
   return bundleIdentifier;
@@ -230,7 +231,7 @@ async function promptForPackageWithInitialAsync(
 ): Promise<string> {
   if (!packageName) {
     memoLog(
-      chalk`\n{bold 📝  Android package} {dim ${learnMore('https://expo.fyi/android-package')}}\n`
+      `\n${styleText('bold', `📝  Android package`)} ${styleText('dim', learnMore('https://expo.fyi/android-package'))}\n`
     );
 
     // Prompt the user for the android package.
@@ -266,7 +267,7 @@ async function promptForPackageWithInitialAsync(
       { android: { package: packageName } }
     )
   ) {
-    Log.log(chalk.gray`\u203A Android package name: ${packageName}`);
+    Log.log(styleText('gray', `\u203A Android package name: ${packageName}`));
   }
 
   return packageName;

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -1,5 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { env } from './env';
@@ -66,6 +66,11 @@ export async function validateGitStatusAsync(): Promise<boolean> {
 }
 
 function logWarning(warning: string, hint: string) {
-  Log.warn(chalk.bold`! ` + warning);
-  Log.log(chalk.gray`\u203A ` + chalk.gray(hint));
+  Log.warn(
+    styleText(
+      'bold',
+      `) + warning);
+  Log.log(styleText("gray", `
+    ) + styleText('gray', hint)
+  );
 }

--- a/packages/@expo/cli/src/utils/link.ts
+++ b/packages/@expo/cli/src/utils/link.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import terminalLink from 'terminal-link';
 
 /**
@@ -16,9 +16,9 @@ export function link(
   if (terminalLink.isSupported) {
     output = terminalLink(text, url);
   } else {
-    output = `${text === url ? '' : text + ': '}${chalk.underline(url)}`;
+    output = `${text === url ? '' : text + ': '}${styleText('underline', url)}`;
   }
-  return dim ? chalk.dim(output) : output;
+  return dim ? styleText('dim', output) : output;
 }
 
 /**

--- a/packages/@expo/cli/src/utils/modifyConfigAsync.ts
+++ b/packages/@expo/cli/src/utils/modifyConfigAsync.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from '@expo/config';
 import { modifyConfigAsync } from '@expo/config';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { SilentError } from './errors';
@@ -24,14 +24,14 @@ export function warnAboutConfigAndThrow(type: string, message: string, edits: Pa
   Log.log();
   if (type === 'warn') {
     // The project is using a dynamic config, give the user a helpful log and bail out.
-    Log.log(chalk.yellow(message));
+    Log.log(styleText('yellow', message));
   }
   notifyAboutManualConfigEdits(edits);
   throw new SilentError();
 }
 
 function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
-  Log.log(chalk.cyan(`Add the following to your Expo config`));
+  Log.log(styleText('cyan', `Add the following to your Expo config`));
   Log.log();
   Log.log(JSON.stringify(edits, null, 2));
   Log.log();

--- a/packages/@expo/cli/src/utils/nodeModules.ts
+++ b/packages/@expo/cli/src/utils/nodeModules.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { logNewSection } from './ora';
@@ -13,6 +13,6 @@ export async function clearNodeModulesAsync(projectRoot: string) {
   // TODO: this is substantially slower, we should find a better alternative to ensuring the modules are installed.
   await fs.promises.rm(path.join(projectRoot, 'node_modules'), { recursive: true, force: true });
   cleanJsDepsStep.succeed(
-    `Cleaned JavaScript dependencies ${chalk.gray(Date.now() - time + 'ms')}`
+    `Cleaned JavaScript dependencies ${styleText('gray', Date.now() - time + 'ms')}`
   );
 }

--- a/packages/@expo/cli/src/utils/ora.ts
+++ b/packages/@expo/cli/src/utils/ora.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import type { Ora } from 'ora';
 import oraReal from 'ora';
 
@@ -95,7 +95,7 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
  * @returns
  */
 export function logNewSection(title: string) {
-  const spinner = ora(chalk.bold(title));
+  const spinner = ora(styleText('bold', title));
   // Prevent the spinner from clashing with debug logs
   spinner.start();
   return spinner;

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { env } from './env';
@@ -86,23 +86,23 @@ export async function choosePortAsync(
 
     let message = isRestricted
       ? `Admin permissions are required to run a server on a port below 1024`
-      : `Port ${chalk.bold(defaultPort)} is`;
+      : `Port ${styleText('bold', `${defaultPort}`)} is`;
 
     const { getRunningProcess } =
       require('./getRunningProcess') as typeof import('./getRunningProcess');
     const runningProcess = isRestricted ? null : await getRunningProcess(defaultPort);
 
     if (runningProcess) {
-      const pidTag = chalk.gray(`(pid ${runningProcess.pid})`);
+      const pidTag = styleText('gray', `(pid ${runningProcess.pid})`);
       if (runningProcess.directory === projectRoot) {
         message += ` running this app in another window`;
         if (reuseExistingPort) {
           return null;
         }
       } else {
-        message += ` running ${chalk.cyan(runningProcess.command)} in another window`;
+        message += ` running ${styleText('cyan', runningProcess.command)} in another window`;
       }
-      message += '\n' + chalk.gray(`  ${runningProcess.directory} ${pidTag}`);
+      message += '\n' + styleText('gray', `  ${runningProcess.directory} ${pidTag}`);
     } else {
       message += ' being used by another process';
     }
@@ -118,7 +118,7 @@ export async function choosePortAsync(
     if (error.code === 'ABORTED') {
       throw error;
     } else if (error.code === 'NON_INTERACTIVE') {
-      Log.warn(chalk.yellow(error.message));
+      Log.warn(styleText('yellow', error.message));
       return null;
     }
     throw error;

--- a/packages/@expo/cli/src/utils/profile.ts
+++ b/packages/@expo/cli/src/utils/profile.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { env } from './env';
@@ -18,7 +18,7 @@ export function profile<IArgs extends any[], T extends (...args: IArgs) => any>(
     return fn;
   }
 
-  const name = chalk.dim(`⏱  [profile] ${functionName ?? 'unknown'}`);
+  const name = styleText('dim', `⏱  [profile] ${functionName ?? 'unknown'}`);
 
   return ((...args: IArgs) => {
     // Start the timer.

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Log } from '../log';
 import { env } from './env';
@@ -227,9 +227,7 @@ export async function getPackageNameWarningInternalAsync(
     if (response.status === 200) {
       // There is no JSON API for the Play Store so we can't concisely
       // locate the app name and developer to match the iOS warning.
-      return `⚠️  The package ${chalk.bold(packageName)} is already in use. ${chalk.dim(
-        learnMore(url)
-      )}`;
+      return `⚠️  The package ${styleText('bold', packageName)} is already in use. ${styleText('dim', learnMore(url))}`;
     }
   } catch (error: any) {
     // Error fetching play store data or the page doesn't exist.
@@ -239,9 +237,7 @@ export async function getPackageNameWarningInternalAsync(
 }
 
 function formatInUseWarning(appName: string, author: string, id: string): string {
-  return `⚠️  The app ${chalk.bold(appName)} by ${chalk.italic(
-    author
-  )} is already using ${chalk.bold(id)}`;
+  return `⚠️  The app ${styleText('bold', appName)} by ${styleText('italic', author)} is already using ${styleText('bold', id)}`;
 }
 
 /** Returns a warning message if an Android package name is potentially already in use. */

--- a/packages/@expo/cli/src/whoami/whoamiAsync.ts
+++ b/packages/@expo/cli/src/whoami/whoamiAsync.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { getActorDisplayName, getUserAsync } from '../api/user/user';
 import * as Log from '../log';
@@ -6,7 +6,7 @@ import * as Log from '../log';
 export async function whoamiAsync() {
   const user = await getUserAsync();
   if (user) {
-    Log.exit(chalk.green(getActorDisplayName(user)), 0);
+    Log.exit(styleText('green', getActorDisplayName(user)), 0);
   } else {
     Log.exit('Not logged in');
   }

--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -94,7 +94,6 @@
     "@expo/plist": "workspace:^0.7.0",
     "@expo/require-utils": "workspace:^56.1.3",
     "@expo/sdk-runtime-versions": "^1.0.0",
-    "chalk": "^4.1.2",
     "debug": "^4.3.5",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",

--- a/packages/@expo/config-plugins/src/plugins/withMod.ts
+++ b/packages/@expo/config-plugins/src/plugins/withMod.ts
@@ -1,7 +1,7 @@
 import type { ExpoConfig } from '@expo/config-types';
 import type { JSONObject } from '@expo/json-file';
-import chalk from 'chalk';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 
 import type { ExportedConfig, ExportedConfigWithProps, Mod, ModPlatform } from '../Plugin.types';
 import { PluginError } from '../utils/errors';
@@ -80,7 +80,7 @@ export function withBaseMod<T>(
     const stack = new Error().stack;
     // Format the stack trace to create the debug log
     debugTrace = getDebugPluginStackFromStackTrace(stack);
-    const modStack = chalk.bold(`${platform}.${mod}`);
+    const modStack = styleText('bold', `${platform}.${mod}`);
 
     debugTrace = `${modStack}: ${debugTrace}`;
   }
@@ -179,18 +179,18 @@ function getDebugPluginStackFromStackTrace(stacktrace?: string): string {
       .map((pluginName, index) => {
         // Base mods indicate a logical section.
         if (pluginName.includes('BaseMod')) {
-          pluginName = chalk.bold(pluginName);
+          pluginName = styleText('bold', pluginName);
         }
         // highlight dangerous mods
         if (pluginName.toLowerCase().includes('dangerous')) {
-          pluginName = chalk.red(pluginName);
+          pluginName = styleText('red', pluginName);
         }
 
         if (index === 0) {
-          return chalk.blue(pluginName);
+          return styleText('blue', pluginName);
         } else if (commonPlugins.includes(pluginName)) {
           // Common mod names often clutter up the logs, dim them out
-          return chalk.dim(pluginName);
+          return styleText('dim', pluginName);
         }
         return pluginName;
       })

--- a/packages/@expo/config-plugins/src/utils/warnings.ts
+++ b/packages/@expo/config-plugins/src/utils/warnings.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { ModPlatform } from '../Plugin.types';
 
@@ -42,7 +42,8 @@ export function addWarningForPlatform(
 }
 
 function formatWarning(platform: string, property: string, warning: string, link?: string) {
-  return chalk.yellow`${'» ' + chalk.bold(platform)}: ${property}: ${warning}${
-    link ? chalk.gray(' ' + link) : ''
-  }`;
+  return styleText(
+    'yellow',
+    `» ${styleText('bold', platform)}: ${property} ${warning}${link ? styleText('gray', ` ${link}`) : ''}`
+  );
 }

--- a/packages/@expo/config-types/package.json
+++ b/packages/@expo/config-types/package.json
@@ -52,7 +52,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
-    "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "expo-module-scripts": "workspace:*",
     "json-schema-to-typescript": "^15.0.0",

--- a/packages/@expo/config-types/scripts/generate.js
+++ b/packages/@expo/config-types/scripts/generate.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
+const { styleText } = require('node:util');
 const { Command } = require('commander');
 const { compile } = require('json-schema-to-typescript');
 const fs = require('node:fs');
@@ -15,7 +15,7 @@ const packageJSON = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
   .arguments('[version]')
-  .usage(`${chalk.green('[version]')} [options]`)
+  .usage(`${styleText('green', '[version]')} [options]`)
   .description('Generate TypeScript types from the Expo config JSON schema.')
   .option('-p, --path <schema-path>', 'Path to a local JSON schema to use.')
   .action(

--- a/packages/@expo/devtools/package.json
+++ b/packages/@expo/devtools/package.json
@@ -47,9 +47,7 @@
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -p tsconfig.json"
   },
-  "dependencies": {
-    "chalk": "^4.1.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^29.2.1",
     "@types/node": "^22.14.0",

--- a/packages/@expo/env/package.json
+++ b/packages/@expo/env/package.json
@@ -32,7 +32,6 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "getenv": "^2.0.0"
   },

--- a/packages/@expo/env/src/index.ts
+++ b/packages/@expo/env/src/index.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk';
 import { boolish } from 'getenv';
 import console from 'node:console';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { isIgnoredEnvKey, isLocalEnvKey, isUnsafeAllowedEnvKey } from './constants';
 import { parse, expand, type EnvOutput } from './parse';
@@ -344,19 +344,17 @@ export function logLoadedEnv(
 
   // Log the loaded environment files, when not skipped
   if (envInfo.result === 'loaded') {
-    console.log(
-      chalk.gray('env: load', envInfo.files.map((file) => path.basename(file)).join(' '))
-    );
+    console.log(styleText('gray', 'env: load'));
   }
 
   // Log the loaded environment variables
-  console.log(chalk.gray('env: export', envInfo.loaded.join(' ')));
+  console.log(styleText('gray', 'env: export'));
 
   // Highlight developer-tool roots / secrets that were loaded from a .local file —
   // the same keys would be refused from any non-.local file. Surfacing them here
   // tells the user which "sensitive" values are influencing the build.
   if (envInfo.result === 'loaded' && envInfo.sensitiveLoadedKeys?.length) {
-    console.log(chalk.yellow('env: export (sensitive)', envInfo.sensitiveLoadedKeys.join(' ')));
+    console.log(styleText('yellow', 'env: export (sensitive)'));
   }
 
   return envInfo;

--- a/packages/@expo/fingerprint/cli/src/cli.ts
+++ b/packages/@expo/fingerprint/cli/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import arg from 'arg';
-import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 
 import { runLegacyCLIAsync } from './runLegacyCLIAsync';
 import { logCmdError } from './utils/errors';
@@ -52,18 +52,18 @@ const commandArgs = args._.slice(1);
 // Handle `--help` flag
 if ((args['--help'] && !command) || !command) {
   Log.exit(
-    chalk`
-{bold Usage}
-  {dim $} npx @expo/fingerprint <command>
+    `
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx @expo/fingerprint <command>
 
-{bold Commands}
+${styleText('bold', 'Commands')}
   ${Object.keys(commands).sort().join(', ')}
 
-{bold Options}
+${styleText('bold', 'Options')}
   --help, -h      Displays this message
 
 For more information run a command with the --help flag
-  {dim $} npx @expo/fingerprint fingerprint:generate --help
+  ${styleText('dim', '$')} npx @expo/fingerprint fingerprint:generate --help
   `,
     0
   );

--- a/packages/@expo/fingerprint/cli/src/commands/diffFingerprints.ts
+++ b/packages/@expo/fingerprint/cli/src/commands/diffFingerprints.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { diffFingerprints } from '../../../build/index';
 import { Command } from '../cli';
@@ -20,12 +20,12 @@ export const diffFingerprintsAsync: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Diff two fingerprints
 
-{bold Usage}
-  {dim $} npx @expo/fingerprint fingerprint:diff <fingerprintFile1> <fingerprintFile2>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx @expo/fingerprint fingerprint:diff <fingerprintFile1> <fingerprintFile2>
 
   Options
   -h, --help                           Output usage information

--- a/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
+++ b/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 
 import { Options, createFingerprintAsync } from '../../../build/index';
 import { Command } from '../cli';
@@ -27,12 +27,12 @@ export const generateFingerprintAsync: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Generate fingerprint for a project
 
-{bold Usage}
-  {dim $} npx @expo/fingerprint fingerprint:generate
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx @expo/fingerprint fingerprint:generate
 
   Options
   --platform <string[]>                Limit native files to those for specified platforms. Default is ['android', 'ios'].

--- a/packages/@expo/fingerprint/cli/src/utils/errors.ts
+++ b/packages/@expo/fingerprint/cli/src/utils/errors.ts
@@ -1,5 +1,5 @@
 import { AssertionError } from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { exit } from './log';
 
@@ -37,7 +37,7 @@ export function logCmdError(error: any): never {
     exit(error);
   }
 
-  const errorDetails = error.stack ? '\n' + chalk.gray(error.stack) : '';
+  const errorDetails = error.stack ? '\n' + styleText('gray', error.stack) : '';
 
-  exit(chalk.red(error.toString()) + errorDetails);
+  exit(styleText('red', error.toString()) + errorDetails);
 }

--- a/packages/@expo/fingerprint/cli/src/utils/log.ts
+++ b/packages/@expo/fingerprint/cli/src/utils/log.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export function time(label?: string): void {
   console.time(label);
@@ -14,11 +14,14 @@ export function error(...message: string[]): void {
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  error(chalk.red(e.toString()) + (process.env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(
+    styleText('red', e.toString()) +
+      (process.env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : '')
+  );
 }
 
 export function warn(...message: string[]): void {
-  console.warn(...message.map((value) => chalk.yellow(value)));
+  console.warn(...message.map((value) => styleText('yellow', value)));
 }
 
 export function log(...message: string[]): void {

--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -49,7 +49,6 @@
     "@expo/env": "workspace:^2.3.0",
     "@expo/spawn-async": "^1.8.0",
     "arg": "^5.0.2",
-    "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",

--- a/packages/@expo/fingerprint/src/sourcer/Bare.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Bare.ts
@@ -1,8 +1,8 @@
 import { getOriginalEnv } from '@expo/env';
 import spawnAsync from '@expo/spawn-async';
 import assert from 'assert';
-import chalk from 'chalk';
 import process from 'node:process';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -21,7 +21,7 @@ export async function getBareAndroidSourcesAsync(
   if (options.platforms.includes('android')) {
     const result = await getFileBasedHashSourceAsync(projectRoot, 'android', 'bareNativeDir');
     if (result != null) {
-      debug(`Adding bare native dir - ${chalk.dim('android')}`);
+      debug(`Adding bare native dir - ${styleText('dim', 'android')}`);
       return [result];
     }
   }
@@ -35,7 +35,7 @@ export async function getBareIosSourcesAsync(
   if (options.platforms.includes('ios')) {
     const result = await getFileBasedHashSourceAsync(projectRoot, 'ios', 'bareNativeDir');
     if (result != null) {
-      debug(`Adding bare native dir - ${chalk.dim('ios')}`);
+      debug(`Adding bare native dir - ${styleText('dim', 'ios')}`);
       return [result];
     }
   }
@@ -58,7 +58,7 @@ export async function getPackageJsonScriptSourcesAsync(
   }
   const results: HashSource[] = [];
   if (packageJson.scripts) {
-    debug(`Adding package.json contents - ${chalk.dim('scripts')}`);
+    debug(`Adding package.json contents - ${styleText('dim', 'scripts')}`);
     const id = 'packageJson:scripts';
     results.push({
       type: 'contents',
@@ -76,7 +76,7 @@ export async function getGitIgnoreSourcesAsync(projectRoot: string, options: Nor
   }
   const result = await getFileBasedHashSourceAsync(projectRoot, '.gitignore', 'bareGitIgnore');
   if (result != null) {
-    debug(`Adding file - ${chalk.dim('.gitignore')}`);
+    debug(`Adding file - ${styleText('dim', '.gitignore')}`);
     return [result];
   }
   return [];
@@ -103,7 +103,7 @@ export async function getCoreAutolinkingSourcesFromRncCliAsync(
     });
     return results;
   } catch (e) {
-    debug(chalk.red(`Error adding react-native core autolinking sources.\n${e}`));
+    debug(styleText('red', `Error adding react-native core autolinking sources.\n${e}`));
     return [];
   }
 }
@@ -137,7 +137,9 @@ export async function getCoreAutolinkingSourcesFromExpoAndroid(
     });
     return results;
   } catch (e) {
-    debug(chalk.red(`Error adding react-native core autolinking sources for android.\n${e}`));
+    debug(
+      styleText('red', `Error adding react-native core autolinking sources for android.\n${e}`)
+    );
     return [];
   }
 }
@@ -171,7 +173,7 @@ export async function getCoreAutolinkingSourcesFromExpoIos(
     });
     return results;
   } catch (e) {
-    debug(chalk.red(`Error adding react-native core autolinking sources for ios.\n${e}`));
+    debug(styleText('red', `Error adding react-native core autolinking sources for ios.\n${e}`));
     return [];
   }
 }
@@ -197,12 +199,12 @@ async function parseCoreAutolinkingSourcesAsync({
     try {
       stripRncoreAutolinkingAbsolutePaths(depData, root);
       const filePath = toPosixPath(depData.root);
-      debug(`Adding ${logTag} - ${chalk.dim(filePath)}`);
+      debug(`Adding ${logTag} - ${styleText('dim', filePath)}`);
       results.push({ type: 'dir', filePath, reasons });
 
       autolinkingConfig[depName] = depData;
     } catch (e) {
-      debug(chalk.red(`Error adding ${logTag} - ${depName}.\n${e}`));
+      debug(styleText('red', `Error adding ${logTag} - ${depName}.\n${e}`));
     }
   }
 

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -1,8 +1,8 @@
 import type { ExpoConfig, ProjectConfig } from '@expo/config';
 import { getOriginalEnv } from '@expo/env';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import type { Props as SplashProps } from 'expo-splash-screen/plugin';
+import { styleText } from 'node:util';
 import path from 'path';
 import semver from 'semver';
 
@@ -244,7 +244,7 @@ export async function createHashSourceExternalFileAsync({
 }): Promise<HashSource | null> {
   const hashSource = await getFileBasedHashSourceAsync(projectRoot, file, reason);
   if (hashSource) {
-    debug(`Adding config external file - ${chalk.dim(file)}`);
+    debug(`Adding config external file - ${styleText('dim', file)}`);
     if (hashSource.type === 'file' || hashSource.type === 'dir') {
       // We include the expo config contents in the fingerprint,
       // the `filePath` hashing for the external files is not necessary.
@@ -264,7 +264,7 @@ export async function getEasBuildSourcesAsync(projectRoot: string, options: Norm
       files.map(async (file) => {
         const result = await getFileBasedHashSourceAsync(projectRoot, file, 'easBuild');
         if (result != null) {
-          debug(`Adding eas file - ${chalk.dim(file)}`);
+          debug(`Adding eas file - ${styleText('dim', file)}`);
         }
         return result;
       })
@@ -296,7 +296,7 @@ export async function getExpoAutolinkingAndroidSourcesAsync(
       for (const project of module.projects) {
         const filePath = toPosixPath(path.relative(realProjectRoot, project.sourceDir));
         project.sourceDir = filePath; // use relative path for the dir
-        debug(`Adding expo-modules-autolinking android dir - ${chalk.dim(filePath)}`);
+        debug(`Adding expo-modules-autolinking android dir - ${styleText('dim', filePath)}`);
         results.push({ type: 'dir', filePath, reasons });
         // `aarProjects` is present in project starting from SDK 53+.
         if (project.aarProjects) {
@@ -321,7 +321,7 @@ export async function getExpoAutolinkingAndroidSourcesAsync(
         for (const plugin of module.plugins) {
           const filePath = toPosixPath(path.relative(realProjectRoot, plugin.sourceDir));
           plugin.sourceDir = filePath; // use relative path for the dir
-          debug(`Adding expo-modules-autolinking android dir - ${chalk.dim(filePath)}`);
+          debug(`Adding expo-modules-autolinking android dir - ${styleText('dim', filePath)}`);
           results.push({ type: 'dir', filePath, reasons });
         }
       }
@@ -359,7 +359,7 @@ export async function getExpoCNGPatchSourcesAsync(
 ): Promise<HashSource[]> {
   const result = await getFileBasedHashSourceAsync(projectRoot, 'cng-patches', 'expoCNGPatches');
   if (result != null) {
-    debug(`Adding dir - ${chalk.dim('cng-patches')}`);
+    debug(`Adding dir - ${styleText('dim', 'cng-patches')}`);
     return [result];
   }
   return [];
@@ -390,7 +390,7 @@ export async function getExpoAutolinkingIosSourcesAsync(
       for (const pod of module.pods) {
         const filePath = toPosixPath(path.relative(realProjectRoot, pod.podspecDir));
         pod.podspecDir = filePath; // use relative path for the dir
-        debug(`Adding expo-modules-autolinking ios dir - ${chalk.dim(filePath)}`);
+        debug(`Adding expo-modules-autolinking ios dir - ${styleText('dim', filePath)}`);
         results.push({ type: 'dir', filePath, reasons });
       }
     }

--- a/packages/@expo/fingerprint/src/sourcer/Packages.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Packages.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -50,7 +50,7 @@ export async function getPackageSourceAsync(
     return null;
   }
 
-  debug(`Adding package - ${chalk.dim(params.packageName)}`);
+  debug(`Adding package - ${styleText('dim', params.packageName)}`);
 
   if (params.packageJsonOnly) {
     return {

--- a/packages/@expo/fingerprint/src/sourcer/PatchPackage.ts
+++ b/packages/@expo/fingerprint/src/sourcer/PatchPackage.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { HashSource, NormalizedOptions } from '../Fingerprint.types';
 import { isIgnoredPathWithMatchObjects } from '../utils/Path';
@@ -11,12 +11,12 @@ export async function getPatchPackageSourcesAsync(
   options: NormalizedOptions
 ): Promise<HashSource[]> {
   if (isIgnoredPathWithMatchObjects('patches', options.ignoreDirMatchObjects)) {
-    debug(`Skipping dir - ${chalk.dim('patches')} (ignored by ignoreDirMatchObjects)`);
+    debug(`Skipping dir - ${styleText('dim', 'patches')} (ignored by ignoreDirMatchObjects)`);
     return [];
   }
   const result = await getFileBasedHashSourceAsync(projectRoot, 'patches', 'patchPackage');
   if (result != null) {
-    debug(`Adding dir - ${chalk.dim('patches')}`);
+    debug(`Adding dir - ${styleText('dim', 'patches')}`);
     return [result];
   }
   return [];

--- a/packages/@expo/fingerprint/src/sourcer/Sourcer.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Sourcer.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { getExpoConfigAsync } from '../ExpoConfig';
@@ -92,7 +92,7 @@ export async function getHashSourcesAsync(
   // extra sources
   if (options.extraSources) {
     for (const source of options.extraSources) {
-      debug(`Adding extra source - ${chalk.dim(JSON.stringify(source))}`);
+      debug(`Adding extra source - ${styleText('dim', JSON.stringify(source))}`);
     }
     results.push(options.extraSources);
   }

--- a/packages/@expo/fingerprint/src/utils/Profile.ts
+++ b/packages/@expo/fingerprint/src/utils/Profile.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { NormalizedOptions } from '../Fingerprint.types';
 
@@ -18,7 +18,7 @@ export function profile<IArgs extends any[], T extends (...args: IArgs) => any>(
     return fn;
   }
 
-  const name = chalk.dim(`⏱  [profile] ${functionName ?? 'unknown'}`);
+  const name = styleText('dim', `⏱  [profile] ${functionName ?? 'unknown'}`);
 
   return ((...args: IArgs) => {
     // Start the timer.

--- a/packages/@expo/image-utils/package.json
+++ b/packages/@expo/image-utils/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@expo/require-utils": "workspace:^56.1.3",
     "@expo/spawn-async": "^1.8.0",
-    "chalk": "^4.0.0",
     "getenv": "^2.0.0",
     "jimp-compact": "0.16.1",
     "parse-png": "^2.1.0",

--- a/packages/@expo/image-utils/src/Image.ts
+++ b/packages/@expo/image-utils/src/Image.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import parsePng from 'parse-png';
 import path from 'path';
 
@@ -115,7 +115,8 @@ async function maybeWarnAboutInstallingSharpAsync() {
   if (env.EXPO_IMAGE_UTILS_DEBUG && !hasWarned && !(await Sharp.isAvailableAsync())) {
     hasWarned = true;
     console.warn(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `Using node to generate images. This is much slower than using native packages.\n\u203A Optionally you can stop the process and try again after successfully running \`npm install -g sharp-cli\`.\n`
       )
     );

--- a/packages/@expo/image-utils/src/sharp.ts
+++ b/packages/@expo/image-utils/src/sharp.ts
@@ -1,7 +1,7 @@
 import { resolveFrom, resolveGlobal } from '@expo/require-utils';
 import spawnAsync from '@expo/spawn-async';
 import assert from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import semver from 'semver';
 
@@ -206,13 +206,18 @@ function showVersionMismatchWarning(requiredCliVersion: string, installedCliVers
   }
   console.warn(
     [
-      chalk.yellow(
+      styleText(
+        'yellow',
         `Expo supports version "${requiredCliVersion}" of \`sharp-cli\`, current version: "${installedCliVersion}".`
       ),
-      chalk.yellow.dim(
+      styleText(
+        ['yellow', 'dim'],
         `If you can remove or upgrade using \`npm (un)install -g sharp-cli@${requiredCliVersion}\`.`
       ),
-      chalk.yellow.dim(`Or disable \`sharp-cli\` with \`EXPO_IMAGE_UTILS_NO_SHARP=1\`.`),
+      styleText(
+        ['yellow', 'dim'],
+        `Or disable \`sharp-cli\` with \`EXPO_IMAGE_UTILS_NO_SHARP=1\`.`
+      ),
     ].join('\n')
   );
   versionMismatchWarningShown = true;

--- a/packages/@expo/local-build-cache-provider/package.json
+++ b/packages/@expo/local-build-cache-provider/package.json
@@ -45,8 +45,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@expo/config": "workspace:~56.0.9",
-    "chalk": "^4.1.2"
+    "@expo/config": "workspace:~56.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/packages/@expo/local-build-cache-provider/src/index.ts
+++ b/packages/@expo/local-build-cache-provider/src/index.ts
@@ -4,9 +4,9 @@ import type {
   RunOptions,
   UploadBuildCacheProps,
 } from '@expo/config';
-import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+import { styleText } from 'node:util';
 
 type Options = {
   cacheDir?: string;
@@ -51,7 +51,7 @@ async function uploadBuildCacheAsync(
   }
 
   try {
-    console.log(chalk`{whiteBright \u203A} {bold Copying build to local cache}`);
+    console.log(`${styleText('whiteBright', '\u203A')} ${styleText('bold', 'Copying build to local cache')}`);
     const destFile = `${platform}-${fingerprintHash}-${getBuildVariant(runOptions)}${path.extname(buildPath)}`;
     const destPath = path.join(cacheDir, destFile);
 

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -84,7 +84,6 @@
     "@jridgewell/remapping": "^2.3.5",
     "@jridgewell/sourcemap-codec": "^1.5.5",
     "browserslist": "^4.25.0",
-    "chalk": "^4.1.0",
     "debug": "^4.3.2",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -11,7 +11,7 @@ import type {
   ReadOnlyGraph,
   Options as GraphOptions,
 } from '@expo/metro/metro/DeltaBundler/types';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -224,7 +224,8 @@ export function getDefaultConfig(
   if (reactNativePath === 'react-native' && !hasWarnedAboutReactNative) {
     hasWarnedAboutReactNative = true;
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `\u203A Could not resolve react-native! Is it installed and a project dependency?`
       )
     );
@@ -254,7 +255,10 @@ export function getDefaultConfig(
   } catch (error: any) {
     if (error && error.name === 'ConfigError') {
       console.log(
-        chalk.yellow(`\u203A Could not find a package.json at the project root! ("${projectRoot}")`)
+        styleText(
+          'yellow',
+          `\u203A Could not find a package.json at the project root! ("${projectRoot}")`
+        )
       );
     } else {
       throw error;

--- a/packages/@expo/metro-config/src/rewriteRequestUrl.ts
+++ b/packages/@expo/metro-config/src/rewriteRequestUrl.ts
@@ -2,8 +2,8 @@
 import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import { resolveEntryPoint, getMetroServerRoot } from '@expo/config/paths';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 const debug = require('debug')('expo:metro:config:rewriteRequestUrl');
@@ -85,7 +85,7 @@ export function getRewriteRequestUrl(projectRoot: string) {
 
       if (!entry) {
         throw new Error(
-          chalk`The project entry file could not be resolved (platform: ${platform}, root: ${projectRoot}). Define it in the {bold package.json} "main" field.`
+          `The project entry file could not be resolved (platform: ${platform}, root: ${projectRoot}). Define it in the ${styleText('bold', `package.json`)} "main" field.`
         );
       }
 

--- a/packages/@expo/metro-config/src/serializer/exportHermes.ts
+++ b/packages/@expo/metro-config/src/serializer/exportHermes.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 import process from 'process';
@@ -131,7 +131,7 @@ async function directlyBuildHermesBundleAsync({
       sourcemap,
     };
   } catch (error: any) {
-    console.error(chalk.red(`\nFailed to generate Hermes bytecode for: ${filename}`));
+    console.error(styleText('red', `\nFailed to generate Hermes bytecode for: ${filename}`));
     if ('status' in error) {
       console.error(error.output.join('\n'));
     }

--- a/packages/@expo/package-manager/package.json
+++ b/packages/@expo/package-manager/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@expo/json-file": "workspace:^10.2.0",
     "@expo/spawn-async": "^1.8.0",
-    "chalk": "^4.0.0",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",
     "resolve-workspace-root": "^2.0.0"

--- a/packages/@expo/package-manager/src/ios/CocoaPodsPackageManager.ts
+++ b/packages/@expo/package-manager/src/ios/CocoaPodsPackageManager.ts
@@ -1,6 +1,6 @@
 import type { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from "node:util";
 import fs from 'fs';
 import type { Ora } from 'ora';
 import os from 'os';
@@ -111,8 +111,8 @@ export class CocoaPodsPackageManager {
       return true;
     } catch (error: any) {
       if (!silent) {
-        console.log(chalk.yellow(`\u203A Failed to install CocoaPods CLI with Gem`));
-        console.log(chalk.red(error.stderr ?? error.message));
+        console.log(styleText("yellow", `\u203A Failed to install CocoaPods CLI with Gem`));
+        console.log(styleText("red", error.stderr ?? error.message));
         console.log(`\u203A Attempting to install CocoaPods CLI with Homebrew`);
       }
       try {
@@ -142,9 +142,7 @@ export class CocoaPodsPackageManager {
       } catch (error: any) {
         !silent &&
           console.warn(
-            chalk.yellow(
-              `\u203A Failed to install CocoaPods with Homebrew. Install CocoaPods CLI and try again: https://cocoapods.org/`
-            )
+            styleText("yellow", `\u203A Failed to install CocoaPods with Homebrew. Install CocoaPods CLI and try again: https://cocoapods.org/`)
           );
         throw new CocoaPodsError(
           `Failed to install CocoaPods with Homebrew. Install CocoaPods CLI and try again: https://cocoapods.org/`,
@@ -157,11 +155,11 @@ export class CocoaPodsPackageManager {
 
   static isAvailable(projectRoot: string, silent: boolean): boolean {
     if (process.platform !== 'darwin') {
-      !silent && console.log(chalk.red('CocoaPods is only supported on macOS machines'));
+      !silent && console.log(styleText("red", 'CocoaPods is only supported on macOS machines'));
       return false;
     }
     if (!CocoaPodsPackageManager.isUsingPods(projectRoot)) {
-      !silent && console.log(chalk.yellow('CocoaPods is not supported in this project'));
+      !silent && console.log(styleText("yellow", 'CocoaPods is not supported in this project'));
       return false;
     }
     return true;
@@ -183,7 +181,7 @@ export class CocoaPodsPackageManager {
       // NOTE(@kitten): We abort here to prevent any command from proceeding
       // We don't want to trigger `installCLIAsync` and let users resolve this
       if (useBundler) {
-        console.warn(chalk.yellow(`\u203A Failed to run \`bundle exec pod\``));
+        console.warn(styleText("yellow", `\u203A Failed to run \`bundle exec pod\``));
         throw new CocoaPodsError(error.stderr, 'COMMAND_FAILED');
       }
       return false;
@@ -302,9 +300,7 @@ export class CocoaPodsPackageManager {
       ['update', updatePackage, shouldUpdateRepo ? '' : '--no-repo-update'].filter(Boolean),
       {
         formatWarning() {
-          const updateMessage = `Failed to update ${chalk.bold(
-            updatePackage
-          )}. Attempting to update the repo instead.`;
+          const updateMessage = `Failed to update ${styleText("bold", updatePackage)}. Attempting to update the repo instead.`;
           return updateMessage;
         },
         spinner,
@@ -358,10 +354,10 @@ export class CocoaPodsPackageManager {
       if (formatWarning) {
         const warning = formatWarning(error);
         if (props.spinner) {
-          props.spinner.text = chalk.bold(warning);
+          props.spinner.text = styleText("bold", warning);
         }
         if (!this.silent) {
-          console.warn(chalk.yellow(warning));
+          console.warn(styleText("yellow", warning));
         }
       }
 
@@ -474,7 +470,7 @@ export function getPodRepoUpdateMessage(errorOutput: string) {
 
   let message: string;
   if (warningInfo) {
-    message = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}.`;
+    message = `Couldn't install: ${warningInfo[1]} » ${styleText("underline", warningInfo[0])}.`;
   } else if (brokenPackage?.updatePackage) {
     message = `Couldn't install: ${brokenPackage?.updatePackage}.`;
   } else {
@@ -505,7 +501,7 @@ export function getImprovedPodInstallError(
     const warningInfo = extractMissingDependencyError(errorOutput);
     let reason: string;
     if (warningInfo) {
-      reason = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}`;
+      reason = `Couldn't install: ${warningInfo[1]} » ${styleText("underline", warningInfo[0])}`;
     } else {
       reason = `This is often due to native package versions mismatching`;
     }
@@ -533,7 +529,7 @@ export function getImprovedPodInstallError(
       const firstWarning = cocoapodsDebugInfo.findIndex((v) => v.startsWith('[!]'));
       if (firstWarning !== -1) {
         const warning = cocoapodsDebugInfo.slice(firstWarning).join(os.EOL);
-        error.message += `\n\n${chalk.gray(warning)}`;
+        error.message += `\n\n${styleText("gray", warning)}`;
       }
     }
     return new CocoaPodsError(

--- a/packages/create-expo-module/package.json
+++ b/packages/create-expo-module/package.json
@@ -52,7 +52,6 @@
     "@types/prompts": "^2.4.9",
     "@types/validate-npm-package-name": "^4.0.2",
     "@vercel/ncc": "^0.38.4",
-    "chalk": "^4.1.2",
     "commander": "^8.3.0",
     "cross-spawn": "^7.0.5",
     "debug": "^4.3.4",

--- a/packages/create-expo-module/src/addPlatformSupport.ts
+++ b/packages/create-expo-module/src/addPlatformSupport.ts
@@ -1,7 +1,7 @@
-import chalk from 'chalk';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import { detectFeaturesFromFile, findModuleDefinitionFile } from './featureDetection';
@@ -284,7 +284,7 @@ type TemplatePathInfo = {
 };
 
 function exitWithError(message: string): never {
-  console.error(chalk.red(message));
+  console.error(styleText('red', message));
   process.exit(1);
 }
 
@@ -338,7 +338,7 @@ async function resolvePlatformsToAdd(
   const availablePlatforms = ALL_PLATFORMS.filter((p) => !moduleInfo.platforms.includes(p));
 
   if (availablePlatforms.length === 0) {
-    console.log(chalk.yellow('ℹ️  All platforms are already supported by this module.'));
+    console.log(styleText('yellow', 'ℹ️  All platforms are already supported by this module.'));
     return null;
   }
 
@@ -413,13 +413,15 @@ async function resolveDetectedFeatures(
     const { features, sharedObjectName } = await detectFeaturesFromFile(moduleDefinitionFile);
     if (features.length === 0) {
       console.warn(
-        chalk.yellow(
+        styleText(
+          'yellow',
           '⚠️  No features detected in the module definition. Generating a minimal scaffold.'
         )
       );
     } else {
       console.log(
-        chalk.dim(
+        styleText(
+          'dim',
           `Detected features from ${path.relative(CWD, moduleDefinitionFile)} (best effort). ` +
             'Use --features to override.'
         )
@@ -429,7 +431,7 @@ async function resolveDetectedFeatures(
   }
 
   // Web-only module adding a native platform: no ModuleDefinition to scan.
-  console.log(chalk.dim('No native module definition found. Generating minimal scaffold.'));
+  console.log(styleText('dim', 'No native module definition found. Generating minimal scaffold.'));
   return { detectedFeatures: [], sharedObjectName: null };
 }
 
@@ -602,13 +604,16 @@ export async function addPlatformSupport(
   console.log();
   console.log(`✅ Successfully added ${platformsToAdd.join(', ')} support to the module.`);
   if (detectedFeatures.length > 0) {
-    console.log(chalk.dim(`   Scaffolded features: ${detectedFeatures.join(', ')}`));
+    console.log(styleText('dim', `   Scaffolded features: ${detectedFeatures.join(', ')}`));
   }
 
   const nativeOpenCommands = getNativeOpenCommands(platformsToAdd);
   if (nativeOpenCommands.length > 0) {
     console.log(
-      chalk.dim(`   To write the native implementation, use ${nativeOpenCommands.join(' or ')}.`)
+      styleText(
+        'dim',
+        `   To write the native implementation, use ${nativeOpenCommands.join(' or ')}.`
+      )
     );
   }
 }

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -1,8 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 import validateNpmPackage from 'validate-npm-package-name';
 
@@ -77,7 +77,8 @@ export function resolveLocalModuleDir(packageJsonPath: string, targetOrSlug: str
     packageJson = JSON.parse(fileContent);
   } catch {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `⚠️ Could not parse package.json at ${packageJsonPath}. Using the \`modules\` directory in the root of the project as the module location.`
       )
     );
@@ -105,12 +106,14 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
   }
   if (!packageJsonPath) {
     console.log(
-      chalk.red.bold(
+      styleText(
+        ['red', 'bold'],
         '⚠️ This command should be run inside your Expo project when run with the --local flag.'
       )
     );
     console.log(
-      chalk.red(
+      styleText(
+        'red',
         'For native modules to autolink correctly, you need to place them in the directory specified in `expo.autolinking.nativeModulesDir` field in `package.json` which defaults to `modules` directory in the root of the project when unspecified.'
       )
     );
@@ -182,13 +185,16 @@ async function resolvePlatformsAsync(
     );
     if (invalid.length > 0) {
       console.warn(
-        chalk.yellow(
+        styleText(
+          'yellow',
           `⚠️  Unknown platform(s) ignored: ${invalid.join(', ')}. Valid values: ${ALL_PLATFORMS.join(', ')}`
         )
       );
     }
     if (valid.length === 0) {
-      console.warn(chalk.yellow(`⚠️  No valid platforms specified. Defaulting to all platforms.`));
+      console.warn(
+        styleText('yellow', `⚠️  No valid platforms specified. Defaulting to all platforms.`)
+      );
       return [...ALL_PLATFORMS];
     }
     return valid;
@@ -216,7 +222,7 @@ export { resolveFeatures };
 
 function warnIfViewAutoIncluded(rawFeatures: Feature[]): void {
   if (rawFeatures.includes('ViewEvent') && !rawFeatures.includes('View')) {
-    console.log(chalk.yellow('⚠️  ViewEvent requires View — adding View automatically.'));
+    console.log(styleText('yellow', '⚠️  ViewEvent requires View — adding View automatically.'));
   }
 }
 
@@ -262,7 +268,8 @@ function resolveModuleName(rawName: string): string {
   if (wasRenamed) {
     console.log();
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `⚠️  Module name "${rawName}" conflicts with an Apple framework. Renamed to "${name}" to avoid build errors.`
       )
     );
@@ -296,9 +303,7 @@ async function main(target: string | undefined, options: CommandOptions) {
   if (options.local) {
     console.log();
     console.log(
-      `${chalk.gray('The local module will be created in ')}${chalk.gray.bold.italic(
-        relativePath
-      )} ${chalk.gray('directory. Learn more: ')}${chalk.gray.bold(FYI_LOCAL_DIR)}`
+      `${styleText('gray', 'The local module will be created in ')}${styleText(['gray', 'bold', 'italic'], relativePath)} ${styleText('gray', 'directory. Learn more: ')}${styleText(['gray', 'bold'], FYI_LOCAL_DIR)}`
     );
     console.log();
   }
@@ -331,7 +336,8 @@ async function main(target: string | undefined, options: CommandOptions) {
     });
   } else if (!options.local && options.barrel) {
     console.warn(
-      chalk.yellow(
+      styleText(
+        'yellow',
         'Warning: The --barrel flag only applies to local modules (--local). It will be ignored.'
       )
     );
@@ -387,7 +393,9 @@ async function main(target: string | undefined, options: CommandOptions) {
 
   console.log();
   if (options.local) {
-    console.log(`✅ Successfully created Expo module in ${chalk.bold.italic(relativePath)}`);
+    console.log(
+      `✅ Successfully created Expo module in ${styleText(['bold', 'italic'], relativePath)}`
+    );
     const importPath = relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
     printFurtherLocalInstructions(
       data.project.moduleName,
@@ -449,11 +457,13 @@ async function createGitRepositoryAsync(targetDir: string) {
       stdio: 'ignore',
       cwd: targetDir,
     });
-    debug(chalk.dim('New project is already inside of a Git repository, skipping `git init`.'));
+    debug(
+      styleText('dim', 'New project is already inside of a Git repository, skipping `git init`.')
+    );
     return null;
   } catch (e: any) {
     if (e.errno === 'ENOENT') {
-      debug(chalk.dim('Unable to initialize Git repo. `git` not in $PATH.'));
+      debug(styleText('dim', 'Unable to initialize Git repo. `git` not in $PATH.'));
       return false;
     }
   }
@@ -468,7 +478,7 @@ async function createGitRepositoryAsync(targetDir: string) {
     cwd: targetDir,
   });
 
-  debug(chalk.dim('Initialized a Git repository.'));
+  debug(styleText('dim', 'Initialized a Git repository.'));
   return true;
 }
 
@@ -656,7 +666,7 @@ async function getSubstitutionDataFromOptions(
 
   if (isLocal) {
     const warning = buildDefaultsWarning(defaults);
-    if (warning) process.stderr.write(chalk.yellow(warning) + '\n');
+    if (warning) process.stderr.write(styleText('yellow', warning) + '\n');
 
     return {
       project: {
@@ -702,7 +712,7 @@ async function getSubstitutionDataFromOptions(
 
   const warning = buildDefaultsWarning(defaults);
   if (warning) {
-    process.stderr.write(chalk.yellow(warning) + '\n');
+    process.stderr.write(styleText('yellow', warning) + '\n');
   }
 
   return {
@@ -743,8 +753,9 @@ async function confirmTargetDirAsync(targetDir: string, options: CommandOptions)
   if (!isInteractive()) {
     debug(`Non-interactive mode: target directory "${targetDir}" is not empty, continuing anyway`);
     console.log(
-      chalk.yellow(
-        `Warning: Target directory ${chalk.magenta(targetDir)} is not empty, continuing anyway.`
+      styleText(
+        'yellow',
+        `Warning: Target directory ${styleText('magenta', targetDir)} is not empty, continuing anyway.`
       )
     );
     return;
@@ -754,9 +765,7 @@ async function confirmTargetDirAsync(targetDir: string, options: CommandOptions)
     {
       type: 'confirm',
       name: 'shouldContinue',
-      message: `The target directory ${chalk.magenta(
-        targetDir
-      )} is not empty, do you want to continue anyway?`,
+      message: `The target directory ${styleText('magenta', targetDir)} is not empty, do you want to continue anyway?`,
       initial: true,
     },
     {
@@ -834,10 +843,10 @@ function printFurtherInstructions(
     console.log(
       'To start developing your module, navigate to the directory and open Android and iOS projects of the example app'
     );
-    commands.forEach((command) => console.log(chalk.gray('>'), chalk.bold(command)));
+    commands.forEach((command) => console.log(styleText('gray', '>'), styleText('bold', command)));
     console.log();
   }
-  console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
+  console.log(`Learn more on Expo Modules APIs: ${styleText(['blue', 'bold'], DOCS_URL)}`);
 }
 
 function printFurtherLocalInstructions(
@@ -851,21 +860,32 @@ function printFurtherLocalInstructions(
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add these lines to your App.tsx or App.js file:`);
   if (barrel) {
-    console.log(chalk.gray.italic(`import ${moduleName}, { ${viewName} } from '${relativePath}';`));
+    console.log(
+      styleText(['gray', 'italic'], `import ${moduleName}, { ${viewName} } from '${relativePath}';`)
+    );
   } else {
     console.log(
-      chalk.gray.italic(`import ${moduleName} from '${relativePath}/src/${moduleName}';`)
+      styleText(
+        ['gray', 'italic'],
+        `import ${moduleName} from '${relativePath}/src/${moduleName}';`
+      )
     );
     console.log(
-      chalk.gray.italic(`import { default as ${viewName} } from '${relativePath}/src/${viewName}';`)
+      styleText(
+        ['gray', 'italic'],
+        `import { default as ${viewName} } from '${relativePath}/src/${viewName}';`
+      )
     );
-    console.log(chalk.gray.italic(`import type { } from '${relativePath}/src/${name}.types';`));
+    console.log(
+      styleText(['gray', 'italic'], `import type { } from '${relativePath}/src/${name}.types';`)
+    );
   }
   console.log();
-  console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
+  console.log(`Learn more on Expo Modules APIs: ${styleText(['blue', 'bold'], DOCS_URL)}`);
   console.log(
-    chalk.yellow(
-      `Remember to re-build your native app (for example, with ${chalk.bold('npx expo run')}) when you make changes to the module. Native code changes are not reloaded with Fast Refresh.`
+    styleText(
+      'yellow',
+      `Remember to re-build your native app (for example, with ${styleText('bold', 'npx expo run')}) when you make changes to the module. Native code changes are not reloaded with Fast Refresh.`
     )
   );
 }

--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -1,8 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { usesExpoUI } from './features';
 import { installDependencies, type PackageManagerName } from './packageManager';
@@ -52,7 +52,10 @@ export async function createExampleApp(
       }
 
       console.warn(
-        chalk.yellow(`Failed to use the "${distTag}" example template, falling back to "latest".`)
+        styleText(
+          'yellow',
+          `Failed to use the "${distTag}" example template, falling back to "latest".`
+        )
       );
 
       await initExampleApp(packageManager, exampleProjectSlug, targetDir, 'latest');

--- a/packages/create-expo-module/src/features.ts
+++ b/packages/create-expo-module/src/features.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export const ALL_FEATURES = [
   'Constant',
@@ -94,7 +94,8 @@ export function filterFeaturesByPlatforms(
   }
   if (dropped.length > 0) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `⚠️  Dropping ${dropped.join(', ')} — required platform not selected ` +
           `(SwiftUI* require apple, Compose* require android).`
       )

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -1,9 +1,9 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import ejs from 'ejs';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { usesCompose, usesExpoUI, usesSwiftUI } from './features';
 import type { Platform } from './prompts';
@@ -196,7 +196,8 @@ async function getTemplateVersion(isLocal: boolean) {
   } catch {
     console.log();
     console.warn(
-      chalk.yellow(
+      styleText(
+        'yellow',
         "Couldn't determine the SDK version from the local project, using `latest` as the template version."
       )
     );
@@ -221,7 +222,8 @@ export async function downloadPackageAsync(targetDir: string, isLocal = false): 
     } catch {
       console.log();
       console.warn(
-        chalk.yellow(
+        styleText(
+          'yellow',
           "Couldn't download the versioned template from npm, falling back to the latest version."
         )
       );

--- a/packages/create-expo-module/src/utils/ora.ts
+++ b/packages/create-expo-module/src/utils/ora.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import ora from 'ora';
 
 export type StepOptions = ora.Options;
@@ -10,7 +10,7 @@ export async function newStep<Result>(
 ): Promise<Result> {
   const disabled = process.env.CI || process.env.EXPO_DEBUG;
   const step = ora({
-    text: chalk.bold(title),
+    text: styleText('bold', title),
     isEnabled: !disabled,
     stream: disabled ? process.stdout : process.stderr,
     ...options,

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -47,7 +47,6 @@
     "@types/prompts": "2.0.14",
     "@vercel/ncc": "^0.38.3",
     "arg": "^5.0.2",
-    "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "expo-module-scripts": "workspace:*",
     "getenv": "^2.0.0",

--- a/packages/create-expo/src/Examples.ts
+++ b/packages/create-expo/src/Examples.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 import prompts from 'prompts';
 
@@ -104,7 +104,9 @@ export async function promptExamplesAsync() {
 
   if (!answer) {
     console.log();
-    console.log(chalk`Specify the example name, for example: {cyan --example with-router}`);
+    console.log(
+      `Specify the example name, for example: ${styleText('cyan', `--example with-router`)}`
+    );
     console.log();
     process.exit(1);
   }

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -2,9 +2,9 @@ import type { ExpoConfig } from '@expo/config';
 import type { JSONObject } from '@expo/json-file';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
 import fs from 'fs';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import path from 'path';
 
@@ -449,7 +449,7 @@ export function logProjectReady({
   cdPath: string;
   packageManager: PackageManagerName;
 }) {
-  console.log(chalk.bold(`✅ Your project is ready!`));
+  console.log(styleText('bold', `✅ Your project is ready!`));
   console.log();
 
   // empty string if project was created in current directory
@@ -458,22 +458,22 @@ export function logProjectReady({
       `To run your project, navigate to the directory and run one of the following ${packageManager} commands.`
     );
     console.log();
-    console.log(`- ${chalk.bold('cd ' + cdPath)}`);
+    console.log(`- ${styleText('bold', 'cd ' + cdPath)}`);
   } else {
     console.log(`To run your project, run one of the following ${packageManager} commands.`);
     console.log();
   }
 
-  console.log(`- ${chalk.bold(formatRunCommand(packageManager, 'android'))}`);
+  console.log(`- ${styleText('bold', formatRunCommand(packageManager, 'android'))}`);
 
   let macOSComment = '';
   if (!isMacOS) {
     macOSComment =
       ' # you need to use macOS to build the iOS project - use the Expo app if you need to do iOS development without a Mac';
   }
-  console.log(`- ${chalk.bold(formatRunCommand(packageManager, 'ios'))}${macOSComment}`);
+  console.log(`- ${styleText('bold', formatRunCommand(packageManager, 'ios'))}${macOSComment}`);
 
-  console.log(`- ${chalk.bold(formatRunCommand(packageManager, 'web'))}`);
+  console.log(`- ${styleText('bold', formatRunCommand(packageManager, 'web'))}`);
 }
 
 export async function installPodsAsync(projectRoot: string) {
@@ -497,7 +497,8 @@ export async function installPodsAsync(projectRoot: string) {
     } catch (e: any) {
       step.stopAndPersist({
         symbol: '⚠️ ',
-        text: chalk.red(
+        text: styleText(
+          'red',
           'Unable to install the CocoaPods CLI. Continuing with initializing the project, you can install CocoaPods afterwards.'
         ),
       });
@@ -515,7 +516,8 @@ export async function installPodsAsync(projectRoot: string) {
   } catch (e: any) {
     step.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.red(
+      text: styleText(
+        'red',
         'Something went wrong running `pod install` in the `ios` directory. Continuing with initializing the project, you can debug this afterwards.'
       ),
     });
@@ -529,7 +531,7 @@ export async function installPodsAsync(projectRoot: string) {
 export function logNewSection(title: string) {
   const disabled = env.CI || env.EXPO_DEBUG;
   const spinner = ora({
-    text: chalk.bold(title),
+    text: styleText('bold', title),
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,
     // In non-interactive mode, send the stream to stdout so it prevents looking like an error.

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import type { Spec } from 'arg';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { CLI_NAME } from './cmd';
 import { ExitError } from './error';
@@ -37,33 +37,33 @@ async function run() {
     const nameWithoutCreate = CLI_NAME.replace('create-', '');
     printHelp(
       `Creates a new Expo project`,
-      chalk`npx ${CLI_NAME} {cyan <path>} [options]`,
+      `npx ${CLI_NAME} ${styleText('cyan', `<path>`)} [options]`,
       [
         `-y, --yes             Use the default options for creating a project`,
         `    --no-install      Skip installing npm packages or CocoaPods`,
         `    --no-agents-md    Skip generating AGENTS.md, CLAUDE.md, and .claude/settings.json`,
-        chalk`-t, --template {gray [pkg]}  NPM template to use: default, blank, blank-typescript, tabs, bare-minimum. Default: default`,
-        chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
+        `-t, --template ${styleText('gray', `[pkg]`)}  NPM template to use: default, blank, blank-typescript, tabs, bare-minimum. Default: default`,
+        `-e, --example ${styleText('gray', `[name]`)}  Example name from ${styleText('underline', `https://github.com/expo/examples`)}.`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,
       ].join('\n'),
-      chalk`
-    {gray To choose a template pass in the {bold --template} arg:}
+      `
+    ${styleText('gray', `To choose a template pass in the ${styleText('bold', `--template`)} arg:`)}
 
-    {gray $} ${formatSelfCommand()} {cyan --template}
+    ${styleText('gray', `$`)} ${formatSelfCommand()} ${styleText('cyan', `--template`)}
 
-    {gray To choose an Expo example pass in the {bold --example} arg:}
+    ${styleText('gray', `To choose an Expo example pass in the ${styleText('bold', `--example`)} arg:`)}
 
-    {gray $} ${formatSelfCommand()} {cyan --example}
-    {gray $} ${formatSelfCommand()} {cyan --example with-router}
+    ${styleText('gray', `$`)} ${formatSelfCommand()} ${styleText('cyan', `--example`)}
+    ${styleText('gray', `$`)} ${formatSelfCommand()} ${styleText('cyan', `--example with-router`)}
 
-    {gray The package manager used for installing}
-    {gray node modules is based on how you invoke the CLI:}
+    ${styleText('gray', `The package manager used for installing`)}
+    ${styleText('gray', `node modules is based on how you invoke the CLI:`)}
 
-    {bold  npm:} {cyan npx ${CLI_NAME}}
-    {bold yarn:} {cyan yarn create ${nameWithoutCreate}}
-    {bold pnpm:} {cyan pnpm create ${nameWithoutCreate}}
-    {bold  bun:} {cyan bun create ${nameWithoutCreate}}
+    ${styleText('bold', ` npm:`)} ${styleText('cyan', `npx ${CLI_NAME}`)}
+    ${styleText('bold', `yarn:`)} ${styleText('cyan', `yarn create ${nameWithoutCreate}`)}
+    ${styleText('bold', `pnpm:`)} ${styleText('cyan', `pnpm create ${nameWithoutCreate}`)}
+    ${styleText('bold', ` bun:`)} ${styleText('cyan', `bun create ${nameWithoutCreate}`)}
     `
     );
   }

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import type { ExamplesMetadata } from './Examples';
@@ -138,7 +138,7 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
       });
     },
     {
-      pending: chalk.bold('Locating project files.'),
+      pending: styleText('bold', 'Locating project files.'),
       success: 'Downloaded and extracted project files.',
       error: (error) =>
         `Something went wrong in downloading and extracting the project files: ${error.message}`,
@@ -194,7 +194,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
 
     if (destination != null) {
       console.log(
-        chalk`{gray The {cyan ${resolvedExample}} example has been renamed to {cyan ${destination}}.}`
+        `${styleText('gray', `The ${styleText('cyan', resolvedExample)} example has been renamed to ${styleText('cyan', destination)}.`)}`
       );
 
       resolvedExample = destination;
@@ -202,7 +202,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
 
     // Optional message to show when an example is aliased, in case additional context is required
     if (typeof alias === 'object' && alias.message) {
-      console.log(chalk`{gray ${alias.message}}`);
+      console.log(`${styleText('gray', alias.message)}`);
     }
   } else if (metadata && metadata.deprecated[resolvedExample]) {
     throw new Error(getDeprecatedExampleErrorMessage(resolvedExample, metadata));
@@ -213,7 +213,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   console.log(
-    chalk`Creating {cyan ${path.basename(projectRoot)}} using the {cyan ${resolvedExample}} example.\n`
+    `Creating ${styleText('cyan', path.basename(projectRoot))} using the ${styleText('cyan', resolvedExample)} example.\n`
   );
   await fs.promises.mkdir(projectRoot, { recursive: true });
 
@@ -232,7 +232,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
       await downloadAndExtractExampleAsync(projectRoot, resolvedExample);
     },
     {
-      pending: chalk.bold('Locating example files...'),
+      pending: styleText('bold', 'Locating example files...'),
       success: 'Downloaded and extracted example files.',
       error: (error) =>
         `Something went wrong in downloading and extracting the example files: ${error.message}`,

--- a/packages/create-expo/src/legacyTemplates.ts
+++ b/packages/create-expo/src/legacyTemplates.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import { env } from './utils/env';
@@ -48,7 +48,9 @@ export async function promptTemplateAsync() {
 
   if (!answer) {
     console.log();
-    console.log(chalk`Specify the template name, example: {cyan --template expo-template-blank}`);
+    console.log(
+      `Specify the template name, example: ${styleText('cyan', `--template expo-template-blank`)}`
+    );
     console.log();
     process.exit(1);
   }

--- a/packages/create-expo/src/log.ts
+++ b/packages/create-expo/src/log.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { ExitError } from './error';
 
@@ -9,7 +9,9 @@ export function error(...message: string[]): void {
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
   const { env } = require('./utils/env');
-  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(
+    styleText('red', e.toString()) + (env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : '')
+  );
 }
 
 export function log(...message: string[]): void {

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import { ALIASES } from './legacyTemplates';
@@ -130,8 +130,8 @@ export async function applySdkVersionToTemplateAsync(
 }
 
 function logCreatingProject(template: string, projectName: string | undefined): void {
-  const subject = projectName ? chalk.cyan(projectName) : 'a project';
-  console.log(chalk`Creating ${subject} using the {cyan ${template}} template.\n`);
+  const subject = projectName ? styleText('cyan', projectName) : 'a project';
+  console.log(`Creating ${subject} using the ${styleText('cyan', template)} template.\n`);
 }
 
 function isKnownExpoTemplate(name: string): boolean {
@@ -177,7 +177,9 @@ async function promptSdkVersionAsync(
 
   if (answer == null) {
     Log.log();
-    Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
+    Log.log(
+      `Specify the SDK version, example: ${styleText('cyan', `--template default@${latest}`)}`
+    );
     process.exit(1);
   }
 
@@ -197,24 +199,26 @@ async function promptSdkVersionAsync(
 
     if (sdkAnswer == null) {
       Log.log();
-      Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
+      Log.log(
+        `Specify the SDK version, example: ${styleText('cyan', `--template default@${latest}`)}`
+      );
       process.exit(1);
     }
     resolved = sdkAnswer as number;
   }
 
   const friendly = templateName.replace(/^expo-template-/, '');
-  const subject = projectName ? chalk.cyan(projectName) : 'a project';
-  console.log(chalk`Creating ${subject} using the {cyan ${friendly}} template.`);
+  const subject = projectName ? styleText('cyan', projectName) : 'a project';
+  console.log(`Creating ${subject} using the ${styleText('cyan', friendly)} template.`);
   if (showAlternatives) {
     const cmd = formatSelfCommand();
     console.log();
-    console.log(chalk.gray('Tip:'));
+    console.log(styleText('gray', 'Tip:'));
     console.log(
-      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--template')}  ${chalk.gray('to pick from other templates')}`
+      `  ${styleText('gray', '•')} ${styleText('gray', cmd)} ${styleText('cyan', '--template')}  ${styleText('gray', 'to pick from other templates')}`
     );
     console.log(
-      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore')} ${chalk.gray.underline('https://github.com/expo/examples')}`
+      `  ${styleText('gray', '•')} ${styleText('gray', cmd)} ${styleText('cyan', '--example')}   ${styleText('gray', 'to explore')} ${styleText(['gray', 'underline'], 'https://github.com/expo/examples')}`
     );
   }
   console.log();

--- a/packages/create-expo/src/resolveProjectRoot.ts
+++ b/packages/create-expo/src/resolveProjectRoot.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 import prompts from 'prompts';
 
@@ -11,12 +11,15 @@ import { getConflictsForDirectory } from './utils/dir';
 export function assertValidName(folderName: string) {
   const validation = Template.validateName(folderName);
   if (typeof validation === 'string') {
-    Log.exit(chalk`{red Cannot create an app named {bold "${folderName}"}. ${validation}}`, 1);
+    Log.exit(
+      `${styleText('red', `Cannot create an app named ${styleText('bold', `"${folderName}"`)}. ${validation}`)}`,
+      1
+    );
   }
   const isFolderNameForbidden = Template.isFolderNameForbidden(folderName);
   if (isFolderNameForbidden) {
     Log.exit(
-      chalk`{red Cannot create an app named {bold "${folderName}"} because it would conflict with a dependency of the same name.}`,
+      `${styleText('red', `Cannot create an app named ${styleText('bold', `"${folderName}"`)} because it would conflict with a dependency of the same name.`)}`,
       1
     );
   }
@@ -25,7 +28,7 @@ export function assertValidName(folderName: string) {
 export function assertFolderEmpty(projectRoot: string, folderName: string) {
   const conflicts = getConflictsForDirectory(projectRoot);
   if (conflicts.length) {
-    Log.log(chalk`The directory {cyan ${folderName}} has files that might be overwritten:`);
+    Log.log(`The directory ${styleText('cyan', folderName)} has files that might be overwritten:`);
     Log.log();
     for (const file of conflicts) {
       Log.log(`  ${file}`);
@@ -62,10 +65,10 @@ export async function resolveProjectRootAsync(input: string): Promise<string> {
     const selfCmd = formatSelfCommand();
     Log.log();
     Log.log('Choose a name for your app:');
-    Log.log(chalk`  {dim $} {cyan ${selfCmd} <name>}`);
+    Log.log(`  ${styleText('dim', `$`)} ${styleText('cyan', `${selfCmd} <name>}`)}`);
     Log.log();
     Log.log(`For more info, run:`);
-    Log.log(chalk`  {dim $} {cyan ${selfCmd} --help}`);
+    Log.log(`  ${styleText('dim', `$`)} ${styleText('cyan', `${selfCmd} --help`)}`);
     Log.log();
     Log.exit('');
   }

--- a/packages/create-expo/src/utils/args.ts
+++ b/packages/create-expo/src/utils/args.ts
@@ -2,7 +2,7 @@
 // These functions should be used by every command.
 import type { Spec } from 'arg';
 import arg from 'arg';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 import { replaceValue } from './array';
@@ -32,14 +32,14 @@ export function assertWithOptionsArgs(
 
 export function printHelp(info: string, usage: string, options: string, extra: string = ''): never {
   Log.exit(
-    chalk`
-  {bold Info}
+    `
+  ${styleText('bold', `Info`)}
     ${info}
 
-  {bold Usage}
-    {dim $} ${usage}
+  ${styleText('bold', `Usage`)}
+    ${styleText('dim', `$`)} ${usage}
 
-  {bold Options}
+  ${styleText('bold', `Options`)}
     ${options.split('\n').join('\n    ')}
 ` + extra,
     0

--- a/packages/create-expo/src/utils/git.ts
+++ b/packages/create-expo/src/utils/git.ts
@@ -1,5 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import { env } from './env';
@@ -29,7 +29,7 @@ async function isGitInstalledAsync(): Promise<boolean> {
 export async function initGitRepoAsync(root: string) {
   // Check if git is installed
   if (!(await isGitInstalledAsync())) {
-    debug(chalk.dim('Unable to initialize Git repo. `git` not in $PATH.'));
+    debug(styleText('dim', 'Unable to initialize Git repo. `git` not in $PATH.'));
     return false;
   }
 
@@ -37,7 +37,12 @@ export async function initGitRepoAsync(root: string) {
   if (await isInsideGitRepoAsync(root)) {
     // In headless/CI mode, skip by default
     if (env.CI) {
-      debug(chalk.dim('New project is already inside of a Git repo, skipping git init (CI mode).'));
+      debug(
+        styleText(
+          'dim',
+          'New project is already inside of a Git repo, skipping git init (CI mode).'
+        )
+      );
       return false;
     }
 
@@ -52,11 +57,11 @@ export async function initGitRepoAsync(root: string) {
 
     // If user confirms skip (or cancels/ctrl+c which returns undefined), skip git init
     if (answer !== false) {
-      debug(chalk.dim('User chose to skip git init inside existing repo.'));
+      debug(styleText('dim', 'User chose to skip git init inside existing repo.'));
       return false;
     }
     // User explicitly chose not to skip, proceed with git init (creates nested repo)
-    debug(chalk.dim('User chose to initialize git inside existing repo.'));
+    debug(styleText('dim', 'User chose to initialize git inside existing repo.'));
   }
 
   const packageJSON = require('../package.json');
@@ -72,7 +77,7 @@ export async function initGitRepoAsync(root: string) {
       cwd: root,
     });
 
-    debug(chalk.dim('Initialized a Git repository.'));
+    debug(styleText('dim', 'Initialized a Git repository.'));
     return true;
   } catch (error: any) {
     debug('Error initializing Git repo:', error);

--- a/packages/create-expo/src/utils/update-check.ts
+++ b/packages/create-expo/src/utils/update-check.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import checkForUpdate from 'update-check';
 
 const packageJson = require('../package.json');
@@ -10,8 +10,12 @@ export default async function shouldUpdate(): Promise<void> {
     const res = await checkForUpdate(packageJson);
     if (res?.latest) {
       console.log();
-      console.log(chalk.yellow.bold(`A new version of \`${packageJson.name}\` is available`));
-      console.log(chalk`You can update by running: {cyan npm install -g ${packageJson.name}}`);
+      console.log(
+        styleText(['yellow', 'bold'], `A new version of \`${packageJson.name}\` is available`)
+      );
+      console.log(
+        `You can update by running: ${styleText('cyan', `npm install -g ${packageJson.name}`)}`
+      );
       console.log();
     }
   } catch (error: any) {

--- a/packages/expo-brownfield/cli/src/commands/tasks-android.ts
+++ b/packages/expo-brownfield/cli/src/commands/tasks-android.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import type { Command } from 'commander';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import {
   processRepositories,
@@ -32,14 +32,14 @@ const tasksAndroid = async (command: Command) => {
     return;
   }
 
-  console.log(chalk.bold('Publishing tasks'));
+  console.log(styleText('bold', 'Publishing tasks'));
   const tasks = processTasks(stdout);
   tasks.forEach((task) => {
-    console.log(` - ${chalk.blue(task)}`);
+    console.log(` - ${styleText('blue', task)}`);
   });
-  console.log(chalk.bold('Repositories'));
+  console.log(styleText('bold', 'Repositories'));
   processRepositories(tasks).forEach((repository) => {
-    console.log(` - ${chalk.blue(repository)}`);
+    console.log(` - ${styleText('blue', repository)}`);
   });
 };
 

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import CLIError from './error';
 import { withSpinner } from './spinner';
@@ -56,14 +56,14 @@ export const findBrownfieldLibrary = (): string | undefined => {
 };
 
 export const printAndroidConfig = (config: AndroidConfig) => {
-  console.log(chalk.bold('Resolved build configuration'));
-  console.log(` - Build variant: ${chalk.blue(config.variant)}`);
-  console.log(` - Library: ${chalk.blue(config.library)}`);
-  console.log(` - Verbose: ${chalk.blue(config.verbose)}`);
-  console.log(` - Dry run: ${chalk.blue(config.dryRun)}`);
+  console.log(styleText('bold', 'Resolved build configuration'));
+  console.log(` - Build variant: ${styleText('blue', config.variant)}`);
+  console.log(` - Library: ${styleText('blue', config.library)}`);
+  console.log(` - Verbose: ${styleText('blue', String(config.verbose))}`);
+  console.log(` - Dry run: ${styleText('blue', String(config.dryRun))}`);
   console.log(` - Tasks:`);
   config.tasks.forEach((task) => {
-    console.log(`   - ${chalk.blue(task)}`);
+    console.log(`   - ${styleText('blue', task)}`);
   });
   console.log();
 };

--- a/packages/expo-brownfield/cli/src/utils/ios.ts
+++ b/packages/expo-brownfield/cli/src/utils/ios.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { XCFramework } from './constants';
 import CLIError from './error';
@@ -545,21 +545,21 @@ export const makeArtifactsDirectory = (config: IosConfig) => {
 };
 
 export const printIosConfig = (config: IosConfig) => {
-  console.log(chalk.bold('Resolved build configuration'));
-  console.log(` - Build configuration: ${chalk.blue(config.buildConfiguration)}`);
-  console.log(` - Scheme: ${chalk.blue(config.scheme)}`);
-  console.log(` - Workspace: ${chalk.blue(config.workspace)}`);
-  console.log(` - Dry run: ${chalk.blue(config.dryRun)}`);
-  console.log(` - Verbose: ${chalk.blue(config.verbose)}`);
-  console.log(` - Artifacts path: ${chalk.blue(config.artifacts)}`);
+  console.log(styleText('bold', 'Resolved build configuration'));
+  console.log(` - Build configuration: ${styleText('blue', config.buildConfiguration)}`);
+  console.log(` - Scheme: ${styleText('blue', config.scheme)}`);
+  console.log(` - Workspace: ${styleText('blue', config.workspace)}`);
+  console.log(` - Dry run: ${styleText('blue', String(config.dryRun))}`);
+  console.log(` - Verbose: ${styleText('blue', String(config.verbose))}`);
+  console.log(` - Artifacts path: ${styleText('blue', config.artifacts)}`);
 
   if (config.output !== 'frameworks') {
-    console.log(` - Package name: ${chalk.blue(config.output.packageName)}`);
+    console.log(` - Package name: ${styleText('blue', config.output.packageName)}`);
   }
-  console.log(` - Bundle precompiled modules: ${chalk.blue(config.usePrebuilds)}`);
+  console.log(` - Bundle precompiled modules: ${styleText('blue', String(config.usePrebuilds))}`);
   if (config.hostProvidedFrameworks.length > 0) {
     console.log(
-      ` - Host-provided frameworks: ${chalk.blue(config.hostProvidedFrameworks.join(', '))}`
+      ` - Host-provided frameworks: ${styleText('blue', config.hostProvidedFrameworks.join(', '))}`
     );
   }
 
@@ -593,7 +593,8 @@ export const validateHostProvided = (config: IosConfig): void => {
     const xcframeworkPath = pathsByName.get(name);
     if (xcframeworkPath === undefined) {
       console.warn(
-        chalk.yellow(
+        styleText(
+          'yellow',
           `expo-brownfield: '${name}' is listed in ios.hostProvidedFrameworks but no matching xcframework was found in ios/Pods/, node_modules/<pkg>/prebuilds/output/, or the shared .spm-deps/ cache. Remove it from the config, or re-run \`pod install\` if the source module isn't installed yet.`
         )
       );
@@ -602,7 +603,8 @@ export const validateHostProvided = (config: IosConfig): void => {
     const version = readXcframeworkShortVersion(xcframeworkPath);
     const versionLabel = version ?? 'unknown version';
     console.log(
-      chalk.dim(
+      styleText(
+        'dim',
         `expo-brownfield: excluding ${name} (${versionLabel}) — the host iOS app must provide ${name} at a compatible version at link time.`
       )
     );

--- a/packages/expo-brownfield/cli/src/utils/prebuild.ts
+++ b/packages/expo-brownfield/cli/src/utils/prebuild.ts
@@ -1,8 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { getConfig, getPackageJson } from 'expo/config';
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import CLIError from './error';
@@ -16,7 +16,7 @@ export const validatePrebuild = async (
   validatePackageInstalled();
 
   if (!checkPrebuild(platform)) {
-    console.info(`${chalk.yellow(`⚠ Prebuild for platform: ${platform} is missing`)}`);
+    console.info(`${styleText('yellow', `⚠ Prebuild for platform: ${platform} is missing`)}`);
     const response = await prompts({
       type: 'confirm',
       name: 'shouldRunPrebuild',
@@ -48,9 +48,7 @@ const validateIosPodsInstalled = async (): Promise<void> => {
   }
 
   console.info(
-    `${chalk.yellow(
-      '⚠ iOS workspace not found. CocoaPods has not been installed in the `ios/` directory yet.'
-    )}`
+    `${styleText('yellow', '⚠ iOS workspace not found. CocoaPods has not been installed in the `ios/` directory yet.')}`
   );
   const response = await prompts({
     type: 'confirm',

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@expo/env": "workspace:~2.3.0",
     "@expo/spawn-async": "^1.8.0",
-    "chalk": "^4.1.2",
     "commander": "^14.0.3",
     "diff": "^5.2.0",
     "expo-build-properties": "workspace:~56.0.15",

--- a/packages/expo-codemod/package.json
+++ b/packages/expo-codemod/package.json
@@ -37,7 +37,6 @@
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },
   "dependencies": {
-    "chalk": "^4.1.2",
     "jscodeshift": "^17.1.2",
     "tinyglobby": "^0.2.15"
   },

--- a/packages/expo-codemod/src/log.ts
+++ b/packages/expo-codemod/src/log.ts
@@ -1,7 +1,7 @@
 /**
  * These functions are copied from packages/@expo/cli/src/log.ts
  */
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export function log(...message: string[]): void {
   console.log(...message);
@@ -14,7 +14,7 @@ export function error(...message: string[]): void {
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
   const { env } = require('./utils/env');
-  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(styleText('red', e.toString()) + (env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : ''));
 }
 
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */

--- a/packages/expo-codemod/src/run/index.ts
+++ b/packages/expo-codemod/src/run/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import { glob } from 'tinyglobby';
 
@@ -9,9 +9,12 @@ import { parseArgsOrExit, printHelp } from '../utils/args';
 import { runTransformAsync } from '../utils/runner';
 
 const transformsBlock = (transforms: string[]): string =>
-  ['', `  ${chalk.bold('Transforms available')}`, ...transforms.map((t) => `    ${t}`), ''].join(
-    '\n'
-  );
+  [
+    '',
+    `  ${styleText('bold', 'Transforms available')}`,
+    ...transforms.map((t) => `    ${t}`),
+    '',
+  ].join('\n');
 
 export type ParsedCommand = {
   transform: string;
@@ -118,10 +121,10 @@ export async function resolveAndDispatch(command: ParsedCommand): Promise<void> 
 
   Log.log('');
   Log.log('Results:');
-  Log.log(chalk.red(`  ${combinedStats.error} errors`));
+  Log.log(styleText('red', `  ${combinedStats.error} errors`));
   // Log.log(chalk.yellow(`  ${combinedStats.nochange} unmodified`));
-  Log.log(chalk.yellow(`  ${combinedStats.skip} skipped`));
-  Log.log(chalk.green(`  ${combinedStats.ok} ok`));
+  Log.log(styleText('yellow', `  ${combinedStats.skip} skipped`));
+  Log.log(styleText('green', `  ${combinedStats.ok} ok`));
   Log.log(`  Time elapsed: ${combinedStats.timeElapsed.toFixed(2)}s`);
 }
 

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -1,3 +1,12 @@
+import type {
+  ASTPath,
+  ImportDeclaration,
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
+  ImportSpecifier,
+  JSCodeshift,
+  Transform,
+} from 'jscodeshift';
 /**
  * Codemod: Replace @react-navigation/* imports with expo-router equivalents.
  *
@@ -13,16 +22,7 @@
  *
  * After replacement, duplicate `expo-router` imports are merged into one.
  */
-import chalk from 'chalk';
-import type {
-  ASTPath,
-  ImportDeclaration,
-  ImportDefaultSpecifier,
-  ImportNamespaceSpecifier,
-  ImportSpecifier,
-  JSCodeshift,
-  Transform,
-} from 'jscodeshift';
+import { styleText } from 'node:util';
 
 // Specifier types in `@types/jscodeshift` (via ast-types) don't expose the
 // inline `type` modifier (`import { type A }`), even though Babel emits it as
@@ -57,9 +57,9 @@ const UNSUPPORTED_SPECIFIERS: Partial<Record<ImportSpecifierWithKind['type'], st
 
 // Prints a prominent, color-formatted error block to stderr.
 const printErrorBlock = (title: string, lines: string[]): void => {
-  const divider = chalk.red.bold('━'.repeat(78));
-  const heading = chalk.red.bold(`  ${title}`);
-  const body = lines.map((line) => chalk.red(`  ${line}`));
+  const divider = styleText(['red', 'bold'], '━'.repeat(78));
+  const heading = styleText(['red', 'bold'], `  ${title}`);
+  const body = lines.map((line) => styleText('red', `  ${line}`));
   console.error(['', divider, heading, divider, '', ...body, ''].join('\n'));
 };
 

--- a/packages/expo-codemod/src/utils/args.ts
+++ b/packages/expo-codemod/src/utils/args.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { parseArgs, type ParseArgsConfig } from 'util';
+import { styleText } from 'node:util';
 
 import * as Log from '../log';
 
@@ -24,14 +24,14 @@ export function parseArgsOrExit<T extends ParseArgsConfig>(
 
 export function printHelp(info: string, usage: string, options: string, extra: string = ''): never {
   Log.exit(
-    chalk`
-  {bold Info}
+    `
+  ${styleText('bold', 'Info')}
     ${info}
 
-  {bold Usage}
-    {dim $} ${usage}
+  ${styleText('bold', 'Usage')}
+    ${styleText('dim', '$')} ${usage}
 
-  {bold Options}
+  ${styleText('bold', 'Options')}
     ${options.split('\n').join('\n    ')}
 ` + extra,
     0

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -44,7 +44,6 @@
     "@types/getenv": "^1.0.0",
     "@types/semver": "^7.5.8",
     "@vercel/ncc": "^0.38.3",
-    "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "expo": "workspace:*",
     "expo-module-scripts": "workspace:*",

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
 import type {
   BaseDependencyResolution,
   DependencyResolution,
 } from 'expo-modules-autolinking/exports';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { learnMore } from '../utils/TerminalLink';
@@ -114,7 +114,7 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
               ? `linked to: ${path.relative(projectRoot, dependency.path)}`
               : 'linked to a different installation';
             const prefix = idx !== versions.length - 1 ? '│' : ' ';
-            line.push(`  ${prefix}  ` + chalk.grey(`└─ ${linkedOutput}`));
+            line.push(`  ${prefix}  ` + styleText('grey', `└─ ${linkedOutput}`));
           }
         }
         issues.push(line.join('\n'));

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { AutolinkingResolutionsCache } from '../utils/autolinkingResolutions';
 import { scanNativeModuleResolutions } from '../utils/autolinkingResolutions';
@@ -122,27 +122,27 @@ export class ReactNativeDirectoryCheck implements DoctorCheck<DoctorCache> {
     if (newArchUnsupportedPackages.length > 0) {
       hasCriticalIssues = true;
       issues.push(
-        `${chalk.bold(`  Unsupported on New Architecture:`)} ${newArchUnsupportedPackages.join(', ')}`
+        `${styleText('bold', `  Unsupported on New Architecture:`)} ${newArchUnsupportedPackages.join(', ')}`
       );
     }
 
     if (newArchUntestedPackages.length > 0) {
       hasCriticalIssues = true;
       issues.push(
-        `${chalk.bold(`  Untested on New Architecture:`)} ${newArchUntestedPackages.join(', ')}`
+        `${styleText('bold', `  Untested on New Architecture:`)} ${newArchUntestedPackages.join(', ')}`
       );
     }
 
     if (unmaintainedPackages.length > 0) {
       hasCriticalIssues = true;
-      issues.push(`${chalk.bold(`  Unmaintained:`)} ${unmaintainedPackages.join(', ')}`);
+      issues.push(`${styleText('bold', `  Unmaintained:`)} ${unmaintainedPackages.join(', ')}`);
     }
 
     if (
       (listUnknownPackagesEnabled === null || listUnknownPackagesEnabled) &&
       unknownPackages.length > 0
     ) {
-      issues.push(`${chalk.bold(`  No metadata available`)}: ${unknownPackages.join(', ')}`);
+      issues.push(`${styleText('bold', `  No metadata available`)}: ${unknownPackages.join(', ')}`);
     }
 
     if (!hasCriticalIssues && listUnknownPackagesEnabled === null) {
@@ -170,20 +170,16 @@ export class ReactNativeDirectoryCheck implements DoctorCheck<DoctorCache> {
       newArchUntestedPackages.length > 0
     ) {
       advice.push(
-        `Use libraries that are actively maintained and support the New Architecture. Find alternative libraries with ${chalk.bold('https://reactnative.directory')}.`
+        `Use libraries that are actively maintained and support the New Architecture. Find alternative libraries with ${styleText('bold', 'https://reactnative.directory')}.`
       );
       advice.push(
-        `Add packages to ${chalk.bold(
-          'expo.doctor.reactNativeDirectoryCheck.exclude'
-        )} in package.json to selectively skip validations, if the warning is not relevant.`
+        `Add packages to ${styleText('bold', 'expo.doctor.reactNativeDirectoryCheck.exclude')} in package.json to selectively skip validations, if the warning is not relevant.`
       );
     }
 
     if (unknownPackages.length > 0) {
       advice.push(
-        `Update React Native Directory to include metadata for unknown packages. Alternatively, set ${chalk.bold(
-          'expo.doctor.reactNativeDirectoryCheck.listUnknownPackages'
-        )} in package.json to ${chalk.bold('false')} to skip warnings about packages with no metadata, if the warning is not relevant.`
+        `Update React Native Directory to include metadata for unknown packages. Alternatively, set ${styleText('bold', 'expo.doctor.reactNativeDirectoryCheck.listUnknownPackages')} in package.json to ${styleText('bold', 'false')} to skip warnings about packages with no metadata, if the warning is not relevant.`
       );
     }
 

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -1,5 +1,5 @@
 import { load as loadEnv } from '@expo/env';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
 import { resolveChecksInScope } from './utils/checkResolver';
@@ -41,7 +41,7 @@ export async function printCheckResultSummaryOnComplete(
   // but outputting these just in time will make the EAS Build log timestamps for each line representative of the execution time.
   if (showVerboseTestResults) {
     Log.log(
-      `${job.result?.isSuccessful ? chalk.green('✔') : chalk.red('✖')} ${job.check.description}` +
+      `${job.result?.isSuccessful ? styleText('green', '✔') : styleText('red', '✖')} ${job.check.description}` +
         (env.EXPO_DEBUG ? ` (${formatMilliseconds(job.duration)})` : '')
     );
   }
@@ -73,16 +73,16 @@ export async function printFailedCheckIssueAndAdvice(job: DoctorCheckRunnerJob) 
     return;
   }
 
-  Log.log(chalk.red(`✖ ${job.check.description}`));
+  Log.log(styleText('red', `✖ ${job.check.description}`));
 
   if (result.issues.length) {
     for (const issue of result.issues) {
-      Log.log(chalk.yellow(issue));
+      Log.log(styleText('yellow', issue));
     }
     if (result.advice.length) {
-      Log.log(chalk.green(`Advice:`));
+      Log.log(styleText('green', `Advice:`));
       for (const advice of result.advice) {
-        Log.log(chalk.green(`${advice}`));
+        Log.log(styleText('green', `${advice}`));
       }
     }
     Log.log();
@@ -147,7 +147,10 @@ export async function actionAsync(projectRoot: string, showVerboseTestResults: b
     // expo-doctor relies on versioned CLI, which is only available for 44+
     if (ltSdkVersion(projectConfig.exp, '46.0.0')) {
       Log.exit(
-        chalk.red(`expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`)
+        styleText(
+          'red',
+          `expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`
+        )
       );
       return;
     }
@@ -173,7 +176,8 @@ export async function actionAsync(projectRoot: string, showVerboseTestResults: b
     if (failedJobs.length) {
       if (failedJobs.some((job) => job.result.issues?.length)) {
         Log.log(
-          chalk.red(
+          styleText(
+            'red',
             `${checksInScope.length - failedJobs.length}/${checksInScope.length} checks passed. ${failedJobs.length} checks failed. Possible issues detected:`
           )
         );
@@ -195,13 +199,15 @@ export async function actionAsync(projectRoot: string, showVerboseTestResults: b
         }
       }
       Log.exit(
-        chalk.red(
+        styleText(
+          'red',
           `${failedJobs.length} ${failedJobs.length === 1 ? 'check' : 'checks'} failed, indicating possible issues with the project.`
         )
       );
     } else {
       Log.log(
-        chalk.green(
+        styleText(
+          'green',
           `${checksInScope.length}/${checksInScope.length} checks passed. No issues detected!`
         )
       );

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import Debug from 'debug';
 import { constants, promises as fs } from 'fs';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { actionAsync } from './doctor';
@@ -16,9 +16,15 @@ if (
   (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1]! < NODE_MIN[1])
 ) {
   console.error(
-    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}` +
-      chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n` +
-      chalk.red`Go to: https://nodejs.org/en/download\n`
+    styleText(
+      'red',
+      `${styleText('bold', `Node.js (${process.version}`)} is outdated and unsupported.`
+    ) +
+      styleText(
+        'red',
+        ` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`
+      ) +
+      styleText('red', `Go to: https://nodejs.org/en/download\n`)
   );
 }
 
@@ -56,7 +62,7 @@ async function run() {
 
   await fs.access(projectRoot, constants.F_OK).catch((err: any) => {
     if (err) {
-      console.error(chalk.red(`Project directory ${projectRoot} does not exist`));
+      console.error(styleText('red', `Project directory ${projectRoot} does not exist`));
       process.exit(1);
     }
   });

--- a/packages/expo-doctor/src/utils/TerminalLink.ts
+++ b/packages/expo-doctor/src/utils/TerminalLink.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import terminalLink from 'terminal-link';
 
 /**
@@ -9,7 +9,7 @@ import terminalLink from 'terminal-link';
  * @param url
  */
 export function learnMore(url: string): string {
-  return terminalLink(chalk.underline('Learn more.'), url, {
-    fallback: (text, url) => `Learn more: ${chalk.underline(url)}`,
+  return terminalLink(styleText('underline', 'Learn more.'), url, {
+    fallback: (text, url) => `Learn more: ${styleText('underline', url)}`,
   });
 }

--- a/packages/expo-doctor/src/utils/explainAsync.ts
+++ b/packages/expo-doctor/src/utils/explainAsync.ts
@@ -1,5 +1,5 @@
 import spawnAsync, { SpawnResult } from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { RootNodePackage } from './explainDependencies.types';
 import { Log } from './log';
@@ -29,9 +29,7 @@ export async function explainAsync(
         return null;
       } else if (error.stdout.match(/Usage: npm <command>/)) {
         throw new Error(
-          `Dependency tree validation for ${chalk.underline(
-            packageName
-          )} failed. This validation is only available on Node 16+ / npm 8.`
+          `Dependency tree validation for ${styleText('underline', packageName)} failed. This validation is only available on Node 16+ / npm 8.`
         );
       }
     }

--- a/packages/expo-doctor/src/utils/explainDependencies.ts
+++ b/packages/expo-doctor/src/utils/explainDependencies.ts
@@ -2,7 +2,7 @@
 // adapted to return warnings instead of displaying, with some modest renaming to match,
 // but otherwise logic is unchanged.
 
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { explainAsync } from './explainAsync';
@@ -68,18 +68,20 @@ function formatInvalidPackagesWarning(
   } else {
     lines.push(`Expected to not find any copies of ${formatPkg(pkg, 'green')}`);
   }
-  lines.push(chalk`Found invalid:`);
+  lines.push(`Found invalid:`);
   lines.push(explanations.map((explanation) => '  ' + formatPkg(explanation, 'red')).join('\n'));
-  lines.push(chalk`  {dim (for more info, run: {bold npm why ${pkg.name}})}`);
+  lines.push(
+    `  ${styleText('dim', `(for more info, run: ${styleText('bold', `npm why ${pkg.name}`)})`)}`
+  );
 
   return lines.join('\n');
 }
 
-function formatPkg(pkg: TargetPackage, versionColor: string) {
+function formatPkg(pkg: TargetPackage, versionColor: Parameters<typeof styleText>[0]) {
   if (pkg.version) {
-    return chalk`{bold ${pkg.name}}{cyan @}{${versionColor} ${pkg.version}}`;
+    return `${styleText('bold', pkg.name)}${styleText('cyan', `@`)}${styleText(versionColor, pkg.version)}`;
   } else {
-    return chalk`{bold ${pkg.name}}`;
+    return `${styleText('bold', pkg.name)}`;
   }
 }
 

--- a/packages/expo-doctor/src/utils/log.ts
+++ b/packages/expo-doctor/src/utils/log.ts
@@ -1,6 +1,6 @@
-// mostly copied from https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/log.ts
-import chalk from 'chalk';
 import Debug from 'debug';
+// mostly copied from https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/log.ts
+import { styleText } from 'node:util';
 
 import { env } from './env';
 
@@ -20,11 +20,13 @@ export function error(...message: string[]): void {
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(
+    styleText('red', e.toString()) + (env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : '')
+  );
 }
 
 export function warn(...message: string[]): void {
-  console.warn(...message.map((value) => chalk.yellow(value)));
+  console.warn(...message.map((value) => styleText('yellow', value)));
 }
 
 export function log(...message: string[]): void {

--- a/packages/expo-doctor/src/utils/ora.ts
+++ b/packages/expo-doctor/src/utils/ora.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import type { Ora } from 'ora';
 import oraReal from 'ora';
 
@@ -90,7 +90,7 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
  * @returns
  */
 export function logNewSection(title: string) {
-  const spinner = ora(chalk.bold(title));
+  const spinner = ora(styleText('bold', title));
   // Prevent the spinner from clashing with debug logs
   spinner.start();
   return spinner;

--- a/packages/expo-doctor/src/utils/parseInstallCheckOutput.ts
+++ b/packages/expo-doctor/src/utils/parseInstallCheckOutput.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 /**
@@ -78,24 +78,20 @@ export function parseInstallCheckOutput(
       const formatSection = (
         title: string,
         rws: Row[],
-        color: (s: string) => string,
+        color: Parameters<typeof styleText>[0],
         icon: string
       ) => {
         if (!rws.length) return '';
         const sectionLines: string[] = [];
 
-        sectionLines.push(chalk.bold(color(`${icon} ${title}`)));
+        sectionLines.push(styleText('bold', styleText(color, `${icon} ${title}`)));
         sectionLines.push(
-          chalk(
-            `${pad('package', nameWidth)}${pad('expected', expWidth)}${pad('found', foundWidth)}`
-          )
+          `${pad('package', nameWidth)}${pad('expected', expWidth)}${pad('found', foundWidth)}`
         );
         sectionLines.push(
           ...rws.map(
             (r) =>
-              `${pad(r.name, nameWidth)}${chalk.green(pad(r.expected, expWidth))}${chalk.red(
-                pad(r.found, foundWidth)
-              )}`
+              `${pad(r.name, nameWidth)}${styleText('green', pad(r.expected, expWidth))}${styleText('red', pad(r.found, foundWidth))}`
           )
         );
         sectionLines.push('');
@@ -109,10 +105,10 @@ export function parseInstallCheckOutput(
             `- ${r.name} → https://github.com/expo/expo/blob/sdk-${projectMajorSdkVersion}/packages/${r.name}/CHANGELOG.md`
         );
       const sections = [
-        formatSection('Major version mismatches', major, chalk.yellow, '❗'),
-        formatSection('Minor version mismatches', minor, chalk.yellow, '⚠️'),
-        formatSection('Patch version mismatches', patch, chalk.yellow, '🔧'),
-        formatSection('Other/prerelease mismatches', unknown, chalk.magenta, '➿'),
+        formatSection('Major version mismatches', major, 'yellow', '❗'),
+        formatSection('Minor version mismatches', minor, 'yellow', '⚠️'),
+        formatSection('Patch version mismatches', patch, 'yellow', '🔧'),
+        formatSection('Other/prerelease mismatches', unknown, 'magenta', '➿'),
       ].filter(Boolean);
 
       const body = sections
@@ -125,10 +121,11 @@ export function parseInstallCheckOutput(
         .join('\n');
 
       const changelogs = changelogLines.length
-        ? chalk.bold('Changelogs:\n') + chalk.dim.blue(changelogLines.join('\n'))
+        ? styleText('bold', 'Changelogs:\n') + styleText(['dim', 'blue'], changelogLines.join('\n'))
         : '';
 
-      const footer = chalk.bold(
+      const footer = styleText(
+        'bold',
         `\n${rows.length} package${rows.length > 1 ? 's' : ''} out of date.`
       );
 

--- a/packages/expo-module-scripts/createJestPreset.cjs
+++ b/packages/expo-module-scripts/createJestPreset.cjs
@@ -4,10 +4,7 @@ const { createModulesTransform } = require('./jest-modules-transform.cjs');
 
 // NOTE: Many modules ship as ESM-only but are otherwise ready to be used directly
 // We can manually list them here to extend support to them and only transpile to CJS with SWC
-const cjsTransformIncludeNames = [
-  '@react-navigation',
-  'standard-navigation',
-];
+const cjsTransformIncludeNames = ['@react-navigation', 'standard-navigation'];
 
 // WARN: Packages here ship Flow/untranspiled source or ESM and assume a transforming bundler
 // Anything not listed (e.g. plain-CommonJS deps) runs as-is to keep test transforms fast

--- a/packages/expo-modules-autolinking/package.json
+++ b/packages/expo-modules-autolinking/package.json
@@ -61,7 +61,6 @@
   "dependencies": {
     "@expo/require-utils": "workspace:^56.1.3",
     "@expo/spawn-async": "^1.8.0",
-    "chalk": "^4.1.0",
     "commander": "^7.2.0"
   },
   "devDependencies": {

--- a/packages/expo-modules-autolinking/src/commands/verifyCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/verifyCommand.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import type commander from 'commander';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import {
@@ -166,7 +166,7 @@ export async function verifySearchResults(
 
   if (groups.duplicates.length) {
     for (const revision of groups.duplicates) {
-      console.warn(`⚠️  Found duplicate installations for ${chalk.green(revision.name)}`);
+      console.warn(`⚠️  Found duplicate installations for ${styleText('green', revision.name)}`);
       const revisions = [revision, ...(revision.duplicates ?? [])];
       for (let idx = 0; idx < revisions.length; idx++) {
         const prefix = idx !== revisions.length - 1 ? '├─' : '└─';

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@babel/runtime": "^7.23.8",
     "@expo/spawn-async": "^1.8.0",
-    "chalk": "^4.1.2",
     "commander": "^7.2.0",
     "dot": "^2.0.0-beta.1",
     "fetch-nodeshim": "^0.4.10",

--- a/packages/expo-test-runner/src/commands/CreateProject.ts
+++ b/packages/expo-test-runner/src/commands/CreateProject.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import type { CommanderStatic } from 'commander';
+import { styleText } from 'node:util';
 
 import type { Config } from '../Config';
 import TemplateProject from '../TemplateProject';
@@ -14,10 +14,10 @@ async function createProjectAsync(config: Config, options: CreateProjectOptions)
   const app = config.applications[options.app];
 
   if (app?.preset === 'detox') {
-    console.log(`Using ${chalk.green('detox')} preset.`);
+    console.log(`Using ${styleText('green', 'detox')} preset.`);
     const preset = new TemplateProject(app, options.app, options.platform, options.configFile);
 
-    console.log(`Creating test app in ${chalk.green(options.path)}.`);
+    console.log(`Creating test app in ${styleText('green', options.path)}.`);
     await preset.createApplicationAsync(options.path);
   } else {
     throw new Error(`Unknown preset: ${app?.preset}`);

--- a/packages/expo-test-runner/src/commands/RunTest.ts
+++ b/packages/expo-test-runner/src/commands/RunTest.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import type { CommanderStatic } from 'commander';
 import fs from 'fs';
+import { styleText } from 'node:util';
 
 import type { Application, Config } from '../Config';
 import TemplateProject from '../TemplateProject';
@@ -34,10 +34,10 @@ async function runTestAsync(config: Config, options: RunTestOptions) {
   }
 
   if (app.preset === 'detox') {
-    console.log(`Using ${chalk.green('detox')} preset.`);
+    console.log(`Using ${styleText('green', 'detox')} preset.`);
     const preset = new TemplateProject(app, appName, options.platform, options.configFile);
 
-    console.log(`Creating test app in ${chalk.green(options.path)}.`);
+    console.log(`Creating test app in ${styleText('green', options.path)}.`);
     await preset.createApplicationAsync(options.path);
 
     console.log(`Building app.`);

--- a/packages/expo-type-information/package.json
+++ b/packages/expo-type-information/package.json
@@ -44,7 +44,6 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
     "commander": "^12.1.0",
     "prettier": "^3.8.3",
     "typescript": "~6.0.3",

--- a/packages/expo-type-information/src/commands/commandUtils.ts
+++ b/packages/expo-type-information/src/commands/commandUtils.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk';
 import { execSync } from 'child_process';
 import commander from 'commander';
 import { createHash } from 'crypto';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import {
@@ -283,7 +283,7 @@ export async function getFileTypeInformationFromArgs({
 
   if (!typeInfo) {
     console.error(
-      chalk.red(`Provided files: ${realInputPaths} couldn't be parsed for type information!`)
+      styleText('red', `Provided files: ${realInputPaths} couldn't be parsed for type information!`)
     );
     return null;
   }

--- a/packages/expo-type-information/src/commands/generateModuleTypesCommand.ts
+++ b/packages/expo-type-information/src/commands/generateModuleTypesCommand.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import commander from 'commander';
+import { styleText } from 'node:util';
 
 import { generateModuleTypesFileContent } from '../typescriptGeneration';
 import {
@@ -29,7 +29,7 @@ export function generateModuleTypesCommand(cli: commander.Command) {
 
         const moduleTypesFileContent = await generateModuleTypesFileContent(typeInfo);
         if (!moduleTypesFileContent) {
-          console.error(chalk.red(`Couldn't generate module types file content!`));
+          console.error(styleText('red', `Couldn't generate module types file content!`));
           return;
         }
         writeStringToFileOrPrintToConsole(moduleTypesFileContent, realOutputPath);

--- a/packages/expo-updates/cli/src/assetsVerify.ts
+++ b/packages/expo-updates/cli/src/assetsVerify.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import arg from 'arg';
-import chalk from 'chalk';
 import path from 'path';
+import { styleText } from 'node:util';
 
 import { getMissingAssetsAsync } from './assetsVerifyAsync';
 import {
@@ -38,12 +38,12 @@ export const expoAssetsVerify: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Verify that all static files in an exported bundle are in either the export or an embedded bundle
 
-{bold Usage}
-  {dim $} npx expo-updates assets:verify {dim <dir>}
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates assets:verify ${styleText('dim', '<dir>')}
 
   Options
   <dir>                                  Directory of the Expo project. Default: Current working directory

--- a/packages/expo-updates/cli/src/cli.ts
+++ b/packages/expo-updates/cli/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import arg from 'arg';
-import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
+import { styleText } from 'node:util';
 
 import { logCmdError } from './utils/errors';
 import * as Log from './utils/log';
@@ -58,18 +58,18 @@ const commandArgs = args._.slice(1);
 // Handle `--help` flag
 if ((args['--help'] && !command) || !command) {
   Log.exit(
-    chalk`
-{bold Usage}
-  {dim $} npx expo-updates <command>
+    `
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates <command>
 
-{bold Commands}
+${styleText('bold', 'Commands')}
   ${Object.keys(commands).sort().join(', ')}
 
-{bold Options}
+${styleText('bold', 'Options')}
   --help, -h      Displays this message
 
 For more information run a command with the --help flag
-  {dim $} npx expo-updates codesigning:generate --help
+  ${styleText('dim', '$')} npx expo-updates codesigning:generate --help
   `,
     0
   );

--- a/packages/expo-updates/cli/src/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/src/configureCodeSigning.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
@@ -21,12 +21,12 @@ export const configureCodeSigning: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Configure expo-updates code signing for this project and verify setup
 
-{bold Usage}
-  {dim $} npx expo-updates codesigning:configure --certificate-input-directory <dir> --key-input-directory <dir>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates codesigning:configure --certificate-input-directory <dir> --key-input-directory <dir>
 
   Options
   --certificate-input-directory <string>     Directory containing code signing certificate

--- a/packages/expo-updates/cli/src/generateCodeSigning.ts
+++ b/packages/expo-updates/cli/src/generateCodeSigning.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
@@ -22,12 +22,12 @@ export const generateCodeSigning: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Generate expo-updates private key, public key, and code signing certificate using that public key (self-signed by the private key)
 
-{bold Usage}
-  {dim $} npx expo-updates codesigning:generate --key-output-directory <dir> --certificate-output-directory <dir> --certificate-validity-duration-years <num years> --certificate-common-name <name>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates codesigning:generate --key-output-directory <dir> --certificate-output-directory <dir> --certificate-validity-duration-years <num years> --certificate-common-name <name>
 
   Options
   --key-output-directory <string>                  Directory in which to put the generated private and public keys

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
@@ -23,12 +23,12 @@ export const generateFingerprint: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Generate fingerprint for use in expo-updates runtime version
 
-{bold Usage}
-  {dim $} npx expo-updates fingerprint:generate --platform <platform>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates fingerprint:generate --platform <platform>
 
   Options
   --platform <string>                  Platform to generate a fingerprint for

--- a/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
+++ b/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
@@ -23,12 +23,12 @@ export const resolveRuntimeVersion: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Resolve expo-updates runtime version
 
-{bold Usage}
-  {dim $} npx expo-updates runtimeversion:resolve --platform <platform>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates runtimeversion:resolve --platform <platform>
 
   Options
   --platform <string>                  Platform to resolve runtime version for

--- a/packages/expo-updates/cli/src/syncConfigurationToNative.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNative.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Command } from './cli';
 import { syncConfigurationToNativeAsync } from './syncConfigurationToNativeAsync';
@@ -22,13 +22,13 @@ export const syncConfigurationToNative: Command = async (argv) => {
 
   if (args['--help']) {
     Log.exit(
-      chalk`
-{bold Description}
+      `
+${styleText('bold', 'Description')}
 Sync configuration from Expo config to native project files if applicable. Note that this really
 only needs to be used by the EAS CLI for generic projects that do't use continuous native generation.
 
-{bold Usage}
-  {dim $} npx expo-updates configuration:syncnative --platform <platform>
+${styleText('bold', 'Usage')}
+  ${styleText('dim', '$')} npx expo-updates configuration:syncnative --platform <platform>
 
   Options
   --platform <string>                  Platform to sync

--- a/packages/expo-updates/cli/src/utils/errors.ts
+++ b/packages/expo-updates/cli/src/utils/errors.ts
@@ -1,5 +1,5 @@
 import { AssertionError } from 'assert';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { exit } from './log';
 
@@ -37,7 +37,7 @@ export function logCmdError(error: any): never {
     exit(error);
   }
 
-  const errorDetails = error.stack ? '\n' + chalk.gray(error.stack) : '';
+  const errorDetails = error.stack ? '\n' + styleText('gray', error.stack) : '';
 
-  exit(chalk.red(error.toString()) + errorDetails);
+  exit(styleText('red', error.toString()) + errorDetails);
 }

--- a/packages/expo-updates/cli/src/utils/log.ts
+++ b/packages/expo-updates/cli/src/utils/log.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export function time(label?: string): void {
   console.time(label);
@@ -14,11 +14,14 @@ export function error(...message: string[]): void {
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  error(chalk.red(e.toString()) + (process.env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(
+    styleText('red', e.toString()) +
+      (process.env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : '')
+  );
 }
 
 export function warn(...message: string[]): void {
-  console.warn(...message.map((value) => chalk.yellow(value)));
+  console.warn(...message.map((value) => styleText('yellow', value)));
 }
 
 export function log(...message: string[]): void {

--- a/packages/expo-updates/cli/src/utils/modifyConfigAsync.ts
+++ b/packages/expo-updates/cli/src/utils/modifyConfigAsync.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { ExpoConfig, modifyConfigAsync } from 'expo/config';
+import { styleText } from 'node:util';
 
 import * as Log from './log';
 
@@ -23,7 +23,7 @@ function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<E
   Log.log();
   if (type === 'warn') {
     // The project is using a dynamic config, give the user a helpful log and bail out.
-    Log.log(chalk.yellow(message));
+    Log.log(styleText('yellow', message));
   }
 
   notifyAboutManualConfigEdits(edits);
@@ -31,7 +31,7 @@ function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<E
 }
 
 function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
-  Log.log(chalk.cyan(`Add the following to your Expo config`));
+  Log.log(styleText('cyan', `Add the following to your Expo config`));
   Log.log();
   Log.log(JSON.stringify(edits, null, 2));
   Log.log();

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -64,7 +64,6 @@
     "@expo/plist": "workspace:^0.7.0",
     "@expo/spawn-async": "^1.8.0",
     "arg": "^4.1.0",
-    "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "expo-eas-client": "workspace:~56.0.0",
     "expo-manifests": "workspace:~56.0.4",

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -46,7 +46,6 @@
     "@expo/spawn-async": "^1.8.0",
     "@types/prompts": "^2.0.6",
     "@types/semver": "^7.0.0",
-    "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "expo-module-scripts": "workspace:*",
     "glob": "^13.0.0",

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -3,8 +3,8 @@
 import { getConfig } from '@expo/config';
 import type { ModPlatform } from '@expo/config-plugins';
 import { compileModsAsync } from '@expo/config-plugins';
-import chalk from 'chalk';
 import { Command } from 'commander';
+import { styleText } from 'node:util';
 import prompts from 'prompts';
 
 import {
@@ -35,7 +35,7 @@ const packageJSON = require('../package.json');
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
   .arguments('[project-directory]')
-  .usage(`${chalk.green('[project-directory]')} [options]`)
+  .usage(`${styleText('green', '[project-directory]')} [options]`)
   .description('Install expo-modules into your project')
   .option('-s, --sdk-version <version>', 'Install specified expo-modules sdk version')
   .option('--non-interactive', 'Disable interactive prompts')
@@ -65,7 +65,7 @@ async function promptUpgradeAgpVersionAsync(projectRoot: string, agpVersion: str
 
   const deploymentTargetMessage = `The minimum Android Gradle Plugin version for Expo modules is ${agpVersion}. This tool will change your AGP version to ${agpVersion}.`;
   if (program.opts().nonInteractive) {
-    console.log(chalk.yellow(`⚠️  ${deploymentTargetMessage}`));
+    console.log(styleText('yellow', `⚠️  ${deploymentTargetMessage}`));
     return true;
   } else {
     const { value } = await prompts({
@@ -90,7 +90,7 @@ async function promptUpgradeIosDeployTargetAsync(projectRoot: string, iosDeploym
 
   const deploymentTargetMessage = `Expo modules minimum iOS requirement is ${iosDeploymentTarget}. This tool will change your iOS deployment target to ${iosDeploymentTarget}.`;
   if (program.opts().nonInteractive) {
-    console.log(chalk.yellow(`⚠️  ${deploymentTargetMessage}`));
+    console.log(styleText('yellow', `⚠️  ${deploymentTargetMessage}`));
     return true;
   } else {
     const { value } = await prompts({
@@ -201,7 +201,7 @@ async function runAsync() {
     await installPodsAsync(projectRoot);
   }
 
-  console.log(chalk.bold('\u203A Installation completed!'));
+  console.log(styleText('bold', '\u203A Installation completed!'));
 }
 
 (async () => {

--- a/packages/install-expo-modules/src/utils/link.ts
+++ b/packages/install-expo-modules/src/utils/link.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import terminalLink from 'terminal-link';
 
 /**
@@ -16,9 +16,9 @@ export function link(
   if (terminalLink.isSupported) {
     output = terminalLink(text, url);
   } else {
-    output = `${text === url ? '' : text + ': '}${chalk.underline(url)}`;
+    output = `${text === url ? '' : text + ': '}${styleText('underline', url)}`;
   }
-  return dim ? chalk.dim(output) : output;
+  return dim ? styleText('dim', output) : output;
 }
 
 /**

--- a/packages/jest-expo/config/withWatchPlugins.js
+++ b/packages/jest-expo/config/withWatchPlugins.js
@@ -1,4 +1,4 @@
-const chalk = require('chalk');
+const { styleText } = require('node:util');
 
 function getWatchPlugins({ projects = [] } = {}) {
   const watchPlugins = [
@@ -11,7 +11,7 @@ function getWatchPlugins({ projects = [] } = {}) {
       {
         key: 'X',
         prompt() {
-          return `select which PLATFORMS to run ${chalk.italic(this._getActiveProjectsText())}`;
+          return `select which PLATFORMS to run ${styleText('italic', this._getActiveProjectsText())}`;
         },
       },
     ]);

--- a/packages/patch-project/package.json
+++ b/packages/patch-project/package.json
@@ -49,7 +49,6 @@
     "@expo/env": "workspace:~2.3.0",
     "@expo/spawn-async": "^1.8.0",
     "arg": "5.0.2",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",

--- a/packages/patch-project/src/cli/index.ts
+++ b/packages/patch-project/src/cli/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import arg from 'arg';
-import chalk from 'chalk';
 import type { ModPlatform } from 'expo/config-plugins';
 import { existsSync } from 'fs';
 import path from 'path';
+import { styleText } from 'node:util';
 
 import * as logger from './logger';
 import { patchProjectAsync } from './patchProjectAsync';
@@ -23,12 +23,12 @@ import { patchProjectAsync } from './patchProjectAsync';
   if (args['--help']) {
     printHelp(
       `(Experimental) Generate patch files for iOS and Android native projects to persist changes made manually after prebuild`,
-      chalk`npx patch-project {dim <dir>}`,
+      `npx patch-project ${styleText('dim', '<dir>')}`,
       [
-        chalk`<dir>                                    Directory of the Expo project. {dim Default: Current working directory}`,
+        `<dir>                                    Directory of the Expo project. ${styleText('dim', 'Default: Current working directory')}`,
         `--clean                                  Delete the native folders after the conversion`,
         `--template <template>                    Project template to clone from. File path pointing to a local tar file or a github repo`,
-        chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
+        `-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. ${styleText('dim', 'Default: all')}`,
         `-h, --help                               Usage info`,
       ].join('\n')
     );
@@ -61,14 +61,14 @@ process.on('SIGTERM', () => process.exit(0));
 
 function printHelp(info: string, usage: string, options: string, extra: string = ''): never {
   logger.exit(
-    chalk`
-  {bold Info}
+    `
+  ${styleText('bold', 'Info')}
     ${info}
 
-  {bold Usage}
-    {dim $} ${usage}
+  ${styleText('bold', 'Usage')}
+    ${styleText('dim', '$')} ${usage}
 
-  {bold Options}
+  ${styleText('bold', 'Options')}
     ${options.split('\n').join('\n    ')}
 ` + extra,
     0

--- a/packages/patch-project/src/cli/logger.ts
+++ b/packages/patch-project/src/cli/logger.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as env from '../env';
 
@@ -7,7 +7,7 @@ export const error = console.error;
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  error(styleText('red', e.toString()) + (env.EXPO_DEBUG ? '\n' + styleText('gray', e.stack!) : ''));
 }
 
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */

--- a/packages/patch-project/src/cli/patchProjectAsync.ts
+++ b/packages/patch-project/src/cli/patchProjectAsync.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk';
 import { getConfig, type ExpoConfig } from 'expo/config';
 import { type ModPlatform } from 'expo/config-plugins';
 import fs from 'fs/promises';
 import { glob as globAsync } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { addAllToGitIndexAsync, commitAsync, diffAsync, initializeGitRepoAsync } from '../gitPatch';
@@ -104,7 +104,7 @@ async function patchProjectForPlatformAsync({
 
   debug(`Generating native projects from prebuild template - projectRoot[${projectRoot}]`);
   logger.log(
-    chalk.bold(`Generating native projects from prebuild template - platform[${platform}]`)
+    styleText('bold', `Generating native projects from prebuild template - platform[${platform}]`)
   );
   const templateChecksum = await generateNativeProjectsAsync(projectRoot, exp, {
     platforms: [platform],
@@ -133,7 +133,7 @@ async function patchProjectForPlatformAsync({
 
   debug(`Generating patch file`);
   const patchFilePath = path.join(projectRoot, patchRoot, `${platform}+${templateChecksum}.patch`);
-  logger.log(chalk.bold(`Saving patch file to ${patchFilePath}`));
+  logger.log(styleText('bold', `Saving patch file to ${patchFilePath}`));
   await diffAsync(diffDir, patchFilePath, options.diffOptions ?? []);
   const stat = await fs.stat(patchFilePath);
   if (stat.size === 0) {

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@expo/package-manager": "workspace:*",
-    "chalk": "^4.0.0",
     "commander": "^12.1.0",
     "expo-module-scripts": "workspace:*",
     "terminal-link": "^2.1.1",

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { CocoaPodsPackageManager } from '@expo/package-manager/build/ios/CocoaPodsPackageManager';
-import chalk from 'chalk';
 import { Command } from 'commander';
 import { existsSync, readFileSync } from 'fs';
+import { styleText } from 'node:util';
 import { join, resolve } from 'path';
 
 import shouldUpdate from './update';
@@ -19,7 +19,7 @@ function info(message: string) {
 
 async function runAsync(maybeProjectDirectory?: string): Promise<void> {
   if (process.platform !== 'darwin') {
-    info(chalk.yellow('⚠️ CocoaPods is only supported on darwin machines'));
+    info(styleText('yellow', '⚠️ CocoaPods is only supported on darwin machines'));
     process.exit(0);
   }
 
@@ -27,7 +27,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
   const possibleProjectRoot = resolve(hasProjectDirectory ? maybeProjectDirectory : process.cwd());
 
   if (!existsSync(possibleProjectRoot)) {
-    info(chalk.red(`\n💥 Target directory does not exist: ${possibleProjectRoot}\n`));
+    info(styleText('red', `\n💥 Target directory does not exist: ${possibleProjectRoot}\n`));
     process.exit(1);
   }
 
@@ -37,7 +37,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
     const packageJsonPath = join(possibleProjectRoot, 'package.json');
 
     if (!existsSync(packageJsonPath)) {
-      info(chalk.red(`\n💥 'package.json' file does not exist: ${packageJsonPath}\n`));
+      info(styleText('red', `\n💥 'package.json' file does not exist: ${packageJsonPath}\n`));
       process.exit(1);
     }
 
@@ -46,19 +46,20 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
 
     if (hasExpoPackage) {
       info(
-        chalk.yellow(
-          `⚠️ No 'ios' directory found, skipping installing pods.`,
-          `\nPods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`,
-          learnMore('https://docs.expo.dev/workflow/prebuild/')
+        styleText(
+          'yellow',
+          `⚠️ No 'ios' directory found, skipping installing pods.\nPods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'. ${learnMore('https://docs.expo.dev/workflow/prebuild/')}`
         )
       );
       process.exit(0);
     }
 
     if (hasProjectDirectory) {
-      info(chalk.yellow(`⚠️ CocoaPods is not supported in project at ${possibleProjectRoot}`));
+      info(
+        styleText('yellow', `⚠️ CocoaPods is not supported in project at ${possibleProjectRoot}`)
+      );
     } else {
-      info(chalk.yellow('⚠️ CocoaPods is not supported in this project'));
+      info(styleText('yellow', '⚠️ CocoaPods is not supported in this project'));
     }
     process.exit(0);
   }
@@ -76,7 +77,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
     await manager.installAsync();
   } catch (error: any) {
     if (error.isPackageManagerError) {
-      console.error(chalk.red(error.message));
+      console.error(styleText('red', error.message));
       process.exit(1);
     }
     // throw unhandled
@@ -87,7 +88,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
   .arguments('[project-directory]')
-  .usage(`${chalk.green('[project-directory]')} [options]`)
+  .usage(`${styleText('green', '[project-directory]')} [options]`)
   .description(
     'A fast, zero-dependency package for cutting down on common issues developers have when running pod install.'
   )
@@ -104,10 +105,13 @@ const program = new Command(packageJSON.name)
     } catch (reason: any) {
       console.log('\nAborting run');
       if (reason.command) {
-        console.log(`  ${chalk.magenta(reason.command)} has failed.`);
+        console.log(`  ${styleText('magenta', reason.command)} has failed.`);
       } else {
         console.log(
-          chalk.red`💥 An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`
+          styleText(
+            'red',
+            `💥 An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`
+          )
         );
         console.log(reason);
       }

--- a/packages/pod-install/src/update.ts
+++ b/packages/pod-install/src/update.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import checkForUpdate from 'update-check';
 
 export default async function shouldUpdate() {
@@ -10,8 +10,12 @@ export default async function shouldUpdate() {
     const res = await update;
     if (res && res.latest) {
       console.log();
-      console.log(chalk.yellow.bold(`A new version of \`${packageJson.name}\` is available`));
-      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${packageJson.name}`));
+      console.log(
+        styleText(['yellow', 'bold'], `A new version of \`${packageJson.name}\` is available`)
+      );
+      console.log(
+        'You can update by running: ' + styleText('cyan', `npm i -g ${packageJson.name}`)
+      );
       console.log();
     }
   } catch {

--- a/packages/pod-install/src/utils.ts
+++ b/packages/pod-install/src/utils.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import terminalLink from 'terminal-link';
 
 /**
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link';
  * @param url
  */
 export function learnMore(url: string): string {
-  return terminalLink(chalk.underline('Learn more.'), url, {
-    fallback: (_, url) => `Learn more: ${chalk.underline(url)}`,
+  return terminalLink(styleText('underline', 'Learn more.'), url, {
+    fallback: (_, url) => `Learn more: ${styleText('underline', url)}`,
   });
 }

--- a/packages/uri-scheme/package.json
+++ b/packages/uri-scheme/package.json
@@ -41,7 +41,6 @@
     "@expo/plist": "workspace:*",
     "@expo/spawn-async": "^1.8.0",
     "@types/prompts": "^2.0.6",
-    "chalk": "^4.0.0",
     "commander": "^12.1.0",
     "expo-module-scripts": "workspace:*",
     "glob": "^13.0.0",

--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -6,8 +6,8 @@ import {
 import * as Scheme from '@expo/config-plugins/build/android/Scheme';
 import { format } from '@expo/config-plugins/build/utils/XML';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { existsSync } from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import type { Options } from './Options';
@@ -41,7 +41,8 @@ export async function addAsync({
   }
   if (Scheme.hasScheme(uri, manifest)) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `\u203A Android: URI scheme "${uri}" already exists in AndroidManifest.xml at: ${resolvedManifestPath}`
       )
     );
@@ -51,7 +52,7 @@ export async function addAsync({
   manifest = Scheme.appendScheme(uri, manifest);
 
   if (dryRun) {
-    console.log(chalk.magenta('Write manifest to: ', resolvedManifestPath));
+    console.log(styleText('magenta', 'Write manifest to: '));
     console.log(format(manifest));
     return false;
   }
@@ -77,7 +78,8 @@ export async function removeAsync({
 
   if (!Scheme.hasScheme(uri, manifest)) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `\u203A Android: URI scheme "${uri}" does not exist in AndroidManifest.xml at: ${resolvedManifestPath}`
       )
     );
@@ -87,7 +89,7 @@ export async function removeAsync({
   manifest = Scheme.removeScheme(uri, manifest);
 
   if (dryRun) {
-    console.log(chalk.magenta('Write manifest to: ', resolvedManifestPath));
+    console.log(styleText('magenta', 'Write manifest to: '));
     console.log(format(manifest));
     return false;
   }

--- a/packages/uri-scheme/src/CLI.ts
+++ b/packages/uri-scheme/src/CLI.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import { Command } from 'commander';
+import { styleText } from 'node:util';
 import { resolve } from 'path';
 
 import * as Android from './Android';
@@ -178,18 +178,23 @@ async function commandDidThrowAsync(reason: any) {
   console.log();
   if (reason.command) {
     console.log(
-      chalk.red(`\u203A ${chalk.bold(`npx ${packageJson().name} ${reason.command}`)} has failed.`)
+      styleText(
+        'red',
+        `\u203A ${styleText('bold', `npx ${packageJson().name} ${reason.command}`)} has failed.`
+      )
     );
     console.log();
   }
   if (reason.origin === 'uri-scheme') {
-    console.log(chalk.black.bgRed(reason.message));
+    console.log(styleText(['black', 'bgRed'], reason.message));
   } else {
     console.log('Aborting run');
 
     console.log(
-      chalk.black
-        .bgRed`An unexpected error was encountered. Report it: https://github.com/expo/expo/issues`
+      styleText(
+        ['black', 'bgRed'],
+        `An unexpected error was encountered. Report it: https://github.com/expo/expo/issues`
+      )
     );
     console.log(reason);
   }

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -2,9 +2,9 @@
 import * as Scheme from '@expo/config-plugins/build/ios/Scheme';
 import plist from '@expo/plist';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs';
 import { globSync } from 'glob';
+import { styleText } from 'node:util';
 import * as path from 'path';
 
 import type { Options } from './Options';
@@ -38,7 +38,8 @@ export async function addAsync({
 
   if (Scheme.hasScheme(uri, config)) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `\u203A iOS: URI scheme "${uri}" already exists in Info.plist at: ${infoPlistPath}`
       )
     );
@@ -48,7 +49,7 @@ export async function addAsync({
   config = Scheme.appendScheme(uri, config);
 
   if (dryRun) {
-    console.log(chalk.magenta('Write plist to: ', infoPlistPath));
+    console.log(styleText('magenta', 'Write plist to: '));
     console.log(formatConfig(config));
     return false;
   }
@@ -68,7 +69,8 @@ export async function removeAsync({
 
   if (!Scheme.hasScheme(uri, config)) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `\u203A iOS: URI scheme "${uri}" does not exist in Info.plist at: ${infoPlistPath}`
       )
     );
@@ -78,7 +80,7 @@ export async function removeAsync({
   config = Scheme.removeScheme(uri, config);
 
   if (dryRun) {
-    console.log(chalk.magenta('Write plist to: ', infoPlistPath));
+    console.log(styleText('magenta', 'Write plist to: '));
     console.log(formatConfig(config));
     return false;
   }

--- a/packages/uri-scheme/src/URIScheme.ts
+++ b/packages/uri-scheme/src/URIScheme.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import { statSync } from 'fs';
+import { styleText } from 'node:util';
 import { relative } from 'path';
 import prompts from 'prompts';
 
@@ -87,7 +87,8 @@ async function normalizeUriProtocolAsync(uri: any): Promise<string> {
     // Create a warning.
     if (normalizedUri) {
       console.log(
-        chalk.yellow(
+        styleText(
+          'yellow',
           `\u203A Supplied URI protocol "${trimmedUri}" does not match normalized scheme "${normalizedUri}".`
         )
       );
@@ -131,7 +132,8 @@ export async function addAsync(options: Options): Promise<string[]> {
 
   if (!actionOccurred) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         'No URI schemes could be added. Ensure there is a native project in "ios" and/or "android" directories.'
       )
     );
@@ -163,7 +165,8 @@ export async function removeAsync(options: Options): Promise<string[]> {
 
   if (!actionOccurred) {
     console.log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         'No URI schemes could be removed. Ensure there is a native project in "ios" and/or "android" directories.'
       )
     );
@@ -216,14 +219,15 @@ export async function listAsync(
   }
 
   if (!actionOccurred) {
-    console.log(chalk.yellow('Could not find any native URI schemes to list.'));
+    console.log(styleText('yellow', 'Could not find any native URI schemes to list.'));
   }
 }
 
 function logPlatformMessage(platform: string, message: string): void {
-  console.log(chalk.magenta(`\u203A ${chalk.bold(platform)}: ${message}`));
+  console.log(styleText('magenta', `\u203A ${styleText('bold', platform)}: ${message}`));
 }
 function logSchemes(schemes: string[]): void {
-  for (const scheme of schemes) console.log(`${chalk.dim('\u203A ')}${scheme}${chalk.dim('://')}`);
+  for (const scheme of schemes)
+    console.log(`${styleText('dim', '\u203A ')}${scheme}${styleText('dim', '://')}`);
   console.log('');
 }

--- a/packages/uri-scheme/src/update.ts
+++ b/packages/uri-scheme/src/update.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import checkForUpdate from 'update-check';
 
 export default async function shouldUpdate(): Promise<void> {
@@ -11,8 +11,12 @@ export default async function shouldUpdate(): Promise<void> {
     if (res && res.latest) {
       const _packageJson = packageJson();
       console.log();
-      console.log(chalk.yellow.bold(`A new version of \`${_packageJson.name}\` is available`));
-      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${_packageJson.name}`));
+      console.log(
+        styleText(['yellow', 'bold'], `A new version of \`${_packageJson.name}\` is available`)
+      );
+      console.log(
+        'You can update by running: ' + styleText('cyan', `npm i -g ${_packageJson.name}`)
+      );
       console.log();
     }
   } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1901,9 +1901,6 @@ importers:
       bplist-parser:
         specifier: ^0.3.1
         version: 0.3.2
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       ci-info:
         specifier: ^3.3.0
         version: 3.9.0
@@ -2209,9 +2206,6 @@ importers:
       '@expo/sdk-runtime-versions':
         specifier: ^1.0.0
         version: 1.0.0
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       debug:
         specifier: ^4.3.5
         version: 4.4.3
@@ -2258,9 +2252,6 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.15
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -2279,9 +2270,6 @@ importers:
 
   packages/@expo/devtools:
     dependencies:
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       react:
         specifier: '*'
         version: 19.2.3
@@ -2329,9 +2317,6 @@ importers:
 
   packages/@expo/env:
     dependencies:
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -2363,9 +2348,6 @@ importers:
       arg:
         specifier: ^5.0.2
         version: 5.0.2
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -2433,9 +2415,6 @@ importers:
       '@expo/spawn-async':
         specifier: ^1.8.0
         version: 1.8.0
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       getenv:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2514,9 +2493,6 @@ importers:
       '@expo/config':
         specifier: workspace:~56.0.9
         version: link:../config
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -2636,9 +2612,6 @@ importers:
       browserslist:
         specifier: ^4.25.0
         version: 4.28.2
-      chalk:
-        specifier: ^4.1.0
-        version: 4.1.2
       debug:
         specifier: ^4.3.2
         version: 4.4.3
@@ -2811,9 +2784,6 @@ importers:
       '@expo/spawn-async':
         specifier: ^1.8.0
         version: 1.8.0
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       npm-package-arg:
         specifier: ^11.0.0
         version: 11.0.3
@@ -3278,9 +3248,6 @@ importers:
       arg:
         specifier: ^5.0.2
         version: 5.0.2
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -3356,9 +3323,6 @@ importers:
       '@vercel/ncc':
         specifier: ^0.38.4
         version: 0.38.4
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       commander:
         specifier: ^8.3.0
         version: 8.3.0
@@ -3955,9 +3919,6 @@ importers:
       '@expo/spawn-async':
         specifier: ^1.8.0
         version: 1.8.0
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -4153,9 +4114,6 @@ importers:
 
   packages/expo-codemod:
     dependencies:
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       jscodeshift:
         specifier: ^17.1.2
         version: 17.3.0(@babel/preset-env@7.29.2(@babel/core@7.29.0))
@@ -4379,9 +4337,6 @@ importers:
       '@vercel/ncc':
         specifier: ^0.38.3
         version: 0.38.4
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -5035,9 +4990,6 @@ importers:
       '@expo/spawn-async':
         specifier: ^1.8.0
         version: 1.8.0
-      chalk:
-        specifier: ^4.1.0
-        version: 4.1.2
       commander:
         specifier: ^7.2.0
         version: 7.2.0
@@ -5792,9 +5744,6 @@ importers:
       '@expo/spawn-async':
         specifier: ^1.8.0
         version: 1.8.0
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       commander:
         specifier: ^7.2.0
         version: 7.2.0
@@ -5842,9 +5791,6 @@ importers:
 
   packages/expo-type-information:
     dependencies:
-      chalk:
-        specifier: ^4.1.0
-        version: 4.1.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -5937,9 +5883,6 @@ importers:
       arg:
         specifier: ^4.1.0
         version: 4.1.3
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -6182,9 +6125,6 @@ importers:
       '@types/semver':
         specifier: ^7.0.0
         version: 7.7.1
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -6285,9 +6225,6 @@ importers:
       arg:
         specifier: 5.0.2
         version: 5.0.2
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       debug:
         specifier: ^4.3.1
         version: 4.4.3
@@ -6325,9 +6262,6 @@ importers:
       '@expo/package-manager':
         specifier: workspace:*
         version: link:../@expo/package-manager
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -6361,9 +6295,6 @@ importers:
       '@types/prompts':
         specifier: ^2.0.6
         version: 2.4.9
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -6412,9 +6343,6 @@ importers:
       '@octokit/rest':
         specifier: ^19.0.7
         version: 19.0.13(encoding@0.1.13)
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5

--- a/tools/package.json
+++ b/tools/package.json
@@ -33,7 +33,6 @@
     "@expo/swiftlint": "^0.57.1",
     "@linear/sdk": "^2.6.0",
     "@octokit/rest": "^19.0.7",
-    "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "cwait": "^1.1.2",
     "diff": "^8.0.3",

--- a/tools/src/Diff.ts
+++ b/tools/src/Diff.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { diffLines } from 'diff';
+import { styleText } from 'node:util';
 
 const CONTEXT_SIZE = 5;
 
@@ -11,9 +11,9 @@ export function printDiff(before: string, after: string): void {
       index < diff.length - 1 && (diff[index + 1].added || diff[index + 1].removed);
     let result = '';
     if (part.added) {
-      result = chalk.green(part.value);
+      result = styleText('green', part.value);
     } else if (part.removed) {
-      result = chalk.red(part.value);
+      result = styleText('red', part.value);
     } else if (isContextEnd && isContextStart) {
       const split = part.value.split('\n');
       if (split.length - 1 > 2 * CONTEXT_SIZE) {

--- a/tools/src/Formatter.ts
+++ b/tools/src/Formatter.ts
@@ -1,10 +1,8 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import terminalLink from 'terminal-link';
 
 import { GitLog, GitFileLog } from './Git';
-
-const { white, cyan, red, green, yellow, blue, gray, dim, reset } = chalk;
 
 /**
  * Uses `terminal-link` to create clickable link in the terminal.
@@ -18,12 +16,12 @@ export function link(text: string, url: string) {
  * Formats an entry from git log.
  */
 export function formatCommitLog(log: GitLog): string {
-  const authorName = green(log.authorName);
+  const authorName = styleText('green', log.authorName);
   const commitHash = formatCommitHash(log.hash);
   const title = formatCommitTitle(log.title);
   const date = log.committerRelativeDate;
 
-  return `${commitHash} ${title} ${gray(`by ${authorName} ${date}`)}`;
+  return `${commitHash} ${title} ${styleText('gray', `by ${authorName} ${date}`)}`;
 }
 
 /**
@@ -32,7 +30,7 @@ export function formatCommitLog(log: GitLog): string {
 export function formatCommitTitle(title: string): string {
   return title.replace(
     /\(#(\d+)\)$/g,
-    `(${blue.bold(link('#$1', 'https://github.com/expo/expo/pull/$1'))})`
+    `(${styleText(['blue', 'bold'], link('#$1', 'https://github.com/expo/expo/pull/$1'))})`
   );
 }
 
@@ -41,12 +39,12 @@ export function formatCommitTitle(title: string): string {
  */
 export function formatCommitHash(hash?: string): string {
   if (!hash) {
-    return gray('undefined');
+    return styleText('gray', 'undefined');
   }
   const url = `https://github.com/expo/expo/commit/${hash}`;
   const abbreviatedHash = hash.substring(0, 6);
 
-  return yellow.bold(`(${link(abbreviatedHash, url)})`);
+  return styleText(['yellow', 'bold'], `(${link(abbreviatedHash, url)})`);
 }
 
 /**
@@ -55,10 +53,10 @@ export function formatCommitHash(hash?: string): string {
  */
 export function formatChangelogEntry(entry: string): string {
   return entry
-    .replace(/\[(#\d+|@\w+)\]\(([^)]+?)\)/g, blue.bold(link('$1', '$2')))
-    .replace(/(\W)([_*]{2})([^\x02]*?)\2(\W)/g, '$1' + reset.bold('$3') + '$4')
-    .replace(/(\W)([_*])([^\x02]*?)\2(\W)/g, '$1' + reset.italic('$3') + '$4')
-    .replace(/`([^`]+?)`/g, dim('$1'));
+    .replace(/\[(#\d+|@\w+)\]\(([^)]+?)\)/g, styleText(['blue', 'bold'], link('$1', '$2')))
+    .replace(/(\W)([_*]{2})([^\x02]*?)\2(\W)/g, '$1' + styleText(['reset', 'bold'], '$3') + '$4')
+    .replace(/(\W)([_*])([^\x02]*?)\2(\W)/g, '$1' + styleText(['reset', 'italic'], '$3') + '$4')
+    .replace(/`([^`]+?)`/g, styleText('dim', '$1'));
 }
 
 /**
@@ -66,7 +64,7 @@ export function formatChangelogEntry(entry: string): string {
  */
 export function formatFileLog(fileLog: GitFileLog): string {
   const uri = `vscode://file/${fileLog.path}`;
-  return `${link(fileLog.relativePath, uri)} ${gray(`(${fileLog.status})`)}`;
+  return `${link(fileLog.relativePath, uri)} ${styleText('gray', `(${fileLog.status})`)}`;
 }
 
 /**
@@ -84,17 +82,18 @@ export function formatXcodeBuildOutput(output: string): string {
   return output
     .replace(/^(\/.*)(:\d+:\d+): (error|warning|note)(:.*)$/gm, (_, p1, p2, p3, p4) => {
       if (p3 === 'note') {
-        return gray.bold(p3) + white.bold(p4);
+        return styleText(['gray', 'bold'], p3) + styleText(['white', 'bold'], p4);
       }
       const relativePath = path.relative(process.cwd(), p1);
-      const logColor = p3 === 'error' ? red.bold : yellow.bold;
+      const logColor: Parameters<typeof styleText>[0] =
+        p3 === 'error' ? ['red', 'bold'] : ['yellow', 'bold'];
 
-      return cyan.bold(relativePath + p2) + ' ' + logColor(p3 + p4);
+      return styleText(['cyan', 'bold'], relativePath + p2) + ' ' + styleText(logColor, p3 + p4);
     })
     .replace(/^(In file included from )(\/[^\n]+)(:\d+:[^\n]*)$/gm, (_, p1, p2, p3) => {
       const relativePath = path.relative(process.cwd(), p2);
-      return gray.italic(p1 + relativePath + p3);
+      return styleText(['gray', 'italic'], p1 + relativePath + p3);
     })
-    .replace(/\s\^\n(\s[^\n]+)?/g, green.bold('$&\n'))
-    .replace(/\*\* BUILD FAILED \*\*/, red.bold('$&'));
+    .replace(/\s\^\n(\s[^\n]+)?/g, styleText(['green', 'bold'], '$&\n'))
+    .replace(/\*\* BUILD FAILED \*\*/, styleText(['red', 'bold'], '$&'));
 }

--- a/tools/src/Logger.ts
+++ b/tools/src/Logger.ts
@@ -1,12 +1,20 @@
-import chalk, { Chalk } from 'chalk';
+import { styleText } from 'node:util';
 import readline from 'readline';
 
 type LogLevel = 'log' | 'debug' | 'info' | 'warn' | 'error';
 
-type LoggerResolver = (level: LogLevel, color: Chalk | null, args: string[]) => void;
+type LoggerResolver = (
+  level: LogLevel,
+  color: Parameters<typeof styleText>[0] | null,
+  args: string[]
+) => void;
 
-const CONSOLE_RESOLVER: LoggerResolver = (level: LogLevel, color: Chalk | null, args: string[]) => {
-  return console[level](...(color ? args.map((arg) => color(arg)) : args));
+const CONSOLE_RESOLVER: LoggerResolver = (
+  level: LogLevel,
+  color: Parameters<typeof styleText>[0] | null,
+  args: string[]
+) => {
+  return console[level](...(color ? args.map((arg) => styleText(color, arg)) : args));
 };
 
 // Process-wide verbose flag. All Logger instances (including LoggerBatch)
@@ -38,11 +46,11 @@ export class Logger {
    */
   verbose(...args: any[]): void {
     if (!_verbose) return;
-    this.resolver('debug', chalk.dim, args);
+    this.resolver('debug', 'dim', args);
   }
 
   debug(...args: any[]): void {
-    this.resolver('debug', chalk.gray, args);
+    this.resolver('debug', 'gray', args);
   }
 
   log(...args: any[]): void {
@@ -50,19 +58,19 @@ export class Logger {
   }
 
   success(...args: any[]): void {
-    this.resolver('log', chalk.green, args);
+    this.resolver('log', 'green', args);
   }
 
   info(...args: any[]): void {
-    this.resolver('info', chalk.cyan, args);
+    this.resolver('info', 'cyan', args);
   }
 
   warn(...args: any[]): void {
-    this.resolver('warn', chalk.yellow.bold, args);
+    this.resolver('warn', ['yellow', 'bold'], args);
   }
 
   error(...args: any[]): void {
-    this.resolver('error', chalk.red.bold, args);
+    this.resolver('error', ['red', 'bold'], args);
   }
 
   batch(): LoggerBatch {
@@ -80,7 +88,7 @@ export class Logger {
  * Useful for asynchronous simultaneous operations to preserve logs order.
  */
 export class LoggerBatch extends Logger {
-  readonly batchedLogs: [LogLevel, Chalk | null, any[]][] = [];
+  readonly batchedLogs: [LogLevel, Parameters<typeof styleText>[0] | null, any[]][] = [];
 
   constructor(readonly parentResolver: LoggerResolver = CONSOLE_RESOLVER) {
     super((level, color, args) => {

--- a/tools/src/TasksRunner.ts
+++ b/tools/src/TasksRunner.ts
@@ -1,6 +1,6 @@
 import JsonFile, { JSONObject } from '@expo/json-file';
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 
 import Git from './Git';
 import logger from './Logger';
@@ -277,7 +277,7 @@ export class TaskRunner<
       logger.error();
 
       if (error instanceof TaskError) {
-        logger.error(`💥 Execution failed for task ${chalk.cyan(error.task.name)}.`);
+        logger.error(`💥 Execution failed for task ${styleText('cyan', error.task.name)}.`);
       }
 
       logger.error('💥 Error:', error.message);
@@ -287,7 +287,7 @@ export class TaskRunner<
         logger.debug(stack[1]);
       }
 
-      error.stderr && logger.error('💥 stderr output:\n', chalk.reset(error.stderr));
+      error.stderr && logger.error('💥 stderr output:\n', styleText('reset', error.stderr));
       process.exit(1);
     }
   }

--- a/tools/src/Utils.ts
+++ b/tools/src/Utils.ts
@@ -1,6 +1,6 @@
 import basicSpawnAsync, { SpawnResult, SpawnOptions, SpawnPromise } from '@expo/spawn-async';
-import chalk from 'chalk';
 import { glob, GlobOptions } from 'glob';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import { stripVTControlCharacters } from 'util';
 
@@ -36,7 +36,9 @@ export async function spawnJSONCommandAsync<T = object>(
     return JSON.parse(child.stdout);
   } catch (e) {
     e.message +=
-      '\n' + chalk.red('Cannot parse this output as JSON: ') + chalk.yellow(child.stdout.trim());
+      '\n' +
+      styleText('red', 'Cannot parse this output as JSON: ') +
+      styleText('yellow', child.stdout.trim());
     throw e;
   }
 }
@@ -180,7 +182,7 @@ export async function runWithSpinner<Result>(
 ): Promise<Result> {
   const disabled = process.env.CI || process.env.EXPO_DEBUG;
   const step = ora({
-    text: chalk.bold(title),
+    text: styleText('bold', title),
     isEnabled: !disabled,
     stream: disabled ? process.stdout : process.stderr,
     ...options,

--- a/tools/src/android-update-native-dependencies/androidProjectReports.ts
+++ b/tools/src/android-update-native-dependencies/androidProjectReports.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import { pathExists, readJSON, unlink, writeJSON } from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import * as path from 'path';
 
@@ -87,9 +87,7 @@ async function executeGradleTask(
   ];
   const spinner = ora({
     spinner: 'dots',
-    text: `Executing gradle command ${chalk.yellow(
-      `${gradleWrapperCommand} ${gradleCommandArguments.join(' ')}`
-    )}. This might take a while.`,
+    text: `Executing gradle command ${styleText('yellow', `${gradleWrapperCommand} ${gradleCommandArguments.join(' ')}`)}. This might take a while.`,
   });
 
   spinner.start();

--- a/tools/src/android-update-native-dependencies/index.ts
+++ b/tools/src/android-update-native-dependencies/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { getAndroidProjectReports, Revision } from './androidProjectReports';
 import { promptForNativeDependenciesUpdates, promptForAndroidProjectsSelection } from './prompts';
@@ -26,18 +26,18 @@ async function printAvailableUpdates(reports: AndroidProjectReport[]) {
     const noDependenciesIssues = unresolvedExceededDependencies.length + outdated.length === 0;
 
     logger.log(
-      `\n● Project: ${chalk.blue(projectName)}${
-        noDependenciesIssues ? chalk.green(` - no dependencies issues ✅`) : ''
+      `\n● Project: ${styleText('blue', projectName)}${
+        noDependenciesIssues ? styleText('green', ` - no dependencies issues ✅`) : ''
       }`
     );
 
     if (outdated.length > 0) {
-      logger.log(chalk.cyan('  ◼︎ outdated dependencies:'));
+      logger.log(styleText('cyan', '  ◼︎ outdated dependencies:'));
       outdated.forEach(printDependency);
     }
 
     if (unresolvedExceededDependencies.length > 0) {
-      logger.log(chalk.yellow('  ◼︎ unresolved/exceeded dependencies:'));
+      logger.log(styleText('yellow', '  ◼︎ unresolved/exceeded dependencies:'));
       unresolvedExceededDependencies.forEach(printDependency);
     }
   }

--- a/tools/src/android-update-native-dependencies/prompts.ts
+++ b/tools/src/android-update-native-dependencies/prompts.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import type { ReleaseType } from 'semver';
 import stripAnsi from 'strip-ansi';
 
@@ -17,10 +17,10 @@ function generateAndroidProjectsSelectionChoice({
   gradleReport: { outdated, exceeded, unresolved },
 }: AndroidProjectReport) {
   const deprecationMarking =
-    outdated.length > 0 ? ` ${chalk.yellow(`(${outdated.length} ⚠️ )`)}` : '';
+    outdated.length > 0 ? ` ${styleText('yellow', `(${outdated.length} ⚠️ )`)}` : '';
   const hasUnresolvedOrExceedeedMarking =
     exceeded.length > 0 || unresolved.length > 0
-      ? ` ${chalk.red(`(${exceeded.length + unresolved.length} ❗️)`)}`
+      ? ` ${styleText('red', `(${exceeded.length + unresolved.length} ❗️)`)}`
       : '';
   const name = `${projectName}${deprecationMarking}${hasUnresolvedOrExceedeedMarking}`;
   return {
@@ -37,11 +37,7 @@ export async function promptForAndroidProjectsSelection(
     {
       type: 'checkbox',
       name: 'selectedProjects',
-      message: `Choose which projects need updates. ${chalk.yellow(
-        '(<number> ⚠️ )'
-      )} shows how many dependencies are outdated. ${chalk.red(
-        '(<number> ❗️)'
-      )} shows other problems with respective project's dependencies.`,
+      message: `Choose which projects need updates. ${styleText('yellow', '(<number> ⚠️ )')} shows how many dependencies are outdated. ${styleText('red', '(<number> ❗️)')} shows other problems with respective project's dependencies.`,
       choices: reports.map(generateAndroidProjectsSelectionChoice),
       pageSize: Math.min(reports.length, (process.stdout.rows || 100) - 2),
     },
@@ -57,7 +53,7 @@ async function promptForDependenciesVersions(
   const sortedDependencies = dependencies.sort((a, b) => a.fullName.localeCompare(b.fullName));
   for (const dependency of sortedDependencies) {
     logger.log(
-      `  ▶︎ ${chalk.blueBright(dependency.fullName)} ${getChangelogLink(
+      `  ▶︎ ${styleText('blueBright', dependency.fullName)} ${getChangelogLink(
         dependency.fullName,
         dependency.projectUrl
       )}`
@@ -106,7 +102,7 @@ async function promptForDependencyVersion(
           },
         ],
         default: 0,
-        prefix: `  ${chalk.green('?')}`,
+        prefix: `  ${styleText('green', '?')}`,
       },
     ])
   ).version;
@@ -118,7 +114,7 @@ async function promptForDependencyVersion(
           name: 'version',
           message: `${dependency.fullName}:${dependency.currentVersion} ➡️ `,
           default: addColorBasedOnSemverDiff(dependency.availableVersion, semverDiff),
-          prefix: `  ${chalk.green('?')}`,
+          prefix: `  ${styleText('green', '?')}`,
         },
       ])
     ).version;
@@ -131,15 +127,15 @@ async function promptForDependenciesUpdatesSelection(
 ): Promise<GradleDependencyUpdate[]> {
   const result: GradleDependencyUpdate[] = [];
 
-  logger.log(`\n● project: ${chalk.blue(report.projectName)}`);
+  logger.log(`\n● project: ${styleText('blue', report.projectName)}`);
   result.push(...(await promptForDependenciesVersions(report.gradleReport.outdated)));
 
   if (report.gradleReport.exceeded.length > 0) {
-    logger.log(`🧐 these dependencies ${chalk.yellow('exceed')} available version:`);
+    logger.log(`🧐 these dependencies ${styleText('yellow', 'exceed')} available version:`);
     result.push(...(await promptForDependenciesVersions(report.gradleReport.exceeded)));
   }
   if (report.gradleReport.unresolved.length > 0) {
-    logger.log(`💥 ${chalk.red('Failed to resolve')} these dependencies:`);
+    logger.log(`💥 ${styleText('red', 'Failed to resolve')} these dependencies:`);
     result.push(...(await promptForDependenciesVersions(report.gradleReport.unresolved)));
   }
 
@@ -151,7 +147,8 @@ export async function promptForNativeDependenciesUpdates(
 ): Promise<AndroidProjectDependenciesUpdates[]> {
   const selectedDependenciesUpdates: AndroidProjectDependenciesUpdates[] = [];
   logger.log(
-    chalk.white.bold(
+    styleText(
+      ['white', 'bold'],
       '\nProvide new native dependencies versions for each project. Check their changes in respective CHANGELOGs. To skip dependency provide no value.'
     )
   );

--- a/tools/src/android-update-native-dependencies/updateGradleFiles.ts
+++ b/tools/src/android-update-native-dependencies/updateGradleFiles.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { readFile, writeFile } from 'fs-extra';
+import { styleText } from 'node:util';
 import * as path from 'path';
 import terminalLink from 'terminal-link';
 
@@ -121,7 +121,7 @@ async function writeGradleFiles(gradleFiles: Record<string, string>) {
 export async function updateGradleDependencies(
   updatesList: AndroidProjectDependenciesUpdates[]
 ): Promise<void> {
-  logger.log(chalk.white.bold(`\nUpdating gradle files.`));
+  logger.log(styleText(['white', 'bold'], `\nUpdating gradle files.`));
   const buildFiles = await readGradleFiles(updatesList);
   for (const updates of updatesList) {
     if (updates.updates.length === 0) {
@@ -130,9 +130,9 @@ export async function updateGradleDependencies(
 
     logger.log(
       `\n📈 Updating %s native dependencies in file: %s`,
-      chalk.blue(updates.report.projectName),
+      styleText('blue', updates.report.projectName),
       terminalLink(
-        chalk.italic.grey(path.relative(EXPO_DIR, updates.report.gradleFilePath)),
+        styleText(['italic', 'grey'], path.relative(EXPO_DIR, updates.report.gradleFilePath)),
         updates.report.gradleFilePath
       )
     );
@@ -140,7 +140,7 @@ export async function updateGradleDependencies(
     let buildFile = buildFiles[updates.report.gradleFilePath];
     for (const singleUpdate of updates.updates) {
       logger.log(
-        `  ▶︎ ${chalk.blueBright(singleUpdate.fullName)}:${
+        `  ▶︎ ${styleText('blueBright', singleUpdate.fullName)}:${
           singleUpdate.oldVersion
         } ➡️  ${addColorBasedOnSemverDiff(
           singleUpdate.newVersion,

--- a/tools/src/android-update-native-dependencies/utils.ts
+++ b/tools/src/android-update-native-dependencies/utils.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver, { type ReleaseType } from 'semver';
 import terminalLink from 'terminal-link';
 
@@ -7,9 +7,11 @@ import dependenciesChangelogs from '../data/androidDependenciesChangelogs.json';
 
 export function getChangelogLink(dependency: string, fallbackLink: string | null) {
   const link = dependenciesChangelogs[dependency] ?? fallbackLink;
-  return chalk.italic.dim(
+  return styleText(
+    ['italic', 'dim'],
     (link && terminalLink('CHANGELOG', link)) ??
-      chalk.whiteBright(
+      styleText(
+        'whiteBright',
         `Hey developer! Add CHANGELOG URL address for this dependency in ${terminalLink(
           'dependenciesChangelogs.json',
           `file://${EXPOTOOLS_DIR}/src/android-update-native-dependencies/dependenciesChangelogs.json`
@@ -42,5 +44,5 @@ export function addColorBasedOnSemverDiff(version: string | null, semverDiff: Re
     }
   }
 
-  return chalk.reset.bold[colorEffect](version ?? '<unknown>');
+  return styleText(['reset', 'bold', colorEffect], version ?? '<unknown>');
 }

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { COMMENT_HEADER, generateReportFromOutputs } from './reports';
 import checkMissingChangelogs from './reviewers/checkMissingChangelogs';
@@ -63,7 +63,7 @@ export async function reviewPullRequestAsync(prNumber: number) {
   const pr = await GitHub.getPullRequestAsync(prNumber);
   const user = await GitHub.getAuthenticatedUserAsync();
 
-  logger.info('👾 Fetching head commit', chalk.yellow.bold(pr.head.sha));
+  logger.info('👾 Fetching head commit', styleText(['yellow', 'bold'], pr.head.sha));
   await Git.fetchAsync({
     remote: 'origin',
     ref: pr.head.sha,
@@ -86,7 +86,7 @@ export async function reviewPullRequestAsync(prNumber: number) {
     try {
       return await action(input);
     } catch (error) {
-      logger.error(`😫 Code review action '${chalk.green(id)}' failed`);
+      logger.error(`😫 Code review action '${styleText('green', id)}' failed`);
       throw error;
     }
   });
@@ -172,11 +172,11 @@ async function updateLabelsAsync(pr: GitHub.PullRequest, newLabel: Label) {
   );
 
   for (const labelToRemove of labelsToRemove) {
-    logger.info(`🏷  Removing ${chalk.yellow(labelToRemove)} label`);
+    logger.info(`🏷  Removing ${styleText('yellow', labelToRemove)} label`);
     await GitHub.removeIssueLabelAsync(pr.number, labelToRemove);
   }
   if (!prLabels.includes(newLabel)) {
-    logger.info(`🏷  Adding ${chalk.yellow(newLabel)} label`);
+    logger.info(`🏷  Adding ${styleText('yellow', newLabel)} label`);
     await GitHub.addIssueLabelsAsync(pr.number, [newLabel]);
   }
 }
@@ -209,7 +209,7 @@ async function submitReportAsync(prNumber: number, reportBody: string) {
 
   const comment = await GitHub.createCommentAsync(prNumber, reportBody);
 
-  logger.info('🎤 Submitted the report at:', chalk.blue(comment.html_url));
+  logger.info('🎤 Submitted the report at:', styleText('blue', comment.html_url));
 }
 
 /**
@@ -230,7 +230,7 @@ async function submitReviewWithCommentsAsync(prNumber: number, comments: ReviewC
     comments,
   });
 
-  logger.info('📝 Submitted the review at:', chalk.blue(review.html_url));
+  logger.info('📝 Submitted the review at:', styleText('blue', review.html_url));
 }
 
 /**

--- a/tools/src/commands/AddChangelog.ts
+++ b/tools/src/commands/AddChangelog.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer, { QuestionCollection } from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Changelogs from '../Changelogs';
@@ -134,13 +134,13 @@ async function action(packageNames: string[], options: ActionOptions) {
 
   const type = toChangeType(options.type);
   if (!type) {
-    throw new Error(`Invalid type: ${chalk.cyan(options.type)}`);
+    throw new Error(`Invalid type: ${styleText('cyan', options.type)}`);
   }
 
   for (const packageName of options.packageNames) {
     const packagePath = path.join(Directories.getPackagesDir(), packageName, 'CHANGELOG.md');
     if (!(await fs.pathExists(packagePath))) {
-      throw new Error(`Package ${chalk.green(packageName)} doesn't have changelog file.`);
+      throw new Error(`Package ${styleText('green', packageName)} doesn't have changelog file.`);
     }
 
     const changelog = Changelogs.loadFrom(packagePath);
@@ -158,13 +158,15 @@ async function action(packageNames: string[], options: ActionOptions) {
       await changelog.saveAsync();
 
       logger.info(
-        `\n➕ Inserted ${chalk.magenta(options.type)} entry to ${chalk.green(packageName)}:`
+        `\n➕ Inserted ${styleText('magenta', options.type)} entry to ${styleText('green', packageName)}:`
       );
       insertedEntries.forEach((entry) => {
         logger.log('  ', formatChangelogEntry(Changelogs.getChangeEntryLabel(entry)));
       });
     } else {
-      logger.info(`\n👌 Specified entry is already added to ${chalk.green(packageName)} changelog`);
+      logger.info(
+        `\n👌 Specified entry is already added to ${styleText('green', packageName)} changelog`
+      );
     }
   }
 }

--- a/tools/src/commands/AndroidBuildPackages.ts
+++ b/tools/src/commands/AndroidBuildPackages.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 import readline from 'readline';
 
@@ -254,8 +254,8 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
         readline.clearLine(process.stdout, 0);
         readline.cursorTo(process.stdout, 0);
         process.stdout.write(` ❌  Failed to build ${pkg.name}:\n`);
-        console.error(chalk.red(e.message));
-        console.error(chalk.red(e.stderr));
+        console.error(styleText('red', e.message));
+        console.error(styleText('red', e.stderr));
       }
     }
   }

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -1,5 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Directories from '../Directories';
@@ -22,7 +22,9 @@ type TestType = (typeof testTypes)[number];
 
 function consoleErrorOutput(output: string, label: string, colorifyLine: (string) => string): void {
   const lines = output.trim().split(/\r\n?|\n/g);
-  console.error(lines.map((line) => `${chalk.gray(label)} ${colorifyLine(line)}`).join('\n'));
+  console.error(
+    lines.map((line) => `${styleText('gray', label)} ${colorifyLine(line)}`).join('\n')
+  );
 }
 
 export async function androidNativeUnitTests({
@@ -67,9 +69,9 @@ export async function androidNativeUnitTests({
     return includesTests;
   });
 
-  console.log(chalk.green('Packages to test: '));
+  console.log(styleText('green', 'Packages to test: '));
   androidPackages.forEach((pkg) => {
-    console.log(chalk.yellow(pkg.packageSlug));
+    console.log(styleText('yellow', pkg.packageSlug));
   });
 
   if (type === 'instrumented') {
@@ -96,22 +98,22 @@ export async function androidNativeUnitTests({
     const spotlessApplyCommand = 'spotlessApply';
     const spotlessCheckCommand = 'spotlessCheck';
     try {
-      console.log(chalk.green('Running spotlessCheck...'));
+      console.log(styleText('green', 'Running spotlessCheck...'));
       await runGradlew(androidPackages, spotlessCheckCommand, BARE_EXPO_DIR);
-      console.log(chalk.green('spotlessCheck succeeded'));
+      console.log(styleText('green', 'spotlessCheck succeeded'));
     } catch (e: any) {
       console.log(
-        chalk.yellow(`spotlessCheck failed: ${e}. Attempting to fix with spotlessApply...`)
+        styleText('yellow', `spotlessCheck failed: ${e}. Attempting to fix with spotlessApply...`)
       );
       await runGradlew(androidPackages, spotlessApplyCommand, BARE_EXPO_DIR);
-      chalk.green('spotlessApply succeeded');
+      styleText('green', 'spotlessApply succeeded');
     }
   } else {
     const testCommand = 'testDebugUnitTest';
     await runGradlew(androidPackages, testCommand, BARE_EXPO_DIR);
   }
 
-  console.log(chalk.green('Finished android unit tests successfully.'));
+  console.log(styleText('green', 'Finished android unit tests successfully.'));
 }
 
 async function runGradlew(packages: Packages.Package[], testCommand: string, cwd: string) {
@@ -131,8 +133,8 @@ async function runGradlew(packages: Packages.Package[], testCommand: string, cwd
     );
   } catch (error) {
     console.error('Failed while executing android unit tests');
-    consoleErrorOutput(error.stdout, 'stdout >', chalk.reset);
-    consoleErrorOutput(error.stderr, 'stderr >', chalk.red);
+    consoleErrorOutput(error.stdout, 'stdout >', (message) => styleText('reset', message));
+    consoleErrorOutput(error.stderr, 'stderr >', (message) => styleText('red', message));
     throw error;
   }
 }

--- a/tools/src/commands/BumpReactNativeVersion.ts
+++ b/tools/src/commands/BumpReactNativeVersion.ts
@@ -1,9 +1,9 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { glob } from 'glob';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import path from 'path';
 
@@ -37,7 +37,9 @@ async function main(options: { version?: string }) {
     throw new Error('Please provide a version using --version <version>');
   }
 
-  logger.info(`Bumping react-native version to ${chalk.bold(newVersion)} across the monorepo...\n`);
+  logger.info(
+    `Bumping react-native version to ${styleText('bold', newVersion)} across the monorepo...\n`
+  );
 
   const packageJsonPaths = await findAllPackageJsonPaths();
   let totalUpdated = 0;
@@ -138,7 +140,7 @@ async function updatePackageJson(packageJsonPath: string, newVersion: string): P
   if (modified) {
     await JsonFile.writeAsync(packageJsonPath, json);
     const relativePath = path.relative(EXPO_DIR, packageJsonPath);
-    logger.log(`  Updated ${chalk.cyan(relativePath)}`);
+    logger.log(`  Updated ${styleText('cyan', relativePath)}`);
   }
 
   return modified;
@@ -171,7 +173,7 @@ async function updateRootResolutions(newVersion: string): Promise<boolean> {
 
   if (modified) {
     await JsonFile.writeAsync(ROOT_PACKAGE_JSON_PATH, json);
-    logger.log(`  Updated ${chalk.cyan('package.json')} (resolutions)`);
+    logger.log(`  Updated ${styleText('cyan', 'package.json')} (resolutions)`);
   }
 
   return modified;
@@ -187,7 +189,7 @@ async function updateBundledNativeModules(newVersion: string): Promise<void> {
   if (currentVersion && currentVersion !== newVersion) {
     json[REACT_NATIVE_PACKAGE] = newVersion;
     await JsonFile.writeAsync(BUNDLED_NATIVE_MODULES_PATH, json);
-    logger.log(`  Updated ${chalk.cyan('packages/expo/bundledNativeModules.json')}`);
+    logger.log(`  Updated ${styleText('cyan', 'packages/expo/bundledNativeModules.json')}`);
   }
 }
 
@@ -244,12 +246,12 @@ async function installPodsInApps(): Promise<void> {
     appDirs.map(async (appDir) => {
       const relativePath = path.relative(EXPO_DIR, appDir);
       const spinner = ora({
-        text: `Installing pods in ${chalk.cyan(relativePath)}`,
+        text: `Installing pods in ${styleText('cyan', relativePath)}`,
         indent: 2,
       }).start();
       try {
         await podInstallAsync(path.join(appDir, 'ios'));
-        spinner.succeed(`Installed pods in ${chalk.cyan(relativePath)}`);
+        spinner.succeed(`Installed pods in ${styleText('cyan', relativePath)}`);
       } catch (error: any) {
         spinner.fail(`Failed to install pods in ${relativePath}: ${error.message}`);
       }

--- a/tools/src/commands/CIInspectCommand.ts
+++ b/tools/src/commands/CIInspectCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import path from 'path';
 
@@ -270,9 +270,9 @@ function computeDailyRates(
 
 function successRateColor(rate: number): string {
   const pct = `${rate.toFixed(1)}%`;
-  if (rate >= 90) return chalk.green(pct);
-  if (rate >= 75) return chalk.yellow(pct);
-  return chalk.red(pct);
+  if (rate >= 90) return styleText('green', pct);
+  if (rate >= 75) return styleText('yellow', pct);
+  return styleText('red', pct);
 }
 
 // --- Auth helpers ---
@@ -310,12 +310,12 @@ function printAuthStatus(auth: AuthStatus): void {
   const warnings: string[] = [];
   if (!auth.github) {
     warnings.push(
-      `GitHub: ${chalk.red('\u2717')} not authenticated \u2014 run ${chalk.cyan('export GITHUB_TOKEN="$(gh auth token)"')}`
+      `GitHub: ${styleText('red', '\u2717')} not authenticated \u2014 run ${styleText('cyan', 'export GITHUB_TOKEN="$(gh auth token)"')}`
     );
   }
   if (!auth.eas) {
     warnings.push(
-      `EAS: ${chalk.red('\u2717')} not authenticated \u2014 run ${chalk.cyan('eas login')}`
+      `EAS: ${styleText('red', '\u2717')} not authenticated \u2014 run ${styleText('cyan', 'eas login')}`
     );
   }
   if (warnings.length > 0) {
@@ -443,7 +443,7 @@ function stripLogTimestamps(log: string): string {
 }
 
 function printLogSnippets(snippets: string[]): void {
-  logger.log(`\n    ${chalk.bold('Error output:')}`);
+  logger.log(`\n    ${styleText('bold', 'Error output:')}`);
   logger.log('    \u250c' + '\u2500'.repeat(70));
   for (let si = 0; si < snippets.length; si++) {
     const indented = snippets[si]
@@ -656,7 +656,10 @@ function showCompactStatus(
 
   logger.log('');
   logger.log(
-    chalk.bold(`CI Metrics \u2014 Week ${weekNum} (${startStr} \u2192 ${endStr}) \u2014 ${branch}`)
+    styleText(
+      'bold',
+      `CI Metrics \u2014 Week ${weekNum} (${startStr} \u2192 ${endStr}) \u2014 ${branch}`
+    )
   );
   logger.log('');
 
@@ -667,12 +670,12 @@ function showCompactStatus(
     logger.log(`  Expo Workflows: ${easTotal} runs, ${successRateColor(easRate)} success rate`);
   }
   if (ghTotal === 0 && easTotal === 0) {
-    logger.log(chalk.gray('  No workflow runs found.'));
+    logger.log(styleText('gray', '  No workflow runs found.'));
   }
 
   const alerts: string[] = [];
-  if (brokenCount > 0) alerts.push(chalk.red(`${brokenCount} broken`));
-  if (attentionCount > 0) alerts.push(chalk.yellow(`${attentionCount} needs attention`));
+  if (brokenCount > 0) alerts.push(styleText('red', `${brokenCount} broken`));
+  if (attentionCount > 0) alerts.push(styleText('yellow', `${attentionCount} needs attention`));
   if (alerts.length > 0) {
     logger.log(`  ${alerts.join(', ')}`);
   }
@@ -685,14 +688,17 @@ function showCategoryList(categories: CategoryInfo[], selectedIndex: number): vo
 
   for (let i = 0; i < categories.length; i++) {
     const cat = categories[i];
-    const prefix = i === selectedIndex ? chalk.green('\u25b6') : ' ';
-    const badge = i === recommendedIdx ? chalk.bgGreen.black(' RECOMMENDED ') + ' ' : '';
-    const count = chalk.cyan(`(${cat.items.length})`);
-    logger.log(`  ${prefix} ${chalk.green(`${i + 1}.`)} ${badge}${chalk.bold(cat.label)} ${count}`);
-    logger.log(chalk.dim(`       ${cat.guidance}`));
+    const prefix = i === selectedIndex ? styleText('green', '\u25b6') : ' ';
+    const badge =
+      i === recommendedIdx ? styleText(['bgGreen', 'black'], ' RECOMMENDED ') + ' ' : '';
+    const count = styleText('cyan', `(${cat.items.length})`);
+    logger.log(
+      `  ${prefix} ${styleText('green', `${i + 1}.`)} ${badge}${styleText('bold', cat.label)} ${count}`
+    );
+    logger.log(styleText('dim', `       ${cat.guidance}`));
     logger.log('');
   }
-  logger.log(chalk.gray('  \u2191\u2193 navigate / Enter select / Esc quit'));
+  logger.log(styleText('gray', '  \u2191\u2193 navigate / Enter select / Esc quit'));
 }
 
 function categoryLineCount(categories: CategoryInfo[]): number {
@@ -704,37 +710,37 @@ function showWorkflowList(category: CategoryInfo, selectedIndex: number): void {
   const total = category.items.length;
   const { start, end } = getScrollWindow(total, selectedIndex);
 
-  logger.log(chalk.bold(category.label));
-  logger.log(chalk.dim(`  ${category.guidance}`));
+  logger.log(styleText('bold', category.label));
+  logger.log(styleText('dim', `  ${category.guidance}`));
   logger.log('');
 
   if (total === 0) {
-    logger.log(chalk.gray('  No workflows in this category.'));
+    logger.log(styleText('gray', '  No workflows in this category.'));
     logger.log('');
-    logger.log(chalk.gray('  Esc back'));
+    logger.log(styleText('gray', '  Esc back'));
     return;
   }
 
   if (start > 0) {
-    logger.log(chalk.gray(`  \u25b2 ${start} more above`));
+    logger.log(styleText('gray', `  \u25b2 ${start} more above`));
   }
 
   for (let i = start; i < end; i++) {
     const wf = category.items[i];
-    const prefix = i === selectedIndex ? chalk.green('\u25b6') : ' ';
-    const pos = chalk.gray(`${i + 1}/${total}`);
-    const sourceTag = wf.source === 'eas' ? chalk.gray(`[${wf.project}] `) : '';
-    const statsStr = `${wf.total} runs, ${successRateColor(wf.successRate)}, ${chalk.red(`${wf.failed}`)} failed`;
+    const prefix = i === selectedIndex ? styleText('green', '\u25b6') : ' ';
+    const pos = styleText('gray', `${i + 1}/${total}`);
+    const sourceTag = wf.source === 'eas' ? styleText('gray', `[${wf.project}] `) : '';
+    const statsStr = `${wf.total} runs, ${successRateColor(wf.successRate)}, ${styleText('red', `${wf.failed}`)} failed`;
 
     logger.log(`  ${prefix} ${pos} ${sourceTag}${wf.name} \u2014 ${statsStr}`);
   }
 
   if (end < total) {
-    logger.log(chalk.gray(`  \u25bc ${total - end} more below`));
+    logger.log(styleText('gray', `  \u25bc ${total - end} more below`));
   }
 
   logger.log('');
-  logger.log(chalk.gray('  \u2191\u2193 navigate / Enter expand / Esc back'));
+  logger.log(styleText('gray', '  \u2191\u2193 navigate / Enter expand / Esc back'));
 }
 
 function workflowListLineCount(category: CategoryInfo, selectedIndex: number): number {
@@ -755,7 +761,7 @@ function renderDailyTrend(dailyRates: DailyRate[]): number {
   let lines = 0;
   const barWidth = 15;
 
-  logger.log(chalk.bold('  Daily Trend'));
+  logger.log(styleText('bold', '  Daily Trend'));
   lines++;
 
   let prevRate: number | null = null;
@@ -763,25 +769,30 @@ function renderDailyTrend(dailyRates: DailyRate[]): number {
     const rate = day.total > 0 ? (day.successful / day.total) * 100 : -1;
 
     if (rate < 0) {
-      logger.log(`    ${chalk.gray(day.label)}  ${chalk.gray('\u2014  no data')}`);
+      logger.log(`    ${styleText('gray', day.label)}  ${styleText('gray', '\u2014  no data')}`);
       lines++;
       continue;
     }
 
     const filled = Math.round((rate / 100) * barWidth);
-    const barColor = rate >= 90 ? chalk.green : rate >= 75 ? chalk.yellow : chalk.red;
-    const bar = barColor('\u2588'.repeat(filled)) + chalk.gray('\u2591'.repeat(barWidth - filled));
+    const barColor = (message: string) => {
+      const color = rate >= 90 ? 'green' : rate >= 75 ? 'yellow' : 'red';
+
+      return styleText(color, message);
+    };
+    const bar =
+      barColor('\u2588'.repeat(filled)) + styleText('gray', '\u2591'.repeat(barWidth - filled));
 
     let trend = '  ';
     if (prevRate !== null) {
       const diff = rate - prevRate;
-      if (diff > 2) trend = chalk.green('\u2191');
-      else if (diff < -2) trend = chalk.red('\u2193');
-      else trend = chalk.gray('\u2192');
+      if (diff > 2) trend = styleText('green', '\u2191');
+      else if (diff < -2) trend = styleText('red', '\u2193');
+      else trend = styleText('gray', '\u2192');
     }
 
     logger.log(
-      `    ${day.label}  ${bar}  ${successRateColor(rate)}  ${trend}  ${chalk.gray(`(${day.total} runs)`)}`
+      `    ${day.label}  ${bar}  ${successRateColor(rate)}  ${trend}  ${styleText('gray', `(${day.total} runs)`)}`
     );
     lines++;
     prevRate = rate;
@@ -795,14 +806,14 @@ function renderDailyTrend(dailyRates: DailyRate[]): number {
 function renderDetailView(wf: WorkflowItem, showFailed: boolean): number {
   let lines = 0;
 
-  const sourceTag = wf.source === 'eas' ? chalk.gray(` [${wf.project}]`) : '';
-  logger.log(chalk.bold(`${wf.name}${sourceTag}`));
+  const sourceTag = wf.source === 'eas' ? styleText('gray', ` [${wf.project}]`) : '';
+  logger.log(styleText('bold', `${wf.name}${sourceTag}`));
   lines++;
   logger.log('');
   lines++;
 
   logger.log(
-    `  Total: ${wf.total}  ${chalk.green(`${wf.success} success`)}  ${chalk.red(`${wf.failed} failed`)}  ${chalk.gray(`${wf.cancelled} cancelled`)}  ${chalk.gray(`${wf.other} other`)}`
+    `  Total: ${wf.total}  ${styleText('green', `${wf.success} success`)}  ${styleText('red', `${wf.failed} failed`)}  ${styleText('gray', `${wf.cancelled} cancelled`)}  ${styleText('gray', `${wf.other} other`)}`
   );
   lines++;
   logger.log(`  Success rate: ${successRateColor(wf.successRate)}`);
@@ -813,16 +824,16 @@ function renderDetailView(wf: WorkflowItem, showFailed: boolean): number {
   lines += renderDailyTrend(wf.dailyRates);
 
   if (showFailed) {
-    logger.log(chalk.bold('  Recent Failed Runs'));
+    logger.log(styleText('bold', '  Recent Failed Runs'));
     lines++;
     if (wf.failedRuns.length === 0) {
-      logger.log(chalk.gray('    No failed runs.'));
+      logger.log(styleText('gray', '    No failed runs.'));
       lines++;
     } else {
       for (const run of wf.failedRuns) {
-        const commit = run.commitMessage ? chalk.gray(` \u2014 ${run.commitMessage}`) : '';
-        const url = run.url ? chalk.gray(` ${run.url}`) : '';
-        logger.log(`    ${chalk.red('\u2717')} ${run.date}${commit}${url}`);
+        const commit = run.commitMessage ? styleText('gray', ` \u2014 ${run.commitMessage}`) : '';
+        const url = run.url ? styleText('gray', ` ${run.url}`) : '';
+        logger.log(`    ${styleText('red', '\u2717')} ${run.date}${commit}${url}`);
         lines++;
       }
     }
@@ -830,9 +841,11 @@ function renderDetailView(wf: WorkflowItem, showFailed: boolean): number {
     lines++;
   }
 
-  const failedToggle = showFailed ? chalk.yellow('(f)ailed runs') : chalk.green('(f)ailed runs');
-  const parts = [failedToggle, chalk.green('(l)ogs'), chalk.gray('Esc back')];
-  logger.log(chalk.gray('  ') + parts.join(chalk.gray(' / ')));
+  const failedToggle = showFailed
+    ? styleText('yellow', '(f)ailed runs')
+    : styleText('green', '(f)ailed runs');
+  const parts = [failedToggle, styleText('green', '(l)ogs'), styleText('gray', 'Esc back')];
+  logger.log(styleText('gray', '  ') + parts.join(styleText('gray', ' / ')));
   lines++;
 
   return lines;
@@ -842,14 +855,14 @@ function renderDetailView(wf: WorkflowItem, showFailed: boolean): number {
 
 async function inspectLatestFailureLogs(wf: WorkflowItem): Promise<void> {
   if (wf.failedRuns.length === 0) {
-    logger.log(chalk.gray('  No failed runs to inspect.'));
+    logger.log(styleText('gray', '  No failed runs to inspect.'));
     return;
   }
 
   const latestFailed = wf.failedRuns[0];
 
   if (wf.source === 'github') {
-    logger.log(chalk.gray(`  Downloading logs for run ${latestFailed.id}...`));
+    logger.log(styleText('gray', `  Downloading logs for run ${latestFailed.id}...`));
 
     let jobs;
     try {
@@ -861,16 +874,16 @@ async function inspectLatestFailureLogs(wf: WorkflowItem): Promise<void> {
 
     const failedJobs = jobs.filter((j) => j.conclusion === 'failure');
     if (!failedJobs.length) {
-      logger.log(chalk.gray('  No failed jobs found.'));
+      logger.log(styleText('gray', '  No failed jobs found.'));
       return;
     }
 
     for (const job of failedJobs) {
-      logger.log(`\n  ${chalk.red('\u2717')} ${chalk.bold(job.name)}`);
+      logger.log(`\n  ${styleText('red', '\u2717')} ${styleText('bold', job.name)}`);
 
       const failedSteps = (job.steps ?? []).filter((s) => s.conclusion === 'failure');
       for (const step of failedSteps) {
-        logger.log(`    Step: ${chalk.red(step.name)}`);
+        logger.log(`    Step: ${styleText('red', step.name)}`);
       }
 
       const rawLog = await downloadJobLogsAsync(job.id);
@@ -888,14 +901,14 @@ async function inspectLatestFailureLogs(wf: WorkflowItem): Promise<void> {
   } else {
     // EAS workflow logs
     if (!wf.project) {
-      logger.log(chalk.gray('  No project info available for this EAS workflow.'));
+      logger.log(styleText('gray', '  No project info available for this EAS workflow.'));
       return;
     }
 
     const projectDirs = await findEASProjectDirs();
     const projectDir = projectDirs.find((d) => path.basename(d) === wf.project);
     if (!projectDir) {
-      logger.log(chalk.gray(`  Could not find project directory for ${wf.project}.`));
+      logger.log(styleText('gray', `  Could not find project directory for ${wf.project}.`));
       return;
     }
 
@@ -905,7 +918,7 @@ async function inspectLatestFailureLogs(wf: WorkflowItem): Promise<void> {
       EAS_BUILD_PROFILE: process.env.EAS_BUILD_PROFILE ?? 'release-client',
     };
 
-    logger.log(chalk.gray(`  Fetching run details for ${latestFailed.id}...`));
+    logger.log(styleText('gray', `  Fetching run details for ${latestFailed.id}...`));
 
     const runDetails = await runEASCommand(
       ['workflow:view', String(latestFailed.id), '--json', '--non-interactive'],
@@ -923,19 +936,19 @@ async function inspectLatestFailureLogs(wf: WorkflowItem): Promise<void> {
     );
 
     if (!failedJobs.length) {
-      logger.log(chalk.gray('  No failed jobs found.'));
+      logger.log(styleText('gray', '  No failed jobs found.'));
       return;
     }
 
     if (runDetails.logURL) {
-      logger.log(`  ${chalk.gray(runDetails.logURL)}`);
+      logger.log(`  ${styleText('gray', runDetails.logURL)}`);
     }
 
     for (const job of failedJobs) {
       const jobName = job.name ?? job.key ?? 'unknown';
-      logger.log(`\n  ${chalk.red('\u2717')} ${chalk.bold(jobName)}`);
+      logger.log(`\n  ${styleText('red', '\u2717')} ${styleText('bold', jobName)}`);
 
-      logger.log(chalk.gray(`    Downloading log for "${jobName}"...`));
+      logger.log(styleText('gray', `    Downloading log for "${jobName}"...`));
 
       let rawLog: string | null = null;
       try {
@@ -994,7 +1007,7 @@ async function showDetailInteractive(wf: WorkflowItem): Promise<void> {
     } else if (key === 'l') {
       await inspectLatestFailureLogs(wf);
       logger.log('');
-      logger.log(chalk.gray('  Press any key to continue...'));
+      logger.log(styleText('gray', '  Press any key to continue...'));
       await waitForKey(['escape', 'f', 'l', 'enter', 'up', 'down']);
       // After viewing logs, reset since output has scrolled
       lastRenderedCount = 0;

--- a/tools/src/commands/CheckSdkPrsCommand.ts
+++ b/tools/src/commands/CheckSdkPrsCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import Git from '../Git';
 import logger from '../Logger';
@@ -136,11 +136,11 @@ function formatPublishInfo(info: PublishInfo): string {
   switch (info.status) {
     case 'published':
       return link(
-        chalk.green('published'),
+        styleText('green', 'published'),
         `https://github.com/expo/expo/commit/${info.commitHash}`
       );
     case 'unpublished':
-      return chalk.dim('unpublished');
+      return styleText('dim', 'unpublished');
     case 'no-packages':
       return '';
   }
@@ -158,21 +158,21 @@ function pad(str: string, width: number): string {
 function formatReviewDecision(decision: GhPr['reviewDecision']): string {
   switch (decision) {
     case 'APPROVED':
-      return chalk.green('approved');
+      return styleText('green', 'approved');
     case 'CHANGES_REQUESTED':
-      return chalk.red('changes requested');
+      return styleText('red', 'changes requested');
     case 'REVIEW_REQUIRED':
-      return chalk.yellow('review needed');
+      return styleText('yellow', 'review needed');
     default:
       return '';
   }
 }
 
 function formatPrLine(pr: GhPr, publishInfo?: PublishInfo): string {
-  const num = link(chalk.yellow(`#${pr.number}`), pr.url);
+  const num = link(styleText('yellow', `#${pr.number}`), pr.url);
   const sha = pr.mergeCommit
     ? link(
-        chalk.dim(pr.mergeCommit.oid.slice(0, 10)),
+        styleText('dim', pr.mergeCommit.oid.slice(0, 10)),
         `https://github.com/expo/expo/commit/${pr.mergeCommit.oid}`
       )
     : '';
@@ -185,10 +185,13 @@ function formatPrLine(pr: GhPr, publishInfo?: PublishInfo): string {
   }
   const titleText = pr.title.length > 60 ? pr.title.slice(0, 57) + '...' : pr.title;
   const title = link(titleText, pr.url);
-  const author = link(chalk.dim(`@${pr.author.login}`), `https://github.com/${pr.author.login}`);
+  const author = link(
+    styleText('dim', `@${pr.author.login}`),
+    `https://github.com/${pr.author.login}`
+  );
   // For merged PRs show merge age, for open PRs show time since last activity
   const timestamp = pr.mergedAt ?? pr.updatedAt;
-  const age = timestamp ? chalk.dim(formatAge(timestamp)) : '';
+  const age = timestamp ? styleText('dim', formatAge(timestamp)) : '';
   return `  ${pad(num, 8)}  ${pad(sha, 10)}  ${pad(status, 17)}  ${pad(title, 60)}  ${pad(author, 20)}  ${age}`;
 }
 
@@ -210,11 +213,11 @@ async function action(sdk: string | undefined, options: ActionOptions) {
 
       if (sorted.length === 0) {
         throw new Error(
-          `Could not detect SDK version. Pass it explicitly: ${chalk.bold('et csp 55')}`
+          `Could not detect SDK version. Pass it explicitly: ${styleText('bold', 'et csp 55')}`
         );
       }
       sdkNumber = sorted[0].split('.')[0];
-      logger.info(`Detected latest SDK version: ${chalk.bold(sdkNumber)}`);
+      logger.info(`Detected latest SDK version: ${styleText('bold', sdkNumber)}`);
     }
   }
 
@@ -222,7 +225,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   const branch = `sdk-${sdkNumber}`;
 
   // Fetch PRs from GitHub
-  logger.info(`Fetching PRs labeled ${chalk.bold(label)}...`);
+  logger.info(`Fetching PRs labeled ${styleText('bold', label)}...`);
 
   let prs: GhPr[];
   try {
@@ -248,7 +251,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   }
 
   if (prs.length === 0) {
-    logger.warn(`No PRs found with label ${chalk.bold(label)}.`);
+    logger.warn(`No PRs found with label ${styleText('bold', label)}.`);
     return;
   }
 
@@ -257,7 +260,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   const closedPrs = prs.filter((pr) => pr.state === 'CLOSED');
 
   // Fetch SDK branch
-  logger.info(`Fetching ${chalk.bold(branch)} branch...`);
+  logger.info(`Fetching ${styleText('bold', branch)} branch...`);
   await Git.fetchAsync({ remote: 'origin', ref: branch });
 
   // Determine which ref to compare against
@@ -269,7 +272,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
       const { ahead } = await Git.compareBranchesAsync(branch, `origin/${branch}`);
       if (ahead > 0) {
         logger.warn(
-          `Local branch ${chalk.bold(branch)} is ${ahead} commit${ahead === 1 ? '' : 's'} ahead of origin — comparing against local.`
+          `Local branch ${styleText('bold', branch)} is ${ahead} commit${ahead === 1 ? '' : 's'} ahead of origin — comparing against local.`
         );
         ref = branch;
       }
@@ -311,7 +314,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   if (options.all) {
     if (needsCherryPick.length > 0) {
       logger.log('');
-      logger.log(chalk.red.bold(`Needs Cherry-Pick (${needsCherryPick.length}):`));
+      logger.log(styleText(['red', 'bold'], `Needs Cherry-Pick (${needsCherryPick.length}):`));
       for (const pr of needsCherryPick) {
         logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
       }
@@ -319,7 +322,9 @@ async function action(sdk: string | undefined, options: ActionOptions) {
 
     if (alreadyCherryPicked.length > 0) {
       logger.log('');
-      logger.log(chalk.green.bold(`Already Cherry-Picked (${alreadyCherryPicked.length}):`));
+      logger.log(
+        styleText(['green', 'bold'], `Already Cherry-Picked (${alreadyCherryPicked.length}):`)
+      );
       for (const pr of alreadyCherryPicked) {
         logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
       }
@@ -327,7 +332,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
 
     if (openPrs.length > 0) {
       logger.log('');
-      logger.log(chalk.blue.bold(`Open (${openPrs.length}):`));
+      logger.log(styleText(['blue', 'bold'], `Open (${openPrs.length}):`));
       for (const pr of openPrs) {
         logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
       }
@@ -335,7 +340,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
 
     if (closedPrs.length > 0) {
       logger.log('');
-      logger.log(chalk.gray.bold(`Closed without Merge (${closedPrs.length}):`));
+      logger.log(styleText(['gray', 'bold'], `Closed without Merge (${closedPrs.length}):`));
       for (const pr of closedPrs) {
         logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
       }
@@ -343,13 +348,13 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   } else {
     if (needsCherryPick.length === 0) {
       logger.success(
-        `All merged PRs have been cherry-picked to ${chalk.bold(branch)}! (${mergedPrs.length} merged, ${openPrs.length} open)`
+        `All merged PRs have been cherry-picked to ${styleText('bold', branch)}! (${mergedPrs.length} merged, ${openPrs.length} open)`
       );
       return;
     }
 
     logger.log('');
-    logger.log(chalk.bold(`PRs that need cherry-picking to ${branch}:`));
+    logger.log(styleText('bold', `PRs that need cherry-picking to ${branch}:`));
     logger.log('');
     for (const pr of needsCherryPick) {
       logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
@@ -359,7 +364,8 @@ async function action(sdk: string | undefined, options: ActionOptions) {
   // Summary
   logger.log('');
   logger.log(
-    chalk.dim(
+    styleText(
+      'dim',
       `${needsCherryPick.length} PR${needsCherryPick.length === 1 ? '' : 's'} need${needsCherryPick.length === 1 ? 's' : ''} cherry-picking (${mergedPrs.length} merged, ${openPrs.length} open)`
     )
   );

--- a/tools/src/commands/CherryPickCommand.ts
+++ b/tools/src/commands/CherryPickCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import Git, { GitLog } from '../Git';
@@ -71,9 +71,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
   }
 
   logger.info(
-    `\nLooking for commits to cherry-pick from ${chalk.bold(chalk.blue(source))} to ${chalk.bold(
-      chalk.blue(destination)
-    )}...\n`
+    `\nLooking for commits to cherry-pick from ${styleText(['bold', 'blue'], source)} to ${styleText(['bold', 'blue'], destination)}...\n`
   );
 
   const packagePaths = packageNames.map((packageName) => path.join('.', 'packages', packageName));
@@ -128,14 +126,14 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
     });
 
   if (commitsBeforeStartDate.length !== 0) {
-    logger.log(chalk.bold(chalk.red('Ignoring the following commits from before the start date:')));
+    logger.log(
+      styleText(['bold', 'red'], 'Ignoring the following commits from before the start date:')
+    );
     logger.log(
       commitsBeforeStartDate
         .map(
           (commit) =>
-            ` ❌ ${chalk.red(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
-              sanitizeTerminalOutput(commit.authorName)
-            )} ${sanitizeTerminalOutput(commit.title)}`
+            ` ❌ ${styleText('red', commit.hash.slice(0, 10))} ${commit.authorDate} ${styleText('magenta', sanitizeTerminalOutput(commit.authorName))} ${sanitizeTerminalOutput(commit.title)}`
         )
         .join('\n')
     );
@@ -151,15 +149,11 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
     {
       type: 'checkbox',
       name: 'commitsToCherryPick',
-      message: `Choose which commits to cherry-pick from ${chalk.blue(source)} to ${chalk.blue(
-        destination
-      )}\n  ${chalk.green('●')} selected  ○ unselected\n`,
+      message: `Choose which commits to cherry-pick from ${styleText('blue', source)} to ${styleText('blue', destination)}\n  ${styleText('green', '●')} selected  ○ unselected\n`,
       choices: candidateCommits.map((commit) => ({
         value: commit.hash,
         short: commit.hash,
-        name: `${chalk.yellow(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
-          sanitizeTerminalOutput(commit.authorName)
-        )} ${sanitizeTerminalOutput(commit.title)}`,
+        name: `${styleText('yellow', commit.hash.slice(0, 10))} ${commit.authorDate} ${styleText('magenta', sanitizeTerminalOutput(commit.authorName))} ${sanitizeTerminalOutput(commit.title)}`,
       })),
       default: candidateCommits.map((commit) => commit.hash),
       pageSize: Math.min(candidateCommits.length, (process.stdout.rows || 100) - 4),
@@ -170,9 +164,9 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
 
   if (destination !== (await Git.getCurrentBranchNameAsync())) {
     if (options.dry) {
-      logger.log(chalk.bold(chalk.yellow(`git checkout ${destination}`)));
+      logger.log(styleText(['bold', 'yellow'], `git checkout ${destination}`));
     } else {
-      logger.info(`Checking out ${chalk.bold(chalk.blue(destination))} branch...`);
+      logger.info(`Checking out ${styleText(['bold', 'blue'], destination)} branch...`);
       await Git.checkoutAsync({
         ref: destination,
       });
@@ -185,9 +179,9 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
   );
   const commitHashes = commitsToCherryPickOrdered.map((commit) => commit.hash);
   if (options.dry) {
-    logger.log(chalk.bold(chalk.yellow(`git cherry-pick ${commitHashes.join(' ')}`)));
+    logger.log(styleText(['bold', 'yellow'], `git cherry-pick ${commitHashes.join(' ')}`));
   } else {
-    logger.info(`Running ${chalk.yellow(`git cherry-pick ${commitHashes.join(' ')}`)}`);
+    logger.info(`Running ${styleText('yellow', `git cherry-pick ${commitHashes.join(' ')}`)}`);
     try {
       // pipe output to current process stdio to emulate user running this command directly
       await Git.cherryPickAsync(commitHashes, { inheritStdio: true });

--- a/tools/src/commands/ClientInstall.ts
+++ b/tools/src/commands/ClientInstall.ts
@@ -1,9 +1,9 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Writable } from 'node:stream';
+import { styleText } from 'node:util';
 import { extract as tarExtract } from 'tar';
 
 import * as AndroidDevice from '../AndroidDevice';
@@ -36,7 +36,7 @@ async function downloadAndInstallOnIOSAsync(downloadUrl: string): Promise<void> 
 
   await Simulator.uninstallAppFromSimulatorAsync(simulator, EXPO_GO_APP_ID_IOS);
 
-  console.log(`Downloading Expo Go from ${chalk.blue(downloadUrl)}`);
+  console.log(`Downloading Expo Go from ${styleText('blue', downloadUrl)}`);
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'expotools-client-install-'));
   try {
     const downloadFilePath = await downloadExpoGoAsync({ downloadUrl, targetDir: tmpDir });
@@ -47,14 +47,14 @@ async function downloadAndInstallOnIOSAsync(downloadUrl: string): Promise<void> 
       cwd: appPath,
       strip: 1,
     });
-    console.log(`Extracted to ${chalk.blue(tmpDir)}`);
-    console.log(`Installing Expo Go from ${chalk.blue(appPath)} on iOS simulator...`);
+    console.log(`Extracted to ${styleText('blue', tmpDir)}`);
+    console.log(`Installing Expo Go from ${styleText('blue', appPath)} on iOS simulator...`);
     await Simulator.installSimulatorAppAsync(simulator, appPath);
-    console.log(`Launching Expo Go with identifier ${chalk.blue(EXPO_GO_APP_ID_IOS)}...`);
+    console.log(`Launching Expo Go with identifier ${styleText('blue', EXPO_GO_APP_ID_IOS)}...`);
     await Simulator.launchSimulatorAppAsync(simulator, EXPO_GO_APP_ID_IOS);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error(chalk.red(`Unable to install Expo Go: ${error.message}`));
+      console.error(styleText('red', `Unable to install Expo Go: ${error.message}`));
     }
   } finally {
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
@@ -84,16 +84,16 @@ async function downloadAndInstallOnAndroidAsync(downloadUrl: string): Promise<vo
       await AndroidDevice.uninstallAppAsync({ device, appId: EXPO_GO_APP_ID_ANDROID });
     } catch {}
 
-    console.log(`Downloading Expo Go from ${chalk.blue(downloadUrl)}`);
+    console.log(`Downloading Expo Go from ${styleText('blue', downloadUrl)}`);
     const downloadFilePath = await downloadExpoGoAsync({ downloadUrl, targetDir: tmpDir });
     console.log(
-      `Installing Expo Go from ${chalk.blue(downloadFilePath)} on Android device ${chalk.blue(device)}...`
+      `Installing Expo Go from ${styleText('blue', downloadFilePath)} on Android device ${styleText('blue', device)}...`
     );
 
     await AndroidDevice.installAppAsync({ device, appPath: downloadFilePath });
 
     const activity = `${EXPO_GO_APP_ID_ANDROID}/.LauncherActivity`;
-    console.log(`Launching Expo Go activity ${chalk.blue(activity)}...`);
+    console.log(`Launching Expo Go activity ${styleText('blue', activity)}...`);
 
     await AndroidDevice.startActivityAsync({
       device,
@@ -101,7 +101,7 @@ async function downloadAndInstallOnAndroidAsync(downloadUrl: string): Promise<vo
     });
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error(chalk.red(`Unable to install Expo Go: ${error.message}`));
+      console.error(styleText('red', `Unable to install Expo Go: ${error.message}`));
     }
   } finally {
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
@@ -133,7 +133,9 @@ async function action(options: ActionOptions) {
     (await askForSDKVersionAsync(platform, await getNewestSDKVersionAsync(platform)));
 
   if (!sdkVersion) {
-    throw new Error(`Unable to find SDK version. Try to use ${chalk.yellow('--sdkVersion')} flag.`);
+    throw new Error(
+      `Unable to find SDK version. Try to use ${styleText('yellow', '--sdkVersion')} flag.`
+    );
   }
   const versionsApiHost = options.production
     ? Versions.VersionsApiHost.PRODUCTION
@@ -143,7 +145,7 @@ async function action(options: ActionOptions) {
   const sdkConfiguration = versions?.sdkVersions?.[sdkVersion];
 
   if (!sdkConfiguration) {
-    throw new Error(`Versions configuration for SDK ${chalk.cyan(sdkVersion)} not found!`);
+    throw new Error(`Versions configuration for SDK ${styleText('cyan', sdkVersion)} not found!`);
   }
 
   const tarballKey = `${platform}ClientUrl`;
@@ -151,7 +153,7 @@ async function action(options: ActionOptions) {
 
   if (!downloadUrl) {
     throw new Error(
-      `Expo Go download url not found at ${chalk.yellow(tarballKey)} key of versions config!`
+      `Expo Go download url not found at ${styleText('yellow', tarballKey)} key of versions config!`
     );
   }
 
@@ -169,7 +171,7 @@ async function action(options: ActionOptions) {
     }
   }
 
-  console.log(chalk.green(`Successfully installed and launched Expo Go 🎉`));
+  console.log(styleText('green', `Successfully installed and launched Expo Go 🎉`));
 }
 
 export default (program: Command) => {

--- a/tools/src/commands/CommentatorCommand.ts
+++ b/tools/src/commands/CommentatorCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { link } from '../Formatter';
 import { commentOnIssueAsync } from '../GitHubActions';
@@ -25,9 +25,7 @@ export default (program: Command) => {
       'Serialized and escaped JSON array describing what and where to comment.'
     )
     .description(
-      `To add "Hello!" comment on issue #1234, run it with ${chalk.blue.italic(
-        `--payload "[{\\"issue\\": 1234, \\"body\\": \\"Hello!\\"}]"`
-      )}`
+      `To add "Hello!" comment on issue #1234, run it with ${styleText(['blue', 'italic'], `--payload "[{\\"issue\\": 1234, \\"body\\": \\"Hello!\\"}]"`)}`
     )
     .asyncAction(main);
 };
@@ -56,7 +54,7 @@ async function main(options: ActionOptions) {
       '✍️  Commented on the following issues: %s',
       commentedIssues
         .map((issue) =>
-          link(chalk.blue('#' + issue), `https://github.com/expo/expo/issues/${issue}`)
+          link(styleText('blue', '#' + issue), `https://github.com/expo/expo/issues/${issue}`)
         )
         .join(', ')
     );

--- a/tools/src/commands/GenerateBareDiffs.ts
+++ b/tools/src/commands/GenerateBareDiffs.ts
@@ -1,8 +1,8 @@
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { PromisyClass, TaskQueue } from 'cwait';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import npmPacklist from 'npm-packlist';
 import os from 'os';
 import path from 'path';
@@ -176,7 +176,8 @@ async function action({ check = false }: ActionOptions) {
     );
 
     logger.log(
-      chalk.green(
+      styleText(
+        'green',
         `\n🎉 Successfully generated diffs for template-bare-minimum for the last 6 SDK versions + main`
       )
     );

--- a/tools/src/commands/GenerateDocsAPIData.ts
+++ b/tools/src/commands/GenerateDocsAPIData.ts
@@ -1,9 +1,9 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import { PromisyClass, TaskQueue } from 'cwait';
 import fs from 'fs-extra';
 import os from 'node:os';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import recursiveOmitBy from 'recursive-omit-by';
 import type { TypeDocOptions } from 'typedoc';
 
@@ -441,7 +441,10 @@ async function action({ packageName, sdk }: ActionOptions) {
       if (packagesEntries.length) {
         await Promise.all(packagesEntries);
         logger.log(
-          chalk.green(`\n🎉 Successful extraction of docs API data for the selected package!`)
+          styleText(
+            'green',
+            `\n🎉 Successful extraction of docs API data for the selected package!`
+          )
         );
       } else {
         logger.warn(
@@ -456,7 +459,10 @@ async function action({ packageName, sdk }: ActionOptions) {
       );
       await Promise.all(packagesEntries);
       logger.log(
-        chalk.green(`\n🎉 Successful extraction of docs API data for all available packages!`)
+        styleText(
+          'green',
+          `\n🎉 Successful extraction of docs API data for all available packages!`
+        )
       );
     }
   } catch (error) {

--- a/tools/src/commands/GenerateSDKDocs.ts
+++ b/tools/src/commands/GenerateSDKDocs.ts
@@ -1,8 +1,8 @@
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Directories from '../Directories';
@@ -35,7 +35,7 @@ async function action(options) {
       throw new Error(`React Native version not found at ${reactNativePackageJsonPath}`);
     }
 
-    console.log(`Updating ${chalk.cyan('react-native-website')} submodule...`);
+    console.log(`Updating ${styleText('cyan', 'react-native-website')} submodule...`);
 
     await spawnAsync('git', ['checkout', 'main'], {
       cwd: reactNativeWebsiteDir,
@@ -45,7 +45,9 @@ async function action(options) {
       cwd: reactNativeWebsiteDir,
     });
 
-    console.log(`Importing React Native docs to ${chalk.yellow('unversioned')} directory...\n`);
+    console.log(
+      `Importing React Native docs to ${styleText('yellow', 'unversioned')} directory...\n`
+    );
 
     await fs.remove(path.join(SDK_DOCS_DIR, 'unversioned', 'react-native'));
 
@@ -62,14 +64,12 @@ async function action(options) {
 
   if (await fs.pathExists(targetSdkDirectory)) {
     console.log(
-      chalk.magenta(versionDirectory),
+      styleText('magenta', versionDirectory),
       'directory already exists. Skipping copy operation.'
     );
   } else {
     console.log(
-      `Copying ${chalk.yellow('unversioned')} docs to ${chalk.yellow(
-        versionDirectory
-      )} directory...`
+      `Copying ${styleText('yellow', 'unversioned')} docs to ${styleText('yellow', versionDirectory)} directory...`
     );
 
     await fs.copy(path.join(SDK_DOCS_DIR, 'unversioned'), targetSdkDirectory);
@@ -93,14 +93,12 @@ async function action(options) {
 
   if (await fs.pathExists(targetExampleDirectory)) {
     console.log(
-      chalk.magenta(versionDirectory),
+      styleText('magenta', versionDirectory),
       'examples directory already exists. Skipping copy operation.'
     );
   } else {
     console.log(
-      `Copying ${chalk.yellow('unversioned')} static examples to ${chalk.yellow(
-        versionDirectory
-      )} directory…`
+      `Copying ${styleText('yellow', 'unversioned')} static examples to ${styleText('yellow', versionDirectory)} directory…`
     );
 
     await fs.copy(path.join(STATIC_EXAMPLES_DIR, 'unversioned'), targetExampleDirectory);
@@ -108,26 +106,20 @@ async function action(options) {
 
   if (await fs.pathExists(targetAPIDataDirectory)) {
     console.log(
-      chalk.magenta(versionDirectory),
+      styleText('magenta', versionDirectory),
       'API data directory already exists. Skipping copy operation.'
     );
   } else {
     console.log(
-      `Copying ${chalk.yellow('unversioned')} generated API files to ${chalk.yellow(
-        versionDirectory
-      )} directory…`
+      `Copying ${styleText('yellow', 'unversioned')} generated API files to ${styleText('yellow', versionDirectory)} directory…`
     );
 
     await fs.copy(path.join(STATIC_API_DATA_DIR, 'unversioned'), targetAPIDataDirectory);
   }
 
   console.log(
-    `\nDocs version ${chalk.red(
-      sdk
-    )} created successfully. By default, it will not be included in the production build.` +
-      `\nWhen the new version is ready to deploy, set version to ${chalk.red(
-        sdk
-      )} in ${chalk.yellow('docs/package.json')}`
+    `\nDocs version ${styleText('red', sdk)} created successfully. By default, it will not be included in the production build.` +
+      `\nWhen the new version is ready to deploy, set version to ${styleText('red', sdk)} in ${styleText('yellow', 'docs/package.json')}`
   );
 }
 

--- a/tools/src/commands/GitHubInspectCommand.ts
+++ b/tools/src/commands/GitHubInspectCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import readline from 'readline';
 
@@ -426,7 +426,7 @@ function showCompactStatus(weekNum: number, weekFriday: Date, categories: Catego
   const endStr = weekFriday.toISOString().slice(0, 10);
 
   logger.info('');
-  logger.info(chalk.bold(`GitHub Inspect — Week ${weekNum} (${startStr} → ${endStr})`));
+  logger.info(styleText('bold', `GitHub Inspect — Week ${weekNum} (${startStr} → ${endStr})`));
   logger.info('');
 
   if (categories.length === 0) {
@@ -470,26 +470,26 @@ async function fetchAllData(
 }
 
 function showItemHeader(item: QueueItem, index: number, total: number, selected: boolean): void {
-  const prefix = selected ? chalk.green('\u25b6') : ' ';
-  const num = chalk.cyan(`#${item.number}`);
+  const prefix = selected ? styleText('green', '\u25b6') : ' ';
+  const num = styleText('cyan', `#${item.number}`);
   const title = truncate(item.title, 60);
-  const author = chalk.dim(item.author);
-  const pos = chalk.gray(`${index + 1}/${total}`);
+  const author = styleText('dim', item.author);
+  const pos = styleText('gray', `${index + 1}/${total}`);
   logger.info(`  ${prefix} ${pos} ${num} ${title} ${author}`);
 }
 
 function showCategoryList(categories: CategoryInfo[], selectedIndex: number): void {
   for (let i = 0; i < categories.length; i++) {
     const cat = categories[i];
-    const prefix = i === selectedIndex ? chalk.green('\u25b6') : ' ';
-    const recommended = i === 0 ? chalk.bgGreen.black(' RECOMMENDED ') + ' ' : '';
+    const prefix = i === selectedIndex ? styleText('green', '\u25b6') : ' ';
+    const recommended = i === 0 ? styleText(['bgGreen', 'black'], ' RECOMMENDED ') + ' ' : '';
     logger.info(
-      `  ${prefix} ${chalk.green(`${i + 1}.`)} ${recommended}${chalk.bold(cat.label)} ${chalk.cyan(`(${cat.items.length})`)}`
+      `  ${prefix} ${styleText('green', `${i + 1}.`)} ${recommended}${styleText('bold', cat.label)} ${styleText('cyan', `(${cat.items.length})`)}`
     );
-    logger.info(chalk.dim(`       ${cat.guidance}`));
+    logger.info(styleText('dim', `       ${cat.guidance}`));
     logger.info('');
   }
-  logger.info(chalk.gray('  \u2191\u2193 navigate / Enter select / Esc quit'));
+  logger.info(styleText('gray', '  \u2191\u2193 navigate / Enter select / Esc quit'));
 }
 
 const MAX_VISIBLE_ITEMS = 15;
@@ -508,12 +508,12 @@ function showItemList(category: CategoryInfo, selectedIndex: number): void {
   const total = category.items.length;
   const { start, end } = getScrollWindow(total, selectedIndex);
 
-  logger.info(chalk.bold(category.label));
-  logger.info(chalk.dim(`  ${category.guidance}`));
+  logger.info(styleText('bold', category.label));
+  logger.info(styleText('dim', `  ${category.guidance}`));
   logger.info('');
 
   if (start > 0) {
-    logger.info(chalk.gray(`  \u25b2 ${start} more above`));
+    logger.info(styleText('gray', `  \u25b2 ${start} more above`));
   }
 
   for (let i = start; i < end; i++) {
@@ -521,11 +521,11 @@ function showItemList(category: CategoryInfo, selectedIndex: number): void {
   }
 
   if (end < total) {
-    logger.info(chalk.gray(`  \u25bc ${total - end} more below`));
+    logger.info(styleText('gray', `  \u25bc ${total - end} more below`));
   }
 
   logger.info('');
-  logger.info(chalk.gray('  \u2191\u2193 navigate / Enter expand / Esc back'));
+  logger.info(styleText('gray', '  \u2191\u2193 navigate / Enter expand / Esc back'));
 }
 
 function clearLines(count: number): void {
@@ -706,7 +706,7 @@ async function fetchDetailData(item: QueueItem): Promise<DetailData> {
     const pr = await getPullRequestAsync(issue.number);
     base.branch = `${pr.base.ref} \u2190 ${pr.head.ref}`;
     base.mergeable = String(pr.mergeable ?? 'unknown');
-    base.diffStats = `${chalk.green(`+${pr.additions}`)} ${chalk.red(`-${pr.deletions}`)} in ${pr.changed_files} files`;
+    base.diffStats = `${styleText('green', `+${pr.additions}`)} ${styleText('red', `-${pr.deletions}`)} in ${pr.changed_files} files`;
     try {
       const reviews = await listPullRequestReviewsAsync(pr.number);
       base.reviews = reviews.map((r) => ({
@@ -814,8 +814,8 @@ function renderDetailView(
   const lines: string[] = [];
   const type = detail.isPR ? 'PR' : 'Issue';
 
-  lines.push(chalk.bold(`=== ${type} #${detail.number} ===`));
-  lines.push(`  URL:     ${chalk.blue(detail.url)}`);
+  lines.push(styleText('bold', `=== ${type} #${detail.number} ===`));
+  lines.push(`  URL:     ${styleText('blue', detail.url)}`);
   lines.push(`  Title:   ${detail.title}`);
   lines.push(`  State:   ${detail.state}`);
   lines.push(`  Author:  ${detail.author}`);
@@ -829,53 +829,49 @@ function renderDetailView(
     lines.push(`  Diff:    ${detail.diffStats}`);
     if (detail.reviews && detail.reviews.length > 0) {
       lines.push('');
-      lines.push(chalk.bold('  Reviews:'));
+      lines.push(styleText('bold', '  Reviews:'));
       for (const r of detail.reviews) {
         const color =
-          r.state === 'APPROVED'
-            ? chalk.green
-            : r.state === 'CHANGES_REQUESTED'
-              ? chalk.red
-              : chalk.gray;
-        lines.push(`    ${chalk.dim(r.login)} — ${color(r.state)} (${r.date})`);
+          r.state === 'APPROVED' ? 'green' : r.state === 'CHANGES_REQUESTED' ? 'red' : 'gray';
+        lines.push(`    ${styleText('dim', r.login)} — ${styleText(color, r.state)} (${r.date})`);
       }
     }
   } else {
     if (detail.reproLinks) {
       lines.push('');
-      lines.push(chalk.bold('  Repro links:'));
-      for (const url of detail.reproLinks) lines.push(`    ${chalk.blue(url)}`);
+      lines.push(styleText('bold', '  Repro links:'));
+      for (const url of detail.reproLinks) lines.push(`    ${styleText('blue', url)}`);
     }
     if (detail.referencedIssues) {
       lines.push(`  Refs:    ${detail.referencedIssues.join(' ')}`);
     }
     if (detail.closedBy) {
-      lines.push(`  Closed:  ${chalk.blue(detail.closedBy)}`);
+      lines.push(`  Closed:  ${styleText('blue', detail.closedBy)}`);
     }
   }
 
   if (showBody) {
     lines.push('');
-    lines.push(chalk.bold('  --- Body ---'));
+    lines.push(styleText('bold', '  --- Body ---'));
     if (detail.body) {
       for (const line of truncate(detail.body, 800).split('\n')) {
         lines.push(`  ${line}`);
       }
     } else {
-      lines.push(chalk.gray('  (no body)'));
+      lines.push(styleText('gray', '  (no body)'));
     }
   }
 
   if (showComments) {
     lines.push('');
-    lines.push(chalk.bold(`  --- Comments (${detail.comments}) ---`));
+    lines.push(styleText('bold', `  --- Comments (${detail.comments}) ---`));
     // Comments are loaded asynchronously, rendered separately
-    lines.push(chalk.gray('  Loading...'));
+    lines.push(styleText('gray', '  Loading...'));
   }
 
   if (analysisText) {
     lines.push('');
-    lines.push(chalk.bold('  --- AI Analysis ---'));
+    lines.push(styleText('bold', '  --- AI Analysis ---'));
     for (const line of analysisText.split('\n')) {
       lines.push(`  ${line}`);
     }
@@ -884,18 +880,22 @@ function renderDetailView(
   lines.push('');
 
   // Hint line
-  const bodyToggle = showBody ? chalk.yellow('(b)ody') : chalk.green('(b)ody');
+  const bodyToggle = showBody ? styleText('yellow', '(b)ody') : styleText('green', '(b)ody');
   const commentsLabel = `(c)omments (${detail.comments})`;
-  const commentsToggle = showComments ? chalk.yellow(commentsLabel) : chalk.green(commentsLabel);
-  const analyzeToggle = analysisText ? chalk.yellow('(a)nalyze') : chalk.green('(a)nalyze');
-  const parts = [bodyToggle, commentsToggle, analyzeToggle, chalk.gray('Esc back')];
-  lines.push(chalk.gray('  ') + parts.join(chalk.gray(' / ')));
+  const commentsToggle = showComments
+    ? styleText('yellow', commentsLabel)
+    : styleText('green', commentsLabel);
+  const analyzeToggle = analysisText
+    ? styleText('yellow', '(a)nalyze')
+    : styleText('green', '(a)nalyze');
+  const parts = [bodyToggle, commentsToggle, analyzeToggle, styleText('gray', 'Esc back')];
+  lines.push(styleText('gray', '  ') + parts.join(styleText('gray', ' / ')));
 
   return lines;
 }
 
 async function showDetailInteractive(item: QueueItem): Promise<void> {
-  logger.info(chalk.gray('  Loading...'));
+  logger.info(styleText('gray', '  Loading...'));
   const detail = await fetchDetailData(item);
   clearLines(1); // remove "Loading..."
 
@@ -963,12 +963,16 @@ async function showDetailInteractive(item: QueueItem): Promise<void> {
         rawComments = comments;
         commentLines = [];
         if (comments.length === 0) {
-          commentLines.push(chalk.gray('  No comments.'));
+          commentLines.push(styleText('gray', '  No comments.'));
         } else {
           for (const comment of comments) {
-            const badge = isTeamResponse(comment) ? chalk.green('[TEAM]') : chalk.gray('[EXT]');
+            const badge = isTeamResponse(comment)
+              ? styleText('green', '[TEAM]')
+              : styleText('gray', '[EXT]');
             const date = new Date(comment.created_at).toISOString().slice(0, 10);
-            commentLines.push(`  ${badge} ${chalk.dim(comment.user?.login ?? '-')} (${date})`);
+            commentLines.push(
+              `  ${badge} ${styleText('dim', comment.user?.login ?? '-')} (${date})`
+            );
             commentLines.push(`    ${truncate(comment.body ?? '', 300)}`);
             commentLines.push('');
           }
@@ -1071,7 +1075,9 @@ async function action(options: ActionOptions) {
 
   if (!(await isAuthenticatedAsync())) {
     spinner.stop();
-    logger.warn(chalk.yellow('Unblocked API not configured — (a)nalyze will be unavailable.'));
+    logger.warn(
+      styleText('yellow', 'Unblocked API not configured — (a)nalyze will be unavailable.')
+    );
     const shouldSetup = await promptYesNo('Set up Unblocked API key now?');
     if (shouldSetup) {
       await authenticateAsync();
@@ -1079,9 +1085,11 @@ async function action(options: ActionOptions) {
       if (key) {
         setApiKey(key.trim());
         if (await isAuthenticatedAsync()) {
-          logger.info(chalk.green('Unblocked authenticated successfully.'));
+          logger.info(styleText('green', 'Unblocked authenticated successfully.'));
         } else {
-          logger.warn(chalk.yellow('Token appears invalid — (a)nalyze will be unavailable.'));
+          logger.warn(
+            styleText('yellow', 'Token appears invalid — (a)nalyze will be unavailable.')
+          );
         }
       }
     }

--- a/tools/src/commands/GitHubMetricsCommand.ts
+++ b/tools/src/commands/GitHubMetricsCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
 import { Octokit } from '@octokit/rest';
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import logger from '../Logger';
@@ -149,7 +149,7 @@ async function fetchIssueMetrics(
   startDate: Date,
   endDate: Date
 ): Promise<IssueMetrics> {
-  logger.info(chalk.gray('Fetching issue metrics...'));
+  logger.info(styleText('gray', 'Fetching issue metrics...'));
 
   // Fetch all issues (not PRs) created or updated in the date range
   // Note: We use a 30-day buffer before startDate to ensure we capture all issues that were open at the start
@@ -191,7 +191,7 @@ async function fetchIssueMetrics(
   const netChange = openedDuringPeriod - closedDuringPeriod;
 
   // Track "needs review" label metrics
-  logger.info(chalk.gray('Tracking "needs review" label...'));
+  logger.info(styleText('gray', 'Tracking "needs review" label...'));
 
   const hasNeedsReviewLabel = (issue: (typeof allIssues)[0]) => {
     return issue.labels.some(
@@ -238,7 +238,7 @@ async function fetchPRMetrics(
   startDate: Date,
   endDate: Date
 ): Promise<PRMetrics> {
-  logger.info(chalk.gray('Fetching pull request metrics...'));
+  logger.info(styleText('gray', 'Fetching pull request metrics...'));
 
   const allPRs = await fetchAllPaginatedData(async (page) => {
     const { data } = await octokit.pulls.list({
@@ -299,7 +299,7 @@ async function fetchPRMetrics(
   const netChange = openedDuringPeriod - closedDuringPeriod;
 
   // Split metrics by external vs internal contributions
-  logger.info(chalk.gray('Splitting PR metrics by contribution type...'));
+  logger.info(styleText('gray', 'Splitting PR metrics by contribution type...'));
 
   const isExternalContribution = (pr: (typeof relevantPRs)[0]) => {
     return pr.head.repo ? pr.head.repo.full_name !== `${owner}/${repo}` : false;
@@ -359,7 +359,7 @@ async function fetchCIMetrics(
   startDate: Date,
   endDate: Date
 ): Promise<CIMetrics> {
-  logger.info(chalk.gray('Fetching CI metrics...'));
+  logger.info(styleText('gray', 'Fetching CI metrics...'));
 
   const workflowRuns = await fetchAllPaginatedData(async (page) => {
     const { data } = await octokit.actions.listWorkflowRunsForRepo({
@@ -448,7 +448,8 @@ async function retryOnError<T>(
 
       if (shouldRetry && attempt < maxRetries) {
         logger.warn(
-          chalk.yellow(
+          styleText(
+            'yellow',
             `⚠ API error (${error.status}), retrying in ${delayMs}ms... (attempt ${attempt}/${maxRetries})`
           )
         );
@@ -482,7 +483,7 @@ async function fetchAllPaginatedData<T>(fetchPage: (page: number) => Promise<T[]
 
       if (page > 50) {
         logger.warn(
-          chalk.yellow('⚠ Reached pagination limit of 50 pages. Some data may be missing.')
+          styleText('yellow', '⚠ Reached pagination limit of 50 pages. Some data may be missing.')
         );
         break;
       }
@@ -599,21 +600,21 @@ async function generateMetricsReport(options: MetricsOptions): Promise<string> {
   try {
     const [issues, pullRequests, ci] = await Promise.all([
       fetchIssueMetrics(owner, repo, startDate, endDate).catch((error) => {
-        logger.error(chalk.red('Error fetching issue metrics:'));
-        logger.error(chalk.red(`Status: ${error.status || 'N/A'}`));
-        logger.error(chalk.red(`Message: ${error.message}`));
+        logger.error(styleText('red', 'Error fetching issue metrics:'));
+        logger.error(styleText('red', `Status: ${error.status || 'N/A'}`));
+        logger.error(styleText('red', `Message: ${error.message}`));
         throw error;
       }),
       fetchPRMetrics(owner, repo, startDate, endDate).catch((error) => {
-        logger.error(chalk.red('Error fetching PR metrics:'));
-        logger.error(chalk.red(`Status: ${error.status || 'N/A'}`));
-        logger.error(chalk.red(`Message: ${error.message}`));
+        logger.error(styleText('red', 'Error fetching PR metrics:'));
+        logger.error(styleText('red', `Status: ${error.status || 'N/A'}`));
+        logger.error(styleText('red', `Message: ${error.message}`));
         throw error;
       }),
       fetchCIMetrics(owner, repo, startDate, endDate).catch((error) => {
-        logger.error(chalk.red('Error fetching CI metrics:'));
-        logger.error(chalk.red(`Status: ${error.status || 'N/A'}`));
-        logger.error(chalk.red(`Message: ${error.message}`));
+        logger.error(styleText('red', 'Error fetching CI metrics:'));
+        logger.error(styleText('red', `Status: ${error.status || 'N/A'}`));
+        logger.error(styleText('red', `Message: ${error.message}`));
         throw error;
       }),
     ]);
@@ -624,11 +625,11 @@ async function generateMetricsReport(options: MetricsOptions): Promise<string> {
       ci,
     };
 
-    logger.info(chalk.green('✓ Metrics collected successfully\n'));
+    logger.info(styleText('green', '✓ Metrics collected successfully\n'));
 
     return generateMarkdownReport(metrics, options);
   } catch (error: any) {
-    logger.error(chalk.red('\n🔥 Failed to generate metrics report'));
+    logger.error(styleText('red', '\n🔥 Failed to generate metrics report'));
     throw error;
   }
 }
@@ -639,7 +640,7 @@ async function action(options: ActionOptions) {
   }
 
   try {
-    logger.info(chalk.bold('📊 Generating GitHub metrics report...\n'));
+    logger.info(styleText('bold', '📊 Generating GitHub metrics report...\n'));
 
     const endDate = options.endDate ? new Date(options.endDate) : getThisWeekEnd();
     const startDate = options.startDate ? new Date(options.startDate) : getThisWeekMonday();
@@ -661,9 +662,9 @@ async function action(options: ActionOptions) {
       throw new Error('Invalid repository format. Use owner/repo format.');
     }
 
-    logger.info(`Repository: ${chalk.cyan(`${owner}/${repo}`)}`);
+    logger.info(`Repository: ${styleText('cyan', `${owner}/${repo}`)}`);
     logger.info(
-      `Date range: ${chalk.cyan(startDate.toISOString().split('T')[0])} to ${chalk.cyan(endDate.toISOString().split('T')[0])}\n`
+      `Date range: ${styleText('cyan', startDate.toISOString().split('T')[0])} to ${styleText('cyan', endDate.toISOString().split('T')[0])}\n`
     );
 
     const report = await generateMetricsReport({
@@ -676,33 +677,33 @@ async function action(options: ActionOptions) {
     if (options.output) {
       const outputPath = path.resolve(options.output);
       await fs.writeFile(outputPath, report);
-      logger.info(chalk.green(`✓ Report saved to: ${outputPath}`));
+      logger.info(styleText('green', `✓ Report saved to: ${outputPath}`));
     } else {
-      logger.info(chalk.bold('📄 Metrics Report:\n'));
+      logger.info(styleText('bold', '📄 Metrics Report:\n'));
       console.log(report);
     }
   } catch (error: any) {
-    logger.error(chalk.red('\n❌ Error Details:'));
-    logger.error(chalk.red(`Message: ${error.message}`));
+    logger.error(styleText('red', '\n❌ Error Details:'));
+    logger.error(styleText('red', `Message: ${error.message}`));
 
     if (error.status) {
-      logger.error(chalk.red(`HTTP Status: ${error.status}`));
+      logger.error(styleText('red', `HTTP Status: ${error.status}`));
     }
 
     if (error.response) {
-      logger.error(chalk.red('Response:'));
-      logger.error(chalk.red(JSON.stringify(error.response, null, 2)));
+      logger.error(styleText('red', 'Response:'));
+      logger.error(styleText('red', JSON.stringify(error.response, null, 2)));
     }
 
     if (error.request) {
-      logger.error(chalk.red('Request:'));
-      logger.error(chalk.red(`URL: ${error.request?.url || 'N/A'}`));
-      logger.error(chalk.red(`Method: ${error.request?.method || 'N/A'}`));
+      logger.error(styleText('red', 'Request:'));
+      logger.error(styleText('red', `URL: ${error.request?.url || 'N/A'}`));
+      logger.error(styleText('red', `Method: ${error.request?.method || 'N/A'}`));
     }
 
     if (error.stack) {
-      logger.error(chalk.gray('\nStack trace:'));
-      logger.error(chalk.gray(error.stack));
+      logger.error(styleText('gray', '\nStack trace:'));
+      logger.error(styleText('gray', error.stack));
     }
 
     throw error;

--- a/tools/src/commands/GithubActionsCacheStats.ts
+++ b/tools/src/commands/GithubActionsCacheStats.ts
@@ -1,6 +1,6 @@
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export default (program: Command) => {
   program
@@ -64,7 +64,7 @@ async function actionAsync(options: Options) {
     displayResults(data, options);
     printSummary(data, options.highlightOnce);
   } catch (error: any) {
-    console.error(chalk.red('\nError:'), error.message);
+    console.error(styleText('red', '\nError:'), error.message);
     process.exit(1);
   }
 }
@@ -82,7 +82,7 @@ async function fetchAllCaches(): Promise<CacheInfo[]> {
   let page = 1;
   const GITHUB_API_PER_PAGE_LIMIT = 100;
 
-  console.log(chalk.cyan(`Fetching cache data...`));
+  console.log(styleText('cyan', `Fetching cache data...`));
 
   let totalCount = 0;
   while (true) {
@@ -145,13 +145,13 @@ function filterCacheData(data: ProcessedCache[], options: Options): ProcessedCac
 
   if (options.ref) {
     const refFilter = options.ref;
-    console.log(chalk.cyan(`Filtering caches by ref: ${refFilter}...`));
+    console.log(styleText('cyan', `Filtering caches by ref: ${refFilter}...`));
     filtered = filtered.filter((c) => c.ref.includes(refFilter));
   }
 
   if (options.accessedOlderThan) {
     const days = parseInt(options.accessedOlderThan, 10);
-    console.log(chalk.cyan(`Filtering caches accessed older than ${days} days...`));
+    console.log(styleText('cyan', `Filtering caches accessed older than ${days} days...`));
 
     if (!isNaN(days)) {
       const cutoffDate = new Date();
@@ -159,14 +159,17 @@ function filterCacheData(data: ProcessedCache[], options: Options): ProcessedCac
       filtered = filtered.filter((c) => c.rawLastAccessed < cutoffDate);
     } else {
       console.log(
-        chalk.yellow(`Invalid number of days: ${options.accessedOlderThan}. Skipping filter.`)
+        styleText(
+          'yellow',
+          `Invalid number of days: ${options.accessedOlderThan}. Skipping filter.`
+        )
       );
     }
   }
 
   if (options.createdOlderThan) {
     const days = parseInt(options.createdOlderThan, 10);
-    console.log(chalk.cyan(`Filtering caches created older than ${days} days...`));
+    console.log(styleText('cyan', `Filtering caches created older than ${days} days...`));
 
     if (!isNaN(days)) {
       const cutoffDate = new Date();
@@ -174,7 +177,7 @@ function filterCacheData(data: ProcessedCache[], options: Options): ProcessedCac
       filtered = filtered.filter((c) => c.rawCreatedAt < cutoffDate);
     } else {
       console.log(
-        chalk.yellow(`Invalid number of days: ${options.createdOlderThan}. Skipping filter.`)
+        styleText('yellow', `Invalid number of days: ${options.createdOlderThan}. Skipping filter.`)
       );
     }
   }
@@ -222,8 +225,8 @@ function displayGroupedByRef(data: ProcessedCache[], highlightOnce?: boolean) {
       .toFixed(2);
 
     console.log(
-      chalk.bold.magenta(`\nRef: ${refKey} `) +
-        chalk.gray(`(${groupItems.length} items, ${groupSize} MB)`)
+      styleText(['bold', 'magenta'], `\nRef: ${refKey} `) +
+        styleText('gray', `(${groupItems.length} items, ${groupSize} MB)`)
     );
     displayList(groupItems, highlightOnce);
   });
@@ -231,7 +234,7 @@ function displayGroupedByRef(data: ProcessedCache[], highlightOnce?: boolean) {
 
 function displayList(data: ProcessedCache[], highlightOnce?: boolean) {
   if (data.length === 0) {
-    console.log(chalk.gray('No caches found.'));
+    console.log(styleText('gray', 'No caches found.'));
     return;
   }
 
@@ -248,8 +251,8 @@ function displayList(data: ProcessedCache[], highlightOnce?: boolean) {
     'ACCESSED'.padEnd(dateWidth) +
     'SIZE'.padStart(sizeWidth);
 
-  console.log(chalk.bold.gray(header));
-  console.log(chalk.gray('-'.repeat(header.length)));
+  console.log(styleText(['bold', 'gray'], header));
+  console.log(styleText('gray', '-'.repeat(header.length)));
 
   data.forEach((item) => {
     const displayKey =
@@ -266,7 +269,7 @@ function displayList(data: ProcessedCache[], highlightOnce?: boolean) {
       (item.sizeMb.toFixed(2) + ' MB').padStart(sizeWidth);
 
     if (highlightOnce && item.isOnce) {
-      console.log(chalk.yellow(row));
+      console.log(styleText('yellow', row));
     } else {
       console.log(row);
     }
@@ -278,12 +281,12 @@ function printSummary(data: ProcessedCache[], highlightOnce?: boolean) {
   const onceCount = data.filter((d) => d.isOnce).length;
 
   console.log(
-    chalk.bold(`\nTOTAL: ${data.length} caches | Combined Size: ${totalMB.toFixed(2)} MB`)
+    styleText('bold', `\nTOTAL: ${data.length} caches | Combined Size: ${totalMB.toFixed(2)} MB`)
   );
 
   if (highlightOnce) {
     console.log(
-      chalk.yellow(`Found ${onceCount} caches accessed strictly within the creation minute.`)
+      styleText('yellow', `Found ${onceCount} caches accessed strictly within the creation minute.`)
     );
   }
 }

--- a/tools/src/commands/IosGenerateDynamicMacros.ts
+++ b/tools/src/commands/IosGenerateDynamicMacros.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export default (program: Command) => {
   program
@@ -8,9 +8,9 @@ export default (program: Command) => {
     .allowUnknownOption()
     .action(() => {
       console.log(
-        chalk.yellow('This command has been deprecated.\n\n') +
+        styleText('yellow', 'This command has been deprecated.\n\n') +
           'Use the shell script directly instead:\n' +
-          chalk.cyan('  apps/expo-go/ios/Build-Phases/generate-dynamic-macros.sh\n\n') +
+          styleText('cyan', '  apps/expo-go/ios/Build-Phases/generate-dynamic-macros.sh\n\n') +
           'The script no longer requires Node.js or expotools.'
       );
       process.exit(1);

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import logger from '../Logger';
 import { DependencyKind, getListOfPackagesAsync } from '../Packages';
@@ -8,8 +8,6 @@ import {
   scanDependenciesAsync,
   type ScannedDependency,
 } from '../check-packages/scanDependenciesAsync';
-
-const { green, yellow, red, cyan, gray, bold } = chalk;
 
 type ActionOptions = {
   json: boolean;
@@ -47,7 +45,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
   const found = new Set(packages.map((p) => p.packageName));
   for (const name of packageNames) {
     if (!found.has(name)) {
-      logger.warn(`Package ${yellow(name)} not found in monorepo.`);
+      logger.warn(`Package ${styleText('yellow', name)} not found in monorepo.`);
     }
   }
 
@@ -94,7 +92,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
           files: d.files.map((f) => ({ path: f.relativePath, line: f.line })),
         }));
       } else {
-        logger.log(`\n${green.bold(label)}`);
+        logger.log(`\n${styleText(['green', 'bold'], label)}`);
         printTable(filtered, monorepoPackageNames);
       }
     }
@@ -133,13 +131,17 @@ function printTable(deps: ScannedDependency[], monorepoPackageNames: Set<string>
   // Header
   logger.log(
     indent +
-      bold('Dependency'.padEnd(depW) + 'Kind'.padEnd(kindW) + 'Hints'.padEnd(hintsW) + 'References')
+      styleText(
+        'bold',
+        'Dependency'.padEnd(depW) + 'Kind'.padEnd(kindW) + 'Hints'.padEnd(hintsW) + 'References'
+      )
   );
 
   // Separator
   logger.log(
     indent +
-      gray(
+      styleText(
+        'gray',
         '─'.repeat(depW - GAP).padEnd(depW) +
           '─'.repeat(kindW - GAP).padEnd(kindW) +
           '─'.repeat(hintsW - GAP).padEnd(hintsW) +
@@ -156,11 +158,11 @@ function printTable(deps: ScannedDependency[], monorepoPackageNames: Set<string>
         depCell(row.dep, row.isInternal, depW) +
         coloredCell(row.kind, kindW) +
         hintCell(row.hints, hintsW) +
-        gray(firstRef)
+        styleText('gray', firstRef)
     );
 
     for (let i = 1; i < row.refs.length; i++) {
-      logger.log(emptyPrefix + gray(row.refs[i]));
+      logger.log(emptyPrefix + styleText('gray', row.refs[i]));
     }
   }
 }
@@ -192,7 +194,7 @@ function kindLabel(kind: DependencyKind | undefined): string {
 }
 
 function depCell(text: string, isInternal: boolean, width: number): string {
-  const colored = isInternal ? green(text) : text;
+  const colored = isInternal ? styleText('green', text) : text;
   return colored + ' '.repeat(Math.max(0, width - text.length));
 }
 
@@ -206,11 +208,11 @@ function kindColorFn(kind: string): (s: string) => string {
   switch (kind) {
     case 'dependency':
     case 'peerDependency':
-      return cyan;
+      return (s: string) => styleText('cyan', s);
     case 'devDependency':
-      return yellow;
+      return (s: string) => styleText('yellow', s);
     case 'undeclared':
-      return red;
+      return (s: string) => styleText('red', s);
     default:
       return (s: string) => s;
   }
@@ -220,5 +222,5 @@ function hintCell(text: string, width: number): string {
   if (!text) {
     return ' '.repeat(width);
   }
-  return yellow(text) + ' '.repeat(Math.max(0, width - text.length));
+  return styleText('yellow', text) + ' '.repeat(Math.max(0, width - text.length));
 }

--- a/tools/src/commands/MergeChangelogs.ts
+++ b/tools/src/commands/MergeChangelogs.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import semver from 'semver';
@@ -156,7 +156,7 @@ async function insertInitialReleasesAsync(
           unshift: true,
         }
       );
-      logger.info(`\n📦 Inserted initial release of ${chalk.green(pkg.packageName)}`);
+      logger.info(`\n📦 Inserted initial release of ${styleText('green', pkg.packageName)}`);
     }
   }
 }
@@ -206,11 +206,11 @@ async function insertNewChangelogEntriesAsync(
 
     // Package was already bundled within previous version.
     logger.info(
-      `\n📦 Inserted ${chalk.green(pkg.packageName)} entries as of ${chalk.yellow(fromVersion)}`
+      `\n📦 Inserted ${styleText('green', pkg.packageName)} entries as of ${styleText('yellow', fromVersion)}`
     );
 
     for (const [type, entries] of Object.entries(insertedEntries)) {
-      logger.log('  ', chalk.magenta(stripNonAsciiChars(type).trim() + ':'));
+      logger.log('  ', styleText('magenta', stripNonAsciiChars(type).trim() + ':'));
       entries.forEach((entry) => {
         logger.log('    ', formatChangelogEntry(entry.message));
       });
@@ -226,7 +226,7 @@ async function cutOffMainChangelogAsync(
   versions: ChangelogVersions,
   nextVersion: string
 ): Promise<void> {
-  logger.info(`\n✂️  Cutting off changelog for SDK ${chalk.cyan(nextVersion)}...`);
+  logger.info(`\n✂️  Cutting off changelog for SDK ${styleText('cyan', nextVersion)}...`);
 
   await mainChangelog.cutOffAsync(nextVersion, [
     ChangeType.LIBRARY_UPGRADES,
@@ -271,7 +271,7 @@ async function promptToMakeInitialReleaseAsync(packageName: string): Promise<boo
       name: 'confirm',
       default: true,
       prefix: '❔',
-      message: `${chalk.green(packageName)} wasn't bundled in SDK yet. Do you want to include it?`,
+      message: `${styleText('green', packageName)} wasn't bundled in SDK yet. Do you want to include it?`,
     },
   ]);
   return confirm;

--- a/tools/src/commands/NativeUnitTests.ts
+++ b/tools/src/commands/NativeUnitTests.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 
 import { androidNativeUnitTests } from './AndroidNativeUnitTests';
 import { iosNativeUnitTests } from './IosNativeUnitTests';
@@ -17,7 +17,7 @@ async function thisAction({
   packages?: string;
 }) {
   if (!platform) {
-    console.log(chalk.yellow("You haven't specified platform to run unit tests for!"));
+    console.log(styleText('yellow', "You haven't specified platform to run unit tests for!"));
     const result = await inquirer.prompt<{ platform: PlatformName }>([
       {
         name: 'platform',

--- a/tools/src/commands/PodInstallCommand.ts
+++ b/tools/src/commands/PodInstallCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import { hashElement } from 'folder-hash';
+import { styleText } from 'node:util';
 import path from 'path';
 import process from 'process';
 
@@ -32,7 +32,7 @@ async function action(options: ActionOptions) {
     const manifestLockHash = await md5(path.join(absoluteProjectPath, 'Pods/Manifest.lock'));
 
     if (!manifestLockHash || podfileLockHash !== manifestLockHash || options.force) {
-      logger.info(`🥥 Installing pods in ${chalk.yellow(relativeProjectPath)} directory`);
+      logger.info(`🥥 Installing pods in ${styleText('yellow', relativeProjectPath)} directory`);
 
       try {
         await npxPodInstallAsync(absoluteProjectPath, !!options.verbose);

--- a/tools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/src/commands/PromoteVersionsToProduction.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
 import * as jsondiffpatch from 'jsondiffpatch';
+import { styleText } from 'node:util';
 
 import * as Versions from '../Versions';
 
@@ -11,18 +11,20 @@ async function action() {
   const delta = jsondiffpatch.diff(versionsProd, versionsStaging);
 
   if (!delta) {
-    console.log(chalk.yellow('There are no changes to apply in the configuration.'));
+    console.log(styleText('yellow', 'There are no changes to apply in the configuration.'));
     return;
   }
 
-  console.log(`Here is the diff from ${chalk.green('staging')} -> ${chalk.green('production')}:`);
+  console.log(
+    `Here is the diff from ${styleText('green', 'staging')} -> ${styleText('green', 'production')}:`
+  );
   console.log(jsondiffpatch.formatters.console.format(delta, versionsProd));
 
   const { isCorrect } = await inquirer.prompt<{ isCorrect: boolean }>([
     {
       type: 'confirm',
       name: 'isCorrect',
-      message: `Does this look correct? Type \`y\` to update ${chalk.green('production')} config.`,
+      message: `Does this look correct? Type \`y\` to update ${styleText('green', 'production')} config.`,
       default: false,
     },
   ]);
@@ -32,11 +34,11 @@ async function action() {
     await Versions.setVersionsAsync(versionsStaging, Versions.VersionsApiHost.PRODUCTION);
 
     console.log(
-      chalk.green('\nSuccessfully updated production config. You can check it out on'),
-      chalk.blue(`https://${Versions.VersionsApiHost.PRODUCTION}/v2/versions`)
+      styleText('green', '\nSuccessfully updated production config. You can check it out on'),
+      styleText('blue', `https://${Versions.VersionsApiHost.PRODUCTION}/v2/versions`)
     );
   } else {
-    console.log(chalk.yellow('Canceled'));
+    console.log(styleText('yellow', 'Canceled'));
   }
 }
 

--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -1,8 +1,8 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import { hashElement } from 'folder-hash';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 import process from 'process';
@@ -53,7 +53,7 @@ async function maybeUpdateHomeSdkVersionAsync(
   const targetSdkVersion = explicitSdkVersion ?? (await findTargetSdkVersionAsync());
 
   if (appJson.expo.sdkVersion !== targetSdkVersion) {
-    console.log(`Updating home's sdkVersion to ${chalk.cyan(targetSdkVersion)}...`);
+    console.log(`Updating home's sdkVersion to ${styleText('cyan', targetSdkVersion)}...`);
 
     // When publishing the sdkVersion needs to be set to the target sdkVersion. The Expo client will
     // load it as UNVERSIONED, but the server uses this field to know which clients to serve the
@@ -94,7 +94,7 @@ async function publishAppOnDevelopmentBranchAsync({
   slug: string;
   message: string;
 }): Promise<{ createdUpdateGroupId: string }> {
-  console.log(`Publishing ${chalk.green(slug)}...`);
+  console.log(`Publishing ${styleText('green', slug)}...`);
 
   const result = await EASUpdate.setAuthAndPublishProjectWithEasCliAsync(EXPO_HOME_PATH, {
     userpass: {
@@ -106,9 +106,7 @@ async function publishAppOnDevelopmentBranchAsync({
   });
 
   console.log(
-    `Done publishing ${chalk.green(slug)}. Update Group ID is: ${chalk.blue(
-      result.createdUpdateGroupId
-    )}`
+    `Done publishing ${styleText('green', slug)}. Update Group ID is: ${styleText('blue', result.createdUpdateGroupId)}`
   );
 
   return result;
@@ -125,7 +123,7 @@ async function updateDevHomeConfigAsync(url: string): Promise<void> {
   );
   const devManifestsFile = new JsonFile(devHomeConfigPath);
 
-  console.log(`Updating dev home config at ${chalk.magenta(devHomeConfigFilename)}...`);
+  console.log(`Updating dev home config at ${styleText('magenta', devHomeConfigFilename)}...`);
   await devManifestsFile.writeAsync({ url });
 }
 
@@ -155,7 +153,7 @@ async function action(options: ActionOptions): Promise<void> {
     throw new Error('No configured EAS project ID in app.json');
   }
 
-  console.log(`Creating backup of ${chalk.magenta('app.json')} file...`);
+  console.log(`Creating backup of ${styleText('magenta', 'app.json')} file...`);
   const appJsonBackup = deepCloneObject<AppConfig>(appJson);
 
   console.log('Getting expo-cli state of the current session...');
@@ -163,7 +161,7 @@ async function action(options: ActionOptions): Promise<void> {
 
   await maybeUpdateHomeSdkVersionAsync(appJson, options.sdkVersion);
 
-  console.log(`Modifying home's slug to ${chalk.green(slug)}...`);
+  console.log(`Modifying home's slug to ${styleText('green', slug)}...`);
   appJson.expo.slug = slug;
 
   // Save the modified `appJson` to the file so it'll be used as a manifest.
@@ -172,7 +170,7 @@ async function action(options: ActionOptions): Promise<void> {
   const cliUsername = cliStateBackup?.auth?.username;
 
   if (cliUsername) {
-    console.log(`Logging out from ${chalk.green(cliUsername)} account...`);
+    console.log(`Logging out from ${styleText('green', cliUsername)} account...`);
     await ExpoCLI.runExpoCliAsync('logout', [], {
       stdio: 'ignore',
     });
@@ -182,28 +180,32 @@ async function action(options: ActionOptions): Promise<void> {
     await publishAppOnDevelopmentBranchAsync({ slug, message: expoHomeHashNode.hash })
   ).createdUpdateGroupId;
 
-  console.log(`Restoring home's slug to ${chalk.green(appJsonBackup.expo.slug)}...`);
+  console.log(`Restoring home's slug to ${styleText('green', appJsonBackup.expo.slug)}...`);
   appJson.expo.slug = appJsonBackup.expo.slug;
 
   if (cliUsername) {
-    console.log(`Restoring ${chalk.green(cliUsername)} session in expo-cli...`);
+    console.log(`Restoring ${styleText('green', cliUsername)} session in expo-cli...`);
     await setExpoCliStateAsync(cliStateBackup);
   } else {
-    console.log(`Logging out from ${chalk.green(EXPO_HOME_DEV_ACCOUNT_USERNAME)} account...`);
+    console.log(
+      `Logging out from ${styleText('green', EXPO_HOME_DEV_ACCOUNT_USERNAME)} account...`
+    );
     await fs.remove(getExpoCliStatePath());
   }
 
-  console.log(`Updating ${chalk.magenta('app.json')} file...`);
+  console.log(`Updating ${styleText('magenta', 'app.json')} file...`);
   await appJsonFile.writeAsync(appJson);
 
   const url = `exps://u.expo.dev/${projectId}/group/${createdUpdateGroupId}`;
   await updateDevHomeConfigAsync(url);
 
   console.log(
-    chalk.yellow(
-      `Finished publishing. Remember to commit changes of ${chalk.magenta(
+    styleText(
+      'yellow',
+      `Finished publishing. Remember to commit changes of ${styleText(
+        'magenta',
         'apps/expo-go/app.json'
-      )} and ${chalk.magenta('dev-home-config.json')}.`
+      )} and ${styleText('magenta', 'dev-home-config.json')}.`
     )
   );
 }
@@ -213,9 +215,7 @@ export default (program: Command) => {
     .command('publish-dev-home')
     .alias('pdh')
     .description(
-      `Automatically logs in your eas-cli to ${chalk.magenta(
-        EXPO_HOME_DEV_ACCOUNT_USERNAME!
-      )} account, publishes home app for development on EAS Update and logs back to your account.`
+      `Automatically logs in your eas-cli to ${styleText('magenta', EXPO_HOME_DEV_ACCOUNT_USERNAME!)} account, publishes home app for development on EAS Update and logs back to your account.`
     )
     .option(
       '-s, --sdkVersion [string]',

--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -1,6 +1,6 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import * as jsondiffpatch from 'jsondiffpatch';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { EXPO_DIR } from '../Constants';
@@ -126,7 +126,7 @@ export default (program: Command) => {
 updating other workspace projects, committing and pushing changes to remote repo.
 
 As it's prone to errors due to its complexity and the fact it sometimes may take some time, we made it stateful.
-It's been splitted into a few tasks after each a backup is saved under ${chalk.magenta.bold(path.relative(EXPO_DIR, BACKUP_PATH))} file
+It's been splitted into a few tasks after each a backup is saved under ${styleText(["magenta", "bold"], path.relative(EXPO_DIR, BACKUP_PATH))} file
 and all file changes they made are added to Git's index as part of the backup. Due to its stateful nature,
 your local repo must be clear (without unstaged changes) and you shouldn't make any changes in the repo while the command is running.
 
@@ -137,13 +137,13 @@ but remember to leave staged changes as they were because they're also part of t
       `
 
 To list packages with unpublished changes:
-${chalk.gray('>')} ${chalk.italic.cyan('et publish -l')}
+${styleText('gray', '>')} ${styleText(['italic', 'cyan'], 'et publish -l')}
 
 To publish all packages with unpublished changes:
-${chalk.gray('>')} ${chalk.italic.cyan('et publish')}
+${styleText('gray', '>')} ${styleText(['italic', 'cyan'], 'et publish')}
 
 To publish just specific packages and their dependencies:
-${chalk.gray('>')} ${chalk.italic.cyan('et publish expo-gl expo-auth-session')}`
+${styleText('gray', '>')} ${styleText(['italic', 'cyan'], 'et publish expo-gl expo-auth-session')}`
     )
     .asyncAction(main);
 };
@@ -217,7 +217,7 @@ async function main(packageNames: string[], options: CommandOptions): Promise<vo
     ): Promise<void> {
       const dateString = new Date(backup.timestamp).toLocaleString();
 
-      logger.info(`♻️  Restoring from backup saved on ${chalk.magenta(dateString)}...`);
+      logger.info(`♻️  Restoring from backup saved on ${styleText('magenta', dateString)}...`);
 
       const allPackages = await getListOfPackagesAsync();
       const graph = new PackagesGraph(allPackages);

--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -4,9 +4,9 @@ import {
   isMultipartPartWithName,
   parseMultipartMixedResponseAsync,
 } from '@expo/multipart-body-parser';
-import chalk from 'chalk';
 import { createWriteStream } from 'fs';
 import fs from 'fs/promises';
+import { styleText } from 'node:util';
 import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
@@ -78,7 +78,7 @@ async function publishAppAsync({
   slug: string;
   message: string;
 }): Promise<{ createdUpdateGroupId: string }> {
-  console.log(`Publishing ${chalk.green(slug)}...`);
+  console.log(`Publishing ${styleText('green', slug)}...`);
 
   const result = await EASUpdate.publishProjectWithEasCliAsync(EXPO_HOME_PATH, {
     branch: 'production',
@@ -86,9 +86,7 @@ async function publishAppAsync({
   });
 
   console.log(
-    `Done publishing ${chalk.green(slug)}. Update Group ID is: ${chalk.blue(
-      result.createdUpdateGroupId
-    )}`
+    `Done publishing ${styleText('green', slug)}. Update Group ID is: ${styleText('blue', result.createdUpdateGroupId)}`
   );
 
   return result;
@@ -200,16 +198,16 @@ async function action(): Promise<void> {
     throw new Error('app.json missing updates.url');
   }
 
-  console.log(`Creating backup of ${chalk.magenta('app.json')} file...`);
+  console.log(`Creating backup of ${styleText('magenta', 'app.json')} file...`);
   const appJsonBackup = deepCloneObject<AppConfig>(appJson);
 
-  console.log(`Modifying home's slug to ${chalk.green(slug)}...`);
+  console.log(`Modifying home's slug to ${styleText('green', slug)}...`);
   appJson.expo.slug = slug;
 
-  console.log(`Modifying home's EAS project ID to ${chalk.green(easProjectId)}...`);
+  console.log(`Modifying home's EAS project ID to ${styleText('green', easProjectId)}...`);
   appJson.expo.extra.eas.projectId = easProjectId;
 
-  console.log(`Modifying home's update URL to ${chalk.green(easUpdateURL)}...`);
+  console.log(`Modifying home's update URL to ${styleText('green', easUpdateURL)}...`);
   appJson.expo.updates.url = easUpdateURL;
 
   // Save the modified `appJson` to the file so it'll be used as a manifest.
@@ -219,7 +217,7 @@ async function action(): Promise<void> {
     await publishAppAsync({ slug, message: `Publish ${appJson.expo.sdkVersion}` })
   ).createdUpdateGroupId;
 
-  console.log(`Restoring ${chalk.magenta('app.json')} file...`);
+  console.log(`Restoring ${styleText('magenta', 'app.json')} file...`);
   await appJsonFile.writeAsync(appJsonBackup);
 
   console.log(`Downloading published manifests and bundles...`);
@@ -229,7 +227,8 @@ async function action(): Promise<void> {
   ]);
 
   console.log(
-    chalk.yellow(
+    styleText(
+      'yellow',
       `Finished publishing. Remember to commit changes of the embedded manifests and bundles.`
     )
   );

--- a/tools/src/commands/PublishReviewApp.ts
+++ b/tools/src/commands/PublishReviewApp.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 import semver from 'semver';
 
@@ -53,18 +53,18 @@ async function ensureLoggedInAsAppleReview(): Promise<string | null> {
   const currentUser = await getCurrentUser();
 
   if (currentUser === REVIEW_CONFIG.owner) {
-    logger.info(`Already logged in as ${chalk.cyan(REVIEW_CONFIG.owner)}`);
+    logger.info(`Already logged in as ${styleText('cyan', REVIEW_CONFIG.owner)}`);
     return null;
   }
 
   if (currentUser) {
     throw new Error(
-      `You are logged in as ${chalk.cyan(currentUser)}. Please run ${chalk.cyan('eas logout')} and then ${chalk.cyan(`eas login`)} as ${chalk.cyan(REVIEW_CONFIG.owner)} before running this command.`
+      `You are logged in as ${styleText('cyan', currentUser)}. Please run ${styleText('cyan', 'eas logout')} and then ${styleText('cyan', `eas login`)} as ${styleText('cyan', REVIEW_CONFIG.owner)} before running this command.`
     );
   }
 
   throw new Error(
-    `You are not logged in. Please run ${chalk.cyan('eas login')} as ${chalk.cyan(REVIEW_CONFIG.owner)} before running this command.`
+    `You are not logged in. Please run ${styleText('cyan', 'eas login')} as ${styleText('cyan', REVIEW_CONFIG.owner)} before running this command.`
   );
 }
 
@@ -89,7 +89,7 @@ async function main(options: ActionOptions): Promise<void> {
   // Read current app.json (for backup/revert)
   const originalAppJson = await JsonFile.readAsync(APP_JSON_PATH);
 
-  logger.info(`Setting sdkVersion and version to ${chalk.cyan(sdkVersion)}`);
+  logger.info(`Setting sdkVersion and version to ${styleText('cyan', sdkVersion)}`);
 
   // Deep clone and apply review config
   const appJson = JSON.parse(JSON.stringify(originalAppJson));
@@ -102,7 +102,9 @@ async function main(options: ActionOptions): Promise<void> {
   // If --config-only, exit here
   if (options.configOnly) {
     logger.info('Config-only mode: exiting without publishing');
-    logger.info(`Run ${chalk.cyan('eas update --branch main')} when you are ready to publish`);
+    logger.info(
+      `Run ${styleText('cyan', 'eas update --branch main')} when you are ready to publish`
+    );
     return;
   }
 

--- a/tools/src/commands/SyncBundledNativeModules.ts
+++ b/tools/src/commands/SyncBundledNativeModules.ts
@@ -1,7 +1,7 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 import semver from 'semver';
 
@@ -60,7 +60,7 @@ async function confirmEnvAsync(env: Env): Promise<void> {
     {
       type: 'confirm',
       name: 'confirmed',
-      message: `Are you sure to run this script against the ${chalk.green(env)} environment?`,
+      message: `Are you sure to run this script against the ${styleText('green', env)} environment?`,
       default: true,
     },
   ]);
@@ -76,9 +76,7 @@ async function resolveSecretAsync(): Promise<string> {
   }
 
   logger.info(
-    `We need the secret to authenticate you with Expo servers.\nPlease set the ${chalk.green(
-      'EXPO_SDK_NATIVE_MODULES_SECRET'
-    )} env var if you want to skip the prompt in the future.`
+    `We need the secret to authenticate you with Expo servers.\nPlease set the ${styleText('green', 'EXPO_SDK_NATIVE_MODULES_SECRET')} env var if you want to skip the prompt in the future.`
   );
 
   const { secret } = await inquirer.prompt<{ secret: string }>([
@@ -103,9 +101,7 @@ async function resolveTargetSdkVersionAsync(): Promise<string> {
     {
       type: 'confirm',
       name: 'confirmed',
-      message: `Do you want to sync bundledNativeModules.json for ${chalk.green(
-        `SDK ${sdkVersion}`
-      )}?`,
+      message: `Do you want to sync bundledNativeModules.json for ${styleText('green', `SDK ${sdkVersion}`)}?`,
       default: true,
     },
   ]);
@@ -158,20 +154,20 @@ async function compareAndConfirmAsync(
     if (versionRange !== currentMap[npmPackage]?.versionRange) {
       hasChanges = true;
       logger.info(
-        ` - ${npmPackage}: ${chalk.red(
-          currentMap[npmPackage]?.versionRange ?? '(none)'
-        )} -> ${chalk.green(versionRange)}`
+        ` - ${npmPackage}: ${styleText('red', currentMap[npmPackage]?.versionRange ?? '(none)')} -> ${styleText('green', versionRange)}`
       );
     }
   }
   for (const { npmPackage, versionRange } of current) {
     if (!nextMap[npmPackage]) {
       hasChanges = true;
-      logger.info(` - ${npmPackage}: ${chalk.red(versionRange)} -> ${chalk.green('(removed)')}`);
+      logger.info(
+        ` - ${npmPackage}: ${styleText('red', versionRange)} -> ${styleText('green', '(removed)')}`
+      );
     }
   }
   if (!hasChanges) {
-    logger.info(chalk.gray('(no changes found)'));
+    logger.info(styleText('gray', '(no changes found)'));
     // there's no need to proceed with the script
     process.exit(0);
   }

--- a/tools/src/commands/SyncSdkBranchChangelogs.ts
+++ b/tools/src/commands/SyncSdkBranchChangelogs.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { Changelog, MemChangelog, UNPUBLISHED_VERSION_NAME } from '../Changelogs';
@@ -36,7 +36,7 @@ export default (program: Command) => {
           changed = await syncChangelogAsync(pkg, options.branch);
         } catch (e) {
           const errorMessage = e.message ?? String(e);
-          console.error(`❌ ${chalk.red(pkg.packageName)}: ${errorMessage}`);
+          console.error(`❌ ${styleText('red', pkg.packageName)}: ${errorMessage}`);
         }
         if (changed) {
           console.log(`✅ ${pkg.packageName}`);

--- a/tools/src/commands/UpdateReactNativeDocs.ts
+++ b/tools/src/commands/UpdateReactNativeDocs.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer, { QuestionCollection } from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { GitDirectory } from '../Git';
@@ -118,11 +118,9 @@ async function validateGitStatusAsync() {
     return true;
   }
 
-  logger.warn(`⚠️  Your git working tree is`, chalk.underline('dirty'));
+  logger.warn(`⚠️  Your git working tree is`, styleText('underline', 'dirty'));
   logger.info(
-    `It's recommended to ${chalk.bold(
-      'commit all your changes before proceeding'
-    )}, so you can revert the changes made by this command if necessary.`
+    `It's recommended to ${styleText('bold', 'commit all your changes before proceeding')}, so you can revert the changes made by this command if necessary.`
   );
 
   const { useDirtyGit } = await inquirer.prompt({
@@ -138,7 +136,7 @@ async function validateGitStatusAsync() {
 }
 
 async function updateDocsAsync(options: Options) {
-  logger.info(`📚 Updating ${chalk.cyan('react-native-website')} submodule...`);
+  logger.info(`📚 Updating ${styleText('cyan', 'react-native-website')} submodule...`);
 
   await rnRepo.runAsync(['checkout', 'main']);
   await rnRepo.pullAsync({});
@@ -153,7 +151,7 @@ async function updateDocsAsync(options: Options) {
 }
 
 async function getLocalFilesAsync(options: Options) {
-  logger.info('🔎 Resolving local docs from', chalk.underline(options.sdk), 'folder...');
+  logger.info('🔎 Resolving local docs from', styleText('underline', options.sdk), 'folder...');
 
   const versionedDocsPath = path.join(SDK_DOCS_DIR, options.sdk, 'react-native');
   const files = await fs.promises.readdir(versionedDocsPath);
@@ -171,7 +169,7 @@ async function getLocalFilesAsync(options: Options) {
 async function getUpstreamFilesAsync(options: Options) {
   logger.info(
     '🔎 Resolving upstream docs from',
-    chalk.underline('react-native-website'),
+    styleText('underline', 'react-native-website'),
     'submodule...'
   );
 
@@ -190,7 +188,7 @@ async function getUpstreamFilesAsync(options: Options) {
     logger.info(
       'Please double-check the sidebar and update the "relevantNestedDocs" in this script.'
     );
-    logger.info(chalk.dim(`./${path.relative(process.cwd(), sidebarPath)}\n`));
+    logger.info(styleText('dim', `./${path.relative(process.cwd(), sidebarPath)}\n`));
     throw error;
   }
 
@@ -230,7 +228,7 @@ function getDocsSummary(localFiles: string[], upstreamFiles: string[]): DocsSumm
 
 async function applyRemovedFilesAsync(options: Options, summary: DocsSummary) {
   if (!summary.removed.length) {
-    return logger.info('🤷‍ Upstream did not', chalk.red('remove'), 'any files');
+    return logger.info('🤷‍ Upstream did not', styleText('red', 'remove'), 'any files');
   }
 
   for (const entry of summary.removed) {
@@ -248,14 +246,14 @@ async function applyRemovedFilesAsync(options: Options, summary: DocsSummary) {
 
   logger.info(
     '➖ Upstream',
-    chalk.underline(`removed ${summary.removed.length} files`),
+    styleText('underline', `removed ${summary.removed.length} files`),
     `see "${PREFIX_REMOVED}*.md" files.`
   );
 }
 
 async function applyAddedFilesAsync(options: Options, summary: DocsSummary) {
   if (!summary.added.length) {
-    return logger.info('🤷‍ Upstream did not', chalk.green('add'), 'any files');
+    return logger.info('🤷‍ Upstream did not', styleText('green', 'add'), 'any files');
   }
 
   for (const entry of summary.added) {
@@ -270,15 +268,13 @@ async function applyAddedFilesAsync(options: Options, summary: DocsSummary) {
   }
 
   logger.info(
-    `➕ Upstream ${chalk.underline(
-      `added ${summary.added.length} files`
-    )}, see "${PREFIX_ADDED}*.md" files.`
+    `➕ Upstream ${styleText('underline', `added ${summary.added.length} files`)}, see "${PREFIX_ADDED}*.md" files.`
   );
 }
 
 async function applyChangedFilesAsync(options: Options, summary: DocsSummary) {
   if (!summary.changed.length) {
-    return logger.info('🤷‍ Upstream did not', chalk.yellow('change'), 'any files');
+    return logger.info('🤷‍ Upstream did not', styleText('yellow', 'change'), 'any files');
   }
 
   for (const entry of summary.changed) {
@@ -302,7 +298,7 @@ async function applyChangedFilesAsync(options: Options, summary: DocsSummary) {
 
   logger.info(
     '➗ Upstream',
-    chalk.underline(`changed ${summary.changed.length} files`),
+    styleText('underline', `changed ${summary.changed.length} files`),
     `see "*${SUFFIX_CHANGED}" files.`
   );
 }
@@ -315,7 +311,7 @@ function logCompleted(options: Options): void {
   logger.info(
     'To revert the changes, use `git clean -xdf .` and `git checkout .` in the versioned folder:'
   );
-  logger.info(chalk.dim(`./${path.relative(process.cwd(), versionedDir)}\n`));
+  logger.info(styleText('dim', `./${path.relative(process.cwd(), versionedDir)}\n`));
 }
 
 export default (program) => {

--- a/tools/src/commands/UpdateVendoredModule.ts
+++ b/tools/src/commands/UpdateVendoredModule.ts
@@ -1,8 +1,8 @@
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 
@@ -118,7 +118,7 @@ async function action(options: ActionOptions) {
     // Clean cloned repo
     await fs.remove(downloadSourceDir);
   }
-  logger.success('💪 Successfully updated %s\n', chalk.bold(moduleName));
+  logger.success('💪 Successfully updated %s\n', styleText('bold', moduleName));
 }
 
 /**
@@ -132,7 +132,11 @@ async function downloadSourceAsync(
 ) {
   if (moduleConfig.sourceType === 'npm') {
     const version = options.commit ?? 'latest';
-    logger.log('📥 Downloading %s@%s from npm', chalk.green(moduleName), chalk.cyan(version));
+    logger.log(
+      '📥 Downloading %s@%s from npm',
+      styleText('green', moduleName),
+      styleText('cyan', version)
+    );
 
     const tarball = await downloadPackageTarballAsync(
       sourceDirectory,
@@ -147,9 +151,9 @@ async function downloadSourceAsync(
   // Clone repository from the source
   logger.log(
     '📥 Cloning %s#%s from %s',
-    chalk.green(moduleName),
-    chalk.cyan(options.commit),
-    chalk.magenta(moduleConfig.source)
+    styleText('green', moduleName),
+    styleText('cyan', options.commit),
+    styleText('magenta', moduleConfig.source)
   );
 
   await GitDirectory.shallowCloneAsync(

--- a/tools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/src/commands/UpdateVersionsEndpoint.ts
@@ -1,10 +1,10 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
 import * as jsondiffpatch from 'jsondiffpatch';
 import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
 import unset from 'lodash/unset';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import * as Versions from '../Versions';
@@ -38,9 +38,7 @@ async function askForCorrectnessAsync(): Promise<boolean> {
     {
       type: 'confirm',
       name: 'isCorrect',
-      message: `Does this look correct? Type \`y\` or press enter to update ${chalk.green(
-        'staging'
-      )} config.`,
+      message: `Does this look correct? Type \`y\` or press enter to update ${styleText('green', 'staging')} config.`,
       default: true,
     },
   ]);
@@ -49,22 +47,22 @@ async function askForCorrectnessAsync(): Promise<boolean> {
 
 function setConfigValueForKey(config: object, key: string, value: any): void {
   if (value === undefined) {
-    console.log(`Deleting ${chalk.yellow(key)} config key ...`);
+    console.log(`Deleting ${styleText('yellow', key)} config key ...`);
     unset(config, key);
   } else {
-    console.log(`Changing ${chalk.yellow(key)} config key ...`);
+    console.log(`Changing ${styleText('yellow', key)} config key ...`);
     set(config, key, value);
   }
 }
 
 async function applyChangesToStagingAsync(delta: any, previousVersions: any, newVersions: any) {
   if (!delta) {
-    console.log(chalk.yellow('There are no changes to apply in the configuration.'));
+    console.log(styleText('yellow', 'There are no changes to apply in the configuration.'));
     return;
   }
 
   console.log(
-    `\nHere is the diff of changes to apply on ${chalk.green('staging')} version config:`
+    `\nHere is the diff of changes to apply on ${styleText('green', 'staging')} version config:`
   );
   console.log(jsondiffpatch.formatters.console.format(delta!, previousVersions));
 
@@ -79,11 +77,11 @@ async function applyChangesToStagingAsync(delta: any, previousVersions: any, new
     }
 
     console.log(
-      chalk.green('\nSuccessfully updated staging config. You can check it out on'),
-      chalk.blue(`https://${Versions.VersionsApiHost.STAGING}/v2/versions`)
+      styleText('green', '\nSuccessfully updated staging config. You can check it out on'),
+      styleText('blue', `https://${Versions.VersionsApiHost.STAGING}/v2/versions`)
     );
   } else {
-    console.log(chalk.yellow('Canceled'));
+    console.log(styleText('yellow', 'Canceled'));
   }
 }
 
@@ -105,7 +103,7 @@ async function applyChangesToRootAsync(options: ActionOptions, versions: any) {
   const newVersions = cloneDeep(versions);
   if (options.key) {
     if (!('value' in options) && !options.delete) {
-      console.log(chalk.red('`--key` flag requires `--value` or `--delete` flag.'));
+      console.log(styleText('red', '`--key` flag requires `--value` or `--delete` flag.'));
       return;
     }
     setConfigValueForKey(newVersions, options.key, options.delete ? undefined : options.value);
@@ -124,7 +122,9 @@ async function applyChangesToSDKVersionAsync(options: ActionOptions, versions: a
   const containsSdk = sdkVersions.includes(sdkVersion);
 
   if (!semver.valid(sdkVersion)) {
-    console.error(chalk.red(`Provided SDK version ${chalk.cyan(sdkVersion)} is invalid.`));
+    console.error(
+      styleText('red', `Provided SDK version ${styleText('cyan', sdkVersion)} is invalid.`)
+    );
     return;
   }
   if (!containsSdk) {
@@ -132,14 +132,12 @@ async function applyChangesToSDKVersionAsync(options: ActionOptions, versions: a
       {
         type: 'confirm',
         name: 'addNewSdk',
-        message: `Configuration for SDK ${chalk.cyan(
-          sdkVersion
-        )} doesn't exist. Do you want to initialize it?`,
+        message: `Configuration for SDK ${styleText('cyan', sdkVersion)} doesn't exist. Do you want to initialize it?`,
         default: true,
       },
     ]);
     if (!addNewSdk) {
-      console.log(chalk.yellow('Canceled'));
+      console.log(styleText('yellow', 'Canceled'));
       return;
     }
   }
@@ -147,8 +145,8 @@ async function applyChangesToSDKVersionAsync(options: ActionOptions, versions: a
   // If SDK is already there, make a deep clone of the sdkVersion config so we can calculate a diff later.
   const sdkVersionConfig = containsSdk ? cloneDeep(versions.sdkVersions[sdkVersion]) : {};
 
-  console.log(`\nUsing ${chalk.blue(Versions.VersionsApiHost.STAGING)} host ...`);
-  console.log(`Using SDK ${chalk.cyan(sdkVersion)} ...`);
+  console.log(`\nUsing ${styleText('blue', Versions.VersionsApiHost.STAGING)} host ...`);
+  console.log(`Using SDK ${styleText('cyan', sdkVersion)} ...`);
 
   if ('deprecated' in options) {
     setConfigValueForKey(sdkVersionConfig, 'isDeprecated', !!options.deprecated);
@@ -158,7 +156,7 @@ async function applyChangesToSDKVersionAsync(options: ActionOptions, versions: a
   }
   if (options.key) {
     if (!('value' in options) && !options.delete) {
-      console.log(chalk.red('`--key` flag requires `--value` or `--delete` flag.'));
+      console.log(styleText('red', '`--key` flag requires `--value` or `--delete` flag.'));
       return;
     }
     setConfigValueForKey(sdkVersionConfig, options.key, options.delete ? undefined : options.value);
@@ -204,7 +202,7 @@ export default (program: Command) => {
     .command('update-versions-endpoint')
     .alias('update-versions')
     .description(
-      `Updates SDK configuration under ${chalk.blue(`https://${Versions.VersionsApiHost.STAGING}/v2/versions`)}`
+      `Updates SDK configuration under ${styleText('blue', `https://${Versions.VersionsApiHost.STAGING}/v2/versions`)}`
     )
     .option(
       '-s, --sdkVersion [string]',

--- a/tools/src/commands/ValidateNpmOwnersCommand.ts
+++ b/tools/src/commands/ValidateNpmOwnersCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import fetch from 'npm-registry-fetch';
 
 import logger from '../Logger';
@@ -27,11 +27,11 @@ async function action(_options: ActionOptions) {
 
   logger.log('Fetching organization members...');
   const orgMembers = await getOrgMembersAsync();
-  logger.log(`${orgMembers.length} members found: ${chalk.dim(orgMembers.join(', '))}\n`);
+  logger.log(`${orgMembers.length} members found: ${styleText('dim', orgMembers.join(', '))}\n`);
 
   logger.log('Fetching organization packages...');
   const packages = await getOrgPackagesAsync();
-  logger.log(`${packages.length} packages found: ${chalk.dim(packages.join(', '))}\n`);
+  logger.log(`${packages.length} packages found: ${styleText('dim', packages.join(', '))}\n`);
 
   logger.log('Validating package owners...');
   const packagesWithInvalidOwners = await validatePackageOwnersAsync(
@@ -104,9 +104,9 @@ async function validatePackageOwnersAsync(orgMembers, packages) {
     }
 
     if (packagesWithInvalidOwners[pkg]) {
-      process.stdout.write(chalk.dim('x'));
+      process.stdout.write(styleText('dim', 'x'));
     } else {
-      process.stdout.write(chalk.dim('.'));
+      process.stdout.write(styleText('dim', '.'));
     }
   }
 

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -1,6 +1,6 @@
 import { Command } from '@expo/commander';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import open from 'open';
 
 import Git from '../Git';
@@ -50,9 +50,7 @@ export default (program: Command) => {
       false
     )
     .description(
-      `Dispatches an event that triggers a workflow on GitHub Actions. Requires ${chalk.magenta(
-        'GITHUB_TOKEN'
-      )} env variable to be set.`
+      `Dispatches an event that triggers a workflow on GitHub Actions. Requires ${styleText('magenta', 'GITHUB_TOKEN')} env variable to be set.`
     )
     .asyncAction(main);
 };
@@ -76,7 +74,7 @@ async function main(workflowSlug: string | undefined, options: CommandOptions) {
   // We need a confirmation to trigger a custom workflow.
   if (!process.env.CI && workflow.inputs && !(await confirmTriggeringWorkflowAsync(workflow))) {
     logger.warn(
-      `\n⚠️  Triggering custom workflow ${chalk.green(workflow.slug)} has been canceled.`
+      `\n⚠️  Triggering custom workflow ${styleText('green', workflow.slug)} has been canceled.`
     );
     return;
   }
@@ -109,12 +107,14 @@ async function main(workflowSlug: string | undefined, options: CommandOptions) {
       if (options.open && !process.env.CI) {
         await open(url);
       }
-      logger.log(`🧭 You can open ${chalk.magenta(url)} to track the new workflow run.`);
+      logger.log(`🧭 You can open ${styleText('magenta', url)} to track the new workflow run.`);
     } else {
       logger.warn(`⚠️  Cannot get URL for job: `, jobs[0]);
     }
   } else {
-    logger.warn(`⚠️  Cannot find any triggered jobs for ${chalk.green(workflow.slug)} workflow`);
+    logger.warn(
+      `⚠️  Cannot find any triggered jobs for ${styleText('green', workflow.slug)} workflow`
+    );
   }
 }
 
@@ -176,7 +176,7 @@ async function promptWorkflowAsync(workflows: Workflow[]): Promise<Workflow> {
       message: 'Which workflow do you want to dispatch?',
       choices: workflows.map((workflow) => {
         return {
-          name: `${chalk.yellow(workflow.name)} (${chalk.green.italic(workflow.slug)})`,
+          name: `${styleText('yellow', workflow.name)} (${styleText(['green', 'italic'], workflow.slug)})`,
           value: workflow,
         };
       }),
@@ -191,7 +191,7 @@ async function promptWorkflowAsync(workflows: Workflow[]): Promise<Workflow> {
  */
 async function confirmTriggeringWorkflowAsync(workflow: Workflow): Promise<boolean> {
   logger.info(
-    `\n👉 I'll trigger ${chalk.green(workflow.baseSlug)} workflow extended by the following input:`
+    `\n👉 I'll trigger ${styleText('green', workflow.baseSlug)} workflow extended by the following input:`
   );
   logger.log(workflow.inputs, '\n');
 

--- a/tools/src/dynamic-macros/AndroidMacrosGenerator.ts
+++ b/tools/src/dynamic-macros/AndroidMacrosGenerator.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import * as Directories from '../Directories';
@@ -60,7 +60,7 @@ export async function generateAndroidBuildConstantsFromMacrosAsync(macros) {
     macros.BUILD_MACHINE_KERNEL_MANIFEST = macros.DEV_PUBLISHED_KERNEL_MANIFEST;
     versionUsed = 'published dev';
   }
-  console.log(`Using ${chalk.yellow(versionUsed)} version of Expo Home.`);
+  console.log(`Using ${styleText('yellow', versionUsed)} version of Expo Home.`);
 
   delete macros['DEV_PUBLISHED_KERNEL_MANIFEST'];
 
@@ -105,7 +105,7 @@ ${source.trim()}
 async function updateBuildConstants(buildConstantsPath, macros) {
   console.log(
     'Generating build config %s ...',
-    chalk.cyan(path.relative(EXPO_DIR, buildConstantsPath))
+    styleText('cyan', path.relative(EXPO_DIR, buildConstantsPath))
   );
 
   const [source, existingSource] = await Promise.all([

--- a/tools/src/dynamic-macros/generateDynamicMacros.ts
+++ b/tools/src/dynamic-macros/generateDynamicMacros.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import AndroidMacrosGenerator from './AndroidMacrosGenerator';
@@ -54,8 +54,8 @@ async function generateMacrosAsync(platform, configuration) {
 
     console.log(
       'Resolved %s macro to %s',
-      chalk.green(name),
-      chalk.yellow(JSON.stringify(macroValue))
+      styleText('green', name),
+      styleText('yellow', JSON.stringify(macroValue))
     );
   }
   console.log();
@@ -113,7 +113,7 @@ async function copyTemplateFileAsync(
   ]);
 
   if (!currentSourceFile) {
-    console.error(`Couldn't find ${chalk.magenta(source)} file.`);
+    console.error(`Couldn't find ${styleText('magenta', source)} file.`);
     process.exit(1);
   }
 
@@ -157,15 +157,15 @@ async function copyTemplateFilesAsync(platform: string, args: any, templateSubst
     if (skipTemplates.includes(source)) {
       console.log(
         'Skipping template %s ...',
-        chalk.cyan(path.join(templateFilesPath, platform, source))
+        styleText('cyan', path.join(templateFilesPath, platform, source))
       );
       continue;
     }
 
     console.log(
       'Rendering %s from template %s...',
-      chalk.cyan(path.join(EXPO_DIR, dest)),
-      chalk.cyan(path.join(templateFilesPath, platform, source))
+      styleText('cyan', path.join(EXPO_DIR, dest)),
+      styleText('cyan', path.join(templateFilesPath, platform, source))
     );
 
     promises.push(

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -4,9 +4,9 @@ import {
   parseMultipartMixedResponseAsync,
 } from '@expo/multipart-body-parser';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import crypto from 'crypto';
 import { lanNetwork } from 'lan-network';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 
@@ -189,10 +189,12 @@ export default {
       return kernelManifestAndAssetRequestHeadersObjectToJson(manifestAndAssetRequestHeaders);
     } catch {
       console.error(
-        chalk.red(
-          `Unable to generate manifest from ${chalk.cyan(
+        styleText(
+          'red',
+          `Unable to generate manifest from ${styleText(
+            'cyan',
             EXPO_GO_DIR
-          )}: Failed to fetch manifest from ${chalk.cyan(url)}`
+          )}: Failed to fetch manifest from ${styleText('cyan', url)}`
         )
       );
       return '';

--- a/tools/src/packages-graph/PackagesGraph.ts
+++ b/tools/src/packages-graph/PackagesGraph.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import PackagesGraphEdge from './PackagesGraphEdge';
 import PackagesGraphNode from './PackagesGraphNode';
@@ -107,7 +107,7 @@ function addDependency(
     // Possible cycle in dependencies. Cycles in peer and optional dependency relations are fine though.
     if (DefaultDependencyKind.includes(kind)) {
       console.error(
-        chalk.red(`Detected a cycle in ${kind}! ${origin.name} -> ${destination.name}`)
+        styleText('red', `Detected a cycle in ${kind}! ${origin.name} -> ${destination.name}`)
       );
     }
     return;

--- a/tools/src/packages-graph/PackagesGraphUtils.ts
+++ b/tools/src/packages-graph/PackagesGraphUtils.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { EOL } from 'os';
 
 import PackagesGraph from './PackagesGraph';
@@ -26,17 +26,17 @@ export function printGraph(
     const name = formatNodeName(node.name, kind, level);
 
     if (visited[node.name] === true) {
-      process.stdout.write(chalk.dim(`${name} ...`) + EOL);
+      process.stdout.write(styleText('dim', `${name} ...`) + EOL);
       return;
     }
 
     visited[node.name] = true;
 
-    process.stdout.write(`${name} ${chalk.cyan(version)}` + EOL);
+    process.stdout.write(`${name} ${styleText('cyan', version)}` + EOL);
 
     if (edges.length === 0 && level === 0) {
       // It has no dependencies, but let's explicitly show that for the origin nodes.
-      process.stdout.write(edgePointer(true, false, false) + chalk.dim('none') + EOL);
+      process.stdout.write(edgePointer(true, false, false) + styleText('dim', 'none') + EOL);
       return;
     }
     for (let i = 0; i < edges.length; i++) {
@@ -45,7 +45,7 @@ export function printGraph(
       const nextEdges = edge.destination.getOutgoingEdgesOfKinds(kinds);
       const hasMore = nextEdges.length > 0 && visited[edge.destination.name] !== true;
 
-      process.stdout.write(chalk.gray(prefix) + edgePointer(isLast, hasMore, edge.isCyclic));
+      process.stdout.write(styleText('gray', prefix) + edgePointer(isLast, hasMore, edge.isCyclic));
 
       visitNodeEdges({
         node: edge.destination,
@@ -82,14 +82,14 @@ export function printNodeDependents(
   const nodes = node.getAllDependents(kinds);
 
   if (nodes.length === 0) {
-    console.log(`${chalk.bold(node.name)} has no dependents`);
+    console.log(`${styleText('bold', node.name)} has no dependents`);
     return;
   }
 
-  console.log(`All dependents of the ${chalk.bold(node.name)} package:`);
+  console.log(`All dependents of the ${styleText('bold', node.name)} package:`);
 
   for (const node of nodes) {
-    console.log(`- ${chalk.bold(node.name)}`);
+    console.log(`- ${styleText('bold', node.name)}`);
   }
 }
 
@@ -97,10 +97,10 @@ function edgePointer(isLast: boolean, hasMore: boolean, isCyclic: boolean): stri
   const rawPointer = [
     isLast ? '└─' : '├─',
     hasMore ? '┬─' : '──',
-    isCyclic ? chalk.red('∞') : '',
+    isCyclic ? styleText('red', '∞') : '',
     ' ',
   ].join('');
-  return chalk.gray(rawPointer);
+  return styleText('gray', rawPointer);
 }
 
 function nodeIndent(isLast: boolean): string {
@@ -109,16 +109,16 @@ function nodeIndent(isLast: boolean): string {
 
 function formatNodeName(name: string, kind: DependencyKind, level: number): string {
   if (level === 0) {
-    return chalk.bold(name);
+    return styleText('bold', name);
   }
   switch (kind) {
     case DependencyKind.Normal:
-      return chalk.green(name);
+      return styleText('green', name);
     case DependencyKind.Dev:
-      return chalk.yellow(name);
+      return styleText('yellow', name);
     case DependencyKind.Peer:
-      return chalk.magenta(name);
+      return styleText('magenta', name);
     case DependencyKind.Optional:
-      return chalk.gray(name);
+      return styleText('gray', name);
   }
 }

--- a/tools/src/prebuilds/Dependencies.ts
+++ b/tools/src/prebuilds/Dependencies.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import logger from '../Logger';
@@ -91,7 +91,7 @@ export const Dependencies = {
    */
   cleanArtifactsAsync: async (artifactsPath: string): Promise<void> => {
     logger.verbose(
-      `🧹 Clearing artifacts folder: ${chalk.gray(path.relative(process.cwd(), artifactsPath))}`
+      `🧹 Clearing artifacts folder: ${styleText('gray', path.relative(process.cwd(), artifactsPath))}`
     );
     await fs.remove(artifactsPath);
   },
@@ -122,7 +122,7 @@ export const Dependencies = {
       react: `${currentVersions.reactNativeVersion}-${currentVersions.buildFlavor}`,
     };
 
-    logger.verbose(`🧹 Pruning unused cache entries from ${chalk.gray(cachePath)}...`);
+    logger.verbose(`🧹 Pruning unused cache entries from ${styleText('gray', cachePath)}...`);
 
     // Iterate through artifact directories (hermes, react-native-dependencies, react)
     const artifactDirs = await fs.readdir(cachePath, { withFileTypes: true });
@@ -154,12 +154,12 @@ export const Dependencies = {
           // This is the current version - keep it
           keptCount++;
           logger.verbose(
-            `  ✓ Keeping ${chalk.green(artifactDir.name)}/${chalk.cyan(versionDir.name)}`
+            `  ✓ Keeping ${styleText('green', artifactDir.name)}/${styleText('cyan', versionDir.name)}`
           );
         } else {
           // Old version - remove it
           logger.verbose(
-            `  🗑  Removing ${chalk.yellow(artifactDir.name)}/${chalk.gray(versionDir.name)}`
+            `  🗑  Removing ${styleText('yellow', artifactDir.name)}/${styleText('gray', versionDir.name)}`
           );
           await fs.remove(versionPath);
           removed.push(`${artifactDir.name}/${versionDir.name}`);
@@ -168,7 +168,7 @@ export const Dependencies = {
     }
 
     if (removed.length > 0) {
-      logger.verbose(`🧹 Pruned ${chalk.yellow(removed.length)} old cache entries`);
+      logger.verbose(`🧹 Pruned ${styleText('yellow', `${removed.length}`)} old cache entries`);
     } else {
       logger.verbose(`🧹 Cache is clean - no old entries to prune`);
     }
@@ -197,7 +197,7 @@ export const Dependencies = {
     } = options;
 
     logger.verbose(
-      `⬇️  ${options.skipArtifacts ? 'Verifying' : 'Preparing'} centralized cache at ${chalk.gray(path.relative(process.cwd(), cachePath))}...`
+      `⬇️  ${options.skipArtifacts ? 'Verifying' : 'Preparing'} centralized cache at ${styleText('gray', path.relative(process.cwd(), cachePath))}...`
     );
 
     // Ensure we have a valid cache path
@@ -288,7 +288,7 @@ export const Dependencies = {
     copyDependencies: boolean
   ): Promise<void> => {
     logger.verbose(
-      `📋 ${copyDependencies ? 'Syncing' : 'Checking'} package dependencies for ${chalk.green(pkg.packageName)}`
+      `📋 ${copyDependencies ? 'Syncing' : 'Checking'} package dependencies for ${styleText('green', pkg.packageName)}`
     );
 
     // Symlink each dependency into the package's Dependencies folder
@@ -350,7 +350,7 @@ export const Dependencies = {
    */
   cleanDependenciesFolderAsync: async (pkg: SPMPackageSource): Promise<void> => {
     logger.verbose(
-      `🧹 Cleaning dependencies folder for package ${chalk.green(pkg.packageName)}...`
+      `🧹 Cleaning dependencies folder for package ${styleText('green', pkg.packageName)}...`
     );
     const buildFolderToClean = Dependencies.getPackageDependenciesPath(pkg);
     await fs.remove(buildFolderToClean);
@@ -370,7 +370,7 @@ export const Dependencies = {
 
     if (fs.existsSync(outputPath)) {
       logger.verbose(
-        `🧹 Cleaning output folder for package ${chalk.green(pkg.packageName)}/${flavor}...`
+        `🧹 Cleaning output folder for package ${styleText('green', pkg.packageName)}/${flavor}...`
       );
       await fs.remove(outputPath);
     }
@@ -384,7 +384,9 @@ export const Dependencies = {
   cleanGeneratedFolderAsync: async (pkg: SPMPackageSource): Promise<void> => {
     const generatedPath = path.join(pkg.path, '.generated');
     if (fs.existsSync(generatedPath)) {
-      logger.verbose(`🧹 Cleaning generated folder for package ${chalk.green(pkg.packageName)}...`);
+      logger.verbose(
+        `🧹 Cleaning generated folder for package ${styleText('green', pkg.packageName)}...`
+      );
       await fs.remove(generatedPath);
     }
   },

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { getPrecompileDir } from '../Directories';
@@ -76,7 +76,7 @@ export const Frameworks = {
     const spmConfig = pkg.getSwiftPMConfiguration();
 
     logger.verbose(
-      `🧩 Composing XCFramework for ${chalk.green(pkg.packageName) + '/' + chalk.green(product.name)}...`
+      `🧩 Composing XCFramework for ${styleText('green', pkg.packageName) + '/' + styleText('green', product.name)}...`
     );
 
     // Get output path for the XCFramework
@@ -449,7 +449,7 @@ const copyResourceBundlesIntoXCFrameworkAsync = async (
       await fs.copy(buildOutputPath, destBundlePath, { overwrite: true });
 
       spinner.info(
-        `Copied resource bundle ${chalk.cyan(bundleName)} → ${chalk.cyan(slice + '/' + bundleName)}`
+        `Copied resource bundle ${styleText('cyan', bundleName)} → ${styleText('cyan', slice + '/' + bundleName)}`
       );
     }
   }
@@ -501,7 +501,7 @@ const copySPMDependencyXCFrameworksAsync = async (
     if (Frameworks.hasSharedSPMDepFramework(productName, buildType)) {
       if (!bundleSharedDeps) {
         logger.info(
-          `⏭️  Skipping shared SPM dep ${chalk.cyan(productName)} (already at shared location)`
+          `⏭️  Skipping shared SPM dep ${styleText('cyan', productName)} (already at shared location)`
         );
         continue;
       }
@@ -509,7 +509,7 @@ const copySPMDependencyXCFrameworksAsync = async (
       const sharedPath = Frameworks.getSharedSPMDepFrameworkPath(productName, buildType);
       const destPath = path.join(outputDir, `${productName}.xcframework`);
       logger.verbose(
-        `📦 Copying shared SPM dep ${chalk.cyan(productName)} from shared location → ${path.relative(pkg.path, destPath)}`
+        `📦 Copying shared SPM dep ${styleText('cyan', productName)} from shared location → ${path.relative(pkg.path, destPath)}`
       );
       await fs.remove(destPath);
       await spawnAsync('rsync', ['-a', '--delete', `${sharedPath}/`, `${destPath}/`], {
@@ -579,7 +579,7 @@ const copySPMDependencyXCFrameworksAsync = async (
 
       if (await fs.pathExists(sourceXCFrameworkPath)) {
         logger.verbose(
-          `📦 Copying SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
+          `📦 Copying SPM dependency ${styleText('cyan', xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
         );
         await fs.remove(destXCFrameworkPath);
         await spawnAsync(
@@ -590,7 +590,7 @@ const copySPMDependencyXCFrameworksAsync = async (
         logger.info(`✅ Copied ${xcframeworkName} alongside ${product.name}.xcframework`);
       } else {
         logger.warn(
-          `⚠️  SPM dependency ${chalk.cyan(productName)} not found in Build/Products/ or SourcePackages/artifacts/`
+          `⚠️  SPM dependency ${styleText('cyan', productName)} not found in Build/Products/ or SourcePackages/artifacts/`
         );
       }
       continue;
@@ -598,7 +598,7 @@ const copySPMDependencyXCFrameworksAsync = async (
 
     // Compose the dependency xcframework with only the relevant slices
     logger.verbose(
-      `📦 Composing SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
+      `📦 Composing SPM dependency ${styleText('cyan', xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
     );
     await fs.remove(destXCFrameworkPath);
 
@@ -677,7 +677,7 @@ const createProductTarballAsync = async (
   }
 
   logger.verbose(
-    `📦 Creating tarball for ${chalk.green(product.name)} (${buildType}): ${xcframeworkEntries.join(', ')}`
+    `📦 Creating tarball for ${styleText('green', product.name)} (${buildType}): ${xcframeworkEntries.join(', ')}`
   );
 
   // Create tarball: tar -czf <Product>.tar.gz -C <outputDir> <entries...>

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import {
@@ -110,7 +110,7 @@ export async function buildFrameworksForProjectAsync(
   // Builds frameworks from flavors.
   const frameworks: Framework[] = [];
   for (const flavor of flavors) {
-    logger.log('   Building framework for %s', chalk.yellow(flavor.sdk));
+    logger.log('   Building framework for %s', styleText('yellow', flavor.sdk));
 
     frameworks.push(
       await xcodeProject.buildFrameworkAsync(xcodeProject.name, flavor, {
@@ -130,11 +130,11 @@ export async function buildFrameworksForProjectAsync(
 
   // Print binary sizes
   const binarySizes = frameworks.map((framework) =>
-    chalk.magenta((framework.binarySize / 1024 / 1024).toFixed(2) + 'MB')
+    styleText('magenta', (framework.binarySize / 1024 / 1024).toFixed(2) + 'MB')
   );
   logger.log('   Binary sizes:', binarySizes.join(', '));
 
-  logger.log('   Merging frameworks to', chalk.magenta(`${xcodeProject.name}.xcframework`));
+  logger.log('   Merging frameworks to', styleText('magenta', `${xcodeProject.name}.xcframework`));
 
   // Merge frameworks into universal xcframework
   await xcodeProject.buildXcframeworkAsync(frameworks, settings);

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { spawn } from 'child_process';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import type { SPMPackageSource } from './ExternalPackage';
@@ -37,7 +37,7 @@ export const SPMBuild = {
     hermesIncludeDirs?: string[]
   ): Promise<void> => {
     logger.verbose(
-      `🏗  Build Package.swift for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)} [${buildType.toLowerCase()}]`
+      `🏗  Build Package.swift for ${styleText('green', pkg.packageName)}/${styleText('green', product.name)} [${buildType.toLowerCase()}]`
     );
 
     // Verify that we have a Package.swift file in the package directory
@@ -87,7 +87,7 @@ export const SPMBuild = {
   ): Promise<void> => {
     const buildFolderToClean = SPMBuild.getPackageBuildPath(pkg, product, buildType);
     logger.verbose(
-      `🧹 Cleaning build folder ${chalk.green(path.relative(pkg.buildPath, buildFolderToClean))}...`
+      `🧹 Cleaning build folder ${styleText('green', path.relative(pkg.buildPath, buildFolderToClean))}...`
     );
     await fs.remove(buildFolderToClean);
   },
@@ -310,7 +310,7 @@ const buildForPlatformAsync = async (
   const { code, error: buildError } = await spawnXcodeBuildWithSpinner(
     args,
     path.dirname(packageSwiftPath),
-    `Building ${chalk.green(pkg.packageName)}/${chalk.green(product.name)} for ${chalk.green(buildPlatform)}/${chalk.green(buildType.toLowerCase())}`
+    `Building ${styleText('green', pkg.packageName)}/${styleText('green', product.name)} for ${styleText('green', buildPlatform)}/${styleText('green', buildType.toLowerCase())}`
   );
 
   if (code !== 0) {
@@ -864,12 +864,14 @@ export async function buildSharedSPMDependencyAsync(
 
   // Check if already built
   if (Frameworks.hasSharedSPMDepFramework(productName, buildType)) {
-    logger.info(`⏭️  Shared SPM dep ${chalk.cyan(productName)} already exists for ${buildType}`);
+    logger.info(
+      `⏭️  Shared SPM dep ${styleText('cyan', productName)} already exists for ${buildType}`
+    );
     return;
   }
 
   logger.verbose(
-    `🔨 Building shared SPM dependency ${chalk.cyan(productName)} [${buildType.toLowerCase()}]...`
+    `🔨 Building shared SPM dependency ${styleText('cyan', productName)} [${buildType.toLowerCase()}]...`
   );
 
   // Set up build directory under .spm-deps/<productName>/
@@ -942,7 +944,7 @@ export async function buildSharedSPMDependencyAsync(
         await fs.remove(destPath);
         await spawnAsync('rsync', ['-a', `${xcframeworkPath}/`, `${destPath}/`], { stdio: 'pipe' });
         logger.info(
-          `✅ Copied binary SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`
+          `✅ Copied binary SPM dep ${styleText('cyan', productName)} → ${path.relative(process.cwd(), destPath)}`
         );
         // Keep buildDir for caching — resolved artifacts persist for reuse
         return;
@@ -990,14 +992,14 @@ export async function buildSharedSPMDependencyAsync(
 
     if (externalInterDeps.length > 0) {
       logger.verbose(
-        `   🔗 ${productName} depends on shared deps: ${externalInterDeps.map((d) => chalk.cyan(d)).join(', ')}`
+        `   🔗 ${productName} depends on shared deps: ${externalInterDeps.map((d) => styleText('cyan', d)).join(', ')}`
       );
 
       // Recursively build any inter-deps that haven't been built yet
       for (const interDepName of externalInterDeps) {
         const interDep = allSharedDeps.get(interDepName);
         if (interDep && !Frameworks.hasSharedSPMDepFramework(interDepName, buildType)) {
-          logger.verbose(`   ↳ Building dependency ${chalk.cyan(interDepName)} first...`);
+          logger.verbose(`   ↳ Building dependency ${styleText('cyan', interDepName)} first...`);
           await buildSharedSPMDependencyAsync(interDep, buildType, allSharedDeps, platforms);
         }
       }
@@ -1039,7 +1041,7 @@ export async function buildSharedSPMDependencyAsync(
     const { code, error: buildError } = await spawnXcodeBuildWithSpinner(
       args,
       cleanBuildDir,
-      `Building ${chalk.cyan(productName)} for ${chalk.green(platform)}/${chalk.green(buildType.toLowerCase())}`
+      `Building ${styleText('cyan', productName)} for ${styleText('green', platform)}/${styleText('green', buildType.toLowerCase())}`
     );
 
     if (code !== 0) {
@@ -1106,7 +1108,9 @@ export async function buildSharedSPMDependencyAsync(
         await spawnAsync('rsync', ['-a', `${artifactXCFrameworkPath}/`, `${destPath}/`], {
           stdio: 'pipe',
         });
-        logger.info(`✅ Copied binary SPM dep ${chalk.cyan(productName)} to shared location`);
+        logger.info(
+          `✅ Copied binary SPM dep ${styleText('cyan', productName)} to shared location`
+        );
 
         // Clean up build directory
         await fs.remove(buildDir);
@@ -1129,7 +1133,7 @@ export async function buildSharedSPMDependencyAsync(
   const { code, error: composeError } = await spawnXcodeBuildWithSpinner(
     frameworkArgs,
     buildDir,
-    `Composing ${chalk.cyan(productName)}.xcframework`
+    `Composing ${styleText('cyan', productName)}.xcframework`
   );
 
   if (code !== 0) {
@@ -1142,6 +1146,6 @@ export async function buildSharedSPMDependencyAsync(
   await fs.remove(derivedDataPath);
 
   logger.info(
-    `✅ Built shared SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`
+    `✅ Built shared SPM dep ${styleText('cyan', productName)} → ${path.relative(process.cwd(), destPath)}`
   );
 }

--- a/tools/src/prebuilds/SPMGenerator.ts
+++ b/tools/src/prebuilds/SPMGenerator.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import logger from '../Logger';
@@ -68,7 +68,7 @@ export const SPMGenerator = {
     artifacts?: DownloadedDependencies
   ): Promise<void> => {
     logger.verbose(
-      `📦 Generating Package.swift for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)}...`
+      `📦 Generating Package.swift for ${styleText('green', pkg.packageName)}/${styleText('green', product.name)}...`
     );
     // Use SPMPackage to generate Package.swift
     const packageSwiftPath = SPMGenerator.getSwiftPackagePath(pkg, product);
@@ -97,7 +97,7 @@ export const SPMGenerator = {
    * @param product Product
    */
   generateIsolatedSourcesForTargetsAsync: async (pkg: SPMPackageSource, product: SPMProduct) => {
-    const loggerTitle = `${chalk.green(pkg.packageName)}/${chalk.green(product.name)}`;
+    const loggerTitle = `${styleText('green', pkg.packageName)}/${styleText('green', product.name)}`;
     logger.verbose(`📂 Generating files for ${loggerTitle}`);
 
     // Walk through all targets for the product and collect source files to copy into spm code structure
@@ -108,7 +108,7 @@ export const SPMGenerator = {
       }
 
       const spinner = createAsyncSpinner(
-        `Generating source folder structure for target ${chalk.green(target.name)}...`,
+        `Generating source folder structure for target ${styleText('green', target.name)}...`,
         pkg,
         product
       );
@@ -146,7 +146,7 @@ export const SPMGenerator = {
             const targetPath = path.join(headerRootPath, mapping.from);
 
             spinner.info(
-              `Creating symlink ${chalk.cyan(mapping.to)} → ${chalk.cyan(mapping.from)}...`
+              `Creating symlink ${styleText('cyan', mapping.to)} → ${styleText('cyan', mapping.from)}...`
             );
 
             await fs.ensureDir(path.dirname(symlinkPath));
@@ -184,7 +184,7 @@ export const SPMGenerator = {
             }
 
             spinner.info(
-              `Mapping ${mapping.type} file ${chalk.cyan(file)} → ${chalk.cyan(path.relative(targetDestination, destinationFilePath))}...`
+              `Mapping ${mapping.type} file ${styleText('cyan', file)} → ${styleText('cyan', path.relative(targetDestination, destinationFilePath))}...`
             );
 
             await fs.ensureDir(path.dirname(destinationFilePath));
@@ -217,7 +217,7 @@ export const SPMGenerator = {
 
         // Create symlink to source file in the target source folder
         spinner.info(
-          `Generating source for target ${chalk.green(target.name)} ${path.basename(file)}...`
+          `Generating source for target ${styleText('green', target.name)} ${path.basename(file)}...`
         );
         const sourceFilePath = path.join(targetSourcePath, file);
         const destinationFilePath = path.join(targetDestination, file);
@@ -238,7 +238,7 @@ export const SPMGenerator = {
         if (!validDestPaths.has(filePath)) {
           const stat = await fs.lstat(filePath).catch(() => null);
           if (stat?.isSymbolicLink()) {
-            spinner.info(`Removing stale symlink ${chalk.yellow(file)}...`);
+            spinner.info(`Removing stale symlink ${styleText('yellow', file)}...`);
             await fs.remove(filePath);
           }
         }
@@ -271,7 +271,7 @@ export const SPMGenerator = {
             const linked = await refreshHardlinkIfNeeded(sourceFilePath, destinationFilePath);
             if (linked) {
               spinner.info(
-                `Linking header file for target ${chalk.green(target.name)} ${path.basename(file)}...`
+                `Linking header file for target ${styleText('green', target.name)} ${path.basename(file)}...`
               );
             }
           }
@@ -286,7 +286,7 @@ export const SPMGenerator = {
         await fs.ensureDir(includeDir);
         if (writeFileIfChanged(moduleMapPath, target.moduleMapContent)) {
           spinner.info(
-            `Generated custom module.modulemap for target ${chalk.green(target.name)}...`
+            `Generated custom module.modulemap for target ${styleText('green', target.name)}...`
           );
         }
       }
@@ -325,7 +325,7 @@ ${allImports.join('\n')}
           // Only write if content changed (preserves mtime for Xcode incremental builds)
           if (writeFileIfChanged(exportsFilePath, fileContent)) {
             spinner.info(
-              `Generated ${product.name}+Exports.swift for target ${loggerTitle + '/' + chalk.green(product.name) + '/' + chalk.green(target.name)}...`
+              `Generated ${product.name}+Exports.swift for target ${loggerTitle + '/' + styleText('green', product.name) + '/' + styleText('green', target.name)}...`
             );
           }
         }
@@ -356,7 +356,7 @@ ${allImports.join('\n')}
             // Only copy if content changed (preserves mtime for Xcode incremental builds)
             if (hasFileContentChanged(sourceFilePath, destinationFilePath)) {
               spinner.info(
-                `Copying resource ${chalk.cyan(file)} → ${chalk.cyan(path.relative(targetDestination, destinationFilePath))}...`
+                `Copying resource ${styleText('cyan', file)} → ${styleText('cyan', path.relative(targetDestination, destinationFilePath))}...`
               );
               await fs.copy(sourceFilePath, destinationFilePath, { overwrite: true });
             }
@@ -364,7 +364,9 @@ ${allImports.join('\n')}
         }
       }
 
-      spinner.succeed(`Generated source folder structure for target ${chalk.green(target.name)}.`);
+      spinner.succeed(
+        `Generated source folder structure for target ${styleText('green', target.name)}.`
+      );
     }
   },
 
@@ -378,7 +380,7 @@ ${allImports.join('\n')}
     product: SPMProduct
   ): Promise<void> => {
     logger.verbose(
-      `🧹 Cleaning generated source code for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)}...`
+      `🧹 Cleaning generated source code for ${styleText('green', pkg.packageName)}/${styleText('green', product.name)}...`
     );
 
     const sourceCodePath = SPMGenerator.getGeneratedProductFilesPath(pkg, product);

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'async_hooks';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import ora from 'ora';
 import path from 'path';
 
@@ -296,16 +296,16 @@ export const validateAllPodNamesAsync = async (
 
   if (allErrors.length > 0) {
     logger.error(
-      chalk.red(`\n⚠️  podName validation failed for ${allErrors.length} product(s):\n`)
+      styleText('red', `\n⚠️  podName validation failed for ${allErrors.length} product(s):\n`)
     );
 
     for (const error of allErrors) {
       logger.error(
-        `  ${chalk.red('✗')} ${chalk.cyan(error.packageName)}/${chalk.yellow(error.productName)}: ` +
-          `podName "${chalk.red(error.declaredPodName)}" does not match any .podspec file`
+        `  ${styleText('red', '✗')} ${styleText('cyan', error.packageName)}/${styleText('yellow', error.productName)}: ` +
+          `podName "${styleText('red', error.declaredPodName)}" does not match any .podspec file`
       );
       if (error.actualPodspecs.length > 0) {
-        logger.error(`    Found podspecs: ${chalk.gray(error.actualPodspecs.join(', '))}`);
+        logger.error(`    Found podspecs: ${styleText('gray', error.actualPodspecs.join(', '))}`);
       } else {
         logger.error(`    No .podspec files found in package`);
       }
@@ -360,15 +360,17 @@ export const verifyAllPackagesAsync = async (
     const expoPackages = packages.filter((p) => p instanceof Package);
     const externalPackages = packages.filter((p) => p instanceof ExternalPackage);
 
-    logger.info(`Discovered ${chalk.cyan(packages.length)} packages with spm.config.json:`);
+    logger.info(
+      `Discovered ${styleText('cyan', `${packages.length}`)} packages with spm.config.json:`
+    );
     if (expoPackages.length > 0) {
       logger.info(
-        `  Expo packages (${expoPackages.length}): ${chalk.green(expoPackages.map((p) => p.packageName).join(', '))}`
+        `  Expo packages (${expoPackages.length}): ${styleText('green', expoPackages.map((p) => p.packageName).join(', '))}`
       );
     }
     if (externalPackages.length > 0) {
       logger.info(
-        `  External packages (${externalPackages.length}): ${chalk.blue(externalPackages.map((p) => p.packageName).join(', '))}`
+        `  External packages (${externalPackages.length}): ${styleText('blue', externalPackages.map((p) => p.packageName).join(', '))}`
       );
     }
 
@@ -382,7 +384,9 @@ export const verifyAllPackagesAsync = async (
       const expoPkg = getPackageByName(name);
       if (expoPkg) {
         if (!expoPkg.hasSwiftPMConfiguration()) {
-          throw new Error(`Package ${chalk.gray(name)} does not have a spm.config.json file.`);
+          throw new Error(
+            `Package ${styleText('gray', name)} does not have a spm.config.json file.`
+          );
         }
         return expoPkg;
       }
@@ -394,7 +398,7 @@ export const verifyAllPackagesAsync = async (
       }
 
       throw new Error(
-        `Package not found: ${chalk.red(name)}. ` +
+        `Package not found: ${styleText('red', name)}. ` +
           `Make sure it exists in packages/ or has a config in external-configs/ios/.`
       );
     })
@@ -530,27 +534,27 @@ export const verifyLocalTarballPathsIfSetAsync = async (options: {
 }): Promise<void> => {
   if (options.reactNativeTarballPath && !(await fs.exists(options.reactNativeTarballPath))) {
     throw new Error(
-      `React Native tarball path does not exist: ${chalk.gray(options.reactNativeTarballPath)}`
+      `React Native tarball path does not exist: ${styleText('gray', options.reactNativeTarballPath)}`
     );
   }
   if (options.hermesTarballPath && !(await fs.exists(options.hermesTarballPath))) {
-    throw new Error(`Hermes tarball path does not exist: ${chalk.gray(options.hermesTarballPath)}`);
+    throw new Error(
+      `Hermes tarball path does not exist: ${styleText('gray', options.hermesTarballPath)}`
+    );
   }
   if (
     options.reactNativeDependenciesTarballPath &&
     !(await fs.exists(options.reactNativeDependenciesTarballPath))
   ) {
     throw new Error(
-      `React Native Dependencies tarball path does not exist: ${chalk.gray(
-        options.reactNativeDependenciesTarballPath
-      )}`
+      `React Native Dependencies tarball path does not exist: ${styleText('gray', options.reactNativeDependenciesTarballPath)}`
     );
   }
 };
 
 const Prefix = '  ';
 const getPackageAndProductPrefix = (
-  colorizer: (...text: unknown[]) => string,
+  colorizer: (text: string) => string,
   pkg?: SPMPackageSource,
   product?: SPMProduct
 ) => {
@@ -567,7 +571,10 @@ export const createAsyncSpinner = (
   // When no pkg is provided but an async-local prefix is active (parallel builds),
   // use it so every log line is attributed to a package.
   const activePrefix = getActiveLogPrefix();
-  const effectivePrefix = (colorizer: (...text: unknown[]) => string) => {
+  const effectivePrefix = (color: Parameters<typeof styleText>[0]) => {
+    const colorizer = (text: string) => {
+      return styleText(color, text);
+    };
     if (pkg) {
       return getPackageAndProductPrefix(colorizer, pkg, product);
     }
@@ -580,34 +587,36 @@ export const createAsyncSpinner = (
   if (isNonInteractive()) {
     return {
       succeed: (text?: string) => {
-        logger.log(`${Prefix} ${chalk.green('✔')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
+        logger.log(`${Prefix} ${styleText('green', '✔')} ${effectivePrefix('green')}${text ?? ''}`);
       },
       fail: (text?: string) => {
-        logger.log(`${Prefix} ${chalk.red('✖')} ${effectivePrefix(chalk.red)}${text ?? ''}`);
+        logger.log(`${Prefix} ${styleText('red', '✖')} ${effectivePrefix('red')}${text ?? ''}`);
       },
       warn: (text?: string) => {
-        logger.log(`${Prefix} ${chalk.yellow('⚠')} ${effectivePrefix(chalk.yellow)}${text ?? ''}`);
+        logger.log(
+          `${Prefix} ${styleText('yellow', '⚠')} ${effectivePrefix('yellow')}${text ?? ''}`
+        );
       },
       info: (text?: string) => {
         if (!logger.isVerbose()) return;
-        logger.log(`${Prefix} ${chalk.blue('ℹ')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
+        logger.log(`${Prefix} ${styleText('blue', 'ℹ')} ${effectivePrefix('green')}${text ?? ''}`);
       },
     };
   }
   const spinnerPrefix = pkg
-    ? `[${chalk.green(pkg.packageName)}] `
+    ? `[${styleText('green', pkg.packageName)}] `
     : activePrefix
-      ? `[${chalk.green(activePrefix)}] `
+      ? `[${styleText('green', activePrefix)}] `
       : '';
   const spinner = ora({
     prefixText: Prefix,
     text: spinnerPrefix + initialText,
   }).start();
   return {
-    succeed: (text?: string) => spinner.succeed(effectivePrefix(chalk.green) + (text ?? '')),
-    fail: (text?: string) => spinner.fail(effectivePrefix(chalk.red) + (text ?? '')),
-    warn: (text?: string) => spinner.warn(effectivePrefix(chalk.yellow) + (text ?? '')),
-    info: (text: string) => (spinner.text = effectivePrefix(chalk.green) + text),
+    succeed: (text?: string) => spinner.succeed(effectivePrefix('green') + (text ?? '')),
+    fail: (text?: string) => spinner.fail(effectivePrefix('red') + (text ?? '')),
+    warn: (text?: string) => spinner.warn(effectivePrefix('yellow') + (text ?? '')),
+    info: (text: string) => (spinner.text = effectivePrefix('green') + text),
   };
 };
 

--- a/tools/src/prebuilds/Verifier.ts
+++ b/tools/src/prebuilds/Verifier.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import { spawn, spawnSync } from 'child_process';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import os from 'os';
 import path from 'path';
 
@@ -37,7 +37,7 @@ export const FrameworkVerifier = {
     options?: XCFrameworkVerifyOptions
   ): Promise<Map<string, XCFrameworkVerificationReport>> => {
     logger.verbose(
-      `🔍 Verifying xcframework for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)} [${buildFlavor.toLowerCase()}]`
+      `🔍 Verifying xcframework for ${styleText('green', pkg.packageName)}/${styleText('green', product.name)} [${buildFlavor.toLowerCase()}]`
     );
 
     // Check required tools once
@@ -84,15 +84,16 @@ export const FrameworkVerifier = {
         }
 
         logger.error(
-          `  ${chalk.red('✗')} Verification failed for ${chalk.green(product.name)}.xcframework: ${failures.join(', ')}`
+          `  ${styleText('red', '✗')} Verification failed for ${styleText('green', product.name)}.xcframework: ${failures.join(', ')}`
         );
 
         // Always show detailed errors for failures
         for (const slice of report.slices) {
           if (!slice.modularHeadersValid.success && slice.modularHeadersValid.details) {
-            logger.log(chalk.gray(`      Modular header error (${slice.sliceId}):`));
+            logger.log(styleText('gray', `      Modular header error (${slice.sliceId}):`));
             logger.log(
-              chalk.gray(
+              styleText(
+                'gray',
                 slice.modularHeadersValid.details
                   .split('\n')
                   .slice(0, 10)
@@ -102,9 +103,10 @@ export const FrameworkVerifier = {
             );
           }
           if (!slice.clangModuleImport.success && slice.clangModuleImport.details) {
-            logger.log(chalk.gray(`      Clang error (${slice.sliceId}):`));
+            logger.log(styleText('gray', `      Clang error (${slice.sliceId}):`));
             logger.log(
-              chalk.gray(
+              styleText(
+                'gray',
                 slice.clangModuleImport.details
                   .split('\n')
                   .slice(0, 10)
@@ -114,9 +116,10 @@ export const FrameworkVerifier = {
             );
           }
           if (!slice.swiftInterfaceTypecheck.success && slice.swiftInterfaceTypecheck.details) {
-            logger.log(chalk.gray(`      Swift typecheck error (${slice.sliceId}):`));
+            logger.log(styleText('gray', `      Swift typecheck error (${slice.sliceId}):`));
             logger.log(
-              chalk.gray(
+              styleText(
+                'gray',
                 slice.swiftInterfaceTypecheck.details
                   .split('\n')
                   .slice(0, 10)
@@ -126,9 +129,10 @@ export const FrameworkVerifier = {
             );
           }
           if (!slice.dsymDebugPrefixMapping.success && slice.dsymDebugPrefixMapping.details) {
-            logger.log(chalk.gray(`      dSYM debug prefix error (${slice.sliceId}):`));
+            logger.log(styleText('gray', `      dSYM debug prefix error (${slice.sliceId}):`));
             logger.log(
-              chalk.gray(
+              styleText(
+                'gray',
                 slice.dsymDebugPrefixMapping.details
                   .split('\n')
                   .slice(0, 10)
@@ -138,9 +142,10 @@ export const FrameworkVerifier = {
             );
           }
           if (!slice.dsymUuidMatch.success && slice.dsymUuidMatch.details) {
-            logger.log(chalk.gray(`      dSYM UUID mismatch (${slice.sliceId}):`));
+            logger.log(styleText('gray', `      dSYM UUID mismatch (${slice.sliceId}):`));
             logger.log(
-              chalk.gray(
+              styleText(
+                'gray',
                 slice.dsymUuidMatch.details
                   .split('\n')
                   .slice(0, 10)
@@ -158,10 +163,11 @@ export const FrameworkVerifier = {
       if (clangWarnings.length > 0 && report.overallSuccess) {
         const sliceIds = clangWarnings.map((s) => s.sliceId).join(', ');
         logger.warn(
-          `  ${chalk.yellow('⚠')} Clang @import warning for ${chalk.green(product.name)}.xcframework (${sliceIds})`
+          `  ${styleText('yellow', '⚠')} Clang @import warning for ${styleText('green', product.name)}.xcframework (${sliceIds})`
         );
         logger.log(
-          chalk.gray(
+          styleText(
+            'gray',
             '      Headers may import React types not available during standalone verification'
           )
         );
@@ -180,26 +186,31 @@ export const FrameworkVerifier = {
       if (dsymMissing.length > 0) {
         const sliceIds = dsymMissing.map((s) => s.sliceId).join(', ');
         logger.warn(
-          `  ${chalk.yellow('⚠')} dSYM missing for ${chalk.green(product.name)}.xcframework (${sliceIds})`
+          `  ${styleText('yellow', '⚠')} dSYM missing for ${styleText('green', product.name)}.xcframework (${sliceIds})`
         );
-        logger.log(chalk.gray('      Source-level debugging will not work for these slices'));
+        logger.log(
+          styleText('gray', '      Source-level debugging will not work for these slices')
+        );
       }
 
       if (dsymUuidIssues.length > 0) {
         const sliceIds = dsymUuidIssues.map((s) => s.sliceId).join(', ');
         logger.warn(
-          `  ${chalk.yellow('⚠')} dSYM UUID mismatch for ${chalk.green(product.name)}.xcframework (${sliceIds})`
+          `  ${styleText('yellow', '⚠')} dSYM UUID mismatch for ${styleText('green', product.name)}.xcframework (${sliceIds})`
         );
-        logger.log(chalk.gray('      dSYMs may be stale — rebuild to regenerate matching symbols'));
+        logger.log(
+          styleText('gray', '      dSYMs may be stale — rebuild to regenerate matching symbols')
+        );
       }
 
       if (dsymPathIssues.length > 0) {
         const sliceIds = dsymPathIssues.map((s) => s.sliceId).join(', ');
         logger.warn(
-          `  ${chalk.yellow('⚠')} dSYM debug prefix mapping issue for ${chalk.green(product.name)}.xcframework (${sliceIds})`
+          `  ${styleText('yellow', '⚠')} dSYM debug prefix mapping issue for ${styleText('green', product.name)}.xcframework (${sliceIds})`
         );
         logger.log(
-          chalk.gray(
+          styleText(
+            'gray',
             '      DWARF source paths contain absolute paths that should have been remapped to /expo-src/'
           )
         );
@@ -244,11 +255,11 @@ export const FrameworkVerifier = {
 
           if (missingSlices.length > 0) {
             logger.error(
-              `  ${chalk.red('✗')} Resource bundle ${chalk.cyan(bundleName)} missing from slices: ${missingSlices.join(', ')}`
+              `  ${styleText('red', '✗')} Resource bundle ${styleText('cyan', bundleName)} missing from slices: ${missingSlices.join(', ')}`
             );
           } else {
             logger.verbose(
-              `  ${chalk.green('✓')} Resource bundle ${chalk.cyan(bundleName)} present in all slices (${foundSlices.join(', ')})`
+              `  ${styleText('green', '✓')} Resource bundle ${styleText('cyan', bundleName)} present in all slices (${foundSlices.join(', ')})`
             );
           }
         }
@@ -260,7 +271,7 @@ export const FrameworkVerifier = {
       }
     } catch (error) {
       logger.error(
-        `  ${chalk.red('✗')} Verification failed for ${chalk.green(product.name)}.xcframework: ${error instanceof Error ? error.message : String(error)}`
+        `  ${styleText('red', '✗')} Verification failed for ${styleText('green', product.name)}.xcframework: ${error instanceof Error ? error.message : String(error)}`
       );
       // Still add a failed report so caller knows about the failure
       results.set(product.name, {

--- a/tools/src/prebuilds/XCodeRunner.ts
+++ b/tools/src/prebuilds/XCodeRunner.ts
@@ -1,6 +1,6 @@
 import { ExpoRunFormatter } from '@expo/xcpretty';
-import chalk from 'chalk';
 import { spawn } from 'child_process';
+import { styleText } from 'node:util';
 import os from 'os';
 
 import logger from '../Logger';
@@ -104,18 +104,18 @@ function printDiagnostics(warnings: string[], errors: string[]): void {
   const MAX = 10;
 
   if (warnings.length > 0) {
-    logger.log(chalk.gray('      Warnings:'));
-    warnings.slice(0, MAX).forEach((warn) => logger.log(chalk.gray(`        ${warn}`)));
+    logger.log(styleText('gray', '      Warnings:'));
+    warnings.slice(0, MAX).forEach((warn) => logger.log(styleText('gray', `        ${warn}`)));
     if (warnings.length > MAX) {
-      logger.log(chalk.gray(`        ... and ${warnings.length - MAX} more warnings`));
+      logger.log(styleText('gray', `        ... and ${warnings.length - MAX} more warnings`));
     }
   }
 
   if (errors.length > 0) {
-    logger.log(chalk.gray('      Errors:'));
-    errors.slice(0, MAX).forEach((err) => logger.log(chalk.gray(`        ${err.trim()}`)));
+    logger.log(styleText('gray', '      Errors:'));
+    errors.slice(0, MAX).forEach((err) => logger.log(styleText('gray', `        ${err.trim()}`)));
     if (errors.length > MAX) {
-      logger.log(chalk.gray(`        ... and ${errors.length - MAX} more errors`));
+      logger.log(styleText('gray', `        ... and ${errors.length - MAX} more errors`));
     }
   }
 }
@@ -127,10 +127,10 @@ function printDiagnostics(warnings: string[], errors: string[]): void {
 function printRawErrorFallback(rawOutput: string, stderr: string): void {
   const rawErrors = extractRawCompileErrors(rawOutput);
   if (rawErrors.length > 0) {
-    logger.log(chalk.gray('      Raw errors:'));
-    rawErrors.slice(0, 10).forEach((err) => logger.log(chalk.gray(`        ${err}`)));
+    logger.log(styleText('gray', '      Raw errors:'));
+    rawErrors.slice(0, 10).forEach((err) => logger.log(styleText('gray', `        ${err}`)));
   } else if (stderr) {
-    logger.log(chalk.gray(stderr));
+    logger.log(styleText('gray', stderr));
   }
 }
 

--- a/tools/src/prebuilds/pipeline/Executor.ts
+++ b/tools/src/prebuilds/pipeline/Executor.ts
@@ -6,7 +6,7 @@
  *     → for each package: package-scope steps → flavor loop → product-scope steps
  *   → report summary → return PrebuildRunResult
  */
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
@@ -368,7 +368,7 @@ export async function runPrebuildPipeline(
 
     if (concurrency > 1) {
       logger.info(
-        `\n⚡ Building ${packages.length} packages with concurrency ${chalk.green(String(concurrency))}`
+        `\n⚡ Building ${packages.length} packages with concurrency ${styleText('green', String(concurrency))}`
       );
     }
 
@@ -386,7 +386,7 @@ export async function runPrebuildPipeline(
       (pkg, signal, failedDeps) => {
         if (failedDeps && failedDeps.length > 0) {
           logger.info(
-            `⏭️  Skipping ${chalk.yellow(pkg.packageName)} — dependency failed: ${chalk.yellow(failedDeps.join(', '))}`
+            `⏭️  Skipping ${styleText('yellow', pkg.packageName)} — dependency failed: ${styleText('yellow', failedDeps.join(', '))}`
           );
           return Promise.resolve(
             synthesizeSkippedResult(
@@ -436,7 +436,7 @@ function finalize(ctx: PrebuildContext, startTime: number, exitCode: number): Pr
   let errorLogPath: string | undefined;
   if (ctx.errors.length > 0 && !ctx.suppressErrorLog) {
     errorLogPath = writeErrorLog(PACKAGES_DIR, ctx.errors);
-    logger.info(`\n📝 Error log written to: ${chalk.yellow(errorLogPath)}`);
+    logger.info(`\n📝 Error log written to: ${styleText('yellow', errorLogPath)}`);
   }
 
   return {

--- a/tools/src/prebuilds/pipeline/ProductSteps.ts
+++ b/tools/src/prebuilds/pipeline/ProductSteps.ts
@@ -4,7 +4,7 @@
  * Each step wraps existing module calls without changing their internals.
  */
 
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import logger from '../../Logger';
@@ -88,9 +88,9 @@ export const generateStep: Step<PrebuildContext> = {
     if (Codegen.hasCodegen(pkg)) {
       const generated = await Codegen.ensureCodegenAsync(pkg, (msg) => logger.info(msg));
       if (generated) {
-        logger.info(`🔧 Generated codegen for ${chalk.green(pkg.packageName)}`);
+        logger.info(`🔧 Generated codegen for ${styleText('green', pkg.packageName)}`);
       } else if (Codegen.isCodegenGenerated(pkg)) {
-        logger.info(`🔧 Codegen already exists for ${chalk.green(pkg.packageName)}`);
+        logger.info(`🔧 Codegen already exists for ${styleText('green', pkg.packageName)}`);
       }
     }
 

--- a/tools/src/prebuilds/pipeline/Reporter.ts
+++ b/tools/src/prebuilds/pipeline/Reporter.ts
@@ -4,8 +4,8 @@
  * Moved from PrebuildPackages.ts and adapted to consume `UnitStatus[]`
  * instead of the old `ProductBuildStatus[]`.
  */
-import chalk from 'chalk';
 import fs from 'fs';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import logger from '../../Logger';
@@ -27,15 +27,15 @@ export function logPackageBanner(
 ): void {
   const flavorInfo = flavors.length > 1 ? ` [${flavors.join(' + ')}]` : ` [${flavors[0]}]`;
   logger.info(
-    `\n📦 [${chalk.dim(`${index + 1}/${total}`)}] ${chalk.green(pkg.packageName)}${flavorInfo}`
+    `\n📦 [${styleText('dim', `${index + 1}/${total}`)}] ${styleText('green', pkg.packageName)}${flavorInfo}`
   );
   logger.info(`${'─'.repeat(60)}`);
   const relPath = (p: string) => path.relative(process.cwd(), p);
-  logger.info(`   ・Package:      ${chalk.dim(relPath(pkg.path))}`);
-  logger.info(`   ・Build:        ${chalk.dim(relPath(pkg.buildPath))}`);
-  logger.info(`   ・Cache:        ${chalk.dim(relPath(artifactsPath))}`);
+  logger.info(`   ・Package:      ${styleText('dim', relPath(pkg.path))}`);
+  logger.info(`   ・Build:        ${styleText('dim', relPath(pkg.buildPath))}`);
+  logger.info(`   ・Cache:        ${styleText('dim', relPath(artifactsPath))}`);
   logger.info(
-    `   ・XCFrameworks: ${chalk.dim(relPath(Frameworks.getFrameworksOutputPath(pkg.buildPath, flavors[0], pkg.outputVersionPrefix)).replace(`/${flavors[0].toLowerCase()}`, '/<flavor>'))}`
+    `   ・XCFrameworks: ${styleText('dim', relPath(Frameworks.getFrameworksOutputPath(pkg.buildPath, flavors[0], pkg.outputVersionPrefix)).replace(`/${flavors[0].toLowerCase()}`, '/<flavor>'))}`
   );
 }
 
@@ -113,11 +113,11 @@ export function printPrebuildSummary(statuses: UnitStatus[], elapsedMs: number):
   for (const status of statuses) {
     const productDisplay =
       status.packageName === status.productName
-        ? chalk.cyan(status.packageName)
-        : `${chalk.cyan(status.packageName)}/${chalk.yellow(`${status.productName} [${status.flavor}]`)}`;
+        ? styleText('cyan', status.packageName)
+        : `${styleText('cyan', status.packageName)}/${styleText('yellow', `${status.productName} [${status.flavor}]`)}`;
 
     if (status.skipReason) {
-      logger.info(`${productDisplay}: ${chalk.red('⛔ Skipped')} (${status.skipReason})`);
+      logger.info(`${productDisplay}: ${styleText('red', '⛔ Skipped')} (${status.skipReason})`);
       continue;
     }
 
@@ -129,11 +129,12 @@ export function printPrebuildSummary(statuses: UnitStatus[], elapsedMs: number):
   const { successful, warnings, failed } = computeSummaryCounts(statuses);
 
   logger.info('─'.repeat(80));
-  const warningText = warnings > 0 ? ` | ${chalk.yellow(`⚠️  ${warnings} with warnings`)}` : '';
-  const failedText = failed > 0 ? ` | ${chalk.red(`❌ ${failed} failed`)}` : '';
-  const timeText = chalk.blue(`⏱️  ${formatDuration(elapsedMs)}`);
+  const warningText =
+    warnings > 0 ? ` | ${styleText('yellow', `⚠️  ${warnings} with warnings`)}` : '';
+  const failedText = failed > 0 ? ` | ${styleText('red', `❌ ${failed} failed`)}` : '';
+  const timeText = styleText('blue', `⏱️  ${formatDuration(elapsedMs)}`);
   logger.info(
-    `Total: ${statuses.length} | ${chalk.green(`✅ ${successful} successful`)}${warningText}${failedText} | ${timeText}`
+    `Total: ${statuses.length} | ${styleText('green', `✅ ${successful} successful`)}${warningText}${failedText} | ${timeText}`
   );
 }
 

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -7,10 +7,10 @@
  *  - resolveFlavorTemplatedPath
  *  - CACHE_DEPS
  */
-import chalk from 'chalk';
 import fs from 'fs';
 import fsExtra from 'fs-extra';
 import { glob } from 'glob';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { PACKAGES_DIR } from '../../Constants';
@@ -221,7 +221,9 @@ export function sortPackagesByDependencies(packages: SPMPackageSource[]): Topolo
     const unsortedPackages = [...packageMap.keys()].filter((name) => !sortedNames.has(name));
 
     logger.warn(`⚠️  Circular dependency detected in packages, building in original order`);
-    logger.warn(`   Packages involved in cycle: ${chalk.yellow(unsortedPackages.join(', '))}`);
+    logger.warn(
+      `   Packages involved in cycle: ${styleText('yellow', unsortedPackages.join(', '))}`
+    );
 
     for (const pkgName of unsortedPackages) {
       const deps = dependsOn.get(pkgName);
@@ -229,7 +231,7 @@ export function sortPackagesByDependencies(packages: SPMPackageSource[]): Topolo
         const cycleDeps = [...deps].filter((d) => unsortedPackages.includes(d));
         if (cycleDeps.length > 0) {
           logger.warn(
-            `   ${chalk.cyan(pkgName)} depends on: ${chalk.yellow(cycleDeps.join(', '))}`
+            `   ${styleText('cyan', pkgName)} depends on: ${styleText('yellow', cycleDeps.join(', '))}`
           );
         }
       }
@@ -242,7 +244,7 @@ export function sortPackagesByDependencies(packages: SPMPackageSource[]): Topolo
   const originalOrder = [...packageMap.keys()].join(', ');
   const sortedOrder = sorted.map((p) => p.packageName).join(', ');
   if (originalOrder !== sortedOrder) {
-    logger.info(`📋 Build order (sorted by dependencies):\n${chalk.cyan(sortedOrder)}`);
+    logger.info(`📋 Build order (sorted by dependencies):\n${styleText('cyan', sortedOrder)}`);
   }
 
   return { sorted, dependsOn };
@@ -452,7 +454,7 @@ export function expandWithUnbuiltDependencies(
           }
 
           logger.info(
-            `📎 Auto-adding ${chalk.cyan(depPackageName)} (required by ${chalk.green(pkg.packageName)}, ${reason})`
+            `📎 Auto-adding ${styleText('cyan', depPackageName)} (required by ${styleText('green', pkg.packageName)}, ${reason})`
           );
           added.set(depPackageName, depPkg);
           changed = true;
@@ -494,7 +496,9 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     }
 
     if (request.packageNames.length > 0) {
-      logger.info(`📦 Prebuilding packages: ${chalk.green(request.packageNames.join(', '))}`);
+      logger.info(
+        `📦 Prebuilding packages: ${styleText('green', request.packageNames.join(', '))}`
+      );
     } else if (request.externalOnly) {
       logger.info(`📦 Discovering external packages with spm.config.json...`);
     } else {
@@ -541,9 +545,7 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     // values are visible in the build output.
     if (externalPackages.length > 0) {
       logger.info(
-        `📦 External packages to build:\n${chalk.blue(
-          externalPackages.map((p) => `${p.packageName}@${p.packageVersion}`).join(', ')
-        )}`
+        `📦 External packages to build:\n${styleText('blue', externalPackages.map((p) => `${p.packageName}@${p.packageVersion}`).join(', '))}`
       );
     }
 
@@ -665,7 +667,7 @@ export const prepareSharedSPMDepsStep: Step<PrebuildContext> = {
       `📦 Found ${shared.length} shared SPM ${shared.length === 1 ? 'dependency' : 'dependencies'}:`
     );
     for (const { dep, usedBy } of shared) {
-      logger.info(`   ${chalk.cyan(dep.productName)} ← ${usedBy.join(', ')}`);
+      logger.info(`   ${styleText('cyan', dep.productName)} ← ${usedBy.join(', ')}`);
     }
 
     // When --clean is passed, wipe shared SPM dep build dirs and xcframeworks

--- a/tools/src/promote-packages/helpers.ts
+++ b/tools/src/promote-packages/helpers.ts
@@ -1,12 +1,10 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Parcel } from './types';
 import * as Changelogs from '../Changelogs';
 import { GitDirectory } from '../Git';
 import logger from '../Logger';
 import { Package } from '../Packages';
-
-const { cyan, green, magenta, red, gray } = chalk;
 
 /**
  * Wraps `Package` object into a parcels - convenient wrapper providing more package-related helpers.
@@ -28,8 +26,10 @@ export function formatVersionChange(
   fromVersion: string | null | undefined,
   toVersion: string
 ): string {
-  const from = fromVersion ? cyan.bold(fromVersion) : gray.bold('none');
-  const to = cyan.bold(toVersion);
+  const from = fromVersion
+    ? styleText(['cyan', 'bold'], fromVersion)
+    : styleText(['gray', 'bold'], 'none');
+  const to = styleText(['cyan', 'bold'], toVersion);
   return `from ${from} to ${to}`;
 }
 
@@ -42,24 +42,24 @@ export function printPackagesToPromote(parcels: Parcel[]): void {
 
   printPackagesToPromoteInternal(
     toPromote,
-    `Following packages would be ${green.bold('promoted')}:`
+    `Following packages would be ${styleText(['green', 'bold'], 'promoted')}:`
   );
   printPackagesToPromoteInternal(
     toDemote,
-    `Following packages could be ${red.bold('demoted')} ${gray(`(requires --demote flag)`)}:`
+    `Following packages could be ${styleText(['red', 'bold'], 'demoted')} ${styleText('gray', `(requires --demote flag)`)}:`
   );
 }
 
 function printPackagesToPromoteInternal(parcels: Parcel[], headerText: string): void {
   if (parcels.length > 0) {
-    logger.log('  ', magenta(headerText));
+    logger.log('  ', styleText('magenta', headerText));
 
     const sorted = [...parcels].sort((a, b) => a.pkg.packageName.localeCompare(b.pkg.packageName));
 
     for (const { pkg, state } of sorted) {
       logger.log(
         '    ',
-        green(pkg.packageName),
+        styleText('green', pkg.packageName),
         formatVersionChange(state.versionToReplace, pkg.packageVersion)
       );
     }

--- a/tools/src/promote-packages/tasks/listPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/listPackagesToPromote.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { findPackagesToPromote } from './findPackagesToPromote';
 import { prepareParcels } from './prepareParcels';
@@ -6,8 +6,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { printPackagesToPromote } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { yellow } = chalk;
 
 /**
  * Lists packages that can be promoted to given tag.
@@ -23,7 +21,7 @@ export const listPackagesToPromote = new Task<TaskArgs>(
       return Task.STOP;
     }
 
-    logger.info(`\n📚 Packages to promote to ${yellow.bold(options.tag)}:`);
+    logger.info(`\n📚 Packages to promote to ${styleText(['yellow', 'bold'], options.tag)}:`);
     printPackagesToPromote(parcels);
   }
 );

--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { findPackagesToPromote } from './findPackagesToPromote';
 import { prepareParcels } from './prepareParcels';
@@ -10,8 +10,6 @@ import { Task } from '../../TasksRunner';
 import { formatVersionChange } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
-const { yellow, red, green, cyan } = chalk;
-
 /**
  * Promotes local versions of selected packages to npm tag passed as an option.
  */
@@ -21,7 +19,7 @@ export const promotePackages = new Task<TaskArgs>(
     dependsOn: [prepareParcels, findPackagesToPromote, selectPackagesToPromote],
   },
   async (parcels: Parcel[], options: CommandOptions): Promise<void> => {
-    logger.info(`\n🚀 Promoting packages to ${yellow.bold(options.tag)} tag...`);
+    logger.info(`\n🚀 Promoting packages to ${styleText(['yellow', 'bold'], options.tag)} tag...`);
 
     // Sort alphabetically, optionally reversed.
     const sorted = [...parcels].sort((a, b) => a.pkg.packageName.localeCompare(b.pkg.packageName));
@@ -38,12 +36,14 @@ export const promotePackages = new Task<TaskArgs>(
       const currentVersion = pkg.packageVersion;
       const { versionToReplace } = state;
 
-      const action = state.isDemoting ? red('Demoting') : green('Promoting');
-      logger.log('  ', green.bold(pkg.packageName));
+      const action = state.isDemoting
+        ? styleText('red', 'Demoting')
+        : styleText('green', 'Promoting');
+      logger.log('  ', styleText(['green', 'bold'], pkg.packageName));
       logger.log(
         '    ',
         action,
-        yellow(options.tag),
+        styleText('yellow', options.tag),
         formatVersionChange(versionToReplace, currentVersion)
       );
 
@@ -53,6 +53,8 @@ export const promotePackages = new Task<TaskArgs>(
       }
     }
 
-    logger.success(`\n✅ Successfully promoted ${cyan(parcels.length + '')} packages.`);
+    logger.success(
+      `\n✅ Successfully promoted ${styleText('cyan', parcels.length + '')} packages.`
+    );
   }
 );

--- a/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import readline from 'readline';
 import stripAnsi from 'strip-ansi';
 
@@ -8,8 +8,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { formatVersionChange } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, red } = chalk;
 
 /**
  * Prompts the user to select packages to promote or demote.
@@ -44,10 +42,12 @@ async function promptForPackagesToPromoteAsync(parcels: Parcel[]): Promise<strin
   const maxLength = sorted.reduce((acc, { pkg }) => Math.max(acc, pkg.packageName.length), 0);
 
   const choices = sorted.map(({ pkg, state }) => {
-    const action = state.isDemoting ? red.bold('demote') : green.bold('promote');
+    const action = state.isDemoting
+      ? styleText(['red', 'bold'], 'demote')
+      : styleText(['green', 'bold'], 'promote');
 
     return {
-      name: `${green(pkg.packageName.padEnd(maxLength))} ${action} ${formatVersionChange(
+      name: `${styleText('green', pkg.packageName.padEnd(maxLength))} ${action} ${formatVersionChange(
         state.versionToReplace,
         pkg.packageVersion
       )}`,

--- a/tools/src/publish-packages/helpers.ts
+++ b/tools/src/publish-packages/helpers.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
 import pick from 'lodash/pick';
+import { styleText } from 'node:util';
 import npmPacklist from 'npm-packlist';
 import semver from 'semver';
 
@@ -10,8 +10,6 @@ import * as Changelogs from '../Changelogs';
 import * as Formatter from '../Formatter';
 import Git, { GitDirectory, GitFileStatus } from '../Git';
 import logger from '../Logger';
-
-const { green, cyan, magenta, gray, red } = chalk;
 
 /**
  * Returns options that are capable of being backed up.
@@ -37,7 +35,7 @@ export async function shouldUseBackupAsync(options: CommandOptions): Promise<boo
       type: 'confirm',
       name: 'restore',
       prefix: '❔',
-      message: cyan('Found valid backup file. Would you like to use it?'),
+      message: styleText('cyan', 'Found valid backup file. Would you like to use it?'),
     },
   ]);
   logger.log();
@@ -54,23 +52,26 @@ export function printPackageParcel(parcel: Parcel): void {
 
   logger.log(
     '\n📦',
-    `${green.bold(pkg.packageName)},`,
-    `current version ${cyan.bold(pkg.packageVersion)},`,
+    `${styleText(['green', 'bold'], pkg.packageName)},`,
+    `current version ${styleText(['cyan', 'bold'], pkg.packageVersion)},`,
     pkgView ? `published from ${Formatter.formatCommitHash(gitHead)}` : 'not published yet'
   );
 
   if (dependents.size) {
     logger.log(
       '  ',
-      magenta('Dependency of:'),
-      [...dependents].map((dependent) => green(dependent.pkg.packageName)).join(', ')
+      styleText('magenta', 'Dependency of:'),
+      [...dependents].map((dependent) => styleText('green', dependent.pkg.packageName)).join(', ')
     );
   }
 
   if (!pkgView) {
     logger.log(
       '  ',
-      magenta(`Version ${cyan.bold(pkg.packageVersion)} hasn't been published yet.`)
+      styleText(
+        'magenta',
+        `Version ${styleText(['cyan', 'bold'], pkg.packageVersion)} hasn't been published yet.`
+      )
     );
   } else if (!logs) {
     logger.warn("   We couldn't determine new commits for this package.");
@@ -84,7 +85,7 @@ export function printPackageParcel(parcel: Parcel): void {
   }
 
   if (dependencies.size) {
-    logger.log('  ', magenta('Package depends on:'));
+    logger.log('  ', styleText('magenta', 'Package depends on:'));
 
     dependencies.forEach((dependency) => {
       const fromVersion = dependency.pkg.packageVersion;
@@ -92,20 +93,27 @@ export function printPackageParcel(parcel: Parcel): void {
 
       logger.log(
         '    ',
-        green(dependency.pkg.packageName),
-        gray(`(upgrades from ${cyan(fromVersion)}${toVersion ? ` to ${cyan(toVersion)}` : ''})`)
+        styleText('green', dependency.pkg.packageName),
+        styleText(
+          'gray',
+          `(upgrades from ${styleText('cyan', fromVersion)}${toVersion ? ` to ${styleText('cyan', toVersion)}` : ''})`
+        )
       );
     });
   }
   if (logs && logs.commits.length > 0) {
-    logger.log('  ', magenta('New commits:'));
+    logger.log('  ', styleText('magenta', 'New commits:'));
 
     [...logs.commits].reverse().forEach((commitLog) => {
       logger.log('    ', Formatter.formatCommitLog(commitLog));
     });
   }
   if (logs && logs.files.length > 0) {
-    logger.log('  ', magenta('File changes:'), gray('(build folder not displayed)'));
+    logger.log(
+      '  ',
+      styleText('magenta', 'File changes:'),
+      styleText('gray', '(build folder not displayed)')
+    );
 
     logs.files.forEach((fileLog) => {
       if (fileLog.relativePath.startsWith('build/')) {
@@ -121,7 +129,7 @@ export function printPackageParcel(parcel: Parcel): void {
     const changes = unpublishedChanges[changeType];
 
     if (changes.length > 0) {
-      logger.log('  ', magenta(`${Formatter.stripNonAsciiChars(changeType).trim()}:`));
+      logger.log('  ', styleText('magenta', `${Formatter.stripNonAsciiChars(changeType).trim()}:`));
 
       for (const change of unpublishedChanges[changeType]) {
         logger.log('    ', Formatter.formatChangelogEntry(change.message));
@@ -132,7 +140,10 @@ export function printPackageParcel(parcel: Parcel): void {
   if (pkgView && releaseType && releaseVersion) {
     logger.log(
       '  ',
-      magenta(`Suggested ${cyan.bold(releaseType)} upgrade to ${cyan.bold(releaseVersion)}`)
+      styleText(
+        'magenta',
+        `Suggested ${styleText(['cyan', 'bold'], releaseType)} upgrade to ${styleText(['cyan', 'bold'], releaseVersion)}`
+      )
     );
   }
 }
@@ -242,8 +253,9 @@ export async function resolveReleaseTypeAndVersion(parcel: Parcel, options: Comm
   } else if (sdkBranch != null) {
     state.releaseType = ReleaseType.PATCH;
     if (highestReleaseType !== ReleaseType.PATCH) {
-      explainer = chalk.dim(
-        `Based on changes made in this package, it should normally be released as ${chalk.blue(highestReleaseType)}, but when releasing from an SDK branch (currently ${chalk.blue(sdkBranch)}) a ${chalk.blue('patch')} bump is recommended instead.`
+      explainer = styleText(
+        'dim',
+        `Based on changes made in this package, it should normally be released as ${styleText('blue', highestReleaseType)}, but when releasing from an SDK branch (currently ${styleText('blue', sdkBranch)}) a ${styleText('blue', 'patch')} bump is recommended instead.`
       );
     }
   } else {
@@ -349,10 +361,16 @@ export function validateVersion(parcel: Parcel) {
   return (input: string) => {
     if (input) {
       if (!semver.valid(input)) {
-        return red(`${cyan.bold(input)} is not a valid semver version.`);
+        return styleText(
+          'red',
+          `${styleText(['cyan', 'bold'], input)} is not a valid semver version.`
+        );
       }
       if (parcel.pkgView && parcel.pkgView.versions.includes(input)) {
-        return red(`${cyan.bold(input)} has already been published.`);
+        return styleText(
+          'red',
+          `${styleText(['cyan', 'bold'], input)} has already been published.`
+        );
       }
     }
     return true;

--- a/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
+++ b/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
@@ -13,8 +13,6 @@ import { Parcel, TaskArgs } from '../types';
 // https://github.com/expo/expo/pulls?q=label:published
 const PUBLISHED_LABEL_NAME = 'published';
 
-const { green, blue, magenta, bold } = chalk;
-
 /**
  * Adds "published" label to pull requests mentioned in changelog entries.
  */
@@ -27,7 +25,7 @@ export const addPublishedLabelToPullRequests = new Task<TaskArgs>(
     if (!process.env.GITHUB_TOKEN) {
       logger.error(
         'Environment variable `%s` must be set to add labels to pull requests',
-        magenta('GITHUB_TOKEN')
+        styleText('magenta', 'GITHUB_TOKEN')
       );
       return;
     }
@@ -98,16 +96,16 @@ export const addPublishedLabelToPullRequests = new Task<TaskArgs>(
 );
 
 function linkToPullRequest(pr: GitHub.PullRequest): string {
-  return link(blue('#' + pr.number), pr.html_url);
+  return link(styleText('blue', '#' + pr.number), pr.html_url);
 }
 
 function linkToAuthor(pr: GitHub.PullRequest): string {
   const { user } = pr;
-  return user ? link(green('@' + user.login), user.html_url) : 'anonymous';
+  return user ? link(styleText('green', '@' + user.login), user.html_url) : 'anonymous';
 }
 
 function formatPullRequest(pr: GitHub.PullRequest): string {
-  return `${linkToPullRequest(pr)}: ${bold(pr.title)} (by ${linkToAuthor(pr)})`;
+  return `${linkToPullRequest(pr)}: ${styleText('bold', pr.title)} (by ${linkToAuthor(pr)})`;
 }
 
 /**

--- a/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
+++ b/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
@@ -11,8 +11,6 @@ import { sdkVersionNumberAsync } from '../../ProjectVersions';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, yellow, cyan } = chalk;
 
 /**
  * Assigns the SDK tag to packages when run on the release branch.
@@ -37,7 +35,7 @@ export const assignTagForSdkRelease = new Task<TaskArgs>(
     }
 
     await runWithSpinner(
-      `Assigning ${yellow(sdkTag)} tag to packages`,
+      `Assigning ${styleText('yellow', sdkTag)} tag to packages`,
       async (step) => {
         for (const { pkg, pkgView } of parcels) {
           const currentTagVersion = pkgView?.['dist-tags']?.[sdkTag];
@@ -47,7 +45,8 @@ export const assignTagForSdkRelease = new Task<TaskArgs>(
           // Skip if the currently tagged version is greater or equal to the current one.
           if (currentTagVersion && semver.lte(pkgVersion, currentTagVersion)) {
             logger.debug(
-              `≫ Skipped ${green(pkgName)} - the tag is already greater or equal (${cyan(
+              `≫ Skipped ${styleText('green', pkgName)} - the tag is already greater or equal (${styleText(
+                'cyan',
                 currentTagVersion
               )})`
             );
@@ -55,7 +54,7 @@ export const assignTagForSdkRelease = new Task<TaskArgs>(
           }
 
           step.start(
-            `Assigning ${yellow.bold(sdkTag)} tag to ${green(pkgName)}@${cyan(pkgVersion)}\n`
+            `Assigning ${styleText(['yellow', 'bold'], sdkTag)} tag to ${styleText('green', pkgName)}@${styleText('cyan', pkgVersion)}\n`
           );
 
           if (!options.dry) {
@@ -63,7 +62,7 @@ export const assignTagForSdkRelease = new Task<TaskArgs>(
           }
         }
       },
-      `Successfully assigned ${yellow(sdkTag)} tag`
+      `Successfully assigned ${styleText('yellow', sdkTag)} tag`
     );
   }
 );
@@ -95,7 +94,7 @@ async function askToAssignSdkTag(sdkTag: string): Promise<boolean> {
       type: 'confirm',
       name: 'assignSdkTag',
       prefix: '❔',
-      message: `Do you want to assign ${yellow(sdkTag)} tag to the current versions?`,
+      message: `Do you want to assign ${styleText('yellow', sdkTag)} tag to the current versions?`,
       default: true,
     },
   ]);

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -1,10 +1,8 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { cyan } = chalk;
 
 /**
  * Checks whether the environment allows to proceed with any further tasks.
@@ -39,7 +37,7 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
 
     if (!teamMembers.includes(npmUser)) {
       throw new Error(
-        `❗️ You must be in ${cyan(Npm.EXPO_DEVELOPERS_TEAM_NAME)} team to publish packages`
+        `❗️ You must be in ${styleText('cyan', Npm.EXPO_DEVELOPERS_TEAM_NAME)} team to publish packages`
       );
     }
   }

--- a/tools/src/publish-packages/tasks/checkPackageAccess.ts
+++ b/tools/src/publish-packages/tasks/checkPackageAccess.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { loadRequestedParcels } from './loadRequestedParcels';
@@ -41,7 +41,7 @@ export const checkPackageAccess = new Task<TaskArgs>(
 
         if (packagesWithoutAccess.length > 0) {
           const formattedPackageNames = packagesWithoutAccess
-            .map((pkgName) => chalk.green(pkgName))
+            .map((pkgName) => styleText('green', pkgName))
             .join(', ');
 
           step.fail();

--- a/tools/src/publish-packages/tasks/checkPackagesIntegrity.ts
+++ b/tools/src/publish-packages/tasks/checkPackagesIntegrity.ts
@@ -1,13 +1,11 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, cyan, blue, yellow } = chalk;
 
 /**
  * Checks packages integrity and warns about violations.
@@ -36,19 +34,19 @@ export const checkPackagesIntegrity = new Task<TaskArgs>(
       const integral = isAncestor && isVersionMatching;
 
       if (!integral) {
-        logger.warn(`\n⚠️  Integrity checks failed for ${green(pkg.packageName)}.`);
+        logger.warn(`\n⚠️  Integrity checks failed for ${styleText('green', pkg.packageName)}.`);
       }
       if (!pkgView.gitHead) {
-        logger.warn(`   Cannot find ${blue('gitHead')} in package view.`);
+        logger.warn(`   Cannot find ${styleText('blue', 'gitHead')} in package view.`);
       } else if (!isAncestor) {
         logger.warn(
-          `   Local version ${cyan(pkgView.version)} has been published from different branch.`
+          `   Local version ${styleText('cyan', pkgView.version)} has been published from different branch.`
         );
       }
       if (!isVersionMatching) {
         logger.warn(
-          `   Last version in changelog ${cyan(lastChangelogVersion!)}`,
-          `doesn't match local version ${cyan(pkgView.version)}.`
+          `   Last version in changelog ${styleText('cyan', lastChangelogVersion!)}`,
+          `doesn't match local version ${styleText('cyan', pkgView.version)}.`
         );
       }
       return integral;
@@ -87,7 +85,10 @@ async function shouldStopOnFailedIntegrityChecksAsync(): Promise<boolean> {
       type: 'confirm',
       name: 'proceed',
       prefix: '❔',
-      message: yellow('Some integrity checks have failed. Do you want to proceed either way?'),
+      message: styleText(
+        'yellow',
+        'Some integrity checks have failed. Do you want to proceed either way?'
+      ),
       default: true,
     },
   ]);

--- a/tools/src/publish-packages/tasks/checkPackagesWithTurbo.ts
+++ b/tools/src/publish-packages/tasks/checkPackagesWithTurbo.ts
@@ -1,12 +1,10 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runTurboTasksAsync } from '../../Turbo';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { cyan } = chalk;
 
 const PUBLISH_CHECK_TASKS = ['build', 'typecheck', 'depscheck', 'test', 'lint'];
 
@@ -29,7 +27,7 @@ export const checkPackagesWithTurbo = new Task<TaskArgs>(
     }
 
     logger.info(
-      `\n🧐 Checking ${cyan(packageNames.length)} package${packageNames.length === 1 ? '' : 's'} with Turbo...`
+      `\n🧐 Checking ${styleText('cyan', `${packageNames.length}`)} package${packageNames.length === 1 ? '' : 's'} with Turbo...`
     );
 
     await runTurboTasksAsync(PUBLISH_CHECK_TASKS, {

--- a/tools/src/publish-packages/tasks/checkRepositoryStatus.ts
+++ b/tools/src/publish-packages/tasks/checkRepositoryStatus.ts
@@ -1,11 +1,9 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { cyan, blue } = chalk;
 
 /**
  * Checks whether the current branch is correct and working dir is not dirty.
@@ -38,7 +36,7 @@ export const checkRepositoryStatus = new Task<TaskArgs>(
 
       if (stats.ahead + stats.behind > 0) {
         logger.error(
-          `🚫 Your local branch ${cyan(currentBranch)} is out of sync with remote branch.`
+          `🚫 Your local branch ${styleText('cyan', currentBranch)} is out of sync with remote branch.`
         );
         return Task.STOP;
       }
@@ -67,7 +65,7 @@ async function checkBranchNameAsync(branchName: string) {
     return true;
   }
 
-  logger.warn('💡', `You are publishing from the ${blue(branchName)}.`);
+  logger.warn('💡', `You are publishing from the ${styleText('blue', branchName)}.`);
 
   // Insert any validation here if needed in the future.
   logger.log();

--- a/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
+++ b/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -46,7 +46,7 @@ export const commentOnIssuesTask = new Task<TaskArgs>(
     if (!process.env.GITHUB_TOKEN) {
       logger.error(
         'Environment variable `%s` must be set to dispatch a commentator workflow',
-        chalk.magenta('GITHUB_TOKEN')
+        styleText('magenta', 'GITHUB_TOKEN')
       );
       logManualFallback(payload);
       return;
@@ -151,7 +151,9 @@ function logManualFallback(payload: CommentatorPayload): void {
  */
 function linksToClosedIssues(issues: number[]): string {
   return issues
-    .map((issue) => link(chalk.blue('#' + issue), `https://github.com/expo/expo/issues/${issue}`))
+    .map((issue) =>
+      link(styleText('blue', '#' + issue), `https://github.com/expo/expo/issues/${issue}`)
+    )
     .join(', ');
 }
 

--- a/tools/src/publish-packages/tasks/commitStagedChanges.ts
+++ b/tools/src/publish-packages/tasks/commitStagedChanges.ts
@@ -1,12 +1,10 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { blue } = chalk;
 
 /**
  * Commits staged changes made by all previous tasks.
@@ -32,7 +30,7 @@ export const commitStagedChanges = new Task<TaskArgs>(
       .map(({ pkg, state }) => `${pkg.packageName}@${state.releaseVersion}`)
       .join('\n');
 
-    logger.info(`\n📼 Committing changes with message: ${blue(commitMessage)}`);
+    logger.info(`\n📼 Committing changes with message: ${styleText('blue', commitMessage)}`);
 
     await Git.commitAsync({
       title: commitMessage,

--- a/tools/src/publish-packages/tasks/cutOffChangelogs.ts
+++ b/tools/src/publish-packages/tasks/cutOffChangelogs.ts
@@ -1,11 +1,9 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-
-const { green, gray } = chalk;
 
 /**
  * Cuts off changelogs - renames unpublished section header
@@ -34,7 +32,7 @@ export const cutOffChangelogs = new Task<TaskArgs>(
           // This prevents unnecessary cut-offs when that version was already cutted off.
           // Maybe we should move "unpublished" entries to this version? It's probably too rare to worry about it.
           if (!versions.includes(state.releaseVersion)) {
-            logger.log('  ', green(pkg.packageName) + '...');
+            logger.log('  ', styleText('green', pkg.packageName) + '...');
             await changelog.cutOffAsync(state.releaseVersion);
             await changelog.saveAsync();
             return;
@@ -43,7 +41,11 @@ export const cutOffChangelogs = new Task<TaskArgs>(
         } else {
           skipReason = 'no changelog file';
         }
-        logger.log('  ', green(pkg.packageName), gray(`- skipped, ${skipReason}`));
+        logger.log(
+          '  ',
+          styleText('green', pkg.packageName),
+          styleText('gray', `- skipped, ${skipReason}`)
+        );
       })
     );
   }

--- a/tools/src/publish-packages/tasks/ensureBareExpoDependencies.ts
+++ b/tools/src/publish-packages/tasks/ensureBareExpoDependencies.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -8,8 +8,6 @@ import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, yellow } = chalk;
 
 const BARE_EXPO_PACKAGE_JSON = path.join(EXPO_DIR, 'apps/bare-expo/package.json');
 
@@ -66,7 +64,7 @@ export const ensureBareExpoDependencies = new Task<TaskArgs>(
 
     logger.info('\n📦 Adding missing native packages to bare-expo...');
     for (const name of missing) {
-      logger.log('  ', `${green('+')} ${yellow(name)}`);
+      logger.log('  ', `${styleText('green', '+')} ${styleText('yellow', name)}`);
       dependencies[name] = 'workspace:*';
     }
 

--- a/tools/src/publish-packages/tasks/grantTeamAccessToPackages.ts
+++ b/tools/src/publish-packages/tasks/grantTeamAccessToPackages.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
 import logger from '../../Logger';
@@ -6,8 +6,6 @@ import * as Npm from '../../Npm';
 import { withOtpRetry } from '../../NpmOtp';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green } = chalk;
 
 /**
  * Grants package access to the whole team. Applies only when the package
@@ -34,7 +32,7 @@ export const grantTeamAccessToPackages = new Task<TaskArgs>(
 
     logger.info(
       `\n🎖  ${options.dry ? 'Team access would be granted to' : 'Granting team access to'}`,
-      packagesToGrantAccess.map((name) => green(name)).join(' ')
+      packagesToGrantAccess.map((name) => styleText('green', name)).join(' ')
     );
 
     if (!options.dry) {
@@ -45,7 +43,7 @@ export const grantTeamAccessToPackages = new Task<TaskArgs>(
           );
         } catch (e) {
           logger.debug(e.stderr || e.stdout);
-          logger.error(`🎖  Granting access to ${green(packageName)} failed`);
+          logger.error(`🎖  Granting access to ${styleText('green', packageName)} failed`);
         }
       }
     }

--- a/tools/src/publish-packages/tasks/loadRequestedParcels.ts
+++ b/tools/src/publish-packages/tasks/loadRequestedParcels.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import * as Changelogs from '../../Changelogs';
 import Git from '../../Git';
@@ -9,7 +9,6 @@ import { PackagesGraph, PackagesGraphNode } from '../../packages-graph';
 import { getMinReleaseType, getPackageGitLogsAsync } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
-const { green } = chalk;
 const parcelsCache = new Map<PackagesGraphNode, Parcel>();
 
 /**
@@ -38,7 +37,9 @@ export const loadRequestedParcels = new Task<TaskArgs>(
     // Verify that provided package names are valid.
     for (const packageName of packageNames) {
       if (!allPackagesObj[packageName]) {
-        throw new Error(`Package with provided name ${green(packageName)} does not exist.`);
+        throw new Error(
+          `Package with provided name ${styleText('green', packageName)} does not exist.`
+        );
       }
     }
 

--- a/tools/src/publish-packages/tasks/packPackageToTarball.ts
+++ b/tools/src/publish-packages/tasks/packPackageToTarball.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
 import logger from '../../Logger';
@@ -21,7 +21,7 @@ export const packPackageToTarball = new Task<TaskArgs>(
       async (step) => {
         try {
           for (const { pkg, state } of parcels) {
-            step.start(`Packing ${chalk.green(pkg.packageName)} to tarball`);
+            step.start(`Packing ${styleText('green', pkg.packageName)} to tarball`);
 
             const packResult = await packToTarballAsync(pkg.path);
 

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -1,8 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { ensureBareExpoDependencies } from './ensureBareExpoDependencies';
@@ -50,7 +50,8 @@ async function cleanupStaleBuildDirectories(): Promise<void> {
         type: 'list',
         name: 'action',
         prefix: '🧹',
-        message: chalk.cyan(
+        message: styleText(
+          'cyan',
           `Found ${dirsToRemove.length} stale build director${dirsToRemove.length === 1 ? 'y' : 'ies'} (*.cxx, android/build). Remove?`
         ),
         choices: [
@@ -65,7 +66,7 @@ async function cleanupStaleBuildDirectories(): Promise<void> {
     if (action === 'list') {
       logger.log();
       for (const dir of dirsToRemove) {
-        logger.log('  ', chalk.gray(path.relative(EXPO_DIR, dir)));
+        logger.log('  ', styleText('gray', path.relative(EXPO_DIR, dir)));
       }
       logger.log();
       return promptForCleanup();
@@ -138,9 +139,9 @@ export const publishAndroidArtifacts = new Task<TaskArgs>(
 
       if (publicationCommands.length === 1) {
         const publicationCommand = publicationCommands[0];
-        batch.log('  ', '  ', `${chalk.green(pkg.packageName)}: ${publicationCommand}`);
+        batch.log('  ', '  ', `${styleText('green', pkg.packageName)}: ${publicationCommand}`);
       } else {
-        batch.log('  ', '  ', `${chalk.green(pkg.packageName)}:`);
+        batch.log('  ', '  ', `${styleText('green', pkg.packageName)}:`);
         for (const command of publicationCommands) {
           batch.log('  ', '  ', '  ', `${command}`);
         }

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { checkEnvironmentTask } from './checkEnvironmentTask';
@@ -20,8 +20,6 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { addTemplateTarball } from './addTemplateTarball';
 import { bundleIOSPrebuilds } from './bundleIOSPrebuilds';
 import { updateAndroidProjects } from './updateAndroidProjects';
-
-const { cyan } = chalk;
 
 /**
  * Prepare packages to be published as canaries.
@@ -146,7 +144,7 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
     const count = parcels.length;
 
     logger.success(
-      `\n✅ Successfully published ${cyan.bold(count + '')} package${count > 1 ? 's' : ''}.\n`
+      `\n✅ Successfully published ${styleText(['cyan', 'bold'], count + '')} package${count > 1 ? 's' : ''}.\n`
     );
   }
 );

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import path from 'path';
 import semver from 'semver';
 
@@ -13,8 +13,6 @@ import { promptOtp, withOtpRetry } from '../../NpmOtp';
 import { Task } from '../../TasksRunner';
 import { sleepAsync } from '../../Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, cyan, yellow } = chalk;
 
 /**
  * Publishes all packages that have been selected to publish.
@@ -44,7 +42,7 @@ export const publishPackages = new Task<TaskArgs>(
 
       logger.log(
         '  ',
-        `${green(pkg.packageName)} version ${cyan(releaseVersion)} as ${yellow(options.tag)}`
+        `${styleText('green', pkg.packageName)} version ${styleText('cyan', releaseVersion)} as ${styleText('yellow', options.tag)}`
       );
 
       // Update `gitHead` property so it will be available to read using `npm view --json`.
@@ -69,7 +67,10 @@ export const publishPackages = new Task<TaskArgs>(
         // Assign SDK tag when package is a template
         if (pkg.isTemplate() && !options.canary) {
           const sdkTag = `sdk-${semver.major(releaseVersion)}`;
-          logger.log('  ', `Assigning ${yellow(sdkTag)} tag to ${green(pkg.packageName)}`);
+          logger.log(
+            '  ',
+            `Assigning ${styleText('yellow', sdkTag)} tag to ${styleText('green', pkg.packageName)}`
+          );
           if (!options.dry) {
             await sleepAsync(1000); // wait for npm to process the package
             await withOtpRetry(() => Npm.addTagAsync(pkg.packageName, releaseVersion, sdkTag));

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
 import { addTemplateTarball } from './addTemplateTarball';
@@ -30,8 +30,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { cyan, yellow } = chalk;
 
 /**
  * Cleans up all the changes that were made by previously run tasks.
@@ -115,12 +113,12 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
     }
     const packagesCount = parcels.length;
     logger.success(
-      `\n✅ Successfully published ${cyan.bold(packagesCount)} package${packagesCount > 1 ? 's' : ''}.\n`
+      `\n✅ Successfully published ${styleText(['cyan', 'bold'], `${packagesCount}`)} package${packagesCount > 1 ? 's' : ''}.\n`
     );
 
     if (options.tag !== 'latest') {
       logger.log(
-        `Run ${cyan.bold('et promote-packages')} to promote them to ${yellow('latest')} tag.`
+        `Run ${styleText(['cyan', 'bold'], 'et promote-packages')} to promote them to ${styleText('yellow', 'latest')} tag.`
       );
     }
   }

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import * as semver from 'semver';
 
 import {
@@ -21,8 +21,6 @@ import {
   validateVersion,
 } from '../helpers';
 import { CommandOptions, Parcel, ReleaseType, TaskArgs } from '../types';
-
-const { green, cyan } = chalk;
 
 let lastAction: string | undefined;
 let lastVersionIndex: number = 0;
@@ -85,7 +83,7 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
               const current = p.pkg.packageVersion;
               const target = resolvedVersions.get(p) ?? current;
               return {
-                name: `${green(name)} (${cyan(target)})`,
+                name: `${styleText('green', name)} (${styleText('cyan', target)})`,
                 value: p,
                 checked: true,
               };
@@ -127,7 +125,7 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
     );
     if (skippedFromCascade.length > 0) {
       logger.info(
-        `\n📦 Skipping dependent cascade for shared packages: ${skippedFromCascade.map((p) => green(p.pkg.packageName)).join(', ')}\n   Use ${chalk.bold('--cascade-all')} to include their dependents.`
+        `\n📦 Skipping dependent cascade for shared packages: ${skippedFromCascade.map((p) => styleText('green', p.pkg.packageName)).join(', ')}\n   Use ${styleText('bold', '--cascade-all')} to include their dependents.`
       );
     }
 
@@ -195,9 +193,10 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
 
       parcelsToPublish.add(templateParcel);
       logger.log(
-        `📦 ${green('expo-template-bare-minimum')} is required to be published with ${green(
+        `📦 ${styleText('green', 'expo-template-bare-minimum')} is required to be published with ${styleText(
+          'green',
           'expo'
-        )} package, will be published as ${cyan.bold(releaseVersion)}.`
+        )} package, will be published as ${styleText(['cyan', 'bold'], releaseVersion)}.`
       );
     }
 
@@ -250,7 +249,7 @@ async function promptToPublishParcel(
     {
       type: 'list',
       name: 'action',
-      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?${explainer ? `\n${explainer}` : ''}`,
+      message: `Do you want to publish ${styleText(['green', 'bold'], packageName)} as ${styleText(['cyan', 'bold'], releaseVersion)}?${explainer ? `\n${explainer}` : ''}`,
       choices,
       default: lastAction || 'yes',
     },
@@ -279,11 +278,11 @@ async function promptToPublishParcel(
     {
       type: 'list',
       name: 'version',
-      message: `What do you want to do with ${green.bold(packageName)}?`,
+      message: `What do you want to do with ${styleText(['green', 'bold'], packageName)}?`,
       choices: [
         ...suggestedVersions.map((version) => {
           return {
-            name: `Publish as ${cyan.bold(version)}`,
+            name: `Publish as ${styleText(['cyan', 'bold'], version)}`,
             value: version,
           };
         }),
@@ -456,7 +455,8 @@ async function promptForDependentNodes(
           .filter((edge) => publishingPackageNames.has(edge.destination.name))
           .map((edge) => edge.destination.name);
 
-        const depsInfo = updatedDeps.length > 0 ? ` ${cyan(`(${updatedDeps.join(', ')})`)}` : '';
+        const depsInfo =
+          updatedDeps.length > 0 ? ` ${styleText('cyan', `(${updatedDeps.join(', ')})`)}` : '';
 
         return {
           name: `${node.name}${depsInfo}`,

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -8,8 +8,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { transformFileAsync } from '../../Transforms';
 import { Parcel, TaskArgs } from '../types';
-
-const { yellow, magenta } = chalk;
 
 /**
  * Updates version props in packages containing Android's native code.
@@ -38,7 +36,10 @@ export const updateAndroidProjects = new Task<TaskArgs>(
 
       const relativeGradlePath = path.relative(EXPO_DIR, gradlePath);
 
-      logger.log('  ', `Updating ${yellow('version')} in ${magenta(relativeGradlePath)}`);
+      logger.log(
+        '  ',
+        `Updating ${styleText('yellow', 'version')} in ${styleText('magenta', relativeGradlePath)}`
+      );
 
       await transformFileAsync(gradlePath, [
         {

--- a/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
+++ b/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
@@ -1,5 +1,5 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -7,8 +7,6 @@ import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { magenta, green, gray, cyan } = chalk;
 
 /**
  * Updates `bundledNativeModules.json` file in `expo` package.
@@ -25,7 +23,9 @@ export const updateBundledNativeModulesFile = new Task<TaskArgs>(
     const bundledNativeModules =
       await JsonFile.readAsync<Record<string, string>>(bundledNativeModulesPath);
 
-    logger.info(`\n✏️  Updating ${magenta.bold('bundledNativeModules.json')} file...`);
+    logger.info(
+      `\n✏️  Updating ${styleText(['magenta', 'bold'], 'bundledNativeModules.json')} file...`
+    );
 
     for (const { pkg, state } of parcels) {
       const currentRange = bundledNativeModules[pkg.packageName];
@@ -33,14 +33,14 @@ export const updateBundledNativeModulesFile = new Task<TaskArgs>(
       const newRange = rangePrefix + state.releaseVersion;
 
       if (!currentRange) {
-        logger.log('  ', green(pkg.packageName), gray('is not defined.'));
+        logger.log('  ', styleText('green', pkg.packageName), styleText('gray', 'is not defined.'));
         continue;
       }
 
       logger.log(
         '  ',
-        green(pkg.packageName),
-        `${cyan.bold(currentRange)} -> ${cyan.bold(newRange)}`
+        styleText('green', pkg.packageName),
+        `${styleText(['cyan', 'bold'], currentRange)} -> ${styleText(['cyan', 'bold'], newRange)}`
       );
 
       bundledNativeModules[pkg.packageName] = newRange;

--- a/tools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/src/publish-packages/tasks/updateIosProjects.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -8,8 +8,6 @@ import { Task } from '../../TasksRunner';
 import { filterAsync } from '../../Utils';
 import * as Workspace from '../../Workspace';
 import { Parcel, TaskArgs } from '../types';
-
-const { green } = chalk;
 
 /**
  * Updates pods in Expo client's and bare-expo.
@@ -40,11 +38,11 @@ export const updateIosProjects = new Task<TaskArgs>(
           .filter(Boolean) as string[];
 
         if (podspecNames.length === 0) {
-          logger.log('  ', `${green(nativeApp.packageName)}: No pods to update.`);
+          logger.log('  ', `${styleText('green', nativeApp.packageName)}: No pods to update.`);
           return;
         }
 
-        logger.log('  ', `${green(nativeApp.packageName)}: Reinstalling pods...`);
+        logger.log('  ', `${styleText('green', nativeApp.packageName)}: Reinstalling pods...`);
 
         // Use `pod update`: we just bumped these pods' versions, and precompiled modules
         // register them as `:podspec =>` sources, which trip CocoaPods' strict version-drift check on
@@ -56,7 +54,7 @@ export const updateIosProjects = new Task<TaskArgs>(
           });
         } catch (e) {
           logger.debug(e.stderr || e.stdout);
-          logger.error('🍎 Failed to install pods in', green(nativeApp.packageName));
+          logger.error('🍎 Failed to install pods in', styleText('green', nativeApp.packageName));
           logger.error('🍎 Please review the output above and fix it once the publish completes');
         }
       })

--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs/promises';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -8,7 +8,6 @@ import { getPackageByName, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
-const { cyan, green } = chalk;
 const MODULE_TEMPLATE_PKG_NAME = 'expo-module-template';
 const TEMPLATE_PACKAGE_JSON_FILENAME = '$package.json';
 const PACKAGES_TO_UPDATE = ['expo-modules-core', 'expo-module-scripts', 'expo'];
@@ -38,7 +37,7 @@ export const updateModuleTemplate = new Task<TaskArgs>(
 
     if (!moduleTemplatePkg) {
       logger.error(
-        `❗️ Unable to find the module template package: ${green(MODULE_TEMPLATE_PKG_NAME)}`
+        `❗️ Unable to find the module template package: ${styleText('green', MODULE_TEMPLATE_PKG_NAME)}`
       );
       return;
     }
@@ -82,8 +81,8 @@ async function updateTemplatePackageJsonAsync(
     }
 
     logger.log(
-      `   Updating dev dependency on ${green(pkg.packageName)}:`,
-      `${cyan.bold(oldVersion)} -> ${cyan.bold(newVersionRange)}`
+      `   Updating dev dependency on ${styleText('green', pkg.packageName)}:`,
+      `${styleText(['cyan', 'bold'], oldVersion)} -> ${styleText(['cyan', 'bold'], newVersionRange)}`
     );
 
     updatedBody = updatedBody.replace(

--- a/tools/src/publish-packages/tasks/updatePackageVersions.ts
+++ b/tools/src/publish-packages/tasks/updatePackageVersions.ts
@@ -1,13 +1,11 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-
-const { magenta, cyan, green } = chalk;
 
 /**
  * Updates versions in packages selected to be published.
@@ -19,7 +17,7 @@ export const updatePackageVersions = new Task<TaskArgs>(
     filesToStage: ['packages/**/package.json', 'templates/**/package.json'],
   },
   async (parcels: Parcel[]) => {
-    logger.info(`\n🆙 Updating versions in ${magenta.bold('package.json')}s...`);
+    logger.info(`\n🆙 Updating versions in ${styleText(['magenta', 'bold'], 'package.json')}s...`);
 
     await Promise.all(
       parcels.map(async ({ pkg, state }) => {
@@ -30,8 +28,8 @@ export const updatePackageVersions = new Task<TaskArgs>(
         );
         logger.log(
           '  ',
-          `${green(pkg.packageName)}:`,
-          `${cyan.bold(pkg.packageVersion)} -> ${cyan.bold(state.releaseVersion!)}`
+          `${styleText('green', pkg.packageName)}:`,
+          `${styleText(['cyan', 'bold'], pkg.packageVersion)} -> ${styleText(['cyan', 'bold'], state.releaseVersion!)}`
         );
       })
     );

--- a/tools/src/publish-packages/tasks/updateProjectTemplates.ts
+++ b/tools/src/publish-packages/tasks/updateProjectTemplates.ts
@@ -1,5 +1,5 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -7,8 +7,6 @@ import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { magenta, green, blue, cyan } = chalk;
 
 const BUNDLED_NATIVE_MODULES_PATH = path.join(PACKAGES_DIR, 'expo', 'bundledNativeModules.json');
 const DEPENDENCIES_KEYS = ['dependencies', 'devDependencies', 'peerDependencies'];
@@ -33,7 +31,7 @@ function resolveTargetVersionRange(targetVersionRange: string, currentVersion: s
  * @param modulesToUpdate An object with module names to update and their version ranges.
  */
 async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<string, string>) {
-  logger.info('  ', `${green.bold(parcel.pkg.packageName)}...`);
+  logger.info('  ', `${styleText(['green', 'bold'], parcel.pkg.packageName)}...`);
 
   const packageJsonPath = path.join(parcel.pkg.path, 'package.json');
   // Read fresh JSON from disk to avoid Node's require cache returning stale data.
@@ -56,7 +54,7 @@ async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<strin
       }
       logger.log(
         '    >',
-        `Updating ${blue(dependencyName)} from ${cyan(currentVersion)} to ${cyan(targetVersion)}...`
+        `Updating ${styleText('blue', dependencyName)} from ${styleText('cyan', currentVersion)} to ${styleText('cyan', targetVersion)}...`
       );
       deps[dependencyName] = targetVersion;
     }
@@ -76,7 +74,9 @@ export const updateProjectTemplates = new Task<TaskArgs>(
   async (parcels: Parcel[], options: CommandOptions) => {
     const bundledNativeModules = require(BUNDLED_NATIVE_MODULES_PATH);
 
-    logger.info(`\n🆙 Updating ${magenta.bold('templates')} with bundledNativeModules...`);
+    logger.info(
+      `\n🆙 Updating ${styleText(['magenta', 'bold'], 'templates')} with bundledNativeModules...`
+    );
 
     for (const parcel of parcels) {
       if (!parcel.pkg.isTemplate()) {

--- a/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
+++ b/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { publishPackages } from './publishPackages';
@@ -7,8 +7,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import * as Versions from '../../Versions';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { cyan, green, yellow } = chalk;
 
 /**
  * Updates the versions endpoint with the published expo package version.
@@ -40,7 +38,7 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
     const sdkVersions = Versions.getSortedSdkVersionKeys(versions);
     const recentSdks = sdkVersions.slice(0, 3);
 
-    logger.info(`\n📡 Expo package published: ${green(publishedVersion)}`);
+    logger.info(`\n📡 Expo package published: ${styleText('green', publishedVersion)}`);
 
     const ENTER_SDK = 'Enter SDK version';
     const SKIP = 'Skip';
@@ -51,14 +49,14 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
       {
         type: 'list',
         name: 'selectedSdk',
-        message: `Update versions endpoint with expoVersion ${green(expoVersionValue)}?`,
+        message: `Update versions endpoint with expoVersion ${styleText('green', expoVersionValue)}?`,
         choices: sdkChoices,
         default: recentSdks[0],
       },
     ]);
 
     if (selectedSdk === SKIP) {
-      logger.info(yellow('  Skipping versions endpoint update.'));
+      logger.info(styleText('yellow', '  Skipping versions endpoint update.'));
       return;
     }
 
@@ -83,11 +81,11 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
     }
 
     logger.info(
-      `\n📡 Updating versions endpoint for SDK ${cyan(targetSdkVersion)} with expoVersion ${green(expoVersionValue)}...`
+      `\n📡 Updating versions endpoint for SDK ${styleText('cyan', targetSdkVersion)} with expoVersion ${styleText('green', expoVersionValue)}...`
     );
 
     if (options.dry) {
-      logger.info(yellow('  Dry run - skipping version update.'));
+      logger.info(styleText('yellow', '  Dry run - skipping version update.'));
       return;
     }
 
@@ -97,7 +95,7 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
         expoVersion: expoVersionValue,
       }));
       logger.success(
-        `\n📡 Successfully updated versions endpoint: SDK ${cyan(targetSdkVersion)} → expoVersion: ${green(expoVersionValue)}`
+        `\n📡 Successfully updated versions endpoint: SDK ${styleText('cyan', targetSdkVersion)} → expoVersion: ${styleText('green', expoVersionValue)}`
       );
     } catch (error) {
       logger.error(`\n📡 Failed to update versions endpoint: ${error.message}`);

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -1,5 +1,5 @@
 import JsonFile from '@expo/json-file';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { EXPO_DIR } from '../../Constants';
@@ -9,8 +9,6 @@ import { getAvailableProjectTemplatesAsync } from '../../ProjectTemplates';
 import { Task } from '../../TasksRunner';
 import * as Workspace from '../../Workspace';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const { green, yellow, cyan } = chalk;
 
 /**
  * Updates versions of packages to be published in other workspace projects depending on them.
@@ -78,7 +76,7 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
         const projectPackageJson = await JsonFile.readAsync(projectPackageJsonPath);
         const batch = logger.batch();
 
-        batch.log('  ', green(projectName));
+        batch.log('  ', styleText('green', projectName));
 
         // Iterate through different dependencies types.
         for (const dependenciesKey of dependenciesKeys) {
@@ -118,8 +116,8 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
 
             batch.log(
               '    ',
-              `Updating ${yellow(`${dependenciesKey}.${pkg.packageName}`)}`,
-              `from ${cyan(currentVersionRange)} to ${cyan(newVersionRange)}`
+              `Updating ${styleText('yellow', `${dependenciesKey}.${pkg.packageName}`)}`,
+              `from ${styleText('cyan', currentVersionRange)} to ${styleText('cyan', newVersionRange)}`
             );
           }
         }

--- a/tools/src/utils/askForSDKVersionAsync.ts
+++ b/tools/src/utils/askForSDKVersionAsync.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { Platform, getSDKVersionsAsync } from '../ProjectVersions';
@@ -13,14 +13,12 @@ export default async function askForSDKVersionAsync(
   if (process.env.CI) {
     if (defaultSdkVersion) {
       console.log(
-        `${chalk.red('`--sdkVersion`')} not provided - defaulting to ${chalk.cyan(
-          defaultSdkVersion
-        )}.`
+        `${styleText('red', '`--sdkVersion`')} not provided - defaulting to ${styleText('cyan', defaultSdkVersion)}.`
       );
       return defaultSdkVersion;
     }
     throw new Error(
-      `${chalk.red('`--sdkVersion`')} not provided and unable to obtain default value.`
+      `${styleText('red', '`--sdkVersion`')} not provided and unable to obtain default value.`
     );
   }
 
@@ -37,7 +35,7 @@ export default async function askForSDKVersionAsync(
       choices: sdkVersions,
       validate(value) {
         if (!semver.valid(value)) {
-          return `Invalid version: ${chalk.cyan(value)}`;
+          return `Invalid version: ${styleText('cyan', value)}`;
         }
         return true;
       },

--- a/tools/src/vendoring/common.ts
+++ b/tools/src/vendoring/common.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import logger from '../Logger';
 import { CopyFileOptions, FileTransform, copyFileWithTransformsAsync } from '../Transforms';
@@ -20,13 +20,17 @@ export async function copyVendoredFilesAsync(
     transformsUsed.forEach((transform) => unusedTransforms.delete(transform));
 
     if (sourceFile !== targetFile) {
-      logger.log('📂 Renamed %s to %s', chalk.magenta(sourceFile), chalk.magenta(targetFile));
+      logger.log(
+        '📂 Renamed %s to %s',
+        styleText('magenta', sourceFile),
+        styleText('magenta', targetFile)
+      );
     }
   }
   for (const unusedTransform of unusedTransforms) {
     logger.warn(
       '⚠️ A transform was never applied to vendored code.\nThis can indicate outdated transforms or bugs in the vendored package.\nPath(s): %s',
-      chalk.magenta(String(unusedTransform.paths ?? ''))
+      styleText('magenta', String(unusedTransform.paths ?? ''))
     );
   }
 }

--- a/tools/src/vendoring/devmenu/Pipe.ts
+++ b/tools/src/vendoring/devmenu/Pipe.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { Task } from './steps/Task';
 import logger from '../../Logger';
@@ -72,9 +72,9 @@ export class Pipe {
   }
 
   public async start(platform: Platform) {
-    logger.debug(`Staring pipe for platform = ${chalk.green(platform)}`);
+    logger.debug(`Staring pipe for platform = ${styleText('green', platform)}`);
     logger.debug(
-      `${chalk.green('<workingDirectory>')} = ${chalk.yellow(this.workingDirectory || '')}`
+      `${styleText('green', '<workingDirectory>')} = ${styleText('yellow', this.workingDirectory || '')}`
     );
     logger.debug();
 

--- a/tools/src/vendoring/devmenu/steps/Append.ts
+++ b/tools/src/vendoring/devmenu/steps/Append.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 
 import { Task } from './Task';
 import { findFiles } from '../utils';
@@ -33,9 +33,7 @@ export class Append extends Task {
     const workDirectory = this.getWorkingDirectory();
 
     this.logSubStep(
-      `➕ append to ${chalk.green(this.overrideWorkingDirectory())}/${chalk.yellow(
-        this.filePattern
-      )}`
+      `➕ append to ${styleText('green', this.overrideWorkingDirectory())}/${styleText('yellow', this.filePattern)}`
     );
 
     const files = await findFiles(workDirectory, this.filePattern);

--- a/tools/src/vendoring/devmenu/steps/Clone.ts
+++ b/tools/src/vendoring/devmenu/steps/Clone.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 
 import { Task } from './Task';
 
@@ -43,11 +43,11 @@ export class Clone extends Task {
   async execute() {
     const workDirectory = this.getWorkingDirectory();
 
-    this.logSubStep(`🧹 remove ${chalk.yellow(this.overrideWorkingDirectory())}`);
+    this.logSubStep(`🧹 remove ${styleText('yellow', this.overrideWorkingDirectory())}`);
     await fs.remove(workDirectory);
 
     this.logSubStep(
-      `📩 clone repo ${chalk.green(this.url)} into ${chalk.yellow(this.overrideWorkingDirectory())}`
+      `📩 clone repo ${styleText('green', this.url)} into ${styleText('yellow', this.overrideWorkingDirectory())}`
     );
 
     const cloneArguments = this.cloneArguments();

--- a/tools/src/vendoring/devmenu/steps/CopyFiles.ts
+++ b/tools/src/vendoring/devmenu/steps/CopyFiles.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { Task } from './Task';
@@ -84,9 +84,7 @@ export class CopyFiles extends Task {
         : workDirectory;
 
       this.logSubStep(
-        `📝 copy ${chalk.green(this.overrideWorkingDirectory())}/${chalk.green(
-          this.subDirectory ? this.subDirectory + '/' : ''
-        )}${chalk.yellow(pattern)} into ${chalk.magenta(this.to)}`
+        `📝 copy ${styleText('green', this.overrideWorkingDirectory())}/${styleText('green', this.subDirectory ? this.subDirectory + '/' : '')}${styleText('yellow', pattern)} into ${styleText('magenta', this.to)}`
       );
 
       const files = await findFiles(subPath, pattern);

--- a/tools/src/vendoring/devmenu/steps/GenerateJsonFromPodspec.ts
+++ b/tools/src/vendoring/devmenu/steps/GenerateJsonFromPodspec.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { Task } from './Task';
@@ -28,7 +28,7 @@ export class GenerateJsonFromPodspec extends Task {
     const workDirectory = this.getWorkingDirectory();
 
     this.logSubStep(
-      `➕ generating podspec from ${chalk.green('<workingDirectory>')}/${chalk.green(this.from)}`
+      `➕ generating podspec from ${styleText('green', '<workingDirectory>')}/${styleText('green', this.from)}`
     );
     const podspec = await readPodspecAsync(path.join(workDirectory, this.from));
     const transformedPodspec = await this.transform(podspec);

--- a/tools/src/vendoring/devmenu/steps/RemoveDirectory.ts
+++ b/tools/src/vendoring/devmenu/steps/RemoveDirectory.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 
 import { Task } from './Task';
 
@@ -26,7 +26,7 @@ export class RemoveDirectory extends Task {
   async execute() {
     const workDirectory = this.getWorkingDirectory();
 
-    this.logSubStep(`🧹 remove ${chalk.yellow(this.overrideWorkingDirectory())}`);
+    this.logSubStep(`🧹 remove ${styleText('yellow', this.overrideWorkingDirectory())}`);
     return await fs.remove(workDirectory);
   }
 }

--- a/tools/src/vendoring/devmenu/steps/RemoveFiles.ts
+++ b/tools/src/vendoring/devmenu/steps/RemoveFiles.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 
 import { Task } from './Task';
 import { findFiles } from '../utils';
@@ -27,7 +27,7 @@ export class RemoveFiles extends Task {
     const workDirectory = this.getWorkingDirectory();
 
     this.logSubStep(
-      `🚮 Remove ${chalk.green(this.overrideWorkingDirectory())}/${chalk.yellow(this.filePattern)}`
+      `🚮 Remove ${styleText('green', this.overrideWorkingDirectory())}/${styleText('yellow', this.filePattern)}`
     );
 
     const files = await findFiles(workDirectory, this.filePattern);

--- a/tools/src/vendoring/devmenu/steps/TransformFilesContent.ts
+++ b/tools/src/vendoring/devmenu/steps/TransformFilesContent.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { Task } from './Task';
@@ -42,9 +42,7 @@ export class TransformFilesContent extends Task {
     const workDirectory = this.getWorkingDirectory();
 
     this.logSubStep(
-      `🔄 find ${chalk.yellow(this.find.toString())} in ${chalk.green(
-        this.overrideWorkingDirectory()
-      )}/${chalk.yellow(this.filePattern)} and replace with ${chalk.magenta(this.replace)}`
+      `🔄 find ${styleText('yellow', this.find.toString())} in ${styleText('green', this.overrideWorkingDirectory())}/${styleText('yellow', this.filePattern)} and replace with ${styleText('magenta', this.replace)}`
     );
 
     const files = await findFiles(workDirectory, this.filePattern);

--- a/tools/src/vendoring/devmenu/steps/TransformFilesName.ts
+++ b/tools/src/vendoring/devmenu/steps/TransformFilesName.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import { styleText } from 'node:util';
 import path from 'path';
 
 import { TransformFilesContent } from './TransformFilesContent';
@@ -10,9 +10,7 @@ export class TransformFilesName extends TransformFilesContent {
     const workDirectory = this.getWorkingDirectory();
 
     this.logSubStep(
-      `🔄 find ${chalk.yellow(this.find.toString())} in files names in path ${chalk.green(
-        this.overrideWorkingDirectory()
-      )}/${chalk.yellow(this.filePattern)} and replace with ${chalk.magenta(this.replace)}`
+      `🔄 find ${styleText('yellow', this.find.toString())} in files names in path ${styleText('green', this.overrideWorkingDirectory())}/${styleText('yellow', this.filePattern)} and replace with ${styleText('magenta', this.replace)}`
     );
 
     const files = await findFiles(workDirectory, this.filePattern);

--- a/tools/src/vendoring/index.ts
+++ b/tools/src/vendoring/index.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
 import Table from 'cli-table3';
+import { styleText } from 'node:util';
 import semver from 'semver';
 
 import { VendoringTargetModulesConfig } from './types';
@@ -37,7 +37,7 @@ export async function listAvailableVendoredModulesAsync(
     const packageView = packageViews.shift();
 
     if (!packageView) {
-      logger.error(`Couldn't get package view for ${chalk.green.bold(packageName)}.\n`);
+      logger.error(`Couldn't get package view for ${styleText(['green', 'bold'], packageName)}.\n`);
       continue;
     }
 
@@ -54,9 +54,9 @@ export async function listAvailableVendoredModulesAsync(
       }
 
       table.push([
-        link(chalk.bold.green(packageName), source),
-        (bundledVersion ? chalk.cyan : chalk.gray)(bundledVersion),
-        chalk.cyan(latestVersion),
+        link(styleText(['bold', 'green'], packageName), source),
+        styleText(bundledVersion ? 'cyan' : 'gray', bundledVersion),
+        styleText('cyan', latestVersion),
         isOutdated ? '❌' : '✅',
       ]);
     }


### PR DESCRIPTION
> [!NOTE]
> `styleText` only restores the outer style after a nested call on Node >=22.19 / >=24.5, see https://github.com/nodejs/node/issues/59035

# Why

Drops the `chalk` dependency in favour of Node's built-in [`styleText()`](https://nodejs.org/api/util.html#utilstyletextformat-text-options).

# How

- Replaced `chalk.x(...)` calls with `styleText('x', ...)`
- `chalk`'s tagged templates (`` chalk`{bold Usage}` ``) have no equivalent, so they were converted to nested `styleText()` calls instead.
- Some sites in `tools/` passed `chalk.<COLOR>()` around, those have been refactored to instead pass modifiers for `styleText()` instead
- Tightened types to match what `styleText()` expects; mainly that it receives a single string for formatting (`chalk` allows variadic arguments)
- Dropped `chalk` from each package's `package.json`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
