### PR TITLE
refactor(expo-router): move data loader loading to router navigation

### DIFF
--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -51,6 +51,7 @@ const IndexScreen = () => {
         <SiteLink href="/(group)">Go to Grouped Index</SiteLink>
         <SiteLink href="/static-helper">Go to Static Helper</SiteLink>
         <SiteLink href="/server-helper">Go to Server Helper</SiteLink>
+        <SiteLink href="/warm-probe">Go to Warm Probe</SiteLink>
       </SiteLinks>
     </>
   );

--- a/apps/router-e2e/__e2e__/server-loader/app/warm-probe.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/warm-probe.tsx
@@ -1,0 +1,42 @@
+import { useLoaderData } from 'expo-router';
+import { Suspense, use, type ReactNode } from 'react';
+import { Text } from 'react-native';
+
+export function loader() {
+  return Promise.resolve({ warmed: true });
+}
+
+// Test-only gate. On the client, `Gate` suspends *above* the `useLoaderData` child, so on a client
+// navigation the data-reading component does not render until the test releases the gate. A loader
+// request that appears while the gate fallback is shown can therefore only have come from the
+// navigation-commit warm (`loaderBootstrap`), never the render-time fallback in `useLoaderData`.
+//
+// The gate is bypassed during SSR/SSG (`typeof window === 'undefined'`) so prerendering this route
+// doesn't hang. This route is reached via client navigation in the E2E only — never hydrated directly.
+const gate = new Promise<void>((resolve) => {
+  if (typeof window !== 'undefined') {
+    (globalThis as any).__releaseWarmGate = resolve;
+  }
+});
+
+function Gate({ children }: { children: ReactNode }) {
+  if (typeof window !== 'undefined') {
+    use(gate);
+  }
+  return <>{children}</>;
+}
+
+function WarmProbeScreen() {
+  const data = useLoaderData<typeof loader>();
+  return <Text testID="warm-result">{JSON.stringify(data)}</Text>;
+}
+
+export default function WarmProbeRoute() {
+  return (
+    <Suspense fallback={<Text testID="gate-fallback">gated</Text>}>
+      <Gate>
+        <WarmProbeScreen />
+      </Gate>
+    </Suspense>
+  );
+}

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -60,6 +60,34 @@ for (const outputMode of outputModes) {
       expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
     });
 
