### PR TITLE
[ios][updates] Add `excludeFromBackup` option

### DIFF
--- a/packages/@expo/config-plugins/src/ios/IosConfig.types.ts
+++ b/packages/@expo/config-plugins/src/ios/IosConfig.types.ts
@@ -53,4 +53,5 @@ export type ExpoPlist = {
   EXUpdatesCodeSigningMetadata?: Record<string, string>;
   EXUpdatesDisableAntiBrickingMeasures?: boolean;
   EXUpdatesEnableBsdiffPatchSupport?: boolean;
+  EXUpdatesExcludeFromBackup?: boolean;
 };

--- a/packages/@expo/config-plugins/src/ios/Updates.ts
+++ b/packages/@expo/config-plugins/src/ios/Updates.ts
@@ -17,6 +17,7 @@ import {
   getUpdatesEnabled,
   getUpdatesTimeout,
   getUpdatesBsdiffPatchSupportEnabled,
+  getUpdatesExcludeFromBackup,
   getUpdatesUseEmbeddedUpdate,
   getUpdateUrl,
 } from '../utils/Updates';
@@ -34,6 +35,7 @@ export enum Config {
   CODE_SIGNING_METADATA = 'EXUpdatesCodeSigningMetadata',
   DISABLE_ANTI_BRICKING_MEASURES = 'EXUpdatesDisableAntiBrickingMeasures',
   ENABLE_BSDIFF_PATCH_SUPPORT = 'EXUpdatesEnableBsdiffPatchSupport',
+  EXCLUDE_FROM_BACKUP = 'EXUpdatesExcludeFromBackup',
 }
 
 // when making changes to this config plugin, ensure the same changes are also made in eas-cli and build-tools
@@ -138,6 +140,13 @@ export async function setUpdatesConfigAsync(
     newExpoPlist[Config.DISABLE_ANTI_BRICKING_MEASURES] = disableAntiBrickingMeasures;
   } else {
     delete newExpoPlist[Config.DISABLE_ANTI_BRICKING_MEASURES];
+  }
+
+  const excludeFromBackup = getUpdatesExcludeFromBackup(config);
+  if (excludeFromBackup) {
+    newExpoPlist[Config.EXCLUDE_FROM_BACKUP] = true;
+  } else {
+    delete newExpoPlist[Config.EXCLUDE_FROM_BACKUP];
   }
 
   newExpoPlist[Config.ENABLE_BSDIFF_PATCH_SUPPORT] = getUpdatesBsdiffPatchSupportEnabled(config);

--- a/packages/@expo/config-plugins/src/ios/Updates.ts
+++ b/packages/@expo/config-plugins/src/ios/Updates.ts
@@ -15,6 +15,7 @@ import {
   getUpdatesEnabled,
   getUpdatesTimeout,
   getUpdatesBsdiffPatchSupportEnabled,
+  getUpdatesExcludeFromBackup,
   getUpdatesUseEmbeddedUpdate,
   getUpdateUrl,
 } from '../utils/Updates';
@@ -34,6 +35,7 @@ export enum Config {
   CODE_SIGNING_METADATA = 'EXUpdatesCodeSigningMetadata',
   DISABLE_ANTI_BRICKING_MEASURES = 'EXUpdatesDisableAntiBrickingMeasures',
   ENABLE_BSDIFF_PATCH_SUPPORT = 'EXUpdatesEnableBsdiffPatchSupport',
+  EXCLUDE_FROM_BACKUP = 'EXUpdatesExcludeFromBackup',
 }
 
 // when making changes to this config plugin, ensure the same changes are also made in eas-cli and build-tools
@@ -138,6 +140,13 @@ export async function setUpdatesConfigAsync(
     newExpoPlist[Config.DISABLE_ANTI_BRICKING_MEASURES] = disableAntiBrickingMeasures;
   } else {
     delete newExpoPlist[Config.DISABLE_ANTI_BRICKING_MEASURES];
+  }
+
+  const excludeFromBackup = getUpdatesExcludeFromBackup(config);
+  if (excludeFromBackup) {
+    newExpoPlist[Config.EXCLUDE_FROM_BACKUP] = true;
+  } else {
+    delete newExpoPlist[Config.EXCLUDE_FROM_BACKUP];
   }
 
   newExpoPlist[Config.ENABLE_BSDIFF_PATCH_SUPPORT] = getUpdatesBsdiffPatchSupportEnabled(config);

