### PR TITLE
[location][Android] Fix compilation warnings

### DIFF
--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -770,7 +770,9 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       suspendCancellableCoroutine { continuation ->
         Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1) { addresses ->
-          val results = addresses.mapNotNull { address -> address?.toGeocodeResponse() }
+          val results = addresses
+            .filterNotNull()
+            .mapNotNull { address -> address.toGeocodeResponse() }
           continuation.resume(results)
         }
       }
@@ -778,15 +780,13 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       withContext(Dispatchers.IO) {
         @Suppress("DEPRECATION") // When minSdkVersion is 33, this code will be removed and the above code will be used instead.
         val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1).orEmpty()
-        addresses.mapNotNull { it.toGeocodeResponse() }
+        addresses.filterNotNull()
+          .mapNotNull { it.toGeocodeResponse() }
       }
     }
   }
 
-  private fun Address?.toGeocodeResponse(): GeocodeResponse? {
-    if (this == null) {
-      return null
-    }
+  private fun Address.toGeocodeResponse(): GeocodeResponse? {
     val newLocation = Location(LocationManager.GPS_PROVIDER)
     newLocation.latitude = latitude
     newLocation.longitude = longitude

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -66,9 +66,10 @@ import expo.modules.location.records.ReverseGeocodeLocation
 import expo.modules.location.records.ReverseGeocodeResponse
 import expo.modules.location.taskConsumers.GeofencingTaskConsumer
 import expo.modules.location.taskConsumers.LocationTaskConsumer
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.Locale
-import kotlin.collections.emptyList
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -766,21 +767,18 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       throw NoGeocodeException()
     }
 
-    return suspendCancellableCoroutine { continuation ->
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      suspendCancellableCoroutine { continuation ->
         Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1) { addresses ->
           val results = addresses.mapNotNull { address -> address?.toGeocodeResponse() }
           continuation.resume(results)
         }
-      } else {
+      }
+    } else {
+      withContext(Dispatchers.IO) {
         @Suppress("DEPRECATION") // When minSdkVersion is 33, this code will be removed and the above code will be used instead.
-        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1)
-        if (addresses == null) {
-          continuation.resume(emptyList())
-          return@suspendCancellableCoroutine
-        }
-        val results = addresses.mapNotNull { it.toGeocodeResponse() }
-        continuation.resume(results)
+        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1).orEmpty()
+        addresses.mapNotNull { it.toGeocodeResponse() }
       }
     }
   }
@@ -813,8 +811,8 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       longitude = location.longitude
     }
 
-    return suspendCancellableCoroutine { continuation ->
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      suspendCancellableCoroutine { continuation ->
         Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1) { addresses ->
           val results = addresses.mapNotNull { address ->
             address?.let {
@@ -823,19 +821,16 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
           }
           continuation.resume(results)
         }
-      } else {
+      }
+    } else {
+      withContext(Dispatchers.IO) {
         @Suppress("DEPRECATION") // When minSdkVersion is 33, this code will be removed and the above code will be used instead.
-        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1)
-        if (addresses == null) {
-          continuation.resume(emptyList())
-          return@suspendCancellableCoroutine
-        }
-        val results = addresses.mapNotNull { address ->
+        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1).orEmpty()
+        return@withContext addresses.mapNotNull { address ->
           address?.let {
             ReverseGeocodeResponse(it)
           }
         }
-        continuation.resume(results)
       }
     }
   }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -18,7 +18,6 @@ import android.location.Geocoder
 import android.location.Location
 import android.location.LocationManager
 import android.os.Build
-import android.os.Bundle
 import android.os.Looper
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -663,7 +662,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
 
   internal fun sendLocationResponse(watchId: Int, response: LocationResponse) {
     val responseBundle = bundleOf()
-    responseBundle.putBundle("location", response.toBundle(Bundle::class.java))
+    responseBundle.putBundle("location", response.toBundle())
     responseBundle.putInt("watchId", watchId)
     sendEvent(LOCATION_EVENT_NAME, responseBundle)
   }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -13,6 +13,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.location.Address
 import android.location.Geocoder
 import android.location.Location
 import android.location.LocationManager
