### PR TITLE
[maps] Promote to stable

### DIFF
--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -6,7 +6,6 @@ packageName: 'expo-maps'
 exampleName: 'with-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
-isAlpha: true
 hasVideoLink: true
 ---
 
@@ -20,7 +19,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **important** **This library is currently in [alpha](/more/release-statuses/#alpha) and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **info** On iOS, Expo Maps uses Apple Maps and requires **iOS 17 or later**. Some features require **iOS 18 or later**, including marker, annotation, and overlay tap callbacks (such as `onMarkerClick` and `onPolylineClick`) and programmatic selection (`selectMarker` and `selectAnnotation`).
 
 ## Installation
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Promote Expo Maps from alpha to stable.
+
 ## 57.0.1 - 2026-07-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Promote Expo Maps from alpha to stable.
+- Promote Expo Maps from alpha to stable. ([#47338](https://github.com/expo/expo/pull/47338) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 57.0.1 - 2026-07-15
 

--- a/packages/expo-maps/README.md
+++ b/packages/expo-maps/README.md
@@ -1,5 +1,3 @@
-> 🚨 Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app.
-
 <p>
   <a href="https://docs.expo.dev/versions/latest/sdk/maps/">
     <img


### PR DESCRIPTION
# Why
expo-maps has been in alpha since it's release and should be considered stable

# How
Up date docs and remove alpha tag

# Test Plan
n/a
