### PR TITLE
[bare-expo][macOS] Fix react-native-macos patch

### DIFF
--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -326,7 +326,7 @@ PODS:
   - EXUpdatesInterface (56.0.2):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.7)
+  - FBLazyVector (0.81.8)
   - fmt (12.1.0)
   - glog (0.3.5)
   - hermes-engine (0.81.6):
@@ -351,28 +351,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 12.1.0)
     - glog
-  - RCTDeprecation (0.81.7)
-  - RCTRequired (0.81.7)
-  - RCTTypeSafety (0.81.7):
-    - FBLazyVector (= 0.81.7)
-    - RCTRequired (= 0.81.7)
-    - React-Core (= 0.81.7)
+  - RCTDeprecation (0.81.8)
+  - RCTRequired (0.81.8)
+  - RCTTypeSafety (0.81.8):
+    - FBLazyVector (= 0.81.8)
+    - RCTRequired (= 0.81.8)
+    - React-Core (= 0.81.8)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.7):
-    - React-Core (= 0.81.7)
-    - React-Core/DevSupport (= 0.81.7)
-    - React-Core/RCTWebSocket (= 0.81.7)
-    - React-RCTActionSheet (= 0.81.7)
-    - React-RCTAnimation (= 0.81.7)
-    - React-RCTBlob (= 0.81.7)
-    - React-RCTImage (= 0.81.7)
-    - React-RCTLinking (= 0.81.7)
-    - React-RCTNetwork (= 0.81.7)
-    - React-RCTSettings (= 0.81.7)
-    - React-RCTText (= 0.81.7)
-    - React-RCTVibration (= 0.81.7)
-  - React-callinvoker (0.81.7)
-  - React-Core (0.81.7):
+  - React (0.81.8):
+    - React-Core (= 0.81.8)
+    - React-Core/DevSupport (= 0.81.8)
+    - React-Core/RCTWebSocket (= 0.81.8)
+    - React-RCTActionSheet (= 0.81.8)
+    - React-RCTAnimation (= 0.81.8)
+    - React-RCTBlob (= 0.81.8)
+    - React-RCTImage (= 0.81.8)
+    - React-RCTLinking (= 0.81.8)
+    - React-RCTNetwork (= 0.81.8)
+    - React-RCTSettings (= 0.81.8)
+    - React-RCTText (= 0.81.8)
+    - React-RCTVibration (= 0.81.8)
+  - React-callinvoker (0.81.8)
+  - React-Core (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -382,7 +382,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.7)
+    - React-Core/Default (= 0.81.8)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -397,82 +397,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.7)
-    - React-Core/RCTWebSocket (= 0.81.7)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.7):
+  - React-Core/CoreModulesHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -497,7 +422,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.7):
+  - React-Core/Default (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.8)
+    - React-Core/RCTWebSocket (= 0.81.8)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -522,7 +497,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.7):
+  - React-Core/RCTAnimationHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -547,7 +522,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.7):
+  - React-Core/RCTBlobHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -572,7 +547,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.7):
+  - React-Core/RCTImageHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -597,7 +572,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.7):
+  - React-Core/RCTLinkingHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -622,7 +597,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.7):
+  - React-Core/RCTNetworkHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -647,7 +622,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.7):
+  - React-Core/RCTSettingsHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -672,7 +647,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.7):
+  - React-Core/RCTTextHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -697,7 +672,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.7):
+  - React-Core/RCTVibrationHeaders (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -707,7 +682,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.7)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -722,7 +697,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.7):
+  - React-Core/RCTWebSocket (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.8)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,20 +730,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.7)
-    - React-Core/CoreModulesHeaders (= 0.81.7)
-    - React-jsi (= 0.81.7)
+    - RCTTypeSafety (= 0.81.8)
+    - React-Core/CoreModulesHeaders (= 0.81.8)
+    - React-jsi (= 0.81.8)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.7)
+    - React-RCTImage (= 0.81.8)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.7):
+  - React-cxxreact (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -752,19 +752,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.7)
-    - React-debug (= 0.81.7)
-    - React-jsi (= 0.81.7)
+    - React-callinvoker (= 0.81.8)
+    - React-debug (= 0.81.8)
+    - React-jsi (= 0.81.8)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.7)
-    - React-perflogger (= 0.81.7)
+    - React-logger (= 0.81.8)
+    - React-perflogger (= 0.81.8)
     - React-runtimeexecutor
-    - React-timing (= 0.81.7)
+    - React-timing (= 0.81.8)
     - SocketRocket
