### PR TITLE
feat(cli,dev-launcher,updates): Provide and resolve relative manifest URLs against request base URLs

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -137,7 +137,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
         this[UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY] = "ALWAYS"
         this[UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY] = 60000
       }
-      this[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders
+      this[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders(httpManifestUrl)
       this[UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY] = "exposdk:${Constants.SDK_VERSION}"
       // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates from the multipart manifest response part
       this[UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE] = context.assets.open("expo-root.pem").readBytes().decodeToString()
@@ -333,30 +333,40 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
   }
 
   // XDL expects the full "exponent-" header names
-  private val requestHeaders: Map<String, String?>
-    get() {
-      val headers = mutableMapOf<String, String>()
-      headers["Expo-Updates-Environment"] = clientEnvironment
-      headers["Expo-Client-Environment"] = clientEnvironment
-      val versionName = ExpoViewKernel.instance.versionName
-      if (versionName != null) {
-        headers["Exponent-Version"] = versionName
-      }
-      val sessionSecret = exponentSharedPreferences.sessionSecret
-      if (sessionSecret != null) {
-        headers["Expo-Session"] = sessionSecret
-      }
-
-      // XDL expects the full "exponent-" header names
-      headers["Exponent-Accept-Signature"] = "true"
-      headers["Exponent-Platform"] = "android"
-      if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
-        headers["Exponent-SDK-Version"] = "UNVERSIONED"
-      } else {
-        headers["Exponent-SDK-Version"] = Constants.SDK_VERSION
-      }
-      return headers
+  private fun requestHeaders(manifestUrl: Uri): Map<String, String?> {
+    val headers = mutableMapOf<String, String>()
+    headers["Expo-Updates-Environment"] = clientEnvironment
+    headers["Expo-Client-Environment"] = clientEnvironment
+    headers.putAll(getForwardedHeaders(manifestUrl))
+    val versionName = ExpoViewKernel.instance.versionName
+    if (versionName != null) {
+      headers["Exponent-Version"] = versionName
     }
+    val sessionSecret = exponentSharedPreferences.sessionSecret
+    if (sessionSecret != null) {
+      headers["Expo-Session"] = sessionSecret
+    }
+
+    // XDL expects the full "exponent-" header names
+    headers["Exponent-Accept-Signature"] = "true"
+    headers["Exponent-Platform"] = "android"
+    if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
+      headers["Exponent-SDK-Version"] = "UNVERSIONED"
+    } else {
+      headers["Exponent-SDK-Version"] = Constants.SDK_VERSION
+    }
+    return headers
+  }
+
+  private fun getForwardedHeaders(url: Uri): Map<String, String> {
+    val authority = url.encodedAuthority ?: return emptyMap()
+    val scheme = url.scheme ?: return emptyMap()
+    return mutableMapOf(
+      "Forwarded" to "host=\"$authority\";proto=$scheme",
+      "X-Forwarded-Host" to authority,
+      "X-Forwarded-Proto" to scheme
+    )
+  }
 
   private val clientEnvironment: String
     get() = if (EmulatorUtilities.isRunningOnEmulator()) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -2,6 +2,7 @@
 package host.exp.exponent
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.easclient.EASClientID

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -196,7 +196,9 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
           override fun onManifestCompleted(manifest: Manifest) {
             lifecycleScope.launch {
               try {
-                val bundleUrl = ExponentUrls.toHttp(manifest.getBundleURL())
+                val bundleUrl = ExponentUrls.toHttp(
+                  ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), this@ExperienceActivity.manifestUrl!!)
+                )
                 setManifest(
                   this@ExperienceActivity.manifestUrl!!,
                   manifest,

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -83,7 +83,11 @@ class InternalHeadlessAppLoader(private val context: Context) :
         override fun onManifestCompleted(manifest: Manifest) {
           Exponent.instance.runOnUiThread {
             try {
-              setManifest(manifestUrl!!, manifest, ExponentUrls.toHttp(manifest.getBundleURL()))
+              val bundleUrl = ExponentUrls.toHttp(
+                ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), manifestUrl!!)
+              )
+              activityIdToBundleUrl.put(activityId, bundleUrl)
+              setManifest(manifestUrl!!, manifest, bundleUrl)
             } catch (e: JSONException) {
               this@InternalHeadlessAppLoader.callback!!.onComplete(false, Exception(e.message))
             }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -86,7 +86,6 @@ class InternalHeadlessAppLoader(private val context: Context) :
               val bundleUrl = ExponentUrls.toHttp(
                 ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), manifestUrl!!)
               )
