### PR TITLE
[expo][jest-expo] Fix Jest 30 "import outside scope" teardown crash

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [iOS] Add ExpoBundleConfiguration to derive RCTBundleConfiguration from the normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
 - [iOS] Resolve the dev server port from the `RCTMetroPort` Info.plist key at runtime so bare projects without expo-dev-client connect to their own Metro instance instead of defaulting to 8081. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix async imports (`import(...)`) via `asyncRequireModule` not a thenable instead of a full promise shape ([#48550](https://github.com/expo/expo/pull/48550) by [@kitten](https://github.com/kitten))
+- Fixed `jest-expo` test suites failing to run on Jest 30 with `You are trying to import a file outside of the scope of the test code`, caused by the `structuredClone` and `__ExpoImportMetaRegistry` winter globals lazily requiring modules during environment teardown. ([#47332](https://github.com/expo/expo/pull/47332) by [@netconomy-stephan-dum](https://github.com/netconomy-stephan-dum), [@janpe](https://github.com/janpe))
 
 ### 💡 Others
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -237,6 +237,7 @@
     "@expo/metro-runtime": "workspace:*",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
+    "@types/ungap__structured-clone": "^1.2.0",
     "expo-updates": "workspace:*",
     "npm-run-all2": "^8.0.4",
     "react": "19.2.3",

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -7,7 +7,9 @@ import 'react-native/Libraries/Core/InitializeCore';
 import '../../types';
 import { installAbortSignalPatch } from './AbortSignal';
 import { installFormDataPatch } from './FormData';
+import { ImportMetaRegistry } from './ImportMetaRegistry';
 import { installGlobal as install } from './installGlobal';
+import structuredClonePolyfill from './structuredClone';
 
 // https://encoding.spec.whatwg.org/#textdecoder
 install('TextDecoder', () => require('./TextDecoder').TextDecoder);
@@ -24,10 +26,12 @@ install('DOMException', () => require('./DOMException').DOMException);
 // https://streams.spec.whatwg.org/#rs
 // ReadableStream is injected by Metro as a global
 
-install('__ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').ImportMetaRegistry);
+// Resolve eagerly: Jest 30 reads these enumerable globals during teardown (`resetModules`),
+// so a lazy `require` in the getter would load a module after the test scope closed and throw.
+install('__ExpoImportMetaRegistry', () => ImportMetaRegistry);
 
 // https://html.spec.whatwg.org/multipage/structured-data.html#structuredclone
-install('structuredClone', () => require('@ungap/structured-clone').default);
+install('structuredClone', () => structuredClonePolyfill);
 
 installFormDataPatch(FormData);
 installAbortSignalPatch(AbortSignal);

--- a/packages/expo/src/winter/structuredClone.ts
+++ b/packages/expo/src/winter/structuredClone.ts
@@ -1,0 +1,8 @@
+import { deserialize, serialize } from '@ungap/structured-clone';
+
+// Round-trip via `serialize`/`deserialize` instead of the default export, which delegates to
+// the global `structuredClone` we install here and would otherwise recurse.
+const structuredClonePolyfill = <T>(value: T, options?: { json?: boolean; lossy?: boolean }): T =>
+  deserialize(serialize(value, options)) as T;
+
+export default structuredClonePolyfill;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3625,6 +3625,9 @@ importers:
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14
+      '@types/ungap__structured-clone':
+        specifier: ^1.2.0
+        version: 1.2.0
       expo-updates:
         specifier: workspace:*
         version: link:../expo-updates
@@ -9614,6 +9617,9 @@ packages:
 
   '@types/uglify-js@3.17.5':
     resolution: {integrity: sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==}
+
+  '@types/ungap__structured-clone@1.2.0':
+    resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -18404,6 +18410,8 @@ snapshots:
   '@types/uglify-js@3.17.5':
     dependencies:
       source-map: 0.6.1
+
+  '@types/ungap__structured-clone@1.2.0': {}
 
   '@types/unist@3.0.3': {}
 


### PR DESCRIPTION
_Based on @netconomy-stephan-dum's #43535 — this rebases that fix onto `main` and adds the root-cause writeup, changelog, and verification. Happy to close this in favor of #43535 if it moves forward instead._

## Why

On **Jest 30**, every `jest-expo` test fails during environment teardown — even a trivial passing one — with:

```
ReferenceError: You are trying to `import` a file outside of the scope of the test code.
```

`expo/src/winter/runtime.native.ts` registers `structuredClone` and `__ExpoImportMetaRegistry` as **lazy** globals (the backing module is `require`d only on first read). Jest 30's teardown (`resetModules`) now reads every global to clear mocks, firing those lazy `require`s after the test scope has closed — and loading a module then throws. The other winter globals are non-enumerable, so teardown skips them; only these two are hit.

Refs #36831, #37261.

## How

Resolve the two globals eagerly at module load instead of lazily `require`-ing inside the getter:
- `__ExpoImportMetaRegistry` → top-level `import`.
- `structuredClone` → a small `structuredClone.ts` wrapper over `@ungap`'s `serialize`/`deserialize` (its default export delegates to the global `structuredClone`, which would recurse once we install it).

The globals stay enumerable; only their resolution timing moves to module load.

## Alternative

A smaller fix is possible: mark these two globals **non-enumerable**, so Jest's teardown loop skips them and the lazy `require` never fires. That drops the wrapper and the `@types` dependency and keeps the existing lazy loading — at the cost of changing an observable attribute (enumerability) of those globals. I went with eager resolution because it's behavior-transparent, but happy to switch to the non-enumerable version if you'd prefer the smaller surface.

## Test Plan

- `et check-packages expo` passes (build, typecheck, oxlint, format); `structuredClone.test.ios.ts` 2/2.
- Jest-30 repro (can't run in this repo's Jest-29 CI): https://github.com/netconomy-stephan-dum/jest-expo-with-jest-30 — fails on `main`, passes with this change.

## Checklist
- [x] `CHANGELOG.md` entry
- [x] `et check-packages expo` green
- [x] No `build/` staged