-  - React-debug (0.81.7)
-  - React-defaultsnativemodule (0.81.7):
+  - React-debug (0.81.8)
+  - React-defaultsnativemodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -781,7 +781,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.7):
+  - React-domnativemodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -801,7 +801,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.7):
+  - React-Fabric (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -815,23 +815,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.7)
-    - React-Fabric/attributedstring (= 0.81.7)
-    - React-Fabric/bridging (= 0.81.7)
-    - React-Fabric/componentregistry (= 0.81.7)
-    - React-Fabric/componentregistrynative (= 0.81.7)
-    - React-Fabric/components (= 0.81.7)
-    - React-Fabric/consistency (= 0.81.7)
-    - React-Fabric/core (= 0.81.7)
-    - React-Fabric/dom (= 0.81.7)
-    - React-Fabric/imagemanager (= 0.81.7)
-    - React-Fabric/leakchecker (= 0.81.7)
-    - React-Fabric/mounting (= 0.81.7)
-    - React-Fabric/observers (= 0.81.7)
-    - React-Fabric/scheduler (= 0.81.7)
-    - React-Fabric/telemetry (= 0.81.7)
-    - React-Fabric/templateprocessor (= 0.81.7)
-    - React-Fabric/uimanager (= 0.81.7)
+    - React-Fabric/animations (= 0.81.8)
+    - React-Fabric/attributedstring (= 0.81.8)
+    - React-Fabric/bridging (= 0.81.8)
+    - React-Fabric/componentregistry (= 0.81.8)
+    - React-Fabric/componentregistrynative (= 0.81.8)
+    - React-Fabric/components (= 0.81.8)
+    - React-Fabric/consistency (= 0.81.8)
+    - React-Fabric/core (= 0.81.8)
+    - React-Fabric/dom (= 0.81.8)
+    - React-Fabric/imagemanager (= 0.81.8)
+    - React-Fabric/leakchecker (= 0.81.8)
+    - React-Fabric/mounting (= 0.81.8)
+    - React-Fabric/observers (= 0.81.8)
+    - React-Fabric/scheduler (= 0.81.8)
+    - React-Fabric/telemetry (= 0.81.8)
+    - React-Fabric/templateprocessor (= 0.81.8)
+    - React-Fabric/uimanager (= 0.81.8)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -843,32 +843,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.7):
+  - React-Fabric/animations (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -893,7 +868,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.7):
+  - React-Fabric/attributedstring (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -918,7 +893,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.7):
+  - React-Fabric/bridging (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -943,7 +918,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.7):
+  - React-Fabric/componentregistry (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -968,36 +943,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.7)
-    - React-Fabric/components/root (= 0.81.7)
-    - React-Fabric/components/scrollview (= 0.81.7)
-    - React-Fabric/components/view (= 0.81.7)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.7):
+  - React-Fabric/componentregistrynative (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1022,7 +968,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.7):
+  - React-Fabric/components (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.8)
+    - React-Fabric/components/root (= 0.81.8)
+    - React-Fabric/components/scrollview (= 0.81.8)
+    - React-Fabric/components/view (= 0.81.8)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1047,7 +1022,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.7):
+  - React-Fabric/components/root (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1072,7 +1047,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.7):
+  - React-Fabric/components/scrollview (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1099,7 +1099,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.7):
+  - React-Fabric/consistency (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1124,7 +1124,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.7):
+  - React-Fabric/core (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1149,7 +1149,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.7):
+  - React-Fabric/dom (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1174,7 +1174,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.7):
+  - React-Fabric/imagemanager (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1199,7 +1199,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.7):
+  - React-Fabric/leakchecker (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1224,7 +1224,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.7):
+  - React-Fabric/mounting (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1249,7 +1249,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.7):
+  - React-Fabric/observers (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1263,7 +1263,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.7)
+    - React-Fabric/observers/events (= 0.81.8)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1275,7 +1275,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.7):
+  - React-Fabric/observers/events (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1300,7 +1300,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.7):
+  - React-Fabric/scheduler (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1327,7 +1327,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.7):
+  - React-Fabric/telemetry (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1352,7 +1352,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.7):
+  - React-Fabric/templateprocessor (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1377,7 +1377,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.7):
+  - React-Fabric/uimanager (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1391,7 +1391,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.7)
+    - React-Fabric/uimanager/consistency (= 0.81.8)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1404,7 +1404,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.7):
+  - React-Fabric/uimanager/consistency (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1430,7 +1430,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.7):
+  - React-FabricComponents (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1445,8 +1445,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.7)
-    - React-FabricComponents/textlayoutmanager (= 0.81.7)
+    - React-FabricComponents/components (= 0.81.8)
+    - React-FabricComponents/textlayoutmanager (= 0.81.8)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1459,7 +1459,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.7):
+  - React-FabricComponents/components (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1474,17 +1474,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.7)
-    - React-FabricComponents/components/iostextinput (= 0.81.7)
-    - React-FabricComponents/components/modal (= 0.81.7)
-    - React-FabricComponents/components/rncore (= 0.81.7)
-    - React-FabricComponents/components/safeareaview (= 0.81.7)
-    - React-FabricComponents/components/scrollview (= 0.81.7)
-    - React-FabricComponents/components/switch (= 0.81.7)
-    - React-FabricComponents/components/text (= 0.81.7)
-    - React-FabricComponents/components/textinput (= 0.81.7)
-    - React-FabricComponents/components/unimplementedview (= 0.81.7)
-    - React-FabricComponents/components/virtualview (= 0.81.7)
+    - React-FabricComponents/components/inputaccessory (= 0.81.8)
+    - React-FabricComponents/components/iostextinput (= 0.81.8)
+    - React-FabricComponents/components/modal (= 0.81.8)
+    - React-FabricComponents/components/rncore (= 0.81.8)
+    - React-FabricComponents/components/safeareaview (= 0.81.8)
+    - React-FabricComponents/components/scrollview (= 0.81.8)
+    - React-FabricComponents/components/switch (= 0.81.8)
+    - React-FabricComponents/components/text (= 0.81.8)
+    - React-FabricComponents/components/textinput (= 0.81.8)
+    - React-FabricComponents/components/unimplementedview (= 0.81.8)
+    - React-FabricComponents/components/virtualview (= 0.81.8)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1497,34 +1497,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.7):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.7):
+  - React-FabricComponents/components/inputaccessory (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1551,7 +1524,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.7):
+  - React-FabricComponents/components/iostextinput (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1578,7 +1551,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.7):
+  - React-FabricComponents/components/modal (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1605,7 +1578,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.7):
+  - React-FabricComponents/components/rncore (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1632,7 +1605,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.7):
+  - React-FabricComponents/components/safeareaview (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1659,7 +1632,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.7):
+  - React-FabricComponents/components/scrollview (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1686,7 +1659,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.7):
+  - React-FabricComponents/components/switch (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1713,7 +1686,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.7):
+  - React-FabricComponents/components/text (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1740,7 +1713,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.7):
+  - React-FabricComponents/components/textinput (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1767,7 +1740,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.7):
+  - React-FabricComponents/components/unimplementedview (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1794,7 +1767,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.7):
+  - React-FabricComponents/components/virtualview (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1821,7 +1794,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.7):
+  - React-FabricComponents/textlayoutmanager (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1830,21 +1803,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.7)
-    - RCTTypeSafety (= 0.81.7)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.8):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.8)
+    - RCTTypeSafety (= 0.81.8)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.7)
+    - React-jsiexecutor (= 0.81.8)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.7):
+  - React-featureflags (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1853,7 +1853,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.7):
+  - React-featureflagsnativemodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1868,7 +1868,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.7):
+  - React-graphics (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1882,7 +1882,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.7):
+  - React-hermes (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1891,16 +1891,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.7)
+    - React-cxxreact (= 0.81.8)
     - React-jsi
