### PR TITLE
[docs][map-view] Clarify process.env API key requires a dynamic config

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -125,6 +125,8 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
+> **Note**: The `process.env.YOUR_GOOGLE_MAPS_API_KEY` reference is only substituted when you use a [dynamic config](/workflow/configuration/#dynamic-configuration) (**app.config.js** or **app.config.ts**). In a static **app.json**, environment variables are not interpolated, so the literal string `process.env.YOUR_GOOGLE_MAPS_API_KEY` is written into **AndroidManifest.xml** and the map renders blank. Either switch to a dynamic config or paste the API key value directly.
+
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).
 
@@ -173,6 +175,8 @@ Since you are using Google as the map provider, you need to add the API key to t
   }
 }
 ```
+
+> **Note**: The `process.env.YOUR_GOOGLE_MAPS_API_KEY` reference is only substituted when you use a [dynamic config](/workflow/configuration/#dynamic-configuration) (**app.config.js** or **app.config.ts**). In a static **app.json**, environment variables are not interpolated, so the literal string `process.env.YOUR_GOOGLE_MAPS_API_KEY` is written into the native project and the map renders blank. Either switch to a dynamic config or paste the API key value directly.
 
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).

--- a/docs/pages/versions/v56.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/map-view.mdx
@@ -125,6 +125,8 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
+> **Note**: The `process.env.YOUR_GOOGLE_MAPS_API_KEY` reference is only substituted when you use a [dynamic config](/workflow/configuration/#dynamic-configuration) (**app.config.js** or **app.config.ts**). In a static **app.json**, environment variables are not interpolated, so the literal string `process.env.YOUR_GOOGLE_MAPS_API_KEY` is written into **AndroidManifest.xml** and the map renders blank. Either switch to a dynamic config or paste the API key value directly.
+
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).
 
@@ -173,6 +175,8 @@ Since you are using Google as the map provider, you need to add the API key to t
   }
 }
 ```
+
+> **Note**: The `process.env.YOUR_GOOGLE_MAPS_API_KEY` reference is only substituted when you use a [dynamic config](/workflow/configuration/#dynamic-configuration) (**app.config.js** or **app.config.ts**). In a static **app.json**, environment variables are not interpolated, so the literal string `process.env.YOUR_GOOGLE_MAPS_API_KEY` is written into the native project and the map renders blank. Either switch to a dynamic config or paste the API key value directly.
 
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).


### PR DESCRIPTION
# Why

The Google Maps setup section of the `react-native-maps` / MapView docs shows the API key as `"process.env.YOUR_GOOGLE_MAPS_API_KEY"` inside a **static `app.json`**. In a static `app.json`, environment variables are **not** interpolated, so the literal string `process.env.YOUR_GOOGLE_MAPS_API_KEY` is written into the native project (e.g. `AndroidManifest.xml`) and the map renders blank/white. The surrounding text says you can use a `.env` file *or* paste the key directly, but the only example shows the env-var form in the one config format where it silently fails.

Fixes #40513

# How

Added a short note callout after the code block in both the **Android** and **iOS** "Add the API key to your project" steps, clarifying that:

- `process.env.*` is only substituted when using a [dynamic config](https://docs.expo.dev/workflow/configuration/#dynamic-configuration) (`app.config.js` / `app.config.ts`);
- a static `app.json` writes the literal string into the native project and the map renders blank;
- you should either switch to a dynamic config or paste the API key value directly.

Applied to both the `unversioned` and current `v56.0.0` copies per the docs versioning rule.

# Test Plan

Docs-only change. Verified the `/workflow/configuration/#dynamic-configuration` anchor exists, and that the note renders as a standard blockquote callout consistent with the rest of the page (the same `> **Note**:` pattern already used elsewhere in the docs). No code or API surface affected.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] Change mirrored to the unversioned copy