### PR TITLE
[create-expo-nightly] Bump Gradle wrapper for nightly builds

### DIFF
--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -100,6 +100,12 @@ async function setupProjectPackageJsonAsync(
     }
   }
 
+  // Also force transitive repo packages (e.g. `expo-modules-autolinking`) to
+  // the workspace copy, so pnpm can't pull a published version that lags it.
+  for (const name of repoPackageNames) {
+    resolutions[name] = 'workspace:*';
+  }
+
   await writeJsonFileAsync(packageJsonPath, {
     ...packageJson,
 

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -159,6 +159,28 @@ export async function prebuildAppAsync(projectRoot: string, templateTarballPath:
   });
 }
 
+// react-native nightlies can require a newer Gradle than the stable template ships with.
+const NIGHTLY_GRADLE_VERSION = '9.4.1';
+
+export async function setupGradleWrapperAsync(projectRoot: string) {
+  const propertiesPath = path.join(
+    projectRoot,
+    'android',
+    'gradle',
+    'wrapper',
+    'gradle-wrapper.properties'
+  );
+
+  const properties = await fs.promises.readFile(propertiesPath, 'utf8');
+
+  const nextProperties = properties.replace(
+    /^(distributionUrl=.*gradle-).*(-bin\.zip)$/m,
+    `$1${NIGHTLY_GRADLE_VERSION}$2`
+  );
+
+  await fs.promises.writeFile(propertiesPath, nextProperties);
+}
+
 export async function installCocoaPodsAsync(projectRoot: string) {
   await runAsync('pod', ['install'], { cwd: path.join(projectRoot, 'ios') });
 }

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -174,7 +174,7 @@ export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPa
     'gradle-wrapper.properties'
   );
 
-  const wrapperProperties = await fs.promises.readFile(wrapperPropertiesPath, 'utf-8');
+  const wrapperProperties = await fs.promises.readFile(wrapperPropertiesPath, 'utf8');
 
   await fs.promises.writeFile(
     wrapperPropertiesPath,
@@ -209,12 +209,13 @@ export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPa
     }
   }
 
-  const gradlePropertiesPath = path.join(projectRoot, 'android', 'gradle.properties');
-  const gradleProperties = await fs.promises.readFile(gradlePropertiesPath, 'utf8');
+  const appBuildGradlePath = path.join(projectRoot, 'android', 'app', 'build.gradle');
+  const appBuildGradle = await fs.promises.readFile(appBuildGradlePath, 'utf8');
 