--- a/packages/@expo/config-plugins/src/ios/__tests__/Updates-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Updates-test.ts
@@ -64,4 +64,30 @@ describe('iOS Updates config', () => {
       EXUpdatesEnableBsdiffPatchSupport: true,
     });
   });
+
+  it('writes EXUpdatesExcludeFromBackup only when updates.excludeFromBackup is true', async () => {
+    const enabled = await Updates.setUpdatesConfigAsync(
+      '/app',
+      {
+        runtimeVersion: '1.0.0',
+        slug: 'my-app',
+        updates: { url: 'https://u.expo.dev/x', excludeFromBackup: true },
+      },
+      {} as any,
+      '0.11.0'
+    );
+    expect(enabled).toMatchObject({ EXUpdatesExcludeFromBackup: true });
+
+    const omitted = await Updates.setUpdatesConfigAsync(
+      '/app',
+      {
+        runtimeVersion: '1.0.0',
+        slug: 'my-app',
+        updates: { url: 'https://u.expo.dev/x' },
+      },
+      {} as any,
+      '0.11.0'
+    );
+    expect(omitted).not.toHaveProperty('EXUpdatesExcludeFromBackup');
+  });
 });

--- a/packages/@expo/config-plugins/src/utils/Updates.ts
+++ b/packages/@expo/config-plugins/src/utils/Updates.ts
@@ -235,3 +235,7 @@ export function getDisableAntiBrickingMeasures(
 ): boolean | undefined {
   return config.updates?.disableAntiBrickingMeasures;
 }
+
+export function getUpdatesExcludeFromBackup(config: Pick<ExpoConfigUpdates, 'updates'>): boolean {
+  return config.updates?.excludeFromBackup ?? false;
+}

--- a/packages/@expo/config-plugins/src/utils/Updates.ts
+++ b/packages/@expo/config-plugins/src/utils/Updates.ts
@@ -248,3 +248,7 @@ export function getDisableAntiBrickingMeasures(
 ): boolean | undefined {
   return config.updates?.disableAntiBrickingMeasures;
 }
+
+export function getUpdatesExcludeFromBackup(config: Pick<ExpoConfigUpdates, 'updates'>): boolean {
+  return config.updates?.excludeFromBackup ?? false;
+}

--- a/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -14,6 +14,7 @@ import {
   getUpdatesRequestHeadersStringified,
   getUpdatesEnabled,
   getUpdatesTimeout,
+  getUpdatesExcludeFromBackup,
   getUpdatesUseEmbeddedUpdate,
   getUpdateUrl,
   FINGERPRINT_RUNTIME_VERSION_SENTINEL,
@@ -186,6 +187,20 @@ describe(getUpdatesUseEmbeddedUpdate, () => {
 
   it('returns true if updates.useEmbeddedUpdate is undefined', () => {
     expect(getUpdatesUseEmbeddedUpdate({ updates: {} })).toBe(true);
+  });
+});
+
+describe(getUpdatesExcludeFromBackup, () => {
+  it('returns true if updates.excludeFromBackup is true', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: { excludeFromBackup: true } })).toBe(true);
+  });
+
+  it('returns false if updates.excludeFromBackup is false', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: { excludeFromBackup: false } })).toBe(false);
+  });
+
+  it('returns false if updates.excludeFromBackup is undefined', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: {} })).toBe(false);
   });
 });
 

--- a/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -15,6 +15,7 @@ import {
   getUpdatesRequestHeadersStringified,
   getUpdatesEnabled,
   getUpdatesTimeout,
+  getUpdatesExcludeFromBackup,
   getUpdatesUseEmbeddedUpdate,
   getUpdateUrl,
   FINGERPRINT_RUNTIME_VERSION_SENTINEL,
@@ -228,6 +229,20 @@ describe(getUpdatesUseEmbeddedUpdate, () => {
 
   it('returns true if updates.useEmbeddedUpdate is undefined', () => {
     expect(getUpdatesUseEmbeddedUpdate({ updates: {} })).toBe(true);
+  });
+});
+
+describe(getUpdatesExcludeFromBackup, () => {
+  it('returns true if updates.excludeFromBackup is true', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: { excludeFromBackup: true } })).toBe(true);
+  });
+
+  it('returns false if updates.excludeFromBackup is false', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: { excludeFromBackup: false } })).toBe(false);
+  });
+
+  it('returns false if updates.excludeFromBackup is undefined', () => {
+    expect(getUpdatesExcludeFromBackup({ updates: {} })).toBe(false);
   });
 });
 

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -180,6 +180,12 @@ export interface ExpoConfig {
      * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to true.
      */
     enableBsdiffPatchSupport?: boolean;
+    /**
+     * Whether to exclude the expo-updates directory from device backups (iCloud). Defaults to false. When set to true, downloaded updates are not included in backups, which can significantly shrink backup size for apps with large updates. On restore the device has no cached update and runs the embedded update until the latest update is downloaded again.
+     *
+     * @platform ios
+     */
+    excludeFromBackup?: boolean;
   };
   /**
    * Provide per-locale values for System Dialog prompts such as Permissions Boxes, and create Localizable.strings file to localize (for example) push notifications. Platform-specific locale strings should be nested under `ios` and `android` keys.

--- a/packages/@expo/config-types/src/__tests__/fixtures/ExpoConfig.backup.ts
+++ b/packages/@expo/config-types/src/__tests__/fixtures/ExpoConfig.backup.ts
@@ -180,6 +180,12 @@ export interface ExpoConfig {
      * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to true.
      */
     enableBsdiffPatchSupport?: boolean;
