### PR TITLE
[docs] fix HorizontalFloatingToolbar example using wrong prop name

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -57,7 +57,7 @@ export default function FloatingToolbarExample() {
             <Icon source={require('./assets/edit.xml')} />
           </IconButton>
           <HorizontalFloatingToolbar.FloatingActionButton
-            onClick={() => console.log('Add pressed')}>
+            onPress={() => console.log('Add pressed')}>
             <Icon source={require('./assets/add.xml')} />
           </HorizontalFloatingToolbar.FloatingActionButton>
         </HorizontalFloatingToolbar>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -57,7 +57,7 @@ export default function FloatingToolbarExample() {
             <Icon source={require('./assets/edit.xml')} />
           </IconButton>
           <HorizontalFloatingToolbar.FloatingActionButton
-            onClick={() => console.log('Add pressed')}>
+            onPress={() => console.log('Add pressed')}>
             <Icon source={require('./assets/add.xml')} />
           </HorizontalFloatingToolbar.FloatingActionButton>
         </HorizontalFloatingToolbar>


### PR DESCRIPTION
Fixes #44571

The floating toolbar scrollable content example had `onClick` on `HorizontalFloatingToolbar.FloatingActionButton`, but the component actually uses `onPress`. Fixed in both unversioned and v56 docs.