-    - React-jsiexecutor (= 0.81.7)
+    - React-jsiexecutor (= 0.81.8)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.7)
+    - React-perflogger (= 0.81.8)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.7):
+  - React-idlecallbacksnativemodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1916,7 +1916,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.7):
+  - React-ImageManager (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1931,7 +1931,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.7):
+  - React-jserrorhandler (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1946,7 +1946,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.7):
+  - React-jsi (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1956,7 +1956,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.7):
+  - React-jsiexecutor (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1965,15 +1965,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.7)
-    - React-jsi (= 0.81.7)
+    - React-cxxreact (= 0.81.8)
+    - React-jsi (= 0.81.8)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.7)
+    - React-perflogger (= 0.81.8)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.7):
+  - React-jsinspector (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -1988,10 +1988,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.7)
+    - React-perflogger (= 0.81.8)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.7):
+  - React-jsinspectorcdp (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2000,7 +2000,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.7):
+  - React-jsinspectornetwork (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2013,7 +2013,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.7):
+  - React-jsinspectortracing (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2024,7 +2024,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.7):
+  - React-jsitooling (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2032,16 +2032,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.7)
-    - React-jsi (= 0.81.7)
+    - React-cxxreact (= 0.81.8)
+    - React-jsi (= 0.81.8)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.7):
+  - React-jsitracing (0.81.8):
     - React-jsi
-  - React-logger (0.81.7):
+  - React-logger (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2050,7 +2050,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.7):
+  - React-Mapbuffer (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2060,7 +2060,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.7):
+  - React-microtasksnativemodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2160,7 +2160,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.7):
+  - React-NativeModulesApple (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2180,8 +2180,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.7)
-  - React-perflogger (0.81.7):
+  - React-oscompat (0.81.8)
+  - React-perflogger (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2190,7 +2190,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.7):
+  - React-performancetimeline (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2203,9 +2203,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.7):
-    - React-Core/RCTActionSheetHeaders (= 0.81.7)
-  - React-RCTAnimation (0.81.7):
+  - React-RCTActionSheet (0.81.8):
+    - React-Core/RCTActionSheetHeaders (= 0.81.8)
+  - React-RCTAnimation (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2221,7 +2221,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.7):
+  - React-RCTAppDelegate (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2255,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.7):
+  - React-RCTBlob (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2274,7 +2274,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.7):
+  - React-RCTFabric (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2309,7 +2309,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.7):
+  - React-RCTFBReactNativeSpec (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2323,10 +2323,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.7)
+    - React-RCTFBReactNativeSpec/components (= 0.81.8)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.7):
+  - React-RCTFBReactNativeSpec/components (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2349,7 +2349,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.7):
+  - React-RCTImage (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2365,14 +2365,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.7):
-    - React-Core/RCTLinkingHeaders (= 0.81.7)
-    - React-jsi (= 0.81.7)
+  - React-RCTLinking (0.81.8):
+    - React-Core/RCTLinkingHeaders (= 0.81.8)
+    - React-jsi (= 0.81.8)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.7)
-  - React-RCTNetwork (0.81.7):
+    - ReactCommon/turbomodule/core (= 0.81.8)
+  - React-RCTNetwork (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2390,7 +2390,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.7):
+  - React-RCTRuntime (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2410,7 +2410,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.7):
+  - React-RCTSettings (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2425,10 +2425,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.7):
-    - React-Core/RCTTextHeaders (= 0.81.7)
+  - React-RCTText (0.81.8):
+    - React-Core/RCTTextHeaders (= 0.81.8)
     - Yoga