@@ -36,6 +37,7 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
+import com.google.android.gms.location.Priority
 import expo.modules.core.interfaces.ActivityEventListener
 import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.UIManager
@@ -65,7 +67,9 @@ import expo.modules.location.records.ReverseGeocodeLocation
 import expo.modules.location.records.ReverseGeocodeResponse
 import expo.modules.location.taskConsumers.GeofencingTaskConsumer
 import expo.modules.location.taskConsumers.LocationTaskConsumer
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Locale
+import kotlin.collections.emptyList
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -596,7 +600,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       )
     } else {
       val locationRequest = LocationRequest.Builder(
-        LocationRequest.PRIORITY_HIGH_ACCURACY,
+        Priority.PRIORITY_HIGH_ACCURACY,
         0L
       ).setMaxUpdates(1)
         .build()
@@ -763,20 +767,33 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       throw NoGeocodeException()
     }
 
-    return suspendCoroutine { continuation ->
-      val locations = Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1)
-      locations?.let { location ->
-        location.let {
-          val results = it.mapNotNull { address ->
-            val newLocation = Location(LocationManager.GPS_PROVIDER)
-            newLocation.latitude = address.latitude
-            newLocation.longitude = address.longitude
-            GeocodeResponse.from(newLocation)
-          }
+    return suspendCancellableCoroutine { continuation ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1) { addresses ->
+          val results = addresses.mapNotNull { address -> address?.toGeocodeResponse() }
           continuation.resume(results)
         }
-      } ?: continuation.resume(emptyList())
+      } else {
+        @Suppress("DEPRECATION") // When minSdkVersion is 33, this code will be removed and the above code will be used instead.
+        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocationName(address, 1)
+        if (addresses == null) {
+          continuation.resume(emptyList())
+          return@suspendCancellableCoroutine
+        }
+        val results = addresses.mapNotNull { it.toGeocodeResponse() }
+        continuation.resume(results)
+      }
     }
+  }
+
+  private fun Address?.toGeocodeResponse(): GeocodeResponse? {
+    if (this == null) {
+      return null
+    }
+    val newLocation = Location(LocationManager.GPS_PROVIDER)
+    newLocation.latitude = latitude
+    newLocation.longitude = longitude
+    return GeocodeResponse.from(newLocation)
   }
 
   private suspend fun reverseGeocode(location: ReverseGeocodeLocation): List<ReverseGeocodeResponse> {
@@ -797,16 +814,30 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       longitude = location.longitude
     }
 
-    return suspendCoroutine { continuation ->
-      val locations = Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1)
-      locations?.let { addresses ->
+    return suspendCancellableCoroutine { continuation ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1) { addresses ->
+          val results = addresses.mapNotNull { address ->
+            address?.let {
+              ReverseGeocodeResponse(address)
+            }
+          }
+          continuation.resume(results)
+        }
+      } else {
+        @Suppress("DEPRECATION") // When minSdkVersion is 33, this code will be removed and the above code will be used instead.
+        val addresses = Geocoder(mContext, Locale.getDefault()).getFromLocation(androidLocation.latitude, androidLocation.longitude, 1)
+        if (addresses == null) {
+          continuation.resume(emptyList())
+          return@suspendCancellableCoroutine
+        }
         val results = addresses.mapNotNull { address ->
           address?.let {
             ReverseGeocodeResponse(it)
           }
         }
         continuation.resume(results)
-      } ?: continuation.resume(emptyList())
+      }
     }
   }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
@@ -117,23 +117,19 @@ internal class LocationResponse(
     }
   )
 
