### PR TITLE
[gh] Fix canaries workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lint-staged": "^17.0.8",
     "oxfmt": "^0.55.0",
     "oxlint": "^1.70.0",
+    "prettier": "~3.8.3",
     "ts-node": "^10.9.2",
     "turbo": "2.10.0",
     "typescript": "^6.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       oxlint:
         specifier: ^1.70.0
         version: 1.70.0
+      prettier:
+        specifier: ~3.8.3
+        version: 3.8.3
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)
@@ -18106,7 +18109,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -1,25 +1,26 @@
 import chalk from 'chalk';
 import semver from 'semver';
 
-import { checkEnvironmentTask } from './checkEnvironmentTask';
-import { checkPackageAccess } from './checkPackageAccess';
-import { loadRequestedParcels } from './loadRequestedParcels';
-import { publishAndroidArtifacts } from './publishAndroidPackages';
-import { publishPackages } from './publishPackages';
-import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
-import { updateModuleTemplate } from './updateModuleTemplate';
-import { updatePackageVersions } from './updatePackageVersions';
-import { updateWorkspaceProjects } from './updateWorkspaceProjects';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { sdkVersionAsync } from '../../ProjectVersions';
 import { Task } from '../../TasksRunner';
+import { runTurboTasksAsync } from '../../Turbo';
 import { runWithSpinner } from '../../Utils';
 import { resolveReleaseTypeAndVersion } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { addTemplateTarball } from './addTemplateTarball';
 import { bundleIOSPrebuilds } from './bundleIOSPrebuilds';
+import { checkEnvironmentTask } from './checkEnvironmentTask';
+import { checkPackageAccess } from './checkPackageAccess';
+import { loadRequestedParcels } from './loadRequestedParcels';
+import { publishAndroidArtifacts } from './publishAndroidPackages';
+import { publishPackages } from './publishPackages';
 import { updateAndroidProjects } from './updateAndroidProjects';
+import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
+import { updateModuleTemplate } from './updateModuleTemplate';
+import { updatePackageVersions } from './updatePackageVersions';
+import { updateWorkspaceProjects } from './updateWorkspaceProjects';
 
 const { cyan } = chalk;
 
@@ -72,6 +73,29 @@ export const prepareCanaries = new Task<TaskArgs>(
     } else {
       options.tag = `canary-sdk-${currentSdkMajor}`;
     }
+  }
+);
+
+export const buildCanaryPackages = new Task<TaskArgs>(
+  {
+    name: 'buildCanaryPackages',
+    dependsOn: [loadRequestedParcels],
+  },
+  async (parcels: Parcel[]) => {
+    const packageNames = [
+      ...new Set(
+        parcels.filter((parcel) => parcel.pkg.scripts.build).map((parcel) => parcel.pkg.packageName)
+      ),
+    ];
+    if (packageNames.length === 0) {
+      return;
+    }
+
+    logger.info(
+      `\n🛠️  Building ${cyan(packageNames.length)} package${packageNames.length === 1 ? '' : 's'} with Turbo...`
+    );
+
+    await runTurboTasksAsync(['build'], { filters: packageNames });
   }
 );
 
@@ -130,6 +154,7 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
       loadRequestedParcels,
       prepareCanaries,
       checkPackageAccess,
+      buildCanaryPackages,
       updatePackageVersions,
       updateBundledNativeModulesFile,
       updateModuleTemplate,


### PR DESCRIPTION
# Why

The nightly Publish Canaries workflow is failing with `Process 'command 'pnpm'' finished with non-zero exit value 254` on the `:expoPublish` Gradle tasks.

The publish flow shells out to `pnpm prettier --write expo-module.config.json` from each package directory (in the `expo-module-gradle-plugin` and in `publishAndroidPackages`). `pnpm <bin>` resolves a binary by walking up to the workspace-root `node_modules/.bin`, so this only works when `prettier` is hoisted there. 

The root cause was the removal `"prettier"` from the root `package.json`. `prettier` is otherwise only a transitive dependency, and pnpm's isolated node_modules layout does not expose transitives at the workspace root, so the publish task could no longer find it. 

# How

Restored `prettier` as a direct root dev dependency 

# Test Plan

CI should be green