### PR TITLE
[expo-router] add badge to android toolbar menu

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/header-items.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/header-items.tsx
@@ -1,6 +1,6 @@
-import { Color, Label, Stack, useLocalSearchParams } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
-import { useState } from 'react';
+import { Color, Label, Stack, useLocalSearchParams } from "expo-router";
+import { SymbolView } from "expo-symbols";
+import { useState } from "react";
 import {
   View,
   Text,
@@ -10,9 +10,14 @@ import {
   Pressable,
   Alert,
   Platform,
-} from 'react-native';
+  TextInput,
+} from "react-native";
 
-import { searchIcon, closeIcon, moreVertIcon, sendIcon, deleteIcon } from './icons';
+import {
+  searchIcon,
+  sendIcon,
+  deleteIcon,
+} from "./icons";
 
 export default function HeaderItemsScreen() {
   const params = useLocalSearchParams();
@@ -21,14 +26,20 @@ export default function HeaderItemsScreen() {
   const [showLeftButton1, setShowLeftButton1] = useState(!!params.leftButton1);
   const [showLeftButton2, setShowLeftButton2] = useState(!!params.leftButton2);
   const [leftButton2Selected, setLeftButton2Selected] = useState(false);
-  const [leftButton2SeparateBackground, setLeftButton2SeparateBackground] = useState(false);
-  const [showLeftCustomItem, setShowLeftCustomItem] = useState(!!params.leftCustomItem);
+  const [leftButton2SeparateBackground, setLeftButton2SeparateBackground] =
+    useState(false);
+  const [showLeftCustomItem, setShowLeftCustomItem] = useState(
+    !!params.leftCustomItem,
+  );
   const [showLeftMenu, setShowLeftMenu] = useState(!!params.leftMenu);
+  const [menuBadgeContent, setMenuBadgeContent] = useState("99");
 
   const [showRightButton, setShowRightButton] = useState(!!params.rightButton);
   const [showRightMenu1, setShowRightMenu1] = useState(!!params.rightMenu1);
   const [showRightMenu2, setShowRightMenu2] = useState(false);
-  const [showSearchButton, setShowSearchButton] = useState(!!params.searchButton);
+  const [showSearchButton, setShowSearchButton] = useState(
+    !!params.searchButton,
+  );
   const [showXcassetButton1, setShowXcassetButton1] = useState(false);
   const [showXcassetButton2, setShowXcassetButton2] = useState(false);
   const [showXcassetMenu1, setShowXcassetMenu1] = useState(false);
@@ -37,70 +48,84 @@ export default function HeaderItemsScreen() {
   // State for menu items
   const [emailsArchived, setEmailsArchived] = useState(false);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
-  const [viewMode, setViewMode] = useState<'icons' | 'list'>('icons');
-  const [sortBy, setSortBy] = useState<'name' | 'kind' | 'date' | 'size' | 'tags'>('name');
-  const [favoriteColors, setFavoriteColors] = useState<('red' | 'blue' | 'green')[]>(['blue']);
+  const [viewMode, setViewMode] = useState<"icons" | "list">("icons");
+  const [sortBy, setSortBy] = useState<
+    "name" | "kind" | "date" | "size" | "tags"
+  >("name");
+  const [favoriteColors, setFavoriteColors] = useState<
+    ("red" | "blue" | "green")[]
+  >(["blue"]);
 
   // State for header customization
-  const [headerBackgroundColor, setHeaderBackgroundColor] = useState('#fff');
+  const [headerBackgroundColor, setHeaderBackgroundColor] = useState("#fff");
   const [hideBackButton, setHideBackButton] = useState(false);
 
   const handleLeftButton1Press = () => {
-    Alert.alert('Left Button 1', 'First left button pressed');
+    Alert.alert("Left Button 1", "First left button pressed");
   };
 
   const handleLeftButton2Press = () => {
-    Alert.alert('Left Button 2', 'Second left button pressed');
+    Alert.alert("Left Button 2", "Second left button pressed");
   };
 
   const handleRightButtonPress = () => {
-    Alert.alert('Right Button', 'Right button pressed');
+    Alert.alert("Right Button", "Right button pressed");
   };
 
   const handleSearchPress = () => {
-    Alert.alert('Search', 'Search button pressed');
+    Alert.alert("Search", "Search button pressed");
   };
 
   const handleSendEmail = () => {
-    Alert.alert('Send Email', 'Email sent successfully!');
+    Alert.alert("Send Email", "Email sent successfully!");
   };
 
   const handleDeleteEmail = () => {
-    Alert.alert('Delete Email', 'Email deleted!');
+    Alert.alert("Delete Email", "Email deleted!");
   };
 
   const handleArchiveToggle = () => {
     setEmailsArchived(!emailsArchived);
-    Alert.alert('Archive', emailsArchived ? 'Unarchived emails' : 'Archived emails');
+    Alert.alert(
+      "Archive",
+      emailsArchived ? "Unarchived emails" : "Archived emails",
+    );
   };
 
   const handleNotificationsToggle = () => {
     setNotificationsEnabled(!notificationsEnabled);
   };
 
-  const handleViewModeSelect = (mode: 'icons' | 'list') => {
+  const handleViewModeSelect = (mode: "icons" | "list") => {
     setViewMode(mode);
-    Alert.alert('View Mode', `Changed to ${mode} view`);
+    Alert.alert("View Mode", `Changed to ${mode} view`);
   };
 
-  const handleSortBySelect = (sort: 'name' | 'kind' | 'date' | 'size' | 'tags') => {
+  const handleSortBySelect = (
+    sort: "name" | "kind" | "date" | "size" | "tags",
+  ) => {
     setSortBy(sort);
-    Alert.alert('Sort By', `Sorting by ${sort}`);
+    Alert.alert("Sort By", `Sorting by ${sort}`);
   };
 
-  const handleColorSelect = (color: 'red' | 'blue' | 'green') => {
+  const handleColorSelect = (color: "red" | "blue" | "green") => {
     setFavoriteColors((prevColors) =>
-      prevColors.includes(color) ? prevColors.filter((c) => c !== color) : [...prevColors, color]
+      prevColors.includes(color)
+        ? prevColors.filter((c) => c !== color)
+        : [...prevColors, color],
     );
-    Alert.alert('Color Selected', `You selected ${color}`);
+    Alert.alert("Color Selected", `You selected ${color}`);
   };
 
   function CustomHeaderElement() {
     return (
       <Pressable
         testID="custom-header-element"
-        onPress={() => Alert.alert('Custom Element', 'Custom header element pressed!')}
-        style={styles.customHeaderElement}>
+        onPress={() =>
+          Alert.alert("Custom Element", "Custom header element pressed!")
+        }
+        style={styles.customHeaderElement}
+      >
         <SymbolView
           size={20}
           tintColor={Platform.select({
@@ -109,8 +134,8 @@ export default function HeaderItemsScreen() {
           })}
           style={{ width: 20, height: 20 }}
           name={{
-            ios: 'heart.fill',
-            android: 'favorite',
+            ios: "heart.fill",
+            android: "favorite",
           }}
         />
       </Pressable>
@@ -128,20 +153,28 @@ export default function HeaderItemsScreen() {
         <Stack.Toolbar placement="left">
           <Stack.Toolbar.Button
             hidden={!showLeftButton1}
-            icon={process.env.EXPO_OS === 'ios' ? 'arrow.left' : searchIcon}
+            icon={process.env.EXPO_OS === "ios" ? "arrow.left" : searchIcon}
             onPress={handleLeftButton1Press}
           />
           <Stack.Toolbar.Button
             hidden={!showLeftButton2}
             separateBackground={leftButton2SeparateBackground}
             selected={leftButton2Selected}
-            icon={process.env.EXPO_OS === 'ios' ? 'star' : searchIcon}
+            icon={
+              process.env.EXPO_OS === "ios"
+                ? "star"
+                : require("../../../assets/expo-logo.png")
+            }
+            iconRenderingMode={
+              process.env.EXPO_OS === "ios" ? "template" : "original"
+            }
             onPress={handleLeftButton2Press}
             style={{
               fontWeight: 500,
               fontSize: 10,
-              color: '#f0f',
-            }}>
+              color: "#f0f",
+            }}
+          >
             <Stack.Toolbar.Label>Button 2</Stack.Toolbar.Label>
             <Stack.Toolbar.Badge>33</Stack.Toolbar.Badge>
           </Stack.Toolbar.Button>
@@ -153,51 +186,73 @@ export default function HeaderItemsScreen() {
           <Stack.Toolbar.Menu
             hidden={!showLeftMenu}
             style={{
-              color: '#00f',
-              fontFamily: 'Arial',
-            }}>
+              color: "#00f",
+              fontFamily: "Arial",
+            }}
+            icon={
+              process.env.EXPO_OS === "ios"
+                ? "list.bullet"
+                : require("../../../assets/expo-logo.png")
+            }
+            iconRenderingMode={
+              process.env.EXPO_OS === "ios" ? "template" : "original"
+            }
+          >
             <Stack.Toolbar.Label>Left Menu</Stack.Toolbar.Label>
-            <Stack.Toolbar.Icon sf="list.bullet" />
             <Stack.Toolbar.Badge
               style={{
-                backgroundColor: '#eee',
-                fontFamily: 'Courier New',
+                backgroundColor: "#eee",
+                fontFamily: "Courier New",
                 fontWeight: 100,
-              }}>
-              99
+              }}
+            >
+              {menuBadgeContent}
             </Stack.Toolbar.Badge>
-            <Stack.Toolbar.MenuAction onPress={() => Alert.alert('Option 1')}>
+            <Stack.Toolbar.MenuAction onPress={() => Alert.alert("Option 1")}>
               <Stack.Toolbar.Label>Option 1</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="1.circle" />
             </Stack.Toolbar.MenuAction>
-            <Stack.Toolbar.MenuAction isOn onPress={() => Alert.alert('Option 2')}>
+            <Stack.Toolbar.MenuAction
+              isOn
+              onPress={() => Alert.alert("Option 2")}
+            >
               <Stack.Toolbar.Label>Option 2</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="2.circle" />
             </Stack.Toolbar.MenuAction>
           </Stack.Toolbar.Menu>
 
           <Stack.Toolbar.Menu
-            icon={require('../../../assets/expo-logo.png')}
-            iconRenderingMode={process.env.EXPO_OS === 'ios' ? 'template' : 'original'}
+            icon={require("../../../assets/expo-logo.png")}
+            iconRenderingMode={
+              process.env.EXPO_OS === "ios" ? "template" : "original"
+            }
             title="Actions"
             tintColor={Platform.select({
               ios: Color.ios.systemBrown,
               android: Color.android.dynamic.primary,
-            })}>
+            })}
+          >
             {/* Simple actions */}
             <Stack.Toolbar.MenuAction
-              icon={require('../../../assets/expo-transparent.png')}
+              icon={require("../../../assets/expo-transparent.png")}
               iconRenderingMode="template"
               destructive
-              onPress={() => Alert.alert('Send', 'Email sent!')}>
+              onPress={() => Alert.alert("Send", "Email sent!")}
+            >
               Send email
             </Stack.Toolbar.MenuAction>
 
             {/* Nested menu */}
-            <Stack.Toolbar.Menu title="Preferences" icon={require('../../../assets/expo-logo.png')}>
+            <Stack.Toolbar.Menu
+              title="Preferences"
+              icon={require("../../../assets/expo-logo.png")}
+            >
               <Stack.Toolbar.MenuAction
                 icon="bell"
-                onPress={() => Alert.alert('Notifications', 'Toggling notifications...')}>
+                onPress={() =>
+                  Alert.alert("Notifications", "Toggling notifications...")
+                }
+              >
                 Enable notifications
               </Stack.Toolbar.MenuAction>
             </Stack.Toolbar.Menu>
@@ -208,61 +263,77 @@ export default function HeaderItemsScreen() {
         <Stack.Toolbar placement="right">
           <Stack.Toolbar.Menu
             hidden={!showRightMenu1}
-            icon={process.env.EXPO_OS === 'ios' ? 'ellipsis.circle' : moreVertIcon}
+            icon={
+              process.env.EXPO_OS === "ios"
+                ? "ellipsis.circle"
+                : require("../../../assets/expo-logo.png")
+            }
+            iconRenderingMode={
+              process.env.EXPO_OS === "ios" ? "template" : "original"
+            }
             title="Actions"
             tintColor={Platform.select({
               ios: Color.ios.systemBrown,
               android: Color.android.dynamic.primary,
             })}
             style={{
-              color: '#00f',
-              fontFamily: 'Arial',
-            }}>
+              color: "#00f",
+              fontFamily: "Arial",
+            }}
+          >
             <Stack.Toolbar.Label>Menu</Stack.Toolbar.Label>
             <Stack.Toolbar.Badge
               style={{
-                backgroundColor: '#eee',
-                fontFamily: 'Courier New',
+                backgroundColor: "#eee",
+                fontFamily: "Courier New",
                 fontWeight: 100,
-              }}>
-              99
+              }}
+            >
+              {menuBadgeContent}
             </Stack.Toolbar.Badge>
 
             {/* Simple actions */}
             <Stack.Toolbar.MenuAction
