### PR TITLE
[ios][updates] Skip embedded asset copying on first launch by default

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4121,7 +4121,7 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 116c2563d2bd3a1e98326a267020e25fea8af79e
   ExpoWebBrowser: 6e3d90e3fe1952d21a8494872b1e1a485cd50e2f
   EXStructuredHeaders: 9e89bcdd636ae2ecb59995cfba3230f5d7547c08
-  EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
+  EXUpdates: 165c09b63ed318b21fdde13d8f0796ea09e350d9
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 4c998771d5218e20701b63d8358199a520a54447

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -47,6 +47,8 @@ After adding this configuration all **.png** files in all subdirectories of **ap
 
 If `assetPatternsToBeBundled` isn't included in the app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
 
+> **info** Asset selection controls which assets are eligible for over-the-air updates. It does not change which assets are bundled into the native binary, so it does not reduce app startup time.
+
 ## Verifying that an update includes all required app assets
 
 When using the asset selection, assets that do not match any file patterns will resolve in the Metro bundler. However, these assets will not be uploaded to the updates server. You have to be certain that assets not included in updates are built into the native build of the app.

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -32,6 +32,11 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
   public var launchAssetUrl: URL?
   public var assetFilesMap: [String: String]?
 
+  /// Set when the launched update is served directly from the embedded app binary. Tracked
+  /// explicitly because `assetFilesMap` is now populated with the bundle-resolved embedded assets,
+  /// so it can no longer double as the "using embedded assets" signal.
+  private var launchedFromEmbeddedBundle = false
+
   private let launcherQueue: DispatchQueue
   private var completedAssets: Int
   private let config: UpdatesConfig
