### PR TITLE
[docs] Lazy-load Kapa Ask AI SDK out of the shared _app bundle

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -22,6 +22,7 @@ import { buildBreadcrumbListSchema, buildTechArticleSchema } from '~/constants/s
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { PageMetadata } from '~/types/common';
+import { AskPageAILoading } from '~/ui/components/AskPageAI/AskPageAILoading';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { InlineHelp } from '~/ui/components/InlineHelp';
@@ -39,6 +40,7 @@ const { LATEST_VERSION } = versions;
 
 const AskPageAILazyMount = dynamic(() => import('~/ui/components/AskPageAI/AskPageAILazyMount'), {
   ssr: false,
+  loading: () => <AskPageAILoading />,
 });
 
 export type DocPageProps = PropsWithChildren<PageMetadata>;

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,6 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
+import dynamic from 'next/dynamic';
 import { useEffect, useState, type PropsWithChildren, useRef, useCallback, useMemo } from 'react';
 
 import { getLocaleFromPath } from '~/common/i18n';
@@ -21,7 +22,6 @@ import { buildBreadcrumbListSchema, buildTechArticleSchema } from '~/constants/s
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { PageMetadata } from '~/types/common';
-import { AskPageAIOverlay } from '~/ui/components/AskPageAI';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { InlineHelp } from '~/ui/components/InlineHelp';
@@ -36,6 +36,10 @@ import {
 import { A } from '~/ui/components/Text';
 
 const { LATEST_VERSION } = versions;
+
+const AskPageAILazyMount = dynamic(() => import('~/ui/components/AskPageAI/AskPageAILazyMount'), {
+  ssr: false,
+});
 
 export type DocPageProps = PropsWithChildren<PageMetadata>;
 
@@ -56,6 +60,7 @@ export default function DocumentationPage({
 }: DocPageProps) {
   const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
   const [isAskAIVisible, setAskAIVisible] = useState(false);
+  const [hasActivatedAskAI, setHasActivatedAskAI] = useState(false);
   const [isSidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [isAskAIExpanded, setAskAIExpanded] = useState(false);
   const [didChatForceSidebarCollapse, setDidChatForceSidebarCollapse] = useState(false);
@@ -186,6 +191,12 @@ export default function DocumentationPage({
       return;
     }
     window.sessionStorage.setItem('expo-docs-ask-ai-visible', String(isAskAIVisible));
+  }, [isAskAIVisible]);
+
+  useEffect(() => {
+    if (isAskAIVisible) {
+      setHasActivatedAskAI(true);
+    }
   }, [isAskAIVisible]);
 
   useEffect(() => {
@@ -392,8 +403,8 @@ export default function DocumentationPage({
           modificationDate={modificationDate}
         />
       </DocumentationNestedScrollLayout>
-      {isAskAIEligiblePage && (
-        <AskPageAIOverlay
+      {isAskAIEligiblePage && hasActivatedAskAI && (
+        <AskPageAILazyMount
           onClose={handleAskAIChatClose}
           onMinimize={handleAskAIMinimize}
           pageTitle={title}

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider } from '@expo/styleguide';
 import { CookieConsentProvider } from '@expo/styleguide-cookie-consent';
-import { KapaProvider } from '@kapaai/react-sdk';
 import { MDXProvider } from '@mdx-js/react';
 import * as Sentry from '@sentry/react';
 import { MotionConfig } from 'framer-motion';
@@ -27,7 +26,6 @@ import '@expo/styleguide/dist/expo-theme.css';
 import '@expo/styleguide-search-ui/dist/expo-search-ui.css';
 
 const isDev = process.env.NODE_ENV === 'development';
-const KAPA_INTEGRATION_ID = '2063233f-1e70-45e8-b1b5-a872c9887afc';
 
 export const regularFont = Inter({
   display: 'swap',
@@ -100,9 +98,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 <CodeBlockSettingsProvider>
                   <MDXProvider components={rootMarkdownComponents}>
                     <Tooltip.Provider>
-                      <KapaProvider integrationId={KAPA_INTEGRATION_ID} callbacks={{}}>
-                        <Component {...pageProps} />
-                      </KapaProvider>
+                      <Component {...pageProps} />
                     </Tooltip.Provider>
                   </MDXProvider>
                 </CodeBlockSettingsProvider>

--- a/docs/ui/components/AskPageAI/AskPageAILazyMount.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAILazyMount.tsx
@@ -1,0 +1,23 @@
+import { KapaProvider } from '@kapaai/react-sdk';
+
+import { AskPageAIOverlay } from './AskPageAIOverlay';
+
+const KAPA_INTEGRATION_ID = '2063233f-1e70-45e8-b1b5-a872c9887afc';
+
+type AskPageAILazyMountProps = {
+  onClose: () => void;
+  onMinimize: () => void;
+  pageTitle?: string;
+  isExpoSdkPage?: boolean;
+  isVisible: boolean;
+  isExpanded: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+};
+
+export default function AskPageAILazyMount(props: AskPageAILazyMountProps) {
+  return (
+    <KapaProvider integrationId={KAPA_INTEGRATION_ID} callbacks={{}}>
+      <AskPageAIOverlay {...props} />
+    </KapaProvider>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAILazyMount.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAILazyMount.tsx
@@ -1,18 +1,11 @@
 import { KapaProvider } from '@kapaai/react-sdk';
+import { type ComponentProps } from 'react';
 
 import { AskPageAIOverlay } from './AskPageAIOverlay';
 
 const KAPA_INTEGRATION_ID = '2063233f-1e70-45e8-b1b5-a872c9887afc';
 
-type AskPageAILazyMountProps = {
-  onClose: () => void;
-  onMinimize: () => void;
-  pageTitle?: string;
-  isExpoSdkPage?: boolean;
-  isVisible: boolean;
-  isExpanded: boolean;
-  onExpandedChange?: (expanded: boolean) => void;
-};
+type AskPageAILazyMountProps = ComponentProps<typeof AskPageAIOverlay>;
 
 export default function AskPageAILazyMount(props: AskPageAILazyMountProps) {
   return (

--- a/docs/ui/components/AskPageAI/AskPageAILoading.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAILoading.tsx
@@ -1,0 +1,16 @@
+import { mergeClasses } from '@expo/styleguide';
+
+export function AskPageAILoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={mergeClasses(
+        'fixed right-4 bottom-4 z-120 flex flex-col items-center justify-center gap-3 rounded-2xl border border-default bg-default py-10 shadow-xl',
+        'w-[min(420px,calc(100vw-24px))]'
+      )}>
+      <span className="size-6 animate-spin rounded-full border-2 border-current border-t-transparent text-icon-secondary" />
+      <span className="text-sm text-secondary">Loading Ask AI…</span>
+    </div>
+  );
+}

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@ import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/Markdow
 import { hasDynamicData, shouldShowMarkdownActions } from '~/ui/components/MarkdownActions/paths';
 import { H1, P } from '~/ui/components/Text';
 
-import { AskPageAIConfigTrigger, AskPageAITrigger } from '../AskPageAI';
+import { AskPageAIConfigTrigger, AskPageAITrigger } from '../AskPageAI/AskPageAITrigger';
 import { PageCliVersion } from './PageCliVersion';
 import { PagePackageVersion } from './PagePackageVersion';
 import { PagePlatformTags } from './PagePlatformTags';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22178

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove the app-root `KapaProvider` from `pages/_app.tsx`.
- Add `ui/components/AskPageAI/AskPageAILazyMount.tsx` to wrap `KapaProvider` and the Ask AI overlay, isolating `@kapaai/react-sdk` into its own chunk.
- Mount the overlay in `DocumentationPage` via `next/dynamic({ ssr: false })`, gated behind a `hasActivatedAskAI` latch so an SDK page loads only on first Ask AI open or `sessionStorage` restore, and stays mounted to preserve the conversation.
- Import the Ask AI triggers in `PageHeader` directly from `./AskPageAITrigger` instead of the `AskPageAI` barrel, so the chat and overlay are no longer pulled into `_app`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and confirm Ask AI widget and overlay are working as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