-              icon={process.env.EXPO_OS === 'ios' ? undefined : sendIcon}
-              onPress={handleSendEmail}>
+              icon={process.env.EXPO_OS === "ios" ? undefined : sendIcon}
+              onPress={handleSendEmail}
+            >
               <Stack.Toolbar.Label>Send email</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="paperplane" />
             </Stack.Toolbar.MenuAction>
             <Stack.Toolbar.MenuAction
-              icon={process.env.EXPO_OS === 'ios' ? undefined : deleteIcon}
+              icon={process.env.EXPO_OS === "ios" ? undefined : deleteIcon}
               destructive
-              onPress={handleDeleteEmail}>
+              onPress={handleDeleteEmail}
+            >
               <Stack.Toolbar.Label>Delete email</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="trash" />
             </Stack.Toolbar.MenuAction>
 
             {/* Toggle action */}
-            <Stack.Toolbar.MenuAction isOn={emailsArchived} onPress={handleArchiveToggle}>
+            <Stack.Toolbar.MenuAction
+              isOn={emailsArchived}
+              onPress={handleArchiveToggle}
+            >
               <Stack.Toolbar.Label>
-                {emailsArchived ? 'Unarchive emails' : 'Archive emails'}
+                {emailsArchived ? "Unarchive emails" : "Archive emails"}
               </Stack.Toolbar.Label>
