### PR TITLE
[gl] Update Expo imports and fix global `__EXGLContexts` typing

### DIFF
--- a/packages/expo-gl/src/GLView.tsx
+++ b/packages/expo-gl/src/GLView.tsx
@@ -1,9 +1,9 @@
 import {
   UnavailabilityError,
   requireNativeModule,
-  requireNativeViewManager,
+  requireNativeView as requireNativeViewManager,
   CodedError,
-} from 'expo-modules-core';
+} from 'expo';
 import * as React from 'react';
 import { Platform, View, findNodeHandle } from 'react-native';
 
@@ -22,8 +22,6 @@ import { createWorkletContextManager } from './GLWorkletContextManager';
 export type WebGLObject = {
   id: number;
 };
-
-declare let global: any;
 
 const GLNativeModule = requireNativeModule('ExpoGL');
 const NativeView = requireNativeViewManager('ExpoGL');

--- a/packages/expo-gl/src/GLView.web.tsx
+++ b/packages/expo-gl/src/GLView.web.tsx
@@ -1,4 +1,4 @@
-import { CodedError, Platform, UnavailabilityError } from 'expo-modules-core';
+import { CodedError, Platform, UnavailabilityError } from 'expo';
 import invariant from 'invariant';
 import * as React from 'react';
 import { Dimensions } from 'react-native';

--- a/packages/expo-gl/src/ts-declarations/lib.dom.d.ts
+++ b/packages/expo-gl/src/ts-declarations/lib.dom.d.ts
@@ -1,3 +1,5 @@
-declare const global: Global & {
-  __EXGLContexts?: Record<string, any>;
-};
+export {};
+
+declare global {
+  var __EXGLContexts: Record<string, any> | undefined;
+}


### PR DESCRIPTION
# Why
Follow-up to: https://github.com/expo/expo/pull/45988
In expo-gl, importing `expo` instead of `expo-modules-core` causes a conflict between the locally declared global and the one from `expo`. This results in `__EXGLContexts` not being visible to TypeScript.
# How
- Removed global declarations from `expo-gl`
- Augmented global imported from `expo`, following the docs: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html
- Changed import from `expo-modules-core` to `expo`
# Test plan
Green CI
