### PR TITLE
style(expo-module-scripts): fix file formatting in `createJestPreset.cjs`

### DIFF
--- a/packages/expo-module-scripts/createJestPreset.cjs
+++ b/packages/expo-module-scripts/createJestPreset.cjs
@@ -4,10 +4,7 @@ const { createModulesTransform } = require('./jest-modules-transform.cjs');
 
 // NOTE: Many modules ship as ESM-only but are otherwise ready to be used directly
 // We can manually list them here to extend support to them and only transpile to CJS with SWC
-const cjsTransformIncludeNames = [
-  '@react-navigation',
-  'standard-navigation',
-];
+const cjsTransformIncludeNames = ['@react-navigation', 'standard-navigation'];
 
 // WARN: Packages here ship Flow/untranspiled source or ESM and assume a transforming bundler
 // Anything not listed (e.g. plain-CommonJS deps) runs as-is to keep test transforms fast


### PR DESCRIPTION
# Why

Fixes the CI failure in the SDK `check-packages` workflow. Seems to have been missed when rebasing [#47096](https://github.com/expo/expo/issues/47096) on `main`.

# How

Ran `pnpm --filter expo-module-scripts format`.

# Test Plan

- SDK `check-packages` workflow should now pass

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