-  internal fun <BundleType : BaseBundle> toBundle(bundleTypeClass: Class<BundleType>): BundleType {
-    @Suppress("UNCHECKED_CAST")
-    val bundle: BundleType = when (bundleTypeClass) {
-      PersistableBundle::class.java -> PersistableBundle()
-      else -> Bundle()
-    } as? BundleType
-      ?: throw ConversionException(LocationResponse::class.java, bundleTypeClass, "Unsupported bundleTypeClass")
+  internal fun toBundle() = Bundle().apply {
+    putLocationResponseFields()
+    putBundle("coords", coords?.toBundle())
+  }
 
-    return bundle.apply {
-      timestamp?.let { putDouble("timestamp", it) }
-      mocked?.let { putBoolean("mocked", it) }
-      if (bundle is PersistableBundle) {
-        (this as PersistableBundle).putPersistableBundle("coords", coords?.toBundle(PersistableBundle::class.java))
-      } else if (bundle is Bundle) {
-        (this as Bundle).putBundle("coords", coords?.toBundle(Bundle::class.java))
-      }
-    }
+  internal fun toPersistableBundle() = PersistableBundle().apply {
+    putLocationResponseFields()
+    putPersistableBundle("coords", coords?.toPersistableBundle())
+  }
+
+  private fun BaseBundle.putLocationResponseFields() {
+    timestamp?.let { putDouble("timestamp", it) }
+    mocked?.let { putBoolean("mocked", it) }
   }
 }
 
@@ -161,24 +157,22 @@ internal class LocationObjectCoords(
     speed = location.speed.toDouble()
   )
 
-  internal fun <BundleType : BaseBundle> toBundle(bundleTypeClass: Class<BundleType>): BundleType {
-    @Suppress("UNCHECKED_CAST")
-    val bundle: BundleType = when (bundleTypeClass) {
-      PersistableBundle::class.java -> PersistableBundle()
-      else -> Bundle()
-    } as? BundleType
-      ?: throw ConversionException(LocationObjectCoords::class.java, bundleTypeClass, "Requested an unsupported bundle type")
+  internal fun toBundle() = Bundle().apply {
+    putLocationObjectCoordsFields()
+  }
 
-    bundle.apply {
-      latitude?.let { putDouble("latitude", it) }
-      longitude?.let { putDouble("longitude", it) }
-      altitude?.let { putDouble("altitude", it) }
-      accuracy?.let { putDouble("accuracy", it) }
-      altitudeAccuracy?.let { putDouble("altitudeAccuracy", it) }
-      heading?.let { putDouble("heading", it) }
-      speed?.let { putDouble("speed", it) }
-    }
-    return bundle
+  internal fun toPersistableBundle() = PersistableBundle().apply {
+    putLocationObjectCoordsFields()
+  }
+
+  private fun BaseBundle.putLocationObjectCoordsFields() {
+    latitude?.let { putDouble("latitude", it) }
+    longitude?.let { putDouble("longitude", it) }
+    altitude?.let { putDouble("altitude", it) }
+    accuracy?.let { putDouble("accuracy", it) }
+    altitudeAccuracy?.let { putDouble("altitudeAccuracy", it) }
+    heading?.let { putDouble("heading", it) }
+    speed?.let { putDouble("speed", it) }
   }
 }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
