### PR TITLE
[expo][Android] Fix compilation warnings

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.kt
@@ -32,7 +32,6 @@ class MainActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
       this,
-      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       object : DefaultReactActivityDelegate(
         this,
         mainComponentName,

--- a/apps/brownfield-tester/integrated/android/app/src/main/java/dev/expo/brownfieldtester/ExpoActivity.kt
+++ b/apps/brownfield-tester/integrated/android/app/src/main/java/dev/expo/brownfieldtester/ExpoActivity.kt
@@ -22,7 +22,6 @@ class ExpoActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
       this,
-      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       object : DefaultReactActivityDelegate(
         this,
         mainComponentName,

--- a/apps/minimal-tester/android/app/src/main/java/com/community/minimaltester/MainActivity.kt
+++ b/apps/minimal-tester/android/app/src/main/java/com/community/minimaltester/MainActivity.kt
@@ -36,7 +36,6 @@ class MainActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
           this,
-          BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
           object : DefaultReactActivityDelegate(
               this,
               mainComponentName,

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -256,7 +256,6 @@ class MyReactActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
           this,
-          BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
           object : DefaultReactActivityDelegate(
               this,
               mainComponentName,

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -232,7 +232,6 @@ class MainActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
       this,
-      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       object : DefaultReactActivityDelegate(
         this,
         mainComponentName,

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -13,7 +13,7 @@ index 1789e54..b6ac31d 100644
     */
    override fun createReactActivityDelegate(): ReactActivityDelegate =
 -      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
-+      ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
++      ReactActivityDelegateWrapper(this, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
  }
 diff --git a/android/app/src/main/java/com/myapp/MainApplication.kt b/android/app/src/main/java/com/myapp/MainApplication.kt
 index 9cb435b..bd46af6 100644

--- a/packages/expo-updates/e2e/fixtures/custom_init/MainActivity.kt
+++ b/packages/expo-updates/e2e/fixtures/custom_init/MainActivity.kt
@@ -39,7 +39,6 @@ class MainActivity : ReactActivity() {
     override fun createReactActivityDelegate(): ReactActivityDelegate {
         return ReactActivityDelegateWrapper(
             this,
-            BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
             object : DefaultReactActivityDelegate(
                 this,
                 mainComponentName,

--- a/packages/expo/android/src/main/java/expo/modules/ExpoModulesPackage.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoModulesPackage.kt
@@ -31,6 +31,7 @@ class ExpoModulesPackage : ReactPackage {
     }
   }
 
+  @Deprecated("Migrate to [BaseReactPackage] and implement [getModule] instead.")
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     return moduleRegistryAdapter.createNativeModules(reactContext)
   }

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -40,12 +40,8 @@ import kotlin.coroutines.suspendCoroutine
 
 class ReactActivityDelegateWrapper(
   private val activity: ReactActivity,
-  private val isNewArchitectureEnabled: Boolean, // TODO(@lukmccall): Unused since SDK 55, remove in SDK 56
   @get:VisibleForTesting internal var delegate: ReactActivityDelegate
 ) : ReactActivityDelegate(activity, null) {
-  constructor(activity: ReactActivity, delegate: ReactActivityDelegate) :
-    this(activity, false, delegate)
-
   private val reactActivityLifecycleListeners = ExpoModulesPackage.packageList
     .flatMap { it.createReactActivityLifecycleListeners(activity) }
   private val reactActivityHandlers = ExpoModulesPackage.packageList

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -19,7 +19,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactDelegate
 import com.facebook.react.ReactHost
-import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
 import com.facebook.react.modules.core.PermissionListener
 import expo.modules.core.interfaces.ReactActivityHandler.DelayLoadAppHandler
@@ -93,10 +92,6 @@ class ReactActivityDelegateWrapper(
 
   override fun getReactHost(): ReactHost? {
     return _reactHost
-  }
-
-  override fun getReactInstanceManager(): ReactInstanceManager {
-    return delegate.reactInstanceManager
   }
 
   override fun getMainComponentName(): String? {

--- a/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
@@ -29,7 +29,7 @@ class ExpoFetchModule : Module() {
       .addInterceptor(TransparentCompressionInterceptor)
       .build()
   }
-  private val cookieHandler by lazy { ForwardingCookieHandler(reactContext) }
+  private val cookieHandler by lazy { ForwardingCookieHandler() }
   private val cookieJarContainer by lazy { client.cookieJar as CookieJarContainer }
 
   private val reactContext: ReactContext

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -39,9 +39,9 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
   val bodyUsed: Boolean
     get() = this.sink.bodyUsed
 
-  override fun deallocate() {
+  override fun sharedObjectDidRelease() {
     this.sink.finalize(directBuffer = false)
-    super.deallocate()
+    super.sharedObjectDidRelease()
   }
 
   fun onStarted() {

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
@@ -268,7 +268,6 @@ internal class MockActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate = spyk(
     ReactActivityDelegateWrapper(
       this,
-      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       spyk(
         object : DefaultReactActivityDelegate(
           this,

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
@@ -17,7 +17,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+    return new ReactActivityDelegateWrapper(this,
       new ReactActivityDelegate(this, getMainComponentName())
     );
   }

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
@@ -15,7 +15,7 @@ class MainActivity : ReactActivity() {
   }
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+    return ReactActivityDelegateWrapper(this,
       ReactActivityDelegate(this, getMainComponentName())
     );
   }

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
@@ -19,7 +19,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, new MainActivityDelegate(this, getMainComponentName()));
+    return new ReactActivityDelegateWrapper(this, new MainActivityDelegate(this, getMainComponentName()));
   }
 
   public static class MainActivityDelegate extends ReactActivityDelegate {

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
@@ -16,7 +16,7 @@ class MainActivity : ReactActivity() {
   }
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, MainActivityDelegate(this, mainComponentName))
+    return ReactActivityDelegateWrapper(this, MainActivityDelegate(this, mainComponentName))
   }
 
   class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.java
@@ -24,7 +24,7 @@ public class MainActivity extends ReactActivity {
    */
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, new DefaultReactActivityDelegate(
+    return new ReactActivityDelegateWrapper(this, new DefaultReactActivityDelegate(
         this,
         getMainComponentName(),
         // If you opted-in for the New Architecture, we enable the Fabric Renderer.

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.kt
@@ -21,7 +21,7 @@ class MainActivity : ReactActivity() {
    * (aka React 18) with two boolean flags.
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(
+    return ReactActivityDelegateWrapper(this, DefaultReactActivityDelegate(
             this,
             mainComponentName!!,  // If you opted-in for the New Architecture, we enable the Fabric Renderer.
             fabricEnabled,  // fabricEnabled

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073-updated.kt
@@ -19,5 +19,5 @@ class MainActivity : ReactActivity() {
    * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
-      ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
+      ReactActivityDelegateWrapper(this, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
 }

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainActivity.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainActivity.ts
@@ -37,14 +37,14 @@ export function setModulesMainActivity(mainActivity: string, language: 'java' | 
       ? [
           '\n  @Override',
           '  protected ReactActivityDelegate createReactActivityDelegate() {',
-          '    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,',
+          '    return new ReactActivityDelegateWrapper(this,',
           '      new ReactActivityDelegate(this, getMainComponentName())',
           '    );',
           '  }\n',
         ]
       : [
           '\n  override fun createReactActivityDelegate(): ReactActivityDelegate {',
-          '    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,',
+          '    return ReactActivityDelegateWrapper(this,',
           '      ReactActivityDelegate(this, getMainComponentName())',
           '    );',
           '  }\n',
@@ -71,8 +71,8 @@ export function setModulesMainActivity(mainActivity: string, language: 'java' | 
     }
 
     const replacement = isJava
-      ? `new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`
-      : `ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`;
+      ? `new ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`
+      : `ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`;
     mainActivity = replaceContentsWithOffset(
       mainActivity,
       replacement,
@@ -102,8 +102,8 @@ export function setModulesMainActivity(mainActivity: string, language: 'java' | 
     }
 
     const replacement = isJava
-      ? `new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`
-      : `ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`;
+      ? `new ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`
+      : `ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`;
     mainActivity = replaceContentsWithOffset(
       mainActivity,
       replacement,

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.kt
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.kt
@@ -32,7 +32,6 @@ class MainActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
           this,
-          BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
           object : DefaultReactActivityDelegate(
               this,
               mainComponentName,


### PR DESCRIPTION
# Why

Fixes the following warnings:
```gradle
`packages/expo/android/src/main/java/expo/modules/ExpoModulesPackage.kt:34:16` - This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
`packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt:22:8` - 'class ReactInstanceManager : Any' is deprecated. Deprecated in Java.
`packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt:102:16` - This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
`packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt:102:43` - 'class ReactInstanceManager : Any' is deprecated. Deprecated in Java.
`packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt:103:21` - 'val reactInstanceManager: ReactInstanceManager' is deprecated. Deprecated in Java.
`packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt:32:39` - 'constructor(reactContext: ReactContext): ForwardingCookieHandler' is deprecated. Use the default constructor.
`packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt:42:16` - This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
`packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt:44:11` - 'fun deallocate(): Unit' is deprecated. Use sharedObjectDidRelease() instead.
```
# How

- Removed `isNewArchitectureEnabled` from `ReactActivityDelegateWrapper` and updated every call in the repo, per the TODO
- Copied the deprecation annotation from `ReactPackage` to `ExpoModulesPackage.createNativeModules()`
- Removed `getReactInstanceManager`, as the docs state: “Do not access ReactInstanceManager directly. This class is going away in the New Architecture. You should access ReactHost instead.”
- Replaced deprecated `ForwardingCookieHandler(reactContext)` with `ForwardingCookieHandler()` in `ExpoFetchModule` 
- Replaced deprecated `deallocate()` with `sharedObjectDidRelease()` in `NativeResponse`, as `deallocate` is a no-op and `sharedObjectDidRelease` calls `deallocate`


# Test Plan
Green CI