### PR TITLE
[tools] Backport prebuild prune support to SDK 57

### DIFF
--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -32,7 +32,7 @@ export default (program: Command) => {
   program
     .command('prebuild-packages [packageNames...]')
     .description(
-      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, discovers all packages with spm.config.json.'
+      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.'
     )
     .alias('prebuild')
     .option(
@@ -92,6 +92,11 @@ export default (program: Command) => {
     .option(
       '--external-only',
       'Build only external (third-party) packages. Implies --include-external.',
+      false
+    )
+    .option(
+      '--all-packages',
+      'When no package names are given, build every Expo package with an spm.config.json instead of only the default distributed set.',
       false
     )
     .option(

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -1,5 +1,6 @@
 import { Command } from '@expo/commander';
 
+import { prunePrebuildBuildFilesAsync } from '../prebuilds/Prune';
 import {
   createRequest,
   createContext,
@@ -24,6 +25,18 @@ export async function runPrebuildPackagesAsync(
 }
 
 async function main(packageNames: string[], options: PrebuildCliOptions) {
+  // `et prebuild prune [all | <packageNames...>]` removes the intermediate build files
+  // (Xcode DerivedData) while keeping the composed xcframeworks. It's keyed off the first
+  // positional rather than a real subcommand because the CLI dispatches on the command name.
+  if (packageNames[0] === 'prune') {
+    const { exitCode } = await prunePrebuildBuildFilesAsync(packageNames.slice(1), {
+      includeExternal: options.includeExternal,
+      externalOnly: options.externalOnly,
+      dryRun: options.dryRun,
+    });
+    process.exit(exitCode);
+  }
+
   const result = await runPrebuildPackagesAsync(packageNames, options);
   process.exit(result.exitCode);
 }
@@ -32,7 +45,8 @@ export default (program: Command) => {
   program
     .command('prebuild-packages [packageNames...]')
     .description(
-      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.'
+      'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.\n' +
+        'Run `et prebuild prune [packageNames...]` to delete the intermediate build files (Xcode DerivedData, ~2GB/package) while keeping the composed xcframeworks. With no names (or `all`) it cleans every build cache found on disk; pass package names to prune only those. Add --dry-run to preview what would be removed.'
     )
     .alias('prebuild')
     .option(
@@ -69,6 +83,11 @@ export default (program: Command) => {
     .option(
       '--clean-cache',
       'Clears the entire dependency cache, forcing a fresh download of all artifacts.',
+      false
+    )
+    .option(
+      '--dry-run',
+      'Only applies to `prebuild prune`: list the build files that would be removed (with sizes) without deleting anything.',
       false
     )
     .option('--skip-generate', 'Skip the generate step.', false)

--- a/tools/src/prebuilds/Prune.test.ts
+++ b/tools/src/prebuilds/Prune.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs-extra';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import { describe, it } from 'node:test';
+import path from 'path';
+
+import { findDerivedDataDirsAsync } from './Prune';
+
+describe('findDerivedDataDirsAsync', () => {
+  it('targets frameworks/ (DerivedData) and never the xcframeworks/ deliverables', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-prune-'));
+    try {
+      // Non-versioned (Expo package) layout
+      await fs.ensureDir(path.join(tmp, 'output', 'debug', 'frameworks', 'ExpoFoo', 'Build'));
+      await fs.outputFile(
+        path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.xcframework', 'x'),
+        '1'
+      );
+      await fs.outputFile(
+        path.join(tmp, 'output', 'debug', 'xcframeworks', 'ExpoFoo.tar.gz'),
+        'tar'
+      );
+      await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'ExpoFoo'));
+
+      // Versioned (external package) layout — xcframeworks live under a version prefix
+      await fs.ensureDir(path.join(tmp, 'output', 'release', 'frameworks', 'RNFoo'));
+      await fs.outputFile(
+        path.join(
+          tmp,
+          'output',
+          '1.2.3',
+          '0.83.0',
+          '1.0.0',
+          'release',
+          'xcframeworks',
+          'RNFoo.xcframework',
+          'x'
+        ),
+        '1'
+      );
+
+      // A directory literally named `frameworks` that is NOT under output/<flavor>/ must
+      // not be mistaken for DerivedData (e.g. nested inside the build products).
+      await fs.ensureDir(path.join(tmp, 'output', 'debug', 'frameworks', 'nested', 'frameworks'));
+
+      const dirs = (await findDerivedDataDirsAsync(tmp)).sort();
+
+      assert.deepEqual(dirs, [
+        path.join(tmp, 'output', 'debug', 'frameworks'),
+        path.join(tmp, 'output', 'release', 'frameworks'),
+      ]);
+      // The substring "frameworks" inside "xcframeworks" must not cause a match.
+      assert.ok(
+        !dirs.some((d) => d.includes('xcframeworks')),
+        'must not select any xcframeworks directory'
+      );
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+
+  it('returns nothing when there is no output directory', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-prune-'));
+    try {
+      assert.deepEqual(await findDerivedDataDirsAsync(tmp), []);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+});

--- a/tools/src/prebuilds/Prune.ts
+++ b/tools/src/prebuilds/Prune.ts
@@ -1,0 +1,188 @@
+/**
+ * Prune intermediate prebuild artifacts.
+ *
+ * A prebuild leaves two kinds of output under `packages/precompile/.build/<pkg>/output/`:
+ *   - `xcframeworks/` — the composed `.xcframework` and its `.tar.gz` (the deliverables)
+ *   - `frameworks/`   — the Xcode DerivedData used to build those slices (intermediates,
+ *                       module caches, per-platform `.framework` copies). This is the bulk
+ *                       (~2GB per package) and is not reusable across a clean rebuild.
+ *
+ * `prunePrebuildBuildFilesAsync` removes the DerivedData (`frameworks/`) while keeping
+ * everything in `xcframeworks/`. It mirrors the cleanup the external SPM dependency path
+ * already does (`SPMBuild` removes its DerivedData after composing).
+ *
+ * With no names (or `all`) it scans the entire `.build` directory and cleans every cache on
+ * disk — independent of package discovery, so it also catches packages that aren't part of
+ * the default distributed set (e.g. `@expo/ui`). With explicit names it prunes just those.
+ */
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import { glob } from 'glob';
+import path from 'path';
+
+import { getPrecompileDir } from '../Directories';
+import logger from '../Logger';
+import { verifyAllPackagesAsync } from './Utils';
+
+export type PruneOptions = {
+  /** Include external (third-party) packages in discovery. Defaults to true. */
+  includeExternal?: boolean;
+  /** Prune only external (third-party) packages. Defaults to false. */
+  externalOnly?: boolean;
+  /** Report what would be removed and how much it would free, without deleting anything. */
+  dryRun?: boolean;
+};
+
+export type PruneResult = {
+  exitCode: number;
+  removedDirs: number;
+  freedKb: number;
+};
+
+/** Root of the centralized prebuild cache: `packages/precompile/.build/`. */
+function getBuildCacheRoot(): string {
+  return path.join(getPrecompileDir(), '.build');
+}
+
+/**
+ * Returns true for a directory that is a DerivedData root. DerivedData always lives at
+ * `output/<flavor>/frameworks` (non-versioned, even for versioned external packages whose
+ * xcframeworks are version-prefixed), so we match the literal `frameworks` segment under
+ * `output/`. This can never match the `xcframeworks` deliverables (different path segment).
+ */
+function isDerivedDataDir(dir: string): boolean {
+  return path.basename(dir) === 'frameworks' && path.dirname(path.dirname(dir)).endsWith('output');
+}
+
+/**
+ * Resolves the DerivedData directories to remove under a single package's `output/` tree.
+ */
+export async function findDerivedDataDirsAsync(buildPath: string): Promise<string[]> {
+  const outputDir = path.join(buildPath, 'output');
+  if (!(await fs.pathExists(outputDir))) {
+    return [];
+  }
+
+  const matches = await glob('*/frameworks', { cwd: outputDir, absolute: true });
+  return matches.filter(isDerivedDataDir);
+}
+
+/**
+ * Scans the entire prebuild cache for DerivedData directories across every package on disk,
+ * regardless of whether the package is part of any discovered/distributed set.
+ */
+export async function findAllDerivedDataDirsAsync(): Promise<string[]> {
+  const buildRoot = getBuildCacheRoot();
+  if (!(await fs.pathExists(buildRoot))) {
+    return [];
+  }
+
+  // `**` spans the package path (including scopes like `@expo/ui`); `*` is the flavor.
+  const matches = await glob('**/output/*/frameworks', { cwd: buildRoot, absolute: true });
+  return matches.filter(isDerivedDataDir);
+}
+
+/** Returns the size of a directory in kilobytes via `du -sk`, or 0 if it can't be measured. */
+async function getDirSizeKbAsync(dir: string): Promise<number> {
+  try {
+    const { stdout } = await spawnAsync('du', ['-sk', dir]);
+    return parseInt(stdout.split('\t')[0], 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function formatSize(kb: number): string {
+  if (kb >= 1024 * 1024) {
+    return `${(kb / 1024 / 1024).toFixed(2)} GB`;
+  }
+  if (kb >= 1024) {
+    return `${(kb / 1024).toFixed(1)} MB`;
+  }
+  return `${kb} KB`;
+}
+
+/**
+ * Derives a human-readable package label from a DerivedData path, e.g.
+ * `.../.build/@expo/ui/output/debug/frameworks` → `@expo/ui`.
+ */
+function labelForDerivedDataDir(dir: string): string {
+  const rel = path.relative(getBuildCacheRoot(), dir);
+  const idx = rel.indexOf(`${path.sep}output${path.sep}`);
+  return idx === -1 ? rel : rel.slice(0, idx);
+}
+
+/**
+ * Removes intermediate build artifacts (Xcode DerivedData) while keeping the composed
+ * xcframeworks and tarballs.
+ *
+ * @param selector An empty array or `['all']` cleans every build cache found on disk;
+ *   otherwise an explicit list of package names prunes just those packages.
+ * @param options Discovery options (external package handling), used only when names are given.
+ */
+export async function prunePrebuildBuildFilesAsync(
+  selector: string[],
+  options: PruneOptions = {}
+): Promise<PruneResult> {
+  const pruneEverything = selector.length === 0 || (selector.length === 1 && selector[0] === 'all');
+
+  // Map each DerivedData dir to a display label (package name).
+  const targets: { label: string; dir: string }[] = [];
+
+  if (pruneEverything) {
+    logger.info('🔎 Scanning the prebuild cache for build files to prune...');
+    for (const dir of await findAllDerivedDataDirsAsync()) {
+      targets.push({ label: labelForDerivedDataDir(dir), dir });
+    }
+  } else {
+    const packages = await verifyAllPackagesAsync(
+      selector,
+      options.includeExternal ?? true,
+      options.externalOnly ?? false,
+      false
+    );
+    for (const pkg of packages) {
+      for (const dir of await findDerivedDataDirsAsync(pkg.buildPath)) {
+        targets.push({ label: pkg.packageName, dir });
+      }
+    }
+  }
+
+  const dryRun = options.dryRun ?? false;
+  let freedKb = 0;
+  const prunedPackages = new Set<string>();
+
+  for (const { label, dir } of targets) {
+    const kb = await getDirSizeKbAsync(dir);
+    freedKb += kb;
+    prunedPackages.add(label);
+    const action = dryRun ? 'would remove' : 'removing';
+    logger.info(
+      `🧹 ${chalk.green(label)}: ${action} ${chalk.gray(
+        path.relative(getBuildCacheRoot(), dir)
+      )} (${formatSize(kb)})`
+    );
+    if (!dryRun) {
+      await fs.remove(dir);
+    }
+  }
+
+  if (targets.length === 0) {
+    logger.info('✨ Nothing to prune — no build files found. XCFrameworks are untouched.');
+  } else if (dryRun) {
+    logger.info(
+      `\n🔍 Dry run: would prune ${chalk.cyan(targets.length)} build folder(s) across ${chalk.cyan(
+        prunedPackages.size
+      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. Re-run without --dry-run to delete.`
+    );
+  } else {
+    logger.info(
+      `\n✅ Pruned ${chalk.cyan(targets.length)} build folder(s) across ${chalk.cyan(
+        prunedPackages.size
+      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. XCFrameworks kept.`
+    );
+  }
+
+  return { exitCode: 0, removedDirs: dryRun ? 0 : targets.length, freedKb };
+}

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -6,7 +6,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { before, describe, it, afterEach } from 'node:test';
 
-import { getVersionsInfoAsync, isNonInteractive, setForceNonInteractive } from './Utils';
+import {
+  getVersionsInfoAsync,
+  isNonInteractive,
+  selectDistributedPackages,
+  setForceNonInteractive,
+  IOS_PREBUILD_PACKAGES,
+} from './Utils';
 import { resolvePackagePath } from './resolvePackage';
 
 // ---------------------------------------------------------------------------
@@ -63,6 +69,34 @@ describe('isNonInteractive', () => {
     process.env.CI = '';
     setForceNonInteractive(false);
     assert.equal(isNonInteractive(), true);
+  });
+});
+
+describe('selectDistributedPackages', () => {
+  const fakePackages = [
+    { packageName: 'expo-modules-core' },
+    { packageName: 'expo-video' },
+    { packageName: 'expo-age-range' },
+    { packageName: 'expo-blur' },
+  ] as any[];
+
+  it('keeps only the distributed set when allPackages is false', () => {
+    const result = selectDistributedPackages(fakePackages, false);
+    assert.deepEqual(
+      result.map((p) => p.packageName),
+      ['expo-modules-core', 'expo-video']
+    );
+  });
+
+  it('returns every package unchanged when allPackages is true', () => {
+    const result = selectDistributedPackages(fakePackages, true);
+    assert.equal(result, fakePackages);
+  });
+
+  it('IOS_PREBUILD_PACKAGES lists the 15 distributed packages', () => {
+    assert.equal(IOS_PREBUILD_PACKAGES.length, 15);
+    assert.ok(IOS_PREBUILD_PACKAGES.includes('expo-modules-core'));
+    assert.ok(!IOS_PREBUILD_PACKAGES.includes('expo-age-range'));
   });
 });
 

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -146,6 +146,39 @@ export const discoverAllSPMPackagesAsync = async (): Promise<SPMPackageSource[]>
 };
 
 /**
+ * Packages whose iOS prebuilt xcframeworks are distributed by default: built by
+ * `et prebuild-packages` with no arguments and bundled into the published npm tarballs.
+ * Many more packages have an `spm.config.json`; pass `--all-packages` to build those too.
+ */
+export const IOS_PREBUILD_PACKAGES = [
+  'expo-brownfield',
+  'expo-camera',
+  'expo-contacts',
+  'expo-file-system',
+  'expo-font',
+  'expo-image',
+  'expo-image-manipulator',
+  'expo-live-photo',
+  'expo-location',
+  'expo-maps',
+  'expo-media-library',
+  'expo-modules-core',
+  'expo-print',
+  'expo-ui',
+  'expo-video',
+];
+
+export const selectDistributedPackages = <T extends { packageName: string }>(
+  expoPackages: T[],
+  allPackages: boolean
+): T[] => {
+  if (allPackages) {
+    return expoPackages;
+  }
+  return expoPackages.filter((pkg) => IOS_PREBUILD_PACKAGES.includes(pkg.packageName));
+};
+
+/**
  * Builds a map from CocoaPods pod name to SPM dependency string
  * (e.g., "UMAppLoader" -> "unimodules-app-loader/UMAppLoader").
  *
@@ -294,22 +327,30 @@ export const validateAllPodNamesAsync = async (
  * @param packageNames Names of packages to verify (if empty, discovers all SPM packages)
  * @param includeExternal Whether to include external packages in discovery (default: true)
  * @param externalOnly Whether to only include external packages (default: false)
+ * @param allPackages When discovering, build every Expo package with an spm.config.json
+ *   instead of only the default distributed set (default: false)
  * @returns Parsed SPMPackageSources that were verified
  */
 export const verifyAllPackagesAsync = async (
   packageNames: string[],
   includeExternal: boolean = true,
-  externalOnly: boolean = false
+  externalOnly: boolean = false,
+  allPackages: boolean = false
 ): Promise<SPMPackageSource[]> => {
-  // If no package names provided, discover all packages with spm.config.json
+  // If no package names provided, discover packages with spm.config.json. By default
+  // only the distributed set is built; --all-packages widens this to every Expo package.
   if (packageNames.length === 0) {
     let packages: SPMPackageSource[];
     if (externalOnly) {
       packages = await discoverExternalPackagesAsync();
     } else if (includeExternal) {
-      packages = await discoverAllSPMPackagesAsync();
+      const [expoPackages, externalPackages] = await Promise.all([
+        discoverPackagesWithSPMConfigAsync(),
+        discoverExternalPackagesAsync(),
+      ]);
+      packages = [...selectDistributedPackages(expoPackages, allPackages), ...externalPackages];
     } else {
-      packages = await discoverPackagesWithSPMConfigAsync();
+      packages = selectDistributedPackages(await discoverPackagesWithSPMConfigAsync(), allPackages);
     }
 
     if (packages.length === 0) {

--- a/tools/src/prebuilds/index.ts
+++ b/tools/src/prebuilds/index.ts
@@ -10,6 +10,8 @@ export {
   discoverAllSPMPackagesAsync,
   discoverPackagesWithSPMConfigAsync,
   getVersionsInfoAsync,
+  IOS_PREBUILD_PACKAGES,
+  selectDistributedPackages,
   validateAllPodNamesAsync,
   validatePodNamesAsync,
   verifyAllPackagesAsync,

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -42,6 +42,8 @@ export type PrebuildCliOptions = {
   verbose: boolean;
   concurrency?: number;
   bundleSharedDeps?: boolean;
+  /** Used only by `prebuild prune`: report what would be removed without deleting. */
+  dryRun?: boolean;
 };
 
 // ---------------------------------------------------------------------------

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -36,6 +36,7 @@ export type PrebuildCliOptions = {
   platform?: BuildPlatform;
   includeExternal?: boolean;
   externalOnly?: boolean;
+  allPackages?: boolean;
   sign?: string;
   noTimestamp?: boolean;
   verbose: boolean;
@@ -61,6 +62,7 @@ export interface PrebuildRequest {
   readonly platformFilter?: BuildPlatform;
   readonly includeExternal: boolean;
   readonly externalOnly: boolean;
+  readonly allPackages: boolean;
   readonly signing?: SigningOptions;
   readonly verbose: boolean;
   readonly bundleSharedDeps: boolean;
@@ -142,6 +144,7 @@ export function createRequest(
     platformFilter: options.platform,
     includeExternal: !!(options.includeExternal || options.externalOnly),
     externalOnly: options.externalOnly ?? false,
+    allPackages: options.allPackages ?? false,
     signing,
     verbose: options.verbose,
     localTarballTemplates: {

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -498,15 +498,17 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     } else if (request.externalOnly) {
       logger.info(`📦 Discovering external packages with spm.config.json...`);
     } else {
+      const scope = request.allPackages ? 'all' : 'the default distributed set of';
       const externalNote = request.includeExternal ? ' (including external packages)' : '';
-      logger.info(`📦 Discovering packages with spm.config.json${externalNote}...`);
+      logger.info(`📦 Discovering ${scope} packages with spm.config.json${externalNote}...`);
     }
 
-    // 1. Verify packages exist and have spm.config.json (or discover all)
+    // 1. Verify packages exist and have spm.config.json (or discover the default set)
     const requestedPackages = await verifyAllPackagesAsync(
       request.packageNames,
       request.includeExternal,
-      request.externalOnly
+      request.externalOnly,
+      request.allPackages
     );
 
     // 2. Auto-add unbuilt dependencies to the build set

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -7,6 +7,7 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner, spawnAsync } from '../../Utils';
 import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
+import { IOS_PREBUILD_PACKAGES } from '../../prebuilds/Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 /**
@@ -117,27 +118,6 @@ export async function ensureSupportedToolchainAsync(
     }
   };
 }
-
-/**
- * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
- */
-const IOS_PREBUILD_PACKAGES = [
-  'expo-brownfield',
-  'expo-camera',
-  'expo-contacts',
-  'expo-file-system',
-  'expo-font',
-  'expo-image',
-  'expo-image-manipulator',
-  'expo-live-photo',
-  'expo-location',
-  'expo-maps',
-  'expo-media-library',
-  'expo-modules-core',
-  'expo-print',
-  'expo-ui',
-  'expo-video',
-];
 
 // Names of the publish set's packages that ship iOS prebuilds (empty when none do).
 export function iosPrebuildPackagesInSet(parcels: Parcel[]): string[] {


### PR DESCRIPTION
## Why

Backports `et prebuild prune` to the **sdk-57** release branch. When running precompile (`et prebuild`) locally we accumulate large intermediate build artifacts (Xcode DerivedData, ~1–2 GB per package); the only outputs we want to keep are the composed `.xcframework`s.

Cherry-picks #47243 (`feat(precompile) add prune support`). That commit depends on #46925 (`[tools] Only build default package set`), which was missing from this branch, so it is cherry-picked first — it also gives us the `--all-packages` option and the "build only the default distributed set" default, which is a welcome improvement for local package builds.

## How

Two cherry-picks onto `sdk-57`:

- `417aaaa04a7` — `[tools] Only build default package set (#46925)` (prerequisite: adds the `allPackages` param to `verifyAllPackagesAsync`, the `--all-packages` CLI option, and moves `IOS_PREBUILD_PACKAGES` into `prebuilds/Utils.ts`).
- `198485b919a` — `feat(precompile) add prune support (#47243)`: new `et prebuild prune [packageNames...]` that deletes intermediate build files while keeping the xcframeworks. `--dry-run` previews what would be removed.

One conflict during the prerequisite pick, in `tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts`: this branch carries the SDK-only `f724bae2023` ("Fail fast on missing iOS toolchain") refactor in the same region. Resolved by keeping the fail-fast toolchain code and taking the upstream move of `IOS_PREBUILD_PACKAGES` into `Utils.ts`. The prune commit then applied with no conflicts.

## Test Plan

- ✅ `tsc --noEmit` on `tools` — clean
- ✅ `node --test` on `Prune.test.js` + `Utils.test.js` — 13/13 pass
- ✅ `et prebuild prune --dry-run` — scans and reports, xcframeworks untouched

## Checklist

- [x] Builds, type-checks, and tests (tools-only change; no published-package CHANGELOG entry needed)
- [ ] N/A — no native or docs changes