+    /**
+     * Whether to exclude the expo-updates directory from device backups (iCloud). Defaults to false. When set to true, downloaded updates are not included in backups, which can significantly shrink backup size for apps with large updates. On restore the device has no cached update and runs the embedded update until the latest update is downloaded again.
+     *
+     * @platform ios
+     */
+    excludeFromBackup?: boolean;
   };
   /**
    * Provide per-locale values for System Dialog prompts such as Permissions Boxes, and create Localizable.strings file to localize (for example) push notifications. Platform-specific locale strings should be nested under `ios` and `android` keys.

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups.
+
 ### 🐛 Bug fixes
 
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups.
+- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups. ([#47290](https://github.com/expo/expo/pull/47290) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`. ([#48020](https://github.com/expo/expo/pull/48020) by [@alanjhughes](https://github.com/alanjhughes))
 - Resolve relative asset URLs from `updateUrl` base URL ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
-- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups.
+- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups. ([#47290](https://github.com/expo/expo/pull/47290) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`. ([#48020](https://github.com/expo/expo/pull/48020) by [@alanjhughes](https://github.com/alanjhughes))
 - Resolve relative asset URLs from `updateUrl` base URL ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
+- [iOS] Add `updates.excludeFromBackup` config option to exclude the updates directory from device backups.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -273,6 +273,7 @@ public class AppController: NSObject {
       let updatesDatabase = UpdatesDatabase()
       do {
         let directory = try initializeUpdatesDirectory()
+        UpdatesUtils.setExcludedFromBackup(directory, excluded: config.excludeFromBackup, logger: logger)
         try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: directory, logger: logger)
         _sharedInstance = EnabledAppController(config: config, database: updatesDatabase, updatesDirectory: directory)
         UpdatesControllerRegistry.sharedInstance.controller = _sharedInstance as? (any UpdatesInterface)

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -81,6 +81,7 @@ public final class UpdatesConfig: NSObject {
   public static let EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey = "EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityMode"
   public static let EXUpdatesConfigDisableAntiBrickingMeasures = "EXUpdatesDisableAntiBrickingMeasures"
   public static let EXUpdatesConfigEnableBsdiffPatchSupportKey = "EXUpdatesEnableBsdiffPatchSupport"
+  public static let EXUpdatesConfigExcludeFromBackupKey = "EXUpdatesExcludeFromBackup"
 
   public static let EXUpdatesConfigCheckOnLaunchValueAlways = "ALWAYS"
   public static let EXUpdatesConfigCheckOnLaunchValueWifiOnly = "WIFI_ONLY"
@@ -104,6 +105,7 @@ public final class UpdatesConfig: NSObject {
   public let hasEmbeddedUpdate: Bool
   public let originalHasEmbeddedUpdate: Bool
   public let disableAntiBrickingMeasures: Bool
+  public let excludeFromBackup: Bool
   public let hasUpdatesOverride: Bool
 
   private let cachedConfigDictionary: [String: Any]
@@ -124,6 +126,7 @@ public final class UpdatesConfig: NSObject {
     enableExpoUpdatesProtocolV0CompatibilityMode: Bool,
     enableBsdiffPatchSupport: Bool,
     disableAntiBrickingMeasures: Bool,
+    excludeFromBackup: Bool,
     hasUpdatesOverride: Bool
   ) {
     self.cachedConfigDictionary = cachedConfigDictionary
@@ -141,6 +144,7 @@ public final class UpdatesConfig: NSObject {
     self.enableExpoUpdatesProtocolV0CompatibilityMode = enableExpoUpdatesProtocolV0CompatibilityMode
     self.enableBsdiffPatchSupport = enableBsdiffPatchSupport
     self.disableAntiBrickingMeasures = disableAntiBrickingMeasures
+    self.excludeFromBackup = excludeFromBackup
     self.hasUpdatesOverride = hasUpdatesOverride
   }
 
@@ -308,6 +312,7 @@ public final class UpdatesConfig: NSObject {
       enableExpoUpdatesProtocolV0CompatibilityMode: enableExpoUpdatesProtocolV0CompatibilityMode,
       enableBsdiffPatchSupport: enableBsdiffPatchSupport,
       disableAntiBrickingMeasures: getDisableAntiBrickingMeasures(fromDictionary: config),
+      excludeFromBackup: config.optionalValue(forKey: EXUpdatesConfigExcludeFromBackupKey) ?? false,
       hasUpdatesOverride: configOverride != nil
     )
   }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -75,6 +75,18 @@ public final class UpdatesUtils: NSObject {
     return updatesDirectory
   }
 
+  // Re-applied on every launch so toggling the config back off re-includes the directory. Only affects backup size.
+  public static func setExcludedFromBackup(_ directory: URL, excluded: Bool, logger: UpdatesLogger) {
+    var url = directory
+    do {
+      var resourceValues = URLResourceValues()
+      resourceValues.isExcludedFromBackup = excluded
+      try url.setResourceValues(resourceValues)
+    } catch {
+      logger.warn(message: "Failed to set isExcludedFromBackup=\(excluded) on updates directory: \(error.localizedDescription)")
+    }
+  }
+
   // MARK: - Internal methods
 
   public static func defaultNativeStateMachineContextJson() -> [String: Any?] {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -92,6 +92,18 @@ public final class UpdatesUtils: NSObject {
       !filename.unicodeScalars.contains("\0")
   }
 
+  // Re-applied on every launch so toggling the config back off re-includes the directory. Only affects backup size.
+  public static func setExcludedFromBackup(_ directory: URL, excluded: Bool, logger: UpdatesLogger) {
+    var url = directory
+    do {
+      var resourceValues = URLResourceValues()
+      resourceValues.isExcludedFromBackup = excluded
+      try url.setResourceValues(resourceValues)
+    } catch {
+      logger.warn(message: "Failed to set isExcludedFromBackup=\(excluded) on updates directory: \(error.localizedDescription)")
+    }
+  }
+
   // MARK: - Internal methods
 
   public static func defaultNativeStateMachineContextJson() -> [String: Any?] {

--- a/packages/expo-updates/ios/Tests/UpdatesConfigTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesConfigTests.swift
@@ -30,6 +30,7 @@ struct UpdatesConfigTests {
     #expect(config.enableBsdiffPatchSupport == true)
     #expect(config.runtimeVersion == "fake-version-1")
     #expect(config.hasEmbeddedUpdate == true)
+    #expect(config.excludeFromBackup == false)
   }
 
   @Test
@@ -45,6 +46,7 @@ struct UpdatesConfigTests {
       UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "http://google.com",
       UpdatesConfig.EXUpdatesConfigRequestHeadersKey: ["Foo": "Bar"],
       UpdatesConfig.EXUpdatesConfigEnableBsdiffPatchSupportKey: false,
+      UpdatesConfig.EXUpdatesConfigExcludeFromBackupKey: true,
     ]
 
     guard let configNSDictionary = NSDictionary(contentsOfFile: configPlistPath) as? [String: Any] else {
@@ -64,6 +66,7 @@ struct UpdatesConfigTests {
     #expect(config.enableBsdiffPatchSupport == false)
     #expect(config.runtimeVersion == "overridden")
     #expect(config.hasEmbeddedUpdate == true)
+    #expect(config.excludeFromBackup == true)
   }
 
   // MARK: - normalizedURLOrigin


### PR DESCRIPTION
# Why
By default the updates directory `.expo-internal`, is included in device backups. It holds downloaded update bundles, their assets, and the updates database, so for apps with large updates it can dominate the iCloud backup. Update bundles are re-downloadable, so backing them up is wasted space.

# How
Added a new `updates.excludeFromBackup` config option. When enabled, we set `isExcludedFromBackup` on the updates directory.

# Test Plan
CI
Added new tests
