### PR TITLE
[expo-go] Use primaryAccountProfileImageUrl instead of deprecated profilePhoto

### DIFF
--- a/apps/expo-go/android/expoview/src/main/graphql/fragments/CurrentUserActorData.fragment.graphql
+++ b/apps/expo-go/android/expoview/src/main/graphql/fragments/CurrentUserActorData.fragment.graphql
@@ -4,7 +4,7 @@ fragment CurrentUserActorData on UserActor {
   username
   firstName
   lastName
-  profilePhoto
+  primaryAccountProfileImageUrl
   bestContactEmail
   accounts {
     id
@@ -12,7 +12,7 @@ fragment CurrentUserActorData on UserActor {
     ownerUserActor {
       id
       username
-      profilePhoto
+      primaryAccountProfileImageUrl
       firstName
       fullName
       lastName

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountHeaderAction.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountHeaderAction.kt
@@ -41,7 +41,7 @@ fun AccountHeaderAction(
 
   // Show account info
   AsyncImage(
-    model = account.ownerUserActor.profilePhoto,
+    model = account.ownerUserActor.primaryAccountProfileImageUrl,
     contentDescription = "Avatar",
     modifier = Modifier
       .size(24.dp)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
@@ -133,7 +133,7 @@ private fun AccountRow(
     icon = {
       if (owner != null) {
         AsyncImage(
-          model = owner.profilePhoto,
+          model = owner.primaryAccountProfileImageUrl,
           contentDescription = "Account icon",
           modifier = Modifier
             .size(24.dp)

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -53,7 +53,7 @@ struct UserActor: Codable {
   let username: String
   let firstName: String?
   let lastName: String?
-  let profilePhoto: String?
+  let primaryAccountProfileImageUrl: String?
   let bestContactEmail: String?
   let accounts: [Account]
   let fullName: String?
@@ -64,7 +64,7 @@ struct UserActor: Codable {
     case username
     case firstName
     case lastName
-    case profilePhoto
+    case primaryAccountProfileImageUrl
     case bestContactEmail
     case accounts
     case fullName
@@ -88,7 +88,7 @@ struct Account: Codable {
 struct UserActorSimple: Codable {
   let id: String
   let username: String
-  let profilePhoto: String?
+  let primaryAccountProfileImageUrl: String?
   let firstName: String?
   let fullName: String?
   let lastName: String?

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
@@ -12,7 +12,7 @@ struct Queries {
         username
         firstName
         lastName
-        profilePhoto
+        primaryAccountProfileImageUrl
         bestContactEmail
         accounts {
           id
@@ -21,7 +21,7 @@ struct Queries {
           ownerUserActor {
             id
             username
-            profilePhoto
+            primaryAccountProfileImageUrl
             firstName
             fullName
             lastName
@@ -137,7 +137,7 @@ struct Queries {
             username
             firstName
             lastName
-            profilePhoto
+            primaryAccountProfileImageUrl
             bestContactEmail
             accounts {
               id
@@ -146,7 +146,7 @@ struct Queries {
               ownerUserActor {
                 id
                 username
-                profilePhoto
+                primaryAccountProfileImageUrl
                 firstName
                 fullName
                 lastName


### PR DESCRIPTION
# Why

Expo Go's Home account UI still fetches the deprecated `profilePhoto` field on `UserActor`. The schema marks it `@deprecated(reason: "Use primaryAccountProfileImageUrl instead")`, and the website already renders actor avatars from `primaryAccountProfileImageUrl`.

# How

Swapped every `profilePhoto` selection on `UserActor` to `primaryAccountProfileImageUrl`:

- **Android** — the `CurrentUserActorData` Apollo fragment and the two Compose call sites that read it (`AccountHeaderAction`, `AccountScreen`).
- **iOS** — the `Home_CurrentUserActor` / `HomeScreenData` query strings and the matching `Codable` models.

The new field is nullable (`String`) where `profilePhoto` was non-null; both clients already feed it into nullable-tolerant image loaders (Coil `AsyncImage`, Swift `String?`). On iOS it was only decoded — avatars there already render from `account.profileImageUrl` — so this just drops the deprecated selection.

# Test Plan

- **Android** — ran the real Apollo 4.3.3 codegen + Kotlin compile over the actual schema/fragment: both succeed and generate `primaryAccountProfileImageUrl: String?` on `CurrentUserActorData` and its nested `OwnerUserActor`, exactly what the two Compose call sites read. Coil's `AsyncImage(model: Any?)` accepts the nullable value, and Apollo no longer flags a deprecated field for this fragment.
- **iOS** — compiled `Models.swift` and ran a decode round-trip including a `null` value, confirming the `String!` → `String?` change decodes to `nil` rather than throwing. The field is decoded but not rendered on iOS (avatars come from `account.profileImageUrl`), so this only drops the deprecated selection.
- **GraphQL** — validated the iOS query strings against the bundled `schema.graphqls` as well; `primaryAccountProfileImageUrl` resolves and `profilePhoto` is gone.

This is a field swap, not a guaranteed identical URL: `primaryAccountProfileImageUrl` is the correct, up-to-date source for actor avatars (as the website uses) and can resolve to a different image than the deprecated `profilePhoto` for some users.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<!-- Internal Expo Go client change with no developer-facing package/SDK surface, so the checklist items above don't apply. -->