-              <Stack.Toolbar.Icon sf={emailsArchived ? 'tray.full' : 'tray'} />
+              <Stack.Toolbar.Icon sf={emailsArchived ? "tray.full" : "tray"} />
             </Stack.Toolbar.MenuAction>
 
             {/* Nested inline menu - View mode */}
             <Stack.Toolbar.Menu inline>
               <Stack.Toolbar.Label>View Mode</Stack.Toolbar.Label>
               <Stack.Toolbar.MenuAction
-                isOn={viewMode === 'icons'}
-                onPress={() => handleViewModeSelect('icons')}>
+                isOn={viewMode === "icons"}
+                onPress={() => handleViewModeSelect("icons")}
+              >
                 <Stack.Toolbar.Label>Icons</Stack.Toolbar.Label>
                 <Stack.Toolbar.Icon sf="square.grid.2x2" />
               </Stack.Toolbar.MenuAction>
               <Stack.Toolbar.MenuAction
-                isOn={viewMode === 'list'}
-                onPress={() => handleViewModeSelect('list')}>
+                isOn={viewMode === "list"}
+                onPress={() => handleViewModeSelect("list")}
+              >
                 <Stack.Toolbar.Label>List</Stack.Toolbar.Label>
                 <Stack.Toolbar.Icon sf="list.bullet" />
               </Stack.Toolbar.MenuAction>
