### PR TITLE
[cli] detect route error on linting stage

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- `expo lint` now fails when an Expo Router route has a platform-specific extension (`.ios`/`.android`/`.native`/`.web`) with no non-platform fallback, which otherwise crashes route generation at runtime. ([#PR](https://github.com/expo/expo/pull/PR) by [@kudo](https://github.com/kudo))
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))

--- a/packages/@expo/cli/src/lint/__tests__/expoRouterRoutes-test.ts
+++ b/packages/@expo/cli/src/lint/__tests__/expoRouterRoutes-test.ts
@@ -1,0 +1,59 @@
+import { findPlatformRouteIssues } from '../expoRouterRoutes';
+
+describe(findPlatformRouteIssues, () => {
+  it('should return no issues when a platform route has a same-directory fallback', () => {
+    expect(findPlatformRouteIssues(['about.tsx', 'about.web.tsx'])).toEqual([]);
+  });
+
+  it('should accept a fallback with any source extension', () => {
+    expect(findPlatformRouteIssues(['legacy.js', 'legacy.android.tsx'])).toEqual([]);
+  });
+
+  it('should accept platform layouts that have a fallback', () => {
+    expect(findPlatformRouteIssues(['_layout.tsx', '_layout.ios.tsx'])).toEqual([]);
+  });
+
+  it('should ignore non-platform route files', () => {
+    expect(findPlatformRouteIssues(['index.tsx', 'about.tsx'])).toEqual([]);
+  });
+
+  it('should ignore non-route special files even without a fallback', () => {
+    expect(findPlatformRouteIssues(['+native-intent.ios.ts', '+html.web.tsx'])).toEqual([]);
+  });
+
+  it('should accept fallbacks within nested group directories', () => {
+    expect(findPlatformRouteIssues(['(tabs)/about.tsx', '(tabs)/about.ios.tsx'])).toEqual([]);
+  });
+
+  it('should flag a platform route with no fallback', () => {
+    expect(findPlatformRouteIssues(['profile.ios.tsx'])).toEqual([
+      { type: 'missing-fallback', file: 'profile.ios.tsx', platform: 'ios', base: 'profile' },
+    ]);
+  });
+
+  it('should report a missing fallback once when multiple platform variants exist', () => {
+    expect(
+      findPlatformRouteIssues(['about.ios.tsx', 'about.android.tsx', 'about.web.tsx'])
+    ).toEqual([
+      { type: 'missing-fallback', file: 'about.ios.tsx', platform: 'ios', base: 'about' },
+    ]);
+  });
+
+  it('should not treat a directory route as a fallback for a file route', () => {
+    // `about/index.tsx` and `about.ios.tsx` are distinct route files; the latter still needs `about.tsx`.
+    expect(findPlatformRouteIssues(['about.ios.tsx', 'about/index.tsx'])).toEqual([
+      { type: 'missing-fallback', file: 'about.ios.tsx', platform: 'ios', base: 'about' },
+    ]);
+  });
+
+  it('should flag API routes that carry a platform extension', () => {
+    expect(findPlatformRouteIssues(['hello+api.ts', 'hello+api.ios.ts'])).toEqual([
+      {
+        type: 'api-platform-extension',
+        file: 'hello+api.ios.ts',
+        platform: 'ios',
+        base: 'hello+api',
+      },
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/lint/__tests__/getExpoRouterLintIssuesAsync-test.ts
+++ b/packages/@expo/cli/src/lint/__tests__/getExpoRouterLintIssuesAsync-test.ts
@@ -1,0 +1,55 @@
+import { getConfig } from '@expo/config';
+import { vol } from 'memfs';
+import resolveFrom from 'resolve-from';
+
+import { getExpoRouterLintIssuesAsync } from '../expoRouterRoutes';
+
+jest.mock('@expo/config');
+jest.mock('resolve-from', () => ({
+  __esModule: true,
+  default: { silent: jest.fn() },
+}));
+
+const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>;
+const mockResolveSilent = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
+
+const projectRoot = '/project';
+
+function fromFiles(files: string[]) {
+  vol.fromJSON(Object.fromEntries(files.map((file) => [file, ''])), projectRoot);
+}
+
+describe(getExpoRouterLintIssuesAsync, () => {
+  beforeEach(() => {
+    vol.reset();
+    mockGetConfig.mockReturnValue({ exp: { extra: {} } } as any);
+    mockResolveSilent.mockReturnValue('/project/node_modules/expo-router/package.json');
+  });
+
+  it('should detect a fallback-less platform route under the default app directory', async () => {
+    fromFiles(['app/_layout.tsx', 'app/index.tsx', 'app/profile.ios.tsx']);
+
+    expect(await getExpoRouterLintIssuesAsync(projectRoot)).toEqual({
+      routerRoot: 'app',
+      issues: [
+        { type: 'missing-fallback', file: 'profile.ios.tsx', platform: 'ios', base: 'profile' },
+      ],
+    });
+  });
+
+  it('should resolve the src/app router root and accept valid platform routes', async () => {
+    fromFiles(['src/app/about.tsx', 'src/app/about.web.tsx']);
+
+    expect(await getExpoRouterLintIssuesAsync(projectRoot)).toEqual({
+      routerRoot: 'src/app',
+      issues: [],
+    });
+  });
+
+  it('should return null when expo-router is not installed', async () => {
+    mockResolveSilent.mockReturnValue(undefined);
+    fromFiles(['app/profile.ios.tsx']);
+
+    expect(await getExpoRouterLintIssuesAsync(projectRoot)).toBeNull();
+  });
+});

--- a/packages/@expo/cli/src/lint/expoRouterRoutes.ts
+++ b/packages/@expo/cli/src/lint/expoRouterRoutes.ts
@@ -1,0 +1,145 @@
+import { getConfig } from '@expo/config';
+import { glob } from 'glob';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
+import { directoryExistsSync } from '../utils/dir';
+
+export const PLATFORM_ROUTES_DOCS_URL =
+  'https://docs.expo.dev/router/advanced/platform-specific-modules/';
+
+// Platform extensions Metro resolves. Mirrors `validPlatforms` in expo-router's getRoutesCore.
+const PLATFORMS = new Set(['android', 'ios', 'native', 'web']);
+
+// File extensions a route or its fallback can use.
+const SOURCE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js'];
+
+// Special files that are not client routes, so platform extensions on them are irrelevant here.
+const NON_ROUTE_FILES = new Set(['+html', '+native-intent', '+middleware']);
+
+export interface PlatformRouteIssue {
+  type: 'missing-fallback' | 'api-platform-extension';
+  /** Path of the offending file, relative to the router root, using POSIX separators. */
+  file: string;
+  platform: string;
+  /** Route base name with the platform extension removed. */
+  base: string;
+}
+
+function posixDirname(file: string): string {
+  const index = file.lastIndexOf('/');
+  return index === -1 ? '' : file.slice(0, index);
+}
+
+function posixBasename(file: string): string {
+  const index = file.lastIndexOf('/');
+  return index === -1 ? file : file.slice(index + 1);
+}
+
+/**
+ * Given a list of route files (relative to the router root, POSIX separators), find platform-specific
+ * routes that would break route generation: those with no non-platform fallback in the same directory,
+ * and API routes that carry a platform extension. Reports each missing fallback once per route.
+ */
+export function findPlatformRouteIssues(routeFiles: string[]): PlatformRouteIssue[] {
+  const fileSet = new Set(routeFiles);
+  const issues: PlatformRouteIssue[] = [];
+  const reportedFallbacks = new Set<string>();
+
+  for (const file of routeFiles) {
+    const parts = posixBasename(file).split('.');
+    // A platform route looks like `name.<platform>.<ext>`, so we need at least three segments.
+    if (parts.length < 3) {
+      continue;
+    }
+
+    const extension = parts[parts.length - 1];
+    const platform = parts[parts.length - 2];
+    if (
+      !extension ||
+      !platform ||
+      !SOURCE_EXTENSIONS.includes(extension) ||
+      !PLATFORMS.has(platform)
+    ) {
+      continue;
+    }
+
+    const base = parts.slice(0, parts.length - 2).join('.');
+    if (!base || NON_ROUTE_FILES.has(base)) {
+      continue;
+    }
+
+    // API routes can never carry a platform extension, regardless of a fallback.
+    if (base.endsWith('+api')) {
+      issues.push({ type: 'api-platform-extension', file, platform, base });
+      continue;
+    }
+
+    const directory = posixDirname(file);
+    const routeKey = `${directory}/${base}`;
+    if (reportedFallbacks.has(routeKey)) {
+      continue;
+    }
+
+    const hasFallback = SOURCE_EXTENSIONS.some((ext) =>
+      fileSet.has(directory ? `${directory}/${base}.${ext}` : `${base}.${ext}`)
+    );
+    if (!hasFallback) {
+      reportedFallbacks.add(routeKey);
+      issues.push({ type: 'missing-fallback', file, platform, base });
+    }
+  }
+
+  return issues;
+}
+
+/** Render a single issue into a human- and agent-readable message. */
+export function formatPlatformRouteIssue(issue: PlatformRouteIssue, routerRoot: string): string {
+  const location = `${routerRoot}/${issue.file}`;
+  if (issue.type === 'api-platform-extension') {
+    return (
+      `${location}: API routes cannot have platform extensions. ` +
+      `Remove ".${issue.platform}" from the filename. See ${PLATFORM_ROUTES_DOCS_URL}`
+    );
+  }
+  return (
+    `${location}: platform-specific route ("${issue.platform}") has no non-platform fallback, so the ` +
+    `"${issue.base}" route will not exist on other platforms and Expo Router throws when building the ` +
+    `route tree. Add a non-platform "${issue.base}" file next to it, or move the screen out of the ` +
+    `router directory and re-export it (e.g. export { default } from '@/components/${issue.base}'). ` +
+    `See ${PLATFORM_ROUTES_DOCS_URL}`
+  );
+}
+
+/**
+ * Scan an Expo Router project for platform-specific routes that lack a non-platform fallback.
+ * Returns `null` when the project does not use Expo Router or has no router directory.
+ */
+export async function getExpoRouterLintIssuesAsync(
+  projectRoot: string
+): Promise<{ routerRoot: string; issues: PlatformRouteIssue[] } | null> {
+  if (!resolveFrom.silent(projectRoot, 'expo-router/package.json')) {
+    return null;
+  }
+
+  const { exp } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+    skipPlugins: true,
+  });
+
+  const routerRoot = getRouterDirectoryModuleIdWithManifest(projectRoot, exp);
+  const absoluteRouterRoot = path.join(projectRoot, routerRoot);
+  if (!directoryExistsSync(absoluteRouterRoot)) {
+    return null;
+  }
+
+  const routeFiles = await glob(`**/*.{${SOURCE_EXTENSIONS.join(',')}}`, {
+    cwd: absoluteRouterRoot,
+    nodir: true,
+    posix: true,
+    ignore: ['**/node_modules/**'],
+  });
+
+  return { routerRoot, issues: findPlatformRouteIssues(routeFiles) };
+}

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -3,10 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
+import { Log } from '../log';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { ESLintProjectPrerequisite } from './ESlintPrerequisite';
+import { formatPlatformRouteIssue, getExpoRouterLintIssuesAsync } from './expoRouterRoutes';
 import type { Options } from './resolveOptions';
 
 const debug = require('debug')('expo:lint');
@@ -108,6 +110,24 @@ export const lintAsync = async (
 
   const manager = createForProject(projectRoot, { silent: true });
 
+  // Expo Router structural checks that ESLint's per-file rules can't express reliably. This scans the
+  // whole route tree once, so it sees the real router root and every platform variant of a route.
+  let hasRouterIssues = false;
+  try {
+    const routerLint = await getExpoRouterLintIssuesAsync(projectRoot);
+    if (routerLint?.issues.length) {
+      hasRouterIssues = true;
+      Log.error(
+        `Found ${routerLint.issues.length} Expo Router issue${routerLint.issues.length === 1 ? '' : 's'}:\n` +
+          routerLint.issues
+            .map((issue) => `  ${formatPlatformRouteIssue(issue, routerLint.routerRoot)}`)
+            .join('\n')
+      );
+    }
+  } catch (error: any) {
+    debug('Skipping Expo Router lint checks: %s', error.message);
+  }
+
   try {
     // TODO: Custom logger
     // - Use relative paths
@@ -117,6 +137,10 @@ export const lintAsync = async (
       stdio: 'inherit',
     });
   } catch (error: any) {
-    process.exit(error.status);
+    process.exit(error.status || 1);
+  }
+
+  if (hasRouterIssues) {
+    process.exit(1);
   }
 };


### PR DESCRIPTION
# Why

detect route errors from tooling

# How

detect route errors on `npx expo lint`

# Test Plan

ci passed

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
