### PR TITLE
[expo-maps][android] Avoid blank marker snippet callout space

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Return the `Promise` from `GoogleMaps.View`'s imperative `setCameraPosition` so callers can `await` it and catch the `Animation cancelled` rejection (matches iOS). ([#46421](https://github.com/expo/expo/pull/46421) by [@chownation](https://github.com/chownation))
+- [Android] Fixed Google Maps marker info windows reserving blank snippet space when `snippet` is omitted. ([#47271](https://github.com/expo/expo/pull/47271) by [@eliotgevers](https://github.com/eliotgevers))
 
 ### 💡 Others
 

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -198,8 +198,8 @@ class GoogleMapsView(context: Context, appContext: AppContext) :
 
           Marker(
             state = state,
-            title = marker.title,
-            snippet = marker.snippet,
+            title = marker.title.takeIf { it.isNotEmpty() },
+            snippet = marker.snippet.takeIf { it.isNotEmpty() },
             draggable = marker.draggable,
             anchor = marker.anchor.toOffset(),
             zIndex = marker.zIndex,


### PR DESCRIPTION
## Why

Android Google Maps marker info windows reserve blank snippet space when a marker has a `title` but omits `snippet`.

Closes #47270

## How

Pass `null` to the Google Maps Compose `Marker` for empty Expo marker title/snippet strings. This preserves the existing JS/native record shape while letting Google Maps treat omitted text as absent.

## Test Plan

- `git diff --check`
- Public repro: https://github.com/eliotgevers/expo-maps-android-snippet-repro
- Verified on Android that `expo-maps@56.0.7` shows blank snippet space for the title-only marker.
- Forced the repro to build `expo-maps` from local Android source and verified this patch makes the title-only marker compact while title+snippet still renders two lines.
- `bunx tsc --noEmit` in the repro app.
- `pnpm --filter expo-maps lint` is blocked in this checkout because `oxlint` is not installed.
- `pnpm --filter expo-maps typecheck` is blocked by existing workspace type errors in `expo-modules-core` / `expo` dependencies before this native change is checked.
