### PR TITLE
[guides] Update Release Workflow to add `pnpm versions-schema-sync` 

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -113,6 +113,7 @@ We use our fork of React Native for building Expo Go, but it is not used otherwi
 - Run `et generate-docs-api-data` to regenerate `unversioned` API data files before cutting new documentation version.
 - Run `et generate-sdk-docs --sdk XX.X.X` to generate versioned docs for the new SDK.
 - Run `pnpm schema-sync XX` (`XX` being the major version number) in `docs` directory and then change the schema import in `pages/versions/<version>/config/app.mdx` from `unversioned` to the new versioned schema file.
+- Run `pnpm versions-schema-sync` in the `docs` directory to fetch the new version's `native-modules.json`, which the package-version header on each SDK page requires. This fetches from `exp.host`, so the new SDK's packages must already be published and synced to the versions endpoint (see [0.6. Publish `next` packages](#06-publish-next-packages)). If the packages are not live yet, the fetch returns nothing, so run this step once they are but you should create the `native-modules.json` file for the new SDK version before cutting the release branch.
 - Ensure that the `version` in package.json has NOT been updated to the new SDK version. SDK versions greater than the `version` in package.json will be hidden in production docs, and we do not want the new version to show up until the SDK has been released.
 - Commit and push changes to main.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add missing step about generating `native-modules.json` for the sdk cut off release here: https://github.com/expo/expo/blob/main/guides/releasing/Release%20Workflow.md?rgh-link-date=2026-01-21T12%3A47%3A46Z#09-generate-new-sdk-docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
