### PR TITLE
[docs] Fix heading element order on Expo Image reference page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -30,7 +30,7 @@ import { Terminal } from '~/ui/components/Snippet';
 - Implements the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) and [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) properties (see [`contentFit`](#contentfit) and [`contentPosition`](#contentposition) props)
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
 
-#### Supported image formats
+**Supported image formats**
 
 |         Format          |   Android   |     iOS     |                          Web                           |
 | :---------------------: | :---------: | :---------: | :----------------------------------------------------: |

--- a/docs/pages/versions/v54.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/image.mdx
@@ -25,7 +25,7 @@ import { Terminal } from '~/ui/components/Snippet';
 - Implements the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) and [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) properties (see [`contentFit`](#contentfit) and [`contentPosition`](#contentposition) props)
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
 
-#### Supported image formats
+**Supported image formats**
 
 |   Format   |   Android   |     iOS     |                          Web                           |
 | :--------: | :---------: | :---------: | :----------------------------------------------------: |

--- a/docs/pages/versions/v55.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/image.mdx
@@ -30,7 +30,7 @@ import { Terminal } from '~/ui/components/Snippet';
 - Implements the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) and [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) properties (see [`contentFit`](#contentfit) and [`contentPosition`](#contentposition) props)
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
 
-#### Supported image formats
+**Supported image formats**
 
 |         Format          |   Android   |     iOS     |                          Web                           |
 | :---------------------: | :---------: | :---------: | :----------------------------------------------------: |

--- a/docs/pages/versions/v56.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/image.mdx
@@ -30,7 +30,7 @@ import { Terminal } from '~/ui/components/Snippet';
 - Implements the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) and [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) properties (see [`contentFit`](#contentfit) and [`contentPosition`](#contentposition) props)
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
 
-#### Supported image formats
+**Supported image formats**
 
 |         Format          |   Android   |     iOS     |                          Web                           |
 | :---------------------: | :---------: | :---------: | :----------------------------------------------------: |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22181

# How

<!--
How did you build this feature or fix this bug and why?
-->

Convert the top most h4 into bold text. Visually, nothing changes.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
