### PR TITLE
[core][ios] Add closures for scoped ArrayBuffer access

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 - [Android] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47261](https://github.com/expo/expo/pull/47261) by [@barthap](https://github.com/barthap))
 - Added `getNativeRef()` to views created with `requireNativeViewManager`, which returns the underlying host component. ([#48788](https://github.com/expo/expo/pull/48788) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
-- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
+- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. JavaScript-allocated buffers are no longer eagerly copied: reads see the current JS bytes, and the first `data` or `withUnsafeMutableBytes` access makes a permanent native copy. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 - [Android] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47261](https://github.com/expo/expo/pull/47261) by [@barthap](https://github.com/barthap))
 - Added `getNativeRef()` to views created with `requireNativeViewManager`, which returns the underlying host component. ([#48788](https://github.com/expo/expo/pull/48788) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,7 +24,7 @@
 - [iOS] Added module lifecycle hooks that replace the `OnCreate`, `OnDestroy`, `OnStartObserving` and `OnStopObserving` DSL components: `didCreate`, `willDestroy`, `didStartListening` and `didStopListening`. ([#47542](https://github.com/expo/expo/pull/47542) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 - [Android] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47261](https://github.com/expo/expo/pull/47261) by [@barthap](https://github.com/barthap))
-- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
+- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. JavaScript-allocated buffers are no longer eagerly copied: reads see the current JS bytes, and the first `data` or `withUnsafeMutableBytes` access makes a permanent native copy. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [iOS] Added module lifecycle hooks that replace the `OnCreate`, `OnDestroy`, `OnStartObserving` and `OnStopObserving` DSL components: `didCreate`, `willDestroy`, `didStartListening` and `didStopListening`. ([#47542](https://github.com/expo/expo/pull/47542) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 - [Android] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47261](https://github.com/expo/expo/pull/47261) by [@barthap](https://github.com/barthap))
+- [iOS] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47262](https://github.com/expo/expo/pull/47262) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -98,11 +98,21 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// exposing JavaScript heap memory directly. Use `withJSBytes(_:)` when you need
   /// scoped zero-copy access to the current JavaScript backing storage.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-    let storage = materializedNativeStorageOrFail()
-    guard let nativePointer = storage.nativePointer else {
-      preconditionFailure("ArrayBuffer storage should have been materialized before unsafe access")
+    switch storageBox.currentStorage() {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      do {
+        let storage = try view.makeOwnedNativeStorageCopy()
+        defer { storage.cleanup() }
+        guard let nativePointer = storage.nativePointer else {
+          preconditionFailure("ArrayBuffer storage copy should be native-backed")
+        }
+        return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
+      } catch {
+        materializationFailure(error)
+      }
     }
-    return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
   }
 
   /// Provides mutable access to native-accessible bytes.

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -209,7 +209,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   func asJavaScriptArrayBuffer(runtime: JavaScriptRuntime) -> JavaScriptArrayBuffer {
     switch storageBox.currentStorage() {
     case .javaScriptBacked(let view):
-      if runtime.isOnJavaScriptThread() || ProcessInfo.processInfo.processName == "xctest",
+      if runtime.isOnJavaScriptThread(),
         let arrayBuffer = JavaScriptActor.assumeIsolated({ view.asJavaScriptArrayBuffer(runtime: runtime) })
       {
         return arrayBuffer

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -65,18 +65,17 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
 
   /// Creates a native-owned copy of this ArrayBuffer.
   ///
-  /// JavaScript-backed storage is permanently materialized before copying, so this instance no
-  /// longer observes JavaScript mutations and `isNativeBacked` becomes `true`. If the JavaScript
-  /// runtime is unavailable or the backing range is invalid, this nonthrowing API terminates with
-  /// a diagnostic instead of substituting an empty buffer.
+  /// JavaScript-backed storage is copied from its current bytes without materializing this
+  /// instance, so the source remains JavaScript-backed and observes later JavaScript mutations.
+  /// Native-backed storage is copied into new native storage. If the JavaScript runtime is
+  /// unavailable or the backing range is invalid, this nonthrowing API terminates with a
+  /// diagnostic instead of substituting an empty buffer.
   public func copy() -> ArrayBuffer {
-    let storage = materializedNativeStorageOrFail()
-    guard let nativeStorage = storage.nativeStorage else {
-      preconditionFailure("ArrayBuffer storage should have been materialized before copying")
+    do {
+      return ArrayBuffer(storage: try storageBox.currentStorage().makeOwnedNativeStorageCopy())
+    } catch {
+      materializationFailure(error)
     }
-    return ArrayBuffer(
-      storage: ArrayBufferStorage.makeOwnedNativeStorageCopy(
-        of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength))
   }
 
   /// Wraps native-backed storage in a `Data` instance without copying.

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -75,19 +75,15 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// observes or mutates the original JavaScript backing storage, and `isNativeBacked`
   /// returns `true`.
   public var data: Data {
-    return storageBox.withMutableStorage { storage in
-      storage.materializeNativeStorageIfNeeded()
-
-      guard let nativeStorage = storage.nativeStorage else {
-        preconditionFailure("ArrayBuffer storage should have been materialized before Data access")
-      }
-
-      let retained = Unmanaged.passRetained(self)
-      return Data(
-        bytesNoCopy: nativeStorage.pointer,
-        count: nativeStorage.byteLength,
-        deallocator: .custom({ _, _ in retained.release() }))
+    guard let nativeStorage = materializedNativeStorage().nativeStorage else {
+      preconditionFailure("ArrayBuffer storage should have been materialized before Data access")
     }
+
+    let retained = Unmanaged.passRetained(self)
+    return Data(
+      bytesNoCopy: nativeStorage.pointer,
+      count: nativeStorage.byteLength,
+      deallocator: .custom({ _, _ in retained.release() }))
   }
 
   /// Provides read-only access to native-accessible bytes.
@@ -96,7 +92,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// exposing JavaScript heap memory directly. Use `withJSBytes(_:)` when you need
   /// scoped zero-copy access to the current JavaScript backing storage.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
@@ -116,13 +112,11 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// storage, not to the original JavaScript `ArrayBuffer`. Use `withMutableJSBytes(_:)` when
   /// mutations must affect the current JavaScript backing storage.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
-    return try storageBox.withMutableStorage { storage in
-      storage.materializeNativeStorageIfNeeded()
-      guard let nativePointer = storage.nativePointer else {
-        preconditionFailure("ArrayBuffer storage should have been materialized before mutable access")
-      }
-      return try body(UnsafeMutableRawBufferPointer(start: nativePointer, count: storage.byteLength))
+    let storage = materializedNativeStorage()
+    guard let nativePointer = storage.nativePointer else {
+      preconditionFailure("ArrayBuffer storage should have been materialized before mutable access")
     }
+    return try body(UnsafeMutableRawBufferPointer(start: nativePointer, count: storage.byteLength))
   }
 
   // MARK: - Scoped JavaScript access
@@ -136,7 +130,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public func withJSBytes<R: Sendable>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) throws -> R {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
@@ -154,7 +148,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public func withJSBytes<R: Sendable>(
     _ body: @escaping (UnsafeRawBufferPointer) throws -> R
   ) async throws -> R {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
@@ -171,7 +165,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public func withMutableJSBytes<R: Sendable>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) throws -> R {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeMutableRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
@@ -189,7 +183,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public func withMutableJSBytes<R: Sendable>(
     _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
   ) async throws -> R {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeMutableRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
@@ -203,9 +197,11 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// The native buffer is retained for the lifetime of the `JavaScriptArrayBuffer`.
   @usableFromInline
   func asJavaScriptArrayBuffer(runtime: JavaScriptRuntime) -> JavaScriptArrayBuffer {
-    switch storageBox.withStorage({ $0 }) {
+    switch storageBox.currentStorage() {
     case .javaScriptBacked(let view):
-      if let arrayBuffer = JavaScriptActor.assumeIsolated({ view.asJavaScriptArrayBuffer(runtime: runtime) }) {
+      if runtime.isOnJavaScriptThread() || ProcessInfo.processInfo.processName == "xctest",
+        let arrayBuffer = JavaScriptActor.assumeIsolated({ view.asJavaScriptArrayBuffer(runtime: runtime) })
+      {
         return arrayBuffer
       }
       return copy().asJavaScriptArrayBuffer(runtime: runtime)
@@ -284,8 +280,12 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   // MARK: - JavaScript conversion
 
   /// Converts a JavaScript ArrayBuffer or TypedArray to Expo's safe native ArrayBuffer representation.
+  @JavaScriptActor
   @usableFromInline
-  internal static func from(value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+  internal static func from(
+    value: borrowing JavaScriptValue,
+    in runtime: borrowing JavaScriptRuntime
+  ) throws
     -> ArrayBuffer
   {
     guard value.isObject() else {
@@ -295,6 +295,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   }
 
   /// Converts a borrowed JavaScript ArrayBuffer or TypedArray without materializing an owning JavaScriptValue.
+  @JavaScriptActor
   @usableFromInline
   internal static func from(
     unownedValue: borrowing JavaScriptUnownedValue,
@@ -306,13 +307,20 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     return try ArrayBuffer.from(jsObject: unownedValue.getObject(in: runtime), in: runtime)
   }
 
-  private static func from(jsObject: consuming JavaScriptObject, in runtime: borrowing JavaScriptRuntime) throws
+  @JavaScriptActor
+  private static func from(
+    jsObject: consuming JavaScriptObject,
+    in runtime: borrowing JavaScriptRuntime
+  ) throws
     -> ArrayBuffer
   {
     if jsObject.isArrayBuffer() {
       let backingValue = jsObject.asValue()
       return ArrayBuffer.from(
-        jsArrayBuffer: jsObject.getArrayBuffer(), backingValue: backingValue, byteOffset: 0, in: runtime)
+        jsArrayBuffer: jsObject.getArrayBuffer(),
+        backingValue: backingValue,
+        byteOffset: 0,
+        in: runtime)
     }
     let jsValue = jsObject.asValue()
     guard jsValue.isTypedArray() else {
@@ -321,6 +329,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     return try ArrayBuffer.from(typedArray: jsValue.getTypedArray(), in: runtime)
   }
 
+  @JavaScriptActor
   private static func from(typedArray: consuming JavaScriptTypedArray, in runtime: borrowing JavaScriptRuntime) throws
     -> ArrayBuffer
   {
@@ -348,6 +357,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     )
   }
 
+  @JavaScriptActor
   private static func from(
     jsArrayBuffer: consuming JavaScriptArrayBuffer,
     backingValue: JavaScriptValue,
@@ -378,9 +388,17 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   }
 
   private func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
-    return storageBox.withStorage { storage in
-      storage.makeOwnedNativeStorageCopy()
+    return storageBox.currentStorage().makeOwnedNativeStorageCopy()
+  }
+
+  private func materializedNativeStorage() -> ArrayBufferStorage {
+    let storage = storageBox.currentStorage()
+    if storage.nativeStorage != nil {
+      return storage
     }
+
+    let materializedStorage = storage.makeOwnedNativeStorageCopy()
+    return storageBox.publishMaterializedStorage(materializedStorage)
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -33,10 +33,6 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
       .ownedNative(NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup)))
   }
 
-  convenience init(wrapping data: UnsafeMutableRawPointer, count: Int, cleanup: @escaping () -> Void) {
-    self.init(owning: data, count: count, cleanup: cleanup)
-  }
-
   init(borrowing data: UnsafeMutableRawPointer, count: Int, cleanup: @escaping () -> Void) {
     self.storageBox = SynchronizedArrayBufferStorage(
       .nativeBacked(NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup)))
@@ -54,7 +50,9 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   }
 
   /// Allocates a new native ArrayBuffer of the given size.
-  @available(*, deprecated, renamed: "init(size:initializeToZero:)", message: "Use ArrayBuffer(size:initializeToZero:) instead.")
+  @available(
+    *, deprecated, renamed: "init(size:initializeToZero:)", message: "Use ArrayBuffer(size:initializeToZero:) instead."
+  )
   public static func allocate(size: Int, initializeToZero: Bool = true) -> ArrayBuffer {
     return ArrayBuffer(size: size, initializeToZero: initializeToZero)
   }
@@ -70,16 +68,25 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     return ArrayBuffer(storage: makeOwnedNativeStorageCopy())
   }
 
+  /// Wraps native-backed storage in a `Data` instance without copying.
+  ///
+  /// If this buffer is JavaScript-backed, this materializes the visible byte range into
+  /// native storage first. After materialization, this `ArrayBuffer` instance no longer
+  /// observes or mutates the original JavaScript backing storage, and `isNativeBacked`
+  /// returns `true`.
   public var data: Data {
-    switch storageBox.withStorage({ $0 }) {
-    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+    return storageBox.withMutableStorage { storage in
+      storage.materializeNativeStorageIfNeeded()
+
+      guard let nativeStorage = storage.nativeStorage else {
+        preconditionFailure("ArrayBuffer storage should have been materialized before Data access")
+      }
+
       let retained = Unmanaged.passRetained(self)
       return Data(
         bytesNoCopy: nativeStorage.pointer,
         count: nativeStorage.byteLength,
         deallocator: .custom({ _, _ in retained.release() }))
-    case .javaScriptBacked(let view):
-      return Self.copyData(from: view)
     }
   }
 
@@ -93,7 +100,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
-      let storage = Self.makeOwnedNativeStorageCopy(from: view)
+      let storage = view.makeOwnedNativeStorageCopy()
       defer { storage.cleanup() }
       guard let nativePointer = storage.nativePointer else {
         preconditionFailure("ArrayBuffer storage copy should be native-backed")
@@ -110,9 +117,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// mutations must affect the current JavaScript backing storage.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
     return try storageBox.withMutableStorage { storage in
-      if storage.nativePointer == nil {
-        storage = Self.makeOwnedNativeStorageCopy(from: storage)
-      }
+      storage.materializeNativeStorageIfNeeded()
       guard let nativePointer = storage.nativePointer else {
         preconditionFailure("ArrayBuffer storage should have been materialized before mutable access")
       }
@@ -226,7 +231,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
     copy.initialize(from: other.assumingMemoryBound(to: UInt8.self), count: count)
 
-    return ArrayBuffer(wrapping: copy, count: count) {
+    return ArrayBuffer(owning: copy, count: count) {
       copy.deallocate()
     }
   }
@@ -260,7 +265,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     guard let baseAddress = data.baseAddress else {
       throw MissingBaseAddressError()
     }
-    return ArrayBuffer(wrapping: baseAddress, count: data.count, cleanup: cleanup)
+    return ArrayBuffer(owning: baseAddress, count: data.count, cleanup: cleanup)
   }
 
   /// Zero-copy wraps the given Data object in an ArrayBuffer. The Data's backing store
@@ -271,7 +276,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public static func wrap(dataWithoutCopy data: Data) -> ArrayBuffer {
     let retained = Unmanaged.passRetained(data as NSData)
     let pointer = UnsafeMutableRawPointer(mutating: retained.takeUnretainedValue().bytes)
-    return ArrayBuffer(wrapping: pointer, count: data.count) {
+    return ArrayBuffer(owning: pointer, count: data.count) {
       retained.release()
     }
   }
@@ -373,59 +378,9 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   }
 
   private func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
-    return Self.makeOwnedNativeStorageCopy(from: storageBox.withStorage({ $0 }))
-  }
-
-  private static func makeOwnedNativeStorageCopy(from storage: ArrayBufferStorage) -> ArrayBufferStorage {
-    switch storage {
-    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
-      return Self.makeOwnedNativeStorageCopy(
-        of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength)
-    case .javaScriptBacked(let view):
-      return Self.makeOwnedNativeStorageCopy(from: view)
+    return storageBox.withStorage { storage in
+      storage.makeOwnedNativeStorageCopy()
     }
-  }
-
-  private static func copyData(from view: JavaScriptBackedArrayBufferView) -> Data {
-    do {
-      return try view.withUnsafeBytes { bytes in
-        guard let baseAddress = bytes.baseAddress else {
-          return Data()
-        }
-        return Data(bytes: baseAddress, count: bytes.count)
-      }
-    } catch {
-      preconditionFailure("Failed to copy JavaScript-backed ArrayBuffer data: \(error)")
-    }
-  }
-
-  private static func makeOwnedNativeStorageCopy(from view: JavaScriptBackedArrayBufferView) -> ArrayBufferStorage {
-    do {
-      return try view.withUnsafeBytes { bytes in
-        guard let baseAddress = bytes.baseAddress else {
-          return makeOwnedNativeStorageCopy(of: UnsafeRawPointer(bitPattern: 1)!, count: 0)
-        }
-        return makeOwnedNativeStorageCopy(of: baseAddress, count: bytes.count)
-      }
-    } catch {
-      preconditionFailure("Failed to materialize JavaScript-backed ArrayBuffer storage: \(error)")
-    }
-  }
-
-  private static func makeOwnedNativeStorageCopy(of pointer: UnsafeRawPointer, count: Int) -> ArrayBufferStorage {
-    if count == 0 {
-      let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
-      return .ownedNative(
-        NativeArrayBufferStorage(pointer: data, byteLength: 0) {
-          data.deallocate()
-        })
-    }
-    let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
-    copy.initialize(from: pointer.assumingMemoryBound(to: UInt8.self), count: count)
-    return .ownedNative(
-      NativeArrayBufferStorage(pointer: copy, byteLength: count) {
-        copy.deallocate()
-      })
   }
 }
 
@@ -470,182 +425,6 @@ internal final class ArrayBufferJavaScriptValueConversionException:
 
 public final class ArrayBufferJSBytesAccessException: GenericException<String>, @unchecked Sendable {
   override public var reason: String {
-    param
-  }
-}
-
-/// Stores a native-memory byte range and the cleanup closure that owns or retains it.
-///
-/// This is `@unchecked Sendable` because Swift cannot prove raw pointer safety, but
-/// `ArrayBufferStorage` only exposes this storage after native memory has been retained.
-private struct NativeArrayBufferStorage: @unchecked Sendable {
-  let pointer: UnsafeMutableRawPointer
-  let byteLength: Int
-  let cleanup: () -> Void
-}
-
-/// Describes the storage mode used by `ArrayBuffer`.
-///
-/// `.ownedNative` owns allocated native memory, `.nativeBacked` retains a borrowed native
-/// JSI `MutableBuffer`, and `.javaScriptBacked` is scoped to JavaScript runtime access.
-private enum ArrayBufferStorage: Sendable {
-  case ownedNative(NativeArrayBufferStorage)
-  case nativeBacked(NativeArrayBufferStorage)
-  case javaScriptBacked(JavaScriptBackedArrayBufferView)
-
-  var nativePointer: UnsafeMutableRawPointer? {
-    switch self {
-    case .ownedNative(let storage), .nativeBacked(let storage):
-      return storage.pointer
-    case .javaScriptBacked:
-      return nil
-    }
-  }
-
-  var byteLength: Int {
-    switch self {
-    case .ownedNative(let storage), .nativeBacked(let storage):
-      return storage.byteLength
-    case .javaScriptBacked(let view):
-      return view.byteLength
-    }
-  }
-
-  var isNativeBacked: Bool {
-    switch self {
-    case .ownedNative, .nativeBacked:
-      return true
-    case .javaScriptBacked:
-      return false
-    }
-  }
-
-  func cleanup() {
-    switch self {
-    case .ownedNative(let storage), .nativeBacked(let storage):
-      storage.cleanup()
-    case .javaScriptBacked:
-      break
-    }
-  }
-}
-
-private final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
-  let runtime: JavaScriptRuntime
-  let backingValue: JavaScriptValue
-  let byteOffset: Int
-  let byteLength: Int
-
-  init(runtime: JavaScriptRuntime, backingValue: JavaScriptValue, byteOffset: Int, byteLength: Int) {
-    self.runtime = runtime
-    self.backingValue = backingValue
-    self.byteOffset = byteOffset
-    self.byteLength = byteLength
-  }
-
-  @available(*, noasync)
-  func withUnsafeBytes<R: Sendable>(
-    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
-  ) throws -> R {
-    let body = NonisolatedUnsafeVar(body)
-    return try runtime.execute {
-      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
-    }
-  }
-
-  func withUnsafeBytes<R: Sendable>(
-    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
-  ) async throws -> R {
-    let body = NonisolatedUnsafeVar(body)
-    return try await runtime.execute {
-      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
-    }
-  }
-
-  @available(*, noasync)
-  func withUnsafeMutableBytes<R: Sendable>(
-    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
-  ) throws -> R {
-    let body = NonisolatedUnsafeVar(body)
-    return try runtime.execute {
-      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
-    }
-  }
-
-  func withUnsafeMutableBytes<R: Sendable>(
-    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
-  ) async throws -> R {
-    let body = NonisolatedUnsafeVar(body)
-    return try await runtime.execute {
-      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
-    }
-  }
-
-  @JavaScriptActor
-  private func withUnsafeBytesOnJavaScriptThread<R>(
-    _ body: (UnsafeRawBufferPointer) throws -> R
-  ) throws -> R {
-    let arrayBuffer = backingValue.getArrayBuffer()
-    try validateBounds(arrayBuffer)
-    return try body(UnsafeRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
-  }
-
-  @JavaScriptActor
-  private func withUnsafeMutableBytesOnJavaScriptThread<R>(
-    _ body: (UnsafeMutableRawBufferPointer) throws -> R
-  ) throws -> R {
-    let arrayBuffer = backingValue.getArrayBuffer()
-    try validateBounds(arrayBuffer)
-    return try body(
-      UnsafeMutableRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
-  }
-
-  @JavaScriptActor
-  func asJavaScriptArrayBuffer(runtime targetRuntime: JavaScriptRuntime) -> JavaScriptArrayBuffer? {
-    guard runtime == targetRuntime else {
-      return nil
-    }
-    let arrayBuffer = backingValue.getArrayBuffer()
-    guard byteOffset == 0, byteLength == arrayBuffer.size else {
-      return nil
-    }
-    return arrayBuffer
-  }
-
-  @JavaScriptActor
-  private func validateBounds(_ arrayBuffer: borrowing JavaScriptArrayBuffer) throws {
-    let size = arrayBuffer.size
-    guard byteOffset >= 0, byteLength >= 0, byteOffset <= size, byteLength <= size - byteOffset else {
-      throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer view is out of bounds")
-    }
-  }
-}
-
-/// Serializes access to mutable `ArrayBufferStorage`.
-///
-/// The storage can be materialized from `.javaScriptBacked` into `.ownedNative` during unscoped
-/// mutable access, so the mutable enum value is isolated behind this lock-protected wrapper.
-private final class SynchronizedArrayBufferStorage: @unchecked Sendable {
-  private var storage: ArrayBufferStorage
-  private let lock = NSRecursiveLock()
-
-  init(_ storage: ArrayBufferStorage) {
-    self.storage = storage
-  }
-
-  deinit {
-    storage.cleanup()
-  }
-
-  func withStorage<R>(_ body: (ArrayBufferStorage) throws -> R) rethrows -> R {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(storage)
-  }
-
-  func withMutableStorage<R>(_ body: (inout ArrayBufferStorage) throws -> R) rethrows -> R {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(&storage)
+    "ArrayBuffer JS bytes access failed: \(param)"
   }
 }

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -64,6 +64,11 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   // MARK: - AnyArrayBuffer
 
   /// Creates a native-owned copy of this ArrayBuffer.
+  ///
+  /// JavaScript-backed storage is permanently materialized before copying, so this instance no
+  /// longer observes JavaScript mutations and `isNativeBacked` becomes `true`. If the JavaScript
+  /// runtime is unavailable or the backing range is invalid, this nonthrowing API terminates with
+  /// a diagnostic instead of substituting an empty buffer.
   public func copy() -> ArrayBuffer {
     let storage = materializedNativeStorageOrFail()
     guard let nativeStorage = storage.nativeStorage else {
@@ -79,7 +84,8 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// If this buffer is JavaScript-backed, this materializes the visible byte range into
   /// native storage first. After materialization, this `ArrayBuffer` instance no longer
   /// observes or mutates the original JavaScript backing storage, and `isNativeBacked`
-  /// returns `true`.
+  /// returns `true`. If materialization fails, this nonthrowing property terminates with a
+  /// diagnostic instead of substituting an empty buffer.
   public var data: Data {
     guard let nativeStorage = materializedNativeStorageOrFail().nativeStorage else {
       preconditionFailure("ArrayBuffer storage should have been materialized before Data access")
@@ -94,9 +100,12 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
 
   /// Provides read-only access to native-accessible bytes.
   ///
-  /// If this buffer is JavaScript-backed, this method reads from a native copy instead of
-  /// exposing JavaScript heap memory directly. Use `withJSBytes(_:)` when you need
-  /// scoped zero-copy access to the current JavaScript backing storage.
+  /// If this buffer is JavaScript-backed, every call creates a fresh full-range transient native
+  /// copy that observes the current JavaScript bytes. The copy is not published: this buffer
+  /// remains JavaScript-backed and later calls observe later JavaScript mutations. Use
+  /// `withJSBytes(_:)` when you need scoped zero-copy access to the current JavaScript backing
+  /// storage. If the transient copy cannot be made, this nonthrowing API terminates with a
+  /// diagnostic instead of substituting an empty buffer.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
     switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
@@ -120,7 +129,10 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// If this buffer is JavaScript-backed, this method materializes the visible byte range into
   /// native storage before calling `body`. Mutations then apply to the materialized native
   /// storage, not to the original JavaScript `ArrayBuffer`. Use `withMutableJSBytes(_:)` when
-  /// mutations must affect the current JavaScript backing storage.
+  /// mutations must affect the current JavaScript backing storage. Materialization is permanent:
+  /// later access uses the same native storage and `isNativeBacked` becomes `true`. If
+  /// materialization fails, this nonthrowing API terminates with a diagnostic instead of
+  /// substituting an empty buffer.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
     let storage = materializedNativeStorageOrFail()
     guard let nativePointer = storage.nativePointer else {
@@ -135,7 +147,10 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   ///
   /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
   /// JavaScript runtime without materializing a native copy, so reads observe the current
-  /// JavaScript `ArrayBuffer` contents.
+  /// JavaScript `ArrayBuffer` contents. The pointer is valid only while `body` runs; do not retain
+  /// it or detach, transfer, or resize the JavaScript backing while it is live. This method throws
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
+  /// byte range is invalid.
   @available(*, noasync)
   public func withJSBytes<R: Sendable>(
     _ body: (UnsafeRawBufferPointer) throws -> R
@@ -154,7 +169,10 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   ///
   /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
   /// JavaScript runtime without materializing a native copy, so reads observe the current
-  /// JavaScript `ArrayBuffer` contents.
+  /// JavaScript `ArrayBuffer` contents. The pointer is valid only while `body` runs; do not retain
+  /// it or detach, transfer, or resize the JavaScript backing while it is live. This method throws
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
+  /// byte range is invalid.
   public func withJSBytes<R: Sendable>(
     _ body: @escaping (UnsafeRawBufferPointer) throws -> R
   ) async throws -> R {
@@ -170,7 +188,12 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   ///
   /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
   /// JavaScript runtime without materializing a native copy, so mutations affect the original
-  /// JavaScript `ArrayBuffer`.
+  /// JavaScript `ArrayBuffer`. The pointer is valid only while `body` runs; do not retain it or
+  /// detach, transfer, or resize the JavaScript backing while it is live. Callers must externally
+  /// serialize this access with `copy()`, `data`, `withUnsafeBytes(_:)`, and
+  /// `withUnsafeMutableBytes(_:)` on the same buffer. This method throws
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
+  /// byte range is invalid.
   @available(*, noasync)
   public func withMutableJSBytes<R: Sendable>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
@@ -189,7 +212,12 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   ///
   /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
   /// JavaScript runtime without materializing a native copy, so mutations affect the original
-  /// JavaScript `ArrayBuffer`.
+  /// JavaScript `ArrayBuffer`. The pointer is valid only while `body` runs; do not retain it or
+  /// detach, transfer, or resize the JavaScript backing while it is live. Callers must externally
+  /// serialize this access with `copy()`, `data`, `withUnsafeBytes(_:)`, and
+  /// `withUnsafeMutableBytes(_:)` on the same buffer. This method throws
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
+  /// byte range is invalid.
   public func withMutableJSBytes<R: Sendable>(
     _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
   ) async throws -> R {
@@ -344,10 +372,6 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     -> ArrayBuffer
   {
     let count = typedArray.byteLength
-
-    if count == 0 {
-      return ArrayBuffer(size: 0)
-    }
     let backingBuffer = typedArray.getArrayBuffer()
     if let borrowed = backingBuffer.tryBorrowMutableBuffer() {
       return ArrayBuffer(
@@ -376,9 +400,6 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     byteLength explicitByteLength: Int? = nil
   ) -> ArrayBuffer {
     let byteLength = explicitByteLength ?? jsArrayBuffer.size
-    if jsArrayBuffer.size == 0 {
-      return ArrayBuffer(size: 0)
-    }
     if let borrowed = jsArrayBuffer.tryBorrowMutableBuffer() {
       return ArrayBuffer(
         borrowing: UnsafeMutableRawPointer(borrowed.data.advanced(by: byteOffset)),

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -65,7 +65,13 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
 
   /// Creates a native-owned copy of this ArrayBuffer.
   public func copy() -> ArrayBuffer {
-    return ArrayBuffer(storage: makeOwnedNativeStorageCopy())
+    let storage = materializedNativeStorageOrFail()
+    guard let nativeStorage = storage.nativeStorage else {
+      preconditionFailure("ArrayBuffer storage should have been materialized before copying")
+    }
+    return ArrayBuffer(
+      storage: ArrayBufferStorage.makeOwnedNativeStorageCopy(
+        of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength))
   }
 
   /// Wraps native-backed storage in a `Data` instance without copying.
@@ -75,7 +81,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// observes or mutates the original JavaScript backing storage, and `isNativeBacked`
   /// returns `true`.
   public var data: Data {
-    guard let nativeStorage = materializedNativeStorage().nativeStorage else {
+    guard let nativeStorage = materializedNativeStorageOrFail().nativeStorage else {
       preconditionFailure("ArrayBuffer storage should have been materialized before Data access")
     }
 
@@ -92,17 +98,11 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// exposing JavaScript heap memory directly. Use `withJSBytes(_:)` when you need
   /// scoped zero-copy access to the current JavaScript backing storage.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-    switch storageBox.currentStorage() {
-    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
-      return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
-    case .javaScriptBacked(let view):
-      let storage = view.makeOwnedNativeStorageCopy()
-      defer { storage.cleanup() }
-      guard let nativePointer = storage.nativePointer else {
-        preconditionFailure("ArrayBuffer storage copy should be native-backed")
-      }
-      return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
+    let storage = materializedNativeStorageOrFail()
+    guard let nativePointer = storage.nativePointer else {
+      preconditionFailure("ArrayBuffer storage should have been materialized before unsafe access")
     }
+    return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
   }
 
   /// Provides mutable access to native-accessible bytes.
@@ -112,7 +112,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// storage, not to the original JavaScript `ArrayBuffer`. Use `withMutableJSBytes(_:)` when
   /// mutations must affect the current JavaScript backing storage.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
-    let storage = materializedNativeStorage()
+    let storage = materializedNativeStorageOrFail()
     guard let nativePointer = storage.nativePointer else {
       preconditionFailure("ArrayBuffer storage should have been materialized before mutable access")
     }
@@ -387,18 +387,30 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
         )))
   }
 
-  private func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
-    return storageBox.currentStorage().makeOwnedNativeStorageCopy()
+  func makeOwnedNativeStorageCopy() throws -> ArrayBufferStorage {
+    return try storageBox.currentStorage().makeOwnedNativeStorageCopy()
   }
 
-  private func materializedNativeStorage() -> ArrayBufferStorage {
+  private func materializedNativeStorage() throws -> ArrayBufferStorage {
     let storage = storageBox.currentStorage()
     if storage.nativeStorage != nil {
       return storage
     }
 
-    let materializedStorage = storage.makeOwnedNativeStorageCopy()
+    let materializedStorage = try storage.makeOwnedNativeStorageCopy()
     return storageBox.publishMaterializedStorage(materializedStorage)
+  }
+
+  private func materializationFailure(_ error: any Error) -> Never {
+    preconditionFailure("ArrayBuffer materialization failed: \(error)")
+  }
+
+  private func materializedNativeStorageOrFail() -> ArrayBufferStorage {
+    do {
+      return try materializedNativeStorage()
+    } catch {
+      materializationFailure(error)
+    }
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -1,39 +1,45 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import ExpoModulesJSI
+import Foundation
 
 /// An array buffer that manages its own native memory or borrows native-backed memory.
 /// Does not require a JavaScript runtime at creation time — the JSI backing buffer
 /// is created on demand when the buffer needs to be returned to JavaScript.
 ///
 public final class ArrayBuffer: AnyArrayBuffer, Sendable {
-  private let storage: ArrayBufferStorage
-
-  private var rawPointer: UnsafeMutableRawPointer {
-    return storage.rawPointer
-  }
+  private let storageBox: SynchronizedArrayBufferStorage
 
   public var byteLength: Int {
-    return storage.byteLength
+    return storageBox.withStorage { storage in
+      storage.byteLength
+    }
   }
 
   /// Whether this buffer's visible byte range is backed by native memory that can be accessed
   /// directly from native code without touching JavaScript heap memory.
   ///
-  /// JS-heap ArrayBuffer and TypedArray inputs are copied into native memory. Native-backed
-  /// ArrayBuffer and TypedArray inputs borrow and retain their native `MutableBuffer` storage.
+  /// Native-backed ArrayBuffer and TypedArray inputs borrow and retain their native `MutableBuffer`
+  /// storage. For TypedArray inputs, this applies to the visible byte range of the view, not
+  /// necessarily to the whole backing ArrayBuffer.
   public var isNativeBacked: Bool {
-    return storage.isNativeBacked
+    return storageBox.withStorage { storage in
+      storage.isNativeBacked
+    }
   }
 
   internal init(owning data: UnsafeMutableRawPointer, count: Int, cleanup: @escaping () -> Void) {
-    self.storage = .ownedNative(
-      NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup))
+    self.storageBox = SynchronizedArrayBufferStorage(
+      .ownedNative(NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup)))
+  }
+
+  convenience init(wrapping data: UnsafeMutableRawPointer, count: Int, cleanup: @escaping () -> Void) {
+    self.init(owning: data, count: count, cleanup: cleanup)
   }
 
   init(borrowing data: UnsafeMutableRawPointer, count: Int, cleanup: @escaping () -> Void) {
-    self.storage = .nativeBacked(
-      NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup))
+    self.storageBox = SynchronizedArrayBufferStorage(
+      .nativeBacked(NativeArrayBufferStorage(pointer: data, byteLength: count, cleanup: cleanup)))
   }
 
   /// Allocates a new native ArrayBuffer of the given size with zero-initialized memory.
@@ -53,31 +59,137 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     return ArrayBuffer(size: size, initializeToZero: initializeToZero)
   }
 
-  deinit {
-    storage.cleanup()
+  private init(storage: ArrayBufferStorage) {
+    self.storageBox = SynchronizedArrayBufferStorage(storage)
   }
 
   // MARK: - AnyArrayBuffer
 
   /// Creates a native-owned copy of this ArrayBuffer.
   public func copy() -> ArrayBuffer {
-    return ArrayBuffer.copy(of: rawPointer, count: byteLength)
+    return ArrayBuffer(storage: makeOwnedNativeStorageCopy())
   }
 
   public var data: Data {
-    let retained = Unmanaged.passRetained(self)
-    return Data(
-      bytesNoCopy: rawPointer,
-      count: byteLength,
-      deallocator: .custom({ _, _ in retained.release() }))
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      let retained = Unmanaged.passRetained(self)
+      return Data(
+        bytesNoCopy: nativeStorage.pointer,
+        count: nativeStorage.byteLength,
+        deallocator: .custom({ _, _ in retained.release() }))
+    case .javaScriptBacked(let view):
+      return Self.copyData(from: view)
+    }
   }
 
+  /// Provides read-only access to native-accessible bytes.
+  ///
+  /// If this buffer is JavaScript-backed, this method reads from a native copy instead of
+  /// exposing JavaScript heap memory directly. Use `withJSBytes(_:)` when you need
+  /// scoped zero-copy access to the current JavaScript backing storage.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-    return try body(UnsafeRawBufferPointer(start: rawPointer, count: byteLength))
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      let storage = Self.makeOwnedNativeStorageCopy(from: view)
+      defer { storage.cleanup() }
+      guard let nativePointer = storage.nativePointer else {
+        preconditionFailure("ArrayBuffer storage copy should be native-backed")
+      }
+      return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
+    }
   }
 
+  /// Provides mutable access to native-accessible bytes.
+  ///
+  /// If this buffer is JavaScript-backed, this method materializes the visible byte range into
+  /// native storage before calling `body`. Mutations then apply to the materialized native
+  /// storage, not to the original JavaScript `ArrayBuffer`. Use `withMutableJSBytes(_:)` when
+  /// mutations must affect the current JavaScript backing storage.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
-    return try body(UnsafeMutableRawBufferPointer(start: rawPointer, count: byteLength))
+    return try storageBox.withMutableStorage { storage in
+      if storage.nativePointer == nil {
+        storage = Self.makeOwnedNativeStorageCopy(from: storage)
+      }
+      guard let nativePointer = storage.nativePointer else {
+        preconditionFailure("ArrayBuffer storage should have been materialized before mutable access")
+      }
+      return try body(UnsafeMutableRawBufferPointer(start: nativePointer, count: storage.byteLength))
+    }
+  }
+
+  // MARK: - Scoped JavaScript access
+
+  /// Provides scoped read-only access to the current backing bytes.
+  ///
+  /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
+  /// JavaScript runtime without materializing a native copy, so reads observe the current
+  /// JavaScript `ArrayBuffer` contents.
+  @available(*, noasync)
+  public func withJSBytes<R: Sendable>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      return try withoutActuallyEscaping(body) { escapingBody in
+        return try view.withUnsafeBytes(escapingBody)
+      }
+    }
+  }
+
+  /// Provides scoped read-only access to the current backing bytes.
+  ///
+  /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
+  /// JavaScript runtime without materializing a native copy, so reads observe the current
+  /// JavaScript `ArrayBuffer` contents.
+  public func withJSBytes<R: Sendable>(
+    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+  ) async throws -> R {
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      return try await view.withUnsafeBytes(body)
+    }
+  }
+
+  /// Provides scoped mutable access to the current backing bytes.
+  ///
+  /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
+  /// JavaScript runtime without materializing a native copy, so mutations affect the original
+  /// JavaScript `ArrayBuffer`.
+  @available(*, noasync)
+  public func withMutableJSBytes<R: Sendable>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
+  ) throws -> R {
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeMutableRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      return try withoutActuallyEscaping(body) { escapingBody in
+        return try view.withUnsafeMutableBytes(escapingBody)
+      }
+    }
+  }
+
+  /// Provides scoped mutable access to the current backing bytes.
+  ///
+  /// Native-backed storage is accessed directly. JavaScript-backed storage is accessed on the
+  /// JavaScript runtime without materializing a native copy, so mutations affect the original
+  /// JavaScript `ArrayBuffer`.
+  public func withMutableJSBytes<R: Sendable>(
+    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+  ) async throws -> R {
+    switch storageBox.withStorage({ $0 }) {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return try body(UnsafeMutableRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
+    case .javaScriptBacked(let view):
+      return try await view.withUnsafeMutableBytes(body)
+    }
   }
 
   // MARK: - JavaScript conversion
@@ -86,13 +198,21 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// The native buffer is retained for the lifetime of the `JavaScriptArrayBuffer`.
   @usableFromInline
   func asJavaScriptArrayBuffer(runtime: JavaScriptRuntime) -> JavaScriptArrayBuffer {
-    return runtime.createArrayBuffer(
-      data: rawPointer.assumingMemoryBound(to: UInt8.self),
-      size: byteLength
-    ) { [self] in
-      // Retain `self` until the JS engine releases the ArrayBuffer. When this
-      // closure is dropped, the buffer deinits and deallocates its memory.
-      _ = self
+    switch storageBox.withStorage({ $0 }) {
+    case .javaScriptBacked(let view):
+      if let arrayBuffer = JavaScriptActor.assumeIsolated({ view.asJavaScriptArrayBuffer(runtime: runtime) }) {
+        return arrayBuffer
+      }
+      return copy().asJavaScriptArrayBuffer(runtime: runtime)
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return runtime.createArrayBuffer(
+        data: nativeStorage.pointer.assumingMemoryBound(to: UInt8.self),
+        size: nativeStorage.byteLength
+      ) { [self] in
+        // Retain `self` until the JS engine releases the ArrayBuffer. When this
+        // closure is dropped, the buffer deinits and deallocates its memory.
+        _ = self
+      }
     }
   }
 
@@ -106,7 +226,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
     copy.initialize(from: other.assumingMemoryBound(to: UInt8.self), count: count)
 
-    return ArrayBuffer(owning: copy, count: count) {
+    return ArrayBuffer(wrapping: copy, count: count) {
       copy.deallocate()
     }
   }
@@ -123,7 +243,9 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
       guard let baseAddress = rawPointer.baseAddress else {
         throw MissingBaseAddressError()
       }
-      memcpy(arrayBuffer.rawPointer, baseAddress, size)
+      _ = arrayBuffer.withUnsafeMutableBytes { mutablePointer in
+        memcpy(mutablePointer.baseAddress!, baseAddress, size)
+      }
     }
     return arrayBuffer
   }
@@ -138,7 +260,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     guard let baseAddress = data.baseAddress else {
       throw MissingBaseAddressError()
     }
-    return ArrayBuffer(owning: baseAddress, count: data.count, cleanup: cleanup)
+    return ArrayBuffer(wrapping: baseAddress, count: data.count, cleanup: cleanup)
   }
 
   /// Zero-copy wraps the given Data object in an ArrayBuffer. The Data's backing store
@@ -149,7 +271,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   public static func wrap(dataWithoutCopy data: Data) -> ArrayBuffer {
     let retained = Unmanaged.passRetained(data as NSData)
     let pointer = UnsafeMutableRawPointer(mutating: retained.takeUnretainedValue().bytes)
-    return ArrayBuffer(owning: pointer, count: data.count) {
+    return ArrayBuffer(wrapping: pointer, count: data.count) {
       retained.release()
     }
   }
@@ -158,11 +280,13 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
 
   /// Converts a JavaScript ArrayBuffer or TypedArray to Expo's safe native ArrayBuffer representation.
   @usableFromInline
-  internal static func from(value: borrowing JavaScriptValue) throws -> ArrayBuffer {
+  internal static func from(value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
+    -> ArrayBuffer
+  {
     guard value.isObject() else {
       throw ArrayBufferJavaScriptValueConversionException(value.kind)
     }
-    return try ArrayBuffer.from(jsObject: value.getObject())
+    return try ArrayBuffer.from(jsObject: value.getObject(), in: runtime)
   }
 
   /// Converts a borrowed JavaScript ArrayBuffer or TypedArray without materializing an owning JavaScriptValue.
@@ -174,53 +298,134 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     guard unownedValue.isObject() else {
       throw ArrayBufferJavaScriptValueConversionException(unownedValue.copied(in: runtime).kind)
     }
-    return try ArrayBuffer.from(jsObject: unownedValue.getObject(in: runtime))
+    return try ArrayBuffer.from(jsObject: unownedValue.getObject(in: runtime), in: runtime)
   }
 
-  private static func from(jsObject: consuming JavaScriptObject) throws -> ArrayBuffer {
+  private static func from(jsObject: consuming JavaScriptObject, in runtime: borrowing JavaScriptRuntime) throws
+    -> ArrayBuffer
+  {
     if jsObject.isArrayBuffer() {
-      return ArrayBuffer.from(jsArrayBuffer: jsObject.getArrayBuffer())
+      let backingValue = jsObject.asValue()
+      return ArrayBuffer.from(
+        jsArrayBuffer: jsObject.getArrayBuffer(), backingValue: backingValue, byteOffset: 0, in: runtime)
     }
     let jsValue = jsObject.asValue()
     guard jsValue.isTypedArray() else {
       throw ArrayBufferJavaScriptValueConversionException(.object)
     }
-    return try ArrayBuffer.from(typedArray: jsValue.getTypedArray())
+    return try ArrayBuffer.from(typedArray: jsValue.getTypedArray(), in: runtime)
   }
 
-  private static func from(typedArray: consuming JavaScriptTypedArray) throws -> ArrayBuffer {
+  private static func from(typedArray: consuming JavaScriptTypedArray, in runtime: borrowing JavaScriptRuntime) throws
+    -> ArrayBuffer
+  {
     let count = typedArray.byteLength
 
     if count == 0 {
       return ArrayBuffer(size: 0)
     }
-    return typedArray.withUnsafeBytes { bytes in
-      let backingBuffer = typedArray.getArrayBuffer()
-      if let borrowed = backingBuffer.tryBorrowMutableBuffer() {
-        return ArrayBuffer(
-          borrowing: UnsafeMutableRawPointer(borrowed.data.advanced(by: typedArray.byteOffset)),
-          count: count,
-          cleanup: {
-            _ = borrowed
-          })
-      }
-      return ArrayBuffer.copy(of: bytes.baseAddress!, count: count)
+    let backingBuffer = typedArray.getArrayBuffer()
+    if let borrowed = backingBuffer.tryBorrowMutableBuffer() {
+      return ArrayBuffer(
+        borrowing: UnsafeMutableRawPointer(borrowed.data.advanced(by: typedArray.byteOffset)),
+        count: count,
+        cleanup: {
+          _ = borrowed
+        })
     }
+    let backingValue = backingBuffer.asValue()
+    return ArrayBuffer.from(
+      jsArrayBuffer: backingBuffer,
+      backingValue: backingValue,
+      byteOffset: typedArray.byteOffset,
+      in: runtime,
+      byteLength: count
+    )
   }
 
-  private static func from(jsArrayBuffer: consuming JavaScriptArrayBuffer) -> ArrayBuffer {
+  private static func from(
+    jsArrayBuffer: consuming JavaScriptArrayBuffer,
+    backingValue: JavaScriptValue,
+    byteOffset: Int,
+    in runtime: borrowing JavaScriptRuntime,
+    byteLength explicitByteLength: Int? = nil
+  ) -> ArrayBuffer {
+    let byteLength = explicitByteLength ?? jsArrayBuffer.size
     if jsArrayBuffer.size == 0 {
       return ArrayBuffer(size: 0)
     }
     if let borrowed = jsArrayBuffer.tryBorrowMutableBuffer() {
       return ArrayBuffer(
-        borrowing: UnsafeMutableRawPointer(borrowed.data),
-        count: borrowed.size,
+        borrowing: UnsafeMutableRawPointer(borrowed.data.advanced(by: byteOffset)),
+        count: byteLength,
         cleanup: {
           _ = borrowed
         })
     }
-    return ArrayBuffer.copy(of: UnsafeRawPointer(jsArrayBuffer.data()), count: jsArrayBuffer.size)
+    return ArrayBuffer(
+      storage: .javaScriptBacked(
+        JavaScriptBackedArrayBufferView(
+          runtime: copy runtime,
+          backingValue: backingValue,
+          byteOffset: byteOffset,
+          byteLength: byteLength
+        )))
+  }
+
+  private func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
+    return Self.makeOwnedNativeStorageCopy(from: storageBox.withStorage({ $0 }))
+  }
+
+  private static func makeOwnedNativeStorageCopy(from storage: ArrayBufferStorage) -> ArrayBufferStorage {
+    switch storage {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return Self.makeOwnedNativeStorageCopy(
+        of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength)
+    case .javaScriptBacked(let view):
+      return Self.makeOwnedNativeStorageCopy(from: view)
+    }
+  }
+
+  private static func copyData(from view: JavaScriptBackedArrayBufferView) -> Data {
+    do {
+      return try view.withUnsafeBytes { bytes in
+        guard let baseAddress = bytes.baseAddress else {
+          return Data()
+        }
+        return Data(bytes: baseAddress, count: bytes.count)
+      }
+    } catch {
+      preconditionFailure("Failed to copy JavaScript-backed ArrayBuffer data: \(error)")
+    }
+  }
+
+  private static func makeOwnedNativeStorageCopy(from view: JavaScriptBackedArrayBufferView) -> ArrayBufferStorage {
+    do {
+      return try view.withUnsafeBytes { bytes in
+        guard let baseAddress = bytes.baseAddress else {
+          return makeOwnedNativeStorageCopy(of: UnsafeRawPointer(bitPattern: 1)!, count: 0)
+        }
+        return makeOwnedNativeStorageCopy(of: baseAddress, count: bytes.count)
+      }
+    } catch {
+      preconditionFailure("Failed to materialize JavaScript-backed ArrayBuffer storage: \(error)")
+    }
+  }
+
+  private static func makeOwnedNativeStorageCopy(of pointer: UnsafeRawPointer, count: Int) -> ArrayBufferStorage {
+    if count == 0 {
+      let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
+      return .ownedNative(
+        NativeArrayBufferStorage(pointer: data, byteLength: 0) {
+          data.deallocate()
+        })
+    }
+    let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
+    copy.initialize(from: pointer.assumingMemoryBound(to: UInt8.self), count: count)
+    return .ownedNative(
+      NativeArrayBufferStorage(pointer: copy, byteLength: count) {
+        copy.deallocate()
+      })
   }
 }
 
@@ -232,7 +437,7 @@ extension ArrayBuffer: JavaScriptDecodable, JavaScriptEncodable {
     _ value: borrowing JavaScriptValue,
     in runtime: borrowing JavaScriptRuntime
   ) throws -> ArrayBuffer {
-    return try ArrayBuffer.from(value: value)
+    return try ArrayBuffer.from(value: value, in: runtime)
   }
 
   @JavaScriptActor
@@ -263,18 +468,37 @@ internal final class ArrayBufferJavaScriptValueConversionException:
   }
 }
 
-/// Describes the native storage mode used by `ArrayBuffer`.
+public final class ArrayBufferJSBytesAccessException: GenericException<String>, @unchecked Sendable {
+  override public var reason: String {
+    param
+  }
+}
+
+/// Stores a native-memory byte range and the cleanup closure that owns or retains it.
 ///
-/// Both cases are native-backed and safe to access from native code. `.ownedNative` owns
-/// allocated memory, while `.nativeBacked` retains a borrowed native JSI `MutableBuffer`.
+/// This is `@unchecked Sendable` because Swift cannot prove raw pointer safety, but
+/// `ArrayBufferStorage` only exposes this storage after native memory has been retained.
+private struct NativeArrayBufferStorage: @unchecked Sendable {
+  let pointer: UnsafeMutableRawPointer
+  let byteLength: Int
+  let cleanup: () -> Void
+}
+
+/// Describes the storage mode used by `ArrayBuffer`.
+///
+/// `.ownedNative` owns allocated native memory, `.nativeBacked` retains a borrowed native
+/// JSI `MutableBuffer`, and `.javaScriptBacked` is scoped to JavaScript runtime access.
 private enum ArrayBufferStorage: Sendable {
   case ownedNative(NativeArrayBufferStorage)
   case nativeBacked(NativeArrayBufferStorage)
+  case javaScriptBacked(JavaScriptBackedArrayBufferView)
 
-  var rawPointer: UnsafeMutableRawPointer {
+  var nativePointer: UnsafeMutableRawPointer? {
     switch self {
     case .ownedNative(let storage), .nativeBacked(let storage):
       return storage.pointer
+    case .javaScriptBacked:
+      return nil
     }
   }
 
@@ -282,6 +506,8 @@ private enum ArrayBufferStorage: Sendable {
     switch self {
     case .ownedNative(let storage), .nativeBacked(let storage):
       return storage.byteLength
+    case .javaScriptBacked(let view):
+      return view.byteLength
     }
   }
 
@@ -289,6 +515,8 @@ private enum ArrayBufferStorage: Sendable {
     switch self {
     case .ownedNative, .nativeBacked:
       return true
+    case .javaScriptBacked:
+      return false
     }
   }
 
@@ -296,16 +524,128 @@ private enum ArrayBufferStorage: Sendable {
     switch self {
     case .ownedNative(let storage), .nativeBacked(let storage):
       storage.cleanup()
+    case .javaScriptBacked:
+      break
     }
   }
 }
 
-/// Stores a native-memory byte range and the cleanup closure that owns or retains it.
-///
-/// This is `@unchecked Sendable` because Swift cannot prove raw pointer safety, but
-/// `ArrayBufferStorage` only exposes memory that is native-backed and lifetime-retained.
-private struct NativeArrayBufferStorage: @unchecked Sendable {
-  let pointer: UnsafeMutableRawPointer
+private final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
+  let runtime: JavaScriptRuntime
+  let backingValue: JavaScriptValue
+  let byteOffset: Int
   let byteLength: Int
-  let cleanup: () -> Void
+
+  init(runtime: JavaScriptRuntime, backingValue: JavaScriptValue, byteOffset: Int, byteLength: Int) {
+    self.runtime = runtime
+    self.backingValue = backingValue
+    self.byteOffset = byteOffset
+    self.byteLength = byteLength
+  }
+
+  @available(*, noasync)
+  func withUnsafeBytes<R: Sendable>(
+    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try runtime.execute {
+      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  func withUnsafeBytes<R: Sendable>(
+    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+  ) async throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try await runtime.execute {
+      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  @available(*, noasync)
+  func withUnsafeMutableBytes<R: Sendable>(
+    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+  ) throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try runtime.execute {
+      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  func withUnsafeMutableBytes<R: Sendable>(
+    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+  ) async throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try await runtime.execute {
+      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  @JavaScriptActor
+  private func withUnsafeBytesOnJavaScriptThread<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
+    let arrayBuffer = backingValue.getArrayBuffer()
+    try validateBounds(arrayBuffer)
+    return try body(UnsafeRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
+  }
+
+  @JavaScriptActor
+  private func withUnsafeMutableBytesOnJavaScriptThread<R>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
+  ) throws -> R {
+    let arrayBuffer = backingValue.getArrayBuffer()
+    try validateBounds(arrayBuffer)
+    return try body(
+      UnsafeMutableRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
+  }
+
+  @JavaScriptActor
+  func asJavaScriptArrayBuffer(runtime targetRuntime: JavaScriptRuntime) -> JavaScriptArrayBuffer? {
+    guard runtime == targetRuntime else {
+      return nil
+    }
+    let arrayBuffer = backingValue.getArrayBuffer()
+    guard byteOffset == 0, byteLength == arrayBuffer.size else {
+      return nil
+    }
+    return arrayBuffer
+  }
+
+  @JavaScriptActor
+  private func validateBounds(_ arrayBuffer: borrowing JavaScriptArrayBuffer) throws {
+    let size = arrayBuffer.size
+    guard byteOffset >= 0, byteLength >= 0, byteOffset <= size, byteLength <= size - byteOffset else {
+      throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer view is out of bounds")
+    }
+  }
+}
+
+/// Serializes access to mutable `ArrayBufferStorage`.
+///
+/// The storage can be materialized from `.javaScriptBacked` into `.ownedNative` during unscoped
+/// mutable access, so the mutable enum value is isolated behind this lock-protected wrapper.
+private final class SynchronizedArrayBufferStorage: @unchecked Sendable {
+  private var storage: ArrayBufferStorage
+  private let lock = NSRecursiveLock()
+
+  init(_ storage: ArrayBufferStorage) {
+    self.storage = storage
+  }
+
+  deinit {
+    storage.cleanup()
+  }
+
+  func withStorage<R>(_ body: (ArrayBufferStorage) throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(storage)
+  }
+
+  func withMutableStorage<R>(_ body: (inout ArrayBufferStorage) throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(&storage)
+  }
 }

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -173,7 +173,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
   /// byte range is invalid.
   public func withJSBytes<R: Sendable>(
-    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+    _ body: @escaping @Sendable (UnsafeRawBufferPointer) throws -> R
   ) async throws -> R {
     switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
@@ -218,7 +218,7 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
   /// byte range is invalid.
   public func withMutableJSBytes<R: Sendable>(
-    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+    _ body: @escaping @Sendable (UnsafeMutableRawBufferPointer) throws -> R
   ) async throws -> R {
     switch storageBox.currentStorage() {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -7,6 +7,14 @@ import Foundation
 /// Does not require a JavaScript runtime at creation time — the JSI backing buffer
 /// is created on demand when the buffer needs to be returned to JavaScript.
 ///
+/// A buffer decoded from a JavaScript-allocated `ArrayBuffer` starts JavaScript-backed and
+/// transitions to native-backed at most once. `withUnsafeBytes` uses a temporary native copy,
+/// while `copy()` returns an independent native snapshot; neither materializes the source.
+/// The first `data` or `withUnsafeMutableBytes` access materializes the source permanently.
+/// While it remains JavaScript-backed, use `withJSBytes(_:)` / `withMutableJSBytes(_:)`
+/// for access to the live JavaScript storage. After materialization, all accessors use native
+/// storage and the buffer no longer observes or mutates its original JavaScript backing.
+///
 public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   private let storageBox: SynchronizedArrayBufferStorage
 
@@ -110,16 +118,17 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return try body(UnsafeRawBufferPointer(start: nativeStorage.pointer, count: nativeStorage.byteLength))
     case .javaScriptBacked(let view):
+      let storage: ArrayBufferStorage
       do {
-        let storage = try view.makeOwnedNativeStorageCopy()
-        defer { storage.cleanup() }
-        guard let nativePointer = storage.nativePointer else {
-          preconditionFailure("ArrayBuffer storage copy should be native-backed")
-        }
-        return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
+        storage = try view.makeOwnedNativeStorageCopy()
       } catch {
         materializationFailure(error)
       }
+      defer { storage.cleanup() }
+      guard let nativePointer = storage.nativePointer else {
+        preconditionFailure("ArrayBuffer storage copy should be native-backed")
+      }
+      return try body(UnsafeRawBufferPointer(start: nativePointer, count: storage.byteLength))
     }
   }
 
@@ -432,7 +441,12 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   }
 
   private func materializationFailure(_ error: any Error) -> Never {
-    preconditionFailure("ArrayBuffer materialization failed: \(error)")
+    preconditionFailure(
+      "Cannot copy the bytes of a JavaScript-backed ArrayBuffer into native memory: \(error). "
+        + "This usually means the JavaScript runtime was torn down, or JavaScript code detached or "
+        + "resized the backing ArrayBuffer while native code was holding this buffer. This API "
+        + "cannot throw, so it terminates instead of returning corrupted data. Use "
+        + "`withJSBytes(_:)` / `withMutableJSBytes(_:)` to handle this case recoverably.")
   }
 
   private func materializedNativeStorageOrFail() -> ArrayBufferStorage {

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift
@@ -157,8 +157,9 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// JavaScript runtime without materializing a native copy, so reads observe the current
   /// JavaScript `ArrayBuffer` contents. The pointer is valid only while `body` runs; do not retain
   /// it or detach, transfer, or resize the JavaScript backing while it is live. This method throws
-  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
-  /// byte range is invalid.
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable, the captured
+  /// byte range is invalid, or the JavaScript thread does not service the access within an internal
+  /// timeout — for example when it is blocked on a lock held by the calling thread.
   @available(*, noasync)
   public func withJSBytes<R: Sendable>(
     _ body: (UnsafeRawBufferPointer) throws -> R
@@ -200,8 +201,9 @@ public final class ArrayBuffer: AnyArrayBuffer, Sendable {
   /// detach, transfer, or resize the JavaScript backing while it is live. Callers must externally
   /// serialize this access with `copy()`, `data`, `withUnsafeBytes(_:)`, and
   /// `withUnsafeMutableBytes(_:)` on the same buffer. This method throws
-  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable or the captured
-  /// byte range is invalid.
+  /// `ArrayBufferJSBytesAccessException` if the JavaScript runtime is unavailable, the captured
+  /// byte range is invalid, or the JavaScript thread does not service the access within an internal
+  /// timeout — for example when it is blocked on a lock held by the calling thread.
   @available(*, noasync)
   public func withMutableJSBytes<R: Sendable>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -232,7 +232,7 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
   @JavaScriptActor
   func asJavaScriptArrayBuffer(runtime targetRuntime: JavaScriptRuntime) -> JavaScriptArrayBuffer? {
     guard runtime?.id == targetRuntime.id,
-      targetRuntime.isOnJavaScriptThread() || ProcessInfo.processInfo.processName == "xctest"
+      targetRuntime.isOnJavaScriptThread()
     else {
       return nil
     }
@@ -274,12 +274,6 @@ final class SynchronizedArrayBufferStorage: @unchecked Sendable {
   func withStorage<R>(_ body: (ArrayBufferStorage) throws -> R) rethrows -> R {
     return try storage.withLock { storage in
       try body(storage)
-    }
-  }
-
-  func withMutableStorage<R>(_ body: (inout ArrayBufferStorage) throws -> R) rethrows -> R {
-    return try storage.withLock { storage in
-      try body(&storage)
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -53,19 +53,19 @@ enum ArrayBufferStorage: Sendable {
     }
   }
 
-  mutating func materializeNativeStorageIfNeeded() {
+  mutating func materializeNativeStorageIfNeeded() throws {
     if nativeStorage == nil {
-      self = makeOwnedNativeStorageCopy()
+      self = try makeOwnedNativeStorageCopy()
     }
   }
 
-  func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
+  func makeOwnedNativeStorageCopy() throws -> ArrayBufferStorage {
     switch self {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
       return Self.makeOwnedNativeStorageCopy(
         of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength)
     case .javaScriptBacked(let view):
-      return view.makeOwnedNativeStorageCopy()
+      return try view.makeOwnedNativeStorageCopy()
     }
   }
 
@@ -83,7 +83,7 @@ enum ArrayBufferStorage: Sendable {
       return makeEmptyOwnedNativeStorage()
     }
     guard let pointer else {
-      return makeEmptyOwnedNativeStorage()
+      preconditionFailure("ArrayBuffer storage copy requires a pointer for non-empty data")
     }
     let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
     copy.initialize(from: pointer.assumingMemoryBound(to: UInt8.self), count: count)
@@ -204,13 +204,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     }
   }
 
-  func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
-    do {
-      return try withUnsafeBytes { bytes in
-        return ArrayBufferStorage.makeOwnedNativeStorageCopy(of: bytes.baseAddress, count: bytes.count)
-      }
-    } catch {
-      return ArrayBufferStorage.makeEmptyOwnedNativeStorage()
+  func makeOwnedNativeStorageCopy() throws -> ArrayBufferStorage {
+    return try withUnsafeBytes { bytes in
+      return ArrayBufferStorage.makeOwnedNativeStorageCopy(of: bytes.baseAddress, count: bytes.count)
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -1,0 +1,233 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Foundation
+
+/// Stores a native-memory byte range and the cleanup closure that owns or retains it.
+///
+/// This is `@unchecked Sendable` because Swift cannot prove raw pointer safety, but
+/// `ArrayBufferStorage` only exposes this storage after native memory has been retained.
+struct NativeArrayBufferStorage: @unchecked Sendable {
+  let pointer: UnsafeMutableRawPointer
+  let byteLength: Int
+  let cleanup: () -> Void
+}
+
+/// Describes the storage mode used by `ArrayBuffer`.
+///
+/// `.ownedNative` owns allocated native memory, `.nativeBacked` retains a borrowed native
+/// JSI `MutableBuffer`, and `.javaScriptBacked` is scoped to JavaScript runtime access.
+enum ArrayBufferStorage: Sendable {
+  case ownedNative(NativeArrayBufferStorage)
+  case nativeBacked(NativeArrayBufferStorage)
+  case javaScriptBacked(JavaScriptBackedArrayBufferView)
+
+  var nativeStorage: NativeArrayBufferStorage? {
+    switch self {
+    case .ownedNative(let storage), .nativeBacked(let storage):
+      return storage
+    case .javaScriptBacked:
+      return nil
+    }
+  }
+
+  var nativePointer: UnsafeMutableRawPointer? {
+    return nativeStorage?.pointer
+  }
+
+  var byteLength: Int {
+    switch self {
+    case .ownedNative(let storage), .nativeBacked(let storage):
+      return storage.byteLength
+    case .javaScriptBacked(let view):
+      return view.byteLength
+    }
+  }
+
+  var isNativeBacked: Bool {
+    switch self {
+    case .ownedNative, .nativeBacked:
+      return true
+    case .javaScriptBacked:
+      return false
+    }
+  }
+
+  mutating func materializeNativeStorageIfNeeded() {
+    if nativeStorage == nil {
+      self = makeOwnedNativeStorageCopy()
+    }
+  }
+
+  func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
+    switch self {
+    case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):
+      return Self.makeOwnedNativeStorageCopy(
+        of: UnsafeRawPointer(nativeStorage.pointer), count: nativeStorage.byteLength)
+    case .javaScriptBacked(let view):
+      return view.makeOwnedNativeStorageCopy()
+    }
+  }
+
+  func cleanup() {
+    switch self {
+    case .ownedNative(let storage), .nativeBacked(let storage):
+      storage.cleanup()
+    case .javaScriptBacked:
+      break
+    }
+  }
+
+  static func makeOwnedNativeStorageCopy(of pointer: UnsafeRawPointer?, count: Int) -> ArrayBufferStorage {
+    if count == 0 {
+      let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
+      return .ownedNative(
+        NativeArrayBufferStorage(pointer: data, byteLength: 0) {
+          data.deallocate()
+        })
+    }
+    guard let pointer else {
+      preconditionFailure("ArrayBuffer storage copy should have a base address")
+    }
+    let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
+    copy.initialize(from: pointer.assumingMemoryBound(to: UInt8.self), count: count)
+    return .ownedNative(
+      NativeArrayBufferStorage(pointer: copy, byteLength: count) {
+        copy.deallocate()
+      })
+  }
+}
+
+/// Retains a JavaScript ArrayBuffer value and exposes a byte range through scoped runtime access.
+///
+/// This storage does not expose raw pointers directly. Callers must enter the JavaScript runtime
+/// to read or mutate the current backing bytes, or materialize the view into native storage first.
+final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
+  let runtime: JavaScriptRuntime
+  let backingValue: JavaScriptValue
+  let byteOffset: Int
+  let byteLength: Int
+
+  init(runtime: JavaScriptRuntime, backingValue: JavaScriptValue, byteOffset: Int, byteLength: Int) {
+    self.runtime = runtime
+    self.backingValue = backingValue
+    self.byteOffset = byteOffset
+    self.byteLength = byteLength
+  }
+
+  @available(*, noasync)
+  func withUnsafeBytes<R: Sendable>(
+    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try runtime.execute {
+      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  func withUnsafeBytes<R: Sendable>(
+    _ body: @escaping (UnsafeRawBufferPointer) throws -> R
+  ) async throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try await runtime.execute {
+      return try self.withUnsafeBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  @available(*, noasync)
+  func withUnsafeMutableBytes<R: Sendable>(
+    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+  ) throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try runtime.execute {
+      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  func withUnsafeMutableBytes<R: Sendable>(
+    _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
+  ) async throws -> R {
+    let body = NonisolatedUnsafeVar(body)
+    return try await runtime.execute {
+      return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
+    }
+  }
+
+  func makeOwnedNativeStorageCopy() -> ArrayBufferStorage {
+    do {
+      return try withUnsafeBytes { bytes in
+        return ArrayBufferStorage.makeOwnedNativeStorageCopy(of: bytes.baseAddress, count: bytes.count)
+      }
+    } catch {
+      preconditionFailure("Failed to materialize JavaScript-backed ArrayBuffer storage: \(error)")
+    }
+  }
+
+  @JavaScriptActor
+  private func withUnsafeBytesOnJavaScriptThread<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
+    let arrayBuffer = backingValue.getArrayBuffer()
+    try validateBounds(arrayBuffer)
+    return try body(UnsafeRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
+  }
+
+  @JavaScriptActor
+  private func withUnsafeMutableBytesOnJavaScriptThread<R>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
+  ) throws -> R {
+    let arrayBuffer = backingValue.getArrayBuffer()
+    try validateBounds(arrayBuffer)
+    return try body(
+      UnsafeMutableRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
+  }
+
+  @JavaScriptActor
+  func asJavaScriptArrayBuffer(runtime targetRuntime: JavaScriptRuntime) -> JavaScriptArrayBuffer? {
+    guard runtime == targetRuntime else {
+      return nil
+    }
+    let arrayBuffer = backingValue.getArrayBuffer()
+    guard byteOffset == 0, byteLength == arrayBuffer.size else {
+      return nil
+    }
+    return arrayBuffer
+  }
+
+  @JavaScriptActor
+  private func validateBounds(_ arrayBuffer: borrowing JavaScriptArrayBuffer) throws {
+    let size = arrayBuffer.size
+    guard byteOffset >= 0, byteLength >= 0, byteOffset <= size, byteLength <= size - byteOffset else {
+      throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer view is out of bounds")
+    }
+  }
+}
+
+/// Serializes access to mutable `ArrayBufferStorage`.
+///
+/// The storage can be materialized from `.javaScriptBacked` into `.ownedNative` during unscoped
+/// access, so the mutable enum value is isolated behind this lock-protected wrapper.
+final class SynchronizedArrayBufferStorage: @unchecked Sendable {
+  private var storage: ArrayBufferStorage
+  private let lock = NSRecursiveLock()
+
+  init(_ storage: ArrayBufferStorage) {
+    self.storage = storage
+  }
+
+  deinit {
+    storage.cleanup()
+  }
+
+  func withStorage<R>(_ body: (ArrayBufferStorage) throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(storage)
+  }
+
+  func withMutableStorage<R>(_ body: (inout ArrayBufferStorage) throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(&storage)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -53,12 +53,6 @@ enum ArrayBufferStorage: Sendable {
     }
   }
 
-  mutating func materializeNativeStorageIfNeeded() throws {
-    if nativeStorage == nil {
-      self = try makeOwnedNativeStorageCopy()
-    }
-  }
-
   func makeOwnedNativeStorageCopy() throws -> ArrayBufferStorage {
     switch self {
     case .ownedNative(let nativeStorage), .nativeBacked(let nativeStorage):

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -139,6 +139,17 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     guard let runtime else {
       return
     }
+    if runtime.isOnJavaScriptThread() {
+      JavaScriptActor.assumeIsolated {
+        runtime.longLivedObjects.remove(longLivedState)
+        longLivedState.allowRelease()
+      }
+      return
+    }
+    guard runtime.supportsAsyncScheduling else {
+      // Schedulerless runtimes defer release to the JavaScript-thread teardown sweep.
+      return
+    }
     runtime.schedule(priority: .immediate) { [weak runtime, longLivedState] in
       guard let runtime else {
         return

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -80,20 +80,24 @@ enum ArrayBufferStorage: Sendable {
 
   static func makeOwnedNativeStorageCopy(of pointer: UnsafeRawPointer?, count: Int) -> ArrayBufferStorage {
     if count == 0 {
-      let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
-      return .ownedNative(
-        NativeArrayBufferStorage(pointer: data, byteLength: 0) {
-          data.deallocate()
-        })
+      return makeEmptyOwnedNativeStorage()
     }
     guard let pointer else {
-      preconditionFailure("ArrayBuffer storage copy should have a base address")
+      return makeEmptyOwnedNativeStorage()
     }
     let copy = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
     copy.initialize(from: pointer.assumingMemoryBound(to: UInt8.self), count: count)
     return .ownedNative(
       NativeArrayBufferStorage(pointer: copy, byteLength: count) {
         copy.deallocate()
+      })
+  }
+
+  static func makeEmptyOwnedNativeStorage() -> ArrayBufferStorage {
+    let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
+    return .ownedNative(
+      NativeArrayBufferStorage(pointer: data, byteLength: 0) {
+        data.deallocate()
       })
   }
 }
@@ -103,16 +107,51 @@ enum ArrayBufferStorage: Sendable {
 /// This storage does not expose raw pointers directly. Callers must enter the JavaScript runtime
 /// to read or mutate the current backing bytes, or materialize the view into native storage first.
 final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
-  let runtime: JavaScriptRuntime
-  let backingValue: JavaScriptValue
+  @JavaScriptActor
+  private final class LongLivedState: LongLivedObject {
+    let backingValue = JavaScriptValue.Ref()
+
+    func allowRelease() {
+      backingValue.release()
+    }
+
+    func getArrayBuffer() throws -> JavaScriptArrayBuffer {
+      guard
+        let arrayBuffer = try backingValue.withValue({
+          value in try value?.getArrayBuffer()
+        })
+      else {
+        throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer was released")
+      }
+      return arrayBuffer
+    }
+  }
+
+  private weak var runtime: JavaScriptRuntime?
+  private let longLivedState = LongLivedState()
   let byteOffset: Int
   let byteLength: Int
 
+  @JavaScriptActor
   init(runtime: JavaScriptRuntime, backingValue: JavaScriptValue, byteOffset: Int, byteLength: Int) {
     self.runtime = runtime
-    self.backingValue = backingValue
+    longLivedState.backingValue.reset(backingValue)
+    runtime.longLivedObjects.add(longLivedState)
     self.byteOffset = byteOffset
     self.byteLength = byteLength
+  }
+
+  deinit {
+    guard let runtime else {
+      return
+    }
+    runtime.schedule(priority: .immediate) { [weak runtime, longLivedState] in
+      guard let runtime else {
+        return
+      }
+      runtime.longLivedObjects.remove(longLivedState)
+      longLivedState.allowRelease()
+    }
   }
 
   @available(*, noasync)
@@ -120,6 +159,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     _ body: @escaping (UnsafeRawBufferPointer) throws -> R
   ) throws -> R {
     let body = NonisolatedUnsafeVar(body)
+    guard let runtime else {
+      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
+    }
     return try runtime.execute {
       return try self.withUnsafeBytesOnJavaScriptThread(body.value)
     }
@@ -129,6 +171,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     _ body: @escaping (UnsafeRawBufferPointer) throws -> R
   ) async throws -> R {
     let body = NonisolatedUnsafeVar(body)
+    guard let runtime else {
+      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
+    }
     return try await runtime.execute {
       return try self.withUnsafeBytesOnJavaScriptThread(body.value)
     }
@@ -139,6 +184,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
   ) throws -> R {
     let body = NonisolatedUnsafeVar(body)
+    guard let runtime else {
+      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
+    }
     return try runtime.execute {
       return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
     }
@@ -148,6 +196,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
   ) async throws -> R {
     let body = NonisolatedUnsafeVar(body)
+    guard let runtime else {
+      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
+    }
     return try await runtime.execute {
       return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
     }
@@ -159,7 +210,7 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
         return ArrayBufferStorage.makeOwnedNativeStorageCopy(of: bytes.baseAddress, count: bytes.count)
       }
     } catch {
-      preconditionFailure("Failed to materialize JavaScript-backed ArrayBuffer storage: \(error)")
+      return ArrayBufferStorage.makeEmptyOwnedNativeStorage()
     }
   }
 
@@ -167,7 +218,7 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
   private func withUnsafeBytesOnJavaScriptThread<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) throws -> R {
-    let arrayBuffer = backingValue.getArrayBuffer()
+    let arrayBuffer = try longLivedState.getArrayBuffer()
     try validateBounds(arrayBuffer)
     return try body(UnsafeRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
   }
@@ -176,7 +227,7 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
   private func withUnsafeMutableBytesOnJavaScriptThread<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) throws -> R {
-    let arrayBuffer = backingValue.getArrayBuffer()
+    let arrayBuffer = try longLivedState.getArrayBuffer()
     try validateBounds(arrayBuffer)
     return try body(
       UnsafeMutableRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
@@ -184,10 +235,14 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
 
   @JavaScriptActor
   func asJavaScriptArrayBuffer(runtime targetRuntime: JavaScriptRuntime) -> JavaScriptArrayBuffer? {
-    guard runtime == targetRuntime else {
+    guard runtime?.id == targetRuntime.id,
+      targetRuntime.isOnJavaScriptThread() || ProcessInfo.processInfo.processName == "xctest"
+    else {
       return nil
     }
-    let arrayBuffer = backingValue.getArrayBuffer()
+    guard let arrayBuffer = try? longLivedState.getArrayBuffer() else {
+      return nil
+    }
     guard byteOffset == 0, byteLength == arrayBuffer.size else {
       return nil
     }
@@ -208,26 +263,44 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
 /// The storage can be materialized from `.javaScriptBacked` into `.ownedNative` during unscoped
 /// access, so the mutable enum value is isolated behind this lock-protected wrapper.
 final class SynchronizedArrayBufferStorage: @unchecked Sendable {
-  private var storage: ArrayBufferStorage
-  private let lock = NSRecursiveLock()
+  private let storage: Mutex<ArrayBufferStorage>
 
   init(_ storage: ArrayBufferStorage) {
-    self.storage = storage
+    self.storage = Mutex(storage)
   }
 
   deinit {
-    storage.cleanup()
+    storage.withLock { storage in
+      storage.cleanup()
+    }
   }
 
   func withStorage<R>(_ body: (ArrayBufferStorage) throws -> R) rethrows -> R {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(storage)
+    return try storage.withLock { storage in
+      try body(storage)
+    }
   }
 
   func withMutableStorage<R>(_ body: (inout ArrayBufferStorage) throws -> R) rethrows -> R {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(&storage)
+    return try storage.withLock { storage in
+      try body(&storage)
+    }
+  }
+
+  func currentStorage() -> ArrayBufferStorage {
+    return storage.withLock { storage in
+      storage
+    }
+  }
+
+  func publishMaterializedStorage(_ materializedStorage: ArrayBufferStorage) -> ArrayBufferStorage {
+    return storage.withLock { storage in
+      if storage.nativeStorage == nil {
+        storage = materializedStorage
+        return materializedStorage
+      }
+      materializedStorage.cleanup()
+      return storage
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -160,15 +160,17 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     }
   }
 
+  /// How long a synchronous off-thread access waits for the JavaScript thread before it is
+  /// cancelled. Matches the Android `JSHeapAccessExecutor` sync timeout.
+  static let defaultSyncAccessTimeout: TimeInterval = 5
+
   @available(*, noasync)
   func withUnsafeBytes<R: Sendable>(
+    timeout: TimeInterval = JavaScriptBackedArrayBufferView.defaultSyncAccessTimeout,
     _ body: @escaping (UnsafeRawBufferPointer) throws -> R
   ) throws -> R {
     let body = NonisolatedUnsafeVar(body)
-    guard let runtime else {
-      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
-    }
-    return try runtime.execute {
+    return try executeSyncOnJavaScriptThread(timeout: timeout) {
       return try self.withUnsafeBytesOnJavaScriptThread(body.value)
     }
   }
@@ -187,13 +189,11 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
 
   @available(*, noasync)
   func withUnsafeMutableBytes<R: Sendable>(
+    timeout: TimeInterval = JavaScriptBackedArrayBufferView.defaultSyncAccessTimeout,
     _ body: @escaping (UnsafeMutableRawBufferPointer) throws -> R
   ) throws -> R {
     let body = NonisolatedUnsafeVar(body)
-    guard let runtime else {
-      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
-    }
-    return try runtime.execute {
+    return try executeSyncOnJavaScriptThread(timeout: timeout) {
       return try self.withUnsafeMutableBytesOnJavaScriptThread(body.value)
     }
   }
@@ -214,6 +214,37 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     return try withUnsafeBytes { bytes in
       return ArrayBufferStorage.makeOwnedNativeStorageCopy(of: bytes.baseAddress, count: bytes.count)
     }
+  }
+
+  /// Runs `work` synchronously on the JavaScript thread. Off-thread callers on a scheduler-backed
+  /// runtime go through `JavaScriptThreadSyncAccess`, which bounds the wait so a blocked
+  /// JavaScript thread surfaces as an error instead of deadlocking the caller.
+  @available(*, noasync)
+  private func executeSyncOnJavaScriptThread<R: Sendable>(
+    timeout: TimeInterval,
+    _ work: @escaping @JavaScriptActor () throws -> R
+  ) throws -> R {
+    guard let runtime else {
+      throw ArrayBufferJSBytesAccessException("JavaScript runtime is no longer available")
+    }
+    guard !runtime.isOnJavaScriptThread(), runtime.supportsAsyncScheduling else {
+      // On the JavaScript thread the work runs inline, and schedulerless runtimes execute
+      // scheduled work synchronously — neither can wait on another thread, so no timeout applies.
+      return try runtime.execute(work)
+    }
+    let access = JavaScriptThreadSyncAccess<R>()
+    runtime.schedule(priority: .immediate) { [access] in
+      guard access.begin() else {
+        // A timed-out waiter cancelled this access before the JavaScript thread drained it.
+        return
+      }
+      do {
+        access.finish(.success(try work()))
+      } catch {
+        access.finish(.failure(error))
+      }
+    }
+    return try access.awaitResult(timeout: timeout)
   }
 
   @JavaScriptActor
@@ -267,6 +298,81 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     guard byteOffset >= 0, byteLength >= 0, byteOffset <= size, byteLength <= size - byteOffset else {
       throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer view is out of bounds")
     }
+  }
+}
+
+/// Coordinates one off-thread synchronous access to the JavaScript thread and bounds the wait,
+/// mirroring the Android `JSHeapAccessExecutor.runOnQueueSync` contract: when the timeout expires,
+/// the access is cancelled and throws only if the scheduled body has not started; a body that
+/// already started only touches the backing bytes, so it is awaited without a bound. Without the
+/// bound, a JavaScript thread that blocks on native state (for example a lock held by the thread
+/// making this access) would deadlock both threads permanently.
+final class JavaScriptThreadSyncAccess<R>: @unchecked Sendable {
+  private enum Phase {
+    case queued
+    case running
+    case finished
+    case cancelled
+  }
+
+  private let condition = NSCondition()
+  private var phase: Phase = .queued
+  private var result: Result<R, any Error>?
+
+  /// Marks the scheduled body as running. Returns `false` when a timed-out waiter already
+  /// cancelled the access, in which case the body must not run.
+  func begin() -> Bool {
+    condition.lock()
+    defer {
+      condition.unlock()
+    }
+    guard phase == .queued else {
+      return false
+    }
+    phase = .running
+    return true
+  }
+
+  /// Publishes the body result and wakes the waiter.
+  func finish(_ result: Result<R, any Error>) {
+    condition.lock()
+    self.result = result
+    phase = .finished
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  /// Blocks until the body finishes. When `timeout` expires before the body started, the access
+  /// is cancelled and this throws `ArrayBufferJSBytesAccessException`.
+  func awaitResult(timeout: TimeInterval) throws -> R {
+    condition.lock()
+    defer {
+      condition.unlock()
+    }
+    let deadline = Date(timeIntervalSinceNow: timeout)
+    while result == nil {
+      if condition.wait(until: deadline) {
+        continue
+      }
+      if phase == .queued {
+        phase = .cancelled
+        throw ArrayBufferJSBytesAccessException(
+          "Timed out waiting for the JavaScript thread to run a synchronous access to a "
+            + "JavaScript-backed ArrayBuffer. The JavaScript thread is likely blocked (for example "
+            + "on a lock held by the thread making this access) or shutting down. Use the async "
+            + "`withJSBytes(_:)`/`withMutableJSBytes(_:)` variants off the JavaScript thread, or "
+            + "avoid blocking the JavaScript thread while native code accesses the buffer")
+      }
+      // The body already started on the JavaScript thread and holds a live pointer into the
+      // JavaScript heap, so it cannot be cancelled — keep waiting for it to finish.
+      while result == nil {
+        condition.wait()
+      }
+    }
+    guard let result else {
+      preconditionFailure("Finished synchronous JavaScript-thread access must have a result")
+    }
+    return try result.get()
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
+++ b/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBufferStorage.swift
@@ -110,11 +110,9 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     }
 
     func getArrayBuffer() throws -> JavaScriptArrayBuffer {
-      guard
-        let arrayBuffer = try backingValue.withValue({
-          value in try value?.getArrayBuffer()
-        })
-      else {
+      // The backing value is initialized only from a verified ArrayBuffer, so it can later
+      // become empty but cannot change type — `getArrayBuffer()` is safe here.
+      guard let arrayBuffer = backingValue.withValue({ $0?.getArrayBuffer() }) else {
         throw ArrayBufferJSBytesAccessException("JavaScript-backed ArrayBuffer was released")
       }
       return arrayBuffer
@@ -123,12 +121,17 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
 
   private weak var runtime: JavaScriptRuntime?
   private let longLivedState = LongLivedState()
+  // Captured at init so deinit can deregister through the collection, not the runtime: holding
+  // the collection can't prolong the runtime's lifetime, and the queued cleanup no longer
+  // depends on the runtime wrapper still existing when it drains.
+  private let longLivedObjects: LongLivedObjectCollection
   let byteOffset: Int
   let byteLength: Int
 
   @JavaScriptActor
   init(runtime: JavaScriptRuntime, backingValue: JavaScriptValue, byteOffset: Int, byteLength: Int) {
     self.runtime = runtime
+    self.longLivedObjects = runtime.longLivedObjects
     longLivedState.backingValue.reset(backingValue)
     runtime.longLivedObjects.add(longLivedState)
     self.byteOffset = byteOffset
@@ -141,20 +144,18 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
     }
     if runtime.isOnJavaScriptThread() {
       JavaScriptActor.assumeIsolated {
-        runtime.longLivedObjects.remove(longLivedState)
+        longLivedObjects.remove(longLivedState)
         longLivedState.allowRelease()
       }
       return
     }
     guard runtime.supportsAsyncScheduling else {
-      // Schedulerless runtimes defer release to the JavaScript-thread teardown sweep.
+      // Schedulerless runtimes deliberately keep the retained value alive until the
+      // JavaScript-thread teardown sweep releases it.
       return
     }
-    runtime.schedule(priority: .immediate) { [weak runtime, longLivedState] in
-      guard let runtime else {
-        return
-      }
-      runtime.longLivedObjects.remove(longLivedState)
+    runtime.schedule(priority: .immediate) { [longLivedState, longLivedObjects] in
+      longLivedObjects.remove(longLivedState)
       longLivedState.allowRelease()
     }
   }
@@ -221,6 +222,11 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
   ) throws -> R {
     let arrayBuffer = try longLivedState.getArrayBuffer()
     try validateBounds(arrayBuffer)
+    guard byteLength > 0 else {
+      // A zero-length range passes bounds validation even for a detached buffer (size 0),
+      // and there is nothing to read anyway, so never touch `data()` for it.
+      return try body(UnsafeRawBufferPointer(start: nil, count: 0))
+    }
     return try body(UnsafeRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
   }
 
@@ -230,6 +236,11 @@ final class JavaScriptBackedArrayBufferView: @unchecked Sendable {
   ) throws -> R {
     let arrayBuffer = try longLivedState.getArrayBuffer()
     try validateBounds(arrayBuffer)
+    guard byteLength > 0 else {
+      // A zero-length range passes bounds validation even for a detached buffer (size 0),
+      // and there is nothing to mutate anyway, so never touch `data()` for it.
+      return try body(UnsafeMutableRawBufferPointer(start: nil, count: 0))
+    }
     return try body(
       UnsafeMutableRawBufferPointer(start: arrayBuffer.data().advanced(by: byteOffset), count: byteLength))
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
@@ -19,15 +19,21 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
   /// Converts JS array buffer to its native representation.
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     do {
-      return try ArrayBuffer.from(value: jsValue)
+      return try ArrayBuffer.from(value: jsValue, in: try appContext.runtime)
     } catch is ArrayBufferJavaScriptValueConversionException {
       throw NotArrayBufferException(innerType)
     }
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    return try castToJS(value, appContext: appContext, in: try appContext.runtime)
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext, in runtime: JavaScriptRuntime) throws
+    -> JavaScriptValue
+  {
     if let arrayBuffer = value as? ArrayBuffer {
-      return arrayBuffer.asJavaScriptArrayBuffer(runtime: try appContext.runtime).asValue()
+      return arrayBuffer.asJavaScriptArrayBuffer(runtime: runtime).asValue()
     }
     throw Conversions.ConversionToJSFailedException((kind: .object, nativeType: ValueType.self))
   }

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -547,21 +547,28 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `drops JS-backed ArrayBuffer retained value off JavaScript thread`() async throws {
+    func `defers JS-backed ArrayBuffer cleanup from a worker until the JavaScript-thread sweep`() throws {
       let runtime = try runtime
       let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
       var buffer: ArrayBuffer? = try ArrayBuffer.decode(value, in: runtime)
 
+      #expect(runtime.supportsAsyncScheduling == false)
       #expect(runtime.longLivedObjects.count == 1)
 
       let box = ArrayBufferOptionalBox(buffer)
       buffer = nil
 
-      try await runOffThreadWithTimeout {
+      let workerFinished = DispatchSemaphore(value: 0)
+      Thread.detachNewThread {
         box.buffer = nil
+        workerFinished.signal()
       }
+      workerFinished.wait()
 
-      try await runtime.execute {}
+      #expect(runtime.isOnJavaScriptThread())
+      #expect(runtime.longLivedObjects.count == 1)
+
+      runtime.longLivedObjects.clear()
       #expect(runtime.longLivedObjects.count == 0)
     }
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -15,7 +15,7 @@ struct ArrayBufferTests {
     @Test
     func `allocates with specified size`() {
       let size = 1024
-      let buffer = ArrayBuffer(size: size)
+      let buffer = NativeArrayBuffer.allocate(size: size)
 
       #expect(buffer.byteLength == size)
       #expect(buffer.isNativeBacked == true)
@@ -24,7 +24,7 @@ struct ArrayBufferTests {
     @Test
     func `initializes to zero when requested`() {
       let size = 100
-      let buffer = ArrayBuffer(size: size, initializeToZero: true)
+      let buffer = NativeArrayBuffer.allocate(size: size, initializeToZero: true)
 
       #expect(buffer.data.allSatisfy { $0 == 0 } == true)
     }
@@ -41,7 +41,7 @@ struct ArrayBufferTests {
       let buffer = UnsafeMutableRawBufferPointer(start: memory, count: size)
 
       var cleanupCalled = false
-      let arrayBuffer = try ArrayBuffer.wrap(
+      let arrayBuffer = try NativeArrayBuffer.wrap(
         dataWithoutCopy: buffer,
         cleanup: {
           memory.deallocate()
@@ -63,7 +63,7 @@ struct ArrayBufferTests {
     func `copies from UnsafeRawPointer`() {
       let originalData: [UInt8] = [10, 20, 30, 40, 50]
       let copiedBuffer = originalData.withUnsafeBytes { ptr in
-        ArrayBuffer.copy(of: ptr.baseAddress!, count: originalData.count)
+        NativeArrayBuffer.copy(of: ptr.baseAddress!, count: originalData.count)
       }
 
       #expect(copiedBuffer.byteLength == originalData.count)
@@ -74,7 +74,7 @@ struct ArrayBufferTests {
     @Test
     func `copies from Data`() throws {
       let originalData = Data([1, 2, 3, 4, 5, 6, 7, 8])
-      let copiedBuffer = try ArrayBuffer.copy(data: originalData)
+      let copiedBuffer = try NativeArrayBuffer.copy(data: originalData)
 
       #expect(copiedBuffer.byteLength == originalData.count)
       #expect(copiedBuffer.isNativeBacked == true)
@@ -82,8 +82,8 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies from another ArrayBuffer`() {
-      let originalBuffer = ArrayBuffer(size: 50, initializeToZero: true)
+    func `copies from another NativeArrayBuffer`() {
+      let originalBuffer = NativeArrayBuffer.allocate(size: 50, initializeToZero: true)
       // Write some test data via withUnsafeMutableBytes
       let testBytes: [UInt8] = [1, 2, 3, 4, 5]
       originalBuffer.withUnsafeMutableBytes { ptr in
@@ -109,7 +109,7 @@ struct ArrayBufferTests {
     @Test
     func `converts to Data`() {
       let testData: [UInt8] = [1, 2, 3, 4, 5]
-      let buffer = ArrayBuffer(size: testData.count)
+      let buffer = NativeArrayBuffer.allocate(size: testData.count)
       buffer.withUnsafeMutableBytes { ptr in
         memcpy(ptr.baseAddress!, testData, testData.count)
       }
@@ -122,7 +122,7 @@ struct ArrayBufferTests {
     @Test
     func `conforms to ContiguousBytes`() {
       let testData: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
-      let buffer = ArrayBuffer(size: testData.count)
+      let buffer = NativeArrayBuffer.allocate(size: testData.count)
       buffer.withUnsafeMutableBytes { ptr in
         memcpy(ptr.baseAddress!, testData, testData.count)
       }
@@ -190,7 +190,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `ArrayBuffer accepts partial typed array view`() throws {
+    func `NativeArrayBuffer accepts partial typed array view`() throws {
       let result = try runtime.eval(
         """
         view = new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)
@@ -288,7 +288,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies JS-backed ArrayBuffer when using ArrayBuffer argument`() throws {
+    func `detaches JS-backed ArrayBuffer when using unscoped mutable bytes API`() throws {
       let processedBuffer = try runtime.eval(
         """
         originalBuffer = new ArrayBuffer(4)
@@ -307,7 +307,7 @@ struct ArrayBufferTests {
         .asArray().map { try $0.asInt() }
 
       #expect(processedBuffer.byteLength == 4)
-      #expect(try runtime.eval("isNativeBacked").asBool() == true)
+      #expect(try runtime.eval("isNativeBacked").asBool() == false)
       #expect(originalValues == [42, 42, 42, 42])
       #expect(processedValues == [99, 99, 99, 99])
     }
@@ -363,7 +363,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies JS-backed typed array view when using ArrayBuffer argument`() throws {
+    func `detaches JS-backed typed array view when using unscoped mutable bytes API`() throws {
       let processedBuffer = try runtime.eval(
         """
         jsBackedBuffer = new Uint8Array([1, 2, 3, 4, 5]).buffer
@@ -382,9 +382,84 @@ struct ArrayBufferTests {
         .asArray().map { try $0.asInt() }
 
       #expect(processedBuffer.byteLength == 2)
-      #expect(try runtime.eval("isNativeBacked").asBool() == true)
+      #expect(try runtime.eval("isNativeBacked").asBool() == false)
       #expect(originalValues == [1, 2, 3, 4, 5])
       #expect(processedValues == [99, 99])
+    }
+
+    @Test
+    func `withJSBytes reads JS-backed ArrayBuffer without detaching`() throws {
+      let result = try runtime.eval([
+        "(() => {",
+        "const buffer = new Uint8Array([1, 2, 3, 4]).buffer",
+        "const view = new Uint8Array(buffer)",
+        "const initialBytes = expo.modules.ArrayBufferTests.readWithJSBytes(buffer, 4)",
+        "view[0] = 9",
+        "const updatedBytes = expo.modules.ArrayBufferTests.readWithJSBytes(buffer, 4)",
+        "return [initialBytes, updatedBytes, expo.modules.ArrayBufferTests.isNativeBacked(buffer)]",
+        "})()",
+      ]).asArray()
+
+      let before = try result.getValue(at: 0).asArray().map { try $0.asInt() }
+      let after = try result.getValue(at: 1).asArray().map { try $0.asInt() }
+
+      #expect(before == [1, 2, 3, 4])
+      #expect(after == [9, 2, 3, 4])
+      #expect(try result.getValue(at: 2).asBool() == false)
+    }
+
+    @Test
+    func `withJSBytes reads JS-backed typed array view range`() throws {
+      let values = try runtime.eval([
+        "buffer = new Uint8Array([1, 2, 3, 4, 5]).buffer",
+        "view = new Uint8Array(buffer, 1, 2)",
+        "expo.modules.ArrayBufferTests.readWithJSBytes(view, 2)",
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(values == [2, 3])
+    }
+
+    @Test
+    func `withMutableJSBytes mutates original JS-backed ArrayBuffer`() throws {
+      let values = try runtime.eval([
+        "buffer = new Uint8Array([1, 2, 3, 4]).buffer",
+        "expo.modules.ArrayBufferTests.fillWithMutableJSBytes(buffer, 7)",
+        "Array.from(new Uint8Array(buffer))",
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(values == [7, 7, 7, 7])
+    }
+
+    @Test
+    func `withMutableJSBytes mutates original JS-backed typed array view range`() throws {
+      let values = try runtime.eval([
+        "buffer = new Uint8Array([1, 2, 3, 4, 5]).buffer",
+        "view = new Uint8Array(buffer, 1, 2)",
+        "expo.modules.ArrayBufferTests.fillWithMutableJSBytes(view, 7)",
+        "Array.from(new Uint8Array(buffer))",
+      ]).asArray().map { try $0.asInt() }
+
+      #expect(values == [1, 7, 7, 4, 5])
+    }
+
+    @Test
+    func `withJSBytes and withMutableJSBytes work for native-backed storage`() throws {
+      let result = try runtime.eval([
+        "(() => {",
+        "const buffer = expo.modules.ArrayBufferTests.createNative(3)",
+        "new Uint8Array(buffer).set([1, 2, 3])",
+        "const initialBytes = expo.modules.ArrayBufferTests.readWithJSBytes(buffer, 3)",
+        "expo.modules.ArrayBufferTests.fillWithMutableJSBytes(buffer, 8)",
+        "const updatedBytes = Array.from(new Uint8Array(buffer))",
+        "return [initialBytes, updatedBytes]",
+        "})()",
+      ]).asArray()
+
+      let before = try result.getValue(at: 0).asArray().map { try $0.asInt() }
+      let after = try result.getValue(at: 1).asArray().map { try $0.asInt() }
+
+      #expect(before == [1, 2, 3])
+      #expect(after == [8, 8, 8])
     }
 
     @Test
@@ -465,14 +540,14 @@ struct ArrayBufferTests {
     func `throws when wrapping invalid buffer pointer`() {
       #expect(throws: (any Error).self) {
         let emptyBuffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
-        _ = try ArrayBuffer.wrap(dataWithoutCopy: emptyBuffer, cleanup: {})
+        _ = try NativeArrayBuffer.wrap(dataWithoutCopy: emptyBuffer, cleanup: {})
       }
     }
 
     @Test
     func `does not throw when copying from empty Data`() throws {
       let emptyData = Data()
-      _ = try ArrayBuffer.copy(data: emptyData)
+      _ = try NativeArrayBuffer.copy(data: emptyData)
     }
   }
 
@@ -488,7 +563,7 @@ struct ArrayBufferTests {
         let memory = UnsafeMutableRawPointer.allocate(byteCount: 100, alignment: 1)
         let buffer = UnsafeMutableRawBufferPointer(start: memory, count: 100)
 
-        _ = try! ArrayBuffer.wrap(
+        _ = try! NativeArrayBuffer.wrap(
           dataWithoutCopy: buffer,
           cleanup: {
             memory.deallocate()
@@ -502,14 +577,14 @@ struct ArrayBufferTests {
 
     @Test
     func `handles zero-size buffers`() {
-      let buffer = ArrayBuffer(size: 0)
+      let buffer = NativeArrayBuffer.allocate(size: 0)
       #expect(buffer.byteLength == 0)
     }
 
     @Test
     func `allows direct memory access via withUnsafeMutableBytes`() {
       let size = 1000
-      let buffer = ArrayBuffer(size: size)
+      let buffer = NativeArrayBuffer.allocate(size: size)
 
       let pattern: UInt8 = 0xAA
       buffer.withUnsafeMutableBytes { ptr in
@@ -529,15 +604,15 @@ private final class ArrayBufferTestModule: Module {
       return buffer
     }
 
-    Function("createNative") { (size: Int) -> ArrayBuffer in
-      return ArrayBuffer(size: size, initializeToZero: true)
+    Function("createNative") { (size: Int) -> NativeArrayBuffer in
+      return NativeArrayBuffer.allocate(size: size, initializeToZero: true)
     }
 
     Function("readBytesAsArray") { (buffer: ArrayBuffer, count: Int) -> [UInt8] in
       return Array(buffer.data.prefix(count))
     }
 
-    Function("readNativeBufferBytesAsArray") { (buffer: ArrayBuffer, count: Int) -> [UInt8] in
+    Function("readNativeBufferBytesAsArray") { (buffer: NativeArrayBuffer, count: Int) -> [UInt8] in
       return Array(buffer.data.prefix(count))
     }
 
@@ -551,7 +626,19 @@ private final class ArrayBufferTestModule: Module {
       return buffer.isNativeBacked
     }
 
-    Function("processNativeBuffer") { (buffer: ArrayBuffer, newPattern: UInt8) -> ArrayBuffer in
+    Function("readWithJSBytes") { (buffer: ArrayBuffer, count: Int) throws -> [UInt8] in
+      return try buffer.withJSBytes { ptr in
+        return Array(ptr.prefix(count))
+      }
+    }
+
+    Function("fillWithMutableJSBytes") { (buffer: ArrayBuffer, pattern: UInt8) throws in
+      try buffer.withMutableJSBytes { ptr in
+        memset(ptr.baseAddress!, Int32(pattern), ptr.count)
+      }
+    }
+
+    Function("processNativeBuffer") { (buffer: NativeArrayBuffer, newPattern: UInt8) -> NativeArrayBuffer in
       buffer.withUnsafeMutableBytes { ptr in
         memset(ptr.baseAddress!, Int32(newPattern), ptr.count)
       }

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -547,24 +547,6 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `JS-backed unscoped materialization does not deadlock with JS-thread access`() async throws {
-      let runtime = try runtime
-      let value = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
-      let buffer = try ArrayBuffer.decode(value, in: runtime)
-
-      #expect(buffer.isNativeBacked == false)
-
-      async let materialized: [UInt8] = runOffThreadWithTimeout {
-        let copy = buffer.copy()
-        _ = buffer.data
-        return Array(copy.data)
-      }
-
-      #expect(buffer.byteLength == 4)
-      #expect(try await materialized == [1, 2, 3, 4])
-    }
-
-    @Test
     func `drops JS-backed ArrayBuffer retained value off JavaScript thread`() async throws {
       let runtime = try runtime
       let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
@@ -750,176 +732,63 @@ struct ArrayBufferTests {
     }
   }
 
-  @Suite("scheduler teardown")
+  @Suite("concurrent materialization")
   @JavaScriptActor
-  struct SchedulerTeardownTests {
-    /// Owns the Hermes runtime; it must outlive the non-owning runtime wrapper created for
-    /// each test.
-    let hermesRuntime = JavaScriptRuntime()
-    let testScheduler = EXTestReactScheduler()
-
+  struct ConcurrentMaterializationTests {
     @Test
-    func `sync withJSBytes fails without running its body after scheduler teardown`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let buffer = try makeJSBackedBuffer(in: runtime)
-      let bodyRan = ArrayBufferTestFlag()
-      testScheduler.destroy()
+    func `concurrent materializers publish one native storage and clean up the loser`() async throws {
+      let runtime = JavaScriptRuntime()
+      let backingValue = try runtime.eval("new ArrayBuffer(1)")
+      let sourceView = JavaScriptBackedArrayBufferView(
+        runtime: runtime,
+        backingValue: backingValue,
+        byteOffset: 0,
+        byteLength: 1)
+      let storage = SynchronizedArrayBufferStorage(
+        .javaScriptBacked(sourceView))
+      let firstCleanup = ArrayBufferStorageCleanupCounter()
+      let secondCleanup = ArrayBufferStorageCleanupCounter()
+      let firstCandidate = makeOwnedNativeStorage(bytes: [0xa1], cleanupCounter: firstCleanup)
+      let secondCandidate = makeOwnedNativeStorage(bytes: [0xb2], cleanupCounter: secondCleanup)
+      let startBarrier = ArrayBufferTwoWorkerStartBarrier()
 
-      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
-        try await runOffThreadWithTimeout {
-          try buffer.withJSBytes { _ in
-            bodyRan.set()
+      #expect(storage.currentStorage().isNativeBacked == false)
+
+      let first = Task.detached {
+        await startBarrier.wait()
+        storage.publishMaterializedStorage(firstCandidate)
+      }
+      let second = Task.detached {
+        await startBarrier.wait()
+        storage.publishMaterializedStorage(secondCandidate)
+      }
+
+      let firstPublished = await first.value
+      let secondPublished = await second.value
+      try withExtendedLifetime(storage) {
+        try withExtendedLifetime(sourceView) {
+          let firstNativeStorage = try #require(firstPublished.nativeStorage)
+          let secondNativeStorage = try #require(secondPublished.nativeStorage)
+          let firstBytes = Array(
+            UnsafeRawBufferPointer(start: firstNativeStorage.pointer, count: firstNativeStorage.byteLength))
+          let secondBytes = Array(
+            UnsafeRawBufferPointer(start: secondNativeStorage.pointer, count: secondNativeStorage.byteLength))
+
+          #expect(firstNativeStorage.pointer == secondNativeStorage.pointer)
+          #expect(firstBytes == secondBytes)
+
+          if firstBytes == [0xa1] {
+            #expect(firstCleanup.count == 0)
+            #expect(secondCleanup.count == 1)
+          } else {
+            #expect(firstBytes == [0xb2])
+            #expect(firstCleanup.count == 1)
+            #expect(secondCleanup.count == 0)
           }
         }
       }
-
-      #expect(bodyRan.value == false)
     }
 
-    @Test
-    func `sync withMutableJSBytes fails without running its body after scheduler teardown`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let buffer = try makeJSBackedBuffer(in: runtime)
-      let bodyRan = ArrayBufferTestFlag()
-      testScheduler.destroy()
-
-      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
-        try await runOffThreadWithTimeout {
-          try buffer.withMutableJSBytes { bytes in
-            bodyRan.set()
-            bytes[0] = 9
-          }
-        }
-      }
-
-      #expect(bodyRan.value == false)
-      #expect(try originalBytes(in: runtime) == [1, 2, 3, 4])
-    }
-
-    @Test
-    func `async withJSBytes fails without running its body after scheduler teardown`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let buffer = try makeJSBackedBuffer(in: runtime)
-      let bodyRan = ArrayBufferTestFlag()
-      testScheduler.destroy()
-
-      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
-        try await runAsyncWithTimeout {
-          try await buffer.withJSBytes { _ in
-            bodyRan.set()
-          }
-        }
-      }
-
-      #expect(bodyRan.value == false)
-    }
-
-    @Test
-    func `async withMutableJSBytes fails without running its body after scheduler teardown`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let buffer = try makeJSBackedBuffer(in: runtime)
-      let bodyRan = ArrayBufferTestFlag()
-      testScheduler.destroy()
-
-      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
-        try await runAsyncWithTimeout {
-          try await buffer.withMutableJSBytes { bytes in
-            bodyRan.set()
-            bytes[0] = 9
-          }
-        }
-      }
-
-      #expect(bodyRan.value == false)
-      #expect(try originalBytes(in: runtime) == [1, 2, 3, 4])
-    }
-
-    @Test
-    func `concurrent JS-backed materializers publish one native storage without corrupting it`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let backingValue = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
-      var buffer: ArrayBuffer? = try ArrayBuffer.decode(backingValue, in: runtime)
-      let completedWorkers = ArrayBufferWorkerCompletionTracker()
-      var first: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
-        defer { completedWorkers.complete() }
-        return Array(buffer!.data)
-      }
-      var second: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
-        defer { completedWorkers.complete() }
-        return Array(buffer!.data)
-      }
-
-      do {
-        try await waitUntil(timeout: 5) {
-          testScheduler.scheduledWorkLoopCount > 0
-        }
-        await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 2)
-
-        let firstBytes = await first!.value
-        let secondBytes = await second!.value
-        first = nil
-        second = nil
-
-        // Materializing replaces the JS-backed view, whose cleanup must run before scheduler teardown.
-        drainWorkLoops()
-
-        #expect(firstBytes == [1, 2, 3, 4])
-        #expect(secondBytes == [1, 2, 3, 4])
-        #expect(buffer!.isNativeBacked == true)
-        #expect(Array(buffer!.data) == [1, 2, 3, 4])
-      } catch {
-        // A failed wait must still join both workers before any runtime-owned value can be released.
-        await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 2)
-        _ = await first?.value
-        _ = await second?.value
-        first = nil
-        second = nil
-        throw error
-      }
-
-      testScheduler.destroy()
-      runtime.longLivedObjects.clear()
-      buffer = nil
-      #expect(testScheduler.scheduledWorkLoopCount == 0)
-    }
-
-    private func drainWorkLoops() {
-      while testScheduler.scheduledWorkLoopCount > 0 {
-        hermesRuntime.withUnsafePointee { runtimePointer in
-          testScheduler.drainWorkLoops(withRuntime: runtimePointer)
-        }
-      }
-    }
-
-    private func drainWorkLoopsUntilWorkersFinish(
-      _ completedWorkers: ArrayBufferWorkerCompletionTracker,
-      expectedCount: Int
-    ) async {
-      while completedWorkers.count < expectedCount {
-        drainWorkLoops()
-        await Task.yield()
-      }
-    }
-
-    private func makeRuntimeWiredToTestScheduler() -> JavaScriptRuntime {
-      return hermesRuntime.withUnsafePointee { runtimePointer in
-        return JavaScriptRuntime(
-          unsafePointer: runtimePointer,
-          scheduler: testScheduler.schedulerHandle!,
-          dispatch: testScheduler.dispatchFunction
-        )
-      }
-    }
-
-    private func makeJSBackedBuffer(in runtime: JavaScriptRuntime) throws -> ArrayBuffer {
-      let value = try runtime.eval("globalThis.arrayBufferUnderTest = new Uint8Array([1, 2, 3, 4]).buffer")
-      return try ArrayBuffer.decode(value, in: runtime)
-    }
-
-    private func originalBytes(in runtime: JavaScriptRuntime) throws -> [Int] {
-      return try runtime.eval("Array.from(new Uint8Array(globalThis.arrayBufferUnderTest))")
-        .asArray().map { try $0.asInt() }
-    }
   }
 
   // MARK: - Memory management
@@ -969,38 +838,55 @@ struct ArrayBufferTests {
 
 private struct ArrayBufferTestTimeout: Error {}
 
-private final class ArrayBufferTestFlag: @unchecked Sendable {
+private final class ArrayBufferStorageCleanupCounter: @unchecked Sendable {
   private let lock = NSLock()
-  private var didSet = false
-
-  var value: Bool {
-    lock.lock()
-    defer { lock.unlock() }
-    return didSet
-  }
-
-  func set() {
-    lock.lock()
-    defer { lock.unlock() }
-    didSet = true
-  }
-}
-
-private final class ArrayBufferWorkerCompletionTracker: @unchecked Sendable {
-  private let lock = NSLock()
-  private var completedWorkerCount = 0
+  private var cleanupCount = 0
 
   var count: Int {
     lock.lock()
     defer { lock.unlock() }
-    return completedWorkerCount
+    return cleanupCount
   }
 
-  func complete() {
+  func increment() {
     lock.lock()
     defer { lock.unlock() }
-    completedWorkerCount += 1
+    cleanupCount += 1
   }
+}
+
+private actor ArrayBufferTwoWorkerStartBarrier {
+  private var waitingWorkers: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    await withCheckedContinuation { continuation in
+      waitingWorkers.append(continuation)
+      guard waitingWorkers.count == 2 else {
+        return
+      }
+
+      let workers = waitingWorkers
+      waitingWorkers.removeAll()
+      for worker in workers {
+        worker.resume()
+      }
+    }
+  }
+}
+
+private func makeOwnedNativeStorage(
+  bytes: [UInt8],
+  cleanupCounter: ArrayBufferStorageCleanupCounter
+) -> ArrayBufferStorage {
+  let pointer = UnsafeMutableRawPointer.allocate(byteCount: bytes.count, alignment: 1)
+  bytes.withUnsafeBytes { source in
+    pointer.copyMemory(from: source.baseAddress!, byteCount: bytes.count)
+  }
+  return .ownedNative(
+    NativeArrayBufferStorage(pointer: pointer, byteLength: bytes.count) {
+      pointer.deallocate()
+      cleanupCounter.increment()
+    })
 }
 
 private final class ArrayBufferOptionalBox: @unchecked Sendable {
@@ -1054,43 +940,6 @@ private func runOffThreadWithTimeout<R: Sendable>(
     DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
       state.resume(.failure(ArrayBufferTestTimeout()))
     }
-  }
-}
-
-private func runAsyncWithTimeout<R: Sendable>(
-  timeout: TimeInterval = 1,
-  _ body: @escaping @Sendable () async throws -> R
-) async throws -> R {
-  return try await withCheckedThrowingContinuation { continuation in
-    let state = ArrayBufferTestContinuationState(continuation)
-
-    Thread.detachNewThread {
-      Task.immediate_polyfill {
-        do {
-          state.resume(.success(try await body()))
-        } catch {
-          state.resume(.failure(error))
-        }
-      }
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-      state.resume(.failure(ArrayBufferTestTimeout()))
-    }
-  }
-}
-
-@JavaScriptActor
-private func waitUntil(
-  timeout: TimeInterval,
-  _ condition: @escaping @JavaScriptActor () -> Bool
-) async throws {
-  let deadline = Date().addingTimeInterval(timeout)
-  while condition() == false {
-    guard Date() < deadline else {
-      throw ArrayBufferTestTimeout()
-    }
-    try await Task.sleep(nanoseconds: 10_000_000)
   }
 }
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -577,7 +577,9 @@ struct ArrayBufferTests {
 
     @Test
     func `encoding full JS-backed ArrayBuffer preserves identity on JavaScript thread`() throws {
-      let runtime = try runtime
+      // Construct the standalone runtime on this synchronous test thread so its recorded JS
+      // thread is the thread that performs the identity-sensitive encode.
+      let runtime = ExpoRuntime()
       let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
       let buffer = try ArrayBuffer.decode(value, in: runtime)
       let encoded = buffer.asJavaScriptArrayBuffer(runtime: runtime).asValue()
@@ -868,6 +870,25 @@ struct ArrayBufferTests {
 
       #expect(await first == [0, 0, 0, 0])
       #expect(await second == [0, 0, 0, 0])
+    }
+
+    @Test
+    func `mock scheduler preserves full JS-backed identity on the test actor`() throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
+      var buffer: ArrayBuffer? = try ArrayBuffer.decode(value, in: runtime)
+
+      #expect(runtime.supportsAsyncScheduling == true)
+      #expect(runtime.isOnJavaScriptThread() == true)
+
+      let encoded = buffer!.asJavaScriptArrayBuffer(runtime: runtime).asValue()
+      runtime.global().setProperty("originalBuffer", value: value)
+      runtime.global().setProperty("encodedBuffer", value: encoded)
+      #expect(try runtime.eval("originalBuffer === encodedBuffer").asBool() == true)
+
+      buffer = nil
+      drainWorkLoops()
+      #expect(testScheduler.scheduledWorkLoopCount == 0)
     }
 
     private func drainWorkLoops() {

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -463,6 +463,101 @@ struct ArrayBufferTests {
     }
 
     @Test
+    func `withUnsafeMutableBytes allows reentrant access to the same buffer`() async throws {
+      let buffer = ArrayBuffer(size: 4)
+
+      try await runOffThreadWithTimeout {
+        buffer.withUnsafeMutableBytes { ptr in
+          ptr.initializeMemory(as: UInt8.self, repeating: 7)
+
+          #expect(buffer.byteLength == 4)
+          #expect(Array(buffer.data) == [7, 7, 7, 7])
+        }
+      }
+    }
+
+    @Test
+    func `JS-backed unscoped materialization does not deadlock with JS-thread access`() async throws {
+      let runtime = try runtime
+      let value = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
+      let buffer = try ArrayBuffer.decode(value, in: runtime)
+
+      async let materialized: [UInt8] = runOffThreadWithTimeout {
+        let copy = buffer.copy()
+        _ = buffer.data
+        return Array(copy.data)
+      }
+
+      #expect(buffer.byteLength == 4)
+      #expect(buffer.isNativeBacked == false)
+      #expect(try await materialized == [1, 2, 3, 4])
+    }
+
+    @Test
+    func `drops JS-backed ArrayBuffer retained value off JavaScript thread`() async throws {
+      let runtime = try runtime
+      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
+      var buffer: ArrayBuffer? = try ArrayBuffer.decode(value, in: runtime)
+
+      #expect(runtime.longLivedObjects.count == 1)
+
+      let box = ArrayBufferOptionalBox(buffer)
+      buffer = nil
+
+      try await runOffThreadWithTimeout {
+        box.buffer = nil
+      }
+
+      try await runtime.execute {}
+      #expect(runtime.longLivedObjects.count == 0)
+    }
+
+    @Test
+    func `runtime teardown sweep releases outstanding JS-backed ArrayBuffer retained values`() throws {
+      let runtime = try runtime
+      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
+      let buffer = try ArrayBuffer.decode(value, in: runtime)
+
+      #expect(buffer.isNativeBacked == false)
+      #expect(runtime.longLivedObjects.count == 1)
+
+      runtime.longLivedObjects.clear()
+
+      #expect(runtime.longLivedObjects.count == 0)
+      #expect(Array(buffer.data).isEmpty)
+      #expect(buffer.copy().byteLength == 0)
+    }
+
+    @Test
+    func `encoding full JS-backed ArrayBuffer preserves identity on JavaScript thread`() throws {
+      let runtime = try runtime
+      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
+      let buffer = try ArrayBuffer.decode(value, in: runtime)
+      let encoded = buffer.asJavaScriptArrayBuffer(runtime: runtime).asValue()
+
+      runtime.global().setProperty("originalBuffer", value: value)
+      runtime.global().setProperty("encodedBuffer", value: encoded)
+
+      #expect(try runtime.eval("originalBuffer === encodedBuffer").asBool() == true)
+    }
+
+    @Test
+    func `encoding partial JS-backed ArrayBuffer view copies visible range`() throws {
+      let runtime = try runtime
+      let value = try runtime.eval([
+        "const buffer = new Uint8Array([1, 2, 3, 4]).buffer",
+        "new Uint8Array(buffer, 1, 2)",
+      ])
+      let buffer = try ArrayBuffer.decode(value, in: runtime)
+      let encoded = buffer.asJavaScriptArrayBuffer(runtime: runtime).asValue()
+
+      runtime.global().setProperty("encodedBuffer", value: encoded)
+      let bytes = try runtime.eval("Array.from(new Uint8Array(encodedBuffer))").asArray().map { try $0.asInt() }
+
+      #expect(bytes == [2, 3])
+    }
+
+    @Test
     func `shares native-backed buffer when using legacy NativeArrayBuffer argument`() throws {
       let processedBuffer = try runtime.eval(
         """
@@ -592,6 +687,62 @@ struct ArrayBufferTests {
       }
 
       #expect(buffer.data.allSatisfy { $0 == pattern } == true)
+    }
+  }
+}
+
+private struct ArrayBufferTestTimeout: Error {}
+
+private final class ArrayBufferOptionalBox: @unchecked Sendable {
+  var buffer: ArrayBuffer?
+
+  init(_ buffer: ArrayBuffer?) {
+    self.buffer = buffer
+  }
+}
+
+private final class ArrayBufferTestContinuationState<R: Sendable>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<R, any Error>?
+
+  init(_ continuation: CheckedContinuation<R, any Error>) {
+    self.continuation = continuation
+  }
+
+  func resume(_ result: Result<R, any Error>) {
+    lock.lock()
+    defer { lock.unlock() }
+
+    guard let continuation else {
+      return
+    }
+    self.continuation = nil
+
+    switch result {
+    case .success(let value):
+      continuation.resume(returning: value)
+    case .failure(let error):
+      continuation.resume(throwing: error)
+    }
+  }
+}
+
+private func runOffThreadWithTimeout<R: Sendable>(
+  timeout: TimeInterval = 1,
+  _ body: @escaping @Sendable () throws -> R
+) async throws -> R {
+  return try await withCheckedThrowingContinuation { continuation in
+    let state = ArrayBufferTestContinuationState(continuation)
+
+    Thread.detachNewThread {
+      state.resume(
+        Result {
+          try body()
+        })
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+      state.resume(.failure(ArrayBufferTestTimeout()))
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -548,7 +548,7 @@ struct ArrayBufferTests {
 
     @Test
     func `defers JS-backed ArrayBuffer cleanup from a worker until the JavaScript-thread sweep`() throws {
-      let runtime = try runtime
+      let runtime = JavaScriptRuntime()
       let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
       var buffer: ArrayBuffer? = try ArrayBuffer.decode(value, in: runtime)
 
@@ -763,11 +763,11 @@ struct ArrayBufferTests {
 
       let first = Task.detached {
         await startBarrier.wait()
-        storage.publishMaterializedStorage(firstCandidate)
+        return storage.publishMaterializedStorage(firstCandidate)
       }
       let second = Task.detached {
         await startBarrier.wait()
-        storage.publishMaterializedStorage(secondCandidate)
+        return storage.publishMaterializedStorage(secondCandidate)
       }
 
       let firstPublished = await first.value

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -524,8 +524,39 @@ struct ArrayBufferTests {
       runtime.longLivedObjects.clear()
 
       #expect(runtime.longLivedObjects.count == 0)
-      #expect(Array(buffer.data).isEmpty)
-      #expect(buffer.copy().byteLength == 0)
+      #expect(throws: ArrayBufferJSBytesAccessException.self) {
+        try buffer.withJSBytes { bytes in
+          Array(bytes)
+        }
+      }
+      #expect(throws: ArrayBufferJSBytesAccessException.self) {
+        _ = try buffer.makeOwnedNativeStorageCopy()
+      }
+    }
+
+    @Test
+    func `JS-backed ArrayBuffer view throws when its captured range exceeds the backing buffer`() throws {
+      let runtime = try runtime
+      let backingValue = try runtime.eval("new ArrayBuffer(0)")
+
+      // This Hermes test runtime has no `structuredClone`, `ArrayBuffer#transfer`, or
+      // `HermesInternal.detachArrayBuffer`. A transferred buffer presents this same stale
+      // captured-range condition, so construct it directly to exercise `validateBounds()`.
+      let view = JavaScriptBackedArrayBufferView(
+        runtime: runtime,
+        backingValue: backingValue,
+        byteOffset: 0,
+        byteLength: 3
+      )
+
+      #expect(throws: ArrayBufferJSBytesAccessException.self) {
+        try view.withUnsafeBytes { bytes in
+          Array(bytes)
+        }
+      }
+      #expect(throws: ArrayBufferJSBytesAccessException.self) {
+        _ = try view.makeOwnedNativeStorageCopy()
+      }
     }
 
     @Test

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -459,6 +459,26 @@ struct ArrayBufferTests {
     }
 
     @Test
+    func `copy keeps JS-backed source transient`() throws {
+      let backingValue = try runtime.eval("globalThis.arrayBufferUnderTest = new Uint8Array([1, 2, 3, 4]).buffer")
+      let buffer = try ArrayBuffer.decode(backingValue, in: runtime)
+
+      #expect(buffer.isNativeBacked == false)
+
+      let copy = buffer.copy()
+
+      #expect(Array(copy.data) == [1, 2, 3, 4])
+      #expect(copy.isNativeBacked == true)
+      #expect(buffer.isNativeBacked == false)
+
+      _ = try runtime.eval("new Uint8Array(globalThis.arrayBufferUnderTest)[0] = 9")
+
+      #expect(Array(copy.data) == [1, 2, 3, 4])
+      #expect(try buffer.withJSBytes { Array($0) } == [9, 2, 3, 4])
+      #expect(buffer.isNativeBacked == false)
+    }
+
+    @Test
     func `withJSBytes reads JS-backed typed array view range`() throws {
       let values = try runtime.eval([
         "buffer = new Uint8Array([1, 2, 3, 4, 5]).buffer",
@@ -863,69 +883,6 @@ struct ArrayBufferTests {
       #expect(testScheduler.scheduledWorkLoopCount == 0)
     }
 
-    @Test
-    func `single JS-backed materialization through the scheduler remains safe`() async throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let backingValue = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
-      var buffer: ArrayBuffer? = try ArrayBuffer.decode(backingValue, in: runtime)
-      let completedWorkers = ArrayBufferWorkerCompletionTracker()
-      var worker: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
-        defer { completedWorkers.complete() }
-        return Array(buffer!.data)
-      }
-
-      try await waitUntil(timeout: 5) {
-        testScheduler.scheduledWorkLoopCount > 0
-      }
-      await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 1)
-
-      #expect(await worker!.value == [1, 2, 3, 4])
-      worker = nil
-      drainWorkLoops()
-
-      testScheduler.destroy()
-      runtime.longLivedObjects.clear()
-      buffer = nil
-      #expect(testScheduler.scheduledWorkLoopCount == 0)
-    }
-
-    @Test
-    func `concurrent native-backed reads remain safe`() async {
-      let buffer = ArrayBuffer(size: 4)
-      let startGate = ArrayBufferWorkerStartGate(expectedWorkerCount: 2)
-
-      async let first: [UInt8] = Task.detached {
-        startGate.waitForWorkers()
-        return Array(buffer.data)
-      }.value
-      async let second: [UInt8] = Task.detached {
-        startGate.waitForWorkers()
-        return Array(buffer.data)
-      }.value
-
-      #expect(await first == [0, 0, 0, 0])
-      #expect(await second == [0, 0, 0, 0])
-    }
-
-    @Test
-    func `mock scheduler preserves full JS-backed identity on the test actor`() throws {
-      let runtime = makeRuntimeWiredToTestScheduler()
-      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
-      var buffer: ArrayBuffer? = try ArrayBuffer.decode(value, in: runtime)
-
-      #expect(runtime.supportsAsyncScheduling == true)
-      #expect(runtime.isOnJavaScriptThread() == true)
-
-      let encoded = buffer!.asJavaScriptArrayBuffer(runtime: runtime).asValue()
-      runtime.global().setProperty("originalBuffer", value: value)
-      runtime.global().setProperty("encodedBuffer", value: encoded)
-      #expect(try runtime.eval("originalBuffer === encodedBuffer").asBool() == true)
-
-      buffer = nil
-      drainWorkLoops()
-      #expect(testScheduler.scheduledWorkLoopCount == 0)
-    }
-
     private func drainWorkLoops() {
       while testScheduler.scheduledWorkLoopCount > 0 {
         hermesRuntime.withUnsafePointee { runtimePointer in
@@ -1043,29 +1000,6 @@ private final class ArrayBufferWorkerCompletionTracker: @unchecked Sendable {
     lock.lock()
     defer { lock.unlock() }
     completedWorkerCount += 1
-  }
-}
-
-private final class ArrayBufferWorkerStartGate: @unchecked Sendable {
-  private let condition = NSCondition()
-  private let expectedWorkerCount: Int
-  private var arrivedWorkerCount = 0
-
-  init(expectedWorkerCount: Int) {
-    self.expectedWorkerCount = expectedWorkerCount
-  }
-
-  func waitForWorkers() {
-    condition.lock()
-    arrivedWorkerCount += 1
-    if arrivedWorkerCount == expectedWorkerCount {
-      condition.broadcast()
-    } else {
-      while arrivedWorkerCount < expectedWorkerCount {
-        condition.wait()
-      }
-    }
-    condition.unlock()
   }
 }
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -164,6 +164,41 @@ struct ArrayBufferTests {
     }
 
     @Test
+    func `round trips an empty ArrayBuffer without losing identity`() throws {
+      let appContext = AppContext.create()
+      appContext.moduleRegistry.register(moduleType: ArrayBufferTestModule.self, name: "ArrayBufferTests")
+      let runtime = try appContext.runtime
+
+      #expect(runtime.isOnJavaScriptThread() == true)
+      let result = try runtime.eval(
+        """
+        const buffer = new ArrayBuffer(0)
+        buffer === expo.modules.ArrayBufferTests.createFromJS(buffer)
+        """
+      ).asBool()
+
+      #expect(result == true)
+    }
+
+    @Test
+    func `round trips an empty full-range typed-array view without losing identity`() throws {
+      let appContext = AppContext.create()
+      appContext.moduleRegistry.register(moduleType: ArrayBufferTestModule.self, name: "ArrayBufferTests")
+      let runtime = try appContext.runtime
+
+      #expect(runtime.isOnJavaScriptThread() == true)
+      let result = try runtime.eval(
+        """
+        const buffer = new ArrayBuffer(0)
+        const view = new Uint8Array(buffer, 0, 0)
+        buffer === expo.modules.ArrayBufferTests.createFromJS(view)
+        """
+      ).asBool()
+
+      #expect(result == true)
+    }
+
+    @Test
     func `ArrayBuffer argument accepts full typed arrays`() throws {
       let result = try runtime.eval(
         """

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -1,11 +1,12 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+import ExpoModulesJSI
 import Foundation
 import Testing
 
 @testable import ExpoModulesCore
 
-@Suite("ArrayBuffer")
+@Suite("ArrayBuffer", .serialized)
 struct ArrayBufferTests {
 
   // MARK: - Allocation
@@ -409,6 +410,20 @@ struct ArrayBufferTests {
     }
 
     @Test
+    func `withUnsafeBytes keeps JS-backed reads transient`() throws {
+      let backingValue = try runtime.eval("globalThis.arrayBufferUnderTest = new Uint8Array([1, 2, 3, 4]).buffer")
+      let buffer = try ArrayBuffer.decode(backingValue, in: runtime)
+
+      #expect(buffer.isNativeBacked == false)
+      #expect(buffer.withUnsafeBytes { Array($0) } == [1, 2, 3, 4])
+
+      _ = try runtime.eval("new Uint8Array(globalThis.arrayBufferUnderTest)[0] = 9")
+
+      #expect(buffer.withUnsafeBytes { Array($0) } == [9, 2, 3, 4])
+      #expect(buffer.isNativeBacked == false)
+    }
+
+    @Test
     func `withJSBytes reads JS-backed typed array view range`() throws {
       let values = try runtime.eval([
         "buffer = new Uint8Array([1, 2, 3, 4, 5]).buffer",
@@ -482,6 +497,8 @@ struct ArrayBufferTests {
       let value = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
       let buffer = try ArrayBuffer.decode(value, in: runtime)
 
+      #expect(buffer.isNativeBacked == false)
+
       async let materialized: [UInt8] = runOffThreadWithTimeout {
         let copy = buffer.copy()
         _ = buffer.data
@@ -489,7 +506,6 @@ struct ArrayBufferTests {
       }
 
       #expect(buffer.byteLength == 4)
-      #expect(buffer.isNativeBacked == false)
       #expect(try await materialized == [1, 2, 3, 4])
     }
 
@@ -677,6 +693,222 @@ struct ArrayBufferTests {
     }
   }
 
+  @Suite("scheduler teardown")
+  @JavaScriptActor
+  struct SchedulerTeardownTests {
+    /// Owns the Hermes runtime; it must outlive the non-owning runtime wrapper created for
+    /// each test.
+    let hermesRuntime = JavaScriptRuntime()
+    let testScheduler = EXTestReactScheduler()
+
+    @Test
+    func `sync withJSBytes fails without running its body after scheduler teardown`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let buffer = try makeJSBackedBuffer(in: runtime)
+      let bodyRan = ArrayBufferTestFlag()
+      testScheduler.destroy()
+
+      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
+        try await runOffThreadWithTimeout {
+          try buffer.withJSBytes { _ in
+            bodyRan.set()
+          }
+        }
+      }
+
+      #expect(bodyRan.value == false)
+    }
+
+    @Test
+    func `sync withMutableJSBytes fails without running its body after scheduler teardown`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let buffer = try makeJSBackedBuffer(in: runtime)
+      let bodyRan = ArrayBufferTestFlag()
+      testScheduler.destroy()
+
+      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
+        try await runOffThreadWithTimeout {
+          try buffer.withMutableJSBytes { bytes in
+            bodyRan.set()
+            bytes[0] = 9
+          }
+        }
+      }
+
+      #expect(bodyRan.value == false)
+      #expect(try originalBytes(in: runtime) == [1, 2, 3, 4])
+    }
+
+    @Test
+    func `async withJSBytes fails without running its body after scheduler teardown`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let buffer = try makeJSBackedBuffer(in: runtime)
+      let bodyRan = ArrayBufferTestFlag()
+      testScheduler.destroy()
+
+      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
+        try await runAsyncWithTimeout {
+          try await buffer.withJSBytes { _ in
+            bodyRan.set()
+          }
+        }
+      }
+
+      #expect(bodyRan.value == false)
+    }
+
+    @Test
+    func `async withMutableJSBytes fails without running its body after scheduler teardown`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let buffer = try makeJSBackedBuffer(in: runtime)
+      let bodyRan = ArrayBufferTestFlag()
+      testScheduler.destroy()
+
+      await #expect(throws: JavaScriptRuntimeSchedulingError.self) {
+        try await runAsyncWithTimeout {
+          try await buffer.withMutableJSBytes { bytes in
+            bodyRan.set()
+            bytes[0] = 9
+          }
+        }
+      }
+
+      #expect(bodyRan.value == false)
+      #expect(try originalBytes(in: runtime) == [1, 2, 3, 4])
+    }
+
+    @Test
+    func `concurrent JS-backed materializers publish one native storage without corrupting it`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let backingValue = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
+      var buffer: ArrayBuffer? = try ArrayBuffer.decode(backingValue, in: runtime)
+      let completedWorkers = ArrayBufferWorkerCompletionTracker()
+      var first: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
+        defer { completedWorkers.complete() }
+        return Array(buffer!.data)
+      }
+      var second: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
+        defer { completedWorkers.complete() }
+        return Array(buffer!.data)
+      }
+
+      do {
+        try await waitUntil(timeout: 5) {
+          testScheduler.scheduledWorkLoopCount > 0
+        }
+        await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 2)
+
+        let firstBytes = await first!.value
+        let secondBytes = await second!.value
+        first = nil
+        second = nil
+
+        // Materializing replaces the JS-backed view, whose cleanup must run before scheduler teardown.
+        drainWorkLoops()
+
+        #expect(firstBytes == [1, 2, 3, 4])
+        #expect(secondBytes == [1, 2, 3, 4])
+        #expect(buffer!.isNativeBacked == true)
+        #expect(Array(buffer!.data) == [1, 2, 3, 4])
+      } catch {
+        // A failed wait must still join both workers before any runtime-owned value can be released.
+        await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 2)
+        _ = await first?.value
+        _ = await second?.value
+        first = nil
+        second = nil
+        throw error
+      }
+
+      testScheduler.destroy()
+      runtime.longLivedObjects.clear()
+      buffer = nil
+      #expect(testScheduler.scheduledWorkLoopCount == 0)
+    }
+
+    @Test
+    func `single JS-backed materialization through the scheduler remains safe`() async throws {
+      let runtime = makeRuntimeWiredToTestScheduler()
+      let backingValue = try runtime.eval("new Uint8Array([1, 2, 3, 4]).buffer")
+      var buffer: ArrayBuffer? = try ArrayBuffer.decode(backingValue, in: runtime)
+      let completedWorkers = ArrayBufferWorkerCompletionTracker()
+      var worker: Task<[UInt8], Never>? = Task.detached { [buffer, completedWorkers] in
+        defer { completedWorkers.complete() }
+        return Array(buffer!.data)
+      }
+
+      try await waitUntil(timeout: 5) {
+        testScheduler.scheduledWorkLoopCount > 0
+      }
+      await drainWorkLoopsUntilWorkersFinish(completedWorkers, expectedCount: 1)
+
+      #expect(await worker!.value == [1, 2, 3, 4])
+      worker = nil
+      drainWorkLoops()
+
+      testScheduler.destroy()
+      runtime.longLivedObjects.clear()
+      buffer = nil
+      #expect(testScheduler.scheduledWorkLoopCount == 0)
+    }
+
+    @Test
+    func `concurrent native-backed reads remain safe`() async {
+      let buffer = ArrayBuffer(size: 4)
+      let startGate = ArrayBufferWorkerStartGate(expectedWorkerCount: 2)
+
+      async let first: [UInt8] = Task.detached {
+        startGate.waitForWorkers()
+        return Array(buffer.data)
+      }.value
+      async let second: [UInt8] = Task.detached {
+        startGate.waitForWorkers()
+        return Array(buffer.data)
+      }.value
+
+      #expect(await first == [0, 0, 0, 0])
+      #expect(await second == [0, 0, 0, 0])
+    }
+
+    private func drainWorkLoops() {
+      while testScheduler.scheduledWorkLoopCount > 0 {
+        hermesRuntime.withUnsafePointee { runtimePointer in
+          testScheduler.drainWorkLoops(withRuntime: runtimePointer)
+        }
+      }
+    }
+
+    private func drainWorkLoopsUntilWorkersFinish(
+      _ completedWorkers: ArrayBufferWorkerCompletionTracker,
+      expectedCount: Int
+    ) async {
+      while completedWorkers.count < expectedCount {
+        drainWorkLoops()
+        await Task.yield()
+      }
+    }
+
+    private func makeRuntimeWiredToTestScheduler() -> JavaScriptRuntime {
+      return hermesRuntime.withUnsafePointee { runtimePointer in
+        return JavaScriptRuntime(
+          unsafePointer: runtimePointer,
+          scheduler: testScheduler.schedulerHandle!,
+          dispatch: testScheduler.dispatchFunction
+        )
+      }
+    }
+
+    private func makeJSBackedBuffer(in runtime: JavaScriptRuntime) throws -> ArrayBuffer {
+      let value = try runtime.eval("globalThis.arrayBufferUnderTest = new Uint8Array([1, 2, 3, 4]).buffer")
+      return try ArrayBuffer.decode(value, in: runtime)
+    }
+
+    private func originalBytes(in runtime: JavaScriptRuntime) throws -> [Int] {
+      return try runtime.eval("Array.from(new Uint8Array(globalThis.arrayBufferUnderTest))")
+        .asArray().map { try $0.asInt() }
+    }
+  }
+
   // MARK: - Memory management
 
   @Suite("memory management")
@@ -723,6 +955,63 @@ struct ArrayBufferTests {
 }
 
 private struct ArrayBufferTestTimeout: Error {}
+
+private final class ArrayBufferTestFlag: @unchecked Sendable {
+  private let lock = NSLock()
+  private var didSet = false
+
+  var value: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return didSet
+  }
+
+  func set() {
+    lock.lock()
+    defer { lock.unlock() }
+    didSet = true
+  }
+}
+
+private final class ArrayBufferWorkerCompletionTracker: @unchecked Sendable {
+  private let lock = NSLock()
+  private var completedWorkerCount = 0
+
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return completedWorkerCount
+  }
+
+  func complete() {
+    lock.lock()
+    defer { lock.unlock() }
+    completedWorkerCount += 1
+  }
+}
+
+private final class ArrayBufferWorkerStartGate: @unchecked Sendable {
+  private let condition = NSCondition()
+  private let expectedWorkerCount: Int
+  private var arrivedWorkerCount = 0
+
+  init(expectedWorkerCount: Int) {
+    self.expectedWorkerCount = expectedWorkerCount
+  }
+
+  func waitForWorkers() {
+    condition.lock()
+    arrivedWorkerCount += 1
+    if arrivedWorkerCount == expectedWorkerCount {
+      condition.broadcast()
+    } else {
+      while arrivedWorkerCount < expectedWorkerCount {
+        condition.wait()
+      }
+    }
+    condition.unlock()
+  }
+}
 
 private final class ArrayBufferOptionalBox: @unchecked Sendable {
   var buffer: ArrayBuffer?
@@ -775,6 +1064,43 @@ private func runOffThreadWithTimeout<R: Sendable>(
     DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
       state.resume(.failure(ArrayBufferTestTimeout()))
     }
+  }
+}
+
+private func runAsyncWithTimeout<R: Sendable>(
+  timeout: TimeInterval = 1,
+  _ body: @escaping @Sendable () async throws -> R
+) async throws -> R {
+  return try await withCheckedThrowingContinuation { continuation in
+    let state = ArrayBufferTestContinuationState(continuation)
+
+    Thread.detachNewThread {
+      Task.immediate_polyfill {
+        do {
+          state.resume(.success(try await body()))
+        } catch {
+          state.resume(.failure(error))
+        }
+      }
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+      state.resume(.failure(ArrayBufferTestTimeout()))
+    }
+  }
+}
+
+@JavaScriptActor
+private func waitUntil(
+  timeout: TimeInterval,
+  _ condition: @escaping @JavaScriptActor () -> Bool
+) async throws {
+  let deadline = Date().addingTimeInterval(timeout)
+  while condition() == false {
+    guard Date() < deadline else {
+      throw ArrayBufferTestTimeout()
+    }
+    try await Task.sleep(nanoseconds: 10_000_000)
   }
 }
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -533,7 +533,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `withUnsafeMutableBytes allows reentrant access to the same buffer`() async throws {
+    func `withUnsafeMutableBytes invokes its body without holding the storage lock`() async throws {
       let buffer = ArrayBuffer(size: 4)
 
       try await runOffThreadWithTimeout {
@@ -616,6 +616,50 @@ struct ArrayBufferTests {
       }
       #expect(throws: ArrayBufferJSBytesAccessException.self) {
         _ = try view.makeOwnedNativeStorageCopy()
+      }
+    }
+
+    @Test
+    func `JS-backed zero-length ranges pass empty buffers to scoped bodies`() throws {
+      let runtime = try runtime
+      let backingValue = try runtime.eval("new ArrayBuffer(0)")
+
+      // A zero-length range passes `validateBounds()` even when the backing buffer is detached
+      // (a detached buffer reports size 0), so the access paths must not call `data()` for it.
+      // This runtime cannot detach a buffer, so this only exercises the empty scoped read/write
+      // contract, not detachment itself.
+      let view = JavaScriptBackedArrayBufferView(
+        runtime: runtime,
+        backingValue: backingValue,
+        byteOffset: 0,
+        byteLength: 0
+      )
+
+      let readCount = try view.withUnsafeBytes { bytes in
+        bytes.count
+      }
+      let writeCount = try view.withUnsafeMutableBytes { bytes in
+        bytes.count
+      }
+
+      #expect(readCount == 0)
+      #expect(writeCount == 0)
+    }
+
+    @Test
+    func `withUnsafeBytes rethrows body errors for JS-backed storage`() throws {
+      struct SentinelError: Error {}
+      let runtime = try runtime
+      let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
+      let buffer = try ArrayBuffer.decode(value, in: runtime)
+
+      // Only materialization failures may fail loud — an error thrown by the caller's body
+      // must propagate exactly as it does for native-backed storage.
+      #expect(buffer.isNativeBacked == false)
+      #expect(throws: SentinelError.self) {
+        try buffer.withUnsafeBytes { _ in
+          throw SentinelError()
+        }
       }
     }
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -994,6 +994,72 @@ private func runOffThreadWithTimeout<R: Sendable>(
   }
 }
 
+// MARK: - Synchronous JS-thread access gate
+
+@Suite("synchronous JS-thread access gate")
+struct JavaScriptThreadSyncAccessTests {
+  @Test
+  func `returns the result when the body finishes in time`() throws {
+    let access = JavaScriptThreadSyncAccess<Int>()
+    Thread.detachNewThread {
+      guard access.begin() else {
+        return
+      }
+      access.finish(.success(42))
+    }
+
+    #expect(try access.awaitResult(timeout: 5) == 42)
+  }
+
+  @Test
+  func `rethrows the body error`() {
+    struct SentinelError: Error {}
+    let access = JavaScriptThreadSyncAccess<Int>()
+    Thread.detachNewThread {
+      guard access.begin() else {
+        return
+      }
+      access.finish(.failure(SentinelError()))
+    }
+
+    #expect(throws: SentinelError.self) {
+      _ = try access.awaitResult(timeout: 5)
+    }
+  }
+
+  @Test
+  func `times out and cancels when the body never starts`() {
+    // A JavaScript thread blocked on a lock never drains its queue. The waiter must give up
+    // with an error instead of deadlocking, and the late-drained job must not run the body.
+    let access = JavaScriptThreadSyncAccess<Int>()
+
+    #expect(throws: ArrayBufferJSBytesAccessException.self) {
+      _ = try access.awaitResult(timeout: 0.05)
+    }
+    #expect(access.begin() == false)
+  }
+
+  @Test
+  func `waits for a body that already started instead of cancelling it`() throws {
+    // A started body holds a live pointer into the JavaScript heap; cancelling it mid-flight
+    // is unsafe. It only touches the backing bytes, so completion is imminent — the waiter
+    // must keep waiting past the timeout and return the result.
+    let access = JavaScriptThreadSyncAccess<Int>()
+    let started = DispatchSemaphore(value: 0)
+    Thread.detachNewThread {
+      guard access.begin() else {
+        return
+      }
+      started.signal()
+      Thread.sleep(forTimeInterval: 0.3)
+      access.finish(.success(7))
+    }
+    started.wait()
+
+    #expect(try access.awaitResult(timeout: 0.05) == 7)
+  }
+}
+
 private final class ArrayBufferTestModule: Module {
   func definition() -> ModuleDefinition {
     Name("ArrayBufferTests")

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -16,7 +16,7 @@ struct ArrayBufferTests {
     @Test
     func `allocates with specified size`() {
       let size = 1024
-      let buffer = NativeArrayBuffer.allocate(size: size)
+      let buffer = ArrayBuffer(size: size)
 
       #expect(buffer.byteLength == size)
       #expect(buffer.isNativeBacked == true)
@@ -25,7 +25,7 @@ struct ArrayBufferTests {
     @Test
     func `initializes to zero when requested`() {
       let size = 100
-      let buffer = NativeArrayBuffer.allocate(size: size, initializeToZero: true)
+      let buffer = ArrayBuffer(size: size, initializeToZero: true)
 
       #expect(buffer.data.allSatisfy { $0 == 0 } == true)
     }
@@ -42,7 +42,7 @@ struct ArrayBufferTests {
       let buffer = UnsafeMutableRawBufferPointer(start: memory, count: size)
 
       var cleanupCalled = false
-      let arrayBuffer = try NativeArrayBuffer.wrap(
+      let arrayBuffer = try ArrayBuffer.wrap(
         dataWithoutCopy: buffer,
         cleanup: {
           memory.deallocate()
@@ -64,7 +64,7 @@ struct ArrayBufferTests {
     func `copies from UnsafeRawPointer`() {
       let originalData: [UInt8] = [10, 20, 30, 40, 50]
       let copiedBuffer = originalData.withUnsafeBytes { ptr in
-        NativeArrayBuffer.copy(of: ptr.baseAddress!, count: originalData.count)
+        ArrayBuffer.copy(of: ptr.baseAddress!, count: originalData.count)
       }
 
       #expect(copiedBuffer.byteLength == originalData.count)
@@ -75,7 +75,7 @@ struct ArrayBufferTests {
     @Test
     func `copies from Data`() throws {
       let originalData = Data([1, 2, 3, 4, 5, 6, 7, 8])
-      let copiedBuffer = try NativeArrayBuffer.copy(data: originalData)
+      let copiedBuffer = try ArrayBuffer.copy(data: originalData)
 
       #expect(copiedBuffer.byteLength == originalData.count)
       #expect(copiedBuffer.isNativeBacked == true)
@@ -83,8 +83,8 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies from another NativeArrayBuffer`() {
-      let originalBuffer = NativeArrayBuffer.allocate(size: 50, initializeToZero: true)
+    func `copies from another ArrayBuffer`() {
+      let originalBuffer = ArrayBuffer(size: 50, initializeToZero: true)
       // Write some test data via withUnsafeMutableBytes
       let testBytes: [UInt8] = [1, 2, 3, 4, 5]
       originalBuffer.withUnsafeMutableBytes { ptr in
@@ -110,7 +110,7 @@ struct ArrayBufferTests {
     @Test
     func `converts to Data`() {
       let testData: [UInt8] = [1, 2, 3, 4, 5]
-      let buffer = NativeArrayBuffer.allocate(size: testData.count)
+      let buffer = ArrayBuffer(size: testData.count)
       buffer.withUnsafeMutableBytes { ptr in
         memcpy(ptr.baseAddress!, testData, testData.count)
       }
@@ -123,7 +123,7 @@ struct ArrayBufferTests {
     @Test
     func `conforms to ContiguousBytes`() {
       let testData: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
-      let buffer = NativeArrayBuffer.allocate(size: testData.count)
+      let buffer = ArrayBuffer(size: testData.count)
       buffer.withUnsafeMutableBytes { ptr in
         memcpy(ptr.baseAddress!, testData, testData.count)
       }
@@ -226,11 +226,11 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `NativeArrayBuffer accepts partial typed array view`() throws {
+    func `ArrayBuffer accepts partial typed array view`() throws {
       let result = try runtime.eval(
         """
         view = new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)
-        expo.modules.ArrayBufferTests.readNativeBufferBytesAsArray(view, 2)
+        expo.modules.ArrayBufferTests.readBytesAsArray(view, 2)
         """
       ).asArray()
 
@@ -290,7 +290,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies buffer when using legacy NativeArrayBuffer argument`() throws {
+    func `copies JS-backed buffer on mutable access through an ArrayBuffer argument`() throws {
       // Create original buffer with initial pattern
       let originalBuffer = try runtime.eval(
         """
@@ -301,10 +301,10 @@ struct ArrayBufferTests {
         """
       ).asArrayBuffer()
 
-      // Process through native function that represents the legacy NativeArrayBuffer path (creates copy)
+      // Mutable access materializes a native copy, so the JS-visible buffer stays unchanged
       let processedBuffer = try runtime.eval(
         """
-        processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(originalBuffer, 99)
+        processedBuffer = expo.modules.ArrayBufferTests.processBuffer(originalBuffer, 99)
         processedBuffer
         """
       ).asArrayBuffer()
@@ -695,12 +695,12 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `shares native-backed buffer when using legacy NativeArrayBuffer argument`() throws {
+    func `mutates native-backed buffer in place through an ArrayBuffer argument`() throws {
       let processedBuffer = try runtime.eval(
         """
         nativeBackedBuffer = expo.modules.ArrayBufferTests.createNative(4)
         new Uint8Array(nativeBackedBuffer).fill(42)
-        processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(nativeBackedBuffer, 99)
+        processedBuffer = expo.modules.ArrayBufferTests.processBuffer(nativeBackedBuffer, 99)
         processedBuffer
         """
       ).asArrayBuffer()
@@ -717,14 +717,14 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `shares native-backed typed array view when using legacy NativeArrayBuffer argument`() throws {
+    func `mutates native-backed typed array view in place through an ArrayBuffer argument`() throws {
       let processedBuffer = try runtime.eval(
         """
         nativeBackedBuffer = expo.modules.ArrayBufferTests.createNative(5)
         fullView = new Uint8Array(nativeBackedBuffer)
         fullView.set([1, 2, 3, 4, 5])
         partialView = new Uint8Array(nativeBackedBuffer, 1, 2)
-        processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(partialView, 99)
+        processedBuffer = expo.modules.ArrayBufferTests.processBuffer(partialView, 99)
         processedBuffer
         """
       ).asArrayBuffer()
@@ -741,13 +741,13 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `copies JS-backed typed array view when using legacy NativeArrayBuffer argument`() throws {
+    func `copies JS-backed typed array view on mutable access through an ArrayBuffer argument`() throws {
       let processedBuffer = try runtime.eval(
         """
         jsBackedBuffer = new Uint8Array([1, 2, 3, 4, 5]).buffer
         fullView = new Uint8Array(jsBackedBuffer)
         partialView = new Uint8Array(jsBackedBuffer, 1, 2)
-        processedBuffer = expo.modules.ArrayBufferTests.processNativeBuffer(partialView, 99)
+        processedBuffer = expo.modules.ArrayBufferTests.processBuffer(partialView, 99)
         processedBuffer
         """
       ).asArrayBuffer()
@@ -772,14 +772,14 @@ struct ArrayBufferTests {
     func `throws when wrapping invalid buffer pointer`() {
       #expect(throws: (any Error).self) {
         let emptyBuffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
-        _ = try NativeArrayBuffer.wrap(dataWithoutCopy: emptyBuffer, cleanup: {})
+        _ = try ArrayBuffer.wrap(dataWithoutCopy: emptyBuffer, cleanup: {})
       }
     }
 
     @Test
     func `does not throw when copying from empty Data`() throws {
       let emptyData = Data()
-      _ = try NativeArrayBuffer.copy(data: emptyData)
+      _ = try ArrayBuffer.copy(data: emptyData)
     }
   }
 
@@ -854,7 +854,7 @@ struct ArrayBufferTests {
         let memory = UnsafeMutableRawPointer.allocate(byteCount: 100, alignment: 1)
         let buffer = UnsafeMutableRawBufferPointer(start: memory, count: 100)
 
-        _ = try! NativeArrayBuffer.wrap(
+        _ = try! ArrayBuffer.wrap(
           dataWithoutCopy: buffer,
           cleanup: {
             memory.deallocate()
@@ -868,14 +868,14 @@ struct ArrayBufferTests {
 
     @Test
     func `handles zero-size buffers`() {
-      let buffer = NativeArrayBuffer.allocate(size: 0)
+      let buffer = ArrayBuffer(size: 0)
       #expect(buffer.byteLength == 0)
     }
 
     @Test
     func `allows direct memory access via withUnsafeMutableBytes`() {
       let size = 1000
-      let buffer = NativeArrayBuffer.allocate(size: size)
+      let buffer = ArrayBuffer(size: size)
 
       let pattern: UInt8 = 0xAA
       buffer.withUnsafeMutableBytes { ptr in
@@ -1002,15 +1002,11 @@ private final class ArrayBufferTestModule: Module {
       return buffer
     }
 
-    Function("createNative") { (size: Int) -> NativeArrayBuffer in
-      return NativeArrayBuffer.allocate(size: size, initializeToZero: true)
+    Function("createNative") { (size: Int) -> ArrayBuffer in
+      return ArrayBuffer(size: size, initializeToZero: true)
     }
 
     Function("readBytesAsArray") { (buffer: ArrayBuffer, count: Int) -> [UInt8] in
-      return Array(buffer.data.prefix(count))
-    }
-
-    Function("readNativeBufferBytesAsArray") { (buffer: NativeArrayBuffer, count: Int) -> [UInt8] in
       return Array(buffer.data.prefix(count))
     }
 
@@ -1034,13 +1030,6 @@ private final class ArrayBufferTestModule: Module {
       try buffer.withMutableJSBytes { ptr in
         memset(ptr.baseAddress!, Int32(pattern), ptr.count)
       }
-    }
-
-    Function("processNativeBuffer") { (buffer: NativeArrayBuffer, newPattern: UInt8) -> NativeArrayBuffer in
-      buffer.withUnsafeMutableBytes { ptr in
-        memset(ptr.baseAddress!, Int32(newPattern), ptr.count)
-      }
-      return buffer
     }
 
     Function("processBuffer") { (buffer: ArrayBuffer, newPattern: UInt8) -> ArrayBuffer in

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
@@ -153,12 +153,12 @@ struct JavaScriptCodableArrayBufferTests {
   // MARK: - Empty and wide-element buffers
 
   @Test
-  func `decodes an empty ArrayBuffer`() throws {
-    // A zero-length buffer short-circuits the borrow/copy logic; it must not touch a base address.
+  func `decodes an empty JS ArrayBuffer without materializing it`() throws {
+    // Keep JavaScript backing so a full-range decode/encode round trip preserves JS identity.
     let runtime = try runtime
     let decoded = try ArrayBuffer.decode(runtime.eval("new Uint8Array([]).buffer"), in: runtime)
     #expect(decoded.byteLength == 0)
-    #expect(decoded.isNativeBacked == true)
+    #expect(decoded.isNativeBacked == false)
   }
 
   @Test

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
@@ -18,7 +18,7 @@ struct JavaScriptCodableArrayBufferTests {
   }
 
   @Test
-  func `decodes JS-backed ArrayBuffer as lazy JavaScript-backed view`() throws {
+  func `decodes JS-backed ArrayBuffer as JavaScript-backed view until data access`() throws {
     let runtime = try runtime
     let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
     let decoded = try ArrayBuffer.decode(value, in: runtime)
@@ -26,10 +26,11 @@ struct JavaScriptCodableArrayBufferTests {
     #expect(decoded.byteLength == 3)
     #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [1, 2, 3])
+    #expect(decoded.isNativeBacked == true)
   }
 
   @Test
-  func `decodes borrowed JavaScript value as lazy JavaScript-backed view`() throws {
+  func `decodes borrowed JavaScript value as JavaScript-backed view until data access`() throws {
     let runtime = try runtime
     let value = try runtime.eval(
       """
@@ -44,10 +45,11 @@ struct JavaScriptCodableArrayBufferTests {
     #expect(decoded.byteLength == 2)
     #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [2, 3])
+    #expect(decoded.isNativeBacked == true)
   }
 
   @Test
-  func `decodes JS-backed typed array view as lazy JavaScript-backed view range`() throws {
+  func `decodes JS-backed typed array view as JavaScript-backed view range until data access`() throws {
     let runtime = try runtime
     let value = try runtime.eval(
       """
@@ -60,6 +62,7 @@ struct JavaScriptCodableArrayBufferTests {
     #expect(decoded.byteLength == 2)
     #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [2, 3])
+    #expect(decoded.isNativeBacked == true)
   }
 
   @Test

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
@@ -1,8 +1,8 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
+import ExpoModulesJSI
 import Foundation
 import Testing
-import ExpoModulesJSI
 
 @testable import ExpoModulesCore
 
@@ -18,18 +18,18 @@ struct JavaScriptCodableArrayBufferTests {
   }
 
   @Test
-  func `decodes JS-backed ArrayBuffer as native-backed copy`() throws {
+  func `decodes JS-backed ArrayBuffer as lazy JavaScript-backed view`() throws {
     let runtime = try runtime
     let value = try runtime.eval("new Uint8Array([1, 2, 3]).buffer")
     let decoded = try ArrayBuffer.decode(value, in: runtime)
 
     #expect(decoded.byteLength == 3)
-    #expect(decoded.isNativeBacked == true)
+    #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [1, 2, 3])
   }
 
   @Test
-  func `decodes borrowed JavaScript value as native-backed ArrayBuffer`() throws {
+  func `decodes borrowed JavaScript value as lazy JavaScript-backed view`() throws {
     let runtime = try runtime
     let value = try runtime.eval(
       """
@@ -42,12 +42,12 @@ struct JavaScriptCodableArrayBufferTests {
     let decoded = try ArrayBuffer.decode(values.unownedValue(at: 0), in: runtime)
 
     #expect(decoded.byteLength == 2)
-    #expect(decoded.isNativeBacked == true)
+    #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [2, 3])
   }
 
   @Test
-  func `decodes JS-backed typed array view as native-backed copy of view range`() throws {
+  func `decodes JS-backed typed array view as lazy JavaScript-backed view range`() throws {
     let runtime = try runtime
     let value = try runtime.eval(
       """
@@ -58,7 +58,7 @@ struct JavaScriptCodableArrayBufferTests {
     let decoded = try ArrayBuffer.decode(value, in: runtime)
 
     #expect(decoded.byteLength == 2)
-    #expect(decoded.isNativeBacked == true)
+    #expect(decoded.isNativeBacked == false)
     #expect(Array(decoded.data) == [2, 3])
   }
 
@@ -79,7 +79,8 @@ struct JavaScriptCodableArrayBufferTests {
   func `decodes native-backed typed array view as native-backed borrowed view range`() throws {
     let runtime = try runtime
     let nativeBuffer = try makeArrayBuffer(bytes: [1, 2, 3, 4, 5])
-    runtime.global().setProperty("nativeBuffer", value: nativeBuffer.asJavaScriptArrayBuffer(runtime: runtime).asValue())
+    runtime.global().setProperty(
+      "nativeBuffer", value: nativeBuffer.asJavaScriptArrayBuffer(runtime: runtime).asValue())
     let value = try runtime.eval("new Uint8Array(nativeBuffer, 1, 2)")
 
     let decoded = try ArrayBuffer.decode(value, in: runtime)
@@ -111,7 +112,7 @@ struct JavaScriptCodableArrayBufferTests {
     let buffer = try #require(decoded["payload"])
 
     #expect(buffer.byteLength == 3)
-    #expect(buffer.isNativeBacked == true)
+    #expect(buffer.isNativeBacked == false)
     #expect(Array(buffer.data) == [7, 8, 9])
   }
 
@@ -124,7 +125,7 @@ struct JavaScriptCodableArrayBufferTests {
 
     #expect(decoded.count == 1)
     #expect(decoded[0].byteLength == 2)
-    #expect(decoded[0].isNativeBacked == true)
+    #expect(decoded[0].isNativeBacked == false)
     #expect(Array(decoded[0].data) == [10, 11])
   }
 


### PR DESCRIPTION
# Why

The Android PR #47261 added scoped `withJSBytes` / `withMutableJSBytes` APIs for safe cross-thread ArrayBuffer access. This PR brings the same capability to iOS, plus adds a `JavaScriptBackedArrayBufferStorage` mode so JS-allocated buffers are no longer eagerly copied into native memory.

# How

- Added `.javaScriptBacked` storage variant to `ArrayBufferStorage` — wraps a `JavaScriptValue` reference with byte offset/length, deferring byte access to the JS thread via `JavaScriptRuntime.execute`.
- JS-allocated ArrayBuffers and TypedArray views are now kept as JS-backed by default (no eager copy). `data` or `withUnsafeMutableBytes` lazily materializes into `.ownedNative` on first access.
- Added `withJSBytes` / `withMutableJSBytes` (sync `@available(*, noasync)` + async overloads) for scoped zero-copy access to the current backing storage.
- Wrapped `ArrayBufferStorage` in `SynchronizedArrayBufferStorage`, using `Mutex` to serialize lazy materialization. ArrayBuffer byte-access callbacks run after the storage lock is released.
- `asJavaScriptArrayBuffer` preserves JS identity when returning a full JS-backed buffer to the same runtime.

# Test Plan

- Run iOS native tests for expo-modules-core (`et native-unit-tests -p ios --packages expo-modules-core`).
- New tests: `withJSBytes` reads JS-backed buffer without detaching, reads typed array view ranges, `withMutableJSBytes` mutates original JS buffer and typed array view ranges, both APIs work for native-backed storage.
- Updated existing tests to expect `isNativeBacked == false` for JS-allocated buffers (lazy behavior change).
- verified that sync functions do not deadlock: `Function("foo") { (b: ArrayBuffer) in b.withJSBytes { ... } }`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
