### PR TITLE
[crypto][android] Fix AESSealedData.fromCombined() throwing when given a base64 string

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `AESSealedData.fromCombined()` throwing on Android when given a base64-encoded string. ([#47274](https://github.com/expo/expo/issues/47274))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-26

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `AESSealedData.fromCombined()` throwing on Android when given a base64-encoded string. ([#47274](https://github.com/expo/expo/issues/47274))
+- Fix `AESSealedData.fromCombined()` throwing on Android when given a base64-encoded string. ([#47317](https://github.com/expo/expo/pull/47317) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/AesCryptoModule.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/AesCryptoModule.kt
@@ -77,9 +77,9 @@ class AesCryptoModule : Module() {
       }
 
       StaticFunction("fromParts", this@AesCryptoModule::sealedDataFromParts)
-      StaticFunction("fromCombined") { combined: ByteArray, config: SealedDataConfig? ->
+      StaticFunction("fromCombined") { combined: BinaryInput, config: SealedDataConfig? ->
         val config = config ?: SealedDataConfig()
-        SealedData(config, content = combined)
+        SealedData(config, content = combined.toBytes())
       }
 
       AsyncFunction("iv") { sealedData: SealedData, format: DataFormat? ->


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/47274

`AESSealedData.fromCombined()` is documented to accept a `BinaryInput`, where "when providing a string, it must be base64-encoded." That works on iOS and Web, but on Android passing a base64 string throws inside `fromCombined`.

# How

Changed the Android `fromCombined` parameter from `ByteArray` to `BinaryInput` and decoded it with the module's existing `toBytes()` helper, matching iOS. This is purely a widening of accepted input: a `ByteArray` still flows through unchanged (`toBytes()` returns it as-is), and base64 strings are now decoded instead of throwing. The public TypeScript type and JS signature are unchanged, so there is no API break.

# Test Plan

The repro from the issue (encrypt, then `AESSealedData.fromCombined(base64String)` and decrypt) now succeeds on Android 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
