### PR TITLE
[ios][jsi] Preserve error code on async function promise rejections

### DIFF
--- a/packages/expo-modules-core/ios/Tests/ExceptionsTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ExceptionsTests.swift
@@ -97,7 +97,52 @@ struct ExceptionsTests {
   func `sync function throw`() throws {
     let appContext = AppContext.create()
     let runtime = try appContext.runtime
+    Self.registerTestModule(on: appContext)
 
+    let error = try runtime.eval("try { expo.modules.TestModule.codedException() } catch (error) { error }").asObject()
+    #expect(error.getProperty("message").getString().contains("FunctionCallException: Calling the 'codedException' function has failed"))
+    #expect(error.getProperty("code").getString() == "E_TEST_CODE")
+  }
+
+  @Test
+  func `async function throw exposes the code to JS`() async throws {
+    let appContext = AppContext.create()
+    let runtime = try appContext.runtime
+    Self.registerTestModule(on: appContext)
+
+    let code = try await runtime.evalAsync(
+      "expo.modules.TestModule.codedExceptionThrowAsync().then(() => 'NO_ERROR', (error) => error.code ?? 'NO_CODE')"
+    )
+    #expect(code.getString() == "E_TEST_CODE")
+  }
+
+  @Test
+  func `async function reject exposes the code to JS`() async throws {
+    let appContext = AppContext.create()
+    let runtime = try appContext.runtime
+    Self.registerTestModule(on: appContext)
+
+    // A manual `promise.reject(error)` passes the error straight through (unlike a thrown error,
+    // which gets wrapped in a `FunctionCallException`), so we only assert on the preserved `code`.
+    let code = try await runtime.evalAsync(
+      "expo.modules.TestModule.codedExceptionRejectAsync().then(() => 'NO_ERROR', (error) => error.code ?? 'NO_CODE')"
+    )
+    #expect(code.getString() == "E_TEST_CODE")
+  }
+
+  @Test
+  func `concurrent async function throw exposes the code to JS`() async throws {
+    let appContext = AppContext.create()
+    let runtime = try appContext.runtime
+    Self.registerTestModule(on: appContext)
+
+    let code = try await runtime.evalAsync(
+      "expo.modules.TestModule.codedExceptionConcurrentAsync().then(() => 'NO_ERROR', (error) => error.code ?? 'NO_CODE')"
+    )
+    #expect(code.getString() == "E_TEST_CODE")
+  }
+
+  private static func registerTestModule(on appContext: AppContext) {
     appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
       Name("TestModule")
 
@@ -117,10 +162,6 @@ struct ExceptionsTests {
         throw TestCodedException()
       }
     })
