### PR TITLE
[ios][updates] Add copyEmbeddedAssets property

### DIFF
--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -9,6 +9,9 @@ end
 if ENV['EX_UPDATES_CUSTOM_INIT'] != '1'
   ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['updatesCustomInit'] == 'true' ? '1' : '0'
 end
+if ENV['EX_UPDATES_COPY_EMBEDDED_ASSETS'] != '1'
+  ENV['EX_UPDATES_COPY_EMBEDDED_ASSETS'] = podfile_properties['updatesCopyEmbeddedAssets'] == 'true' ? '1' : '0'
+end
 
 use_dev_client = false
 begin
@@ -72,6 +75,7 @@ Pod::Spec.new do |s|
 
   ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
   ex_updates_custom_init = ENV['EX_UPDATES_CUSTOM_INIT'] == '1'
+  ex_updates_copy_embedded_assets = ENV['EX_UPDATES_COPY_EMBEDDED_ASSETS'] == '1'
   if ex_updates_native_debug
     other_debug_c_flags << ' -DEX_UPDATES_NATIVE_DEBUG=1'
     other_debug_swift_flags << ' -DEX_UPDATES_NATIVE_DEBUG'
@@ -81,6 +85,12 @@ Pod::Spec.new do |s|
     other_debug_swift_flags << ' -DEX_UPDATES_CUSTOM_INIT'
     other_release_c_flags << ' -DEX_UPDATES_CUSTOM_INIT=1'
     other_release_swift_flags << ' -DEX_UPDATES_CUSTOM_INIT'
+  end
+  if ex_updates_copy_embedded_assets
+    other_debug_c_flags << ' -DEX_UPDATES_COPY_EMBEDDED_ASSETS=1'
+    other_debug_swift_flags << ' -DEX_UPDATES_COPY_EMBEDDED_ASSETS'
+    other_release_c_flags << ' -DEX_UPDATES_COPY_EMBEDDED_ASSETS=1'
+    other_release_swift_flags << ' -DEX_UPDATES_COPY_EMBEDDED_ASSETS'
   end
   if use_dev_client
     other_debug_c_flags << ' -DUSE_DEV_CLIENT=1'

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -165,6 +165,14 @@ public final class UpdatesUtils: NSObject {
 #endif
   }
 
+  internal static func shouldCopyEmbeddedAssets() -> Bool {
+#if EX_UPDATES_COPY_EMBEDDED_ASSETS
+    return true
+#else
+    return false
+#endif
+  }
+
   internal static func runBlockOnMainThread(_ block: @escaping () -> Void) {
     if Thread.isMainThread {
       block()


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C013ZK4SA12/p1782392708325469

On iOS, expo-updates reads and hashes every embedded asset and inserts a database row for it on first launch. That work synchronously gates app startup but isn't used by the launch it blocks, the embedded update serves its JS bundle and assets directly from the app binary. The copy only pre-seeds the updates cache so a later OTA update that reuses an embedded asset key can skip a re-download.

Android already exposes this as an opt-out via `EX_UPDATES_COPY_EMBEDDED_ASSETS` #36059 iOS had no equivalent.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- updates.copyEmbeddedAssets in app config
- EXUpdates.podspec reads updatesCopyEmbeddedAssets and sets the compile flag for Debug and Release.
- UpdatesUtils.shouldCopyEmbeddedAssets() exposes the macro to Swift.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- New BuildProperties-test.ts cases assert the plugin writes `updatesCopyEmbeddedAssets` correctly.
- ExpoConfig test passes