### PR TITLE
[docs] Update outdated examples in `@expo/ui`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
@@ -119,7 +119,7 @@ export default function ButtonWithIconsExample() {
     <Host matchContents>
       {/* Leading icon */}
       <Button onClick={() => {}}>
-        <Icon source={addIcon} size={18} tintColor="#FFFFFF" />
+        <Icon source={addIcon} size={18} tint="#FFFFFF" />
         <Spacer modifiers={[width(8)]} />
         <Text>Add Item</Text>
       </Button>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/colors.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/colors.mdx
@@ -70,16 +70,16 @@ function PaletteInspector() {
 
 ### Computing a specific palette with arguments
 
-Pass arguments to [`useMaterialColors()`](#usematerialcolorsoptions) to compute a palette on demand, even outside a `<Host>`. The `scheme` takes `'light'` or `'dark'`, you can omit it to follow the system.
+Pass arguments to [`useMaterialColors()`](#usematerialcolorsoptions) to compute a palette on demand, even outside a `<Host>`. The `colorScheme` takes `'light'` or `'dark'`, you can omit it to follow the system.
 
 ```tsx UseMaterialColorsExample.tsx
 import { Column, Host, Text, useMaterialColors } from '@expo/ui/jetpack-compose';
 import { padding } from '@expo/ui/jetpack-compose/modifiers';
 
 export default function UseMaterialColorsExample() {
-  const dark = useMaterialColors({ scheme: 'dark' });
+  const dark = useMaterialColors({ colorScheme: 'dark' });
   const brand = useMaterialColors({ seedColor: '#8E24AA' });
-  const brandedDark = useMaterialColors({ scheme: 'dark', seedColor: '#8E24AA' });
+  const brandedDark = useMaterialColors({ colorScheme: 'dark', seedColor: '#8E24AA' });
 
   return (
     <Host style={{ flex: 1 }}>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -47,9 +47,7 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <OutlinedButton onClick={() => setIsExpanded(true)}>
-            Show Menu
-          </OutlinedButton>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>Show Menu</OutlinedButton>
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           <DropdownMenuItem

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -29,8 +29,17 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import { Host, DropdownMenu, DropdownMenuItem, Button, Text, Icon } from '@expo/ui/jetpack-compose';
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  OutlinedButton,
+  Text,
+  Icon,
+} from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
+
+const homeIcon = require('./assets/home.xml');
 
 export default function BasicDropdownMenuExample() {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -38,9 +47,9 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <Button variant="bordered" onClick={() => setIsExpanded(true)}>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>
             Show Menu
-          </Button>
+          </OutlinedButton>
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           <DropdownMenuItem

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
@@ -30,7 +30,7 @@ Expo UI `ExposedDropdownMenuBox` matches the official Jetpack Compose [`ExposedD
 
 ### Basic
 
-> When using an uncontrolled `TextField` as the anchor, pass `key={selected}` to force a remount when the selected value changes — `defaultValue` is only read on mount.
+> The anchor is a read-only `TextField` bound to a [`useNativeState`](usenativestate) observable. Update that observable in each item's `onClick` to reflect the selected value.
 
 ```tsx BasicExposedDropdownMenuBoxExample.tsx
 import {
@@ -40,6 +40,7 @@ import {
   Host,
   Text,
   TextField,
+  useNativeState,
 } from '@expo/ui/jetpack-compose';
 import { menuAnchor } from '@expo/ui/jetpack-compose/modifiers';
 import { useState } from 'react';
@@ -51,26 +52,19 @@ const LANGUAGES = [
 ];
 
 export default function BasicExposedDropdownMenuBoxExample() {
-  const [selected, setSelected] = useState('java');
+  const selectedLabel = useNativeState('Java');
   const [expanded, setExpanded] = useState(false);
-
-  const selectedLabel = LANGUAGES.find(l => l.value === selected)?.label ?? '';
 
   return (
     <Host matchContents>
       <ExposedDropdownMenuBox expanded={expanded} onExpandedChange={setExpanded}>
-        <TextField
-          defaultValue={selectedLabel}
-          key={selected}
-          readOnly
-          modifiers={[menuAnchor()]}
-        />
+        <TextField value={selectedLabel} readOnly modifiers={[menuAnchor()]} />
         <ExposedDropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
           {LANGUAGES.map(lang => (
             <DropdownMenuItem
               key={lang.value}
               onClick={() => {
-                setSelected(lang.value);
+                selectedLabel.value = lang.label;
                 setExpanded(false);
               }}>
               <DropdownMenuItem.Text>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -31,7 +31,7 @@ A lazily-loaded vertical list component that only renders visible items for effi
 ### Basic lazy column
 
 ```tsx BasicLazyColumn.tsx
-import { Host, LazyColumn, ListItem } from '@expo/ui/jetpack-compose';
+import { Host, LazyColumn, ListItem, Text } from '@expo/ui/jetpack-compose';
 
 const items = Array.from({ length: 100 }, (_, i) => `Item ${i + 1}`);
 
@@ -40,7 +40,11 @@ export default function BasicLazyColumn() {
     <Host style={{ height: 400 }}>
       <LazyColumn>
         {items.map(item => (
-          <ListItem key={item} headline={item} />
+          <ListItem key={item}>
+            <ListItem.HeadlineContent>
+              <Text>{item}</Text>
+            </ListItem.HeadlineContent>
+          </ListItem>
         ))}
       </LazyColumn>
     </Host>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -38,10 +38,10 @@ Expo UI provides three text field components that match the official Jetpack Com
 
 Bind a [`useNativeState`](usenativestate) observable to `value`. The field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
-```tsx BasicTextFieldExample.tsx
+```tsx UncontrolledTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
-export default function BasicTextFieldExample() {
+export default function UncontrolledTextFieldExample() {
   const text = useNativeState('');
 
   return (

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/alert.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/alert.mdx
@@ -20,7 +20,7 @@ Expo UI Alert matches the official SwiftUI [alert API](<https://developer.apple.
   alt="Alert asking the user to confirm signing out"
 />
 
-`Alert` is the centered modal counterpart to [`ConfirmationDialog`](confirmationdialog.mdx), which renders as an action sheet from the bottom of the screen. Both share the same trigger/actions/message slot model so callers can swap between them by changing the component name.
+`Alert` is the centered modal counterpart to [`ConfirmationDialog`](confirmationdialog), which renders as an action sheet from the bottom of the screen. Both share the same trigger/actions/message slot model so callers can swap between them by changing the component name.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -90,7 +90,7 @@ Use the [`presentationDetents`](modifiers/#presentationdetentsdetents-options) m
 
 ```tsx BottomSheetWithDetentsExample.tsx
 import { useState } from 'react';
-import { Host, BottomSheet, Button, Text, VStack } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
 import { presentationDetents } from '@expo/ui/swift-ui/modifiers';
 
 export default function BottomSheetWithDetentsExample() {
@@ -179,7 +179,7 @@ Use the [`presentationBackgroundInteraction`](modifiers/#presentationbackgroundi
 
 ```tsx BottomSheetWithBackgroundInteractionExample.tsx
 import { useState } from 'react';
-import { Host, BottomSheet, Button, Text, VStack } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
 import {
   presentationDetents,
   presentationBackgroundInteraction,
@@ -213,7 +213,7 @@ Use the [`interactiveDismissDisabled`](modifiers/#interactivedismissdisabledisdi
 
 ```tsx NonDismissibleBottomSheetExample.tsx
 import { useState } from 'react';
-import { Host, BottomSheet, Button, Text, VStack } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
 import { interactiveDismissDisabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function NonDismissibleBottomSheetExample() {
@@ -244,7 +244,7 @@ Use `RNHostView` to embed React Native components inside the bottom sheet. Set `
 ```tsx BottomSheetWithRNContentExample.tsx
 import { useState } from 'react';
 import { Pressable, Text as RNText, View } from 'react-native';
-import { Host, BottomSheet, Button, RNHostView, VStack } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, RNHostView, VStack } from '@expo/ui/swift-ui';
 import { presentationDragIndicator } from '@expo/ui/swift-ui/modifiers';
 
 export default function BottomSheetWithRNContentExample() {
@@ -301,7 +301,7 @@ When using React Native content with `flex: 1`, omit the `matchContents` prop on
 ```tsx BottomSheetWithFlexRNContentExample.tsx
 import { useState } from 'react';
 import { Text as RNText, View } from 'react-native';
-import { Host, BottomSheet, Button, RNHostView, VStack } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, RNHostView, VStack } from '@expo/ui/swift-ui';
 import { presentationDetents, presentationDragIndicator } from '@expo/ui/swift-ui/modifiers';
 
 export default function BottomSheetWithFlexRNContentExample() {

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
@@ -28,7 +28,7 @@ import { foregroundStyle } from '@expo/ui/swift-ui/modifiers';
 export default function BasicGroupExample() {
   return (
     <Host matchContents>
-      <Group modifiers={[foregroundStyle({ color: 'blue' })]}>
+      <Group modifiers={[foregroundStyle('blue')]}>
         <Text>First item</Text>
         <Text>Second item</Text>
         <Text>Third item</Text>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -111,7 +111,7 @@ export default function IgnoreKeyboardExample() {
             backgroundColor: 'green',
           }}>
           <Host matchContents ignoreSafeArea="keyboard" style={{ backgroundColor: 'red' }}>
-            <TextField placeholder="Enter text" multiline />
+            <TextField placeholder="Enter text" axis="vertical" />
           </Host>
         </KeyboardStickyView>
       </View>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
@@ -58,7 +58,7 @@ export default function LabelCustomIconExample() {
 
 ### Icon only
 
-Use the [`labelStyle`](/versions/latest/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
+Use the [`labelStyle`](modifiers/#labelstylestyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
 
 ```tsx LabelIconOnlyExample.tsx
 import { Host, Label } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
@@ -76,11 +76,12 @@ You can pass a React node as the label for custom styling.
 
 ```tsx CustomLabelMenuExample.tsx
 import { Host, Menu, Button, Text } from '@expo/ui/swift-ui';
+import { foregroundStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function CustomLabelMenuExample() {
   return (
     <Host matchContents>
-      <Menu label={<Text color="accentColor">Custom Label</Text>}>
+      <Menu label={<Text modifiers={[foregroundStyle('accentColor')]}>Custom Label</Text>}>
         <Button label="Action 1" onPress={() => console.log('Action 1')} />
         <Button label="Action 2" onPress={() => console.log('Action 2')} />
       </Menu>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
@@ -179,7 +179,9 @@ function MatchedGeometryExample() {
                 },
               }),
             ]}>
-            <Text modifiers={[foregroundStyle('#fff')]}>{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
+            <Text modifiers={[foregroundStyle('#fff')]}>
+              {isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}
+            </Text>
           </Button>
         </VStack>
       </VStack>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
@@ -39,6 +39,7 @@ import {
   background,
   cornerRadius,
   frame,
+  foregroundStyle,
 } from '@expo/ui/swift-ui/modifiers';
 import { useId, useState } from 'react';
 
@@ -178,7 +179,7 @@ function MatchedGeometryExample() {
                 },
               }),
             ]}>
-            <Text color="#fff">{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
+            <Text modifiers={[foregroundStyle('#fff')]}>{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
           </Button>
         </VStack>
       </VStack>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
@@ -37,7 +37,7 @@ function Example() {
   return (
     <Host style={{ flex: 1 }}>
       <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
-      <BottomSheet isOpened={isPresented} onIsOpenedChange={setIsPresented}>
+      <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
         <RNHostView matchContents>
           <View style={{ padding: 24 }}>
             <Text style={{ fontSize: 18, fontWeight: 'bold' }}>React Native Content</Text>
@@ -61,7 +61,8 @@ When using `flex: 1` in your React Native content, omit the `matchContents` prop
 ```tsx RNHostView with flex content
 import { useState } from 'react';
 import { Text, View } from 'react-native';
-import { Host, BottomSheet, Button, RNHostView } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, RNHostView } from '@expo/ui/swift-ui';
+import { presentationDetents } from '@expo/ui/swift-ui/modifiers';
 
 function Example() {
   const [isPresented, setIsPresented] = useState(false);
@@ -69,17 +70,16 @@ function Example() {
   return (
     <Host style={{ flex: 1 }}>
       <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
-      <BottomSheet
-        isOpened={isPresented}
-        onIsOpenedChange={setIsPresented}
-        presentationDetents={['medium', 'large']}>
-        <RNHostView>
-          <View style={{ flex: 1, backgroundColor: '#007AFF', padding: 24 }}>
-            <Text style={{ color: 'white', fontSize: 18 }}>
-              This content fills the available space
-            </Text>
-          </View>
-        </RNHostView>
+      <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
+        <Group modifiers={[presentationDetents(['medium', 'large'])]}>
+          <RNHostView>
+            <View style={{ flex: 1, backgroundColor: '#007AFF', padding: 24 }}>
+              <Text style={{ color: 'white', fontSize: 18 }}>
+                This content fills the available space
+              </Text>
+            </View>
+          </RNHostView>
+        </Group>
       </BottomSheet>
     </Host>
   );

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
@@ -95,6 +95,7 @@ Use the `isExpanded` prop to control whether the section is expanded or collapse
 ```tsx CollapsibleSectionExample.tsx
 import { useState } from 'react';
 import { Host, List, Section, Text } from '@expo/ui/swift-ui';
+import { listStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function CollapsibleSectionExample() {
   const [favoritesExpanded, setFavoritesExpanded] = useState(false);
@@ -102,7 +103,7 @@ export default function CollapsibleSectionExample() {
 
   return (
     <Host style={{ flex: 1 }}>
-      <List listStyle="sidebar">
+      <List modifiers={[listStyle('sidebar')]}>
         <Section
           title="Favorites"
           isExpanded={favoritesExpanded}

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/securefield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/securefield.mdx
@@ -37,7 +37,7 @@ export default function BasicSecureFieldExample() {
 
   return (
     <Host matchContents>
-      <SecureField placeholder="Password" onValueChange={setPassword} />
+      <SecureField placeholder="Password" onTextChange={setPassword} />
     </Host>
   );
 }
@@ -59,7 +59,7 @@ export default function SecureFieldSubmitExample() {
     <Host matchContents>
       <SecureField
         placeholder="Password"
-        onValueChange={setPassword}
+        onTextChange={setPassword}
         modifiers={[submitLabel('done'), onSubmit(() => console.log('Login submitted'))]}
       />
     </Host>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/tabview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/tabview.mdx
@@ -20,7 +20,7 @@ Expo UI TabView matches the official SwiftUI [TabView API](https://developer.app
   alt="A TabView with a bottom tab bar showing Home, Search, and Profile tabs in iOS 26 Liquid Glass style"
 />
 
-> **Note:** For routed bottom-tab navigation across full-screen routes, use [expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
+> **Note:** For routed bottom-tab navigation across full-screen routes, use [`expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
 
 ## Installation
 
@@ -200,7 +200,7 @@ function Page({ label, color }: { label: string; color: string }) {
 
 Use `tabViewStyle({ type: 'automatic' })` for the SwiftUI default tab bar. Each tab's `label` and `systemImage` populate the bar item. Use the [`badge`](modifiers/#badgevalue) modifier on a tab to attach a badge to its bar item.
 
-> **Note:** For routed bottom-tab navigation across full-screen routes, use [expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
+> **Note:** For routed bottom-tab navigation across full-screen routes, use [`expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
 
 ```tsx BottomTabsExample.tsx
 import { useState } from 'react';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
@@ -37,7 +37,7 @@ export default function BasicZStackExample() {
     <Host matchContents>
       <ZStack>
         <Rectangle modifiers={[frame({ width: 100, height: 100 })]} />
-        <Text modifiers={[foregroundStyle({ color: 'white' })]}>Overlay</Text>
+        <Text modifiers={[foregroundStyle('white')]}>Overlay</Text>
       </ZStack>
     </Host>
   );
@@ -57,9 +57,9 @@ export default function ZStackAlignmentExample() {
     <Host matchContents>
       <ZStack alignment="bottomTrailing">
         <Rectangle
-          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle({ color: 'blue' })]}
+          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]}
         />
-        <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle({ color: 'red' })]} />
+        <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>
   );
@@ -77,7 +77,7 @@ export default function ZStackBadgeExample() {
     <Host matchContents>
       <ZStack alignment="topTrailing">
         <Image systemName="bell.fill" size={32} color="blue" />
-        <Circle modifiers={[frame({ width: 16, height: 16 }), foregroundStyle({ color: 'red' })]} />
+        <Circle modifiers={[frame({ width: 16, height: 16 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>
   );

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
@@ -56,9 +56,7 @@ export default function ZStackAlignmentExample() {
   return (
     <Host matchContents>
       <ZStack alignment="bottomTrailing">
-        <Rectangle
-          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]}
-        />
+        <Rectangle modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]} />
         <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/button.mdx
@@ -119,7 +119,7 @@ export default function ButtonWithIconsExample() {
     <Host matchContents>
       {/* Leading icon */}
       <Button onClick={() => {}}>
-        <Icon source={addIcon} size={18} tintColor="#FFFFFF" />
+        <Icon source={addIcon} size={18} tint="#FFFFFF" />
         <Spacer modifiers={[width(8)]} />
         <Text>Add Item</Text>
       </Button>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/colors.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/colors.mdx
@@ -70,16 +70,16 @@ function PaletteInspector() {
 
 ### Computing a specific palette with arguments
 
-Pass arguments to [`useMaterialColors()`](#usematerialcolorsoptions) to compute a palette on demand, even outside a `<Host>`. The `scheme` takes `'light'` or `'dark'`, you can omit it to follow the system.
+Pass arguments to [`useMaterialColors()`](#usematerialcolorsoptions) to compute a palette on demand, even outside a `<Host>`. The `colorScheme` takes `'light'` or `'dark'`, you can omit it to follow the system.
 
 ```tsx UseMaterialColorsExample.tsx
 import { Column, Host, Text, useMaterialColors } from '@expo/ui/jetpack-compose';
 import { padding } from '@expo/ui/jetpack-compose/modifiers';
 
 export default function UseMaterialColorsExample() {
-  const dark = useMaterialColors({ scheme: 'dark' });
+  const dark = useMaterialColors({ colorScheme: 'dark' });
   const brand = useMaterialColors({ seedColor: '#8E24AA' });
-  const brandedDark = useMaterialColors({ scheme: 'dark', seedColor: '#8E24AA' });
+  const brandedDark = useMaterialColors({ colorScheme: 'dark', seedColor: '#8E24AA' });
 
   return (
     <Host style={{ flex: 1 }}>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -47,9 +47,7 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <OutlinedButton onClick={() => setIsExpanded(true)}>
-            Show Menu
-          </OutlinedButton>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>Show Menu</OutlinedButton>
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           <DropdownMenuItem

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -29,8 +29,17 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import { Host, DropdownMenu, DropdownMenuItem, Button, Text, Icon } from '@expo/ui/jetpack-compose';
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  OutlinedButton,
+  Text,
+  Icon,
+} from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
+
+const homeIcon = require('./assets/home.xml');
 
 export default function BasicDropdownMenuExample() {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -38,9 +47,9 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <Button variant="bordered" onClick={() => setIsExpanded(true)}>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>
             Show Menu
-          </Button>
+          </OutlinedButton>
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           <DropdownMenuItem

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
@@ -30,7 +30,7 @@ Expo UI `ExposedDropdownMenuBox` matches the official Jetpack Compose [`ExposedD
 
 ### Basic
 
-> When using an uncontrolled `TextField` as the anchor, pass `key={selected}` to force a remount when the selected value changes — `defaultValue` is only read on mount.
+> The anchor is a read-only `TextField` bound to a [`useNativeState`](usenativestate) observable. Update that observable in each item's `onClick` to reflect the selected value.
 
 ```tsx BasicExposedDropdownMenuBoxExample.tsx
 import {
@@ -40,6 +40,7 @@ import {
   Host,
   Text,
   TextField,
+  useNativeState,
 } from '@expo/ui/jetpack-compose';
 import { menuAnchor } from '@expo/ui/jetpack-compose/modifiers';
 import { useState } from 'react';
@@ -51,26 +52,19 @@ const LANGUAGES = [
 ];
 
 export default function BasicExposedDropdownMenuBoxExample() {
-  const [selected, setSelected] = useState('java');
+  const selectedLabel = useNativeState('Java');
   const [expanded, setExpanded] = useState(false);
-
-  const selectedLabel = LANGUAGES.find(l => l.value === selected)?.label ?? '';
 
   return (
     <Host matchContents>
       <ExposedDropdownMenuBox expanded={expanded} onExpandedChange={setExpanded}>
-        <TextField
-          defaultValue={selectedLabel}
-          key={selected}
-          readOnly
-          modifiers={[menuAnchor()]}
-        />
+        <TextField value={selectedLabel} readOnly modifiers={[menuAnchor()]} />
         <ExposedDropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
           {LANGUAGES.map(lang => (
             <DropdownMenuItem
               key={lang.value}
               onClick={() => {
-                setSelected(lang.value);
+                selectedLabel.value = lang.label;
                 setExpanded(false);
               }}>
               <DropdownMenuItem.Text>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -31,7 +31,7 @@ A lazily-loaded vertical list component that only renders visible items for effi
 ### Basic lazy column
 
 ```tsx BasicLazyColumn.tsx
-import { Host, LazyColumn, ListItem } from '@expo/ui/jetpack-compose';
+import { Host, LazyColumn, ListItem, Text } from '@expo/ui/jetpack-compose';
 
 const items = Array.from({ length: 100 }, (_, i) => `Item ${i + 1}`);
 
@@ -40,7 +40,11 @@ export default function BasicLazyColumn() {
     <Host style={{ height: 400 }}>
       <LazyColumn>
         {items.map(item => (
-          <ListItem key={item} headline={item} />
+          <ListItem key={item}>
+            <ListItem.HeadlineContent>
+              <Text>{item}</Text>
+            </ListItem.HeadlineContent>
+          </ListItem>
         ))}
       </LazyColumn>
     </Host>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -38,10 +38,10 @@ Expo UI provides three text field components that match the official Jetpack Com
 
 Bind a [`useNativeState`](usenativestate) observable to `value`. The field tracks the user's input on its own, and you read the current value from `text.value`. The filled style shown here is the default Material3 text input.
 
-```tsx BasicTextFieldExample.tsx
+```tsx UncontrolledTextFieldExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 
-export default function BasicTextFieldExample() {
+export default function UncontrolledTextFieldExample() {
   const text = useNativeState('');
 
   return (

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/alert.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/alert.mdx
@@ -20,7 +20,7 @@ Expo UI Alert matches the official SwiftUI [alert API](<https://developer.apple.
   alt="Alert asking the user to confirm signing out"
 />
 
-`Alert` is the centered modal counterpart to [`ConfirmationDialog`](confirmationdialog.mdx), which renders as an action sheet from the bottom of the screen. Both share the same trigger/actions/message slot model so callers can swap between them by changing the component name.
+`Alert` is the centered modal counterpart to [`ConfirmationDialog`](confirmationdialog), which renders as an action sheet from the bottom of the screen. Both share the same trigger/actions/message slot model so callers can swap between them by changing the component name.
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/group.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/group.mdx
@@ -28,7 +28,7 @@ import { foregroundStyle } from '@expo/ui/swift-ui/modifiers';
 export default function BasicGroupExample() {
   return (
     <Host matchContents>
-      <Group modifiers={[foregroundStyle({ color: 'blue' })]}>
+      <Group modifiers={[foregroundStyle('blue')]}>
         <Text>First item</Text>
         <Text>Second item</Text>
         <Text>Third item</Text>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/host.mdx
@@ -111,7 +111,7 @@ export default function IgnoreKeyboardExample() {
             backgroundColor: 'green',
           }}>
           <Host matchContents ignoreSafeArea="keyboard" style={{ backgroundColor: 'red' }}>
-            <TextField placeholder="Enter text" multiline />
+            <TextField placeholder="Enter text" axis="vertical" />
           </Host>
         </KeyboardStickyView>
       </View>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/label.mdx
@@ -58,7 +58,7 @@ export default function LabelCustomIconExample() {
 
 ### Icon only
 
-Use the [`labelStyle`](/versions/latest/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
+Use the [`labelStyle`](modifiers/#labelstylestyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
 
 ```tsx LabelIconOnlyExample.tsx
 import { Host, Label } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/menu.mdx
@@ -76,11 +76,12 @@ You can pass a React node as the label for custom styling.
 
 ```tsx CustomLabelMenuExample.tsx
 import { Host, Menu, Button, Text } from '@expo/ui/swift-ui';
+import { foregroundStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function CustomLabelMenuExample() {
   return (
     <Host matchContents>
-      <Menu label={<Text color="accentColor">Custom Label</Text>}>
+      <Menu label={<Text modifiers={[foregroundStyle('accentColor')]}>Custom Label</Text>}>
         <Button label="Action 1" onPress={() => console.log('Action 1')} />
         <Button label="Action 2" onPress={() => console.log('Action 2')} />
       </Menu>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/namespace.mdx
@@ -179,7 +179,9 @@ function MatchedGeometryExample() {
                 },
               }),
             ]}>
-            <Text modifiers={[foregroundStyle('#fff')]}>{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
+            <Text modifiers={[foregroundStyle('#fff')]}>
+              {isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}
+            </Text>
           </Button>
         </VStack>
       </VStack>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/namespace.mdx
@@ -39,6 +39,7 @@ import {
   background,
   cornerRadius,
   frame,
+  foregroundStyle,
 } from '@expo/ui/swift-ui/modifiers';
 import { useId, useState } from 'react';
 
@@ -178,7 +179,7 @@ function MatchedGeometryExample() {
                 },
               }),
             ]}>
-            <Text color="#fff">{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
+            <Text modifiers={[foregroundStyle('#fff')]}>{isGlassExpanded ? 'Hide Tools' : 'Show More Tools'}</Text>
           </Button>
         </VStack>
       </VStack>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/rnhostview.mdx
@@ -37,7 +37,7 @@ function Example() {
   return (
     <Host style={{ flex: 1 }}>
       <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
-      <BottomSheet isOpened={isPresented} onIsOpenedChange={setIsPresented}>
+      <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
         <RNHostView matchContents>
           <View style={{ padding: 24 }}>
             <Text style={{ fontSize: 18, fontWeight: 'bold' }}>React Native Content</Text>
@@ -61,7 +61,8 @@ When using `flex: 1` in your React Native content, omit the `matchContents` prop
 ```tsx RNHostView with flex content
 import { useState } from 'react';
 import { Text, View } from 'react-native';
-import { Host, BottomSheet, Button, RNHostView } from '@expo/ui/swift-ui';
+import { Host, BottomSheet, Button, Group, RNHostView } from '@expo/ui/swift-ui';
+import { presentationDetents } from '@expo/ui/swift-ui/modifiers';
 
 function Example() {
   const [isPresented, setIsPresented] = useState(false);
@@ -69,17 +70,16 @@ function Example() {
   return (
     <Host style={{ flex: 1 }}>
       <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
-      <BottomSheet
-        isOpened={isPresented}
-        onIsOpenedChange={setIsPresented}
-        presentationDetents={['medium', 'large']}>
-        <RNHostView>
-          <View style={{ flex: 1, backgroundColor: '#007AFF', padding: 24 }}>
-            <Text style={{ color: 'white', fontSize: 18 }}>
-              This content fills the available space
-            </Text>
-          </View>
-        </RNHostView>
+      <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
+        <Group modifiers={[presentationDetents(['medium', 'large'])]}>
+          <RNHostView>
+            <View style={{ flex: 1, backgroundColor: '#007AFF', padding: 24 }}>
+              <Text style={{ color: 'white', fontSize: 18 }}>
+                This content fills the available space
+              </Text>
+            </View>
+          </RNHostView>
+        </Group>
       </BottomSheet>
     </Host>
   );

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/section.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/section.mdx
@@ -95,6 +95,7 @@ Use the `isExpanded` prop to control whether the section is expanded or collapse
 ```tsx CollapsibleSectionExample.tsx
 import { useState } from 'react';
 import { Host, List, Section, Text } from '@expo/ui/swift-ui';
+import { listStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function CollapsibleSectionExample() {
   const [favoritesExpanded, setFavoritesExpanded] = useState(false);
@@ -102,7 +103,7 @@ export default function CollapsibleSectionExample() {
 
   return (
     <Host style={{ flex: 1 }}>
-      <List listStyle="sidebar">
+      <List modifiers={[listStyle('sidebar')]}>
         <Section
           title="Favorites"
           isExpanded={favoritesExpanded}

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/securefield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/securefield.mdx
@@ -37,7 +37,7 @@ export default function BasicSecureFieldExample() {
 
   return (
     <Host matchContents>
-      <SecureField placeholder="Password" onValueChange={setPassword} />
+      <SecureField placeholder="Password" onTextChange={setPassword} />
     </Host>
   );
 }
@@ -59,7 +59,7 @@ export default function SecureFieldSubmitExample() {
     <Host matchContents>
       <SecureField
         placeholder="Password"
-        onValueChange={setPassword}
+        onTextChange={setPassword}
         modifiers={[submitLabel('done'), onSubmit(() => console.log('Login submitted'))]}
       />
     </Host>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/tabview.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/tabview.mdx
@@ -20,7 +20,7 @@ Expo UI TabView matches the official SwiftUI [TabView API](https://developer.app
   alt="A TabView with a bottom tab bar showing Home, Search, and Profile tabs in iOS 26 Liquid Glass style"
 />
 
-> **Note:** For routed bottom-tab navigation across full-screen routes, use [expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
+> **Note:** For routed bottom-tab navigation across full-screen routes, use [`expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
 
 ## Installation
 
@@ -200,7 +200,7 @@ function Page({ label, color }: { label: string; color: string }) {
 
 Use `tabViewStyle({ type: 'automatic' })` for the SwiftUI default tab bar. Each tab's `label` and `systemImage` populate the bar item. Use the [`badge`](modifiers/#badgevalue) modifier on a tab to attach a badge to its bar item.
 
-> **Note:** For routed bottom-tab navigation across full-screen routes, use [expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
+> **Note:** For routed bottom-tab navigation across full-screen routes, use [`expo-router/unstable-native-tabs`](/router/advanced/native-tabs/) instead.
 
 ```tsx BottomTabsExample.tsx
 import { useState } from 'react';

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/zstack.mdx
@@ -37,7 +37,7 @@ export default function BasicZStackExample() {
     <Host matchContents>
       <ZStack>
         <Rectangle modifiers={[frame({ width: 100, height: 100 })]} />
-        <Text modifiers={[foregroundStyle({ color: 'white' })]}>Overlay</Text>
+        <Text modifiers={[foregroundStyle('white')]}>Overlay</Text>
       </ZStack>
     </Host>
   );
@@ -57,9 +57,9 @@ export default function ZStackAlignmentExample() {
     <Host matchContents>
       <ZStack alignment="bottomTrailing">
         <Rectangle
-          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle({ color: 'blue' })]}
+          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]}
         />
-        <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle({ color: 'red' })]} />
+        <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>
   );
@@ -77,7 +77,7 @@ export default function ZStackBadgeExample() {
     <Host matchContents>
       <ZStack alignment="topTrailing">
         <Image systemName="bell.fill" size={32} color="blue" />
-        <Circle modifiers={[frame({ width: 16, height: 16 }), foregroundStyle({ color: 'red' })]} />
+        <Circle modifiers={[frame({ width: 16, height: 16 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>
   );

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/zstack.mdx
@@ -56,9 +56,7 @@ export default function ZStackAlignmentExample() {
   return (
     <Host matchContents>
       <ZStack alignment="bottomTrailing">
-        <Rectangle
-          modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]}
-        />
+        <Rectangle modifiers={[frame({ width: 100, height: 100 }), foregroundStyle('blue')]} />
         <Circle modifiers={[frame({ width: 30, height: 30 }), foregroundStyle('red')]} />
       </ZStack>
     </Host>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22131

# How

<!--
How did you build this feature or fix this bug and why?
-->

# How

**Jetpack Compose examples**
- Fix `Icon` `tintColor` → `tint` in `button`.
- Fix `useMaterialColors` `scheme` → `colorScheme` in `colors`.
- Replace `Button variant="bordered"` with `OutlinedButton` and define the missing `homeIcon` in `dropdownmenu`.
- Replace the nonexistent `TextField` `defaultValue` with a `useNativeState` controlled anchor in `exposeddropdownmenubox`.
- Replace the `ListItem` `headline` prop with the `ListItem.HeadlineContent` slot in `lazycolumn`.
- Rename the duplicate `BasicTextFieldExample` to `UncontrolledTextFieldExample` in `textfield`.

**SwiftUI examples**
- Fix `TextField` `multiline` → `axis="vertical"` in `host`.
- Fix `SecureField` `onValueChange` → `onTextChange`.
- Fix `BottomSheet` `isOpened`/`onIsOpenedChange` → `isPresented`/`onIsPresentedChange` and move `presentationDetents` to a `Group` modifier in `rnhostview`.
- Replace `Text` `color` with the `foregroundStyle` modifier in `menu` and `namespace`.
- Replace the `List` `listStyle` prop with the `listStyle` modifier in `section`.
- Fix invalid `foregroundStyle({ color })` to the string form in `group` and `zstack`.
- Add the missing `Group` import to the affected `bottomsheet` examples.

**Internal links**
- Fix the `alert` link to `confirmationdialog` (drop the `.mdx` extension).
- Fix the `tabview` stray backtick in the `expo-router/unstable-native-tabs` link.
- Fix the `label` `labelStyle` link to a relative path with the `#labelstylestyle` anchor.

_Changes applied to unversioned and SDK 56 _.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
