### PR TITLE
[expo-module-scripts] Fix prepublishOnly wiping build output for expo-build packages

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add missing `publishConfig.executableFiles` ([#46074](https://github.com/expo/expo/pull/46074) by [@kitten](https://github.com/kitten))
+- Fix `prepublishOnly` wiping `build/` for packages that compile with `expo-build`, by rebuilding via the package's own `build` script instead of `tsc`. ([#47344](https://github.com/expo/expo/pull/47344) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo-module-scripts/bin/expo-module-prepublishOnly
+++ b/packages/expo-module-scripts/bin/expo-module-prepublishOnly
@@ -4,14 +4,15 @@ process.env.EXPO_NONINTERACTIVE = 1;
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { commandRunner } from '../utils/commandUtils.js';
+import { commandRunner, packageManagerRunAsync } from '../utils/commandUtils.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function runAsync() {
   console.log('Preparing module for publishing');
   await commandRunner(path.join(dirname, 'expo-module-clean'));
-  await commandRunner(path.join(dirname, 'expo-module-build'));
+  // Run the package's own `build` script so `expo-build` modules still emit output before publishing.
+  await packageManagerRunAsync(['build']);
 }
 
 (async () => {

--- a/packages/expo-module-scripts/utils/commandUtils.js
+++ b/packages/expo-module-scripts/utils/commandUtils.js
@@ -35,6 +35,28 @@ export async function packageManagerExecAsync(params, { cwd } = {}) {
   return commandRunner(command, args, { cwd });
 }
 
+export async function packageManagerRunAsync(params, { cwd } = {}) {
+  let command = '';
+  const args = [];
+
+  const npmConfigUserAgent = process.env.npm_config_user_agent;
+  if (npmConfigUserAgent?.includes('yarn')) {
+    command = 'yarn';
+    args.push(...params);
+  } else if (npmConfigUserAgent?.includes('pnpm')) {
+    command = 'pnpm';
+    args.push('run', ...params);
+  } else if (npmConfigUserAgent?.includes('bun')) {
+    command = 'bun';
+    args.push('run', ...params);
+  } else {
+    command = 'npm';
+    args.push('run', ...params);
+  }
+
+  return commandRunner(command, args, { cwd });
+}
+
 export function getArgs({ maybeAddWatchFlag = false } = {}) {
   let args = process.argv.slice(2);
   if (maybeAddWatchFlag) {


### PR DESCRIPTION
# Why

The `Publish Canaries` workflow has been failing on `main`. `expo-doctor`'s build couldn't resolve `expo-modules-autolinking/exports`.

# How

`expo-module prepublishOnly` ran `expo-module-clean && expo-module-build`, where the build step is plain `tsc`. Since the Turborepo migration (#46801), all packages compile with `expo-build` (SWC) and set `noEmit: true`, so `tsc` emitted nothing — `build/` was deleted and never regenerated. During the canary publish this wiped `expo-modules-autolinking/build/`, breaking `expo-doctor`'s ncc build downstream.

Rebuild via the package's own `build` script instead of `tsc`, which works for both `expo-build` packages and tsc-based ones.

# Test Plan

Reproduced locally: running the old `clean && build` on `expo-modules-autolinking` left no `build/`; the `expo-doctor` ncc build then failed with the same `TS2307`. After the fix, the build script regenerates `build/exports.d.ts` and `expo-doctor` builds cleanly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
