### PR TITLE
[dev-launcher][iOS] Add build's expiration date to Settings 

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
@@ -3,6 +3,7 @@
 import SwiftUI
 import AuthenticationServices
 import AppTrackingTransparency
+import EXApplication
 
 struct SettingsTabView: View {
   @Binding var selectedTab: HomeTab
@@ -126,6 +127,10 @@ struct SettingsTabView: View {
             AppInfoRow(label: "Client Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")
             Divider()
             AppInfoRow(label: "Supported SDK", value: getExpoSDKVersion())
+            if let expiration = appExpirationValue() {
+              Divider()
+              AppInfoRow(label: "Expires in", value: expiration)
+            }
           }
           .background(Color.expoSecondarySystemBackground)
           .clipShape(RoundedRectangle(cornerRadius: BorderRadius.large))
@@ -204,6 +209,24 @@ struct SettingsTabView: View {
 
   private func getExpoSDKVersion() -> String {
     return getSupportedSDKVersion()
+  }
+
+  private func appExpirationValue() -> String? {
+    guard let expiration = EXProvisioningProfile.main().expirationDate() else {
+      return nil
+    }
+
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    let expirationDay = calendar.startOfDay(for: expiration)
+    let days = calendar.dateComponents([.day], from: today, to: expirationDay).day ?? 0
+
+    if days == 0 {
+      return "today"
+    } else if days == 1 {
+      return "1 day"
+    }
+    return "\(days) days"
   }
 
   private func copyBuildInfoToClipboard() {

--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Expose the embedded provisioning profile's `expirationDate`. ([#47190](https://github.com/expo/expo/pull/47190) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 56.0.3 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-application/ios/EXApplication/EXProvisioningProfile.h
+++ b/packages/expo-application/ios/EXApplication/EXProvisioningProfile.h
@@ -18,5 +18,6 @@ typedef NS_ENUM(NSInteger, EXAppReleaseType) {
 
 - (EXAppReleaseType)appReleaseType;
 - (nullable NSString *)notificationServiceEnvironment;
+- (nullable NSDate *)expirationDate;
 
 @end

--- a/packages/expo-application/ios/EXApplication/EXProvisioningProfile.m
+++ b/packages/expo-application/ios/EXApplication/EXProvisioningProfile.m
@@ -36,6 +36,12 @@
   return apsEnvironment;
 }
 
+- (nullable NSDate *)expirationDate
+{
+  id expiration = _plist[@"ExpirationDate"];
+  return [expiration isKindOfClass:[NSDate class]] ? expiration : nil;
+}
+
 - (EXAppReleaseType)appReleaseType {
   NSString *provisioningPath = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
   if (!provisioningPath) {

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add a Settings toggle to switch between auto-launching the most recent app and showing the launcher. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Add build's expiration date to Settings. ([#47190](https://github.com/expo/expo/pull/47190) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -685,7 +685,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
 -(nullable NSString *)getAppExpirationDate
 { 
-  // App Store and Simulator builds have don't have mobileprovision
+  // App Store and Simulator builds don't have mobileprovision
   NSString *path = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
   if (!path) {
     return nil;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -675,7 +675,69 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     [buildInfo setObject:sdkVersion forKey:@"sdkVersion"];
   }
 
+  NSString *appExpirationDate = [self getAppExpirationDate];
+  if (appExpirationDate) {
+    [buildInfo setObject:appExpirationDate forKey:@"appExpirationDate"];
+  }
+
   return buildInfo;
+}
+
+-(nullable NSString *)getAppExpirationDate
+{ 
+  // App Store and Simulator builds have don't have mobileprovision
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
+  if (!path) {
+    return nil;
+  }
+ 
+  NSError *error;
+  NSString *profileString = [NSString stringWithContentsOfFile:path encoding:NSASCIIStringEncoding error:&error];
+  if (!profileString) {
+    return nil;
+  }
+
+  NSScanner *scanner = [NSScanner scannerWithString:profileString];
+  if (![scanner scanUpToString:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" intoString:nil]) {
+    return nil;
+  }
+
+  NSString *plistString;
+  if (![scanner scanUpToString:@"</plist>" intoString:&plistString]) {
+    return nil;
+  }
+  plistString = [plistString stringByAppendingString:@"</plist>"];
+
+  NSData *plistData = [plistString dataUsingEncoding:NSUTF8StringEncoding];
+  id plist = [NSPropertyListSerialization propertyListWithData:plistData
+                                                       options:NSPropertyListImmutable
+                                                        format:NULL
+                                                         error:NULL];
+  NSDate *expiration = [plist isKindOfClass:[NSDictionary class]] ? plist[@"ExpirationDate"] : nil;
+  if (![expiration isKindOfClass:[NSDate class]]) {
+    return nil;
+  }
+
+  NSDateFormatter *formatter = [NSDateFormatter new];
+  formatter.dateStyle = NSDateFormatterMediumStyle;
+  formatter.timeStyle = NSDateFormatterNoStyle;
+  NSString *formattedDate = [formatter stringFromDate:expiration];
+ 
+  NSCalendar *calendar = [NSCalendar currentCalendar];
+  NSDate *today = [calendar startOfDayForDate:[NSDate date]];
+  NSDate *expirationDay = [calendar startOfDayForDate:expiration];
+  NSInteger days = [calendar components:NSCalendarUnitDay fromDate:today toDate:expirationDay options:0].day;
+
+  NSString *relative; 
+  if (days == 0) {
+    relative = @"today";
+  } else if (days == 1) {
+    relative = @"1 day";
+  } else {
+    relative = [NSString stringWithFormat:@"%ld days", (long)days];
+  }
+
+  return relative;
 }
 
 -(NSString *)getAppIcon

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -17,7 +17,8 @@ struct SettingsTabView: View {
       "runtimeVersion": viewModel.buildInfo["runtimeVersion"] as? String ?? "",
       "sdkVersion": viewModel.structuredBuildInfo.sdkVersion ?? "",
       "appName": viewModel.buildInfo["appName"] as? String ?? "",
-      "appVersion": viewModel.buildInfo["appVersion"] as? String ?? ""
+      "appVersion": viewModel.buildInfo["appVersion"] as? String ?? "",
+      "appExpirationDate": viewModel.buildInfo["appExpirationDate"] as? String ?? ""
     ]
 
     do {
@@ -51,6 +52,10 @@ struct SettingsTabView: View {
 
           VStack(spacing: 0) {
             version
+            if let expiration = viewModel.buildInfo["appExpirationDate"] as? String {
+              Divider()
+              expirationRow(expiration)
+            }
             Divider()
             copyToClipboardButton
           }
@@ -164,6 +169,17 @@ struct SettingsTabView: View {
       Text("Version")
       Spacer()
       Text(viewModel.buildInfo["appVersion"] as? String ?? "")
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
+  private func expirationRow(_ text: String) -> some View {
+    HStack {
+      Text("Expires in")
+      Spacer()
+      Text(text)
         .foregroundColor(.secondary)
     }
     .padding(.horizontal)


### PR DESCRIPTION
# Why

Development and internal distribution build embed a provisioning profile with an `ExpirationDate`, once that date passes, iOS refuses to launch the app. Currently, we don't display this information anywhere.

# How

Update dev-launcher and Expo Go to display how many days the app will be available before it expires.

We read that directly from `embedded.mobileprovision`, which is present only on development, ad hoc, and enterprise builds, causing this not to show up in App Store and Simulator builds.

The change spans three packages:

Also had to update expo-application to expose `ExpirationDate` for Expo Go, it already parses the embedded profile plist to determine the app release type, so it is the natural home for this.

# Test Plan

Build a BareExpo and Expo Go to a physical device, then open Settings and confirm that "Expires in" row is displayed correctly.

Then cross-check the value against the profile itself:

```sh
security cms -D -i "<App>.app/embedded.mobileprovision" | plutil -extract ExpirationDate raw -
```