### PR TITLE
[ios][autolinking] Enable react-native-screens gamma in the precompiled XCFramework

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Added support for compile-only inline module files, which are compiled into the target without being registered as Expo modules. ([#46969](https://github.com/expo/expo/pull/46969) by [@behenate](https://github.com/behenate))
-- [iOS] Enable `react-native-screens`' gamma architecture (`RNS_GAMMA_ENABLED`) in its precompiled XCFramework by building the gamma sources and adding a Swift target for the split-view controllers.
+- [iOS] Enable `react-native-screens`' gamma architecture (`RNS_GAMMA_ENABLED`) in its precompiled XCFramework by building the gamma sources and adding a Swift target for the split-view controllers. ([#47240](https://github.com/expo/expo/pull/47240) by [@chrfalch](https://github.com/chrfalch))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Added support for compile-only inline module files, which are compiled into the target without being registered as Expo modules. ([#46969](https://github.com/expo/expo/pull/46969) by [@behenate](https://github.com/behenate))
+- [iOS] Enable `react-native-screens`' gamma architecture (`RNS_GAMMA_ENABLED`) in its precompiled XCFramework by building the gamma sources and adding a Swift target for the split-view controllers.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
@@ -93,7 +93,7 @@
                     "path": "ios",
                     "pattern": "**/*.{m,mm}",
                     "headerPattern": "**/*.h",
-                    "exclude": [ "gamma/**", "RNScreens.xcodeproj/**" ],
+                    "exclude": [ "stubs/**", "RNScreens.xcodeproj/**" ],
                     "dependencies": [
                         "Hermes",
                         "React",
@@ -105,7 +105,20 @@
                     ],
                     "includeDirectories": [ ".", "../.build/codegen/build/generated/ios/ReactCodegen", "../cpp", "../.build/generated/RNScreens/RNScreens_common_cpp/include/rnscreens" ],
                     "linkedFrameworks": [ "Foundation", "UIKit", "QuartzCore", "CoreGraphics" ],
-                    "compilerFlags": [ "-include", "UIKit/UIKit.h" ]
+                    "compilerFlags": [ "-include", "UIKit/UIKit.h", "-DRNS_GAMMA_ENABLED=1" ]
+                },
+                {
+                    "type": "swift",
+                    "name": "RNScreens_gamma_swift",
+                    "path": "ios",
+                    "pattern": "**/*.swift",
+                    "dependencies": [
+                        "Hermes",
+                        "React",
+                        "ReactNativeDependencies",
+                        "RNScreens"
+                    ],
+                    "linkedFrameworks": [ "Foundation", "UIKit" ]
                 }
             ]
         }


### PR DESCRIPTION
## Why

Build react-native-screens' "gamma" architecture into its prebuilt SwiftPM XCFramework. Gamma's split-view layer is a mixed ObjC++/Swift module, which SwiftPM cannot build as a single target, so this change:

Requires a fix in RNScreens to work:

https://github.com/software-mansion/react-native-screens/pull/4211

## How

- Updates the `react-native-screens` `spm.config.json` to compile the gamma sources (excluding the gamma-off stubs), set `RNS_GAMMA_ENABLED` on the ObjC target, and add a Swift target for the gamma controllers.

# Test Plan

Test by building our 3rd party libs as XCFrameworks with the above fix to RNScreens

✅ `et prebuild -f Debug react-native-screens`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