-
-    let error = try runtime.eval("try { expo.modules.TestModule.codedException() } catch (error) { error }").asObject()
-    #expect(error.getProperty("message").getString().contains("FunctionCallException: Calling the 'codedException' function has failed"))
-    #expect(error.getProperty("code").getString() == "E_TEST_CODE")
   }
 }
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [iOS] Clear stale build intermediates before rebuilding xcframework slices to avoid compiler errors. ([#46399](https://github.com/expo/expo/pull/46399) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Type the host-object setter pointer explicitly so the nil-check conversion type-checks reliably. ([#46736](https://github.com/expo/expo/pull/46736) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Awaiting a `JavaScriptPromise` that is rejected after the await begins now throws instead of resuming with the rejection value as if fulfilled. ([#47154](https://github.com/expo/expo/pull/47154) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), by routing it through the code-preserving `JavaScriptError(from:)` initializer in `JavaScriptPromise.reject` instead of stringifying it — mirroring the synchronous throw path. ([#27959](https://github.com/expo/expo/issues/27959) by [@wwdrew](https://github.com/wwdrew))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [iOS] Clear stale build intermediates before rebuilding xcframework slices to avoid compiler errors. ([#46399](https://github.com/expo/expo/pull/46399) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Type the host-object setter pointer explicitly so the nil-check conversion type-checks reliably. ([#46736](https://github.com/expo/expo/pull/46736) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Awaiting a `JavaScriptPromise` that is rejected after the await begins now throws instead of resuming with the rejection value as if fulfilled. ([#47154](https://github.com/expo/expo/pull/47154) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), by routing it through the code-preserving `JavaScriptError(from:)` initializer in `JavaScriptPromise.reject` instead of stringifying it — mirroring the synchronous throw path. ([#27959](https://github.com/expo/expo/issues/27959) by [@wwdrew](https://github.com/wwdrew))
+- [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47259](https://github.com/expo/expo/pull/47259) by [@wwdrew](https://github.com/wwdrew))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
@@ -50,6 +50,21 @@ public final class JavaScriptError: Error, Sendable {
     }
   }
 
+  /// Returns the `JavaScriptError` representing an arbitrary native error. An existing
+  /// `JavaScriptError` is returned unchanged so its wrapped value reaches JS as-is; a
+  /// `JavaScriptThrowable` is routed through the code-preserving initializer above; any
+  /// other error is stringified into a generic `Error`.
+  @inlinable
+  public static func from(_ error: any Error, in runtime: JavaScriptRuntime) -> JavaScriptError {
+    if let jsError = error as? JavaScriptError {
+      return jsError
+    }
+    if let throwable = error as? JavaScriptThrowable {
+      return JavaScriptError(runtime, from: throwable)
+    }
+    return JavaScriptError(runtime, message: String(describing: error))
+  }
+
   /// Returns the error as a `JavaScriptValue`, which may be an arbitrary value rather than an
   /// `Error` instance when the error was created from one.
   public func toValue() -> JavaScriptValue {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -102,21 +102,11 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       guard let rejecter = rejectFunction.take() else {
         return
       }
-      // A `JavaScriptError` already carries the value to reject with (which may be an arbitrary JS
-      // value rather than an `Error`), so reuse it. Errors conforming to `JavaScriptThrowable`
-      // (e.g. expo-modules-core's `Exception`) carry a structured `code`, so route them through the
-      // code-preserving initializer to mirror the synchronous throw path in
-      // `forwardingSwiftErrorsToJS`; otherwise the `code` is lost and JS only sees the message.
-      // Any other native error is stringified into a generic `Error`.
-      let jsError: JavaScriptError
-      if let javaScriptError = error as? JavaScriptError {
-        jsError = javaScriptError
-      } else if let throwable = error as? JavaScriptThrowable {
-        jsError = JavaScriptError(runtime, from: throwable)
-      } else {
-        jsError = JavaScriptError(runtime, message: String(describing: error))
-      }
-      let errorValue = jsError.toValue()
+      // Convert the error to its JavaScript representation. This preserves an existing
+      // `JavaScriptError`'s wrapped value and a `JavaScriptThrowable`'s structured `code`
+      // (mirroring the synchronous throw path in `forwardingSwiftErrorsToJS`), so the `code`
+      // is not lost on async rejection. See `JavaScriptError.from(_:in:)`.
+      let errorValue = JavaScriptError.from(error, in: runtime).toValue()
 
       // Call the actual rejecter given in the Promise setup.
       // This will also call `deferredPromise.reject` in the `then` handler.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -103,9 +103,19 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
         return
       }
       // A `JavaScriptError` already carries the value to reject with (which may be an arbitrary JS
-      // value rather than an `Error`), so reuse it. Any other native error is stringified into a
-      // generic `Error`.
-      let jsError = error as? JavaScriptError ?? JavaScriptError(runtime, message: String(describing: error))
+      // value rather than an `Error`), so reuse it. Errors conforming to `JavaScriptThrowable`
+      // (e.g. expo-modules-core's `Exception`) carry a structured `code`, so route them through the
+      // code-preserving initializer to mirror the synchronous throw path in
+      // `forwardingSwiftErrorsToJS`; otherwise the `code` is lost and JS only sees the message.
+      // Any other native error is stringified into a generic `Error`.
+      let jsError: JavaScriptError
+      if let javaScriptError = error as? JavaScriptError {
+        jsError = javaScriptError
+      } else if let throwable = error as? JavaScriptThrowable {
+        jsError = JavaScriptError(runtime, from: throwable)
+      } else {
+        jsError = JavaScriptError(runtime, message: String(describing: error))
+      }
       let errorValue = jsError.toValue()
 
       // Call the actual rejecter given in the Promise setup.

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
@@ -179,6 +179,39 @@ struct JavaScriptErrorTests {
     #expect(caught.getObject().getProperty("message").getString() == "native failure")
   }
 
+  // MARK: - JavaScriptError.from(_:in:) helper
+
+  @Test
+  func `from returns an existing JavaScriptError unchanged`() {
+    // An existing `JavaScriptError` must be returned as the very same instance so its wrapped
+    // value (which may be an arbitrary JS value) reaches JS unchanged.
+    let original = JavaScriptError(runtime, value: JavaScriptValue(runtime, "just a string"))
+    let result = JavaScriptError.from(original, in: runtime)
+
+    #expect(result === original)
+    #expect(result.toValue().getString() == "just a string")
+  }
+
+  @Test
+  func `from routes a JavaScriptThrowable through the code-preserving initializer`() {
+    let throwable = CodedError(message: "Not found", code: "ERR_NOT_FOUND")
+    let object = JavaScriptError.from(throwable, in: runtime).toValue().getObject()
+
+    #expect(object.getProperty("message").getString() == "Not found")
+    #expect(object.getProperty("code").getString() == "ERR_NOT_FOUND")
+  }
+
+  @Test
+  func `from stringifies any other native error into a generic Error`() {
+    struct TestError: Error, CustomStringConvertible {
+      var description: String { "native failure" }
+    }
+    let object = JavaScriptError.from(TestError(), in: runtime).toValue().getObject()
+
+    #expect(object.getProperty("message").getString() == "native failure")
+    #expect(object.getProperty("code").isUndefined() == true)
+  }
+
   @Test
   func `nested host function errors are independent`() throws {
     let outer = runtime.createFunction("outer") { [self] _, _ in


### PR DESCRIPTION
## Why

`JavaScriptPromise.reject` stringified any non-`JavaScriptError`, dropping the structured `code` carried by `JavaScriptThrowable` errors (e.g. `Exception`). As a result, async functions on the new architecture lost the `code` on the JS error, even though the synchronous throw path (`forwardingSwiftErrorsToJS`) preserved it.

## How

- Route `JavaScriptThrowable` errors through the code-preserving `JavaScriptError(from:)` initializer in `reject`, mirroring the sync path.
- This completes the async half of expo#27959, whose async coverage in expo#27960 was left commented out because there was no way to evaluate async code in tests at the time.
- Add async error-code tests (throw / reject / concurrent) to `ExceptionsTests` using the now-available `runtime.evalAsync` harness.

## Test Plan

- New async tests in `ExceptionsTests.swift` assert the `code` is preserved across the async throw, reject, and concurrent paths.
