### PR TITLE
[cli] add agent detection to telemetry

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -78,6 +78,7 @@
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0",
     "accepts": "^1.3.8",
+    "agent-cli-detector": "^0.1.2",
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",

--- a/packages/@expo/cli/src/utils/telemetry/Telemetry.ts
+++ b/packages/@expo/cli/src/utils/telemetry/Telemetry.ts
@@ -5,6 +5,7 @@ import { env } from '../env';
 import { FetchClient } from './clients/FetchClient';
 import { FetchDetachedClient } from './clients/FetchDetachedClient';
 import type { TelemetryClient, TelemetryClientStrategy, TelemetryRecord } from './types';
+import { getAgentTelemetryContext } from './utils/agent';
 import { createContext } from './utils/context';
 
 const debug = require('debug')('expo:telemetry') as typeof console.log;
@@ -90,6 +91,8 @@ export class Telemetry {
   }
 
   private recordInternal(records: TelemetryRecord[]) {
+    const agent = getAgentTelemetryContext();
+
     return this.client.record(
       records.map((record) => ({
         ...record,
@@ -101,6 +104,7 @@ export class Telemetry {
         context: {
           ...this.context,
           sessionId: this.actor.sessionId,
+          ...(agent ? { agent } : {}),
           client: { mode: this.client.strategy },
         },
       }))

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/Telemetry.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/Telemetry.test.ts
@@ -1,5 +1,19 @@
 import { Telemetry } from '../Telemetry';
 import { commandEvent } from '../events';
+import { getAgentTelemetryContext } from '../utils/agent';
+
+jest.mock('../utils/agent', () => ({
+  getAgentTelemetryContext: jest.fn(),
+}));
+
+const getAgentTelemetryContextMock = getAgentTelemetryContext as jest.MockedFunction<
+  typeof getAgentTelemetryContext
+>;
+
+beforeEach(() => {
+  getAgentTelemetryContextMock.mockReset();
+  getAgentTelemetryContextMock.mockReturnValue(null);
+});
 
 it('starts with default detached client', () => {
   const telemetry = new Telemetry({ anonymousId: 'xxx' });
@@ -25,6 +39,7 @@ it('waits until telemetry is initialized', () => {
   expect(client.record).toHaveBeenCalledWith([
     expect.objectContaining({
       userHash: null,
+      context: expect.not.objectContaining({ agent: expect.anything() }),
     }),
   ]);
 });
@@ -50,11 +65,32 @@ it('preprocesses all records', () => {
       }),
     }),
   ]);
+  expect(client.record.mock.calls[0][0][0].context).not.toHaveProperty('agent');
 
   // Ensure the user hash was used instead of the actual user id
   expect(client.record).toHaveBeenCalledWith([
     expect.objectContaining({
       userHash: expect.not.stringMatching('yyy'),
+    }),
+  ]);
+});
+
+it('adds detected agent context to all records', () => {
+  getAgentTelemetryContextMock.mockReturnValue({ id: 'codex', sessionId: 'zzz' });
+
+  const telemetry = new Telemetry({ anonymousId: 'xxx', userId: 'yyy' });
+  const client = mockTelemetryClient(telemetry);
+
+  telemetry.record(commandEvent('start'));
+
+  expect(client.record).toHaveBeenCalledWith([
+    expect.objectContaining({
+      context: expect.objectContaining({
+        agent: {
+          id: 'codex',
+          sessionId: 'zzz',
+        },
+      }),
     }),
   ]);
 });

--- a/packages/@expo/cli/src/utils/telemetry/utils/agent.ts
+++ b/packages/@expo/cli/src/utils/telemetry/utils/agent.ts
@@ -1,0 +1,31 @@
+import { detectAgent } from 'agent-cli-detector';
+
+const debug = require('debug')('expo:telemetry:agent') as typeof console.log;
+
+export type AgentTelemetryContext = {
+  id: string;
+  sessionId: string | undefined;
+};
+
+let agentTelemetryContext: AgentTelemetryContext | null | undefined;
+
+export function getAgentTelemetryContext(): AgentTelemetryContext | null {
+  if (agentTelemetryContext === undefined) {
+    agentTelemetryContext = resolveAgentTelemetryContext();
+  }
+
+  return agentTelemetryContext;
+}
+
+function resolveAgentTelemetryContext(): AgentTelemetryContext | null {
+  try {
+    const { agent, detected } = detectAgent();
+    if (!detected || agent == null) {
+      return null;
+    }
+    return { id: agent.id, sessionId: agent.sessionId };
+  } catch (error: any) {
+    debug('Failed to detect coding agent: %s', error?.message ?? error);
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,6 +1895,9 @@ importers:
       accepts:
         specifier: ^1.3.8
         version: 1.3.8
+      agent-cli-detector:
+        specifier: ^0.1.2
+        version: 0.1.2
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -10047,6 +10050,11 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agent-cli-detector@0.1.2:
+    resolution: {integrity: sha512-qdZ/9JFORtTKJNhT/IczMeEfEUbUU0K5umYeiIQHX+AjHs+Y9SXVzSgaYlpZeyNMrvuh2HpZiOTpvS57iPfBkQ==}
+    engines: {node: '>=18.18'}
+    hasBin: true
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -19099,6 +19107,8 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  agent-cli-detector@0.1.2: {}
 
   aggregate-error@3.1.0:
     dependencies:


### PR DESCRIPTION
Adds `agent-cli-detector` to Expo CLI telemetry so events recorded from known coding agents include lightweight agent context. The CLI uses `agent-cli-detector@0.1.2`, which exposes a CommonJS entry point, so detection stays synchronous and does not participate in telemetry initialization.

When a known agent is detected, telemetry event context includes:

```ts
context.agent = {
  id: string,
  sessionId: string | undefined,
}
```

When no known agent is detected, `context.agent` is omitted to keep RudderStack and BigQuery payloads sparse. CLI version is already available in telemetry, so analysis can distinguish newer CLI versions with no detected agent from older CLI versions without this integration.

Tests cover detected and undetected telemetry payloads. Locally verified with `format`, `lint`, `depscheck`, and the focused telemetry Jest tests.