### PR TITLE
feat(metro-config): Treat dynamic imports with rejection handlers as optional dependencies

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix stack frame collapsing for Windows paths. ([#46645](https://github.com/expo/expo/pull/46645) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Bump `hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
+- Treat dynamic imports with rejection handlers as optional dependencies, ported from [react/metro#1697](https://github.com/react/metro/pull/1697) ([#47334](https://github.com/expo/expo/pull/47334) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/collect-dependencies-upstream.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/collect-dependencies-upstream.test.ts
@@ -1650,6 +1650,91 @@ describe('optional dependencies', () => {
     validateDependencies(dependencies, 4);
   });
 
+  describe('dynamic import with rejection handler', () => {
+    it('import().catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a').catch(() => {});
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('import().then(handler, onReject) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a').then(() => {}, () => {});
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('import().then(...).then(...).catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a')
+          .then(x => x)
+          .then(x => x)
+          .catch(() => {});
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('await import().catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        async function f() {
+          await import('optional-async-a').catch(() => {});
+        }
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('try { await import() } catch {} is optional', () => {
+      const ast = astFromCode(`
+        async function f() {
+          try {
+            await import('optional-async-a');
+          } catch (e) {}
+        }
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('import().then(handler) without onReject is not optional', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').then(() => {});
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('import().catch() with no handler argument is not optional', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').catch();
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    it('import().then(handler, null) is not optional (null/undefined onReject)', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').then(() => {}, null);
+        import('not-optional-async-b').then(() => {}, undefined);
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 3);
+    });
+
+    it('import() detached from chain is not optional', () => {
+      const ast = astFromCode(`
+        const p = import('not-optional-async-a');
+        p.catch(() => {});
+      `);
+      const { dependencies } = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+  });
+
   describe('isESMImport', () => {
     it('distinguishes require calls, static imports and async imports', () => {
       const ast = astFromCode(`

--- a/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
+++ b/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
@@ -769,6 +769,15 @@ function isOptionalDependency(name: string, path: NodePath<any>, state: State): 
     return false;
   }
 
+  // Treat dynamic imports as optional when a rejection handler is attached
+  // close to the import call, e.g.
+  //   import('x').catch(handler)
+  //   import('x').then(handler, onReject)
+  //   import('x').then(...).catch(handler)
+  if (isInPromiseChainWithRejectionHandler(path)) {
+    return true;
+  }
+
   // Valid statement stack for single-level try-block: expressionStatement -> blockStatement -> tryStatement
   let sCount = 0;
   let p: NodePath<any> | NodePath<t.Node> | null = path;
@@ -785,6 +794,55 @@ function isOptionalDependency(name: string, path: NodePath<any>, state: State): 
   }
 
   return false;
+}
+
+// Walk up a chain of `.then(...)` / `.catch(...)` member calls starting from
+// `path` (typically an `import()` CallExpression) and return true if any
+// chained call provides a rejection handler — either `.catch(handler)` or
+// `.then(_, handler)`. The chain must be unbroken: as soon as the parent is
+// not a member call applied to the previous expression, we stop. This keeps
+// the heuristic local to the import, matching the behaviour of the
+// try/catch heuristic above.
+function isInPromiseChainWithRejectionHandler(path: NodePath<any>): boolean {
+  let current: NodePath<any> = path;
+  while (current.parentPath != null) {
+    const member = current.parentPath;
+    if (
+      member.node.type !== 'MemberExpression' ||
+      member.node.object !== current.node ||
+      member.node.computed ||
+      member.node.property.type !== 'Identifier' ||
+      member.parentPath == null
+    ) {
+      return false;
+    }
+    const call = member.parentPath;
+    if (call.node.type !== 'CallExpression' || call.node.callee !== member.node) {
+      return false;
+    }
+    const propertyName = member.node.property.name;
+    const args = call.node.arguments;
+    if (propertyName === 'catch' && args.length >= 1 && isNonNullishCallbackArg(args[0])) {
+      return true;
+    }
+    if (propertyName === 'then' && args.length >= 2 && isNonNullishCallbackArg(args[1])) {
+      return true;
+    }
+    current = call;
+  }
+  return false;
+}
+
+function isNonNullishCallbackArg(arg: t.CallExpression['arguments'][number] | undefined): boolean {
+  if (arg == null) {
+    return false;
+  } else if (arg.type === 'NullLiteral') {
+    return false;
+  } else if (arg.type === 'Identifier' && arg.name === 'undefined') {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 function getModuleNameFromCallArgs(path: NodePath<t.CallExpression>): string | null {


### PR DESCRIPTION
# Why

Ported from: https://github.com/react/metro/pull/1697

Dynamic imports with a catch handler, such as `import('node:test').catch(() => { /*...*/ })` should be treated as an optional dependency, as per the `transformer.allowOptionalDependencies` option, which is by default enabled in Expo.

# How

- Apply upstream changes to `collect-dependencies.ts` and upstream tests file

We shouldn't backport this to older versions than `sdk-56` potentially, unless requested, since this may constitute a "slightly" breaking change. I wouldn't expect it to break existing, working cases, but it'd be best to be careful for now.

# Test Plan

- Upstream tested, and test file updated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