@@ -272,29 +343,34 @@ export default function HeaderItemsScreen() {
             <Stack.Toolbar.Menu inline>
               <Stack.Toolbar.Label>Sort By</Stack.Toolbar.Label>
               <Stack.Toolbar.MenuAction
-                isOn={sortBy === 'name'}
+                isOn={sortBy === "name"}
                 subtitle="Ascending"
-                onPress={() => handleSortBySelect('name')}>
+                onPress={() => handleSortBySelect("name")}
+              >
                 Name
               </Stack.Toolbar.MenuAction>
               <Stack.Toolbar.MenuAction
-                isOn={sortBy === 'kind'}
-                onPress={() => handleSortBySelect('kind')}>
+                isOn={sortBy === "kind"}
+                onPress={() => handleSortBySelect("kind")}
+              >
                 Kind
               </Stack.Toolbar.MenuAction>
               <Stack.Toolbar.MenuAction
-                isOn={sortBy === 'date'}
-                onPress={() => handleSortBySelect('date')}>
+                isOn={sortBy === "date"}
+                onPress={() => handleSortBySelect("date")}
+              >
                 Date
               </Stack.Toolbar.MenuAction>
               <Stack.Toolbar.MenuAction
-                isOn={sortBy === 'size'}
-                onPress={() => handleSortBySelect('size')}>
+                isOn={sortBy === "size"}
+                onPress={() => handleSortBySelect("size")}
+              >
                 Size
               </Stack.Toolbar.MenuAction>
               <Stack.Toolbar.MenuAction
-                isOn={sortBy === 'tags'}
-                onPress={() => handleSortBySelect('tags')}>
+                isOn={sortBy === "tags"}
+                onPress={() => handleSortBySelect("tags")}
+              >
                 Tags
               </Stack.Toolbar.MenuAction>
             </Stack.Toolbar.Menu>
@@ -303,9 +379,12 @@ export default function HeaderItemsScreen() {
             <Stack.Toolbar.Menu title="Preferences">
               <Stack.Toolbar.MenuAction
                 isOn={notificationsEnabled}
-                onPress={handleNotificationsToggle}>
+                onPress={handleNotificationsToggle}
+              >
                 <Stack.Toolbar.Label>
-                  {notificationsEnabled ? 'Disable notifications' : 'Enable notifications'}
+                  {notificationsEnabled
+                    ? "Disable notifications"
+                    : "Enable notifications"}
                 </Stack.Toolbar.Label>
                 <Stack.Toolbar.Icon sf="bell" />
               </Stack.Toolbar.MenuAction>
@@ -313,20 +392,23 @@ export default function HeaderItemsScreen() {
               {/* Color selection submenu */}
               <Stack.Toolbar.Menu inline title="Favorite Color">
                 <Stack.Toolbar.MenuAction
-                  isOn={favoriteColors.includes('red')}
-                  onPress={() => handleColorSelect('red')}>
+                  isOn={favoriteColors.includes("red")}
+                  onPress={() => handleColorSelect("red")}
+                >
                   <Stack.Toolbar.Label>Red</Stack.Toolbar.Label>
                   <Stack.Toolbar.Icon sf="circle.fill" />
                 </Stack.Toolbar.MenuAction>
                 <Stack.Toolbar.MenuAction
-                  isOn={favoriteColors.includes('blue')}
-                  onPress={() => handleColorSelect('blue')}>
+                  isOn={favoriteColors.includes("blue")}
+                  onPress={() => handleColorSelect("blue")}
+                >
                   <Stack.Toolbar.Label>Blue</Stack.Toolbar.Label>
                   <Stack.Toolbar.Icon sf="circle.fill" />
                 </Stack.Toolbar.MenuAction>
                 <Stack.Toolbar.MenuAction
-                  isOn={favoriteColors.includes('green')}
-                  onPress={() => handleColorSelect('green')}>
+                  isOn={favoriteColors.includes("green")}
+                  onPress={() => handleColorSelect("green")}
+                >
                   <Stack.Toolbar.Label>Green</Stack.Toolbar.Label>
                   <Stack.Toolbar.Icon sf="circle.fill" />
                 </Stack.Toolbar.MenuAction>
@@ -336,13 +418,23 @@ export default function HeaderItemsScreen() {
             {/* Palette menu */}
             <Stack.Toolbar.Menu palette destructive title="quick-actions">
               <Label>Quick Actions</Label>
-              <Stack.Toolbar.MenuAction isOn icon="star" onPress={() => Alert.alert('Star')}>
+              <Stack.Toolbar.MenuAction
+                isOn
+                icon="star"
+                onPress={() => Alert.alert("Star")}
+              >
                 Star
               </Stack.Toolbar.MenuAction>
-              <Stack.Toolbar.MenuAction icon="flag" onPress={() => Alert.alert('Flag')}>
+              <Stack.Toolbar.MenuAction
+                icon="flag"
+                onPress={() => Alert.alert("Flag")}
+              >
                 Flag
               </Stack.Toolbar.MenuAction>
-              <Stack.Toolbar.MenuAction icon="pin" onPress={() => Alert.alert('Pin')}>
+              <Stack.Toolbar.MenuAction
+                icon="pin"
+                onPress={() => Alert.alert("Pin")}
+              >
                 Pin
               </Stack.Toolbar.MenuAction>
             </Stack.Toolbar.Menu>
@@ -360,27 +452,34 @@ export default function HeaderItemsScreen() {
 
           <Stack.Toolbar.Button
             hidden={!showRightButton}
-            style={{ color: 'green' }}
-            onPress={handleRightButtonPress}>
+            style={{ color: "green" }}
+            onPress={handleRightButtonPress}
+          >
             Right
           </Stack.Toolbar.Button>
 
           <Stack.Toolbar.Button
             hidden={!showSearchButton}
-            icon={process.env.EXPO_OS === 'ios' ? 'magnifyingglass' : searchIcon}
+            icon={
+              process.env.EXPO_OS === "ios" ? "magnifyingglass" : searchIcon
+            }
             onPress={handleSearchPress}
           />
 
           {/* Xcasset icon buttons */}
           <Stack.Toolbar.Button
             hidden={!showXcassetButton1}
-            onPress={() => Alert.alert('Xcasset Button', 'expo-logo pressed')}>
+            onPress={() => Alert.alert("Xcasset Button", "expo-logo pressed")}
+          >
             <Stack.Toolbar.Icon xcasset="expo-logo" />
           </Stack.Toolbar.Button>
           <Stack.Toolbar.Button
             hidden={!showXcassetButton2}
             tintColor={Color.ios.systemTeal}
-            onPress={() => Alert.alert('Xcasset Button', 'expo-transparent pressed')}>
+            onPress={() =>
+              Alert.alert("Xcasset Button", "expo-transparent pressed")
+            }
+          >
             <Stack.Toolbar.Icon xcasset="expo-transparent" />
           </Stack.Toolbar.Button>
 
@@ -389,7 +488,10 @@ export default function HeaderItemsScreen() {
             <Stack.Toolbar.Icon xcasset="expo-logo" />
             <Stack.Toolbar.Label>Expo Logo</Stack.Toolbar.Label>
             <Stack.Toolbar.MenuAction
-              onPress={() => Alert.alert('Action', 'Action from expo-logo menu')}>
+              onPress={() =>
+                Alert.alert("Action", "Action from expo-logo menu")
+              }
+            >
               <Stack.Toolbar.Label>Logo Action</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="star" />
             </Stack.Toolbar.MenuAction>
@@ -397,11 +499,15 @@ export default function HeaderItemsScreen() {
           <Stack.Toolbar.Menu
             hidden={!showXcassetMenu2}
             title="Xcasset Menu 2"
-            tintColor={Color.ios.systemTeal}>
+            tintColor={Color.ios.systemTeal}
+          >
             <Stack.Toolbar.Icon xcasset="expo-transparent" />
             <Stack.Toolbar.Label>Expo Transparent</Stack.Toolbar.Label>
             <Stack.Toolbar.MenuAction
-              onPress={() => Alert.alert('Action', 'Action from expo-transparent menu')}>
+              onPress={() =>
+                Alert.alert("Action", "Action from expo-transparent menu")
+              }
+            >
               <Stack.Toolbar.Label>Transparent Action</Stack.Toolbar.Label>
               <Stack.Toolbar.Icon sf="star" />
             </Stack.Toolbar.MenuAction>
@@ -412,7 +518,8 @@ export default function HeaderItemsScreen() {
       <ScrollView
         style={styles.container}
         contentContainerStyle={styles.contentContainer}
-        contentInsetAdjustmentBehavior="automatic">
+        contentInsetAdjustmentBehavior="automatic"
+      >
         <Text style={styles.title}>Stack Header Items E2E Test Screen</Text>
 
         <View style={styles.section}>
@@ -448,7 +555,9 @@ export default function HeaderItemsScreen() {
               </View>
 
               <View style={styles.switchRow}>
-                <Text style={styles.label}>Left Button 2 Separate Background</Text>
+                <Text style={styles.label}>
+                  Left Button 2 Separate Background
+                </Text>
                 <Switch
                   testID="toggle-left-button-2-separate-background"
                   value={leftButton2SeparateBackground}
@@ -473,6 +582,19 @@ export default function HeaderItemsScreen() {
               testID="toggle-left-menu"
               value={showLeftMenu}
               onValueChange={setShowLeftMenu}
+            />
+          </View>
+
+          <View style={styles.switchRow}>
+            <Text style={styles.label}>Menu Badge Content</Text>
+            <TextInput
+              testID="input-menu-badge-content"
+              style={styles.textInput}
+              value={menuBadgeContent}
+              onChangeText={setMenuBadgeContent}
+              placeholder="Badge text"
+              autoCapitalize="none"
+              autoCorrect={false}
             />
           </View>
         </View>
@@ -526,7 +648,9 @@ export default function HeaderItemsScreen() {
           </View>
 
           <View style={styles.switchRow}>
-            <Text style={styles.label}>Show Xcasset Button (expo-transparent)</Text>
+            <Text style={styles.label}>
+              Show Xcasset Button (expo-transparent)
+            </Text>
             <Switch
               testID="toggle-xcasset-button-2"
               value={showXcassetButton2}
@@ -544,7 +668,9 @@ export default function HeaderItemsScreen() {
           </View>
 
           <View style={styles.switchRow}>
-            <Text style={styles.label}>Show Xcasset Menu (expo-transparent)</Text>
+            <Text style={styles.label}>
+              Show Xcasset Menu (expo-transparent)
+            </Text>
             <Switch
               testID="toggle-xcasset-menu-2"
               value={showXcassetMenu2}
@@ -570,23 +696,26 @@ export default function HeaderItemsScreen() {
             <View style={styles.colorButtonsRow}>
               <Pressable
                 testID="color-white"
-                style={[styles.colorButton, { backgroundColor: '#fff' }]}
-                onPress={() => setHeaderBackgroundColor('#fff')}
+                style={[styles.colorButton, { backgroundColor: "#fff" }]}
+                onPress={() => setHeaderBackgroundColor("#fff")}
               />
               <Pressable
                 testID="color-transparent"
-                style={[styles.colorButton, { backgroundColor: 'transparent', borderWidth: 1 }]}
-                onPress={() => setHeaderBackgroundColor('transparent')}
+                style={[
+                  styles.colorButton,
+                  { backgroundColor: "transparent", borderWidth: 1 },
+                ]}
+                onPress={() => setHeaderBackgroundColor("transparent")}
               />
               <Pressable
                 testID="color-blue"
-                style={[styles.colorButton, { backgroundColor: '#007AFF' }]}
-                onPress={() => setHeaderBackgroundColor('#007AFF')}
+                style={[styles.colorButton, { backgroundColor: "#007AFF" }]}
+                onPress={() => setHeaderBackgroundColor("#007AFF")}
               />
               <Pressable
                 testID="color-red"
-                style={[styles.colorButton, { backgroundColor: '#FF3B30' }]}
-                onPress={() => setHeaderBackgroundColor('#FF3B30')}
+                style={[styles.colorButton, { backgroundColor: "#FF3B30" }]}
+                onPress={() => setHeaderBackgroundColor("#FF3B30")}
               />
             </View>
           </View>
@@ -596,23 +725,43 @@ export default function HeaderItemsScreen() {
           <Text style={styles.sectionTitle}>Current State</Text>
           <Text style={styles.stateText}>View Mode: {viewMode}</Text>
           <Text style={styles.stateText}>Sort By: {sortBy}</Text>
-          <Text style={styles.stateText}>Emails Archived: {emailsArchived ? 'Yes' : 'No'}</Text>
           <Text style={styles.stateText}>
-            Notifications: {notificationsEnabled ? 'Enabled' : 'Disabled'}
+            Emails Archived: {emailsArchived ? "Yes" : "No"}
           </Text>
-          <Text style={styles.stateText}>Favorite Colors: {favoriteColors.join(', ')}</Text>
-          <Text style={styles.stateText}>Header Background: {headerBackgroundColor}</Text>
+          <Text style={styles.stateText}>
+            Notifications: {notificationsEnabled ? "Enabled" : "Disabled"}
+          </Text>
+          <Text style={styles.stateText}>
+            Favorite Colors: {favoriteColors.join(", ")}
+          </Text>
+          <Text style={styles.stateText}>
+            Header Background: {headerBackgroundColor}
+          </Text>
         </View>
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Instructions</Text>
-          <Text style={styles.instruction}>1. Toggle switches above to show/hide header items</Text>
-          <Text style={styles.instruction}>2. Test left and right header buttons</Text>
-          <Text style={styles.instruction}>3. Test nested menus and submenus</Text>
-          <Text style={styles.instruction}>4. Test menu item states (selected, disabled)</Text>
-          <Text style={styles.instruction}>5. Test custom header element and badge displays</Text>
-          <Text style={styles.instruction}>6. Test palette menu and destructive actions</Text>
-          <Text style={styles.instruction}>7. Observe state changes reflected in menu items</Text>
+          <Text style={styles.instruction}>
+            1. Toggle switches above to show/hide header items
+          </Text>
+          <Text style={styles.instruction}>
+            2. Test left and right header buttons
+          </Text>
+          <Text style={styles.instruction}>
+            3. Test nested menus and submenus
+          </Text>
+          <Text style={styles.instruction}>
+            4. Test menu item states (selected, disabled)
+          </Text>
+          <Text style={styles.instruction}>
+            5. Test custom header element and badge displays
+          </Text>
+          <Text style={styles.instruction}>
+            6. Test palette menu and destructive actions
+          </Text>
+          <Text style={styles.instruction}>
+            7. Observe state changes reflected in menu items
+          </Text>
         </View>
       </ScrollView>
     </>
@@ -622,7 +771,7 @@ export default function HeaderItemsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
   },
   contentContainer: {
     padding: 16,
@@ -630,55 +779,64 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 24,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     marginBottom: 24,
-    textAlign: 'center',
+    textAlign: "center",
   },
   section: {
     marginBottom: 24,
     padding: 16,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "#f5f5f5",
     borderRadius: 8,
   },
   sectionTitle: {
     fontSize: 18,
-    fontWeight: '600',
+    fontWeight: "600",
     marginBottom: 12,
   },
   switchRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: 8,
   },
   label: {
     fontSize: 16,
     flex: 1,
   },
+  textInput: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    minWidth: 100,
+    fontSize: 16,
+  },
   stateText: {
     fontSize: 14,
     marginVertical: 4,
-    color: '#333',
+    color: "#333",
   },
   instruction: {
     fontSize: 14,
     marginVertical: 4,
-    color: '#666',
+    color: "#666",
   },
   customHeaderElement: {
     width: 32,
     height: 32,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   colorButtonsRow: {
-    flexDirection: 'row',
+    flexDirection: "row",
     gap: 8,
   },
   colorButton: {
     width: 32,
     height: 32,
     borderRadius: 16,
-    borderColor: '#ccc',
+    borderColor: "#ccc",
   },
 });

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [android] Support `Stack.Toolbar.Badge` in header left/right placements ([#46537](https://github.com/expo/expo/pull/46537) by [@benjaminkomen](https://github.com/benjaminkomen))
+- [android] Support `Stack.Toolbar.Badge` on `Stack.Toolbar.Menu` icons in header left/right placements ([#47276](https://github.com/expo/expo/pull/47276) by [@Ubax](https://github.com/Ubax))
 - Add `standard-navigation` integration ([#46456](https://github.com/expo/expo/pull/46456) by [@Ubax](https://github.com/Ubax))
 - Re-export drawer content components and types (`DrawerContentScrollView`, `DrawerItem`, `DrawerItemList`, `DrawerContentComponentProps`, `DrawerNavigationProp`, and more) from `expo-router/drawer` ([#46635](https://github.com/expo/expo/pull/46635) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Emit a `tabPress` event with `isPrevented: true` when a `disabled` tab is tapped, without selecting it. ([#46445](https://github.com/expo/expo/pull/46445) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.android.tsx
@@ -397,4 +397,99 @@ describe('Stack.Toolbar Android integration tests', () => {
       expect(screen.queryByTestId('Box')).toBeNull();
     });
   });
+
+  describe('menu badge support in left/right placement', () => {
+    it.each(['left', 'right'] as const)(
+      'renders Box with Badge when menu has a Badge child in %s placement',
+      (placement) => {
+        renderRouter({
+          _layout: () => (
+            <Stack>
+              <Stack.Screen name="index">
+                <Stack.Toolbar placement={placement}>
+                  <Stack.Toolbar.Menu icon={{ uri: 'menu-icon' }}>
+                    <Stack.Toolbar.Badge>3</Stack.Toolbar.Badge>
+                    <Stack.Toolbar.MenuAction onPress={() => {}}>Action 1</Stack.Toolbar.MenuAction>
+                  </Stack.Toolbar.Menu>
+                </Stack.Toolbar>
+              </Stack.Screen>
+            </Stack>
+          ),
+          index: () => <View testID="index" />,
+        });
+
+        expect(screen.getByTestId('index')).toBeVisible();
+        expect(screen.getByTestId('Box')).toBeDefined();
+        const badge = screen.getByTestId('Badge');
+        expect(badge).toBeDefined();
+        expect(within(badge).getByTestId('ComposeText')).toBeDefined();
+        expect(within(badge).getByTestId('ComposeText').props.children).toBe('3');
+      }
+    );
+
+    it('renders dot badge when menu Badge has no children', () => {
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index">
+              <Stack.Toolbar placement="right">
+                <Stack.Toolbar.Menu icon={{ uri: 'menu-icon' }}>
+                  <Stack.Toolbar.Badge />
+                  <Stack.Toolbar.MenuAction onPress={() => {}}>Action 1</Stack.Toolbar.MenuAction>
+                </Stack.Toolbar.Menu>
+              </Stack.Toolbar>
+            </Stack.Screen>
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+      const badge = screen.getByTestId('Badge');
+      expect(badge).toBeDefined();
+      expect(within(badge).queryByTestId('ComposeText')).toBeNull();
+    });
+
+    it('folds the badge value into the icon contentDescription for TalkBack', () => {
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index">
+              <Stack.Toolbar placement="right">
+                <Stack.Toolbar.Menu icon={{ uri: 'menu-icon' }} accessibilityLabel="Notifications">
+                  <Stack.Toolbar.Badge>5</Stack.Toolbar.Badge>
+                  <Stack.Toolbar.MenuAction onPress={() => {}}>Action 1</Stack.Toolbar.MenuAction>
+                </Stack.Toolbar.Menu>
+              </Stack.Toolbar>
+            </Stack.Screen>
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+      const icon = within(screen.getByTestId('Box')).getByTestId('Icon');
+      expect(icon.props.contentDescription).toBe('Notifications, 5');
+    });
+
+    it('does not render Box when menu has no Badge child', () => {
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index">
+              <Stack.Toolbar placement="right">
+                <Stack.Toolbar.Menu icon={{ uri: 'menu-icon' }}>
+                  <Stack.Toolbar.MenuAction onPress={() => {}}>Action 1</Stack.Toolbar.MenuAction>
+                </Stack.Toolbar.Menu>
+              </Stack.Toolbar>
+            </Stack.Screen>
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+      expect(screen.queryByTestId('Box')).toBeNull();
+    });
+  });
 });

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -1,9 +1,8 @@
 'use client';
-import { Badge, Box, Icon, IconButton, Text as ComposeText } from '@expo/ui/jetpack-compose';
-import { alpha as alphaModifier } from '@expo/ui/jetpack-compose/modifiers';
+import { Icon, IconButton } from '@expo/ui/jetpack-compose';
 
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
-import { convertFontWeightToComposeFontWeight } from '../../../../utils/font';
+import { getBadgeContentDescription, ToolbarItemBadge } from '../ToolbarItemBadge';
 import { useToolbarColors } from '../context';
 import { DEFAULT_TOOLBAR_TINT_COLOR } from '../defaults';
 import type { NativeToolbarButtonProps } from './types';
@@ -32,54 +31,22 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
       ? null
       : (props.tintColor ?? toolbarColors.tintColor ?? DEFAULT_TOOLBAR_TINT_COLOR());
 
-  const hasBadge = props.badge?.value != null && props.badge?.value !== '';
-
-  const contentDescription = props.accessibilityLabel
-    ? hasBadge
-      ? `${props.accessibilityLabel}, ${props.badge!.value}`
-      : props.accessibilityLabel
-    : undefined;
-
-  const iconElement = (
-    <Icon
-      source={props.source}
-      tint={tintColor}
-      size={24}
-      contentDescription={contentDescription}
-    />
-  );
-
   const button = (
     <IconButton onClick={props.onPress} enabled={!props.disabled}>
-      {iconElement}
+      <Icon
+        source={props.source}
+        tint={tintColor}
+        size={24}
+        contentDescription={getBadgeContentDescription(props.accessibilityLabel, props.badge)}
+      />
     </IconButton>
   );
 
   return (
     <AnimatedItemContainer visible={!props.hidden}>
-      {props.badge ? (
-        <Box contentAlignment="topEnd">
-          {button}
-          <Badge
-            containerColor={props.badge.style?.backgroundColor}
-            contentColor={props.badge.style?.color}
-            modifiers={props.disabled ? [alphaModifier(0.38)] : undefined}>
-            {hasBadge ? (
-              <ComposeText
-                style={{
-                  typography: 'labelSmall',
-                  fontWeight: convertFontWeightToComposeFontWeight(props.badge.style?.fontWeight),
-                  fontSize: props.badge.style?.fontSize,
-                  fontFamily: props.badge.style?.fontFamily,
-                }}>
-                {String(props.badge.value)}
-              </ComposeText>
-            ) : null}
-          </Badge>
-        </Box>
-      ) : (
-        button
-      )}
+      <ToolbarItemBadge badge={props.badge} disabled={props.disabled}>
+        {button}
+      </ToolbarItemBadge>
     </AnimatedItemContainer>
   );
 };

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/index.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/index.tsx
@@ -121,7 +121,7 @@ export const StackToolbarMenu: React.FC<StackToolbarMenuProps> = (props) => {
     }
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production' && placement === 'bottom') {
     const hasBadge = getFirstChildOfType(props.children, StackToolbarBadge);
     if (hasBadge) {
       console.warn(
@@ -141,6 +141,7 @@ export const StackToolbarMenu: React.FC<StackToolbarMenuProps> = (props) => {
       imageRenderingMode={imageRenderingMode}
       label={computedLabel}
       title={computedMenuTitle}
+      badge={sharedProps?.badge}
       children={validChildren}
     />
   );

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
@@ -13,6 +13,7 @@ import { createContext, use, useCallback, useState } from 'react';
 import { Label } from '../../../../primitives';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
 import { getFirstChildOfType } from '../../../../utils/children';
+import { getBadgeContentDescription, ToolbarItemBadge } from '../ToolbarItemBadge';
 import { useToolbarColors } from '../context';
 import {
   DEFAULT_DESTRUCTIVE_COLOR,
@@ -55,6 +56,12 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
     setExpanded(false);
     parentClose?.();
   }, [parentClose]);
+
+  if (process.env.NODE_ENV !== 'production' && isNested && props.badge) {
+    console.warn(
+      'Stack.Toolbar.Badge on a nested Stack.Toolbar.Menu is not supported on Android; it is only rendered on a root menu. The badge will be ignored.'
+    );
+  }
 
   // Inline nested: render children directly with a divider separator
   if (isNested && props.inline) {
@@ -121,6 +128,20 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
     return null;
   }
 
+  const iconButton = (
+    <IconButton
+      onClick={() => setExpanded(true)}
+      enabled={!props.disabled}
+      modifiers={[background(backgroundColor)]}>
+      <Icon
+        source={props.source}
+        tint={sourceTint}
+        size={24}
+        contentDescription={getBadgeContentDescription(props.accessibilityLabel, props.badge)}
+      />
+    </IconButton>
+  );
+
   return (
     <AnimatedItemContainer visible={!props.hidden}>
       <DropdownMenu
@@ -128,17 +149,9 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
         onDismissRequest={() => setExpanded(false)}
         color={backgroundColor}>
         <DropdownMenu.Trigger>
-          <IconButton
-            onClick={() => setExpanded(true)}
-            enabled={!props.disabled}
-            modifiers={[background(backgroundColor)]}>
-            <Icon
-              source={props.source}
-              tint={sourceTint}
-              size={24}
-              contentDescription={props.accessibilityLabel}
-            />
-          </IconButton>
+          <ToolbarItemBadge badge={props.badge} disabled={props.disabled}>
+            {iconButton}
+          </ToolbarItemBadge>
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           <ToolbarMenuCloseContext value={closeMenu}>{props.children}</ToolbarMenuCloseContext>

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react';
 import type { ColorValue, ImageSourcePropType, StyleProp, TextStyle } from 'react-native';
 import type { SFSymbol } from 'sf-symbols-typescript';
 
-import type { NativeStackHeaderItemButton } from '../../../../react-navigation/native-stack';
 import type { LinkMenuActionProps } from '../../../../link/elements';
+import type { NativeStackHeaderItemButton } from '../../../../react-navigation/native-stack';
 import type { StackHeaderItemSharedProps } from '../shared';
 
 export interface StackToolbarMenuProps {

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { ColorValue, ImageSourcePropType, StyleProp, TextStyle } from 'react-native';
 import type { SFSymbol } from 'sf-symbols-typescript';
 
+import type { NativeStackHeaderItemButton } from '../../../../react-navigation/native-stack';
 import type { LinkMenuActionProps } from '../../../../link/elements';
 import type { StackHeaderItemSharedProps } from '../shared';
 
@@ -211,6 +212,9 @@ export interface NativeToolbarMenuProps {
   elementSize?: 'auto' | 'small' | 'medium' | 'large';
   /** @platform android */
   source?: ImageSourcePropType;
+  /** Badge overlay on the menu icon. Only rendered at the root (left/right placements).
+   * @platform android */
+  badge?: NativeStackHeaderItemButton['badge'];
 }
 
 export interface StackToolbarMenuActionProps {

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { Badge, Box, Text as ComposeText } from '@expo/ui/jetpack-compose';
+import { alpha as alphaModifier } from '@expo/ui/jetpack-compose/modifiers';
+import type { ReactElement, ReactNode } from 'react';
+
+import type { NativeStackHeaderItemButton } from '../../../react-navigation/native-stack';
+import { convertFontWeightToComposeFontWeight } from '../../../utils/font';
+
+type ToolbarBadge = NativeStackHeaderItemButton['badge'];
+
+/** A badge shows text when its value is neither null nor empty; otherwise it's a bare dot. */
+function badgeHasValue(badge: ToolbarBadge): badge is NonNullable<ToolbarBadge> {
+  return badge?.value != null && badge.value !== '';
+}
+
+/**
+ * Builds the spoken description for a badged icon so TalkBack announces the
+ * badge value (e.g. an unread count) alongside the label.
+ */
+export function getBadgeContentDescription(
+  accessibilityLabel: string | undefined,
+  badge: ToolbarBadge
+): string | undefined {
+  if (!accessibilityLabel) {
+    return undefined;
+  }
+  return badgeHasValue(badge) ? `${accessibilityLabel}, ${badge.value}` : accessibilityLabel;
+}
+
+/**
+ * Overlays a Material 3 Badge on the top-end corner of a toolbar item's icon.
+ * Compose anchors a badge to a single child, so the icon is wrapped in a Box.
+ * Renders the anchor unchanged when there's no badge, and a dot (no text) when
+ * the badge has no value. Shared by Stack.Toolbar.Button and Stack.Toolbar.Menu.
+ */
+export function ToolbarItemBadge({
+  badge,
+  disabled,
+  children,
+}: {
+  badge: ToolbarBadge;
+  disabled?: boolean;
+  children: ReactNode;
+}): ReactElement {
+  if (!badge) {
+    return <>{children}</>;
+  }
+  return (
+    <Box contentAlignment="topEnd">
+      {children}
+      <Badge
+        containerColor={badge.style?.backgroundColor}
+        contentColor={badge.style?.color}
+        modifiers={disabled ? [alphaModifier(0.38)] : undefined}>
+        {badgeHasValue(badge) ? (
+          <ComposeText
+            style={{
+              typography: 'labelSmall',
+              fontWeight: convertFontWeightToComposeFontWeight(badge.style?.fontWeight),
+              fontSize: badge.style?.fontSize,
+              fontFamily: badge.style?.fontFamily,
+            }}>
+            {String(badge.value)}
+          </ComposeText>
+        ) : null}
+      </Badge>
+    </Box>
+  );
+}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+import type { NativeStackHeaderItemButton } from '../../../react-navigation/native-stack';
+
+type ToolbarBadge = NativeStackHeaderItemButton['badge'];
+
+// Toolbar badges are only rendered through Jetpack Compose on Android
+// (see ToolbarItemBadge.android.tsx). On other platforms these are no-ops —
+// iOS badge support flows through native header items instead.
+
+export function getBadgeContentDescription(
+  _accessibilityLabel: string | undefined,
+  _badge: ToolbarBadge
+): string | undefined {
+  return undefined;
+}
+
+export function ToolbarItemBadge(_props: {
+  badge: ToolbarBadge;
+  disabled?: boolean;
+  children: ReactNode;
+}): null {
+  return null;
+}


### PR DESCRIPTION
# Why

Follow-up to: https://github.com/expo/expo/pull/46537

In the mentioned PR, badge was only added to toolbar button - and not to menu

# How

1. Extract common badge component
2. Use it in both button and menu

# Test Plan

1. CI
2. Manual testing of rotuer-e2e

<img height="512" alt="image" src="https://github.com/user-attachments/assets/28690427-d643-49d9-93b2-4ec1634a10c4" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
