### PR TITLE
fix(require-utils): Throw a clear error for import.meta in CommonJS-loaded .ts/.cts modules

### DIFF
--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Throw a clear error when `import.meta` is used in a `.ts`/`.cts` module loaded as CommonJS, instead of failing with a cryptic "exports is not defined in ES module scope" or silently evaluating to `undefined`. ([#PR](https://github.com/expo/expo/pull/PR) by [@jiunshinn](https://github.com/jiunshinn))
+
 ### 💡 Others
 
 ## 56.1.3 — 2026-05-23

--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Throw a clear error when `import.meta` is used in a `.ts`/`.cts` module loaded as CommonJS, instead of failing with a cryptic "exports is not defined in ES module scope" or silently evaluating to `undefined`. ([#PR](https://github.com/expo/expo/pull/PR) by [@jiunshinn](https://github.com/jiunshinn))
+- Throw a clear error when `import.meta` is used in a `.ts`/`.cts` module loaded as CommonJS, instead of failing with a cryptic "exports is not defined in ES module scope" or silently evaluating to `undefined`. ([#47358](https://github.com/expo/expo/pull/47358) by [@jiunshinn](https://github.com/jiunshinn))
 
 ### 💡 Others
 

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -76,4 +76,30 @@ describe('evalModule', () => {
       default: 'test',
     });
   });
+
+  it('throws a helpful error when .ts code uses import.meta (loaded as CommonJS)', () => {
+    expect(() =>
+      evalModule(`export const dir = import.meta.dirname;`, path.join(basepath, 'eval.ts'))
+    ).toThrow(/import\.meta/);
+  });
+
+  it('does not confuse "import.meta" inside a string or comment for the meta-property', () => {
+    const mod = evalModule(
+      `// import.meta.dirname is unavailable here\nexport const note = 'use import.meta in .mts files';`,
+      path.join(basepath, 'eval.ts')
+    );
+
+    expect(mod).toEqual({
+      note: 'use import.meta in .mts files',
+    });
+  });
+
+  it('accepts .mts code using import.meta (loaded as an ES module)', () => {
+    const mod = evalModule(
+      `export const hasMeta = typeof import.meta.url === 'string';`,
+      path.join(basepath, 'eval.mts')
+    );
+
+    expect(mod.hasMeta).toBe(true);
+  });
 });

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -63,6 +63,32 @@ function maybeReadFileSync(filename: string) {
   }
 }
 
+/** Whether the source contains an `import.meta` meta-property, ignoring string and comment
+ * occurrences. Used to detect `import.meta` in files that are loaded as CommonJS. */
+function sourceUsesImportMeta(tsModule: typeof import('typescript'), code: string): boolean {
+  const sourceFile = tsModule.createSourceFile(
+    'module.ts',
+    code,
+    tsModule.ScriptTarget.Latest,
+    false
+  );
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return;
+    } else if (
+      tsModule.isMetaProperty(node) &&
+      node.keywordToken === tsModule.SyntaxKind.ImportKeyword
+    ) {
+      found = true;
+    } else {
+      tsModule.forEachChild(node, visit);
+    }
+  };
+  visit(sourceFile);
+  return found;
+}
+
 type Format = 'commonjs' | 'module' | 'module-typescript' | 'commonjs-typescript' | 'typescript';
 
 function toFormat(filename: string, isLegacy: true): Format;
@@ -304,6 +330,24 @@ function evalModule(
         mode: 'transform',
         sourceMap: true,
       });
+    }
+
+    // `import.meta` survives the CommonJS transpile but can't be evaluated as CommonJS,
+    // so fail early with an actionable error instead of a cryptic Node failure. The cheap
+    // regex avoids parsing the file again unless it's likely affected.
+    if (
+      format === 'commonjs-typescript' &&
+      /\bimport\s*\.\s*meta\b/.test(code) &&
+      (!ts || sourceUsesImportMeta(ts, code))
+    ) {
+      throw new SyntaxError(
+        `Cannot use "import.meta" in "${path.basename(filename)}". ` +
+          `".ts" and ".cts" files are loaded as CommonJS for backwards compatibility, ` +
+          `and "import.meta" only exists in ES modules.\n` +
+          `Replace "import.meta.dirname" with "__dirname" and "import.meta.url" with ` +
+          `"require('node:url').pathToFileURL(__filename).href", or rename the file to ".mts" ` +
+          `to load it as an ES module.`
+      );
     }
 
     if (inputCode !== code) {


### PR DESCRIPTION
# Why

Related to #47272.

A `.ts`/`.cts` config plugin that uses `import.meta` (e.g. `import.meta.dirname`) fails during `expo prebuild` with a confusing `exports is not defined in ES module scope` that never mentions `import.meta` — because, as @kitten noted in the issue, these files are transpiled to CommonJS and `import.meta` is left untouched in the output.

The failure is also Node-version dependent: on Node 24 `import.meta` silently evaluates to `undefined`, while on Node 26 it throws the error above. Either way it never works, and nothing points the user at the cause.

This PR only improves the diagnostic — it does not add native ESM support for `.ts` plugins, which is a separate design decision.

# How

After a `.ts`/`.cts` file is transpiled to CommonJS, detect an `import.meta` meta-property and throw an actionable error instead of letting it reach Node:

```
Cannot use "import.meta" in "withCopyDirectoryAndroid.ts". ".ts" and ".cts" files are
loaded as CommonJS for backwards compatibility, and "import.meta" only exists in ES modules.
Replace "import.meta.dirname" with "__dirname" and "import.meta.url" with
"require('node:url').pathToFileURL(__filename).href", or rename the file to ".mts" to load
it as an ES module.
```

Detection is gated by a cheap regex and confirmed via the TypeScript AST, so `import.meta` in a string or comment is not misdetected. `.mts` files are untouched, since they load as ES modules where `import.meta` works.

# Test Plan

Added unit tests in `src/__tests__/load-test.ts` (`.ts` with `import.meta` throws; string/comment occurrence is ignored; `.mts` still loads). `build`, `typecheck`, `lint`, and `test` pass via `turbo run … --filter=@expo/require-utils`.

Happy to adjust the approach or wording, or close this if you'd prefer to handle it differently.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