-              activityIdToBundleUrl.put(activityId, bundleUrl)
               setManifest(manifestUrl!!, manifest, bundleUrl)
             } catch (e: JSONException) {
               this@InternalHeadlessAppLoader.callback!!.onComplete(false, Exception(e.message))

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -4,8 +4,10 @@ package host.exp.exponent.kernel
 import android.net.Uri
 import expo.modules.jsonutils.require
 import host.exp.exponent.Constants
+import host.exp.exponent.ExponentManifest
 import okhttp3.Request
 import org.json.JSONObject
+import java.net.URI
 
 object ExponentUrls {
   private val HTTPS_HOSTS = setOf(
@@ -26,6 +28,11 @@ object ExponentUrls {
     val uri = Uri.parse(rawUrl)
     val useHttps = isHttpsHost(uri.host) || rawUrl.startsWith("exps")
     return uri.buildUpon().scheme(if (useHttps) "https" else "http").build().toString()
+  }
+
+  @JvmStatic fun resolveManifestUrl(rawUrl: String, manifestUrl: String): String {
+    val baseUrl = ExponentManifest.httpManifestUrl(manifestUrl).toString()
+    return URI(baseUrl).resolve(rawUrl).toString()
   }
 
   @JvmStatic fun addExponentHeadersToUrl(urlString: String): Request.Builder {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -32,7 +32,11 @@ object ExponentUrls {
 
   @JvmStatic fun resolveManifestUrl(rawUrl: String, manifestUrl: String): String {
     val baseUrl = ExponentManifest.httpManifestUrl(manifestUrl).toString()
-    return URI(baseUrl).resolve(rawUrl).toString()
+    return try {
+      URI(baseUrl).resolve(rawUrl).toString()
+    } catch (e: Exception) {
+      rawUrl
+    }
   }
 
   @JvmStatic fun addExponentHeadersToUrl(urlString: String): Request.Builder {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -693,7 +693,7 @@ class Kernel : KernelInterface() {
     manifest: Manifest,
     existingTask: AppTask?
   ) {
-    val bundleUrl = toHttp(manifest.getBundleURL())
+    val bundleUrl = toHttp(ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), manifestUrl))
     val task = getExperienceActivityTask(manifestUrl)
     task.bundleUrl = bundleUrl
     if (existingTask == null) {

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
@@ -60,7 +60,7 @@ public class DevMenuManager: NSObject {
 
   var currentBundleURL: URL? {
     guard let manifest = currentManifest else { return nil }
-    return ApiUtil.bundleUrlFromManifest(manifest)
+    return ApiUtil.bundleUrlFromManifest(manifest, relativeTo: currentManifestURL)
   }
 
   var hasActiveApp: Bool {

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
                             error:(void (^)(NSError *))errorBlock
 {
   EXJavaScriptResource *jsResource = [[EXJavaScriptResource alloc] initWithBundleName:[self.dataSource bundleResourceNameForAppFetcher:self withManifest:manifest]
-                                                                            remoteUrl:[EXApiUtil bundleUrlFromManifest:manifest]
+                                                                            remoteUrl:[EXApiUtil bundleUrlFromManifest:manifest relativeTo:self.appLoader.manifestUrl]
                                                                       devToolsEnabled:manifest.isUsingDeveloperTool];
   jsResource.abiVersion = [[EXVersions sharedInstance] availableSdkVersionForManifest:manifest];
   jsResource.requestTimeoutInterval = timeoutInterval;
@@ -65,4 +65,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXApiUtil.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXApiUtil.swift
@@ -6,10 +6,23 @@ import EXManifests
 @objcMembers
 public class ApiUtil: NSObject {
   public static func bundleUrlFromManifest(_ manifest: Manifest) -> URL? {
-    return self.encodedUrlFromString(manifest.bundleUrl())
+    return bundleUrlFromManifest(manifest, relativeTo: nil)
+  }
+
+  public static func bundleUrlFromManifest(_ manifest: Manifest, relativeTo manifestUrl: URL?) -> URL? {
+    return self.encodedUrlFromString(manifest.bundleUrl(), relativeTo: manifestUrl)
   }
 
   public static func encodedUrlFromString(_ urlString: String) -> URL? {
-    return URL(string: urlString) ?? URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")
+    return encodedUrlFromString(urlString, relativeTo: nil)
+  }
+
+  public static func encodedUrlFromString(_ urlString: String, relativeTo baseUrl: URL?) -> URL? {
+    let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    if let baseUrl = baseUrl {
+      return URL(string: urlString, relativeTo: baseUrl)?.absoluteURL
+        ?? URL(string: encodedUrlString, relativeTo: baseUrl)?.absoluteURL
+    }
+    return URL(string: urlString) ?? URL(string: encodedUrlString)
   }
 }

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -781,14 +781,31 @@ static BOOL isEASUpdateHost(NSString * _Nullable host)
       @"Expo-Client-Release-Type": [EXClientReleaseType clientReleaseType]
   };
 
+  NSMutableDictionary *requestHeadersMutable = [requestHeaders mutableCopy];
+  [requestHeadersMutable addEntriesFromDictionary:[self forwardedHeadersForURL:[[self class] _httpUrlFromManifestUrl:_manifestUrl]]];
+
   NSString *sessionSecret = [[EXSession sharedInstance] sessionSecret];
   if (sessionSecret) {
-    NSMutableDictionary *requestHeadersMutable = [requestHeaders mutableCopy];
     requestHeadersMutable[@"Expo-Session"] = sessionSecret;
-    requestHeaders = requestHeadersMutable;
   }
 
-  return requestHeaders;
+  return requestHeadersMutable;
+}
+
+- (NSDictionary *)forwardedHeadersForURL:(NSURL *)url
+{
+  NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+  if (!components.host || !components.scheme) {
+    return @{};
+  }
+
+  NSString *authority = components.port ? [NSString stringWithFormat:@"%@:%@", components.host, components.port] : components.host;
+  NSMutableDictionary *headers = @{
+    @"Forwarded": [NSString stringWithFormat:@"host=\"%@\";proto=%@", authority, components.scheme],
+    @"X-Forwarded-Host": authority,
+    @"X-Forwarded-Proto": components.scheme,
+  }.mutableCopy;
+  return headers;
 }
 
 - (NSString *)_userAgentString

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -233,7 +233,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (NSURL *)bundleUrl
 {
-  return [EXApiUtil bundleUrlFromManifest:_appRecord.appLoader.manifest];
+  return [EXApiUtil bundleUrlFromManifest:_appRecord.appLoader.manifest relativeTo:_appRecord.appLoader.manifestUrl];
 }
 
 #pragma mark - EXAppFetcherDataSource

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
 - Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))
+- Emit relative asset URLs and `bundleUrl` in manifest responses conditionally ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -53,6 +53,14 @@ interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
   expectSignature: string | null;
 }
 
+function shouldUseRelativeManifestUrls(req: ServerRequest): boolean {
+  return !!(
+    req.headers['forwarded'] ||
+    req.headers['x-forwarded-host'] ||
+    req.headers['x-forwarded-proto']
+  );
+}
+
 export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
   public getParsedHeaders(req: ServerRequest): ExpoGoManifestRequestInfo {
     let platform = parsePlatformHeader(req);
@@ -101,6 +109,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       expectSignature: expectSignature ? String(expectSignature) : null,
       hostname: stripPort(req.headers['host']),
       protocol: req.headers['x-forwarded-proto'] as 'http' | 'https' | undefined,
+      ...(shouldUseRelativeManifestUrls(req) ? { shouldUseRelativeManifestUrls: true } : null),
     };
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -46,6 +46,8 @@ export interface ManifestRequestInfo {
   hostname?: string | null;
   /** The protocol used to request the manifest */
   protocol?: 'http' | 'https';
+  /** Whether URL-valued manifest fields should be emitted relative to the manifest URL. */
+  shouldUseRelativeManifestUrls?: boolean;
 }
 
 /** Project related info. */
@@ -95,9 +97,10 @@ export abstract class ManifestMiddleware<
     platform,
     hostname,
     protocol,
+    shouldUseRelativeManifestUrls,
   }: Pick<
     TManifestRequestInfo,
-    'hostname' | 'platform' | 'protocol'
+    'hostname' | 'platform' | 'protocol' | 'shouldUseRelativeManifestUrls'
   >): Promise<ResponseProjectSettings> {
     // Read the config
     const projectConfig = getConfig(this.projectRoot);
@@ -123,7 +126,7 @@ export abstract class ManifestMiddleware<
 
     const hostUri = this.options.constructUrl({ scheme: '', hostname });
 
-    const bundleUrl = this._getBundleUrl({
+    const absoluteBundleUrl = this._getBundleUrl({
       platform,
       mainModuleName,
       hostname,
@@ -140,7 +143,15 @@ export abstract class ManifestMiddleware<
     });
 
     // Resolve all assets and set them on the manifest as URLs
-    await this.mutateManifestWithAssetsAsync(projectConfig.exp, bundleUrl);
+    await this.mutateManifestWithAssetsAsync(
+      projectConfig.exp,
+      absoluteBundleUrl,
+      !!shouldUseRelativeManifestUrls
+    );
+
+    const bundleUrl = shouldUseRelativeManifestUrls
+      ? this.toPathRelativeUrl(absoluteBundleUrl)
+      : absoluteBundleUrl;
 
     return {
       expoGoConfig,
@@ -260,10 +271,22 @@ export abstract class ManifestMiddleware<
   }
 
   /** Resolve all assets and set them on the manifest as URLs */
-  private async mutateManifestWithAssetsAsync(manifest: ExpoConfig, bundleUrl: string) {
+  private toPathRelativeUrl(url: string): string {
+    const parsedUrl = new URL(url);
+    return parsedUrl.pathname.replace(/^\//, '') + parsedUrl.search + parsedUrl.hash;
+  }
+
+  private async mutateManifestWithAssetsAsync(
+    manifest: ExpoConfig,
+    bundleUrl: string,
+    shouldUseRelativeManifestUrls: boolean
+  ) {
     await resolveManifestAssets(this.projectRoot, {
       manifest,
       resolver: async (path) => {
+        if (shouldUseRelativeManifestUrls) {
+          return this.options.isNativeWebpack ? path : 'assets/' + path;
+        }
         if (this.options.isNativeWebpack) {
           // When using our custom dev server, just do assets normally
           // without the `assets/` subpath redirect.

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -170,6 +170,25 @@ describe('getParsedHeaders', () => {
       platform: 'ios',
     });
   });
+
+  it('requests relative manifest URLs when forwarding headers are present', () => {
+    expect(
+      middleware.getParsedHeaders(
+        asReq({
+          url: 'http://localhost:3000',
+          headers: {
+            host: 'localhost:8081',
+            'expo-platform': 'ios',
+            forwarded: 'host=proxy.test;proto=https',
+          },
+        })
+      )
+    ).toMatchObject({
+      hostname: 'localhost',
+      platform: 'ios',
+      shouldUseRelativeManifestUrls: true,
+    });
+  });
 });
 
 describe('_getManifestResponseAsync', () => {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -8,6 +8,7 @@ import { getPlatformBundlers } from '../../platformBundlers';
 import { createTemplateHtmlFromExpoConfigAsync } from '../../webTemplate';
 import type { ManifestRequestInfo } from '../ManifestMiddleware';
 import { ManifestMiddleware } from '../ManifestMiddleware';
+import { resolveManifestAssets } from '../resolveAssets';
 import type { ServerRequest, ServerResponse } from '../server.types';
 
 class MockServerResponse extends PassThrough {
@@ -218,6 +219,7 @@ describe('_resolveProjectSettingsAsync', () => {
     });
 
     jest.mocked(getConfig).mockClear();
+    jest.mocked(resolveManifestAssets).mockClear();
 
     middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
 
@@ -239,6 +241,33 @@ describe('_resolveProjectSettingsAsync', () => {
 
     // Limit this to a single call since it can get expensive.
     expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+  it(`returns relative bundle and asset URLs when requested`, async () => {
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'http://fake.mock'),
+      mode: 'development',
+    });
+
+    jest.mocked(getConfig).mockClear();
+    jest.mocked(resolveManifestAssets).mockClear();
+
+    middleware._getBundleUrl = jest.fn(
+      () =>
+        'http://fake.mock/index.bundle?platform=android&dev=true&hot=false&lazy=true#debug'
+    );
+
+    const settings = await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+      shouldUseRelativeManifestUrls: true,
+    } as any);
+
+    expect(settings.bundleUrl).toBe(
+      'index.bundle?platform=android&dev=true&hot=false&lazy=true#debug'
+    );
+
+    const resolver = jest.mocked(resolveManifestAssets).mock.calls[0][1].resolver;
+    await expect(resolver('./assets/icon.png')).resolves.toBe('assets/./assets/icon.png');
   });
   it(`returns the project settings for Webpack dev servers`, async () => {
     const middleware = new MockManifestMiddleware('/', {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -266,8 +266,8 @@ describe('_resolveProjectSettingsAsync', () => {
       'index.bundle?platform=android&dev=true&hot=false&lazy=true#debug'
     );
 
-    const resolver = jest.mocked(resolveManifestAssets).mock.calls[0][1].resolver;
-    await expect(resolver('./assets/icon.png')).resolves.toBe('assets/./assets/icon.png');
+    const resolver = jest.mocked(resolveManifestAssets).mock.calls?.[0]?.[1].resolver;
+    await expect(resolver?.('./assets/icon.png')).resolves.toBe('assets/./assets/icon.png');
   });
   it(`returns the project settings for Webpack dev servers`, async () => {
     const middleware = new MockManifestMiddleware('/', {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -252,8 +252,7 @@ describe('_resolveProjectSettingsAsync', () => {
     jest.mocked(resolveManifestAssets).mockClear();
 
     middleware._getBundleUrl = jest.fn(
-      () =>
-        'http://fake.mock/index.bundle?platform=android&dev=true&hot=false&lazy=true#debug'
+      () => 'http://fake.mock/index.bundle?platform=android&dev=true&hot=false&lazy=true#debug'
     );
 
     const settings = await middleware._resolveProjectSettingsAsync({

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Resolve asset URLs and `bundleUrl` from base request URL ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -48,6 +48,7 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, runtimeVersion:
   val requestHeaders = hashMapOf(
     "Expo-Updates-Environment" to "DEVELOPMENT"
   )
+  requestHeaders.putAll(getForwardedHeaders(url))
   if (installationID != null) {
     requestHeaders["Expo-Dev-Client-ID"] = installationID
   }
@@ -60,5 +61,15 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, runtimeVersion:
     "enabled" to true,
     "requestHeaders" to requestHeaders,
     "runtimeVersion" to runtimeVersion
+  )
+}
+
+private fun getForwardedHeaders(url: Uri): Map<String, String> {
+  val authority = url.encodedAuthority ?: return emptyMap()
+  val scheme = url.scheme ?: return emptyMap()
+  return mutableMapOf(
+    "Forwarded" to "host=\"$authority\";proto=$scheme",
+    "X-Forwarded-Host" to authority,
+    "X-Forwarded-Proto" to scheme
   )
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -44,9 +44,20 @@ class DevLauncherManifestParser(
       "expo-platform" to "android",
       "accept" to "application/expo+json,application/json"
     )
+    headersMap.putAll(getForwardedHeaders(url))
     if (installationID != null) {
       headersMap["expo-dev-client-id"] = installationID
     }
     return headersMap.toHeaders()
+  }
+
+  private fun getForwardedHeaders(url: Uri): Map<String, String> {
+    val authority = url.encodedAuthority ?: return emptyMap()
+    val scheme = url.scheme ?: return emptyMap()
+    return mutableMapOf(
+      "forwarded" to "host=\"$authority\";proto=$scheme",
+      "x-forwarded-host" to authority,
+      "x-forwarded-proto" to scheme
+    )
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -7,8 +7,10 @@ import expo.modules.manifests.core.Manifest
 import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.Reader
+import java.net.URI
 
 class DevLauncherManifestParser(
   private val httpClient: OkHttpClient,
@@ -35,8 +37,32 @@ class DevLauncherManifestParser(
 
   suspend fun parseManifest(): Manifest {
     downloadManifest().use {
-      return Manifest.fromManifestJson(JSONObject(it.readText()))
+      return Manifest.fromManifestJson(resolveManifestUrls(JSONObject(it.readText())))
     }
+  }
+
+  private fun resolveManifestUrls(manifestJson: JSONObject): JSONObject {
+    if (manifestJson.has("bundleUrl")) {
+      manifestJson.put("bundleUrl", resolveUrl(manifestJson.getString("bundleUrl")))
+    }
+
+    manifestJson.optJSONObject("launchAsset")?.let { launchAsset ->
+      launchAsset.put("url", resolveUrl(launchAsset.getString("url")))
+    }
+
+    manifestJson.optJSONArray("assets")?.resolveAssetUrls()
+    return manifestJson
+  }
+
+  private fun JSONArray.resolveAssetUrls() {
+    for (i in 0 until length()) {
+      val asset = getJSONObject(i)
+      asset.put("url", resolveUrl(asset.getString("url")))
+    }
+  }
+
+  private fun resolveUrl(rawUrl: String): String {
+    return URI(url.toString()).resolve(rawUrl).toString()
   }
 
   private fun getHeaders(): Headers {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -62,7 +62,11 @@ class DevLauncherManifestParser(
   }
 
   private fun resolveUrl(rawUrl: String): String {
-    return URI(url.toString()).resolve(rawUrl).toString()
+    return try {
+      URI(url.toString()).resolve(rawUrl).toString()
+    } catch (e: Exception) {
+      rawUrl
+    }
   }
 
   private fun getHeaders(): Headers {
@@ -86,4 +90,5 @@ class DevLauncherManifestParser(
       "x-forwarded-proto" to scheme
     )
   }
+
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -90,5 +90,4 @@ class DevLauncherManifestParser(
       "x-forwarded-proto" to scheme
     )
   }
-
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -107,4 +107,15 @@ internal class DevLauncherUpdatesHelperTest {
 
     Truth.assertThat((configuration["requestHeaders"] as HashMap<*, *>)["Expo-Dev-Client-ID"]).isEqualTo(installationID)
   }
+
+  @Test
+  fun `createUpdatesConfiguration sets forwarding headers`() {
+    val url = Uri.parse("https://proxy.example.dev/dev/manifest")
+    val configuration = createUpdatesConfigurationWithUrl(url, url, runtimeVersion, null)
+    val requestHeaders = configuration["requestHeaders"] as HashMap<*, *>
+
+    Truth.assertThat(requestHeaders["Forwarded"]).isEqualTo("host=\"proxy.example.dev\";proto=https")
+    Truth.assertThat(requestHeaders["X-Forwarded-Host"]).isEqualTo("proxy.example.dev")
+    Truth.assertThat(requestHeaders["X-Forwarded-Proto"]).isEqualTo("https")
+  }
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -149,6 +149,23 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
+  fun `isManifestUrl includes forwarding headers`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(server.url("/dev/manifest").toString()),
+      null
+    )
+
+    server.enqueue(MockResponse().setResponseCode(200))
+    manifestParser.isManifestUrl()
+
+    val request = server.takeRequest()
+    Truth.assertThat(request.getHeader("forwarded")).contains("proto=http")
+    Truth.assertThat(request.getHeader("x-forwarded-host")).isEqualTo(server.url("/").host + ":" + server.port)
+    Truth.assertThat(request.getHeader("x-forwarded-proto")).isEqualTo("http")
+  }
+
+  @Test
   fun `checks if parseManifest parses successful response`() = runBlocking {
     val manifestParser = DevLauncherManifestParser(
       client,

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -193,6 +193,33 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
+  fun `parseManifest resolves relative bundle URL`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(server.url("/dev/manifest").toString()),
+      null
+    )
+
+    server.enqueue(
+      MockResponse().setBody(
+        """
+        {
+          "name": "testproject",
+          "slug": "testproject",
+          "sdkVersion": "UNVERSIONED",
+          "bundleUrl": "index.bundle?platform=android"
+        }
+        """.trimIndent()
+      )
+    )
+
+    val manifest = manifestParser.parseManifest()
+
+    Truth.assertThat(manifest.getBundleURL())
+      .isEqualTo(server.url("/dev/index.bundle?platform=android").toString())
+  }
+
+  @Test
   fun `checks if parseManifest fails on unsuccessful response`() {
     val manifestParser = DevLauncherManifestParser(
       client,

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      installationID:(NSString *)installationID
 {
   NSMutableDictionary *requestHeaders = @{@"Expo-Updates-Environment": @"DEVELOPMENT"}.mutableCopy;
+  [requestHeaders addEntriesFromDictionary:[self forwardedHeadersForURL:url]];
   if (installationID) {
     requestHeaders[@"Expo-Dev-Client-ID"] = installationID;
   }
@@ -26,6 +27,22 @@ NS_ASSUME_NONNULL_BEGIN
     @"EXUpdatesRequestHeaders": requestHeaders,
     @"EXUpdatesRuntimeVersion": runtimeVersion,
   };
+}
+
++ (NSDictionary *)forwardedHeadersForURL:(NSURL *)url
+{
+  NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+  if (!components.host || !components.scheme) {
+    return @{};
+  }
+
+  NSString *authority = components.port ? [NSString stringWithFormat:@"%@:%@", components.host, components.port] : components.host;
+  NSMutableDictionary *headers = @{
+    @"Forwarded": [NSString stringWithFormat:@"host=\"%@\";proto=%@", authority, components.scheme],
+    @"X-Forwarded-Host": authority,
+    @"X-Forwarded-Proto": components.scheme,
+  }.mutableCopy;
+  return headers;
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -103,6 +103,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   [request setHTTPMethod:method];
   [request setValue:@"ios" forHTTPHeaderField:@"expo-platform"];
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"accept"];
+  [self _setForwardedHeadersOnRequest:request];
   [request setTimeoutInterval:self.requestTimeout];
   if (self.installationID) {
     [request setValue:self.installationID forHTTPHeaderField:@"Expo-Dev-Client-ID"];
@@ -115,6 +116,19 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     }
   }];
   [dataTask resume];
+}
+
+- (void)_setForwardedHeadersOnRequest:(NSMutableURLRequest *)request
+{
+  NSURLComponents *components = [NSURLComponents componentsWithURL:self.url resolvingAgainstBaseURL:NO];
+  if (!components.host || !components.scheme) {
+    return;
+  }
+
+  NSString *authority = components.port ? [NSString stringWithFormat:@"%@:%@", components.host, components.port] : components.host;
+  [request setValue:[NSString stringWithFormat:@"host=\"%@\";proto=%@", authority, components.scheme] forHTTPHeaderField:@"Forwarded"];
+  [request setValue:authority forHTTPHeaderField:@"X-Forwarded-Host"];
+  [request setValue:components.scheme forHTTPHeaderField:@"X-Forwarded-Proto"];
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -81,7 +81,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
       }
     }
     NSError *error;
-    NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+    NSMutableDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
     if (!jsonObject) {
       NSMutableDictionary *details = [NSMutableDictionary dictionary];
       details[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"Couldn't parse the manifest. %@", (error ? error.localizedDescription : @"")];
@@ -91,6 +91,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
       onError([[NSError alloc] initWithDomain:@"DevelopmentClient" code:1 userInfo:details]);
       return;
     }
+    [self _resolveManifestUrls:jsonObject];
     EXManifestsManifest *manifest = [EXManifestsManifestFactory manifestForManifestJSON:jsonObject];
     onParsed(manifest);
   }];
@@ -129,6 +130,32 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   [request setValue:[NSString stringWithFormat:@"host=\"%@\";proto=%@", authority, components.scheme] forHTTPHeaderField:@"Forwarded"];
   [request setValue:authority forHTTPHeaderField:@"X-Forwarded-Host"];
   [request setValue:components.scheme forHTTPHeaderField:@"X-Forwarded-Proto"];
+}
+
+- (void)_resolveManifestUrls:(NSMutableDictionary *)manifestJson
+{
+  NSString *bundleUrl = manifestJson[@"bundleUrl"];
+  if (bundleUrl) {
+    manifestJson[@"bundleUrl"] = [self _resolveUrlString:bundleUrl];
+  }
+
+  NSMutableDictionary *launchAsset = manifestJson[@"launchAsset"];
+  if (launchAsset[@"url"]) {
+    launchAsset[@"url"] = [self _resolveUrlString:launchAsset[@"url"]];
+  }
+
+  NSArray *assets = manifestJson[@"assets"];
+  for (NSMutableDictionary *asset in assets) {
+    if (asset[@"url"]) {
+      asset[@"url"] = [self _resolveUrlString:asset[@"url"]];
+    }
+  }
+}
+
+- (NSString *)_resolveUrlString:(NSString *)urlString
+{
+  NSURL *resolvedUrl = [NSURL URLWithString:urlString relativeToURL:self.url];
+  return resolvedUrl.absoluteURL.absoluteString ?: urlString;
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -190,6 +190,35 @@
   [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testIsManifestURL_RequestIncludesForwardingHeaders
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/dev/manifest"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    XCTAssertEqualObjects(@"host=\"ohhttpstubs\";proto=http", request.allHTTPHeaderFields[@"Forwarded"]);
+    XCTAssertEqualObjects(@"ohhttpstubs", request.allHTTPHeaderFields[@"X-Forwarded-Host"]);
+    XCTAssertEqualObjects(@"http", request.allHTTPHeaderFields[@"X-Forwarded-Proto"]);
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
+  }];
+
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/dev/manifest"]
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"request should include forwarding headers"];
+
+  [parser isManifestURLWithCompletion:^(BOOL isManifestURL) {
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
 - (void)testParseManifest
 {
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -219,6 +219,35 @@
   [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testParseManifest_ResolvesRelativeBundleURL
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/dev/manifest"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    NSString *manifestString = @"{\"name\":\"testproject\",\"slug\":\"testproject\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"index.bundle?platform=ios\"}";
+    NSData *jsonData = [manifestString dataUsingEncoding:NSUTF8StringEncoding];
+    return [HTTPStubsResponse responseWithData:jsonData statusCode:200 headers:nil];
+  }];
+
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/dev/manifest"]
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"should resolve relative bundle URL"];
+
+  [parser tryToParseManifest:^(EXManifestsManifest * _Nonnull manifest) {
+    XCTAssertEqualObjects(@"http://ohhttpstubs/dev/index.bundle?platform=ios", manifest.bundleUrl);
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
 - (void)testParseManifest
 {
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
@@ -64,4 +64,18 @@
   XCTAssertEqualObjects(installationID, requestHeaders[@"Expo-Dev-Client-ID"]);
 }
 
+- (void)testCreateUpdatesConfiguration_forwardingHeaders
+{
+  NSURL *url = [NSURL URLWithString:@"https://proxy.example.dev/dev/manifest"];
+  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url
+                                                                                   projectURL:url
+                                                                               runtimeVersion:@"1.0.0"
+                                                                               installationID:nil];
+
+  NSDictionary *requestHeaders = configuration[@"EXUpdatesRequestHeaders"];
+  XCTAssertEqualObjects(@"host=\"proxy.example.dev\";proto=https", requestHeaders[@"Forwarded"]);
+  XCTAssertEqualObjects(@"proxy.example.dev", requestHeaders[@"X-Forwarded-Host"]);
+  XCTAssertEqualObjects(@"https", requestHeaders[@"X-Forwarded-Proto"]);
+}
+
 @end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`. ([#48020](https://github.com/expo/expo/pull/48020) by [@alanjhughes](https://github.com/alanjhughes))
+- Resolve relative asset URLs from `updateUrl` base URL ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ExpoUpdatesUpdateTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ExpoUpdatesUpdateTest.kt
@@ -23,6 +23,28 @@ class ExpoUpdatesUpdateTest {
     Assert.assertNotNull(ExpoUpdatesUpdate.fromExpoUpdatesManifest(manifest, null, createConfig()))
   }
 
+  @Test
+  @Throws(JSONException::class)
+  fun testFromManifestJson_RelativeAssetUrls() {
+    val manifestJson =
+      "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"key\":\"bundle\",\"url\":\"index.bundle?platform=android\",\"contentType\":\"application/javascript\"},\"assets\":[{\"key\":\"asset\",\"url\":\"assets/icon.png\",\"fileExtension\":\".png\"}]}"
+    val manifest = ExpoUpdatesManifest(JSONObject(manifestJson))
+    val update = ExpoUpdatesUpdate.fromExpoUpdatesManifest(manifest, null, createConfig())
+
+    Assert.assertEquals(
+      "https://exp.host/@test/index.bundle?platform=android",
+      update.assetEntityList[0].url.toString()
+    )
+    Assert.assertEquals(
+      "https://exp.host/@test/assets/icon.png",
+      update.assetEntityList[1].url.toString()
+    )
+    Assert.assertEquals(
+      "https://exp.host/@test/index.bundle?platform=android",
+      update.manifest.getBundleURL()
+    )
+  }
+
   @Test(expected = JSONException::class)
   @Throws(JSONException::class)
   fun testFromManifestJson_NoId() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
@@ -14,6 +14,7 @@ import expo.modules.updates.db.enums.UpdateStatus
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.net.URI
 import java.text.ParseException
 import java.util.*
 
@@ -100,22 +101,46 @@ class ExpoUpdatesUpdate private constructor(
       manifest: ExpoUpdatesManifest,
       extensions: JSONObject?,
       configuration: UpdatesConfiguration
-    ): ExpoUpdatesUpdate = ExpoUpdatesUpdate(
-      manifest,
-      id = UUID.fromString(manifest.getID()),
-      configuration.scopeKey,
-      commitTime = try {
-        UpdatesUtils.parseDateString(manifest.getCreatedAt())
-      } catch (e: ParseException) {
-        Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e)
-        Date()
-      },
-      runtimeVersion = manifest.getRuntimeVersion(),
-      launchAsset = manifest.getLaunchAsset(),
-      assets = manifest.getAssets(),
-      extensions = extensions,
-      url = configuration.updateUrl,
-      requestHeaders = configuration.requestHeaders
-    )
+    ): ExpoUpdatesUpdate {
+      val resolvedManifest = ExpoUpdatesManifest(
+        resolveManifestAssetUrls(manifest.getRawJson(), configuration.updateUrl)
+      )
+      return ExpoUpdatesUpdate(
+        resolvedManifest,
+        id = UUID.fromString(resolvedManifest.getID()),
+        configuration.scopeKey,
+        commitTime = try {
+          UpdatesUtils.parseDateString(resolvedManifest.getCreatedAt())
+        } catch (e: ParseException) {
+          Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e)
+          Date()
+        },
+        runtimeVersion = resolvedManifest.getRuntimeVersion(),
+        launchAsset = resolvedManifest.getLaunchAsset(),
+        assets = resolvedManifest.getAssets(),
+        extensions = extensions,
+        url = configuration.updateUrl,
+        requestHeaders = configuration.requestHeaders
+      )
+    }
+
+    private fun resolveManifestAssetUrls(manifestJson: JSONObject, baseUrl: Uri): JSONObject {
+      val resolvedManifestJson = JSONObject(manifestJson.toString())
+      val launchAsset = resolvedManifestJson.getJSONObject("launchAsset")
+      launchAsset.put("url", resolveUrl(launchAsset.getString("url"), baseUrl))
+
+      val assets = resolvedManifestJson.getNullable<JSONArray>("assets")
+      if (assets != null) {
+        for (i in 0 until assets.length()) {
+          val asset = assets.getJSONObject(i)
+          asset.put("url", resolveUrl(asset.getString("url"), baseUrl))
+        }
+      }
+      return resolvedManifestJson
+    }
+
+    private fun resolveUrl(url: String, baseUrl: Uri): String {
+      return URI(baseUrl.toString()).resolve(url).toString()
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
@@ -140,7 +140,11 @@ class ExpoUpdatesUpdate private constructor(
     }
 
     private fun resolveUrl(url: String, baseUrl: Uri): String {
-      return URI(baseUrl.toString()).resolve(url).toString()
+      return try {
+        URI(baseUrl.toString()).resolve(url).toString()
+      } catch (e: Exception) {
+        url
+      }
     }
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
@@ -16,7 +16,10 @@ public final class ExpoUpdatesUpdate: Update {
     config: UpdatesConfig,
     database: UpdatesDatabase
   ) -> Update {
-    let manifest = withExpoUpdatesManifest
+    let manifest = ExpoUpdatesManifest(rawManifestJSON: resolveManifestAssetUrls(
+      manifestJson: withExpoUpdatesManifest.rawManifestJSON(),
+      baseUrl: config.updateUrl
+    ))
     let assetHeaders: [String: Any] = extensions.optionalValue(forKey: "assetRequestHeaders") ?? [:]
 
     let updateId = manifest.rawId()
@@ -93,5 +96,31 @@ public final class ExpoUpdatesUpdate: Update {
       url: config.updateUrl,
       requestHeaders: config.requestHeaders
     )
+  }
+
+  private static func resolveManifestAssetUrls(manifestJson: [String: Any], baseUrl: URL) -> [String: Any] {
+    var resolvedManifestJson = manifestJson
+
+    var launchAsset: [String: Any] = resolvedManifestJson.requiredValue(forKey: "launchAsset")
+    let launchAssetUrlString: String = launchAsset.requiredValue(forKey: "url")
+    launchAsset["url"] = resolveUrl(launchAssetUrlString, baseUrl: baseUrl).absoluteString
+    resolvedManifestJson["launchAsset"] = launchAsset
+
+    if var assets: [[String: Any]] = resolvedManifestJson.optionalValue(forKey: "assets") {
+      assets = assets.map { asset in
+        var resolvedAsset = asset
+        let assetUrlString: String = resolvedAsset.requiredValue(forKey: "url")
+        resolvedAsset["url"] = resolveUrl(assetUrlString, baseUrl: baseUrl).absoluteString
+        return resolvedAsset
+      }
+      resolvedManifestJson["assets"] = assets
+    }
+
+    return resolvedManifestJson
+  }
+
+  private static func resolveUrl(_ urlString: String, baseUrl: URL) -> URL {
+    return URL(string: urlString, relativeTo: baseUrl)?.absoluteURL
+      ?? URL(string: urlString).require("asset url should be a valid URL")
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
@@ -103,14 +103,14 @@ public final class ExpoUpdatesUpdate: Update {
 
     var launchAsset: [String: Any] = resolvedManifestJson.requiredValue(forKey: "launchAsset")
     let launchAssetUrlString: String = launchAsset.requiredValue(forKey: "url")
-    launchAsset["url"] = resolveUrl(launchAssetUrlString, baseUrl: baseUrl).absoluteString
+    launchAsset["url"] = resolveUrl(launchAssetUrlString, baseUrl: baseUrl)
     resolvedManifestJson["launchAsset"] = launchAsset
 
     if var assets: [[String: Any]] = resolvedManifestJson.optionalValue(forKey: "assets") {
       assets = assets.map { asset in
         var resolvedAsset = asset
         let assetUrlString: String = resolvedAsset.requiredValue(forKey: "url")
-        resolvedAsset["url"] = resolveUrl(assetUrlString, baseUrl: baseUrl).absoluteString
+        resolvedAsset["url"] = resolveUrl(assetUrlString, baseUrl: baseUrl)
         return resolvedAsset
       }
       resolvedManifestJson["assets"] = assets
@@ -119,8 +119,7 @@ public final class ExpoUpdatesUpdate: Update {
     return resolvedManifestJson
   }
 
-  private static func resolveUrl(_ urlString: String, baseUrl: URL) -> URL {
-    return URL(string: urlString, relativeTo: baseUrl)?.absoluteURL
-      ?? URL(string: urlString).require("asset url should be a valid URL")
+  private static func resolveUrl(_ urlString: String, baseUrl: URL) -> String {
+    return URL(string: urlString, relativeTo: baseUrl)?.absoluteURL.absoluteString ?? urlString
   }
 }

--- a/packages/expo-updates/ios/Tests/NewUpdateTests.swift
+++ b/packages/expo-updates/ios/Tests/NewUpdateTests.swift
@@ -40,6 +40,40 @@ struct NewUpdateTests {
   }
 
   @Test
+  func `relative asset urls`() {
+    let manifest = ExpoUpdatesManifest(
+      rawManifestJSON: [
+        "runtimeVersion": "1",
+        "id": "0eef8214-4833-4089-9dff-b4138a14f196",
+        "createdAt": "2020-11-11T00:17:54.797Z",
+        "launchAsset": [
+          "key": "bundle",
+          "url": "index.bundle?platform=ios",
+          "contentType": "application/javascript"
+        ],
+        "assets": [
+          [
+            "key": "asset",
+            "url": "assets/icon.png",
+            "fileExtension": ".png"
+          ]
+        ]
+      ]
+    )
+
+    let update = ExpoUpdatesUpdate.update(
+      withExpoUpdatesManifest: manifest,
+      extensions: [:],
+      config: config,
+      database: database
+    )
+
+    #expect(update.assets()?[0].url?.absoluteString == "https://u.expo.dev/index.bundle?platform=ios")
+    #expect(update.assets()?[1].url?.absoluteString == "https://u.expo.dev/assets/icon.png")
+    #expect(update.manifest.bundleUrl() == "https://u.expo.dev/index.bundle?platform=ios")
+  }
+
+  @Test
   func `throws no runtime version`() {
     let manifest = ExpoUpdatesManifest(
       rawManifestJSON: [


### PR DESCRIPTION
# Why

We shouldn't assume a LAN IP address or URL based on what the dev-server thinks is the target URL. This can fail if the request is proxied or if the dev-server can be served on multiple networks or IP addresses that aren't all accessible from the dev-client.

# How

We should conditionally serve relative URLs/pathnames and resolve them against the request URL that the dev-client has made the initial request to.

- Send `Forwarded` and related headers as an indicator of what the dev-client thinks it's connecting to in `expo-dev-launcher`
- Conditionally use `Forwarded` as a signal to send relative URLs in manifest responses in `@expo/cli`
- Resolve relative URLs in the manifest using the base request URL
- Update `expo-updates` accordingly to match these changes

We could tighten the condition under which the dev-server sends relative URLs, however, in practice, switching this on and sending them when the `Forwarded` header is now set should overlap perfectly with the cases that may have failed before.

# Test Plan

> [!NOTE]
> I haven't tested this yet, and that's an **Open TODO** before merging. Part of these changes are speculative.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
