### PR TITLE
chore(precompile) added support for precompile/pod install without VFS overlay

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] Detect React Native versions that ship self-contained XCFrameworks (no VFS overlay) during precompile and pod install, falling back to the legacy VFS overlay integration on pre-0.87 versions. ([#47256](https://github.com/expo/expo/pull/47256) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
 - [Android] Apply the `android.cmakeVersion` build property to the app and all library subprojects. ([#47377](https://github.com/expo/expo/pull/47377) by [@zoontek](https://github.com/zoontek))
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] Detect React Native versions that ship self-contained XCFrameworks (no VFS overlay) during precompile and pod install, falling back to the legacy VFS overlay integration on pre-0.87 versions. ([#47256](https://github.com/expo/expo/pull/47256) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
 - [Android] Support linking published Gradle plugins. ([#48334](https://github.com/expo/expo/pull/48334) by [@jakex7](https://github.com/jakex7))
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -989,11 +989,22 @@ module Expo
           update_xcconfig_header_search_paths(xcconfig_path, paths_string)
         end
 
-        # Also update the main project targets' build settings directly
+        # Also update the main project targets' build settings directly.
+        # NOTE: Xcodeproj build settings can be either a String or an Array — React Native's
+        # post_install sets HEADER_SEARCH_PATHS as an Array (e.g. ["$(inherited)",
+        # "\"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/...\""]) on every pod that depends on
+        # ReactCodegen. Interpolating an Array into a String serializes its inspect form
+        # (`["$(inherited)", ...]`), which clang receives as a single bogus `-I[...` argument that
+        # swallows all inherited header search paths for the target ("ReactCodegen/... file not
+        # found" under use_frameworks). Append per-type instead.
+        quoted_paths = header_search_paths.map { |p| "\"#{p}\"" }
         installer.pods_project.targets.each do |target|
           target.build_configurations.each do |config|
             existing = config.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)'
-            unless existing.include?(paths_string)
+            if existing.is_a?(Array)
+              missing = quoted_paths.reject { |path| existing.include?(path) }
+              config.build_settings['HEADER_SEARCH_PATHS'] = existing + missing if missing.any?
+            elsif !existing.include?(paths_string)
               config.build_settings['HEADER_SEARCH_PATHS'] = "#{existing} #{paths_string}"
             end
           end

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -847,6 +847,23 @@ module Expo
       # build time when switching Debug↔Release configurations.
       def configure_use_frameworks(installer)
         return unless prebuilt_react_active?
+
+        # Modern modular prebuilt React (React.xcframework + flattened ReactNativeHeaders, no VFS
+        # overlay): React Native's rncore.rb wires the header resolution — <React/...> and
+        # `@import React` via the framework, and the relocated namespaces (<react/...>, <yoga/...>,
+        # RCTDeprecation/, ...) via a clang module map at React-Core-prebuilt/Headers/module.modulemap.
+        # But RN's pod-target loop only covers the React-* pods; it misses every Expo pod (Expo,
+        # ExpoModulesCore, ExpoImage, ...). Re-apply that module-map coverage to the pods RN missed so
+        # their <React/...> explicit-module precompile resolves the lowercase namespaces modularly
+        # instead of tripping -Wnon-modular-include-in-framework-module. (The coverage self-skips if the
+        # prebuilt did not actually ship the module map — see ensure_modular_react_header_flags.)
+        unless prebuilt_react_uses_vfs?(installer)
+          ensure_modular_react_header_flags(installer)
+          return
+        end
+
+        # Legacy VFS prebuilt React: the use_frameworks! compat below only applies when use_frameworks!
+        # is active.
         return if linkage(installer).nil?
 
         react_prebuilt_dir = File.join(installer.sandbox.root, 'React-Core-prebuilt')
@@ -861,6 +878,86 @@ module Expo
         inject_isystem_flags(installer, target_support_dir)
 
         Pod::UI.puts "[Expo] ".blue + "Created non-framework React modulemap for use_frameworks! compatibility"
+      end
+
+      # Central discriminator for how the prebuilt React-Core-prebuilt pod exposes its headers. Two
+      # layouts ship today; everything that branches on "are we modular?" should route through here
+      # rather than re-deriving it (the signals diverged once before — keying on the transient
+      # Headers/module.modulemap — and silently broke the build):
+      #
+      #   - Legacy VFS: a single React.xcframework whose headers live at React.xcframework/Headers;
+      #     <react/...>/<yoga/...> are made resolvable via a generated clang VFS overlay. Expo must
+      #     install use_frameworks! compatibility (non-framework modulemap + -isystem) for it.
+      #   - Modern framework-resolved: ReactNativeHeaders' headers are flattened into a top-level
+      #     React-Core-prebuilt/Headers/ directory and vended as ordinary public pod headers, while
+      #     <React/...> resolves through the framework. No VFS, no module-map flag, no Expo compat.
+      #
+      # The presence of the flattened top-level Headers/ directory is the stable signal: it is the
+      # pod's header_mappings_dir output (re-created by prepare_command on every build-time re-extract),
+      # unlike Headers/module.modulemap which the modern layout copies in transiently and then discards.
+      def prebuilt_react_uses_vfs?(installer)
+        return false unless prebuilt_react_active?
+
+        react_prebuilt_dir = File.join(installer.sandbox.root, 'React-Core-prebuilt')
+        !Dir.exist?(File.join(react_prebuilt_dir, 'Headers'))
+      end
+
+      # Mirrors React Native's rncore.rb add_prebuilt_header_search_paths for the pods RN's own loop
+      # misses (it only covers the React-* pod targets, not the Expo pods). Re-applies the flattened
+      # ReactNativeHeaders module map + header search path idempotently, skipping any xcconfig that
+      # already carries the flag (those RN already covered).
+      #
+      # Gated on the module map actually existing: the Maven prebuilt path (RCT_USE_PREBUILT_RNCORE
+      # without RCT_TESTONLY_RNCORE_TARBALL_PATH) can install a React-Core-prebuilt that does not ship
+      # Headers/module.modulemap. Pointing -fmodule-map-file at a missing file fails `ScanDependencies`
+      # ("module map file ... not found"), so when it is absent we inject nothing and warn — the
+      # faithful path is a tarball that ships ReactNativeHeaders via RCT_TESTONLY_RNCORE_TARBALL_PATH.
+      def ensure_modular_react_header_flags(installer)
+        module_map_file = File.join(installer.sandbox.root, 'React-Core-prebuilt', 'Headers', 'module.modulemap')
+        unless File.exist?(module_map_file)
+          Pod::UI.warn "[Expo] Prebuilt React-Core-prebuilt is missing Headers/module.modulemap — " \
+            "skipping Expo module-map coverage. If the build fails with a missing module map or " \
+            "-Wnon-modular-include, the installed prebuilt React does not match React Native's " \
+            "CocoaPods scripts; install a tarball that ships ReactNativeHeaders via " \
+            "RCT_TESTONLY_RNCORE_TARBALL_PATH."
+          return
+        end
+
+        module_map = '$(PODS_ROOT)/React-Core-prebuilt/Headers/module.modulemap'
+        header_path = '"$(PODS_ROOT)/React-Core-prebuilt/Headers"'
+        cflags_flag = "-fmodule-map-file=#{module_map}"
+        swift_flag = "-Xcc -fmodule-map-file=#{module_map}"
+        swift_flags = "-Xcc -Wno-incomplete-umbrella #{swift_flag}"
+
+        patched = 0
+        Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
+          content = File.read(xcconfig_path)
+          original = content.dup
+
+          # Each flag is ensured INDEPENDENTLY (not "skip the pod if the module-map flag is present").
+          # A pod can carry the -fmodule-map-file flag from its own podspec (e.g. react-native-reanimated
+          # 4.x adds it) yet still lack the flattened-headers search path — in which case the module map
+          # activates the yoga/react modules but <yoga/style/Style.h> & co. textually fail to resolve
+          # (the modules' headers live under React-Core-prebuilt/Headers/). Add whichever piece is absent.
+          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path) unless content.include?(header_path)
+          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag) unless content.include?(cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flags) unless content.include?(swift_flag)
+
+          next if content == original
+          File.write(xcconfig_path, content)
+          patched += 1
+        end
+
+        Pod::UI.puts "[Expo] ".blue + "Ensured modular React header flags on #{patched} xcconfig(s)"
+      end
+
+      # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.
+      def append_xcconfig_flag(content, key, value)
+        if content =~ /^#{Regexp.escape(key)}\s*=.*$/
+          content.sub(/^(#{Regexp.escape(key)}\s*=.*)$/) { "#{$1} #{value}" }
+        else
+          (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
+        end
       end
 
       # TODO(ExpoModulesJSI-xcframework): Remove this method when ExpoModulesJSI.xcframework

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -185,6 +185,7 @@ module Expo
         configure_header_search_paths(installer)
         configure_codegen_for_prebuilt_modules(installer)
         stub_bundled_pod_targets(installer)
+        quote_swift_compatibility_header_search_paths(installer)
       end
 
       # Runs all precompiled module pre-install steps.
@@ -949,6 +950,26 @@ module Expo
         end
 
         Pod::UI.puts "[Expo] ".blue + "Ensured modular React header flags on #{patched} xcconfig(s)"
+      end
+
+      # Re-quote unquoted `.../Swift Compatibility Header` entries in HEADER_SEARCH_PATHS. The path
+      # has a space, and CocoaPods drops the podspec's quotes when it's supplied via a joined
+      # `pod_target_xcconfig` string, so clang space-splits it and a cross-pod `#import
+      # "<Pod>-Swift.h"` fails in the static-library source build (no framework bundle, and no VFS
+      # overlay since RN removed it). Runs on the final xcconfigs; RN's post-install preserves
+      # quotes, so this stays authoritative. Idempotent (already-quoted tokens are skipped).
+      def quote_swift_compatibility_header_search_paths(installer)
+        # $(…)/${…}PODS_CONFIGURATION_BUILD_DIR / <pod-name> / "Swift Compatibility Header", unquoted only.
+        token = /(?<!")(\$[({]PODS_CONFIGURATION_BUILD_DIR[)}]\/[^\s"\/]+\/Swift Compatibility Header)(?!")/
+        patched = 0
+        Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
+          content = File.read(xcconfig_path)
+          new_content = content.gsub(/^HEADER_SEARCH_PATHS\s*=.*$/) { |line| line.gsub(token, '"\1"') }
+          next if new_content == content
+          File.write(xcconfig_path, new_content)
+          patched += 1
+        end
+        Pod::UI.puts "[Expo] ".blue + "Quoted Swift compatibility header search paths in #{patched} xcconfig(s)" if patched > 0
       end
 
       # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -828,6 +828,23 @@ module Expo
       # build time when switching Debug↔Release configurations.
       def configure_use_frameworks(installer)
         return unless prebuilt_react_active?
+
+        # Modern modular prebuilt React (React.xcframework + flattened ReactNativeHeaders, no VFS
+        # overlay): React Native's rncore.rb wires the header resolution — <React/...> and
+        # `@import React` via the framework, and the relocated namespaces (<react/...>, <yoga/...>,
+        # RCTDeprecation/, ...) via a clang module map at React-Core-prebuilt/Headers/module.modulemap.
+        # But RN's pod-target loop only covers the React-* pods; it misses every Expo pod (Expo,
+        # ExpoModulesCore, ExpoImage, ...). Re-apply that module-map coverage to the pods RN missed so
+        # their <React/...> explicit-module precompile resolves the lowercase namespaces modularly
+        # instead of tripping -Wnon-modular-include-in-framework-module. (The coverage self-skips if the
+        # prebuilt did not actually ship the module map — see ensure_modular_react_header_flags.)
+        unless prebuilt_react_uses_vfs?(installer)
+          ensure_modular_react_header_flags(installer)
+          return
+        end
+
+        # Legacy VFS prebuilt React: the use_frameworks! compat below only applies when use_frameworks!
+        # is active.
         return if linkage(installer).nil?
 
         react_prebuilt_dir = File.join(installer.sandbox.root, 'React-Core-prebuilt')
@@ -842,6 +859,86 @@ module Expo
         inject_isystem_flags(installer, target_support_dir)
 
         Pod::UI.puts "[Expo] ".blue + "Created non-framework React modulemap for use_frameworks! compatibility"
+      end
+
+      # Central discriminator for how the prebuilt React-Core-prebuilt pod exposes its headers. Two
+      # layouts ship today; everything that branches on "are we modular?" should route through here
+      # rather than re-deriving it (the signals diverged once before — keying on the transient
+      # Headers/module.modulemap — and silently broke the build):
+      #
+      #   - Legacy VFS: a single React.xcframework whose headers live at React.xcframework/Headers;
+      #     <react/...>/<yoga/...> are made resolvable via a generated clang VFS overlay. Expo must
+      #     install use_frameworks! compatibility (non-framework modulemap + -isystem) for it.
+      #   - Modern framework-resolved: ReactNativeHeaders' headers are flattened into a top-level
+      #     React-Core-prebuilt/Headers/ directory and vended as ordinary public pod headers, while
+      #     <React/...> resolves through the framework. No VFS, no module-map flag, no Expo compat.
+      #
+      # The presence of the flattened top-level Headers/ directory is the stable signal: it is the
+      # pod's header_mappings_dir output (re-created by prepare_command on every build-time re-extract),
+      # unlike Headers/module.modulemap which the modern layout copies in transiently and then discards.
+      def prebuilt_react_uses_vfs?(installer)
+        return false unless prebuilt_react_active?
+
+        react_prebuilt_dir = File.join(installer.sandbox.root, 'React-Core-prebuilt')
+        !Dir.exist?(File.join(react_prebuilt_dir, 'Headers'))
+      end
+
+      # Mirrors React Native's rncore.rb add_prebuilt_header_search_paths for the pods RN's own loop
+      # misses (it only covers the React-* pod targets, not the Expo pods). Re-applies the flattened
+      # ReactNativeHeaders module map + header search path idempotently, skipping any xcconfig that
+      # already carries the flag (those RN already covered).
+      #
+      # Gated on the module map actually existing: the Maven prebuilt path (RCT_USE_PREBUILT_RNCORE
+      # without RCT_TESTONLY_RNCORE_TARBALL_PATH) can install a React-Core-prebuilt that does not ship
+      # Headers/module.modulemap. Pointing -fmodule-map-file at a missing file fails `ScanDependencies`
+      # ("module map file ... not found"), so when it is absent we inject nothing and warn — the
+      # faithful path is a tarball that ships ReactNativeHeaders via RCT_TESTONLY_RNCORE_TARBALL_PATH.
+      def ensure_modular_react_header_flags(installer)
+        module_map_file = File.join(installer.sandbox.root, 'React-Core-prebuilt', 'Headers', 'module.modulemap')
+        unless File.exist?(module_map_file)
+          Pod::UI.warn "[Expo] Prebuilt React-Core-prebuilt is missing Headers/module.modulemap — " \
+            "skipping Expo module-map coverage. If the build fails with a missing module map or " \
+            "-Wnon-modular-include, the installed prebuilt React does not match React Native's " \
+            "CocoaPods scripts; install a tarball that ships ReactNativeHeaders via " \
+            "RCT_TESTONLY_RNCORE_TARBALL_PATH."
+          return
+        end
+
+        module_map = '$(PODS_ROOT)/React-Core-prebuilt/Headers/module.modulemap'
+        header_path = '"$(PODS_ROOT)/React-Core-prebuilt/Headers"'
+        cflags_flag = "-fmodule-map-file=#{module_map}"
+        swift_flag = "-Xcc -fmodule-map-file=#{module_map}"
+        swift_flags = "-Xcc -Wno-incomplete-umbrella #{swift_flag}"
+
+        patched = 0
+        Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
+          content = File.read(xcconfig_path)
+          original = content.dup
+
+          # Each flag is ensured INDEPENDENTLY (not "skip the pod if the module-map flag is present").
+          # A pod can carry the -fmodule-map-file flag from its own podspec (e.g. react-native-reanimated
+          # 4.x adds it) yet still lack the flattened-headers search path — in which case the module map
+          # activates the yoga/react modules but <yoga/style/Style.h> & co. textually fail to resolve
+          # (the modules' headers live under React-Core-prebuilt/Headers/). Add whichever piece is absent.
+          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path) unless content.include?(header_path)
+          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag) unless content.include?(cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flags) unless content.include?(swift_flag)
+
+          next if content == original
+          File.write(xcconfig_path, content)
+          patched += 1
+        end
+
+        Pod::UI.puts "[Expo] ".blue + "Ensured modular React header flags on #{patched} xcconfig(s)"
+      end
+
+      # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.
+      def append_xcconfig_flag(content, key, value)
+        if content =~ /^#{Regexp.escape(key)}\s*=.*$/
+          content.sub(/^(#{Regexp.escape(key)}\s*=.*)$/) { "#{$1} #{value}" }
+        else
+          (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
+        end
       end
 
       # TODO(ExpoModulesJSI-xcframework): Remove this method when ExpoModulesJSI.xcframework

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -185,6 +185,7 @@ module Expo
         configure_header_search_paths(installer)
         configure_codegen_for_prebuilt_modules(installer)
         stub_bundled_pod_targets(installer)
+        quote_swift_compatibility_header_search_paths(installer)
       end
 
       # Runs all precompiled module pre-install steps.
@@ -930,6 +931,26 @@ module Expo
         end
 
         Pod::UI.puts "[Expo] ".blue + "Ensured modular React header flags on #{patched} xcconfig(s)"
+      end
+
+      # Re-quote unquoted `.../Swift Compatibility Header` entries in HEADER_SEARCH_PATHS. The path
+      # has a space, and CocoaPods drops the podspec's quotes when it's supplied via a joined
+      # `pod_target_xcconfig` string, so clang space-splits it and a cross-pod `#import
+      # "<Pod>-Swift.h"` fails in the static-library source build (no framework bundle, and no VFS
+      # overlay since RN removed it). Runs on the final xcconfigs; RN's post-install preserves
+      # quotes, so this stays authoritative. Idempotent (already-quoted tokens are skipped).
+      def quote_swift_compatibility_header_search_paths(installer)
+        # $(…)/${…}PODS_CONFIGURATION_BUILD_DIR / <pod-name> / "Swift Compatibility Header", unquoted only.
+        token = /(?<!")(\$[({]PODS_CONFIGURATION_BUILD_DIR[)}]\/[^\s"\/]+\/Swift Compatibility Header)(?!")/
+        patched = 0
+        Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
+          content = File.read(xcconfig_path)
+          new_content = content.gsub(/^HEADER_SEARCH_PATHS\s*=.*$/) { |line| line.gsub(token, '"\1"') }
+          next if new_content == content
+          File.write(xcconfig_path, new_content)
+          patched += 1
+        end
+        Pod::UI.puts "[Expo] ".blue + "Quoted Swift compatibility header search paths in #{patched} xcconfig(s)" if patched > 0
       end
 
       # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -926,9 +926,12 @@ module Expo
 
         module_map = '$(PODS_ROOT)/React-Core-prebuilt/Headers/module.modulemap'
         header_path = '"$(PODS_ROOT)/React-Core-prebuilt/Headers"'
-        cflags_flag = "-fmodule-map-file=#{module_map}"
-        swift_flag = "-Xcc -fmodule-map-file=#{module_map}"
-        swift_flags = "-Xcc -Wno-incomplete-umbrella #{swift_flag}"
+        # Quoted exactly as RN's rncore.rb writes it, for two reasons: a $(PODS_ROOT) containing
+        # spaces has to stay a single clang argument, and the already-present checks below only
+        # recognise RN's own injection — and skip re-adding it — if the spelling matches.
+        cflags_flag = %("-fmodule-map-file=#{module_map}")
+        swift_flag = "-Xcc #{cflags_flag}"
+        umbrella_flag = '-Xcc -Wno-incomplete-umbrella'
 
         patched = 0
         Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
@@ -940,9 +943,16 @@ module Expo
           # 4.x adds it) yet still lack the flattened-headers search path — in which case the module map
           # activates the yoga/react modules but <yoga/style/Style.h> & co. textually fail to resolve
           # (the modules' headers live under React-Core-prebuilt/Headers/). Add whichever piece is absent.
-          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path) unless content.include?(header_path)
-          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag) unless content.include?(cflags_flag)
-          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flags) unless content.include?(swift_flag)
+          #
+          # OTHER_CPLUSPLUSFLAGS needs its own copy: Xcode does not fold OTHER_CFLAGS into it, so once a
+          # target sets it (RN's new_architecture.rb does, for -DRCT_NEW_ARCH_ENABLED) that value replaces
+          # OTHER_CFLAGS for every .mm/.cpp/.cc translation unit. Without it the module map never reaches
+          # the C++ sources that consume the relocated react/ and yoga/ namespaces.
+          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path)
+          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_CPLUSPLUSFLAGS', cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', umbrella_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flag)
 
           next if content == original
           File.write(xcconfig_path, content)
@@ -973,12 +983,19 @@ module Expo
       end
 
       # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.
+      # No-ops when `key` already carries `value`.
+      #
+      # The already-present check is scoped to `key`'s own line, not the whole file: the same flag
+      # legitimately belongs on several keys (OTHER_CFLAGS and OTHER_CPLUSPLUSFLAGS both need the
+      # module map), so a file-wide check would let whichever key is written first silently suppress
+      # every later one.
       def append_xcconfig_flag(content, key, value)
-        if content =~ /^#{Regexp.escape(key)}\s*=.*$/
-          content.sub(/^(#{Regexp.escape(key)}\s*=.*)$/) { "#{$1} #{value}" }
-        else
-          (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
-        end
+        line = /^(#{Regexp.escape(key)}\s*=.*)$/
+        existing = content[line, 1]
+        return content if existing&.include?(value)
+        return content.sub(line) { "#{$1} #{value}" } if existing
+
+        (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
       end
 
       # TODO(ExpoModulesJSI-xcframework): Remove this method when ExpoModulesJSI.xcframework

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -907,9 +907,12 @@ module Expo
 
         module_map = '$(PODS_ROOT)/React-Core-prebuilt/Headers/module.modulemap'
         header_path = '"$(PODS_ROOT)/React-Core-prebuilt/Headers"'
-        cflags_flag = "-fmodule-map-file=#{module_map}"
-        swift_flag = "-Xcc -fmodule-map-file=#{module_map}"
-        swift_flags = "-Xcc -Wno-incomplete-umbrella #{swift_flag}"
+        # Quoted exactly as RN's rncore.rb writes it, for two reasons: a $(PODS_ROOT) containing
+        # spaces has to stay a single clang argument, and the already-present checks below only
+        # recognise RN's own injection — and skip re-adding it — if the spelling matches.
+        cflags_flag = %("-fmodule-map-file=#{module_map}")
+        swift_flag = "-Xcc #{cflags_flag}"
+        umbrella_flag = '-Xcc -Wno-incomplete-umbrella'
 
         patched = 0
         Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', '**', '*.xcconfig')).each do |xcconfig_path|
@@ -921,9 +924,16 @@ module Expo
           # 4.x adds it) yet still lack the flattened-headers search path — in which case the module map
           # activates the yoga/react modules but <yoga/style/Style.h> & co. textually fail to resolve
           # (the modules' headers live under React-Core-prebuilt/Headers/). Add whichever piece is absent.
-          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path) unless content.include?(header_path)
-          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag) unless content.include?(cflags_flag)
-          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flags) unless content.include?(swift_flag)
+          #
+          # OTHER_CPLUSPLUSFLAGS needs its own copy: Xcode does not fold OTHER_CFLAGS into it, so once a
+          # target sets it (RN's new_architecture.rb does, for -DRCT_NEW_ARCH_ENABLED) that value replaces
+          # OTHER_CFLAGS for every .mm/.cpp/.cc translation unit. Without it the module map never reaches
+          # the C++ sources that consume the relocated react/ and yoga/ namespaces.
+          content = append_xcconfig_flag(content, 'HEADER_SEARCH_PATHS', header_path)
+          content = append_xcconfig_flag(content, 'OTHER_CFLAGS', cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_CPLUSPLUSFLAGS', cflags_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', umbrella_flag)
+          content = append_xcconfig_flag(content, 'OTHER_SWIFT_FLAGS', swift_flag)
 
           next if content == original
           File.write(xcconfig_path, content)
@@ -954,12 +964,19 @@ module Expo
       end
 
       # Appends `value` to an xcconfig `key` line (preserving $(inherited)), or adds the key if absent.
+      # No-ops when `key` already carries `value`.
+      #
+      # The already-present check is scoped to `key`'s own line, not the whole file: the same flag
+      # legitimately belongs on several keys (OTHER_CFLAGS and OTHER_CPLUSPLUSFLAGS both need the
+      # module map), so a file-wide check would let whichever key is written first silently suppress
+      # every later one.
       def append_xcconfig_flag(content, key, value)
-        if content =~ /^#{Regexp.escape(key)}\s*=.*$/
-          content.sub(/^(#{Regexp.escape(key)}\s*=.*)$/) { "#{$1} #{value}" }
-        else
-          (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
-        end
+        line = /^(#{Regexp.escape(key)}\s*=.*)$/
+        existing = content[line, 1]
+        return content if existing&.include?(value)
+        return content.sub(line) { "#{$1} #{value}" } if existing
+
+        (content.end_with?("\n") ? content : content + "\n") + "#{key} = $(inherited) #{value}\n"
       end
 
       # TODO(ExpoModulesJSI-xcframework): Remove this method when ExpoModulesJSI.xcframework

--- a/tools/src/prebuilds/Dependencies.ts
+++ b/tools/src/prebuilds/Dependencies.ts
@@ -244,21 +244,36 @@ export const Dependencies = {
       }
     );
 
-    // Generate VFS overlay and stage missing headers for stock Maven xcframework.
-    // The xcframework itself is never modified (preserves Meta's code signature).
-    // Skipped if already generated and RN source version hasn't changed.
+    // React header resolution comes in two flavors:
+    //  - Modern modular artifact: ships ReactNativeHeaders.xcframework with a flattened clang
+    //    module map. Nothing to generate — the module map is consumed directly.
+    //  - Legacy artifact: ships only React.xcframework, so we synthesize a VFS overlay (and stage
+    //    missing headers) without ever modifying the xcframework (preserves Meta's code signature).
     const reactNativeSourcePath = resolvePackagePath('react-native');
     const xcframeworkPath = path.join(reactNativePath, 'React.xcframework');
-    if (fs.existsSync(xcframeworkPath) && !isVFSGenerated(reactNativePath, reactNativeSourcePath)) {
-      logger.verbose('🔄 Generating VFS overlay for stock React.xcframework...');
-      await transformReactXCFrameworkAsync({
-        outputPath: reactNativePath,
-        reactNativePath: reactNativeSourcePath,
-      });
-    }
+    const usesModularHeaders = fs.existsSync(
+      path.join(reactNativePath, 'ReactNativeHeaders.xcframework')
+    );
+    if (usesModularHeaders) {
+      logger.verbose(
+        '📦 Modular React headers detected (ReactNativeHeaders.xcframework) — skipping VFS overlay'
+      );
+    } else {
+      // Skipped if already generated and RN source version hasn't changed.
+      if (
+        fs.existsSync(xcframeworkPath) &&
+        !isVFSGenerated(reactNativePath, reactNativeSourcePath)
+      ) {
+        logger.verbose('🔄 Generating VFS overlay for stock React.xcframework...');
+        await transformReactXCFrameworkAsync({
+          outputPath: reactNativePath,
+          reactNativePath: reactNativeSourcePath,
+        });
+      }
 
-    // Generate the VFS overlay file from the template (resolves ${ROOT_PATH} placeholders)
-    await resolveVFSOverlayTemplate(reactNativePath);
+      // Generate the VFS overlay file from the template (resolves ${ROOT_PATH} placeholders)
+      await resolveVFSOverlayTemplate(reactNativePath);
+    }
 
     return {
       hermes: hermesPath,
@@ -325,8 +340,11 @@ export const Dependencies = {
         spinner.succeed('Artifacts already up-to-date in local .dependencies folder');
       }
 
-      // Resolve the VFS overlay template with the correct paths
-      await resolveVFSOverlayTemplate(rnDest);
+      // Legacy artifacts only: resolve the VFS overlay template with the correct paths. Modular
+      // artifacts (ReactNativeHeaders.xcframework) ship a module map and need no overlay.
+      if (!fs.existsSync(path.join(rnDest, 'ReactNativeHeaders.xcframework'))) {
+        await resolveVFSOverlayTemplate(rnDest);
+      }
     } else {
       const spinner = createAsyncSpinner('Verifying artifacts for local dependencies', pkg);
 

--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -227,7 +227,10 @@ describe('React header flags: modular module map vs legacy VFS overlay', () => {
         'Headers'
       );
       fs.mkdirSync(headersDir, { recursive: true });
-      fs.writeFileSync(path.join(headersDir, 'module.modulemap'), 'module ReactNativeHeaders_react {}');
+      fs.writeFileSync(
+        path.join(headersDir, 'module.modulemap'),
+        'module ReactNativeHeaders_react {}'
+      );
     });
 
     const settings = buildSwiftSettings(
@@ -248,7 +251,7 @@ describe('React header flags: modular module map vs legacy VFS overlay', () => {
       // Legacy artifact: a generated VFS overlay, no ReactNativeHeaders.xcframework.
       fs.writeFileSync(
         path.join(debugBase, 'React-VFS.yaml'),
-        "version: 0\ncase-sensitive: false\nroots: []\n"
+        'version: 0\ncase-sensitive: false\nroots: []\n'
       );
     });
 

--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
@@ -9,6 +11,18 @@ import {
   findSiblingProductDependencies,
   type ExternalDepResolver,
 } from './SPMPackage';
+
+/** Builds an ArtifactPaths fixture whose React cache slot we then populate per-format. */
+function makeArtifactPaths(cachePath: string, version: string) {
+  return {
+    hermes: path.join(cachePath, 'hermes'),
+    reactNativeDependencies: path.join(cachePath, 'deps'),
+    react: path.join(cachePath, 'react', version, 'debug'),
+    cachePath,
+    hermesVersion: '1.0.0',
+    reactNativeVersion: version,
+  };
+}
 
 function makeProduct(name: string, targetDeps: string[] = []): SPMProduct {
   return {
@@ -190,5 +204,63 @@ describe('buildSwiftSettings ExpoModulesMacros plugin flags', () => {
   it('should not emit load-plugin-executable flags when no swift target is provided', () => {
     const settings = buildSwiftSettings(['ExpoModulesCore'], null, '/tmp/pkg', 'Debug');
     assert.equal(hasMacroPluginFlags(settings), false);
+  });
+});
+
+describe('React header flags: modular module map vs legacy VFS overlay', () => {
+  const version = '1000.0.0';
+
+  function withCache(populate: (debugBase: string) => void): string {
+    const cachePath = fs.mkdtempSync(path.join(os.tmpdir(), 'spm-react-flags-'));
+    const debugBase = path.join(cachePath, 'react', version, 'debug');
+    fs.mkdirSync(debugBase, { recursive: true });
+    populate(debugBase);
+    return cachePath;
+  }
+
+  it('emits -fmodule-map-file + -I when ReactNativeHeaders.xcframework is present', () => {
+    const cachePath = withCache((debugBase) => {
+      const headersDir = path.join(
+        debugBase,
+        'ReactNativeHeaders.xcframework',
+        'ios-arm64',
+        'Headers'
+      );
+      fs.mkdirSync(headersDir, { recursive: true });
+      fs.writeFileSync(path.join(headersDir, 'module.modulemap'), 'module ReactNativeHeaders_react {}');
+    });
+
+    const settings = buildSwiftSettings(
+      ['React'],
+      makeArtifactPaths(cachePath, version),
+      path.join(cachePath, 'pkg'),
+      'Debug'
+    );
+    const joined = settings.join(' ');
+
+    // clang requires the joined form `-fmodule-map-file=<path>`; the space-separated variant errors.
+    assert.match(joined, /-fmodule-map-file=\S*module\.modulemap/);
+    assert.ok(!joined.includes('-ivfsoverlay'), 'must not fall back to the VFS overlay');
+  });
+
+  it('falls back to -ivfsoverlay when only the legacy React-VFS overlay is present', () => {
+    const cachePath = withCache((debugBase) => {
+      // Legacy artifact: a generated VFS overlay, no ReactNativeHeaders.xcframework.
+      fs.writeFileSync(
+        path.join(debugBase, 'React-VFS.yaml'),
+        "version: 0\ncase-sensitive: false\nroots: []\n"
+      );
+    });
+
+    const settings = buildSwiftSettings(
+      ['React'],
+      makeArtifactPaths(cachePath, version),
+      path.join(cachePath, 'pkg'),
+      'Debug'
+    );
+    const joined = settings.join(' ');
+
+    assert.ok(joined.includes('-ivfsoverlay'), 'should use the VFS overlay for legacy artifacts');
+    assert.ok(!joined.includes('-fmodule-map-file'), 'must not emit a module map flag');
   });
 });

--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 
 import type { SPMProduct, SwiftTarget } from './SPMConfig.types';
 import {
@@ -209,9 +209,17 @@ describe('buildSwiftSettings ExpoModulesMacros plugin flags', () => {
 
 describe('React header flags: modular module map vs legacy VFS overlay', () => {
   const version = '1000.0.0';
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+    }
+  });
 
   function withCache(populate: (debugBase: string) => void): string {
     const cachePath = fs.mkdtempSync(path.join(os.tmpdir(), 'spm-react-flags-'));
+    tmpDirs.push(cachePath);
     const debugBase = path.join(cachePath, 'react', version, 'debug');
     fs.mkdirSync(debugBase, { recursive: true });
     populate(debugBase);

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -67,6 +67,43 @@ function findXCFrameworkHeadersDir(xcframeworkPath: string): string | null {
 }
 
 /**
+ * Finds the Headers directory of a headers-only xcframework (one whose slices contain a `Headers/`
+ * directory directly, with no `.framework` wrapper — e.g. ReactNativeHeaders.xcframework). The
+ * directory is identified by the presence of a `module.modulemap` and is architecture-independent,
+ * so the first matching slice is used.
+ * @param xcframeworkPath Absolute path to the .xcframework directory
+ * @returns Absolute path to the slice's Headers directory, or null if not found
+ */
+function findModularHeadersDir(xcframeworkPath: string): string | null {
+  if (!fs.existsSync(xcframeworkPath)) {
+    return null;
+  }
+  for (const entry of fs.readdirSync(xcframeworkPath, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const headersDir = path.join(xcframeworkPath, entry.name, 'Headers');
+    if (fs.existsSync(path.join(headersDir, 'module.modulemap'))) {
+      return headersDir;
+    }
+  }
+  return null;
+}
+
+/**
+ * Detects whether a React artifact still uses the legacy VFS overlay. The modern modular artifact
+ * ships ReactNativeHeaders.xcframework (and drops the React-VFS template that the overlay was
+ * generated from), so its absence means we should fall back to the VFS path.
+ * @param basePath Flavor-specific artifact base path (contains React.xcframework)
+ */
+function reactArtifactIsModular(basePath?: string): boolean {
+  if (!basePath) {
+    return false;
+  }
+  return fs.existsSync(path.join(basePath, 'ReactNativeHeaders.xcframework'));
+}
+
+/**
  * Escapes a string for use in a Swift string literal.
  * Handles backslashes and double quotes.
  */
@@ -496,6 +533,13 @@ const ARTIFACT_RELATIVE_PATHS: Record<
     xcframeworkPath: string;
     includeDirectories: string[];
     vfsOverlayFile?: string;
+    /**
+     * Headers-only xcframework (e.g. ReactNativeHeaders.xcframework) shipping a flattened clang
+     * module map under <slice>/Headers/module.modulemap. When present in the artifact, this is the
+     * modern modular replacement for the VFS overlay: consumers get `-fmodule-map-file` + `-I` to
+     * the headers dir instead of `-ivfsoverlay`.
+     */
+    moduleMapXcframework?: string;
     /** Display name used in Package.swift */
     displayName: string;
     /** Key on ArtifactPaths for the flavor-specific base path */
@@ -518,6 +562,7 @@ const ARTIFACT_RELATIVE_PATHS: Record<
     xcframeworkPath: 'React.xcframework',
     includeDirectories: ['Headers', 'React_Core'],
     vfsOverlayFile: 'React-VFS.yaml',
+    moduleMapXcframework: 'ReactNativeHeaders.xcframework',
     displayName: 'React',
     artifactKey: 'react',
     cacheDirName: 'react',
@@ -1238,6 +1283,40 @@ function collectVfsAndHeaderMapFlags(
       buildType
     );
     if (config) {
+      const lowerName = depName.toLowerCase();
+      const artifactConfig = ARTIFACT_RELATIVE_PATHS[lowerName];
+
+      // Modern modular React: when the artifact ships ReactNativeHeaders.xcframework, the lowercase
+      // `react/`, `yoga/`, … namespaces are served by its flattened clang module map instead of a
+      // VFS overlay. Activate the module map (so the includes are modular) and add the headers dir
+      // to the search path (so they resolve). `<React/X.h>` keeps resolving via the React.framework
+      // binary target. This replaces the entire -ivfsoverlay + -I roots dance below.
+      if (lowerName === 'react' && artifactConfig?.moduleMapXcframework) {
+        const isModular =
+          reactArtifactIsModular(config.debugBasePath) ||
+          reactArtifactIsModular(config.releaseBasePath);
+        if (isModular) {
+          const pushModularFlags = (flags: string[], basePath?: string) => {
+            if (!basePath) {
+              return;
+            }
+            const headersDir = findModularHeadersDir(
+              path.join(basePath, artifactConfig.moduleMapXcframework!)
+            );
+            if (headersDir) {
+              // clang requires the joined `-fmodule-map-file=<path>` form (unlike `-ivfsoverlay`,
+              // it rejects the space-separated variant). `-I` adds the headers dir to the search
+              // path so the `<react/…>`, `<yoga/…>` includes resolve.
+              flags.push(`-fmodule-map-file=${path.join(headersDir, 'module.modulemap')}`);
+              flags.push('-I', headersDir);
+            }
+          };
+          pushModularFlags(debug, config.debugBasePath);
+          pushModularFlags(release, config.releaseBasePath);
+          continue;
+        }
+      }
+
       // Add VFS overlay per configuration — each flavor has its own VFS YAML
       // with absolute paths pointing to its specific artifact directory.
       // Paths are emitted as absolute strings since Package.swift is a generated file.

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -9,13 +9,13 @@ import fs from 'fs-extra';
 import { glob } from 'glob';
 import path from 'path';
 
+import { getPrecompileDir } from '../Directories';
+import { getPackageByName } from '../Packages';
 import type { DownloadedDependencies } from './Artifacts.types';
 import type { SPMPackageSource } from './ExternalPackage';
 import { getExternalPackageByProductName } from './ExternalPackage';
 import { Frameworks } from './Frameworks';
 import { BuildFlavor } from './Prebuilder.types';
-import { getPrecompileDir } from '../Directories';
-import { getPackageByName } from '../Packages';
 import {
   ObjcTarget,
   SwiftTarget,
@@ -1291,6 +1291,13 @@ function collectVfsAndHeaderMapFlags(
       // VFS overlay. Activate the module map (so the includes are modular) and add the headers dir
       // to the search path (so they resolve). `<React/X.h>` keeps resolving via the React.framework
       // binary target. This replaces the entire -ivfsoverlay + -I roots dance below.
+      //
+      // The `continue` also skips `config.includeDirectories`, which on the legacy path contributes
+      // `-I React.xcframework/Headers` and `-I React.xcframework/React_Core`. Both are genuinely
+      // redundant here — verified by prebuilding ExpoModulesCore (C++ target, consumes the react/
+      // and yoga/ namespaces) and ExpoCrypto against 0.87.0-rc.3 artifacts: neither root is emitted
+      // and both flavors compose and verify. Keep them out when the VFS branch below is deleted;
+      // dropping the `continue` without replacing it would silently reintroduce them.
       if (lowerName === 'react' && artifactConfig?.moduleMapXcframework) {
         const isModular =
           reactArtifactIsModular(config.debugBasePath) ||

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -176,4 +176,17 @@ describe('getVersionsInfoAsync — Hermes V1 polarity', () => {
     const { hermesVersion } = await getVersionsInfoAsync({});
     assert.equal(hermesVersion, classicVersion);
   });
+
+  // React Native 0.87+ collapsed the dual engines back to a single HERMES_VERSION_NAME.
+  // With V1 enabled by default, resolution must fall back to HERMES_VERSION_NAME instead
+  // of throwing because the (now absent) HERMES_V1_VERSION_NAME key can't be read.
+  it('falls back to HERMES_VERSION_NAME when there is no V1 key (single-engine RN)', async (t) => {
+    if (!(classicVersion && !v1Version)) {
+      t.skip('version.properties exposes a V1 key; single-engine fallback not applicable');
+      return;
+    }
+    delete process.env.RCT_HERMES_V1_ENABLED;
+    const { hermesVersion } = await getVersionsInfoAsync({});
+    assert.equal(hermesVersion, classicVersion);
+  });
 });

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -9,6 +9,7 @@ import { before, describe, it, afterEach } from 'node:test';
 import {
   getVersionsInfoAsync,
   isNonInteractive,
+  resolveHermesVersion,
   selectDistributedPackages,
   setForceNonInteractive,
   IOS_PREBUILD_PACKAGES,
@@ -116,6 +117,60 @@ describe('selectDistributedPackages', () => {
 // pipeline downloads classic Hermes headers (HERMES_VERSION_NAME) while the
 // consuming app links V1 Hermes (HERMES_V1_VERSION_NAME) → release crashes
 // from struct-layout drift.
+
+// The selection itself is pure, so every combination is covered here regardless of which
+// React Native happens to be installed. The integration tests below can only exercise the
+// polarity the pinned RN's version.properties actually exposes — dual-engine RN skips the
+// single-engine case and vice versa — so they cannot stand in for these.
+describe('resolveHermesVersion', () => {
+  const DUAL = { HERMES_VERSION_NAME: '0.17.0', HERMES_V1_VERSION_NAME: '250829098.0.14' };
+  const SINGLE = { HERMES_VERSION_NAME: '0.18.0' };
+  const NO_TAGS = { classic: null, v1: null };
+
+  it('prefers the V1 key when RCT_HERMES_V1_ENABLED is unset', () => {
+    assert.equal(resolveHermesVersion(DUAL, NO_TAGS, {}), '250829098.0.14');
+  });
+
+  it('prefers the V1 key when RCT_HERMES_V1_ENABLED is "1"', () => {
+    assert.equal(
+      resolveHermesVersion(DUAL, NO_TAGS, { RCT_HERMES_V1_ENABLED: '1' }),
+      '250829098.0.14'
+    );
+  });
+
+  it('uses the classic key only when RCT_HERMES_V1_ENABLED is "0"', () => {
+    assert.equal(resolveHermesVersion(DUAL, NO_TAGS, { RCT_HERMES_V1_ENABLED: '0' }), '0.17.0');
+  });
+
+  it('falls back to the classic key when there is no V1 key (single-engine RN)', () => {
+    assert.equal(resolveHermesVersion(SINGLE, NO_TAGS, {}), '0.18.0');
+  });
+
+  it('prefers the matching tag over version.properties, normalizing it', () => {
+    assert.equal(
+      resolveHermesVersion(DUAL, { classic: 'hermes-2024', v1: 'v250829098.0.99' }, {}),
+      '250829098.0.99'
+    );
+    assert.equal(
+      resolveHermesVersion(
+        DUAL,
+        { classic: 'hermes-2024', v1: 'v250829098.0.99' },
+        {
+          RCT_HERMES_V1_ENABLED: '0',
+        }
+      ),
+      '2024'
+    );
+  });
+
+  it('ignores the V1 tag when falling back to the classic key', () => {
+    assert.equal(resolveHermesVersion(SINGLE, { classic: null, v1: 'v9.9.9' }, {}), '0.18.0');
+  });
+
+  it('throws when neither key resolves', () => {
+    assert.throws(() => resolveHermesVersion({}, NO_TAGS, {}), /could not be resolved/);
+  });
+});
 
 describe('getVersionsInfoAsync — Hermes V1 polarity', () => {
   let classicVersion;

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -472,16 +472,21 @@ export const getVersionsInfoAsync = async (options: {
     let classicTag: string | null = null;
     let v1Tag: string | null = null;
 
+    // The .hermesversion / .hermesv1version tag files only exist in the React Native
+    // monorepo source — they are not shipped in published npm tarballs, so a miss here
+    // is expected and harmless (we fall back to the version from version.properties).
     try {
       classicTag = await readHermesTag(reactNativePath);
     } catch (error) {
-      logger.warn(`Could not read .hermesversion: ${String((error as Error).message || error)}`);
+      logger.verbose(`Could not read .hermesversion: ${String((error as Error).message || error)}`);
     }
 
     try {
       v1Tag = await readHermesV1Tag(reactNativePath);
     } catch (error) {
-      logger.warn(`Could not read .hermesv1version: ${String((error as Error).message || error)}`);
+      logger.verbose(
+        `Could not read .hermesv1version: ${String((error as Error).message || error)}`
+      );
     }
 
     const normalizeHermesVersion = (value: string) =>
@@ -490,13 +495,16 @@ export const getVersionsInfoAsync = async (options: {
         .replace(/^v/i, '')
         .trim();
 
-    // Matches hermes-engine.podspec polarity: V1 is the default, classic is
-    // selected only when the consuming app explicitly sets the env var to "0".
+    // React Native 0.85.x shipped two Hermes engines side by side, keyed as
+    // HERMES_VERSION_NAME (classic) and HERMES_V1_VERSION_NAME (V1); the podspec
+    // defaulted to V1 unless RCT_HERMES_V1_ENABLED was set to "0". Newer RN (0.87+)
+    // collapsed back to a single HERMES_VERSION_NAME (which hermes-engine.podspec
+    // reads directly). So prefer the V1 key only when it actually exists, and fall
+    // back to HERMES_VERSION_NAME otherwise — matching whatever the podspec reads.
     const isHermesV1Enabled = process.env.RCT_HERMES_V1_ENABLED !== '0';
-    const version = isHermesV1Enabled
-      ? properties.HERMES_V1_VERSION_NAME
-      : properties.HERMES_VERSION_NAME;
-    const tag = isHermesV1Enabled ? v1Tag : classicTag;
+    const useV1 = isHermesV1Enabled && !!properties.HERMES_V1_VERSION_NAME;
+    const version = useV1 ? properties.HERMES_V1_VERSION_NAME : properties.HERMES_VERSION_NAME;
+    const tag = useV1 ? v1Tag : classicTag;
 
     if (!version) {
       throw new Error(

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -401,6 +401,48 @@ export const verifyAllPackagesAsync = async (
   );
 };
 
+const normalizeHermesVersion = (value: string) =>
+  value
+    .replace(/^hermes-?/i, '')
+    .replace(/^v/i, '')
+    .trim();
+
+/**
+ * Picks which Hermes engine's version to use, given the keys `version.properties` exposes.
+ *
+ * React Native 0.85.x shipped two engines side by side, keyed as HERMES_VERSION_NAME (classic)
+ * and HERMES_V1_VERSION_NAME (V1); the podspec defaulted to V1 unless RCT_HERMES_V1_ENABLED was
+ * set to "0". Newer RN (0.87+) collapsed back to a single HERMES_VERSION_NAME. So prefer the V1
+ * key only when it actually exists, and fall back to HERMES_VERSION_NAME otherwise — matching
+ * whatever hermes-engine.podspec reads. Getting the polarity wrong downloads classic Hermes
+ * headers while the app links V1, which crashes on struct-layout drift.
+ *
+ * Kept pure and exported so every combination is testable without a matching RN checkout.
+ *
+ * @param properties Parsed `sdks/hermes-engine/version.properties`.
+ * @param tags Contents of the `.hermesversion` / `.hermesv1version` tag files, if present.
+ * @param env Environment to read `RCT_HERMES_V1_ENABLED` from.
+ * @returns The normalized Hermes version, preferring the tag matching the selected engine.
+ */
+export const resolveHermesVersion = (
+  properties: Record<string, string | undefined>,
+  tags: { classic?: string | null; v1?: string | null },
+  env: Record<string, string | undefined>
+): string => {
+  const useV1 = env.RCT_HERMES_V1_ENABLED !== '0' && !!properties.HERMES_V1_VERSION_NAME;
+  const version = useV1 ? properties.HERMES_V1_VERSION_NAME : properties.HERMES_VERSION_NAME;
+
+  if (!version) {
+    throw new Error(
+      'Hermes version could not be resolved from version.properties. ' +
+        'Provide --hermes-version explicitly.'
+    );
+  }
+
+  const tag = useV1 ? tags.v1 : tags.classic;
+  return normalizeHermesVersion(tag ?? version);
+};
+
 /**
  * Tries to resolve versions for React Native and Hermes.
  * @param options Options containing optional versions if none is found.
@@ -489,31 +531,7 @@ export const getVersionsInfoAsync = async (options: {
       );
     }
 
-    const normalizeHermesVersion = (value: string) =>
-      value
-        .replace(/^hermes-?/i, '')
-        .replace(/^v/i, '')
-        .trim();
-
-    // React Native 0.85.x shipped two Hermes engines side by side, keyed as
-    // HERMES_VERSION_NAME (classic) and HERMES_V1_VERSION_NAME (V1); the podspec
-    // defaulted to V1 unless RCT_HERMES_V1_ENABLED was set to "0". Newer RN (0.87+)
-    // collapsed back to a single HERMES_VERSION_NAME (which hermes-engine.podspec
-    // reads directly). So prefer the V1 key only when it actually exists, and fall
-    // back to HERMES_VERSION_NAME otherwise — matching whatever the podspec reads.
-    const isHermesV1Enabled = process.env.RCT_HERMES_V1_ENABLED !== '0';
-    const useV1 = isHermesV1Enabled && !!properties.HERMES_V1_VERSION_NAME;
-    const version = useV1 ? properties.HERMES_V1_VERSION_NAME : properties.HERMES_VERSION_NAME;
-    const tag = useV1 ? v1Tag : classicTag;
-
-    if (!version) {
-      throw new Error(
-        'Hermes version could not be resolved from version.properties. ' +
-          'Provide --hermes-version explicitly.'
-      );
-    }
-
-    return normalizeHermesVersion(tag ?? version);
+    return resolveHermesVersion(properties, { classic: classicTag, v1: v1Tag }, process.env);
   };
 
   const reactNativeVersion =


### PR DESCRIPTION
## Summary

In RN 0.87 we've released a new version of our precompiled binaries that works without the VFS overlay:

- https://github.com/react/react-native/pull/57285 - removal of VFS overlay
- https://github.com/react/react-native/pull/57305 - moved resource bundles to xcframework

Giving us completely self-contained XCFrameworks from RN which is a prerequisite for SwiftPM to not become too complex.

Expo needs to detect wether we have a VFS overlay or not.

## How

This PR addds support for detecting wether we're running with an RN version that uses these new frameworks or not - making sure we fallback to the old version when running with pre 0.87.

In addition it updates the pod install pipeline with the same tests.

NOTE: When merging 0.87 into Expo (as our current React Native), we can remove a lot of code in a follow-up PR that removes the VFS support all-over.

There are a couple of 3rd party packages not compatible with RN 0.87 yet, so I tested with some patches for these packages. In addition a small binary fix was added to fix a missing method in 0.87 in EXpo's code.

## Test-plan

- ✅ Built Bare-Expo, minimal-tester and precompiled with the new binaries from React native
- ✅ Verified that the same versions are using VFS and precompiling correctly when using RN 0.86
