### PR TITLE
[expo-app-metrics] add display name to log event

### DIFF
--- a/apps/observe-tester/components/LogEventsSection.tsx
+++ b/apps/observe-tester/components/LogEventsSection.tsx
@@ -1,5 +1,6 @@
 import AppMetrics, { type LogAttributeValue, type LogSeverity } from 'expo-app-metrics';
-import { StyleSheet, Text } from 'react-native';
+import { useState } from 'react';
+import { StyleSheet, Text, TextInput } from 'react-native';
 
 import { Button } from '@/components/Button';
 import { severityColors, usePaletteScheme } from '@/utils/severity';
@@ -99,6 +100,7 @@ const LOG_EVENT_TRIGGERS: LogEventTrigger[] = [
 export function LogEventsSection() {
   const theme = useTheme();
   const paletteScheme = usePaletteScheme();
+  const [displayName, setDisplayName] = useState('');
 
   return (
     <>
@@ -107,6 +109,22 @@ export function LogEventsSection() {
         Record a log event of the chosen severity against the current session. Each tap dispatches
         on the next flush to the OpenTelemetry logs endpoint.
       </Text>
+      <TextInput
+        style={[
+          styles.input,
+          {
+            color: theme.text.default,
+            borderColor: theme.border.default,
+            backgroundColor: theme.background.element,
+          },
+        ]}
+        value={displayName}
+        onChangeText={setDisplayName}
+        placeholder="Display name (optional)"
+        placeholderTextColor={theme.text.tertiary}
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
       {LOG_EVENT_TRIGGERS.map(({ severity, title, description, body, attributes }) => {
         const colors = severityColors(severity, theme, paletteScheme);
         return (
@@ -119,6 +137,7 @@ export function LogEventsSection() {
                 severity,
                 body,
                 attributes,
+                displayName: displayName.trim() || undefined,
               })
             }
             theme="secondary"
@@ -143,5 +162,13 @@ const styles = StyleSheet.create({
   sectionHint: {
     fontSize: 13,
     marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    marginBottom: 16,
+    fontSize: 16,
   },
 });

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Capture unhandled JavaScript errors on iOS and Android by wrapping React Native's `global.ErrorUtils` handler, recording each as an `exception` log event following OpenTelemetry's exception conventions (`exception.type`/`exception.message`/`exception.stacktrace`). Fatal errors are written to disk synchronously before the process terminates and ingested on the next launch. ([#46923](https://github.com/expo/expo/pull/46923) by [@tsapeta](https://github.com/tsapeta))
 - Add android crash reports ([#46869](https://github.com/expo/expo/pull/46869) by [@Ubax](https://github.com/Ubax))
 - Record an `expo.memory.warning` log event on iOS when the system delivers a low-memory warning, carrying the memory usage snapshot (`expo.memory.*`) taken at warning time. ([#47108](https://github.com/expo/expo/pull/47108) by [@tsapeta](https://github.com/tsapeta))
+- Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -16,8 +16,10 @@ import expo.modules.appmetrics.networkrequests.NetworkRequestFilter
 import expo.modules.appmetrics.networkrequests.NetworkRequestObserver
 import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.logevents.sanitizeLogEventAttributes
+import expo.modules.appmetrics.logevents.validateDisplayName
 import expo.modules.appmetrics.logevents.validateEventBody
 import expo.modules.appmetrics.logevents.validateEventName
+import expo.modules.appmetrics.logevents.withDisplayNameAttribute
 import expo.modules.appmetrics.memory.MemoryMetricsManager
 import expo.modules.appmetrics.storage.JsDebugSession
 import expo.modules.appmetrics.storage.JsLogRecord
@@ -90,6 +92,10 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         val validatedName = validateEventName(name) ?: return@Function
         val validatedBody = validateEventBody(options?.body)
         val sanitized = sanitizeLogEventAttributes(options?.attributes)
+        val attributes = withDisplayNameAttribute(
+          sanitized.attributes,
+          validateDisplayName(options?.displayName)
+        )
         val severity = options?.severity ?: Severity.INFO
 
         scope.launch {
@@ -109,7 +115,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
                 name = validatedName,
                 body = validatedBody,
                 severity = severity.rawValue,
-                attributes = sanitized.attributes?.let { JsonAny.encodeMapToJsonString(it) },
+                attributes = attributes?.let { JsonAny.encodeMapToJsonString(it) },
                 droppedAttributesCount = sanitized.droppedCount
               )
             )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
@@ -20,6 +20,13 @@ private val RESERVED_ATTRIBUTE_PATTERNS: List<Regex> = listOf(
 )
 
 /**
+ * Attribute key under which the SDK stores a log event's display name. Reserved (it matches the
+ * `expo.*` pattern above), so callers can't set it themselves; the SDK injects it after
+ * sanitization via [withDisplayNameAttribute].
+ */
+internal const val DISPLAY_NAME_ATTRIBUTE_KEY = "expo.log.display_name"
+
+/**
  * Maximum number of attributes accepted per log record. Mirrors the OTel SDK
  * default (`OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT`) — collectors and backends
  * start to push back well before this limit, so we cap eagerly and surface the
@@ -112,4 +119,19 @@ internal fun sanitizeLogEventAttributes(attributes: Map<String, Any?>?): Sanitiz
     attributes = if (sanitized.isEmpty()) null else sanitized,
     droppedCount = emptyKeyDrops + reservedKeyDrops.size + overflowDrops
   )
+}
+
+/**
+ * Returns `attributes` with the validated display name added under [DISPLAY_NAME_ATTRIBUTE_KEY],
+ * or `attributes` unchanged when `displayName` is `null`. Call this after
+ * [sanitizeLogEventAttributes] so the reserved key bypasses the `expo.*` drop.
+ */
+internal fun withDisplayNameAttribute(
+  attributes: Map<String, Any?>?,
+  displayName: String?
+): Map<String, Any?>? {
+  if (displayName == null) {
+    return attributes
+  }
+  return (attributes ?: emptyMap()) + (DISPLAY_NAME_ATTRIBUTE_KEY to displayName)
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/DisplayNameValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/DisplayNameValidation.kt
@@ -1,0 +1,25 @@
+package expo.modules.appmetrics.logevents
+
+// Max length of a log event display name in characters; overlong values are truncated, not dropped.
+private const val MAX_DISPLAY_NAME_LENGTH = 128
+
+/**
+ * Validates and normalizes a caller-provided log event display name.
+ *
+ * Trims surrounding whitespace and returns `null` for `null` or blank input so the call site
+ * can omit the field entirely. Overlong values are truncated with a warning, preserving the prefix.
+ */
+internal fun validateDisplayName(displayName: String?): String? {
+  if (displayName == null) {
+    return null
+  }
+  val trimmed = displayName.trim()
+  if (trimmed.isEmpty()) {
+    return null
+  }
+  return truncateToMaxLength(
+    trimmed,
+    MAX_DISPLAY_NAME_LENGTH,
+    "[AppMetrics] logEvent truncated displayName from ${trimmed.length} characters to the $MAX_DISPLAY_NAME_LENGTH-character limit."
+  )
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
@@ -1,8 +1,5 @@
 package expo.modules.appmetrics.logevents
 
-import android.util.Log
-import expo.modules.appmetrics.TAG
-
 /**
  * Maximum length of a log event body, measured in UTF-16 code units (Kotlin
  * `String.length`). Bodies longer than this are truncated rather than dropped,
@@ -17,12 +14,6 @@ import expo.modules.appmetrics.TAG
 private const val MAX_EVENT_BODY_LENGTH = 4096
 
 /**
- * Suffix appended to truncated bodies. Single character so the prefix stays
- * close to the original length budget.
- */
-private const val TRUNCATION_SUFFIX = "…"
-
-/**
  * Truncates a caller-provided log event body to `MAX_EVENT_BODY_LENGTH` characters,
  * logging a warning when truncation happens. Returns `null` for `null` input so
  * the call site can pass the result through unchanged.
@@ -31,13 +22,9 @@ internal fun validateEventBody(body: String?): String? {
   if (body == null) {
     return null
   }
-  if (body.length <= MAX_EVENT_BODY_LENGTH) {
-    return body
-  }
-  val truncated = body.substring(0, MAX_EVENT_BODY_LENGTH - TRUNCATION_SUFFIX.length) + TRUNCATION_SUFFIX
-  Log.w(
-    TAG,
+  return truncateToMaxLength(
+    body,
+    MAX_EVENT_BODY_LENGTH,
     "[AppMetrics] logEvent truncated body from ${body.length} characters to the $MAX_EVENT_BODY_LENGTH-character limit."
   )
-  return truncated
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/LogEventOptions.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/LogEventOptions.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.types.OptimizedRecord
  */
 @OptimizedRecord
 data class LogEventOptions(
+  @Field val displayName: String? = null,
   @Field val body: String? = null,
   @Field val attributes: Map<String, Any?>? = null,
   @Field val severity: Severity? = null

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Truncation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Truncation.kt
@@ -1,0 +1,21 @@
+package expo.modules.appmetrics.logevents
+
+import android.util.Log
+import expo.modules.appmetrics.TAG
+
+// Single-character ellipsis appended to a truncated value, kept short so the
+// prefix stays close to the original length budget.
+internal const val TRUNCATION_SUFFIX = "…"
+
+/**
+ * Truncates `value` to `maxLength` characters, appending [TRUNCATION_SUFFIX] and logging
+ * `warningMessage` (when given) only if truncation actually happens. Returns `value`
+ * unchanged when it already fits.
+ */
+internal fun truncateToMaxLength(value: String, maxLength: Int, warningMessage: String? = null): String {
+  if (value.length <= maxLength) {
+    return value
+  }
+  warningMessage?.let { Log.w(TAG, it) }
+  return value.substring(0, maxLength - TRUNCATION_SUFFIX.length) + TRUNCATION_SUFFIX
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
@@ -147,4 +147,27 @@ class AttributeValidationTest {
     assertEquals(1, attributes.size)
     assertEquals("ok", attributes["valid"])
   }
+
+  @Test
+  fun `withDisplayNameAttribute leaves attributes unchanged when display name is null`() {
+    val attributes = mapOf("userId" to "u_42")
+    assertEquals(attributes, withDisplayNameAttribute(attributes, null))
+    assertNull(withDisplayNameAttribute(null, null))
+  }
+
+  @Test
+  fun `withDisplayNameAttribute adds the reserved key even onto a null map`() {
+    val result = withDisplayNameAttribute(null, "Login failed")!!
+    assertEquals("Login failed", result["expo.log.display_name"])
+  }
+
+  @Test
+  fun `withDisplayNameAttribute injects the reserved key past sanitization`() {
+    // The key matches the `expo.*` reserved pattern, so it only survives because it is
+    // added after `sanitizeLogEventAttributes` rather than passing through it.
+    val sanitized = sanitizeLogEventAttributes(mapOf("userId" to "u_42")).attributes
+    val result = withDisplayNameAttribute(sanitized, "Login failed")!!
+    assertEquals("u_42", result["userId"])
+    assertEquals("Login failed", result["expo.log.display_name"])
+  }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/DisplayNameValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/DisplayNameValidationTest.kt
@@ -1,0 +1,52 @@
+package expo.modules.appmetrics.logevents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class DisplayNameValidationTest {
+  @Test
+  fun `returns null when input is null`() {
+    assertNull(validateDisplayName(null))
+  }
+
+  @Test
+  fun `passes through a short display name unchanged`() {
+    assertEquals("Login failed", validateDisplayName("Login failed"))
+  }
+
+  @Test
+  fun `trims surrounding whitespace`() {
+    assertEquals("Login failed", validateDisplayName("  Login failed\n"))
+  }
+
+  @Test
+  fun `returns null for an empty display name`() {
+    assertNull(validateDisplayName(""))
+  }
+
+  @Test
+  fun `returns null for a whitespace-only display name`() {
+    assertNull(validateDisplayName("   \t\n"))
+  }
+
+  @Test
+  fun `passes through a display name exactly at the cap`() {
+    val atLimit = "a".repeat(128)
+    assertEquals(atLimit, validateDisplayName(atLimit))
+  }
+
+  @Test
+  fun `truncates a display name just past the cap`() {
+    val oversized = "a".repeat(129)
+    val result = validateDisplayName(oversized)!!
+    assertEquals(128, result.length)
+    assertTrue(result.endsWith("…"))
+  }
+}

--- a/packages/expo-app-metrics/ios/AppMetricsModule.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsModule.swift
@@ -42,11 +42,15 @@ public final class AppMetricsModule: Module, UpdatesStateChangeListener {
       }
       let validatedBody = validateEventBody(options?.body)
       let sanitized = sanitizeLogEventAttributes(options?.attributes)
+      let attributes = withDisplayNameAttribute(
+        sanitized.attributes,
+        displayName: validateDisplayName(options?.displayName)
+      )
       // Globals merge happens in `LogRow.from` so every persistence path picks them up.
       let record = LogRecord(
         name: validatedName,
         body: validatedBody,
-        attributes: sanitized.attributes,
+        attributes: attributes,
         droppedAttributesCount: sanitized.droppedCount,
         severity: options?.severity ?? .info
       )

--- a/packages/expo-app-metrics/ios/LogEvents/AttributeValidation.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/AttributeValidation.swift
@@ -18,6 +18,11 @@ nonisolated(unsafe) private let reservedAttributePatterns: [Regex<Substring>] = 
   /^event\.name$/,
 ]
 
+/// Attribute key under which the SDK stores a log event's display name. Reserved (it matches the
+/// `expo.*` pattern above), so callers can't set it themselves; the SDK injects it after
+/// sanitization via `withDisplayNameAttribute`.
+let displayNameAttributeKey = "expo.log.display_name"
+
 /// Maximum number of attributes accepted per log record. Mirrors the OTel SDK
 /// default — collectors and backends start to push back well before this limit,
 /// so we cap eagerly and surface the overflow via `droppedAttributesCount`.
@@ -99,4 +104,16 @@ func sanitizeLogEventAttributes(_ attributes: [String: Any]?) -> SanitizedLogAtt
     attributes: sanitized.isEmpty ? nil : sanitized,
     droppedCount: emptyKeyDrops + reservedKeyDrops.count + overflowDrops
   )
+}
+
+/// Returns `attributes` with the validated display name added under `displayNameAttributeKey`,
+/// or `attributes` unchanged when `displayName` is `nil`. Call this after
+/// `sanitizeLogEventAttributes` so the reserved key bypasses the `expo.*` drop.
+func withDisplayNameAttribute(_ attributes: [String: Any]?, displayName: String?) -> [String: Any]? {
+  guard let displayName else {
+    return attributes
+  }
+  var merged = attributes ?? [:]
+  merged[displayNameAttributeKey] = displayName
+  return merged
 }

--- a/packages/expo-app-metrics/ios/LogEvents/DisplayNameValidation.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/DisplayNameValidation.swift
@@ -1,0 +1,25 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/// Max length of a log event display name in characters; overlong values are truncated, not dropped.
+private let maxDisplayNameLength = 128
+
+/// Validates and normalizes a caller-provided log event display name.
+///
+/// Trims surrounding whitespace and returns `nil` for `nil` or blank input so the call site
+/// can omit the field entirely. Overlong values are truncated with a warning, preserving the prefix.
+func validateDisplayName(_ displayName: String?) -> String? {
+  guard let displayName else {
+    return nil
+  }
+  let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmed.isEmpty {
+    return nil
+  }
+  return truncateToMaxLength(
+    trimmed,
+    maxLength: maxDisplayNameLength,
+    warningMessage:
+      "[AppMetrics] logEvent truncated displayName from \(trimmed.count) characters "
+      + "to the \(maxDisplayNameLength)-character limit."
+  )
+}

--- a/packages/expo-app-metrics/ios/LogEvents/EventBodyValidation.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/EventBodyValidation.swift
@@ -6,10 +6,6 @@
 /// was cut. Mirrors the OTel `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` default.
 private let maxEventBodyLength = 4096
 
-/// Suffix appended to truncated bodies. Single character so the prefix stays
-/// close to the original length budget.
-private let truncationSuffix = "…"
-
 /// Truncates a caller-provided log event body to `maxEventBodyLength` characters,
 /// logging a warning when truncation happens. Returns `nil` for `nil` input so
 /// the call site can pass the result through unchanged.
@@ -17,12 +13,11 @@ func validateEventBody(_ body: String?) -> String? {
   guard let body else {
     return nil
   }
-  if body.count <= maxEventBodyLength {
-    return body
-  }
-  let truncated = body.prefix(maxEventBodyLength - truncationSuffix.count) + truncationSuffix
-  logger.warn(
-    "[AppMetrics] logEvent truncated body from \(body.count) characters to the \(maxEventBodyLength)-character limit."
+  return truncateToMaxLength(
+    body,
+    maxLength: maxEventBodyLength,
+    warningMessage:
+      "[AppMetrics] logEvent truncated body from \(body.count) characters "
+      + "to the \(maxEventBodyLength)-character limit."
   )
-  return String(truncated)
 }

--- a/packages/expo-app-metrics/ios/LogEvents/LogEventOptions.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/LogEventOptions.swift
@@ -6,6 +6,7 @@ import ExpoModulesCore
 /// passed as a separate positional argument and is therefore not part of this
 /// record.
 struct LogEventOptions: Record {
+  @Field var displayName: String?
   @Field var body: String?
   @Field var attributes: [String: Any]?
   @Field var severity: Severity?

--- a/packages/expo-app-metrics/ios/LogEvents/Truncation.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/Truncation.swift
@@ -1,0 +1,18 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/// Single-character ellipsis appended to a truncated value, kept short so the
+/// prefix stays close to the original length budget.
+private let truncationSuffix = "…"
+
+/// Truncates `value` to `maxLength` characters, appending the ellipsis suffix and logging
+/// `warningMessage` (when given) only if truncation actually happens. Returns `value`
+/// unchanged when it already fits.
+func truncateToMaxLength(_ value: String, maxLength: Int, warningMessage: String? = nil) -> String {
+  if value.count <= maxLength {
+    return value
+  }
+  if let warningMessage {
+    logger.warn(warningMessage)
+  }
+  return String(value.prefix(maxLength - truncationSuffix.count) + truncationSuffix)
+}

--- a/packages/expo-app-metrics/ios/Tests/AttributeValidationTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/AttributeValidationTests.swift
@@ -136,4 +136,26 @@ struct AttributeValidationTests {
     #expect(attributes.count == 1)
     #expect(attributes["valid"] as? String == "ok")
   }
+
+  @Test
+  func `withDisplayNameAttribute leaves attributes unchanged when display name is nil`() {
+    #expect(withDisplayNameAttribute(["userId": "u_42"], displayName: nil)?["userId"] as? String == "u_42")
+    #expect(withDisplayNameAttribute(nil, displayName: nil) == nil)
+  }
+
+  @Test
+  func `withDisplayNameAttribute adds the reserved key even onto a nil map`() {
+    let result = try! #require(withDisplayNameAttribute(nil, displayName: "Login failed"))
+    #expect(result["expo.log.display_name"] as? String == "Login failed")
+  }
+
+  @Test
+  func `withDisplayNameAttribute injects the reserved key past sanitization`() {
+    // The key matches the `expo.*` reserved pattern, so it only survives because it is
+    // added after `sanitizeLogEventAttributes` rather than passing through it.
+    let sanitized = sanitizeLogEventAttributes(["userId": "u_42"]).attributes
+    let result = try! #require(withDisplayNameAttribute(sanitized, displayName: "Login failed"))
+    #expect(result["userId"] as? String == "u_42")
+    #expect(result["expo.log.display_name"] as? String == "Login failed")
+  }
 }

--- a/packages/expo-app-metrics/ios/Tests/DisplayNameValidationTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/DisplayNameValidationTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("validateDisplayName")
+struct DisplayNameValidationTests {
+  @Test
+  func `returns nil when input is nil`() {
+    #expect(validateDisplayName(nil) == nil)
+  }
+
+  @Test
+  func `passes through a short display name unchanged`() {
+    #expect(validateDisplayName("Login failed") == "Login failed")
+  }
+
+  @Test
+  func `trims surrounding whitespace`() {
+    #expect(validateDisplayName("  Login failed\n") == "Login failed")
+  }
+
+  @Test
+  func `returns nil for an empty display name`() {
+    #expect(validateDisplayName("") == nil)
+  }
+
+  @Test
+  func `returns nil for a whitespace-only display name`() {
+    #expect(validateDisplayName("   \t\n") == nil)
+  }
+
+  @Test
+  func `passes through a display name exactly at the cap`() {
+    let atLimit = String(repeating: "a", count: 128)
+    #expect(validateDisplayName(atLimit) == atLimit)
+  }
+
+  @Test
+  func `truncates a display name just past the cap`() {
+    let oversized = String(repeating: "a", count: 129)
+    let result = try! #require(validateDisplayName(oversized))
+    #expect(result.count == 128)
+    #expect(result.hasSuffix("…"))
+  }
+}

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -178,6 +178,12 @@ export type LogRecord = {
  */
 export type LogEventOptions = {
   /**
+   * Optional human-friendly label for the event. Unlike `name` (a stable machine
+   * identifier), this is meant for display in dashboards and is not constrained
+   * to a naming scheme.
+   */
+  displayName?: string | null;
+  /**
    * Optional free-form message describing the event.
    */
   body?: string | null;


### PR DESCRIPTION
# Why

Adds `displayName` argument to `logEvent` function, so that event names in UI can be customized from JS.

# How

1. Add new function argument
2. Add validation function
3. Extract truncation utility and reuse it in this function
4. Map the argument to `expo.display_name` attribute

# Test Plan

1. Observe tester
2. Unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
