### PR TITLE
[expo-dev-launcher][android] Forward launch-intent extras on cold launch

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix auto-launching into the most recently opened project on startup. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Forward the launching intent's extras when cold-launching the most recently opened bundle, so launch arguments (e.g. from Maestro/Detox or `adb am start -e`) reach the app and `react-native-launch-arguments` can read them. ([#47352](https://github.com/expo/expo/pull/47352) by [@kanzelm3](https://github.com/kanzelm3))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -321,6 +321,12 @@ class DevLauncherController private constructor(
         DependencyInjection.devMenuPreferences?.tryToLaunchLastBundle ?: true
       val lastOpenedApp = recentlyOpedAppsRegistry.getMostRecentApp()
       if (shouldTryToLaunchLastOpenedBundle && lastOpenedApp != null) {
+        // Forward the launching intent's extras (e.g. launch arguments passed by
+        // Maestro / Detox / `adb am start -e`) so they reach the loaded app via
+        // `createAppIntent()`. Without this, cold-launching the last opened bundle
+        // drops the extras and consumers like `react-native-launch-arguments` read
+        // nothing. Mirrors `handleExternalIntent`, which already stores extras.
+        pendingIntentExtras = intent.extras
         coroutineScope.launch {
           try {
             loadApp(lastOpenedApp.url.toUri(), activityToBeInvalidated)


### PR DESCRIPTION
# Why

On Android, cold-launching a **development build** with a plain `ACTION_MAIN` intent that carries **extras** (e.g. `adb shell am start -e key value`, which is how Maestro/Detox and other automation pass launch arguments) drops those extras — they never reach the loaded app. Anything that reads them, e.g. [`react-native-launch-arguments`](https://github.com/iamolegga/react-native-launch-arguments) (which reads `getCurrentActivity().getIntent().getExtras()`), sees an empty bundle.

This makes launch-argument-based E2E setup (feature-flag overrides, test config, seeded state, etc.) impossible on Android dev builds. iOS is unaffected because it reads process arguments, which are launcher-independent; standalone/release Android builds are unaffected because there's no `DevLauncherActivity` in the path. So it's a dev-client-specific asymmetry.

# How

`DevLauncherController.handleIntent()` already forwards the launching intent's extras to the app in two of its three paths:

- deep-link URL → `pendingIntentRegistry.intent = intent`
- `handleExternalIntent` → `pendingIntentExtras = intent.extras` (*"Always store the intent extras…"*)

…and `createAppIntent()` copies `pendingIntentExtras` onto the intent used to start `DevLauncherActivity`. But the third path — a plain `ACTION_MAIN` cold launch that auto-opens the most recently opened bundle — calls `loadApp(...)` **without** capturing `intent.extras`, so `createAppIntent()` forwards nothing and the app loads with a clean intent.

This PR sets `pendingIntentExtras = intent.extras` in that branch, mirroring `handleExternalIntent`. It's in the `debug` source set only (the release `DevLauncherController` is a no-op), so there is no production-build impact.

# Test Plan

- Dev build with `react-native-launch-arguments` installed; open a bundle once so it's the most-recently-opened app.
- `adb shell am force-stop <pkg> && adb shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -n <pkg>/.MainActivity -e isE2E true`
- **Before:** `LaunchArguments.value()` → `{}`; `dumpsys activity activities` shows the app in `DevLauncherActivity` with an intent that has no extras.
- **After:** `LaunchArguments.value()` → `{ isE2E: true }`; the extras are present on the app's hosting intent.

Verified end-to-end against `expo-dev-launcher@6.0.20` via a local patch (`LaunchArguments.value()` returned the full set of extras and the app behaved as expected); the change applies identically to `main`.

# Checklist

- [x] Documentation is up to date (CHANGELOG entry added under expo-dev-launcher 🐛 Bug fixes).
- [x] Conforms to the [Expo Universal Module API].
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (debug source set only; no template/config changes).