@@ -54,7 +59,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
   }
 
   public func isUsingEmbeddedAssets() -> Bool {
-    return assetFilesMap == nil
+    return launchedFromEmbeddedBundle
   }
 
   public static func launchableUpdate(
@@ -178,7 +183,10 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     }
 
     if launchedUpdate.status == UpdateStatus.StatusEmbedded {
-      precondition(assetFilesMap == nil, "assetFilesMap should be null for embedded updates")
+      launchedFromEmbeddedBundle = true
+      // The embedded update's assets aren't copied into the cache, so resolve them from the app
+      // binary. Populating the map here keeps `Updates.localAssets` available instead of empty.
+      assetFilesMap = UpdatesUtils.embeddedAssetsMap(withConfig: config, database: database, logger: logger)
       launchAssetUrl = updatesBundle.url(
         forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
         withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -8,14 +8,12 @@
 import Foundation
 
 /**
- * Subclass of AppLoader which handles copying the embedded update's assets into the
- * expo-updates cache location.
+ * Subclass of AppLoader which loads the embedded update.
  *
- * Rather than launching the embedded update directly from its location in the app bundle/apk, we
- * first try to read it into the expo-updates cache and database and launch it like any other
- * update. The benefits of this include (a) a single code path for launching most updates and (b)
- * assets included in embedded updates and copied into the cache in this way do not need to be
- * redownloaded if included in future updates.
+ * By default (`EX_UPDATES_COPY_EMBEDDED_ASSETS` off) the update is registered but its assets aren't
+ * read into the database; it keeps StatusEmbedded and launches from the app binary, so first launch
+ * stays fast. When the flag is on, assets are read into the database and it launches like any other
+ * update, so a later update reusing them avoids a redownload.
  */
 @objc(EXUpdatesEmbeddedAppLoader)
 @objcMembers
@@ -28,6 +26,24 @@ public final class EmbeddedAppLoader: AppLoader {
   public static let EXUpdatesBareEmbeddedBundleFileType = "jsbundle"
 
   private static var embeddedManifestInternal: EmbeddedUpdate?
+
+  /// Whether to read and hash embedded assets into the database on first launch. Defaults to the
+  /// build-time `EX_UPDATES_COPY_EMBEDDED_ASSETS` flag (off). Overridable for testing.
+  internal var shouldCopyEmbeddedAssets: Bool = UpdatesUtils.shouldCopyEmbeddedAssets()
+
+  internal let completionQueue: DispatchQueue
+
+  public required override init(
+    config: UpdatesConfig,
+    logger: UpdatesLogger,
+    database: UpdatesDatabase,
+    directory: URL,
+    launchedUpdate: Update?,
+    completionQueue: DispatchQueue
+  ) {
+    self.completionQueue = completionQueue
+    super.init(config: config, logger: logger, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
+  }
 
   /**
    Gets the embedded update.
@@ -136,11 +152,57 @@ public final class EmbeddedAppLoader: AppLoader {
     self.assetBlock = assetBlock
     self.successBlock = successBlock
     self.errorBlock = errorBlock
+    startEmbeddedLoad(fromEmbeddedManifest: embeddedManifest)
+  }
+
+  /// Loads the embedded update: with copying off (default) registers it without ingesting assets,
+  /// otherwise loads them like any other update. Separate from `loadUpdateResponseFromEmbeddedManifest`
+  /// so tests can pass a manifest without reading the bundle.
+  internal func startEmbeddedLoad(fromEmbeddedManifest embeddedManifest: Update) {
+    if !shouldCopyEmbeddedAssets {
+      registerEmbeddedUpdateWithoutCopying(embeddedManifest)
+      return
+    }
+
     startLoading(fromUpdateResponse: UpdateResponse(
       responseHeaderData: nil,
       manifestUpdateResponsePart: ManifestUpdateResponsePart(updateManifest: embeddedManifest),
       directiveUpdateResponsePart: nil
     ))
+  }
+
+  /// Registers the embedded update without reading, hashing, or copying its assets. A StatusEmbedded
+  /// update resolves its bundle and assets from the app binary at launch. Tradeoff: a future update
+  /// reusing an embedded asset re-downloads it.
+  private func registerEmbeddedUpdateWithoutCopying(_ embeddedManifest: Update) {
+    database.databaseQueue.async {
+      do {
+        let existingUpdate = try? self.database.update(withId: embeddedManifest.updateId, config: self.config)
+        if existingUpdate == nil {
+          try self.database.addUpdate(embeddedManifest, config: self.config)
+        }
+        // Mark finished (keep = 1) so the reaper retains it; it stays StatusEmbedded since copying is off.
+        try self.database.markUpdateFinished(embeddedManifest)
+      } catch {
+        let errorBlock = self.errorBlock
+        self.completionQueue.async {
+          errorBlock?(UpdatesError.appLoaderUnknownError(cause: error))
+          self.reset()
+        }
+        return
+      }
+
+      let successBlock = self.successBlock
+      let updateResponse = UpdateResponse(
+        responseHeaderData: nil,
+        manifestUpdateResponsePart: ManifestUpdateResponsePart(updateManifest: embeddedManifest),
+        directiveUpdateResponsePart: nil
+      )
+      self.completionQueue.async {
+        successBlock?(updateResponse)
+        self.reset()
+      }
+    }
   }
 
   override public func downloadAsset(_ asset: UpdateAsset, extraHeaders: [String: Any]) {

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -280,7 +280,11 @@ public final class UpdatesDatabase: NSObject {
   }
 
   public func markUpdateFinished(_ update: Update) throws {
-    if update.status != UpdateStatus.StatusDevelopment {
+    // With copying off, embedded updates have no asset rows, so they must stay StatusEmbedded to keep
+    // launching from the bundle. Promoting to StatusReady would route launch through the database
+    // asset path, which has no rows for them.
+    let keepEmbedded = update.status == UpdateStatus.StatusEmbedded && !UpdatesUtils.shouldCopyEmbeddedAssets()
+    if update.status != UpdateStatus.StatusDevelopment && !keepEmbedded {
       update.status = UpdateStatus.StatusReady
     }
 

--- a/packages/expo-updates/ios/Tests/EmbeddedAppLoaderTests.swift
+++ b/packages/expo-updates/ios/Tests/EmbeddedAppLoaderTests.swift
@@ -1,0 +1,94 @@
+//  Copyright (c) 2024 650 Industries, Inc. All rights reserved.
+
+import Testing
+
+@testable import EXUpdates
+
+import EXManifests
+
+@Suite("EmbeddedAppLoader", .serialized)
+@MainActor
+class EmbeddedAppLoaderTests {
+  var testDatabaseDir: URL
+  var db: UpdatesDatabase
+
+  init() throws {
+    let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+    testDatabaseDir = applicationSupportDir!.appendingPathComponent("EmbeddedAppLoaderTests")
+
+    try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+    if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+      try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+    }
+
+    db = UpdatesDatabase()
+    db.databaseQueue.sync {
+      try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+    }
+  }
+
+  deinit {
+    db.databaseQueue.sync {
+      db.closeDatabase()
+    }
+    try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+  }
+
+  @Test
+  func `no-copy registers the embedded update without ingesting non-launch assets`() async throws {
+    let config = try UpdatesConfig.config(fromDictionary: [
+      UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://example.com",
+      UpdatesConfig.EXUpdatesConfigScopeKeyKey: "dummyScope",
+      UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+    ])
+
+    // Build an embedded update with a couple of non-launch assets without touching the app bundle,
+    // mirroring UpdateTests' `works for embedded bare manifest`.
+    let embeddedManifestJSON: [String: Any] = [
+      "id": "0eef8214-4833-4089-9dff-b4138a14f196",
+      "commitTime": 1609975977832,
+      "assets": [
+        ["packagerHash": "embedded-asset-1", "type": "png", "nsBundleFilename": "image1"],
+        ["packagerHash": "embedded-asset-2", "type": "png", "nsBundleFilename": "image2"],
+      ],
+    ]
+    let embeddedUpdate = Update.update(
+      withRawEmbeddedManifest: embeddedManifestJSON,
+      config: config,
+      database: db
+    )
+
+    let loader = EmbeddedAppLoader(
+      config: config,
+      logger: UpdatesLogger(),
+      database: db,
+      directory: testDatabaseDir,
+      launchedUpdate: nil,
+      completionQueue: DispatchQueue.global(qos: .default)
+    )
+    loader.shouldCopyEmbeddedAssets = false
+
+    let success: Bool = await withCheckedContinuation { continuation in
+      loader.updateResponseBlock = { _ in true }
+      loader.assetBlock = { _, _, _, _ in }
+      loader.successBlock = { _ in continuation.resume(returning: true) }
+      loader.errorBlock = { _ in continuation.resume(returning: false) }
+      loader.startEmbeddedLoad(fromEmbeddedManifest: embeddedUpdate)
+    }
+
+    #expect(success == true)
+
+    db.databaseQueue.sync {
+      // The update row is registered and stays StatusEmbedded (not promoted to StatusReady), so later
+      // launches keep resolving it from the app bundle rather than the empty database asset path.
+      let storedUpdate = try! db.update(withId: embeddedUpdate.updateId, config: config)
+      #expect(storedUpdate != nil)
+      #expect(storedUpdate?.status == .StatusEmbedded)
+
+      // Its non-launch assets were not read, hashed, or inserted.
+      let asset = try? db.asset(withKey: "embedded-asset-1")
+      #expect(asset == nil)
+    }
+  }
+}


### PR DESCRIPTION
# Why

This makes no-copy the default on iOS, matching Android. The embedded asset copy/hash/insert work was gating first launch without benefiting it, since embedded updates resolve their bundle and assets directly from the .app binary. Removing it from the default launch path is a large startup win that scales with bundled asset count and size.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- EmbeddedAppLoader.swift takes an `shouldCopyEmbeddedAssets` boolean. In the default no-copy path it registers the embedded update row without reading or hashing the non-launch assets.
- UpdatesDatabase.swift gates markUpdateFinished so that in no-copy mode embedded updates stay StatusEmbedded rather than being promoted to StatusReady by the reaper. This keeps every launch on the bundle-resolution branch. Without it, the second launch took the non-embedded ensureAllAssetsExist path with zero registered asset rows, so the completion never fired and the JS bundle never loaded.
- Docs: clarify that asset selection controls OTA eligibility, not what's bundled into the binary, and document the updates.copyEmbeddedAssets opt-in and its first-launch cost tradeoff.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Native tests are passing
- Local e2e pass
- Benchmark bare-expo in Release. Updates.launchDuration on first launch:
    - copy ON: 303.23 ms
    - copy OFF (new default): 19.21 ms