### PR TITLE
Fix template splash screen

### DIFF
--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -31,14 +31,12 @@
         "expo-splash-screen",
         {
           "backgroundColor": "#208AEF",
-          "android": {
-            "image": "./assets/images/splash-icon.png",
-            "imageWidth": 76
-          }
+          "image": "./assets/images/splash-icon.png",
+          "imageWidth": 76
         }
       ],
       [
-        "expo-brownfield", 
+        "expo-brownfield",
         {
           "ios": {
             "buildReactNativeFromSource": false

--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -29,10 +29,8 @@
         "expo-splash-screen",
         {
           "backgroundColor": "#208AEF",
-          "android": {
-            "image": "./assets/images/splash-icon.png",
-            "imageWidth": 76
-          }
+          "image": "./assets/images/splash-icon.png",
+          "imageWidth": 76
         }
       ]
     ],

--- a/templates/expo-template-default/src/app/_layout.tsx
+++ b/templates/expo-template-default/src/app/_layout.tsx
@@ -1,8 +1,11 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import { useColorScheme } from 'react-native';
 
 import { AnimatedSplashOverlay } from '@/components/animated-icon';
 import AppTabs from '@/components/app-tabs';
+
+SplashScreen.preventAutoHideAsync();
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();

--- a/templates/expo-template-default/src/components/animated-icon.tsx
+++ b/templates/expo-template-default/src/components/animated-icon.tsx
@@ -1,4 +1,5 @@
 import { Image } from 'expo-image';
+import * as SplashScreen from 'expo-splash-screen';
 import { useState } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import Animated, { Easing, Keyframe } from 'react-native-reanimated';
@@ -8,13 +9,14 @@ const INITIAL_SCALE_FACTOR = Dimensions.get('screen').height / 90;
 const DURATION = 600;
 
 export function AnimatedSplashOverlay() {
+  const [animate, setAnimate] = useState(false);
   const [visible, setVisible] = useState(true);
 
   if (!visible) return null;
 
   const splashKeyframe = new Keyframe({
     0: {
-      transform: [{ scale: INITIAL_SCALE_FACTOR }],
+      transform: [{ scale: 1 }],
       opacity: 1,
     },
     20: {
@@ -31,7 +33,9 @@ export function AnimatedSplashOverlay() {
     },
   });
 
-  return (
+  const image = <Image style={styles.image} source={require('@/assets/images/expo-logo.png')} />;
+
+  return animate ? (
     <Animated.View
       entering={splashKeyframe.duration(DURATION).withCallback((finished) => {
         'worklet';
@@ -39,8 +43,19 @@ export function AnimatedSplashOverlay() {
           scheduleOnRN(setVisible, false);
         }
       })}
-      style={styles.backgroundSolidColor}
-    />
+      style={styles.splashOverlay}>
+      {image}
+    </Animated.View>
+  ) : (
+    <View
+      onLayout={() => {
+        SplashScreen.hideAsync().finally(() => {
+          setAnimate(true);
+        });
+      }}
+      style={styles.splashOverlay}>
+      {image}
+    </View>
   );
 }
 
@@ -113,7 +128,6 @@ const styles = StyleSheet.create({
     zIndex: 100,
   },
   image: {
-    position: 'absolute',
     width: 76,
     height: 71,
   },
@@ -124,9 +138,11 @@ const styles = StyleSheet.create({
     height: 128,
     position: 'absolute',
   },
-  backgroundSolidColor: {
+  splashOverlay: {
     ...StyleSheet.absoluteFill,
     backgroundColor: '#208AEF',
+    alignItems: 'center',
+    justifyContent: 'center',
     zIndex: 1000,
   },
 });


### PR DESCRIPTION
# Why

The default template's animated splash screen had two issues:

- The `expo-splash-screen` config nested `image` and `imageWidth` under an `android` key, so the splash icon only showed on Android. iOS fell back to a blank background.
- When the JS app mounted, the animated overlay swapped in immediately with a solid background and a logo scaled up by `INITIAL_SCALE_FACTOR`. That produced a visible flash / jump between the native splash and the animated one instead of a smooth handoff.

# How

- Flattened the `expo-splash-screen` plugin config in the default template so `image` / `imageWidth` apply to all platforms, matching the native splash on iOS and Android.
- Reworked `AnimatedSplashOverlay` to bridge cleanly from the native splash to the JS animation:
  - `_layout.tsx` now calls `SplashScreen.preventAutoHideAsync()` so the native splash stays up until JS is ready.
  - The overlay first renders a static `View` that mirrors the native splash (same background color, logo centered at its real size). On its `onLayout`, it hides the native splash and only then flips to the animated view, so the two frames line up and there's no flash.
  - The animation now starts the logo at `scale: 1` and animates opacity/scale out, rather than starting from the large initial scale.

# Test Plan

Created a project from the default template and ran it on iOS and Android:

- The native splash and the JS overlay now show the same centered logo on both platforms, with no flash or jump during the handoff.
- The overlay fades out smoothly and unmounts after the animation completes.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

# Video

https://github.com/user-attachments/assets/8078cd88-dd3d-4b80-9060-9f5dd2443c08