### PR TITLE
[expo-module-scripts] Fix lint error

### DIFF
--- a/packages/expo-module-scripts/createJestPreset.cjs
+++ b/packages/expo-module-scripts/createJestPreset.cjs
@@ -4,10 +4,7 @@ const { createModulesTransform } = require('./jest-modules-transform.cjs');
 
 // NOTE: Many modules ship as ESM-only but are otherwise ready to be used directly
 // We can manually list them here to extend support to them and only transpile to CJS with SWC
-const cjsTransformIncludeNames = [
-  '@react-navigation',
-  'standard-navigation',
-];
+const cjsTransformIncludeNames = ['@react-navigation', 'standard-navigation'];
 
 // WARN: Packages here ship Flow/untranspiled source or ESM and assume a transforming bundler
 // Anything not listed (e.g. plain-CommonJS deps) runs as-is to keep test transforms fast


### PR DESCRIPTION
# Why
`check-packages` is failing due to formatting issue.

Ref: https://github.com/expo/expo/actions/runs/28161961060/job/83404457134

# How

- Ran `pnpm format`

# Test Plan

Green CI
