### PR TITLE
[ios][autolinking] Fix duplicate pod with precompiled modules and multiple targets

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.4.1` upstream defaults, adding the `CSS/core/transition` and `PseudoStyles` header mappings along with the missing `IOS_CSS_CORE_ANIMATION` and `USE_ANIMATION_BACKEND` feature flags so its XCFramework builds. ([#46950](https://github.com/expo/expo/pull/46950) by [@zoontek](https://github.com/zoontek))
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))
 - Fixed the macro plugin flag not being applied to test targets, so macros couldn't be used in unit tests. ([#46595](https://github.com/expo/expo/pull/46595) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -973,8 +973,12 @@ module Expo
       # ──────────────────────────────────────────────────────────────────────
 
       # Returns true when the prebuilt React.xcframework is in use.
+      #
+      # Must mirror React Native's default (`!= '0'`): `use_react_native!` defaults
+      # `RCT_USE_PREBUILT_RNCORE` to "1" but runs after `use_expo_modules!`, so reading
+      # `== '1'` here would see the value before React Native sets it.
       def prebuilt_react_active?
-        ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+        ENV['RCT_USE_PREBUILT_RNCORE'] != '0'
       end
 
       # Builds a `file://` URI for a local filesystem path, percent-encoding


### PR DESCRIPTION
# Why

On SDK 56 with `ios.useFrameworks: "static"`, `pod install` fails with a duplicate pod error for a first-party Expo module:

```
[!] There are multiple dependencies with different sources for `ExpoContacts` in `Podfile`:
- ExpoContacts (from `../../../node_modules/expo-contacts/ios`)
- ExpoContacts (from `../../../node_modules/expo-contacts/ios/ExpoContacts.podspec`)
```

It reproduces locally with `EXPO_USE_PRECOMPILED_MODULES=1 pod install` in any project whose Podfile has more than one target; EAS Build surfaces it because it auto-enables `EXPO_USE_PRECOMPILED_MODULES` on SDK 56.

Refs: expo/expo#47266, expo/eas-cli#3910.

# How

Root cause: React Native made the prebuilt React core the default — `use_react_native!` sets `RCT_USE_PREBUILT_RNCORE` to `"1"` unless it is explicitly `"0"`. But it applies that default *inside* `use_react_native!`, which runs **after** `use_expo_modules!`. Expo's `prebuilt_react_active?` checks `ENV['RCT_USE_PREBUILT_RNCORE'] == '1'`, so it reads the value before React Native has set it.

In a multi-target Podfile each target calls `use_expo_modules!` then `use_react_native!`, so the env var changes between targets:
- **Target 1** `use_expo_modules!`: env unset → `enabled?` false → `ExpoContacts` registered with `:path`.
- Target 1 `use_react_native!` defaults `RCT_USE_PREBUILT_RNCORE=1`.
- **Target 2** `use_expo_modules!`: env now `1` → `enabled?` true → `ExpoContacts` registered with `:podspec`.

Static linking then rejects the two different sources.

The fix mirrors React Native's default: `prebuilt_react_active?` returns `ENV['RCT_USE_PREBUILT_RNCORE'] != '0'`. The decision no longer depends on whether `use_react_native!` has run yet — every target agrees, and when React core is prebuilt (the default) precompiled Expo modules are used as intended, capturing the value of the prebuilt core.

### Behavior change (technically breaking)

This flips the effective default. Today, with `RCT_USE_PREBUILT_RNCORE` unset (the common case), `enabled?` is evaluated at registration time *before* `use_react_native!` sets the env var, so it returns false and Expo modules build from source — precompiled modules are effectively **off** by default. With this change `enabled?` returns true whenever React core is prebuilt (the default), so precompiled Expo modules become **on** by default. That is the intended behavior, but projects that were implicitly getting source-built Expo modules will now get precompiled ones.

The change is in a Ruby pod-install script (`scripts/ios/`), which ships as-is and has no build step, so it was verified with a real `pod install`.

# Test Plan

SDK 56 app, `ios.useFrameworks: "static"`, multi-target Podfile.

**Before** — `EXPO_USE_PRECOMPILED_MODULES=1 pod install`:
```
Analyzing dependencies
[!] There are multiple dependencies with different sources for `ExpoContacts` in `Podfile`:
- ExpoContacts (from `../../../node_modules/expo-contacts/ios`)
- ExpoContacts (from `../../../node_modules/expo-contacts/ios/ExpoContacts.podspec`)
```

**After** (same command) — completes cleanly with the prebuilt modules in use:
```
Analyzing dependencies
Generating Pods project
Pod installation complete! There are 151 dependencies from the Podfile and 172 total pods installed.
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (Ruby script; no build output to regenerate)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

