### PR TITLE
[core][jsi][ios] Pair a shared object with one JS object per runtime

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Pair a native shared object with one JavaScript object per runtime, so a shared object exposed to several runtimes (e.g. the main and UI runtimes, or worklet contexts) keeps a live pairing in each instead of only the one paired last. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
 - [Android][compose] Guard `onLayout` against detached window to prevent `LayoutNode should be attached to an owner` crash. ([#47085](https://github.com/expo/expo/pull/47085) by [@roitium](https://github.com/roitium))
 - [Android] Fix Jetpack Compose `Host` content disappearing before a react-native-screens pop animation finishes, by deferring composition disposal to window detach while the view is still on-screen for a transition. ([#45914](https://github.com/expo/expo/issues/45914), [#47086](https://github.com/expo/expo/issues/47086) by [@aubrey-wodonga](https://github.com/aubrey-wodonga)) ([#47099](https://github.com/expo/expo/pull/47099) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `Record` arguments crashing with a `NullPointerException` in R8-optimized release builds when converted through the reflection fallback path. ([#46852](https://github.com/expo/expo/pull/46852) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectNativeState.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectNativeState.swift
@@ -2,24 +2,52 @@
 
 import ExpoModulesJSI
 
-/**
- Native state subclass attached to a SharedObject's JS object. Holds the paired
- native `SharedObject` so callers that already have the JS object can recover
- the native counterpart via `JavaScriptObject.getNativeState(as:)` without going
- through `SharedObjectRegistry`.
- */
+/// Native state attached to a `SharedObject`'s JS object(s). Holds the paired native `SharedObject` so
+/// callers that already have the JS object can recover the native counterpart via
+/// `JavaScriptObject.getNativeState(as:)` without going through `SharedObjectRegistry`.
+///
+/// A single instance is shared across every runtime the native object is exposed to: its underlying C++
+/// `jsi::NativeState` is attached to each runtime's JS object (the same `shared_ptr`, reused via
+/// `JavaScriptNativeState.acquireShared`), and this instance maps each runtime to its paired JS object so
+/// the native object can recover *its* JS counterpart in any given runtime.
 internal final class SharedObjectNativeState: JavaScriptNativeState {
   internal let native: SharedObject
 
-  /**
-   Weak reference to the JS object this native state is attached to. Populated
-   right after `setNativeState` so callers can recover the JS object from the
-   native side without going through `SharedObjectRegistry`.
-   */
-  internal var pairedWeakObject: JavaScriptWeakObject?
+  /// The JS object paired with the native object in each runtime, keyed by runtime identity and held
+  /// weakly. One native object can be exposed to several runtimes (e.g. the main and UI runtimes, or
+  /// worklet contexts), each with its own JS counterpart.
+  private var pairedObjects: [JavaScriptRuntime.ID: JavaScriptRef<JavaScriptWeakObject>] = [:]
 
   internal init(native: SharedObject, factory: @escaping JavaScriptNativeState.Factory) {
     self.native = native
     super.init(factory: factory)
+  }
+
+  /// Records `jsObject` as the native object's JS counterpart in `runtime`. The caller is responsible
+  /// for having attached this native state to `jsObject` (`jsObject.setNativeState(self)`), which reuses
+  /// the shared C++ pointee across runtimes.
+  internal func setJavaScriptObject(_ jsObject: borrowing JavaScriptObject, in runtime: JavaScriptRuntime) {
+    // Drop entries whose runtime or JS object has gone away before inserting, so the map doesn't
+    // accumulate dead keys for runtimes that paired once and were torn down.
+    pruneExpired()
+    pairedObjects[runtime.id] = jsObject.createWeak().ref()
+  }
+
+  /// Returns the JS object paired with the native object in `runtime`, or `nil` if there is no live
+  /// pairing there (none was created, or the JS object has been garbage-collected).
+  internal func javaScriptObject(in runtime: JavaScriptRuntime) -> JavaScriptObject? {
+    // Unwrap the ref first so the dictionary subscript's optional doesn't nest with `withValue`'s,
+    // which would form a `JavaScriptObject??` that the non-`Copyable` element can't be wrapped in.
+    guard let ref = pairedObjects[runtime.id] else {
+      return nil
+    }
+    return ref.withValue { $0?.lock() }
+  }
+
+  private func pruneExpired() {
+    pairedObjects = pairedObjects.filter { _, ref in
+      // Keep the entry only while its weak JS object still resolves; an empty ref is dropped.
+      return ref.withValue { $0?.lock() != nil } ?? false
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -13,21 +13,6 @@ public typealias SharedObjectId = Int
 let sharedObjectIdPropertyName = "__expo_shared_object_id__"
 
 /**
- A pair of matching native and JS objects. Uses a weak reference to the JS object
- so that the registry doesn't prevent JS garbage collection. The C++ NativeState
- deallocator removes the pair from the registry when the JS object is collected.
- */
-internal final class SharedObjectPair: @unchecked Sendable {
-  let native: SharedObject
-  let javaScript: JavaScriptWeakObject
-
-  init(native: SharedObject, javaScript: consuming JavaScriptWeakObject) {
-    self.native = native
-    self.javaScript = javaScript
-  }
-}
-
-/**
  The registry of shared objects.
  */
 public final class SharedObjectRegistry: Sendable {
@@ -36,15 +21,20 @@ public final class SharedObjectRegistry: Sendable {
    */
   private weak let appContext: AppContext?
 
-  internal struct State: Sendable {
+  // `@unchecked` because `SharedObjectNativeState` isn't `Sendable` (its JSI base class isn't), yet a
+  // value escapes `withLock` whenever `get`/the lookups return it. Access is always serialized through
+  // `state`'s `Mutex` and the callers run on `JavaScriptActor`, so the unchecked assertion is sound.
+  internal struct State: @unchecked Sendable {
     /**
-     A dictionary of shared object pairs.
+     Maps each shared object id to the native object's `SharedObjectNativeState`, which carries the
+     native object and its per-runtime JS counterparts. The state is held strongly so an id stays
+     resolvable via `get(_:)` until an explicit `delete(_:)`, independent of JS garbage collection.
      */
-    var pairs = [SharedObjectId: SharedObjectPair]()
+    var pairs = [SharedObjectId: SharedObjectNativeState]()
 
     /**
-     The counter of IDs to assign to the shared object pairs.
-     The next pair added to the registry will be saved using this ID.
+     The counter of IDs to assign to the shared objects.
+     The next object added to the registry will be saved using this ID.
      */
     var nextId: SharedObjectId = 1
   }
@@ -89,9 +79,10 @@ public final class SharedObjectRegistry: Sendable {
   }
 
   /**
-   Returns a pair of shared objects with given ID or `nil` when there is no such pair in the registry.
+   Returns the native state registered under the given ID, or `nil` when there is no such entry.
+   The state carries the native object (`native`) and its per-runtime JS counterparts.
    */
-  internal func get(_ id: SharedObjectId) -> SharedObjectPair? {
+  internal func get(_ id: SharedObjectId) -> SharedObjectNativeState? {
     return state.withLock { state in
       return state.pairs[id]
     }
@@ -102,7 +93,10 @@ public final class SharedObjectRegistry: Sendable {
    */
   @discardableResult
   internal func add(native nativeObject: SharedObject, javaScript jsObject: borrowing JavaScriptObject) -> SharedObjectId {
-    let id = pullNextId()
+    // A native object that already carries a native state was paired in an earlier runtime. Reuse its
+    // id rather than minting a new one: the C++ `NativeState.objectId` is immutable and drives the
+    // releaser/`delete`, so a fresh id would disagree with it and leak this object's registry entry.
+    let id = nativeObject.nativeState != nil ? nativeObject.sharedObjectId : pullNextId()
 
     // Assign the ID and the app context to the object.
     nativeObject.sharedObjectId = id
@@ -122,32 +116,48 @@ public final class SharedObjectRegistry: Sendable {
       jsObject.setExternalMemoryPressure(memoryPressure)
     }
 
-    // Save the pair in the dictionary with a weak reference to the JS object.
-    state.withLock { state in
-      state.pairs[id] = SharedObjectPair(native: nativeObject, javaScript: jsObject.createWeak())
-    }
-
     // Attach the C++ shared-object native state. Because `expo::SharedObject::NativeState`
     // inherits from `expo::EventEmitter::NativeState`, later `addListener` calls see an
     // existing native state (via the inheritance check) and don't overwrite it.
-    let releaser: ObjectReleaser = { [weak self] id in
-      self?.delete(id)
+    //
+    // A native object may already carry a native state from a previous pairing in another runtime.
+    // Reuse it so all runtimes share one native state (and one underlying C++ pointee, via
+    // `acquireShared`); a fresh state per runtime would leave `nativeObject.nativeState` pointing at
+    // whichever ran last and lose the earlier runtimes' pairings.
+    let nativeState = nativeObject.nativeState ?? {
+      let releaser: ObjectReleaser = { [weak self] id in
+        self?.delete(id)
+      }
+      let state = SharedObjectNativeState(native: nativeObject) { context, deallocator in
+        return SharedObjectUtils.makeSharedObjectNativeStatePtr(
+          objectId: id,
+          releaser: releaser,
+          context: context,
+          contextDeallocator: deallocator
+        )
+      }
+      nativeObject.nativeState = state
+      return state
+    }()
+
+    // Index the native state by id. One entry per native object: re-pairing in another runtime stores
+    // the same state under the same id (idempotent); the per-runtime JS counterparts live on the state.
+    state.withLock { state in
+      state.pairs[id] = nativeState
     }
-    let nativeState = SharedObjectNativeState(native: nativeObject) { context, deallocator in
-      return SharedObjectUtils.makeSharedObjectNativeStatePtr(
-        objectId: id,
-        releaser: releaser,
-        context: context,
-        contextDeallocator: deallocator
-      )
-    }
+
     // setNativeState calls acquireShared() synchronously, which retains `nativeState`
     // via Unmanaged.passRetained. That's the wrapper's only strong reference — once
-    // the C++ pointee dies, the contextDeallocator releases it. The local going out
-    // of scope here is intentional.
+    // the C++ pointee dies, the contextDeallocator releases it. Reattaching the same
+    // native state to another runtime's JS object reuses that same C++ pointee.
     jsObject.setNativeState(nativeState)
-    nativeState.pairedWeakObject = jsObject.createWeak()
-    nativeObject.nativeState = nativeState
+
+    // The registry is scoped to its app context, so the JS object being paired here lives in that
+    // context's runtime. Record the pairing under that runtime so the native object can recover this
+    // JS counterpart via `native.nativeState?.javaScriptObject(in:)`.
+    if let runtime = try? appContext?.runtime {
+      nativeState.setJavaScriptObject(jsObject, in: runtime)
+    }
 
     return id
   }
@@ -157,14 +167,15 @@ public final class SharedObjectRegistry: Sendable {
    */
   internal func delete(_ id: SharedObjectId) {
     state.withLock { state in
-      if let pair = state.pairs[id] {
-        pair.native.sharedObjectWillRelease()
-        // Reset an ID on the objects.
-        pair.native.sharedObjectId = 0
+      if let nativeState = state.pairs[id] {
+        let native = nativeState.native
+        native.sharedObjectWillRelease()
+        // Reset an ID on the object.
+        native.sharedObjectId = 0
 
-        // Delete the pair from the dictionary.
+        // Delete the entry from the dictionary.
         state.pairs[id] = nil
-        pair.native.sharedObjectDidRelease()
+        native.sharedObjectDidRelease()
       }
     }
   }
@@ -200,25 +211,29 @@ public final class SharedObjectRegistry: Sendable {
    */
   @JavaScriptActor
   internal func toJavaScriptValue(sharedObjectId id: SharedObjectId) -> JavaScriptValue? {
-    let pair = state.withLock { state in
+    guard let runtime = try? appContext?.runtime else {
+      return nil
+    }
+    let nativeState = state.withLock { state in
       return state.pairs[id]
     }
-    return pair?.javaScript.lock()?.asValue()
+    return nativeState?.javaScriptObject(in: runtime)?.asValue()
   }
 
   /**
-   Gets the JS shared object that is paired with a given native object.
+   Gets the JS shared object that is paired with a given native object in this registry's runtime.
    */
   internal func toJavaScriptObject(_ nativeObject: SharedObject) -> JavaScriptObject? {
-    if let pairedObject = nativeObject.nativeState?.pairedWeakObject?.lock() {
-      return pairedObject
+    guard let runtime = try? appContext?.runtime else {
+      return nil
     }
-    // Fallback to the id-based lookup for cases where the native object was registered
-    // through a path that doesn't attach a `SharedObjectNativeState`.
-    let pair = state.withLock { state in
+    // The id table and the native object both resolve to the same `SharedObjectNativeState`, which
+    // owns the per-runtime JS counterparts, so a single lookup serves both. Prefer the native object's
+    // own back-pointer and fall back to the id table for objects whose back-pointer was cleared.
+    let nativeState = nativeObject.nativeState ?? state.withLock { state in
       return state.pairs[nativeObject.sharedObjectId]
     }
-    return pair?.javaScript.lock()
+    return nativeState?.javaScriptObject(in: runtime)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -59,9 +59,9 @@ final class SharedObjectRegistrySpec: ExpoSpec {
         let nativeObject = TestSharedObject()
         let jsObject = runtime.createObject()
         let id = sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
-        let pair = sharedObjectRegistry.get(id)
-        expect(pair?.native) === nativeObject
-        expect(pair?.javaScript.lock()?.asValue()) == jsObject.asValue()
+        let nativeState = sharedObjectRegistry.get(id)
+        expect(nativeState?.native) === nativeObject
+        expect(nativeState?.javaScriptObject(in: runtime)?.asValue()) == jsObject.asValue()
       }
     }
 

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistryTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistryTests.swift
@@ -48,15 +48,75 @@ struct SharedObjectRegistryTests {
   }
 
   @Test
-  func `native state holds the paired weak JS object after add`() throws {
+  func `native state holds the paired JS object per runtime after add`() throws {
+    let runtime = try runtime
     let nativeObject = TestSharedObject()
     let jsObject = try runtime.createObject()
     registry.add(native: nativeObject, javaScript: jsObject)
 
-    // The native side carries a back-pointer to its native state, which holds a
-    // `JavaScriptWeakObject` to the JS counterpart. `lock()` should resolve.
-    let resolved = nativeObject.nativeState?.pairedWeakObject?.lock() != nil
+    // The native side carries a back-pointer to its native state, which maps the runtime to its
+    // paired JS counterpart. Recovering it for this runtime should resolve.
+    let resolved = nativeObject.nativeState?.javaScriptObject(in: runtime) != nil
     #expect(resolved)
+  }
+
+  @Test
+  func `javaScriptObject(in:) is repeatable, not consumed on first read`() throws {
+    let runtime = try runtime
+    let nativeObject = TestSharedObject()
+    let jsObject = runtime.createObject()
+    registry.add(native: nativeObject, javaScript: jsObject)
+    let nativeState = try #require(nativeObject.nativeState)
+
+    // Reading the pairing must not consume it: two consecutive lookups for the same runtime should
+    // both resolve to the originally paired JS object.
+    #expect(nativeState.javaScriptObject(in: runtime)?.asValue() == jsObject.asValue())
+    #expect(nativeState.javaScriptObject(in: runtime)?.asValue() == jsObject.asValue())
+  }
+
+  @Test
+  func `native object is paired independently per runtime`() throws {
+    let primaryRuntime = try runtime
+    let secondaryRuntime = JavaScriptRuntime()
+
+    let nativeObject = TestSharedObject()
+    let primaryObject = primaryRuntime.createObject()
+    registry.add(native: nativeObject, javaScript: primaryObject)
+
+    // Pair the same native object with a second runtime's JS object, reusing the existing native state.
+    let nativeState = try #require(nativeObject.nativeState)
+    let secondaryObject = secondaryRuntime.createObject()
+    secondaryObject.setNativeState(nativeState)
+    nativeState.setJavaScriptObject(secondaryObject, in: secondaryRuntime)
+
+    // Each runtime resolves to its own JS counterpart. Compare within a runtime only (cross-runtime
+    // strict-equality is meaningless).
+    #expect(nativeState.javaScriptObject(in: primaryRuntime)?.asValue() == primaryObject.asValue())
+    #expect(nativeState.javaScriptObject(in: secondaryRuntime)?.asValue() == secondaryObject.asValue())
+  }
+
+  @Test
+  func `the same native state is shared across runtimes, not duplicated`() throws {
+    let primaryRuntime = try runtime
+    let secondaryRuntime = JavaScriptRuntime()
+
+    let nativeObject = TestSharedObject()
+    let primaryObject = primaryRuntime.createObject()
+    registry.add(native: nativeObject, javaScript: primaryObject)
+
+    // Attach the existing native state to a second runtime's JS object, reusing the shared C++ pointee.
+    let nativeState = try #require(nativeObject.nativeState)
+    let secondaryObject = secondaryRuntime.createObject()
+    secondaryObject.setNativeState(nativeState)
+    nativeState.setJavaScriptObject(secondaryObject, in: secondaryRuntime)
+
+    // Both runtimes' JS objects recover the very same `SharedObjectNativeState` instance — the state is
+    // shared, not duplicated per runtime.
+    let recoveredFromPrimary = primaryObject.getNativeState(as: SharedObjectNativeState.self)
+    let recoveredFromSecondary = secondaryObject.getNativeState(as: SharedObjectNativeState.self)
+    #expect(recoveredFromPrimary === nativeState)
+    #expect(recoveredFromSecondary === nativeState)
+    #expect(recoveredFromPrimary === recoveredFromSecondary)
   }
 
   @Test
@@ -72,6 +132,26 @@ struct SharedObjectRegistryTests {
 
     #expect(registry.get(id) == nil)
     #expect(nativeObject.sharedObjectId == 0)
+  }
+
+  @Test
+  func `re-adding a still-paired native object reuses its id and single registry entry`() throws {
+    let primaryRuntime = try runtime
+    let secondaryRuntime = JavaScriptRuntime()
+
+    let nativeObject = TestSharedObject()
+    let firstId = registry.add(native: nativeObject, javaScript: primaryRuntime.createObject())
+
+    // Pair the same, still-alive native object again (e.g. from a second runtime). Because it already
+    // carries a native state, `add` must reuse that state's id rather than mint a new one — otherwise
+    // the C++ `NativeState.objectId` (which drives the releaser/`delete`) would disagree with
+    // `sharedObjectId`, leaking the first registry entry.
+    let secondId = registry.add(native: nativeObject, javaScript: secondaryRuntime.createObject())
+
+    #expect(secondId == firstId)
+    #expect(nativeObject.sharedObjectId == firstId)
+    #expect(registry.size == 1)
+    #expect(registry.get(firstId)?.native === nativeObject)
   }
 
   @Test

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [iOS] Add closure-taking `JavaScriptObject.setProperty(_:function:)` overloads that create a sync or async host function from the given closure. ([#46622](https://github.com/expo/expo/pull/46622) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Conform `JavaScriptRuntime` to `Identifiable` with an `id` based on the underlying runtime, equal across multiple wrappers of the same runtime. ([#47068](https://github.com/expo/expo/pull/47068) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add `JavaScriptRef.withValue`, a non-consuming borrow accessor that reads the referenced value without taking it, so a long-lived reference can be read repeatedly. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
@@ -52,6 +52,18 @@ public final class JavaScriptRef<T: JavaScriptType & ~Copyable>: JavaScriptType,
     return value.take()
   }
 
+  /// Borrows the referenced value for the duration of `body` without consuming it, so the reference
+  /// keeps holding the value and can be read again. `body` receives the value as a borrow, or `nil` when
+  /// the reference is empty (already taken, released, or never set), and its result is returned as-is.
+  /// Use this instead of `take()` when the value must stay in the reference (e.g. a long-lived ref read
+  /// repeatedly).
+  ///
+  /// `body` returns `R` directly (rather than this method wrapping it in `R?`) so the result can itself
+  /// be a non-`Copyable` optional like `JavaScriptObject?`, which can't be nested inside another optional.
+  public func withValue<R: ~Copyable>(_ body: (borrowing T?) throws -> R?) rethrows -> R? {
+    return try body(value)
+  }
+
   /// Takes the value as a `JavaScriptValue`. Returns `undefined` value if the reference does not hold any value.
   public func asValue() -> JavaScriptValue {
     return take()?.asValue() ?? .undefined


### PR DESCRIPTION
## Why

A single native `SharedObject` could only be paired with one JS object at a time. When the same native object is exposed to more than one runtime (the main runtime, the UI runtime, worklet contexts), each `SharedObjectRegistry.add` created a fresh native state and repointed `nativeObject.nativeState` at whichever runtime paired last, silently losing the earlier runtimes' pairings.

## How

- `SharedObjectNativeState` now holds a `[JavaScriptRuntime.ID: weak JS object]` map (`setJavaScriptObject(_:in:)` / `javaScriptObject(in:)`) instead of a single `pairedWeakObject`. Dead keys are pruned on insert so runtimes that paired once and were torn down don't accumulate.
- One native state instance is shared across every runtime the native object is exposed to. Its underlying C++ `jsi::NativeState` is reattached to each runtime's JS object via `acquireShared`, so `add` reuses the existing native state rather than creating a new one per call.
- The registry now indexes ids directly to that `SharedObjectNativeState` (held strongly) instead of a separate native + weak-JS pair, collapsing the two parallel pairing records into one. Re-pairing a still-live native object in another runtime reuses its existing id and single registry entry rather than minting a fresh id that the immutable C++ `NativeState.objectId` (which drives the releaser) would never release.
- `toJavaScriptObject` / `toJavaScriptValue(sharedObjectId:)` recover the JS counterpart for the registry's own runtime through the native state's per-runtime map, so there is no single JS slot to record under the wrong runtime.
- Adds `JavaScriptRef.withValue`, a non-consuming borrow accessor, so the weak object stored in the map can be locked repeatedly without being consumed.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-core`

New tests in `SharedObjectRegistryTests` cover: the per-runtime pairing resolving after `add`, the lookup being repeatable (not consumed on first read), independent pairing per runtime, the same native state being shared across runtimes rather than duplicated, and re-adding a still-paired native object reusing its id and single registry entry.
