### PR TITLE
[media-library][camera] Suppress compilation warnings

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt
@@ -1,10 +1,10 @@
 package expo.modules.camera
 
 import android.graphics.Bitmap
-import expo.modules.kotlin.RuntimeContext
+import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.sharedobjects.SharedRef
 
-class PictureRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext) {
+class PictureRef(bitmap: Bitmap, runtime: Runtime) : SharedRef<Bitmap>(bitmap, runtime) {
   override val nativeRefType: String = "image"
 
   override fun getAdditionalMemoryPressure(): Int {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -239,7 +239,7 @@ object MediaLibraryUtils {
     return if (useCameraDir) Environment.DIRECTORY_DCIM else Environment.DIRECTORY_PICTURES
   }
 
-  @Deprecated("It uses deprecated Android method under the hood. See implementation for details.")
+  // It uses deprecated Android method under the hood. See implementation for details.
   fun getEnvDirectoryForAssetType(mimeType: String?, useCameraDir: Boolean): File =
     Environment.getExternalStoragePublicDirectory(getRelativePathForAssetType(mimeType, useCameraDir))
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -294,7 +294,9 @@ fun getAssetDimensionsFromCursor(
 fun exportMediaType(mediaType: Int) = when (mediaType) {
   MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaType.PHOTO
   MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO,
-  MediaStore.Files.FileColumns.MEDIA_TYPE_PLAYLIST -> MediaType.AUDIO
+  @Suppress("DEPRECATION") // MEDIA_TYPE_PLAYLIST is deprecated, we keep it for backward compatibility, however it has been removed in the new API
+  MediaStore.Files.FileColumns.MEDIA_TYPE_PLAYLIST
+  -> MediaType.AUDIO
   MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaType.VIDEO
   else -> MediaType.UNKNOWN
 }.apiName


### PR DESCRIPTION
# Why

fixes:
```gradle
`packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AlbumUtils.kt:138:36` - 'fun getEnvDirectoryForAssetType(mimeType: String?, useCameraDir: Boolean): File' is deprecated. It uses deprecated Android method under the hood. See implementation for details.
`packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt:297:32` - 'static field MEDIA_TYPE_PLAYLIST: Int' is deprecated. Deprecated in Java.
`packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt:131:50` - 'fun getEnvDirectoryForAssetType(mimeType: String?, useCameraDir: Boolean): File' is deprecated. It uses deprecated Android method under the hood. See implementation for details.
`packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt:4:8` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
`packages/expo-camera/android/src/main/java/expo/modules/camera/PictureRef.kt:7:50` - 'typealias RuntimeContext = Runtime' is deprecated. Use expo.modules.kotlin.runtime.Runtime instead.
```

# How

- Replaced `RuntimeContext` with `Runtime` in Camera
- Suppressed warnings in MediaLibrary

# Test Plan
Green CI