-  - React-RCTVibration (0.81.7):
+  - React-RCTVibration (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2442,11 +2442,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.7)
-  - React-renderercss (0.81.7):
+  - React-rendererconsistency (0.81.8)
+  - React-renderercss (0.81.8):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.7):
+  - React-rendererdebug (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2456,7 +2456,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.7):
+  - React-RuntimeApple (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2485,7 +2485,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.7):
+  - React-RuntimeCore (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2507,7 +2507,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.7):
+  - React-runtimeexecutor (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2517,10 +2517,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.7)
+    - React-jsi (= 0.81.8)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.7):
+  - React-RuntimeHermes (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2541,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.7):
+  - React-runtimescheduler (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2563,9 +2563,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.7):
+  - React-timing (0.81.8):
     - React-debug
-  - React-utils (0.81.7):
+  - React-utils (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2575,11 +2575,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.7)
+    - React-jsi (= 0.81.8)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.7):
+  - ReactAppDependencyProvider (0.81.8):
     - ReactCodegen
-  - ReactCodegen (0.81.7):
+  - ReactCodegen (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,7 +2605,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.7):
+  - ReactCommon (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2613,9 +2613,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.7)
+    - ReactCommon/turbomodule (= 0.81.8)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.7):
+  - ReactCommon/turbomodule (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2624,15 +2624,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.7)
-    - React-cxxreact (= 0.81.7)
-    - React-jsi (= 0.81.7)
-    - React-logger (= 0.81.7)
-    - React-perflogger (= 0.81.7)
-    - ReactCommon/turbomodule/bridging (= 0.81.7)
-    - ReactCommon/turbomodule/core (= 0.81.7)
+    - React-callinvoker (= 0.81.8)
+    - React-cxxreact (= 0.81.8)
+    - React-jsi (= 0.81.8)
+    - React-logger (= 0.81.8)
+    - React-perflogger (= 0.81.8)
+    - ReactCommon/turbomodule/bridging (= 0.81.8)
+    - ReactCommon/turbomodule/core (= 0.81.8)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.7):
+  - ReactCommon/turbomodule/bridging (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2641,13 +2641,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.7)
-    - React-cxxreact (= 0.81.7)
-    - React-jsi (= 0.81.7)
-    - React-logger (= 0.81.7)
-    - React-perflogger (= 0.81.7)
+    - React-callinvoker (= 0.81.8)
+    - React-cxxreact (= 0.81.8)
+    - React-jsi (= 0.81.8)
+    - React-logger (= 0.81.8)
+    - React-perflogger (= 0.81.8)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.7):
+  - ReactCommon/turbomodule/core (0.81.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2656,14 +2656,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.7)
-    - React-cxxreact (= 0.81.7)
-    - React-debug (= 0.81.7)
-    - React-featureflags (= 0.81.7)
-    - React-jsi (= 0.81.7)
-    - React-logger (= 0.81.7)
-    - React-perflogger (= 0.81.7)
-    - React-utils (= 0.81.7)
+    - React-callinvoker (= 0.81.8)
+    - React-cxxreact (= 0.81.8)
+    - React-debug (= 0.81.8)
+    - React-featureflags (= 0.81.8)
+    - React-jsi (= 0.81.8)
+    - React-logger (= 0.81.8)
+    - React-perflogger (= 0.81.8)
+    - React-utils (= 0.81.8)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -2721,7 +2721,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.4.1):
+  - RNReanimated (4.5.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2749,43 +2749,13 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/apple (= 4.4.1)
-    - RNReanimated/common (= 4.4.1)
+    - RNReanimated/apple (= 4.5.0)
+    - RNReanimated/common (= 4.5.0)
+    - RNReanimated/view (= 4.5.0)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/apple (4.4.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNWorklets
-    - SocketRocket
-    - Yoga
-  - RNReanimated/common (4.4.1):
+  - RNReanimated/apple (4.5.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2816,7 +2786,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets (0.9.2):
+  - RNReanimated/common (4.5.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2844,11 +2814,73 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/apple (= 0.9.2)
-    - RNWorklets/common (= 0.9.2)
+    - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets/apple (0.9.2):
+  - RNReanimated/view (4.5.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNWorklets (0.10.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets/apple (= 0.10.0)
+    - RNWorklets/common (= 0.10.0)
+    - SocketRocket
+    - Yoga
+  - RNWorklets/apple (0.10.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2878,7 +2910,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets/common (0.9.2):
+  - RNWorklets/common (0.10.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2984,7 +3016,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native-macos/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/microtasks`)
   - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_865d02cabcce576cfb49c3440e59e525/node_modules/@react-native-community/netinfo`)"
-  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_ce67b1ee41c9bbb22437b76ecacb4cab/node_modules/@shopify/react-native-skia`)"
+  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_71649f90ed6bd3f9def977a43f88e93b/node_modules/@shopify/react-native-skia`)"
   - "react-native-webview (from `../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_2ad29fc6ed84400bc7c1b37294513663/node_modules/react-native-webview`)"
   - React-NativeModulesApple (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native-macos/ReactCommon/oscompat`)
@@ -3018,8 +3050,8 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
   - "RNCAsyncStorage (from `../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0_patch_hash=621e3afe_66d5f5ec4ae21dbc551ca70b9b6398ff/node_modules/@react-native-async-storage/async-storage`)"
   - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6_39b75e4a70338f171d6684faf7ca9570/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.4.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bf1e5d2e94b392769214d84a500de3e4/node_modules/react-native-reanimated`)"
-  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.9.2_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa75012_0dd4946a87621cf8144f218ebc71dc79/node_modules/react-native-worklets`)"
+  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.0_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b822792399a9e605f420cce8ab3589aa/node_modules/react-native-reanimated`)"
+  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.0_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_4a3ca1186fdd18dd396468f99cf10366/node_modules/react-native-worklets`)"
   - SocketRocket (~> 0.7.1)
   - Yoga (from `../node_modules/react-native-macos/ReactCommon/yoga`)
 
@@ -3202,7 +3234,7 @@ EXTERNAL SOURCES:
   react-native-netinfo:
     :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_865d02cabcce576cfb49c3440e59e525/node_modules/@react-native-community/netinfo"
   react-native-skia:
-    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_ce67b1ee41c9bbb22437b76ecacb4cab/node_modules/@shopify/react-native-skia"
+    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_71649f90ed6bd3f9def977a43f88e93b/node_modules/@shopify/react-native-skia"
   react-native-webview:
     :path: "../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_2ad29fc6ed84400bc7c1b37294513663/node_modules/react-native-webview"
   React-NativeModulesApple:
@@ -3270,9 +3302,9 @@ EXTERNAL SOURCES:
   RNGestureHandler:
     :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6_39b75e4a70338f171d6684faf7ca9570/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.4.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bf1e5d2e94b392769214d84a500de3e4/node_modules/react-native-reanimated"
+    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.0_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b822792399a9e605f420cce8ab3589aa/node_modules/react-native-reanimated"
   RNWorklets:
-    :path: "../../../node_modules/.pnpm/react-native-worklets@0.9.2_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa75012_0dd4946a87621cf8144f218ebc71dc79/node_modules/react-native-worklets"
+    :path: "../../../node_modules/.pnpm/react-native-worklets@0.10.0_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_4a3ca1186fdd18dd396468f99cf10366/node_modules/react-native-worklets"
   Yoga:
     :path: "../node_modules/react-native-macos/ReactCommon/yoga"
 
@@ -3298,10 +3330,10 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: 93f29833d2a8b957f996eddc05a632eb2bdeaa7d
   ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
   ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
-  ExpoModulesCore: c9125d136b81901cdd3aa0e3ed17fd2ab091cac4
+  ExpoModulesCore: 2f9f4e243ddc998ba151ed74df97cec90a0e7ae7
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
-  ExpoModulesWorkletsAdapter: 0e4f94a660e5f2bcecf51f131264dde1553990ed
+  ExpoModulesWorkletsAdapter: 6d23c1e7a078075c4885c3595c335b9c8c1511bb
   ExpoNetwork: d244aa406eb0aba7e36e5f009a061b2744ab11d7
   ExpoSQLite: 38a35f67bbb3370d9bb859aa65d106909c4e3b19
   ExpoSymbols: b3c964ddc1f1c8d8ddb0eeb830e3a8e42b77ed2d
@@ -3310,83 +3342,83 @@ SPEC CHECKSUMS:
   EXUpdates: f729bd14cd6088ca8e65013515ff15dfa2328082
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   fast_float: 20817c22759af6ac8d4d67e6e059b8b499953656
-  FBLazyVector: e8ec216d79635ba4c9fb0e9becc30391ca4bff1b
+  FBLazyVector: 3b2a51be15bc2f31a5e38d1bb4c007eef833372b
   fmt: 4cf0c5ec5864511c96d8d4bd7b03c3c69040af06
   glog: 0b31c25149b9d350b2666c7d459229861a00ec07
   hermes-engine: 7219f6e751ad6ec7f3d7ec121830ee34dae40749
   RCT-Folly: a3d9b23289a456c318f4814703664bdc33c771cc
-  RCTDeprecation: 32fb5034012098ad1f67eba8a62d73bdd7d082e7
-  RCTRequired: 9f51919b547926d0c148032cf2a7271a37655af4
-  RCTTypeSafety: 7a8749345a241f79e1a39960cae63a1a3d24bf8d
+  RCTDeprecation: 777decf5c531f5f1ce3cf2b292e9c4b07e0d3253
+  RCTRequired: 52ab26a5abbaec60bc25f9b00e46c55be4facfc6
+  RCTTypeSafety: 7f9692e86dc2e7bb49f20731ce17638543c501d2
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 2e4b3b93f8e991cb7f2b6d2a67a05bd414e24e55
-  React-callinvoker: 7e08474aff5f213c0ac49b969d6255e0dc3c66b3
-  React-Core: 8f694cc945ccfddce51a62ecb188b084912d32da
-  React-CoreModules: 60d55869c56b278619ef1bbc947f47c80a096a0a
-  React-cxxreact: 6bd31cd7bc80d13054bef4cd8d3638ac20ca24db
-  React-debug: 207d37bc47ef38d4724508618a0cc5b83b1cb20a
-  React-defaultsnativemodule: 0ee5039f5fd32df6f6bf243113a44b6894f7b7ec
-  React-domnativemodule: ac9484b449658ad14b99633966db21114564c422
-  React-Fabric: 256225934877f0fb55ae5494f082f448a54e6a1d
-  React-FabricComponents: 8221ca24f6115f39c853c931e0b6c4f933733d55
-  React-FabricImage: b034a7c8aab660ed6f61ca8f0a75634631e1553c
-  React-featureflags: 93d275fba0c5e685c39d2dc4bc45c61dbb625e9f
-  React-featureflagsnativemodule: a7878fc4fd20debc412b9b7edc521e8ba00cb427
-  React-graphics: e61609bd356099e78bffa25609ed727e2f094847
-  React-hermes: 722450a717a9abcb01f739f8af7dc7eeff9bc1e9
-  React-idlecallbacksnativemodule: a6941ddd8901d2a49f1c1045dcf8f7729c3f43ad
-  React-ImageManager: 151ec0aeaec18e5cbe1e1f782fa8543a40bdeb0e
-  React-jserrorhandler: e5ee655d980c52332159018195bbf65cbf635f41
-  React-jsi: 4de0c818d5b460dcb27cb9c7f872d1cfacb88702
-  React-jsiexecutor: 1e1791ab5eb62ae869b9e5a8e36c0d4f3c7b4f0c
-  React-jsinspector: 6914fa269ce6713985198a72874c418188bb4474
-  React-jsinspectorcdp: 65ebed497c18cd5440e036a4b36fcd9a77bf9d72
-  React-jsinspectornetwork: 81904aed3e8a0b5713358e936100ddd0181a6a29
-  React-jsinspectortracing: 4c839acedf9223928a29ac93c3c03b495b7cd7f0
-  React-jsitooling: cf03cc37314989985a61d61b2479050fbd17b9c6
-  React-jsitracing: 19525a5bb43ea3d9cb5f1e01385fc81ebc4dbd11
-  React-logger: 079107325dda1ad527b324f4f3cf61e4f6ce4600
-  React-Mapbuffer: 59df6730a578de280cd8675cdf5440b91c243bdf
-  React-microtasksnativemodule: 255f0b29a74d001ecd202e4d5f7f170a009b3987
+  React: f879e4fe279376e17d96a9f8ffc383c82f375283
+  React-callinvoker: 8bbc7484f58f559645d4bdd04052a5bdcfad7aad
+  React-Core: 7fc11c8ef2f77e422f62d845a86fb7b7cf4edb79
+  React-CoreModules: 7f5c43a6c5890e2e4055259bc5856aac7e5ef41f
+  React-cxxreact: 5fd1ead32854b87bfd3035bae004d2b32bc0b582
+  React-debug: 1621ceca6bb14a8f02bff4d1b2e5de87185aceb8
+  React-defaultsnativemodule: 8555b9f7a1b4f93f836921842687748b57b9f8d6
+  React-domnativemodule: 957a2b1fad9e59ee3a9fe682356303950915668f
+  React-Fabric: 275eb16cff2a35b91fa7692ea02d2dc9239d903c
+  React-FabricComponents: 0a695bd01bf13df7ab12e644a60361474ec9ae9a
+  React-FabricImage: 1139abad409bbbe84290b7a7d2e7d40c03877c16
+  React-featureflags: 4333d212c40db734863a9b2b33e0c54af3df0265
+  React-featureflagsnativemodule: eb0fd4b7fd30fcecd1f87cdcacd94539eeae7147
+  React-graphics: f008e545fef39134ab66fadbe7f84f620ee4da1b
+  React-hermes: a264a4dbe286a44fd29aeee37dabd0fb82f5bc28
+  React-idlecallbacksnativemodule: 111d80a5415471fc8af8d166e37b092f9ec804e5
+  React-ImageManager: e6da229ebb5815dc28d54d07fcb765c29ad0e4aa
+  React-jserrorhandler: 445c4ada0c96bf4a0ce36355aa429938dfe368b9
+  React-jsi: 699088da9e1c66b7436aae409add6e8a19751a76
+  React-jsiexecutor: 90ec95035647a000dc118807e6f1a900be9008ec
+  React-jsinspector: 11cd3631e80beefd4e752d28c57e491f711ccada
+  React-jsinspectorcdp: 630b2e989d6b5517b641f0509e293b8020fa1adc
+  React-jsinspectornetwork: e925d0378e0a1a2cd2937990aff4df4bad244d31
+  React-jsinspectortracing: 3d7339ccf855d93d2d819bf6ceeb18c076df0c06
+  React-jsitooling: 9bb90758b9ca3d2473bdd9340653bd0d782e5ec7
+  React-jsitracing: 847cfde62317c109c7388f50704103b73905a936
+  React-logger: 85780074297fc704c4d6832f951229c21d5fd35e
+  React-Mapbuffer: 037786a5502d8d25502f892ec2fec7237969b0f6
+  React-microtasksnativemodule: 4963088a1ab9c2ce4bbbfd4db49c5fe667c7911e
   react-native-netinfo: a0be8c77f8420a60ddf07eb87be1a36f02a1bd65
   react-native-skia: 03e8994164f792bc9fa464ed475e7f8edce36d0e
   react-native-webview: 8407aaaf6b539b1e38b72fabb55d6885de03beaf
-  React-NativeModulesApple: c1e8f5e34efed354e5a066ef47c45a4ca5dddbb4
-  React-oscompat: b359d251f6ea20fa91e5e0f99fd7b563f50a8af3
-  React-perflogger: e5156a6e931998e62a95a5e1a4428e3a17a0e5cf
-  React-performancetimeline: c70a120a541259720a162b70584872de56c9a45c
-  React-RCTActionSheet: ad14f1859da2922d9e5553a345cf22f7f473a088
-  React-RCTAnimation: 15cfc40a9ba414333b0114821ce52d7f861408a4
-  React-RCTAppDelegate: 4e7436b47fa2dae36543ab6d23430e462e66d71c
-  React-RCTBlob: b1a8fb66b2ce78ccb298055568de12299af9cc56
-  React-RCTFabric: 547c0c2b1cfced08f44d24b1fc11c455ffb81ef8
-  React-RCTFBReactNativeSpec: 447a5a70cf2565ddcb766df4f23e12fc742cd873
-  React-RCTImage: 9864bc6f5d445d59944a1cdcb47f0438d6f225c6
-  React-RCTLinking: 752cffa398760505fc49d27658d51cd4dbc818b7
-  React-RCTNetwork: 6036a74dd368620ba0bd5284726ae7cb8bdc91a9
-  React-RCTRuntime: 1d1d146bcc23e5cb2536ceeecc7d0a27ae79390e
-  React-RCTSettings: ae40f7b38bc1b54bc2bac7c8dfbc419fa7de7688
-  React-RCTText: d18da7a4e5c238e2449691a0ef0797e93b40f6ba
-  React-RCTVibration: 2deb3c049b4f43e7e13b3e8f3002af3e39eaac3e
-  React-rendererconsistency: 1fcf510f34fd097b01bf863c428954830e2522b1
-  React-renderercss: b20e451702f8745323bb45151b9cd8668f872b89
-  React-rendererdebug: 59d6befee3ff240e8cf760800d3510e22046987a
-  React-RuntimeApple: 5c6077d0621b0c2d0bcd5c2cbc8425fb2075d334
-  React-RuntimeCore: 442a96cf122dbd3912ecb0e7afebe02466ea4d48
-  React-runtimeexecutor: ab1f335e25e1cb6a57249f1b37fa8c4540329ec2
-  React-RuntimeHermes: af403e01be15bb5a750bca4be4e0e4ffd06358b3
-  React-runtimescheduler: e2fb53731e08ee2c518072e66069310f6c178abb
-  React-timing: f91e37f2154ef9b25e1ded28326f9998669145f1
-  React-utils: 35e85af00d70760e6fda280c78d184da64d89e3d
-  ReactAppDependencyProvider: 17d150a60ad301142905427154168f58641e38c4
-  ReactCodegen: 11f74a80a463d29f80bc9605b0be54ea0b34ba0e
-  ReactCommon: b2b6ff304cf01e1b67d8e9646e34d58320be0964
+  React-NativeModulesApple: beeeb17d842ad64aa26f8700340bb14a3fa68d7b
+  React-oscompat: 0f67bb3326c613877d9a4c50031f215fe2764d89
+  React-perflogger: d744ee5245595aa3586331677a6aa0b14650eda7
+  React-performancetimeline: f287cd33bb25fe026c338f1749bf5358d7c09e73
+  React-RCTActionSheet: b1fe9b795181d1cbb7e6d819fbfa34fbb2c7b88f
+  React-RCTAnimation: 976c902ad19df7f18276677b59338aea3b73a0a1
+  React-RCTAppDelegate: f27856e96032bed0f3eef6ff50e882f58503d394
+  React-RCTBlob: 2dac7194b54f761ac9166e85e7051e3f0a55e4d5
+  React-RCTFabric: 6465732b5467224d67d8365f1124282020d999b0
+  React-RCTFBReactNativeSpec: a33df083edcdf80f1f5a51c1b6a583ac07406147
+  React-RCTImage: 8b2f23278e83c8b73ec6a0c14d1eb17f188405cd
+  React-RCTLinking: 29f8d337665a106289a4fc08dff82cef4016e660
+  React-RCTNetwork: b5fa6ca39b05fd9dff160fea4c8deb6e4cc3eae4
+  React-RCTRuntime: 28aa6ecce86849b9ea908d7e17c0408d9caf8ade
+  React-RCTSettings: 353a6d166069f5fdb11fa22ec077936469e9d1c7
+  React-RCTText: a60be83b40f2fd79d5f212b53d035c6087e0965e
+  React-RCTVibration: 1ed99f155147a23a10467a97d06e6a8f81439ee9
+  React-rendererconsistency: cfefe66cc332df4558869980f2a7d859d85ca8db
+  React-renderercss: ba358637db48e3573ead1127de9a0b7d35828346
+  React-rendererdebug: 6ed86fc7285ff47d738a78fc2ef9ffe34f38c5ea
+  React-RuntimeApple: 9fdb57f861eaba3315d38113aebba6ebb175875c
+  React-RuntimeCore: b805aed8a5f9b02fab9a798714d447f3ca2bfb07
+  React-runtimeexecutor: b3b48446f479d9ab899baac746c1e0a384977f46
+  React-RuntimeHermes: af5bf63a349a02eccda90a0d7b7d2b742bd8cac6
+  React-runtimescheduler: ae3507d757dfa085f019c03cbee29811377671aa
+  React-timing: c64eae92f7e50abef3f7952001de9722be2a1df1
+  React-utils: c7eb720119e56ea1e4927cee1182ebabe75ab72c
+  ReactAppDependencyProvider: 3a4b47b0501d4d1068eef3c457c9ebef0b6ae49b
+  ReactCodegen: 28b0869099548209689f9534c1734e146cad1ddb
+  ReactCommon: ef913092a4501cf30c176155312c30abc82dbd34
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNGestureHandler: 83e66307c200b98c746bd03113c4403da5c9b486
-  RNReanimated: 5f80a187ffeefae6855f723e41f615e74da9a4d8
-  RNWorklets: 1b1d41bd2bb8e70c0f74a278196b36a5468703f6
+  RNReanimated: 9b5c7dc33fd865193f7a0461bd8957e71f9d11e1
+  RNWorklets: a1009c962243f6faeff04494e483deef5866cbac
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 8a0df683a71bee13fe0b9d8b653d1a062ff65b2e
+  Yoga: 9f9bacf26f441fa32d25c32e5583ff72f6d2806d
 
 PODFILE CHECKSUM: 2080184fe7378b7b21bd66f763b107271b042a9b
 

--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos.patch
@@ -1,8 +1,8 @@
 diff --git a/react-native.config.js b/react-native.config.js
-index a34cefa6cf076b7ddca4a6dd9e0f6be8f4b9891a..b38a2837e35555d3834fb35578c45886d455329c 100644
+index 3bdd6b5e8ff20b097865b83c4310345d3be4a5ef..fc2992a360adb1c4b7bc2bd2703e1f2682125c86 100644
 --- a/react-native.config.js
 +++ b/react-native.config.js
-@@ -83,7 +83,19 @@ try {
+@@ -87,7 +87,19 @@ try {
  }
  
  // $FlowFixMe[untyped-import]
@@ -23,7 +23,7 @@ index a34cefa6cf076b7ddca4a6dd9e0f6be8f4b9891a..b38a2837e35555d3834fb35578c45886
  const {
    bundleCommand,
    startCommand,
-@@ -156,7 +168,9 @@ if (android != null) {
+@@ -160,7 +172,9 @@ if (android != null) {
  }
  
  // [macOS
@@ -57,37 +57,3 @@ index d8e9c7cec2f57c124cc2b2fc52b69de8940d3eb5..3eede671066cb814ca43567815e166ac
  
      name = package["name"]
      podspec_path = package_config["podspecPath"]
-diff --git a/third-party-podspecs/fmt.podspec b/third-party-podspecs/fmt.podspec
-index 2f38990e226c13f483aaf1b986302d4094243814..a40c5755e049974e98a4038c177661d2bdc5681f 100644
---- a/third-party-podspecs/fmt.podspec
-+++ b/third-party-podspecs/fmt.podspec
-@@ -8,14 +8,14 @@ fmt_git_url = fmt_config[:git]
- 
- Pod::Spec.new do |spec|
-   spec.name = "fmt"
--  spec.version = "11.0.2"
-+  spec.version = "12.1.0"
-   spec.license = { :type => "MIT" }
-   spec.homepage = "https://github.com/fmtlib/fmt"
-   spec.summary = "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
-   spec.authors = "The fmt contributors"
-   spec.source = {
-     :git => fmt_git_url,
--    :tag => "11.0.2"
-+    :tag => "12.1.0"
-   }
-   spec.pod_target_xcconfig = {
-     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-diff --git a/third-party-podspecs/RCT-Folly.podspec b/third-party-podspecs/RCT-Folly.podspec
-index 8852179b6ce2ef6ae64e0239edb2594925ff8bc1..040c4f0ca82e6a7342d5b3ed54e556431e5853d2 100644
---- a/third-party-podspecs/RCT-Folly.podspec
-+++ b/third-party-podspecs/RCT-Folly.podspec
-@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
-   spec.dependency "DoubleConversion"
-   spec.dependency "glog"
-   spec.dependency "fast_float", "8.0.0"
--  spec.dependency "fmt", "11.0.2"
-+  spec.dependency "fmt", "12.1.0"
-   spec.compiler_flags = '-Wno-documentation -faligned-new'
-   spec.source_files = 'folly/String.cpp',
-                       'folly/Conv.cpp',


### PR DESCRIPTION
# Why

After the react-native-macos 0.81.8 release our CI started failing

# How

Update react-native-macos patch and return pod install

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
