### PR TITLE
[dev-launcher] Migrate from `overridePendingTransition` to `overrideActivityTransition`

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -1,5 +1,6 @@
 package expo.modules.devlauncher.launcher
 
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import expo.modules.devlauncher.compose.BindingView
@@ -7,12 +8,21 @@ import expo.modules.devlauncher.helpers.enableEdgeToEdge
 
 class DevLauncherActivity : AppCompatActivity() {
   override fun onStart() {
-    overridePendingTransition(0, 0)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      @Suppress("DEPRECATION")
+      overridePendingTransition(0, 0)
+    }
     super.onStart()
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+      overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+    }
+
     window.enableEdgeToEdge()
 
     setContentView(
@@ -21,7 +31,10 @@ class DevLauncherActivity : AppCompatActivity() {
   }
 
   override fun onPause() {
-    overridePendingTransition(0, 0)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      @Suppress("DEPRECATION")
+      overridePendingTransition(0, 0)
+    }
     super.onPause()
   }
 }


### PR DESCRIPTION
# Why

`overridePendingTransition` was deprecated:

```gradle
`packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt:10:5` - 'fun overridePendingTransition(p0: Int, p1: Int): Unit' is deprecated. Deprecated in Java.
`packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt:24:5` - 'fun overridePendingTransition(p0: Int, p1: Int): Unit' is deprecated. Deprecated in Java.
```

# How

- Keep the previous flow for Android API level < 34
- For API >= 34, use `overrideActivityTransition` in `onCreate` with both `OVERRIDE_TRANSITION_OPEN` and `OVERRIDE_TRANSITION_CLOSE`

Related docs: https://developer.android.com/about/versions/14/features/predictive-back#custom-activity
Similar usage in AOSP: https://android.googlesource.com/platform/frameworks/base/+/c98f60b12bcb/packages/CredentialManager/src/com/android/credentialmanager/CredentialSelectorActivity.kt

# Test Plan

BareExpo
