### PR TITLE
[navigation-bar] Update Expo imports and fix `setImmediate` type conflict

### DIFF
--- a/packages/expo-navigation-bar/src/ExpoNavigationBar.android.ts
+++ b/packages/expo-navigation-bar/src/ExpoNavigationBar.android.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoNavigationBar');

--- a/packages/expo-navigation-bar/src/ExpoNavigationBar.ts
+++ b/packages/expo-navigation-bar/src/ExpoNavigationBar.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 import type { NavigationBarVisibility, NavigationBarVisibilityEvent } from './NavigationBar.types';
 

--- a/packages/expo-navigation-bar/src/NavigationBar.android.ts
+++ b/packages/expo-navigation-bar/src/NavigationBar.android.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Appearance, useColorScheme } from 'react-native';
 
@@ -59,7 +59,7 @@ function createStackEntry({ style, hidden }: NavigationBarProps): NavigationBarP
 const entriesStack: NavigationBarProps[] = [];
 
 // Timer for updating the native module values at the end of the frame
-let updateImmediate: number | null = null;
+let updateImmediate: ReturnType<typeof setImmediate> | null = null;
 
 // The current merged values from the entries stack
 const currentValues: {

--- a/packages/expo-navigation-bar/src/NavigationBar.ts
+++ b/packages/expo-navigation-bar/src/NavigationBar.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import { type EventSubscription, UnavailabilityError } from 'expo';
 import { useEffect, useState } from 'react';
 
 import type {


### PR DESCRIPTION
# Why
Follow-up to: https://github.com/expo/expo/pull/45988

In `expo-navigation-bar`, importing `expo` instead of `expo-modules-core` causes a `setImmediate` return type conflict.

When `expo` is imported instead of `expo-modules-core`, the global function declaration gets the signature from `@types/node`, which causes a conflict with the React Native type as follows:
```ts
// React Native:
function setImmediate(handler: () => void): number;

// Node:
function setImmediate(callback: (_: void) => void): NodeJS.Immediate;
```
# How
- Change the `updateImmediate` return type to  `ReturnType<typeof setImmediate> | null` instead of `number | null`
- Changed import from `expo-modules-core` to `expo`
# Test plan
Green CI