@@ -109,10 +109,16 @@ internal class LocationResponse(
   constructor(location: Location) : this(
     coords = LocationObjectCoords(location),
     timestamp = location.time.toDouble(),
-    mocked = location.isFromMockProvider
+    mocked = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      location.isMock
+    } else {
+      @Suppress("DEPRECATION") // When minSdkVersion is 31, this code will be removed and the above code will be used instead.
+      location.isFromMockProvider
+    }
   )
 
   internal fun <BundleType : BaseBundle> toBundle(bundleTypeClass: Class<BundleType>): BundleType {
+    @Suppress("UNCHECKED_CAST")
     val bundle: BundleType = when (bundleTypeClass) {
       PersistableBundle::class.java -> PersistableBundle()
       else -> Bundle()
@@ -156,6 +162,7 @@ internal class LocationObjectCoords(
   )
 
   internal fun <BundleType : BaseBundle> toBundle(bundleTypeClass: Class<BundleType>): BundleType {
+    @Suppress("UNCHECKED_CAST")
     val bundle: BundleType = when (bundleTypeClass) {
       PersistableBundle::class.java -> PersistableBundle()
       else -> Bundle()

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
@@ -8,7 +8,6 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Binder
 import android.os.Build
@@ -48,7 +47,7 @@ class LocationTaskService : Service() {
   }
 
   fun stop() {
-    stopForeground(true)
+    stopForeground(STOP_FOREGROUND_REMOVE)
     stopSelf()
   }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
@@ -254,7 +254,7 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
       // Some devices may broadcast the same location multiple times (mostly twice)
       // so we're filtering out these locations.
       if (timestamp > sLastTimestamp) {
-        val bundle = LocationResponse(location).toBundle(PersistableBundle::class.java)
+        val bundle = LocationResponse(location).toPersistableBundle()
         data.add(bundle)
         sLastTimestamp = timestamp
         lastReported = location
@@ -290,7 +290,7 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
       // Some devices may broadcast the same location multiple times (mostly twice) so we're filtering out these locations,
       // so only one location at the specific timestamp can schedule a job.
       if (timestamp > sLastTimestamp) {
-        val bundle = LocationResponse(location).toBundle(PersistableBundle::class.java)
+        val bundle = LocationResponse(location).toPersistableBundle()
         data.add(bundle)
         sLastTimestamp = timestamp
       }


### PR DESCRIPTION
# Why

This PR is part of a series aimed at removing compilation warnings.

It removes the following warnings:
```gradle
`packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt:599:25` - 'static field PRIORITY_HIGH_ACCURACY: Int' is deprecated. Deprecated in Java.
`packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt:767:63` - 'fun getFromLocationName(p0: String, p1: Int): (Mutable)List<Address!>?' is deprecated. Deprecated in Java.
`packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt:801:63` - 'fun getFromLocation(p0: Double, p1: Double, p2: Int): (Mutable)List<Address!>?' is deprecated. Deprecated in Java.
`packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt:112:23` - 'val isFromMockProvider: Boolean' is deprecated. Deprecated in Java.
`packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt:119:7` - Unchecked cast of 'BaseBundle & Cloneable & Parcelable' to 'BundleType (of fun <BundleType : BaseBundle> toBundle)'.
`packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt:162:7` - Unchecked cast of 'BaseBundle & Cloneable & Parcelable' to 'BundleType (of fun <BundleType : BaseBundle> toBundle)'.
`packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt:51:5` - 'fun stopForeground(p0: Boolean): Unit' is deprecated. Deprecated in Java.
```

# How

- Replaced deprecated `LocationRequest.PRIORITY_HIGH_ACCURACY` with `Priority.PRIORITY_HIGH_ACCURACY` (both are `100` under the hood)
- Replaced deprecated 
`fun getFromLocationName(p0: String, p1: Int)` and `fun getFromLocation(p0: Double, p1: Double, p2: Int)` 
with 
`fun getFromLocationName(p0: String, p1: Int, p2: GeocodeListener)` and `fun getFromLocation(p0: Double, p1: Double, p2: Int, p3: GeocodeListener)`
- Added `withContext(Dispatchers.IO)` to the legacy paths of the geocoding functions and removed `suspendCoroutine` around the legacy blocking calls
- Replaced deprecated `isFromMockProvider` with `isMock` (`isFromMockProvider` calls `isMock` directly)
- Replaced deprecated `stopForeground(boolean)` with `stopForeground(STOP_FOREGROUND_REMOVE)`, following the docs:
```gradle
Call stopForeground(int) and pass either STOP_FOREGROUND_REMOVE or STOP_FOREGROUND_DETACH explicitly instead.
```
- Split `toBundle` into two non-generic functions without unchecked casts

# Test Plan

BareExpo ✅