### PR TITLE
[expo-image] add `imageLoaded` event

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added `Image.writeToCacheAsync` and `Image.readFromCacheAsync` to seed and read the image cache by cache key. ([#46620](https://github.com/expo/expo/pull/46620) by [@tsapeta](https://github.com/tsapeta))
+- Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - [web] Improved `static` image source selection on web to be based on the rendered layout size by leading the generated `sizes` with `auto`, and default `static` images to `loading="lazy"` (opt out with `loading="eager"`). ([#46425](https://github.com/expo/expo/pull/46425) by [@sebholl](https://github.com/sebholl))
 
 ### 🐛 Bug fixes

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -50,8 +50,18 @@ import java.io.FileOutputStream
 import java.net.URL
 
 class ExpoImageModule : Module() {
+  // Whether JS subscribed to `imageLoaded`. Skips the per-image-load bridge hop when nothing is
+  // listening
+  @Volatile
+  private var hasImageLoadedListener = false
+
   override fun definition() = ModuleDefinition {
     Name("ExpoImage")
+
+    Events("imageLoaded")
+
+    OnStartObserving("imageLoaded") { hasImageLoadedListener = true }
+    OnStopObserving("imageLoaded") { hasImageLoadedListener = false }
 
     OnCreate {
       appContext.reactContext?.registerComponentCallbacks(ExpoImageComponentCallbacks)
@@ -177,7 +187,9 @@ class ExpoImageModule : Module() {
     }
 
     AsyncFunction("loadAsync") Coroutine { source: SourceMap, options: ImageLoadOptions? ->
-      ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load()
+      val image = ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load()
+      emitImageLoaded(source.uri ?: "", image.ref.intrinsicWidth, image.ref.intrinsicHeight)
+      image
     }
 
     suspend fun generatePlaceholder(
@@ -419,5 +431,19 @@ class ExpoImageModule : Module() {
         }
       }
     }
+  }
+
+  fun emitImageLoaded(url: String, width: Int, height: Int) {
+    if (!hasImageLoadedListener || width <= 0 || height <= 0 || url.isEmpty()) {
+      return
+    }
+    sendEvent(
+      "imageLoaded",
+      mapOf(
+        "url" to url,
+        "width" to width,
+        "height" to height
+      )
+    )
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
@@ -7,7 +7,9 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+import expo.modules.image.ExpoImageModule
 import expo.modules.image.ExpoImageViewWrapper
+import expo.modules.image.decodedsource.DecodedModel
 import expo.modules.image.enums.ImageCacheType
 import expo.modules.image.records.ImageErrorEvent
 import expo.modules.image.records.ImageLoadEvent
@@ -70,6 +72,14 @@ class GlideRequestListener(
           )
         )
       )
+
+      // The observe check needs a real URL (`model.toString()`). An in-memory `DecodedModel` —
+      // used when `source` is a `SharedRef<Drawable>`/`SharedRef<Bitmap>` instead of a URL.
+      if (model !is DecodedModel) {
+        appContext.registry
+          .getModule<ExpoImageModule>()
+          ?.emitImageLoaded(model.toString(), intrinsicWidth, intrinsicHeight)
+      }
     }
 
     return false

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -8,8 +8,17 @@ internal import SDWebImageSVGCoder
 public final class ImageModule: Module {
   lazy var prefetcher = SDWebImagePrefetcher.shared
 
+  // Whether JS subscribed to `imageLoaded`. Skips the per-image-load bridge hop when nothing is
+  // listening
+  private var hasImageLoadedListener = false
+
   public func definition() -> ModuleDefinition {
     Name("ExpoImage")
+
+    Events("imageLoaded")
+
+    OnStartObserving("imageLoaded") { self.hasImageLoadedListener = true }
+    OnStopObserving("imageLoaded") { self.hasImageLoadedListener = false }
 
     OnCreate {
       ImageModule.registerCoders()
@@ -288,8 +297,15 @@ public final class ImageModule: Module {
       return Image(cachedImage)
     }
 
-    AsyncFunction("loadAsync") { (source: ImageSource, options: ImageLoadOptions?) -> Image? in
+    AsyncFunction("loadAsync") { [weak appContext = self.appContext] (source: ImageSource, options: ImageLoadOptions?) -> Image? in
       let image = try await ImageLoadTask(source, options: options ?? ImageLoadOptions()).load()
+      // Going through the `appContext` instead of capturing `self` keeps this `@Sendable async` closure from forcing 
+      // the whole module to be Sendable.
+      appContext?.moduleRegistry.getModule(implementing: ImageModule.self)?.emitImageLoaded(
+        url: source.uri?.absoluteString ?? "",
+        width: image.size.width * image.scale,
+        height: image.size.height * image.scale
+      )
       return Image(image)
     }
 
@@ -302,6 +318,17 @@ public final class ImageModule: Module {
         return imageFormatToMediaType(image.ref.sd_imageFormat)
       }
     }
+  }
+
+  func emitImageLoaded(url: String, width: CGFloat, height: CGFloat) {
+    guard hasImageLoadedListener, width > 0, height > 0, !url.isEmpty else {
+      return
+    }
+    emit(event: "imageLoaded", payload: [
+      "url": url,
+      "width": Double(width),
+      "height": Double(height)
+    ])
   }
 
   func generatePlaceholder(

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -270,6 +270,12 @@ public final class ImageView: ExpoView {
         ]
       ])
 
+      appContext?.moduleRegistry.getModule(implementing: ImageModule.self)?.emitImageLoaded(
+        url: imageUrl?.absoluteString ?? "",
+        width: image.size.width * image.scale,
+        height: image.size.height * image.scale
+      )
+
       let scale = window?.screen.scale ?? UIScreen.main.scale
       imageLayoutSize = idealSize(
         contentPixelSize: image.size * image.scale,

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -792,9 +792,21 @@ export declare class ImageRef extends SharedRef<'image'> {
 }
 
 /**
+ * Module-level events emitted by the native `ExpoImage` module.
  * @hidden
  */
-export declare class ImageNativeModule extends NativeModule {
+export type ImageModuleEvents = {
+  /**
+   * Fires from every relevant load path (`loadAsync`, `useImage`, and the rendered `<Image>` view)
+   * with the decoded pixel size.
+   */
+  imageLoaded: (event: { url: string; width: number; height: number }) => void;
+};
+
+/**
+ * @hidden
+ */
+export declare class ImageNativeModule extends NativeModule<ImageModuleEvents> {
   // TODO: Add missing function declarations
   Image: typeof ImageRef;
 

--- a/packages/expo-image/src/ImageModule.web.ts
+++ b/packages/expo-image/src/ImageModule.web.ts
@@ -1,9 +1,15 @@
 import { NativeModule, registerWebModule } from 'expo-modules-core';
 
-import type { ImageCacheConfig, ImageRef, ImageSource, ImageNativeModule } from './Image.types';
+import type {
+  ImageCacheConfig,
+  ImageRef,
+  ImageSource,
+  ImageNativeModule,
+  ImageModuleEvents,
+} from './Image.types';
 import ImageRefWeb from './web/ImageRef';
 
-class ImageModule extends NativeModule implements ImageNativeModule {
+class ImageModule extends NativeModule<ImageModuleEvents> implements ImageNativeModule {
   Image: typeof ImageRef = ImageRefWeb;
 
   async prefetch(urls: string | string[], _: unknown, __: unknown): Promise<boolean> {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -55,6 +55,7 @@
 - [Android] Ignore already-settled promises. ([#46770](https://github.com/expo/expo/pull/46770) by [@jakex7](https://github.com/jakex7))
 - [iOS] `SharedObject` is now paired with its JS counterpart through a `SharedObjectNativeState` attached to the JS object, so registry lookups in both directions go through the native state and fall back to the legacy id-based path. ([#46712](https://github.com/expo/expo/pull/46712) by [@tsapeta](https://github.com/tsapeta))
 - [iOS][android] Resolve the worklet UI runtime from its `react-native-worklets` holder instead of the reanimated `_WORKLET_RUNTIME` global; `installOnUIRuntime` now takes the holder from `getUIRuntimeHolder()`. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
+- iOS Turn `getModule(implementing:)` into a public function ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
@@ -98,7 +98,7 @@ public final class ModuleRegistry: Sequence {
     }
   }
 
-  internal func getModule<ModuleProtocol>(implementing protocol: ModuleProtocol.Type) -> ModuleProtocol? {
+  public func getModule<ModuleProtocol>(implementing protocol: ModuleProtocol.Type) -> ModuleProtocol? {
     return registry.withLock { registry in
       for holder in registry.values {
         if let module = holder.module as? ModuleProtocol {


### PR DESCRIPTION
# Why

In order to integrate expo-image with expo-observe we need information when image is loaded.

# How

Add `onImageLoaded` event on iOS and Android and emit it when an image is loaded

# Test Plan

Tested in the follow-up PR

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
