### PR TITLE
feat(precompile) add prune support

### DIFF
--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -1,5 +1,6 @@
 import { Command } from '@expo/commander';
 
+import { prunePrebuildBuildFilesAsync } from '../prebuilds/Prune';
 import {
   createRequest,
   createContext,
@@ -7,7 +8,6 @@ import {
   installSignalHandlers,
 } from '../prebuilds/pipeline/Index';
 import type { PrebuildCliOptions } from '../prebuilds/pipeline/Index';
-import { prunePrebuildBuildFilesAsync } from '../prebuilds/Prune';
 
 export async function runPrebuildPackagesAsync(
   packageNames: string[],

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -7,6 +7,7 @@ import {
   installSignalHandlers,
 } from '../prebuilds/pipeline/Index';
 import type { PrebuildCliOptions } from '../prebuilds/pipeline/Index';
+import { prunePrebuildBuildFilesAsync } from '../prebuilds/Prune';
 
 export async function runPrebuildPackagesAsync(
   packageNames: string[],
@@ -24,6 +25,18 @@ export async function runPrebuildPackagesAsync(
 }
 
 async function main(packageNames: string[], options: PrebuildCliOptions) {
+  // `et prebuild prune [all | <packageNames...>]` removes the intermediate build files
+  // (Xcode DerivedData) while keeping the composed xcframeworks. It's keyed off the first
+  // positional rather than a real subcommand because the CLI dispatches on the command name.
+  if (packageNames[0] === 'prune') {
+    const { exitCode } = await prunePrebuildBuildFilesAsync(packageNames.slice(1), {
+      includeExternal: options.includeExternal,
+      externalOnly: options.externalOnly,
+      dryRun: options.dryRun,
+    });
+    process.exit(exitCode);
+  }
+
   const result = await runPrebuildPackagesAsync(packageNames, options);
   process.exit(result.exitCode);
 }
@@ -32,7 +45,8 @@ export default (program: Command) => {
   program
     .command('prebuild-packages [packageNames...]')
     .description(
-      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.'
+      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.\n' +
+        'Run `et prebuild prune [packageNames...]` to delete the intermediate build files (Xcode DerivedData, ~2GB/package) while keeping the composed xcframeworks. With no names (or `all`) it cleans every build cache found on disk; pass package names to prune only those. Add --dry-run to preview what would be removed.'
     )
     .alias('prebuild')
     .option(
@@ -69,6 +83,11 @@ export default (program: Command) => {
     .option(
       '--clean-cache',
       'Clears the entire dependency cache, forcing a fresh download of all artifacts.',
+      false
+    )
+    .option(
+      '--dry-run',
+      'Only applies to `prebuild prune`: list the build files that would be removed (with sizes) without deleting anything.',
       false
     )
     .option('--skip-generate', 'Skip the generate step.', false)

--- a/tools/src/prebuilds/Prune.test.ts
+++ b/tools/src/prebuilds/Prune.test.ts
@@ -12,14 +12,30 @@ describe('findDerivedDataDirsAsync', () => {
     try {
       // Non-versioned (Expo package) layout
       await fs.ensureDir(path.join(tmp, 'output', 'debug', 'frameworks', 'ExpoFoo', 'Build'));
-      await fs.outputFile(path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.xcframework', 'x'), '1');
-      await fs.outputFile(path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.gz'), 'tar');
+      await fs.outputFile(
+        path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.xcframework', 'x'),
+        '1'
+      );
+      await fs.outputFile(
+        path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.gz'),
+        'tar'
+      );
       await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'ExpoFoo'));
 
       // Versioned (external package) layout — xcframeworks live under a version prefix
       await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'RNFoo'));
       await fs.outputFile(
-        path.join(tmp, 'output', '1.2.3', '0.83.0', '1.0.0', 'release', 'xcframeworks', 'RNFoo.xcframework', 'x'),
+        path.join(
+          tmp,
+          'output',
+          '1.2.3',
+          '0.83.0',
+          '1.0.0',
+          'release',
+          'xcframeworks',
+          'RNFoo.xcframework',
+          'x'
+        ),
         '1'
       );
 

--- a/tools/src/prebuilds/Prune.test.ts
+++ b/tools/src/prebuilds/Prune.test.ts
@@ -1,0 +1,54 @@
+import fs from 'fs-extra';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import { describe, it } from 'node:test';
+import path from 'path';
+
+import { findDerivedDataDirsAsync } from './Prune';
+
+describe('findDerivedDataDirsAsync', () => {
+  it('targets frameworks/ (DerivedData) and never the xcframeworks/ deliverables', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-prune-'));
+    try {
+      // Non-versioned (Expo package) layout
+      await fs.ensureDir(path.join(tmp, 'output', 'debug', 'frameworks', 'ExpoFoo', 'Build'));
+      await fs.outputFile(path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.xcframework', 'x'), '1');
+      await fs.outputFile(path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.gz'), 'tar');
+      await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'ExpoFoo'));
+
+      // Versioned (external package) layout — xcframeworks live under a version prefix
+      await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'RNFoo'));
+      await fs.outputFile(
+        path.join(tmp, 'output', '1.2.3', '0.83.0', '1.0.0', 'release', 'xcframeworks', 'RNFoo.xcframework', 'x'),
+        '1'
+      );
+
+      // A directory literally named `frameworks` that is NOT under output/<flavor>/ must
+      // not be mistaken for DerivedData (e.g. nested inside the build products).
+      await fs.ensureDir(path.join(tmp, 'output', 'debug', 'frameworks', 'nested', 'frameworks'));
+
+      const dirs = (await findDerivedDataDirsAsync(tmp)).sort();
+
+      assert.deepEqual(dirs, [
+        path.join(tmp, 'output', 'debug', 'frameworks'),
+        path.join(tmp, 'output', 'release', 'frameworks'),
+      ]);
+      // The substring "frameworks" inside "xcframeworks" must not cause a match.
+      assert.ok(
+        !dirs.some((d) => d.includes('xcframeworks')),
+        'must not select any xcframeworks directory'
+      );
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+
+  it('returns nothing when there is no output directory', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-prune-'));
+    try {
+      assert.deepEqual(await findDerivedDataDirsAsync(tmp), []);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+});

--- a/tools/src/prebuilds/Prune.ts
+++ b/tools/src/prebuilds/Prune.ts
@@ -1,0 +1,188 @@
+/**
+ * Prune intermediate prebuild artifacts.
+ *
+ * A prebuild leaves two kinds of output under `packages/precompile/.build/<pkg>/output/`:
+ *   - `xcframeworks/` — the composed `.xcframework` and its `.tar.gz` (the deliverables)
+ *   - `frameworks/`   — the Xcode DerivedData used to build those slices (intermediates,
+ *                       module caches, per-platform `.framework` copies). This is the bulk
+ *                       (~2GB per package) and is not reusable across a clean rebuild.
+ *
+ * `prunePrebuildBuildFilesAsync` removes the DerivedData (`frameworks/`) while keeping
+ * everything in `xcframeworks/`. It mirrors the cleanup the external SPM dependency path
+ * already does (`SPMBuild` removes its DerivedData after composing).
+ *
+ * With no names (or `all`) it scans the entire `.build` directory and cleans every cache on
+ * disk — independent of package discovery, so it also catches packages that aren't part of
+ * the default distributed set (e.g. `@expo/ui`). With explicit names it prunes just those.
+ */
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import { glob } from 'glob';
+import path from 'path';
+
+import { getPrecompileDir } from '../Directories';
+import logger from '../Logger';
+import { verifyAllPackagesAsync } from './Utils';
+
+export type PruneOptions = {
+  /** Include external (third-party) packages in discovery. Defaults to true. */
+  includeExternal?: boolean;
+  /** Prune only external (third-party) packages. Defaults to false. */
+  externalOnly?: boolean;
+  /** Report what would be removed and how much it would free, without deleting anything. */
+  dryRun?: boolean;
+};
+
+export type PruneResult = {
+  exitCode: number;
+  removedDirs: number;
+  freedKb: number;
+};
+
+/** Root of the centralized prebuild cache: `packages/precompile/.build/`. */
+function getBuildCacheRoot(): string {
+  return path.join(getPrecompileDir(), '.build');
+}
+
+/**
+ * Returns true for a directory that is a DerivedData root. DerivedData always lives at
+ * `output/<flavor>/frameworks` (non-versioned, even for versioned external packages whose
+ * xcframeworks are version-prefixed), so we match the literal `frameworks` segment under
+ * `output/`. This can never match the `xcframeworks` deliverables (different path segment).
+ */
+function isDerivedDataDir(dir: string): boolean {
+  return path.basename(dir) === 'frameworks' && path.dirname(path.dirname(dir)).endsWith('output');
+}
+
+/**
+ * Resolves the DerivedData directories to remove under a single package's `output/` tree.
+ */
+export async function findDerivedDataDirsAsync(buildPath: string): Promise<string[]> {
+  const outputDir = path.join(buildPath, 'output');
+  if (!(await fs.pathExists(outputDir))) {
+    return [];
+  }
+
+  const matches = await glob('*/frameworks', { cwd: outputDir, absolute: true });
+  return matches.filter(isDerivedDataDir);
+}
+
+/**
+ * Scans the entire prebuild cache for DerivedData directories across every package on disk,
+ * regardless of whether the package is part of any discovered/distributed set.
+ */
+export async function findAllDerivedDataDirsAsync(): Promise<string[]> {
+  const buildRoot = getBuildCacheRoot();
+  if (!(await fs.pathExists(buildRoot))) {
+    return [];
+  }
+
+  // `**` spans the package path (including scopes like `@expo/ui`); `*` is the flavor.
+  const matches = await glob('**/output/*/frameworks', { cwd: buildRoot, absolute: true });
+  return matches.filter(isDerivedDataDir);
+}
+
+/** Returns the size of a directory in kilobytes via `du -sk`, or 0 if it can't be measured. */
+async function getDirSizeKbAsync(dir: string): Promise<number> {
+  try {
+    const { stdout } = await spawnAsync('du', ['-sk', dir]);
+    return parseInt(stdout.split('\t')[0], 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function formatSize(kb: number): string {
+  if (kb >= 1024 * 1024) {
+    return `${(kb / 1024 / 1024).toFixed(2)} GB`;
+  }
+  if (kb >= 1024) {
+    return `${(kb / 1024).toFixed(1)} MB`;
+  }
+  return `${kb} KB`;
+}
+
+/**
+ * Derives a human-readable package label from a DerivedData path, e.g.
+ * `.../.build/@expo/ui/output/debug/frameworks` → `@expo/ui`.
+ */
+function labelForDerivedDataDir(dir: string): string {
+  const rel = path.relative(getBuildCacheRoot(), dir);
+  const idx = rel.indexOf(`${path.sep}output${path.sep}`);
+  return idx === -1 ? rel : rel.slice(0, idx);
+}
+
+/**
+ * Removes intermediate build artifacts (Xcode DerivedData) while keeping the composed
+ * xcframeworks and tarballs.
+ *
+ * @param selector An empty array or `['all']` cleans every build cache found on disk;
+ *   otherwise an explicit list of package names prunes just those packages.
+ * @param options Discovery options (external package handling), used only when names are given.
+ */
+export async function prunePrebuildBuildFilesAsync(
+  selector: string[],
+  options: PruneOptions = {}
+): Promise<PruneResult> {
+  const pruneEverything = selector.length === 0 || (selector.length === 1 && selector[0] === 'all');
+
+  // Map each DerivedData dir to a display label (package name).
+  const targets: { label: string; dir: string }[] = [];
+
+  if (pruneEverything) {
+    logger.info('🔎 Scanning the prebuild cache for build files to prune...');
+    for (const dir of await findAllDerivedDataDirsAsync()) {
+      targets.push({ label: labelForDerivedDataDir(dir), dir });
+    }
+  } else {
+    const packages = await verifyAllPackagesAsync(
+      selector,
+      options.includeExternal ?? true,
+      options.externalOnly ?? false,
+      false
+    );
+    for (const pkg of packages) {
+      for (const dir of await findDerivedDataDirsAsync(pkg.buildPath)) {
+        targets.push({ label: pkg.packageName, dir });
+      }
+    }
+  }
+
+  const dryRun = options.dryRun ?? false;
+  let freedKb = 0;
+  const prunedPackages = new Set<string>();
+
+  for (const { label, dir } of targets) {
+    const kb = await getDirSizeKbAsync(dir);
+    freedKb += kb;
+    prunedPackages.add(label);
+    const action = dryRun ? 'would remove' : 'removing';
+    logger.info(
+      `🧹 ${chalk.green(label)}: ${action} ${chalk.gray(
+        path.relative(getBuildCacheRoot(), dir)
+      )} (${formatSize(kb)})`
+    );
+    if (!dryRun) {
+      await fs.remove(dir);
+    }
+  }
+
+  if (targets.length === 0) {
+    logger.info('✨ Nothing to prune — no build files found. XCFrameworks are untouched.');
+  } else if (dryRun) {
+    logger.info(
+      `\n🔍 Dry run: would prune ${chalk.cyan(targets.length)} build folder(s) across ${chalk.cyan(
+        prunedPackages.size
+      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. Re-run without --dry-run to delete.`
+    );
+  } else {
+    logger.info(
+      `\n✅ Pruned ${chalk.cyan(targets.length)} build folder(s) across ${chalk.cyan(
+        prunedPackages.size
+      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. XCFrameworks kept.`
+    );
+  }
+
+  return { exitCode: 0, removedDirs: dryRun ? 0 : targets.length, freedKb };
+}

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -42,6 +42,8 @@ export type PrebuildCliOptions = {
   verbose: boolean;
   concurrency?: number;
   bundleSharedDeps?: boolean;
+  /** Used only by `prebuild prune`: report what would be removed without deleting. */
+  dryRun?: boolean;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

When running precompile (et prebuild) locally we get a lot of big files in our repo - the things we want are the xcframeworks only.

## How

Addded a new command `et prebuild prune` that will remove the build artifacts and keep the xcframeworks.

It will make the next build run from scratch - but saves between 1-2GB of build data from each package.

## Test-plan

- ✅ Test `et prebuild prune --dry-run` to see which packages that will be cleaned
- ✅ Run `et prebuild prune` to clean packages
- ✅ Verify that the XCFrameworks are still available after running prune
