### PR TITLE
[ci] Fix failing `brownfield-isolated` workflow

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -1,5 +1,5 @@
 name: E2E Test Suite for Expo Brownfield (Isolated)
-# test
+
 on:
   workflow_dispatch: {}
   push:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -1,5 +1,5 @@
 name: E2E Test Suite for Expo Brownfield (Isolated)
-
+# test
 on:
   workflow_dispatch: {}
   push:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -11,6 +11,10 @@ on:
       - '!**/*.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/communication.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/navigation.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/_nested-flows/**
   pull_request:
     paths:
       - apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -19,6 +23,10 @@ on:
       - '!**/*.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/communication.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/navigation.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
+      - packages/expo-brownfield/e2e/maestro/__tests__/common/_nested-flows/**
 
 concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}

--- a/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
+++ b/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
@@ -21,7 +21,10 @@ appId: ${APP_ID}
 - assertVisible:
     text: 'Toggle element inspector'
     enabled: true
-- assertVisible: 'Open DevTools'
+- scrollUntilVisible:
+    element:
+      text: 'Open DevTools'
+    direction: DOWN
 
 # Assert that information about the app
 # is correctly loaded

--- a/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
+++ b/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
@@ -24,7 +24,6 @@ appId: ${APP_ID}
 - scrollUntilVisible:
     element:
       text: 'Open DevTools'
-    direction: DOWN
 
 # Assert that information about the app
 # is correctly loaded


### PR DESCRIPTION
# Why

The `E2E Test Suite for Expo Brownfield (Isolated)` workflow has been failing since we bumped RN to 0.86. This change makes the test pass again.

# How

Replaced the `assertVisible` check for `Open DevTools` with `scrollUntilVisible`.

# Test Plan

Green CI