### PR TITLE
 [docs] Add `--example` flag to Create a project guide

### DIFF
--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -53,10 +53,10 @@ To create a known example directly, pass its name:
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --example with-router'],
-    yarn: ['$ yarn create expo-app --example with-router'],
-    pnpm: ['$ pnpm create expo-app --example with-router'],
-    bun: ['$ bun create expo --example with-router'],
+    npm: ['$ npx create-expo-app@latest --example with-widgets'],
+    yarn: ['$ yarn create expo-app --example with-widgets'],
+    pnpm: ['$ pnpm create expo-app --example with-widgets'],
+    bun: ['$ bun create expo --example with-widgets'],
   }}
 />
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -17,7 +17,9 @@ We also make [Expo Application Services (EAS)](https://expo.dev/eas), a set of s
 - [Node.js (LTS)](https://nodejs.org/en/).
 - macOS, Windows (Powershell and [WSL 2](https://expo.fyi/wsl)), and Linux are supported.
 
-We recommend starting with the default project created by `create-expo-app`. The default project includes example code to help you get started.
+## Start with a default project
+
+We recommend starting with the default project created by [`create-expo-app`](/more/create-expo/). The default project includes example code to help you get started.
 
 To create a new project, run the following command:
 
@@ -31,6 +33,34 @@ To create a new project, run the following command:
 />
 
 > **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
+
+## Start from an example
+
+Instead of the default project, you can start from one of the [Expo examples](https://github.com/expo/examples). These are small apps that each demonstrate a specific feature or integration, such as Expo Router, Expo Widgets, or a camera screen.
+
+To browse the full list and pick one interactively, run `create-expo-app` with the [`--example`](/more/create-expo/#--example) option and no name:
+
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest --example'],
+    yarn: ['$ yarn create expo-app --example'],
+    pnpm: ['$ pnpm create expo-app --example'],
+    bun: ['$ bun create expo --example'],
+  }}
+/>
+
+To create a known example directly, pass its name:
+
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest --example with-router'],
+    yarn: ['$ yarn create expo-app --example with-router'],
+    pnpm: ['$ pnpm create expo-app --example with-router'],
+    bun: ['$ bun create expo --example with-router'],
+  }}
+/>
+
+> **info** The rest of the guides in this **"Get started"** section follows the default project. An example app may be organized differently but the concepts are the same.
 
 ## Next step
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22261

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a **Start from an example** section to `create-a-project.mdx` covering the [`--example`](/more/create-expo/#--example) flag (no name for the interactive list, or a name like `with-router`), linking to [`expo/examples`](https://github.com/expo/examples).
- Add a **Start with a default project** heading to split the default template flow from the new example path.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2570" height="1824" alt="CleanShot 2026-06-29 at 22 39 53@2x" src="https://github.com/user-attachments/assets/0cd779c9-ca29-4f5d-87dd-043f2e33355e" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
