### PR TITLE
[ios][audio] Fix playlist track index

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Deactivate the audio session off the main thread to avoid app hangs. ([#47066](https://github.com/expo/expo/pull/47066) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix playlist `currentIndex` freezing after the first auto-advance.
+- [iOS] Fix playlist `currentIndex` freezing after the first auto-advance. ([#47257](https://github.com/expo/expo/pull/47257) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Deactivate the audio session off the main thread to avoid app hangs. ([#47066](https://github.com/expo/expo/pull/47066) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix playlist `currentIndex` freezing after the first auto-advance.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -289,9 +289,10 @@ public class AudioModule: Module {
 
     Class(AudioPlaylist.self) {
       Constructor { (sources: [AudioSource], updateInterval: Double, loopMode: LoopMode) -> AudioPlaylist in
-        let items = sources.compactMap { AudioUtils.createAVPlayerItem(from: $0) }
-        let avQueuePlayer = AVQueuePlayer(items: items)
-        let playlist = AudioPlaylist(avQueuePlayer, sources: sources, interval: updateInterval, loopMode: loopMode)
+        // Keep one slot per source, nil where an item can't be created, so playerItems stays aligned with sources.
+        let items = sources.map { AudioUtils.createAVPlayerItem(from: $0) }
+        let avQueuePlayer = AVQueuePlayer(items: items.compactMap { $0 })
+        let playlist = AudioPlaylist(avQueuePlayer, sources: sources, items: items, interval: updateInterval, loopMode: loopMode)
         playlist.owningRegistry = self.registry
         self.registry.add(playlist)
         return playlist

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -180,7 +180,12 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     }
 
     let wasPlaying = isPlaying
-    let resumeIndex = index <= currentTrackIndex ? currentTrackIndex + 1 : currentTrackIndex
+    let resumeIndex: Int
+    if ref.currentItem != nil {
+      resumeIndex = index <= currentTrackIndex ? currentTrackIndex + 1 : currentTrackIndex
+    } else {
+      resumeIndex = index
+    }
     sources.insert(source, at: index)
 
     previousTrackIndex = resumeIndex
@@ -214,6 +219,11 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
       if wasPlaying {
         play(at: currentRate)
       }
+    } else if index < playerItems.count {
+      if let item = playerItems[index] {
+        ref.remove(item)
+      }
+      playerItems.remove(at: index)
     }
 
     updateStatus(with: ["trackCount": trackCount])

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -82,13 +82,13 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     sources.count
   }
 
-  init(_ ref: AVQueuePlayer, sources: [AudioSource], interval: Double, loopMode: LoopMode) {
+  init(_ ref: AVQueuePlayer, sources: [AudioSource], items: [AVPlayerItem?], interval: Double, loopMode: LoopMode) {
     self.interval = interval
     self.loopMode = loopMode
     self.sources = sources
+    self.playerItems = items
     super.init(ref)
 
-    self.playerItems = ref.items().map { $0 as AVPlayerItem? }
     ref.actionAtItemEnd = loopMode == .single ? .pause : .advance
     setupPublisher()
     addPlaybackEndNotification()

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -19,13 +19,22 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   var wasPlaying = false
 
   private(set) var sources: [AudioSource] = []
-  private(set) var currentTrackIndex: Int = 0
+
+  private var playerItems: [AVPlayerItem?] = []
+  private var previousTrackIndex = 0
+
+  var currentTrackIndex: Int {
+    guard let current = ref.currentItem,
+          let index = playerItems.firstIndex(where: { $0 === current }) else {
+      return min(max(previousTrackIndex, 0), max(sources.count - 1, 0))
+    }
+    return index
+  }
 
   func getSourceInfo() -> [AudioSource] {
     return sources
   }
 
-  private var currentItem: AVPlayerItem?
   private var timeToken: Any?
   private var cancellables = Set<AnyCancellable>()
   private var endObserver: NSObjectProtocol?
@@ -79,7 +88,8 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     self.sources = sources
     super.init(ref)
 
-    self.currentItem = ref.currentItem
+    self.playerItems = ref.items().map { $0 as AVPlayerItem? }
+    ref.actionAtItemEnd = loopMode == .single ? .pause : .advance
     setupPublisher()
     addPlaybackEndNotification()
   }
@@ -102,29 +112,20 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   func next() {
-    let previousIndex = currentTrackIndex
-
     if currentTrackIndex < sources.count - 1 {
       ref.advanceToNextItem()
-      currentTrackIndex += 1
-      currentItem = ref.currentItem
-      emitTrackChanged(previousIndex: previousIndex, currentIndex: currentTrackIndex)
     } else if loopMode == .all && !sources.isEmpty {
       skipTo(index: 0)
     }
   }
 
   func previous() {
-    let previousIndex = currentTrackIndex
-
     if currentTrackIndex > 0 {
       let wasPlaying = isPlaying
-      currentTrackIndex -= 1
-      rebuildPlaylist(startingAt: currentTrackIndex)
+      rebuildPlaylist(startingAt: currentTrackIndex - 1)
       if wasPlaying {
         play(at: currentRate)
       }
-      emitTrackChanged(previousIndex: previousIndex, currentIndex: currentTrackIndex)
     } else if loopMode == .all && !sources.isEmpty {
       skipTo(index: sources.count - 1)
     }
@@ -143,17 +144,12 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
       return
     }
 
-    let previousIndex = currentTrackIndex
     let wasPlaying = isPlaying
-
-    currentTrackIndex = index
     rebuildPlaylist(startingAt: index)
 
     if wasPlaying {
       play(at: currentRate)
     }
-
-    emitTrackChanged(previousIndex: previousIndex, currentIndex: currentTrackIndex)
   }
 
   func seekTo(seconds: Double) async {
@@ -170,12 +166,11 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
 
   func add(source: AudioSource) {
     sources.append(source)
-    if let item = AudioUtils.createAVPlayerItem(from: source) {
+    let item = AudioUtils.createAVPlayerItem(from: source)
+    if let item {
       ref.insert(item, after: nil)
     }
-    if currentItem == nil {
-      currentItem = ref.currentItem
-    }
+    playerItems.append(item)
     updateStatus(with: ["trackCount": trackCount])
   }
 
@@ -185,13 +180,11 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     }
 
     let wasPlaying = isPlaying
+    let resumeIndex = index <= currentTrackIndex ? currentTrackIndex + 1 : currentTrackIndex
     sources.insert(source, at: index)
 
-    if index <= currentTrackIndex {
-      currentTrackIndex += 1
-    }
-
-    rebuildPlaylist(startingAt: currentTrackIndex)
+    previousTrackIndex = resumeIndex
+    rebuildPlaylist(startingAt: resumeIndex)
     if wasPlaying {
       play(at: currentRate)
     }
@@ -204,19 +197,20 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     }
 
     let wasPlaying = isPlaying
+    let current = currentTrackIndex
     sources.remove(at: index)
 
-    if index == currentTrackIndex {
-      if currentTrackIndex >= sources.count {
-        currentTrackIndex = max(0, sources.count - 1)
-      }
-      rebuildPlaylist(startingAt: currentTrackIndex)
+    if index == current {
+      let resumeIndex = min(current, max(0, sources.count - 1))
+      previousTrackIndex = resumeIndex
+      rebuildPlaylist(startingAt: resumeIndex)
       if wasPlaying && !sources.isEmpty {
         play(at: currentRate)
       }
-    } else if index < currentTrackIndex {
-      currentTrackIndex -= 1
-      rebuildPlaylist(startingAt: currentTrackIndex)
+    } else if index < current {
+      let resumeIndex = current - 1
+      previousTrackIndex = resumeIndex
+      rebuildPlaylist(startingAt: resumeIndex)
       if wasPlaying {
         play(at: currentRate)
       }
@@ -229,8 +223,8 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     ref.pause()
     ref.removeAllItems()
     sources.removeAll()
-    currentTrackIndex = 0
-    currentItem = nil
+    playerItems.removeAll()
+    previousTrackIndex = 0
 
     updateStatus(with: [
       "trackCount": 0,
@@ -241,6 +235,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
 
   func setLoopMode(_ mode: LoopMode) {
     loopMode = mode
+    ref.actionAtItemEnd = mode == .single ? .pause : .advance
     updateStatus(with: ["loop": mode.rawValue])
   }
 
@@ -304,14 +299,18 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   private func rebuildPlaylist(startingAt index: Int) {
-    ref.removeAllItems()
-
+    var items = [AVPlayerItem?](repeating: nil, count: sources.count)
     for i in index..<sources.count {
-      if let item = AudioUtils.createAVPlayerItem(from: sources[i]) {
+      items[i] = AudioUtils.createAVPlayerItem(from: sources[i])
+    }
+    playerItems = items
+
+    ref.removeAllItems()
+    for i in index..<sources.count {
+      if let item = items[i] {
         ref.insert(item, after: nil)
       }
     }
-    currentItem = ref.currentItem
   }
 
   private func setupPublisher() {
@@ -331,7 +330,13 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
         guard let self else {
           return
         }
-        self.updateStatus(with: [:])
+        let index = self.currentTrackIndex
+        if index != self.previousTrackIndex {
+          self.emitTrackChanged(previousIndex: self.previousTrackIndex, currentIndex: index)
+          self.previousTrackIndex = index
+        } else {
+          self.updateStatus(with: [:])
+        }
       }
       .store(in: &cancellables)
   }
@@ -344,38 +349,29 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
     ) { [weak self] notification in
       guard let self,
             let item = notification.object as? AVPlayerItem,
-            item == self.currentItem else {
+            let finishedIndex = self.playerItems.firstIndex(where: { $0 === item }) else {
         return
       }
 
-      let previousIndex = self.currentTrackIndex
+      let isLastTrack = finishedIndex >= self.sources.count - 1
 
       switch self.loopMode {
       case .single:
-        self.rebuildPlaylist(startingAt: self.currentTrackIndex)
+        self.ref.seek(to: .zero)
         self.play(at: self.currentRate)
 
       case .all:
-        if self.currentTrackIndex >= self.sources.count - 1 {
+        if isLastTrack {
           self.skipTo(index: 0)
           self.play(at: self.currentRate)
-        } else {
-          self.currentItem = self.ref.currentItem
-          self.currentTrackIndex += 1
-          self.emitTrackChanged(previousIndex: previousIndex, currentIndex: self.currentTrackIndex)
         }
 
       case .none:
-        if self.currentTrackIndex >= self.sources.count - 1 {
-          self.currentItem = nil
+        if isLastTrack {
           self.updateStatus(with: [
             "playing": false,
             "didJustFinish": true
           ])
-        } else {
-          self.currentItem = self.ref.currentItem
-          self.currentTrackIndex += 1
-          self.emitTrackChanged(previousIndex: previousIndex, currentIndex: self.currentTrackIndex)
         }
       }
     }


### PR DESCRIPTION
# Why
Closes #47247

# How
The iOS playlist kept its own currentTrackIndex and a currentItem reference, and updated them from inside the `AVPlayerItemDidPlayToEndTime` notification. That read races the queue player, which has not reliably advanced its current item at the moment the notification fires, so currentItem got pinned to the track that just finished. Every end notification after then failed the item == currentItem guard and bailed out, leaving the index stuck.

This reworks the iOS side, where the index comes from the player rather than managing it manually ourselves.

- currentTrackIndex is now derived from the identity of ref.currentItem within an ordered playerItems map, so it cannot drift out of sync with playback.
- trackChanged is emitted from the currentItem KVO observer.
- The end-of-track notification is reduced to the cases the player cannot handle on its own, replaying in single mode, wrapping to the start in all mode, and reporting didJustFinish at the end in none mode.

# Test Plan
Bare expo