+    test('fetches the loader at navigation-commit, before the screen renders', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/')) {
+          loaderRequests.push(request.url());
+        }
+      });
+
+      await page.goto(expoStart.url.href);
+
+      // `/warm-probe` gates its `useLoaderData` child behind a Suspense boundary, so the data-reading
+      // component does not render until the test releases the gate.
+      await page.click('a[href="/warm-probe"]');
+      await page.waitForSelector('[data-testid="gate-fallback"]');
+
+      // The data-reading component is provably not rendered yet, so any loader request can only have
+      // come from the navigation-commit warm — not the render-time fallback in `useLoaderData`.
+      await expect(page.locator('[data-testid="warm-result"]')).not.toBeVisible();
+      expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/warm-probe'));
+
+      // Releasing the gate renders the screen from the warmed cache — no second request.
+      await page.evaluate(() => (globalThis as any).__releaseWarmGate?.());
+      await page.waitForSelector('[data-testid="warm-result"]');
+      expect(
+        loaderRequests.filter((url) => url.includes('/_expo/loaders/warm-probe'))
+      ).toHaveLength(1);
+    });
+
     test('caches loader data for subsequent navigations', async ({ page }) => {
       const loaderRequests: string[] = [];
       page.on('request', (request) => {

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -61,6 +61,35 @@ test.describe('server loaders in production', () => {
     expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
+  test('fetches the loader at navigation-commit, before the screen renders', async ({ page }) => {
+    const loaderRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/_expo/loaders/')) {
+        loaderRequests.push(request.url());
+      }
+    });
+
+    await page.goto(expoServe.url.href);
+
+    // `/warm-probe` gates its `useLoaderData` child behind a Suspense boundary, so the data-reading
+    // component does not render until the test releases the gate.
+    await page.click('a[href="/warm-probe"]');
+    await page.waitForSelector('[data-testid="gate-fallback"]');
+
+    // The data-reading component is provably not rendered yet, so any loader request can only have
+    // come from the navigation-commit warm — not the render-time fallback in `useLoaderData`. This
+    // runs against the real minified export, so it also guards against the loader stub being stripped.
+    await expect(page.locator('[data-testid="warm-result"]')).not.toBeVisible();
+    expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/warm-probe'));
+
+    // Releasing the gate renders the screen from the warmed cache — no second request.
+    await page.evaluate(() => (globalThis as any).__releaseWarmGate?.());
+    await page.waitForSelector('[data-testid="warm-result"]');
+    expect(loaderRequests.filter((url) => url.includes('/_expo/loaders/warm-probe'))).toHaveLength(
+      1
+    );
+  });
+
   test('caches loader data for subsequent navigations', async ({ page }) => {
     const loaderRequests: string[] = [];
     page.on('request', (request) => {

--- a/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
+++ b/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
@@ -95,9 +95,9 @@ function transformTest(code: string, { bundleType, ...defaultOverrideOpts }: Tra
 
 describe('client and server', () => {
   describe.each<BundleTypes>(['client', 'server'])(
-    'removes loader exports for %s bundles',
+    'replaces loader exports with a no-op stub for %s bundles',
     (bundleType: BundleTypes) => {
-      it('removes `export async function loader() {}`', () => {
+      it('stubs `export async function loader() {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -119,6 +119,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
           "import { useLoaderData } from 'expo-router';
           import { jsx as _jsx } from "react/jsx-runtime";
+          export const loader = () => {};
           export default function Index() {
             const data = useLoaderData();
             return /*#__PURE__*/_jsx("div", {
@@ -128,7 +129,7 @@ describe('client and server', () => {
       `);
       });
 
-      it('removes `export function loader() {}`', () => {
+      it('stubs `export function loader() {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -150,6 +151,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
               "import { useLoaderData } from 'expo-router';
               import { jsx as _jsx } from "react/jsx-runtime";
+              export const loader = () => {};
               export default function Index() {
                 const data = useLoaderData();
                 return /*#__PURE__*/_jsx("div", {
@@ -159,7 +161,7 @@ describe('client and server', () => {
           `);
       });
 
-      it('removes `export const loader = async () => {}`', () => {
+      it('stubs `export const loader = async () => {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -181,6 +183,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
               "import { useLoaderData } from 'expo-router';
               import { jsx as _jsx } from "react/jsx-runtime";
+              export const loader = () => {};
               export default function Index() {
                 const data = useLoaderData();
                 return /*#__PURE__*/_jsx("div", {
@@ -190,7 +193,7 @@ describe('client and server', () => {
           `);
       });
 
-      it('removes `export const loader = () => {}`', () => {
+      it('stubs `export const loader = () => {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -212,6 +215,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
               "import { useLoaderData } from 'expo-router';
               import { jsx as _jsx } from "react/jsx-runtime";
+              export const loader = () => {};
               export default function Index() {
                 const data = useLoaderData();
                 return /*#__PURE__*/_jsx("div", {
@@ -221,7 +225,7 @@ describe('client and server', () => {
           `);
       });
 
-      it('removes `export const loader = async function() {}`', () => {
+      it('stubs `export const loader = async function() {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -243,6 +247,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
               "import { useLoaderData } from 'expo-router';
               import { jsx as _jsx } from "react/jsx-runtime";
+              export const loader = () => {};
               export default function Index() {
                 const data = useLoaderData();
                 return /*#__PURE__*/_jsx("div", {
@@ -252,7 +257,7 @@ describe('client and server', () => {
           `);
       });
 
-      it('removes `export const loader = function() {}`', () => {
+      it('stubs `export const loader = function() {}`', () => {
         const res = transformTest(
           `
       import { useLoaderData } from 'expo-router';
@@ -274,6 +279,7 @@ describe('client and server', () => {
         expect(res.code).toMatchInlineSnapshot(`
               "import { useLoaderData } from 'expo-router';
               import { jsx as _jsx } from "react/jsx-runtime";
+              export const loader = () => {};
               export default function Index() {
                 const data = useLoaderData();
                 return /*#__PURE__*/_jsx("div", {
@@ -287,6 +293,29 @@ describe('client and server', () => {
 });
 
 describe('client', () => {
+  describe('replaces loader with a stub', () => {
+    it('keeps a no-op `loader` export so the route is detectable at runtime', () => {
+      const res = transformTest(
+        `
+      export async function loader() {
+        return { data: 'secret-server-only' };
+      }
+
+      export default function Index() {
+        return <div>Index</div>;
+      }
+    `,
+        { bundleType: 'client' }
+      );
+
+      // The implementation (and its server-only deps) is stripped from the client bundle...
+      expect(res.code).not.toContain('secret-server-only');
+      // ...but a truthy no-op stub remains so `loadRoute().loader` stays detectable on the client.
+      expect(res.code).toContain('export const loader = () => {}');
+      expect(res.metadata.loaderReference).toBe('/app/index');
+    });
+  });
+
   describe('preserves non-loader exports', () => {
     it('preserves other named exports', () => {
       const res = transformTest(
@@ -312,6 +341,7 @@ describe('client', () => {
       expect(res.code).toMatchInlineSnapshot(`
         "import { useLoaderData } from 'expo-router';
         import { jsx as _jsx } from "react/jsx-runtime";
+        export const loader = () => {};
         export const unstable_settings = {
           anchor: 'index'
         };
@@ -350,7 +380,8 @@ describe('client', () => {
       expect(res.code).toMatchInlineSnapshot(`
         "import { useLoaderData } from 'expo-router';
         import { jsx as _jsx } from "react/jsx-runtime";
-        export const unstable_settings = {
+        export const loader = () => {},
+          unstable_settings = {
             anchor: 'index'
           },
           generateStaticParams = () => [{
@@ -403,7 +434,7 @@ describe('client', () => {
 
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`""`);
+      expect(res.code).toMatchInlineSnapshot(`"export const loader = () => {};"`);
     });
 
     it('skips files outside app directory', () => {
@@ -474,6 +505,7 @@ describe('server', () => {
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
         "import { jsx as _jsx } from "react/jsx-runtime";
+        export const loader = () => {};
         export const unstable_settings = {
           anchor: 'index'
         };

--- a/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
@@ -68,10 +68,11 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
             markWithLoaderReference(state);
 
             if (!isLoaderBundle) {
-              // Client bundles: remove loader
-              debug('Found and removed loader function declaration');
+              // Stub rather than remove: keeps `loadRoute().loader` truthy on the client for loader
+              // detection, while dropping the server-only implementation.
+              debug('Found and stubbed loader function declaration');
               markForConstantFolding(state);
-              path.remove();
+              path.node.declaration = createLoaderStubDeclaration(t);
             }
             // Loader bundle: keep the loader
           } else if (name && isLoaderBundle) {
@@ -113,24 +114,21 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
               }
             );
           } else {
-            // Client bundles: remove loader declarations
-            declaration.declarations = declaration.declarations.filter(
-              (declarator: t.VariableDeclarator) => {
-                const name = t.isIdentifier(declarator.id) ? declarator.id.name : null;
-                if (name && isLoaderIdentifier(name)) {
-                  debug('Found and removed loader variable declaration');
-                  hasModified = true;
-                  return false;
-                }
-                return true;
+            // Stub the loader initializer in place (see the function-declaration branch above).
+            for (const declarator of declaration.declarations) {
+              const name = t.isIdentifier(declarator.id) ? declarator.id.name : null;
+              if (name && isLoaderIdentifier(name)) {
+                debug('Found and stubbed loader variable declaration');
+                declarator.init = createLoaderStub(t);
+                hasModified = true;
               }
-            );
+            }
           }
 
           if (hasModified) {
             markForConstantFolding(state);
 
-            // If all declarations were removed, remove the export
+            // Filtering can empty a loader-bundle declaration; drop the empty export.
             if (declaration.declarations.length === 0) {
               path.remove();
             }
@@ -146,6 +144,16 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
  */
 function isLoaderIdentifier(name: string): boolean {
   return name === LOADER_EXPORT_NAME;
+}
+
+function createLoaderStub(t: typeof import('@babel/core').types) {
+  return t.arrowFunctionExpression([], t.blockStatement([]));
+}
+
+function createLoaderStubDeclaration(t: typeof import('@babel/core').types) {
+  return t.variableDeclaration('const', [
+    t.variableDeclarator(t.identifier(LOADER_EXPORT_NAME), createLoaderStub(t)),
+  ]);
 }
 
 function assertExpoMetadata(metadata: any): asserts metadata is {

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { type PropsWithChildren, Fragment, type ComponentType, useMemo } from 'react';
+import Constants from 'expo-constants';
+import {
+  type PropsWithChildren,
+  Fragment,
+  type ComponentType,
+  use,
+  useEffect,
+  useMemo,
+} from 'react';
 import { Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -14,6 +22,8 @@ import { ServerContext } from './global-state/serverLocationContext';
 import { StoreContext } from './global-state/storeContext';
 import { shouldAppendNotFound, shouldAppendSitemap } from './global-state/utils';
 import { LinkPreviewContextProvider } from './link/preview/LinkPreviewContext';
+import { LoaderCacheContext } from './loaders/LoaderCache';
+import { subscribeToLoaderWarming } from './loaders/loaderBootstrap';
 import { handleNavigationOnReady } from './navigationEvents/navigation';
 import { Screen } from './primitives';
 import type { LinkingOptions, NavigationAction } from './react-navigation/native';
@@ -136,6 +146,20 @@ function ContextNavigator({
   const store = useStore(context, linking, serverUrl);
 
   useDomComponentNavigation();
+
+  // Same cache `useLoaderData` reads, so the warm and the read can't diverge.
+  const loaderCache = use(LoaderCacheContext);
+
+  // Warm the focused leaf's loader on navigation commit. Client- and flag-gated; mounts once.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (!Constants.expoConfig?.extra?.router?.unstable_useServerDataLoaders) {
+      return;
+    }
+    return subscribeToLoaderWarming(loaderCache);
+  }, [loaderCache]);
 
   if (store.shouldShowTutorial()) {
     SplashScreen.hideAsync();

--- a/packages/expo-router/src/global-state/__tests__/resolveFocusedLoaderRoute.test.ts
+++ b/packages/expo-router/src/global-state/__tests__/resolveFocusedLoaderRoute.test.ts
@@ -1,0 +1,184 @@
+import { getRouteInfoFromState } from '../getRouteInfoFromState';
+import { resolveFocusedLoaderRoute } from '../resolveFocusedLoaderRoute';
+import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../../constants';
+import type { RouteNode } from '../../Route';
+import { resolveLoaderKey } from '../../loaders/resolveLoaderKey';
+import type { ReactNavigationState } from '../types';
+
+const loader = () => ({ ok: true });
+
+function leaf(route: string, contextKey: string, opts: { loader?: boolean } = {}): RouteNode {
+  return {
+    type: 'route',
+    route,
+    contextKey,
+    children: [],
+    dynamic: null,
+    loadRoute: () => (opts.loader ? { loader } : {}),
+  } as unknown as RouteNode;
+}
+
+function layout(route: string, contextKey: string, children: RouteNode[]): RouteNode {
+  return {
+    type: 'layout',
+    route,
+    contextKey,
+    children,
+    dynamic: null,
+    loadRoute: () => ({}),
+  } as unknown as RouteNode;
+}
+
+/** Wrap a navigator state under the `__root` slot, as React Navigation commits it. */
+function root(inner: any): ReactNavigationState {
+  return { index: 0, routes: [{ name: INTERNAL_SLOT_NAME, key: '__root', state: inner }] } as any;
+}
+
+describe(resolveFocusedLoaderRoute, () => {
+  it('resolves a top-level leaf with a loader', () => {
+    const tree = layout('', './_layout.tsx', [leaf('index', './index.tsx', { loader: true })]);
+    const state = root({ index: 0, routes: [{ name: 'index', key: 'index-1' }] });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result).not.toBeNull();
+    expect(result!.resolvedPath).toBe('/index');
+    expect(result!.contextKey).toBe('/index');
+  });
+
+  it('resolves the focused leaf inside a nested navigator (tabs)', () => {
+    const tree = layout('', './_layout.tsx', [
+      layout('(tabs)', './(tabs)/_layout.tsx', [
+        leaf('home', './(tabs)/home.tsx', { loader: true }),
+        leaf('profile', './(tabs)/profile.tsx', { loader: true }),
+      ]),
+    ]);
+    const state = root({
+      index: 0,
+      routes: [
+        {
+          name: '(tabs)',
+          key: 'tabs-1',
+          state: {
+            index: 1,
+            routes: [
+              { name: 'home', key: 'home-1' },
+              { name: 'profile', key: 'profile-1' },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result!.resolvedPath).toBe('/(tabs)/profile');
+  });
+
+  it('fills dynamic segments from params', () => {
+    const tree = layout('', './_layout.tsx', [leaf('posts/[id]', './posts/[id].tsx', { loader: true })]);
+    const state = root({
+      index: 0,
+      routes: [{ name: 'posts/[id]', key: 'posts-1', params: { id: '123' } }],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result!.resolvedPath).toBe('/posts/123');
+    expect(result!.params).toEqual({ id: '123' });
+  });
+
+  it('appends search params', () => {
+    const tree = layout('', './_layout.tsx', [leaf('request', './request.tsx', { loader: true })]);
+    const state = root({
+      index: 0,
+      routes: [{ name: 'request', key: 'request-1', params: { foo: 'bar' } }],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result!.resolvedPath).toBe('/request?foo=bar');
+    expect(result!.searchParams.get('foo')).toBe('bar');
+  });
+
+  it('resolves a catch-all leaf', () => {
+    const tree = layout('', './_layout.tsx', [
+      leaf('[...rest]', './[...rest].tsx', { loader: true }),
+    ]);
+    const state = root({
+      index: 0,
+      routes: [{ name: '[...rest]', key: 'rest-1', params: { rest: ['x', 'y'] } }],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result!.resolvedPath).toBe('/x/y');
+  });
+
+  it('resolves a grouped index route', () => {
+    const tree = layout('', './_layout.tsx', [
+      layout('(group)', './(group)/_layout.tsx', [
+        leaf('index', './(group)/index.tsx', { loader: true }),
+      ]),
+    ]);
+    const state = root({
+      index: 0,
+      routes: [{ name: '(group)', key: 'group-1', state: { index: 0, routes: [{ name: 'index', key: 'gi-1' }] } }],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+
+    expect(result!.resolvedPath).toBe('/(group)/index');
+    expect(result!.contextKey).toBe('/(group)/index');
+  });
+
+  it('returns null when the focused leaf has no loader', () => {
+    const tree = layout('', './_layout.tsx', [leaf('index', './index.tsx', { loader: false })]);
+    const state = root({ index: 0, routes: [{ name: 'index', key: 'index-1' }] });
+
+    expect(resolveFocusedLoaderRoute(state, tree)).toBeNull();
+  });
+
+  it('returns null when the focused leaf is not in the route tree', () => {
+    const tree = layout('', './_layout.tsx', [leaf('index', './index.tsx', { loader: true })]);
+    const state = root({ index: 0, routes: [{ name: 'ghost', key: 'ghost-1' }] });
+
+    expect(resolveFocusedLoaderRoute(state, tree)).toBeNull();
+  });
+
+  it.each([NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME])('returns null for the %s route', (name) => {
+    const tree = layout('', './_layout.tsx', [leaf('index', './index.tsx', { loader: true })]);
+    const state = { index: 0, routes: [{ name, key: `${name}-1` }] } as any;
+
+    expect(resolveFocusedLoaderRoute(state, tree)).toBeNull();
+  });
+
+  it('resolvedPath matches resolveLoaderKey for the same route (router key === component key)', () => {
+    const tree = layout('', './_layout.tsx', [
+      layout('(tabs)', './(tabs)/_layout.tsx', [
+        leaf('posts/[id]', './(tabs)/posts/[id].tsx', { loader: true }),
+      ]),
+    ]);
+    const state = root({
+      index: 0,
+      routes: [
+        {
+          name: '(tabs)',
+          key: 'tabs-1',
+          state: {
+            index: 0,
+            routes: [{ name: 'posts/[id]', key: 'posts-1', params: { id: '7', q: 'x' } }],
+          },
+        },
+      ],
+    });
+
+    const result = resolveFocusedLoaderRoute(state, tree);
+    const routeInfo = getRouteInfoFromState(state);
+
+    expect(result!.resolvedPath).toBe(
+      resolveLoaderKey(result!.contextKey, routeInfo.params, routeInfo.searchParams)
+    );
+    expect(result!.resolvedPath).toBe('/(tabs)/posts/7?q=x');
+  });
+});

--- a/packages/expo-router/src/global-state/resolveFocusedLoaderRoute.ts
+++ b/packages/expo-router/src/global-state/resolveFocusedLoaderRoute.ts
@@ -1,0 +1,86 @@
+import type { RouteNode } from '../Route';
+import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../constants';
+import { resolveLoaderKey } from '../loaders/resolveLoaderKey';
+import { getContextKey } from '../matchers';
+import { getRouteInfoFromState } from './getRouteInfoFromState';
+import type { ReactNavigationState } from './types';
+
+export type ActiveLoaderRoute = {
+  /** Resolved URL (pathname + search) — the loader cache key. */
+  resolvedPath: string;
+  // routeKey: string; // per-instance React Navigation route.key — re-enable for the revalidation follow-up.
+  /** Normalized context key, matching `useContextKey()`. */
+  contextKey: string;
+  params: Record<string, string | string[]>;
+  searchParams: URLSearchParams;
+  loadRoute: RouteNode['loadRoute'];
+};
+
+/** Focused route at a navigator level, matching `getRouteInfoFromState`'s index selection. */
+function focusedRoute(state: { index?: number; routes: any[] }) {
+  return state.routes['index' in state && typeof state.index === 'number' ? state.index : 0];
+}
+
+/**
+ * Resolve the focused leaf route to warm for a just-committed navigation state, or `null` if there
+ * is nothing to warm (no loader, a special route, or no matching `RouteNode`).
+ *
+ * Only leaf routes can export loaders, so the focused branch has at most one. `getRouteInfoFromState`
+ * gives params/search; a parallel `RouteNode` walk gives the two things the URL can't: whether the
+ * leaf has a `loader` and its `contextKey` (the cache key derives from `getContextKey`, not the URL).
+ */
+export function resolveFocusedLoaderRoute(
+  state: ReactNavigationState,
+  routeNode: RouteNode
+): ActiveLoaderRoute | null {
+  // `+not-found`/`_sitemap` sit beside the `__root` slot and carry no loader.
+  const outer = focusedRoute(state);
+  if (!outer || outer.name === NOT_FOUND_ROUTE_NAME || outer.name === SITEMAP_ROUTE_NAME) {
+    return null;
+  }
+  if (outer.name !== INTERNAL_SLOT_NAME) {
+    return null;
+  }
+
+  // Match each focused nav-state `route.name` to a child `RouteNode.route` — both are the same
+  // (possibly multi-segment) string.
+  let navState: any = outer.state;
+  let nodes: RouteNode[] | undefined = routeNode.children;
+  let node: RouteNode | null = null;
+
+  while (navState) {
+    const route = focusedRoute(navState);
+    if (!route) {
+      return null;
+    }
+
+    const name = route.name.startsWith('/') ? route.name.slice(1) : route.name;
+    node = nodes?.find((child) => child.route === name) ?? null;
+    if (!node) {
+      return null;
+    }
+
+    nodes = node.children;
+    navState = route.state;
+  }
+
+  if (!node) {
+    return null;
+  }
+
+  // A loaderless route would 404 — nothing to warm.
+  if (!node.loadRoute().loader) {
+    return null;
+  }
+
+  const routeInfo = getRouteInfoFromState(state);
+  const contextKey = getContextKey(node.contextKey);
+
+  return {
+    resolvedPath: resolveLoaderKey(contextKey, routeInfo.params, routeInfo.searchParams),
+    contextKey,
+    params: routeInfo.params,
+    searchParams: routeInfo.searchParams,
+    loadRoute: node.loadRoute,
+  };
+}

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -58,12 +58,12 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
 
   // The second invocation happens after the client has hydrated on initial load, so we look up the data injected
   // by `<PreloadedDataScript />` using `globalThis.__EXPO_ROUTER_LOADER_DATA__`
-  if (typeof window !== 'undefined' && globalThis.__EXPO_ROUTER_LOADER_DATA__) {
-    if (globalThis.__EXPO_ROUTER_LOADER_DATA__[resolvedPath]) {
-      return globalThis.__EXPO_ROUTER_LOADER_DATA__[resolvedPath];
-    }
+  if (typeof window !== 'undefined' && globalThis.__EXPO_ROUTER_LOADER_DATA__?.[resolvedPath]) {
+    return globalThis.__EXPO_ROUTER_LOADER_DATA__[resolvedPath];
   }
 
+  // Usually a cache read — `loaderBootstrap` warms this on navigation commit. Falls back to fetching
+  // for routes reached without a warm (deep link, direct load, an unfocused sibling).
   const result = getLoaderData<LoaderFunctionResult<T>>({
     resolvedPath,
     cache: loaderCache,

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -8,9 +8,9 @@ import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
 import { LoaderCacheContext } from '../loaders/LoaderCache';
 import { ServerDataLoaderContext } from '../loaders/ServerDataLoaderContext';
 import { getLoaderData } from '../loaders/getLoaderData';
+import { resolveLoaderKey } from '../loaders/resolveLoaderKey';
 import { fetchLoader } from '../loaders/utils';
 import { useStateForPath } from '../react-navigation/native';
-import { getSingularId } from '../useScreens';
 
 type LoaderFunctionResult<T extends LoaderFunction<any>> =
   T extends LoaderFunction<infer R> ? R : unknown;
@@ -48,11 +48,7 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
 
   const resolvedPath = useMemo(() => {
     const routeInfo = getRouteInfoFromState(stateForPath);
-    const contextPath = contextKey.startsWith('/') ? contextKey.slice(1) : contextKey;
-    const resolvedPathname = `/${getSingularId(contextPath, { params: routeInfo.params })}`;
-    const searchString = routeInfo.searchParams?.toString() || '';
-
-    return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
+    return resolveLoaderKey(contextKey, routeInfo.params, routeInfo.searchParams);
   }, [contextKey, stateForPath]);
 
   // First invocation of this hook will happen server-side, so we look up the loaded data from context

--- a/packages/expo-router/src/loaders/__tests__/loaderBootstrap.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/loaderBootstrap.test.ts
@@ -1,0 +1,131 @@
+import { INTERNAL_SLOT_NAME } from '../../constants';
+import type { RouteNode } from '../../Route';
+import { store, storeRef } from '../../global-state/store';
+import { LoaderCache } from '../LoaderCache';
+import { subscribeToLoaderWarming } from '../loaderBootstrap';
+import { fetchLoader } from '../utils';
+
+jest.mock('../utils', () => ({ fetchLoader: jest.fn() }));
+
+const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+const loader = () => ({ ok: true });
+
+function leaf(route: string, contextKey: string, hasLoader: boolean): RouteNode {
+  return {
+    type: 'route',
+    route,
+    contextKey,
+    children: [],
+    dynamic: null,
+    loadRoute: () => (hasLoader ? { loader } : {}),
+  } as unknown as RouteNode;
+}
+
+function tree(children: RouteNode[]): RouteNode {
+  return {
+    type: 'layout',
+    route: '',
+    contextKey: './_layout.tsx',
+    children,
+    dynamic: null,
+    loadRoute: () => ({}),
+  } as unknown as RouteNode;
+}
+
+function commit(name: string, key: string, params?: Record<string, string | string[]>) {
+  store.onStateChange({
+    index: 0,
+    routes: [
+      {
+        name: INTERNAL_SLOT_NAME,
+        key: '__root',
+        state: { index: 0, routes: [{ name, key, params }] },
+      },
+    ],
+  } as any);
+}
+
+describe(subscribeToLoaderWarming, () => {
+  const originalStore = storeRef.current;
+  const originalWindow = global.window;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storeRef.current = { ...originalStore } as any;
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    storeRef.current = originalStore;
+    global.window = originalWindow;
+    delete globalThis.__EXPO_ROUTER_LOADER_DATA__;
+  });
+
+  it('warms the focused leaf loader on commit', async () => {
+    fetchLoaderMock.mockResolvedValue({ fromFetch: true });
+    storeRef.current.routeNode = tree([leaf('posts/[id]', './posts/[id].tsx', true)]);
+
+    const cache = new LoaderCache();
+    unsubscribe = subscribeToLoaderWarming(cache);
+
+    commit('posts/[id]', 'posts-1', { id: '123' });
+
+    expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
+    expect(fetchLoaderMock).toHaveBeenCalledWith('/posts/123');
+
+    await fetchLoaderMock.mock.results[0]!.value;
+
+    expect(cache.getData('/posts/123')).toEqual({ fromFetch: true });
+  });
+
+  it('warms each focused URL only once', async () => {
+    fetchLoaderMock.mockResolvedValue({ fromFetch: true });
+    storeRef.current.routeNode = tree([leaf('posts/[id]', './posts/[id].tsx', true)]);
+
+    const cache = new LoaderCache();
+    unsubscribe = subscribeToLoaderWarming(cache);
+
+    commit('posts/[id]', 'posts-1', { id: '123' });
+    await fetchLoaderMock.mock.results[0]!.value;
+    commit('posts/[id]', 'posts-1', { id: '123' });
+
+    expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the focused leaf has no loader', () => {
+    storeRef.current.routeNode = tree([leaf('about', './about.tsx', false)]);
+
+    const cache = new LoaderCache();
+    unsubscribe = subscribeToLoaderWarming(cache);
+
+    commit('about', 'about-1');
+
+    expect(fetchLoaderMock).not.toHaveBeenCalled();
+  });
+
+  it('skips warming when the route data is already hydrated', () => {
+    global.window = { location: { origin: 'http://localhost:8081' } } as any;
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = { '/posts/123': { hydrated: true } };
+    storeRef.current.routeNode = tree([leaf('posts/[id]', './posts/[id].tsx', true)]);
+
+    const cache = new LoaderCache();
+    unsubscribe = subscribeToLoaderWarming(cache);
+
+    commit('posts/[id]', 'posts-1', { id: '123' });
+
+    expect(fetchLoaderMock).not.toHaveBeenCalled();
+  });
+
+  it('stops warming after unsubscribe', () => {
+    fetchLoaderMock.mockResolvedValue({ fromFetch: true });
+    storeRef.current.routeNode = tree([leaf('posts/[id]', './posts/[id].tsx', true)]);
+
+    const cache = new LoaderCache();
+    subscribeToLoaderWarming(cache)();
+
+    commit('posts/[id]', 'posts-1', { id: '123' });
+
+    expect(fetchLoaderMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/expo-router/src/loaders/__tests__/resolveLoaderKey.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/resolveLoaderKey.test.ts
@@ -1,0 +1,53 @@
+import { resolveLoaderKey } from '../resolveLoaderKey';
+
+describe(resolveLoaderKey, () => {
+  it.each<{
+    name: string;
+    contextKey: string;
+    params: Record<string, string | string[]>;
+    searchParams?: URLSearchParams;
+    expected: string;
+  }>([
+    {
+      name: 'root index',
+      contextKey: '/index',
+      params: {},
+      searchParams: undefined,
+      expected: '/index',
+    },
+    {
+      name: 'grouped index',
+      contextKey: '/(group)/index',
+      params: {},
+      searchParams: undefined,
+      expected: '/(group)/index',
+    },
+    {
+      name: 'dynamic segment',
+      contextKey: '/posts/[id]',
+      params: { id: '123' },
+      searchParams: undefined,
+      expected: '/posts/123',
+    },
+    {
+      name: 'dynamic segment with search params',
+      contextKey: '/a/[b]',
+      params: { b: '1' },
+      searchParams: new URLSearchParams('x=1'),
+      expected: '/a/1?x=1',
+    },
+    {
+      name: 'catch-all',
+      contextKey: '/[...rest]',
+      params: { rest: ['x', 'y'] },
+      searchParams: undefined,
+      expected: '/x/y',
+    },
+  ])('resolves $name', ({ contextKey, params, searchParams, expected }) => {
+    expect(resolveLoaderKey(contextKey, params, searchParams)).toBe(expected);
+  });
+
+  it('omits the query when search params are empty', () => {
+    expect(resolveLoaderKey('/request', {}, new URLSearchParams())).toBe('/request');
+  });
+});

--- a/packages/expo-router/src/loaders/loaderBootstrap.ts
+++ b/packages/expo-router/src/loaders/loaderBootstrap.ts
@@ -1,0 +1,47 @@
+import { resolveFocusedLoaderRoute } from '../global-state/resolveFocusedLoaderRoute';
+import { routeInfoSubscribe } from '../global-state/routeInfoCache';
+import { store } from '../global-state/store';
+import { defaultLoaderCache, type LoaderCache } from './LoaderCache';
+import { getLoaderData } from './getLoaderData';
+import { fetchLoader } from './utils';
+
+/**
+ * Warm the focused leaf's loader for the just-committed navigation state. Routes through
+ * `getLoaderData` so the warm and `useLoaderData` share one promise/data/error map and never
+ * double-fetch.
+ */
+function warmFocusedLoader(cache: LoaderCache) {
+  const state = store.state;
+  const routeNode = store.routeNode;
+  if (!state || !routeNode) {
+    return;
+  }
+
+  const route = resolveFocusedLoaderRoute(state, routeNode);
+  if (!route) {
+    return;
+  }
+
+  const { resolvedPath } = route;
+
+  // Hydration data is served straight from the global by the read path; no fetch needed.
+  if (globalThis.__EXPO_ROUTER_LOADER_DATA__?.[resolvedPath]) {
+    return;
+  }
+
+  const result = getLoaderData({ resolvedPath, cache, fetcher: fetchLoader });
+
+  // The warm runs before render, so swallow the rejection here; the rejected promise stays cached
+  // for `useLoaderData` to surface.
+  if (result instanceof Promise) {
+    result.catch(() => {});
+  }
+}
+
+/**
+ * Subscribe to navigation commits and warm the focused leaf's loader. Returns the unsubscribe.
+ * Mounted once on the client behind `unstable_useServerDataLoaders` (see `ExpoRoot`).
+ */
+export function subscribeToLoaderWarming(cache: LoaderCache = defaultLoaderCache): () => void {
+  return routeInfoSubscribe(() => warmFocusedLoader(cache));
+}

--- a/packages/expo-router/src/loaders/resolveLoaderKey.ts
+++ b/packages/expo-router/src/loaders/resolveLoaderKey.ts
@@ -1,0 +1,20 @@
+import { getSingularId } from '../useScreens';
+
+/**
+ * Build the loader cache key (and request URL) for a route: its resolved URL — `pathname` with
+ * dynamic segments filled from `params`, plus the query string. The single source of this key, so
+ * the `useLoaderData` read and the navigation warm always agree.
+ *
+ * @param contextKey Already normalized via `getContextKey` (e.g. `/posts/[id]`).
+ */
+export function resolveLoaderKey(
+  contextKey: string,
+  params: Record<string, string | string[]>,
+  searchParams?: URLSearchParams
+): string {
+  const contextPath = contextKey.startsWith('/') ? contextKey.slice(1) : contextKey;
+  const resolvedPathname = `/${getSingularId(contextPath, { params })}`;
+  const searchString = searchParams?.toString() || '';
+
+  return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
+}

--- a/packages/expo-router/src/react-navigation/stack/utils/useKeyboardManager.tsx
+++ b/packages/expo-router/src/react-navigation/stack/utils/useKeyboardManager.tsx
@@ -7,7 +7,7 @@ export function useKeyboardManager({ enabled, focused }: { enabled: boolean; foc
   // When a gesture didn't change the tab, we can restore the focused input with this
   const previouslyFocusedTextInputRef = React.useRef<HostInstance>(undefined);
   const startTimestampRef = React.useRef<number>(0);
-  const keyboardTimeoutRef = React.useRef<NodeJS.Timeout>(undefined);
+  const keyboardTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const enabledRef = React.useRef(enabled);
 
   const clearKeyboardTimeout = React.useCallback(() => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
