### PR TITLE
[docs] Add Bun example to Jest `transformIgnorePatterns`, fix pnpm

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -133,7 +133,22 @@ You can transpile node modules your project uses by configuring [`transformIgnor
   "preset": "jest-expo",
   /* @info */
   "transformIgnorePatterns": [
-    "node_modules/(?!(?:.pnpm/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg))"
+    "node_modules/(?!(.pnpm|(jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg))"
+  ]
+  /* @end */
+}
+```
+
+</Tab>
+
+<Tab label="Bun">
+
+```json package.json
+"jest": {
+  "preset": "jest-expo",
+  /* @info */
+  "transformIgnorePatterns": [
+    "node_modules/(?!(.bun|(jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg))"
   ]
   /* @end */
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22207

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a **Bun** tab to the `transformIgnorePatterns` config in `unit-testing.mdx` using a `.bun` allowlist entry, so Jest transforms ESM dependencies under Bun's isolated `node_modules/.bun` layout.
- Fix the `pnpm` tab to allowlist `.pnpm` directly instead of the `(?:.pnpm/)?` prefix, which skipped scoped packages (for example `@sentry/react-native`) in isolated installs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
