### PR TITLE
[docs][maps] Add custom marker icon examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -160,6 +160,72 @@ export default function App() {
 }
 ```
 
+### Custom marker icons
+
+You can use the [`useImage`](/versions/latest/sdk/image/#useimage) hook from `expo-image` to load custom marker and annotation icons.
+
+<Tabs>
+<Tab label="Google Maps">
+
+The following example shows how to display a custom marker icon with Google Maps on Android.
+
+```tsx
+import { useImage } from 'expo-image';
+import { GoogleMaps } from 'expo-maps';
+
+export default function Map() {
+  const icon = useImage('https://example.com/marker.svg', { maxWidth: 48, maxHeight: 48 });
+
+  return (
+    <GoogleMaps.View
+      style={{ flex: 1 }}
+      markers={[
+        {
+          coordinates: { latitude: 37.78825, longitude: -122.4324 },
+          icon: icon ?? undefined,
+          anchor: { x: 0.5, y: 0.5 },
+        },
+      ]}
+    />
+  );
+}
+```
+
+`GoogleMaps.Marker.icon` expects an image reference, such as the value returned by the `useImage` hook from the `expo-image` package. It does not accept an image source directly.
+
+The loaded image dimensions determine the marker size, not a marker style prop. For SVG icons, set `width`, `height`, and `viewBox` in the SVG, or pass `maxWidth` and `maxHeight` to the `useImage` hook. You can use `anchor` to align custom icons with their coordinates.
+
+</Tab>
+<Tab label="Apple Maps">
+
+The following example shows how to display a custom annotation icon with Apple Maps on iOS.
+
+```tsx
+import { useImage } from 'expo-image';
+import { AppleMaps } from 'expo-maps';
+
+export default function Map() {
+  const icon = useImage('https://example.com/marker.svg');
+
+  return (
+    <AppleMaps.View
+      style={{ flex: 1 }}
+      annotations={[
+        {
+          coordinates: { latitude: 37.78825, longitude: -122.4324 },
+          icon: icon ?? undefined,
+        },
+      ]}
+    />
+  );
+}
+```
+
+`AppleMaps.Annotation.icon` expects an image reference, such as the value returned by the `useImage` hook from the `expo-image` library. You can use `AppleMaps.Annotation` for custom image icons. `AppleMaps.Marker` supports marker-specific options such as `systemImage`, `monogram`, and `tintColor`.
+
+</Tab>
+</Tabs>
+
 ## API
 
 ```js

--- a/docs/pages/versions/v56.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/maps.mdx
@@ -160,6 +160,72 @@ export default function App() {
 }
 ```
 
+### Custom marker icons
+
+You can use the [`useImage`](/versions/v56.0.0/sdk/image/#useimage) hook from `expo-image` to load custom marker and annotation icons.
+
+<Tabs>
+<Tab label="Google Maps">
+
+The following example shows how to display a custom marker icon with Google Maps on Android.
+
+```tsx
+import { useImage } from 'expo-image';
+import { GoogleMaps } from 'expo-maps';
+
+export default function Map() {
+  const icon = useImage('https://example.com/marker.svg', { maxWidth: 48, maxHeight: 48 });
+
+  return (
+    <GoogleMaps.View
+      style={{ flex: 1 }}
+      markers={[
+        {
+          coordinates: { latitude: 37.78825, longitude: -122.4324 },
+          icon: icon ?? undefined,
+          anchor: { x: 0.5, y: 0.5 },
+        },
+      ]}
+    />
+  );
+}
+```
+
+`GoogleMaps.Marker.icon` expects an image reference, such as the value returned by the `useImage` hook from the `expo-image` package. It does not accept an image source directly.
+
+The loaded image dimensions determine the marker size, not a marker style prop. For SVG icons, set `width`, `height`, and `viewBox` in the SVG, or pass `maxWidth` and `maxHeight` to the `useImage` hook. You can use `anchor` to align custom icons with their coordinates.
+
+</Tab>
+<Tab label="Apple Maps">
+
+The following example shows how to display a custom annotation icon with Apple Maps on iOS.
+
+```tsx
+import { useImage } from 'expo-image';
+import { AppleMaps } from 'expo-maps';
+
+export default function Map() {
+  const icon = useImage('https://example.com/marker.svg');
+
+  return (
+    <AppleMaps.View
+      style={{ flex: 1 }}
+      annotations={[
+        {
+          coordinates: { latitude: 37.78825, longitude: -122.4324 },
+          icon: icon ?? undefined,
+        },
+      ]}
+    />
+  );
+}
+```
+
+`AppleMaps.Annotation.icon` expects an image reference, such as the value returned by the `useImage` hook from the `expo-image` library. You can use `AppleMaps.Annotation` for custom image icons. `AppleMaps.Marker` supports marker-specific options such as `systemImage`, `monogram`, and `tintColor`.
+
+</Tab>
+</Tabs>
+
 ## API
 
 ```js


### PR DESCRIPTION
## Why

I ran into this while adding custom map icons with `expo-maps`.

`GoogleMaps.Marker.icon` and `AppleMaps.Annotation.icon` expect a `SharedRef<'image'>`, but the docs currently only show basic map usage. The generated API type is correct, but it is easy to assume that `icon` accepts the same image source values as the `Image` component, such as a URL, local asset, or SVG data URI.

On Android, it is also easy to assume that Google Maps marker size comes from a marker prop, style, `anchor`, or another map-level setting. In practice, the loaded image dimensions determine the marker size. For SVG marker icons, that means the SVG needs explicit dimensions, or the image should be loaded with `maxWidth` and `maxHeight`.

## How

Add a small custom icon example to the `expo-maps` docs with separate tabs for Google Maps and Apple Maps.

The examples show:

- `useImage` from `expo-image` to create the image reference expected by the map APIs
- `GoogleMaps.Marker.icon` with `maxWidth`, `maxHeight`, and `anchor`
- `AppleMaps.Annotation.icon`, since custom image icons on Apple Maps are annotations rather than markers

The same docs update is applied to the current SDK page and the unversioned page.

## Test Plan

- `git diff --check`

## Checklist

- [x] Documentation change only; no `CHANGELOG.md` entry or package rebuild required.
- [x] Applied to both `v56.0.0` and `unversioned` docs.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