-  if (!/^android\.builtInKotlin=/m.test(gradleProperties)) {
-    await fs.promises.appendFile(gradlePropertiesPath, '\nandroid.builtInKotlin=false\n');
-  }
+  await fs.promises.writeFile(
+    appBuildGradlePath,
+    appBuildGradle.replace(/^apply plugin: ["']org\.jetbrains\.kotlin\.android["']\r?\n/m, '')
+  );
 }
 
 export async function installCocoaPodsAsync(projectRoot: string) {

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -184,26 +184,31 @@ export async function setupGradleWrapperAsync(projectRoot: string) {
 export async function setupGradlePluginKotlinAsync(expoRepoPath: string) {
   const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
 
-  const pluginRoot = path.join(
-    expoRepoPath,
-    'packages',
-    'expo-modules-autolinking',
-    'android',
-    'expo-gradle-plugin'
-  );
+  const pluginRoots = [
+    path.join(expoRepoPath, 'packages', 'expo-modules-core', 'expo-module-gradle-plugin'),
+    path.join(
+      expoRepoPath,
+      'packages',
+      'expo-modules-autolinking',
+      'android',
+      'expo-gradle-plugin'
+    ),
+  ];
 
-  for await (const relativePath of fs.promises.glob('*/build.gradle.kts', { cwd: pluginRoot })) {
-    const buildGradlePath = path.join(pluginRoot, relativePath);
-    const contents = await fs.promises.readFile(buildGradlePath, 'utf8');
+  for (const pluginRoot of pluginRoots) {
+    for await (const relativePath of fs.promises.glob('**/build.gradle.kts', { cwd: pluginRoot })) {
+      const buildGradlePath = path.join(pluginRoot, relativePath);
+      const contents = await fs.promises.readFile(buildGradlePath, 'utf8');
 
-    if (!contents.includes(skipMetadataVersionCheck)) {
-      const nextContents = contents.replace(
-        /^(\s*)(jvmTarget\.set\(JvmTarget\.JVM_11\))$/m,
-        `$1$2\n$1${skipMetadataVersionCheck}`
-      );
+      if (!contents.includes(skipMetadataVersionCheck)) {
+        const nextContents = contents.replace(
+          /^(\s*)(jvmTarget\.set\(JvmTarget\.JVM_11\))$/m,
+          `$1$2\n$1${skipMetadataVersionCheck}`
+        );
 
-      if (nextContents !== contents) {
-        await fs.promises.writeFile(buildGradlePath, nextContents);
+        if (nextContents !== contents) {
+          await fs.promises.writeFile(buildGradlePath, nextContents);
+        }
       }
     }
   }

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -181,6 +181,34 @@ export async function setupGradleWrapperAsync(projectRoot: string) {
   await fs.promises.writeFile(propertiesPath, nextProperties);
 }
 
+export async function setupGradlePluginKotlinAsync(expoRepoPath: string) {
+  const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
+
+  const pluginRoot = path.join(
+    expoRepoPath,
+    'packages',
+    'expo-modules-autolinking',
+    'android',
+    'expo-gradle-plugin'
+  );
+
+  for await (const relativePath of fs.promises.glob('*/build.gradle.kts', { cwd: pluginRoot })) {
+    const buildGradlePath = path.join(pluginRoot, relativePath);
+    const contents = await fs.promises.readFile(buildGradlePath, 'utf8');
+
+    if (!contents.includes(skipMetadataVersionCheck)) {
+      const nextContents = contents.replace(
+        /^(\s*)(jvmTarget\.set\(JvmTarget\.JVM_11\))$/m,
+        `$1$2\n$1${skipMetadataVersionCheck}`
+      );
+
+      if (nextContents !== contents) {
+        await fs.promises.writeFile(buildGradlePath, nextContents);
+      }
+    }
+  }
+}
+
 export async function installCocoaPodsAsync(projectRoot: string) {
   await runAsync('pod', ['install'], { cwd: path.join(projectRoot, 'ios') });
 }

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -164,8 +164,9 @@ export async function prebuildAppAsync(projectRoot: string, templateTarballPath:
  */
 export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPath: string) {
   const nightlyGradleVersion = '9.4.1';
-  const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
 
+  // react-native nightlies can require a newer Gradle than the stable template ships with, so bump
+  // the generated project's Gradle wrapper to a version recent enough to run their Android plugin.
   const wrapperPropertiesPath = path.join(
     projectRoot,
     'android',
@@ -184,10 +185,19 @@ export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPa
     )
   );
 
+  const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
   const packagesPath = path.join(expoRepoPath, 'packages');
 
+  const expoModuleGradlePlugin = path.join(
+    packagesPath,
+    'expo-modules-core',
+    'expo-module-gradle-plugin'
+  );
+
+  // The Expo Gradle plugins are compiled with an older Kotlin than the one bundled with that newer
+  // Gradle, so skip the metadata check to let them compile against its newer kotlin-stdlib.
   const pluginRoots = [
-    path.join(packagesPath, 'expo-modules-core', 'expo-module-gradle-plugin'),
+    expoModuleGradlePlugin,
     path.join(packagesPath, 'expo-modules-autolinking', 'android', 'expo-gradle-plugin'),
   ];
 
@@ -209,6 +219,8 @@ export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPa
     }
   }
 
+  // AGP 9 (pulled in by recent nightlies) ships built-in Kotlin support that clashes with the
+  // template's explicit `kotlin.android` plugin, so drop it and let AGP's built-in Kotlin take over.
   const appBuildGradlePath = path.join(projectRoot, 'android', 'app', 'build.gradle');
   const appBuildGradle = await fs.promises.readFile(appBuildGradlePath, 'utf8');
 
@@ -216,6 +228,34 @@ export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPa
     appBuildGradlePath,
     appBuildGradle.replace(/^apply plugin: ["']org\.jetbrains\.kotlin\.android["']\r?\n/m, '')
   );
+
+  // AGP 9 disables the `buildConfig` feature by default, but several Expo modules declare custom
+  // BuildConfig fields. Enable it for every module through the shared plugin so they keep compiling.
+  const androidLibraryExtensionPath = path.join(
+    packagesPath,
+    'expo-modules-core',
+    'expo-module-gradle-plugin',
+    'src',
+    'main',
+    'kotlin',
+    'expo',
+    'modules',
+    'plugin',
+    'android',
+    'AndroidLibraryExtension.kt'
+  );
+
+  const androidLibraryExtension = await fs.promises.readFile(androidLibraryExtensionPath, 'utf8');
+
+  if (!androidLibraryExtension.includes('buildFeatures.buildConfig = true')) {
+    await fs.promises.writeFile(
+      androidLibraryExtensionPath,
+      androidLibraryExtension.replace(
+        /^(\s*)(this\.compileSdk = compileSdk)$/m,
+        '$1$2\n$1buildFeatures.buildConfig = true'
+      )
+    );
+  }
 }
 
 export async function installCocoaPodsAsync(projectRoot: string) {

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -159,11 +159,14 @@ export async function prebuildAppAsync(projectRoot: string, templateTarballPath:
   });
 }
 
-// react-native nightlies can require a newer Gradle than the stable template ships with.
-const NIGHTLY_GRADLE_VERSION = '9.4.1';
+/**
+ * Apply the Gradle tweaks needed to build the generated project against react-native nightlies.
+ */
+export async function setupGradleForNightlyAsync(projectRoot: string, expoRepoPath: string) {
+  const nightlyGradleVersion = '9.4.1';
+  const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
 
-export async function setupGradleWrapperAsync(projectRoot: string) {
-  const propertiesPath = path.join(
+  const wrapperPropertiesPath = path.join(
     projectRoot,
     'android',
     'gradle',
@@ -171,28 +174,21 @@ export async function setupGradleWrapperAsync(projectRoot: string) {
     'gradle-wrapper.properties'
   );
 
-  const properties = await fs.promises.readFile(propertiesPath, 'utf8');
+  const wrapperProperties = await fs.promises.readFile(wrapperPropertiesPath, 'utf-8');
 
-  const nextProperties = properties.replace(
-    /^(distributionUrl=.*gradle-).*(-bin\.zip)$/m,
-    `$1${NIGHTLY_GRADLE_VERSION}$2`
+  await fs.promises.writeFile(
+    wrapperPropertiesPath,
+    wrapperProperties.replace(
+      /^(distributionUrl=.*gradle-).*(-bin\.zip)$/m,
+      `$1${nightlyGradleVersion}$2`
+    )
   );
 
-  await fs.promises.writeFile(propertiesPath, nextProperties);
-}
-
-export async function setupGradlePluginKotlinAsync(expoRepoPath: string) {
-  const skipMetadataVersionCheck = 'freeCompilerArgs.add("-Xskip-metadata-version-check")';
+  const packagesPath = path.join(expoRepoPath, 'packages');
 
   const pluginRoots = [
-    path.join(expoRepoPath, 'packages', 'expo-modules-core', 'expo-module-gradle-plugin'),
-    path.join(
-      expoRepoPath,
-      'packages',
-      'expo-modules-autolinking',
-      'android',
-      'expo-gradle-plugin'
-    ),
+    path.join(packagesPath, 'expo-modules-core', 'expo-module-gradle-plugin'),
+    path.join(packagesPath, 'expo-modules-autolinking', 'android', 'expo-gradle-plugin'),
   ];
 
   for (const pluginRoot of pluginRoots) {
@@ -211,6 +207,13 @@ export async function setupGradlePluginKotlinAsync(expoRepoPath: string) {
         }
       }
     }
+  }
+
+  const gradlePropertiesPath = path.join(projectRoot, 'android', 'gradle.properties');
+  const gradleProperties = await fs.promises.readFile(gradlePropertiesPath, 'utf8');
+
+  if (!/^android\.builtInKotlin=/m.test(gradleProperties)) {
+    await fs.promises.appendFile(gradlePropertiesPath, '\nandroid.builtInKotlin=false\n');
   }
 }
 

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -15,6 +15,7 @@ import {
   createExpoApp,
   installCocoaPodsAsync,
   prebuildAppAsync,
+  setupGradlePluginKotlinAsync,
   setupGradleWrapperAsync,
 } from './Project.js';
 import { checkRequiredToolsAsync } from './SanityChecks.js';
@@ -92,6 +93,7 @@ async function runAsync(programName: string) {
 
   console.log(chalk.cyan(`Overriding Gradle wrapper for nightly`));
   await setupGradleWrapperAsync(projectRoot);
+  await setupGradlePluginKotlinAsync(expoRepoPath);
 
   if (programOpts.install) {
     if (process.platform === 'darwin') {

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -15,8 +15,7 @@ import {
   createExpoApp,
   installCocoaPodsAsync,
   prebuildAppAsync,
-  setupGradlePluginKotlinAsync,
-  setupGradleWrapperAsync,
+  setupGradleForNightlyAsync,
 } from './Project.js';
 import { checkRequiredToolsAsync } from './SanityChecks.js';
 
@@ -91,9 +90,8 @@ async function runAsync(programName: string) {
   console.log(chalk.cyan(`Running prebuild`));
   await prebuildAppAsync(projectRoot, tarballPath);
 
-  console.log(chalk.cyan(`Overriding Gradle wrapper for nightly`));
-  await setupGradleWrapperAsync(projectRoot);
-  await setupGradlePluginKotlinAsync(expoRepoPath);
+  console.log(chalk.cyan(`Setting up Gradle for nightly`));
+  await setupGradleForNightlyAsync(projectRoot, expoRepoPath);
 
   if (programOpts.install) {
     if (process.platform === 'darwin') {

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -15,6 +15,7 @@ import {
   createExpoApp,
   installCocoaPodsAsync,
   prebuildAppAsync,
+  setupGradleWrapperAsync,
 } from './Project.js';
 import { checkRequiredToolsAsync } from './SanityChecks.js';
 
@@ -88,6 +89,9 @@ async function runAsync(programName: string) {
   );
   console.log(chalk.cyan(`Running prebuild`));
   await prebuildAppAsync(projectRoot, tarballPath);
+
+  console.log(chalk.cyan(`Overriding Gradle wrapper for nightly`));
+  await setupGradleWrapperAsync(projectRoot);
 
   if (programOpts.install) {
     if (process.platform === 'darwin') {


### PR DESCRIPTION
# Why

react-native nightlies can ship an Android Gradle Plugin that requires a newer Gradle than the stable `expo-template-bare-minimum`. Override the generated nightly project's Gradle wrapper (9.4.1) after prebuild, without bumping the user-facing template.

# How

Add a `setupGradleWrapperAsync` helper function in `create-expo-nightly`

# Test Plan

Check the CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
