### PR TITLE
[camera] Add support for document scanning

### DIFF
--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -568,6 +568,40 @@ export type ScanningOptions = {
 };
 
 /**
+ * @platform android
+ * @platform ios
+ */
+export type DocumentScanningOptions = {
+  /**
+   * Whether to also produce a multi-page PDF of the scan in addition to per-page images.
+   * @default false
+   */
+  requestPdf?: boolean;
+  /**
+   * The JPEG compression quality of the saved page images, between `0` and `1`. `0` means
+   * compress for the smallest size, `1` means compress for maximum quality.
+   * > On Android the value is mapped to ML Kit's nearest supported quality.
+   * @default 0.9
+   */
+  quality?: number;
+};
+
+/**
+ * @platform android
+ * @platform ios
+ */
+export type DocumentScanningResult = {
+  /**
+   * An ordered array of `file://` URIs, one per scanned page image.
+   */
+  pages: string[];
+  /**
+   * A `file://` URI of the generated multi-page PDF. Only present when `requestPdf` was `true`.
+   */
+  pdfUri?: string;
+};
+
+/**
  * The available barcode types that can be scanned.
  */
 export type BarcodeType =
@@ -642,10 +676,14 @@ export declare class CameraNativeModule extends NativeModule<CameraEvents> {
   Picture: typeof PictureRef;
 
   readonly isModernBarcodeScannerAvailable: boolean;
+  readonly isDocumentScannerAvailable: boolean;
   readonly toggleRecordingAsyncAvailable: boolean;
   readonly isAvailableAsync: () => Promise<boolean>;
   readonly launchScanner: (options?: ScanningOptions) => Promise<void>;
   readonly dismissScanner: () => Promise<void>;
+  readonly scanDocumentAsync: (
+    options?: DocumentScanningOptions
+  ) => Promise<DocumentScanningResult | null>;
   readonly scanFromURLAsync: (
     url: string,
     barcodeTypes?: BarcodeType[]

--- a/packages/expo-camera/src/CameraView.tsx
+++ b/packages/expo-camera/src/CameraView.tsx
@@ -8,6 +8,8 @@ import type {
   CameraViewProps,
   CameraRecordingOptions,
   CameraViewRef,
+  DocumentScanningOptions,
+  DocumentScanningResult,
   ScanningOptions,
   ScanningResult,
   VideoCodec,
@@ -79,6 +81,7 @@ export default class CameraView extends Component<CameraViewProps> {
    * Property that determines if the current device has the ability to use `DataScannerViewController` (iOS 16+) or the Google code scanner (Android).
    */
   static isModernBarcodeScannerAvailable: boolean = CameraManager.isModernBarcodeScannerAvailable;
+  static isDocumentScannerAvailable: boolean = CameraManager.isDocumentScannerAvailable;
   /**
    * Check whether the current device has a camera. This is useful for web and simulators cases.
    * This isn't influenced by the Permissions API (all platforms), or HTTP usage (in the browser).
@@ -236,6 +239,25 @@ export default class CameraView extends Component<CameraViewProps> {
     if (Platform.OS !== 'web' && CameraView.isModernBarcodeScannerAvailable) {
       await CameraManager.dismissScanner();
     }
+  }
+
+  /**
+   * Presents a system document scanner. On iOS this uses VisionKit's
+   * [`VNDocumentCameraViewController`](https://developer.apple.com/documentation/visionkit/vndocumentcameraviewcontroller);
+   * on Android it uses the [ML Kit document scanner](https://developers.google.com/ml-kit/vision/doc-scanner).
+   * Resolves with the scanned pages once the user saves, or `null` if they cancel.
+   * @param options A map of `DocumentScanningOptions`.
+   * @return A promise resolving to a [`DocumentScanningResult`](#documentscanningresult), or `null` on cancel or when unavailable.
+   * @platform android
+   * @platform ios
+   */
+  static async scanDocumentAsync(
+    options?: DocumentScanningOptions
+  ): Promise<DocumentScanningResult | null> {
+    if (Platform.OS === 'web' || !CameraView.isDocumentScannerAvailable) {
+      return null;
+    }
+    return (await CameraManager.scanDocumentAsync(options ?? {})) ?? null;
   }
 
   /**

--- a/packages/expo-camera/src/ExpoCameraManager.web.ts
+++ b/packages/expo-camera/src/ExpoCameraManager.web.ts
@@ -82,6 +82,10 @@ async function handlePermissionsQueryAsync(
 
 export default {
   isModernBarcodeScannerAvailable: false,
+  isDocumentScannerAvailable: false,
+  async scanDocumentAsync() {
+    return null;
+  },
   toggleRecordingAsyncAvailable: false,
   addListener(_eventName: string, _listener: (...args: any[]) => any) {
     return { remove: () => {} };


### PR DESCRIPTION
# Why

Adds support for document scanning in expo-camera

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Adds `CameraView.scanDocumentAsync()`. Adds `isDocumentScannerAvailable`, `DocumentScanningOptions` and `DocumentScanningResult` types. On web the scanner as unavailable.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Just the js api. Tested in follow up prs