### PR TITLE
[go] Fix EAS pnpm version

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -8,6 +8,7 @@
   "build": {
     "base": {
       "node": "22.17.1",
+      "pnpm": "10.33.0",
       "credentialsSource": "local",
       "android": {
         "image": "ubuntu-24.04-jdk-17-ndk-r27b-sdk-55",


### PR DESCRIPTION
# Why

#47202 raised the root `package.json` `engines.pnpm` to `^10.33.0`, but the EAS build image ships an older bundled pnpm version, causing CI to fail https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/workflows/019f0519-3ec9-7caf-a38b-54c2199d67dd#job-019f0519-4156-7529-94d8-12bae60f1f9d.

# How

Pinned `pnpm` to `10.33.0` in `eas.json`.  

# Test Plan

iOS Client (Expo Go) - EAS Build` workflow should succeed 