### PR TITLE
[ios][camera] Add support for document scanning

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -44,6 +44,13 @@ export const CameraScreens = [
       return optionalRequire(() => require('./CameraScreenImageRef'));
     },
   },
+  {
+    name: 'Camera (document scanner)',
+    route: 'camera/expo-camera-document-scanner',
+    getComponent() {
+      return optionalRequire(() => require('./CameraScreenDocumentScanner'));
+    },
+  },
 ];
 
 export default function CameraScreen() {

--- a/apps/native-component-list/src/screens/Camera/CameraScreenDocumentScanner.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenDocumentScanner.tsx
@@ -1,0 +1,110 @@
+import { CameraView, DocumentScanningOptions, DocumentScanningResult } from 'expo-camera';
+import Checkbox from 'expo-checkbox';
+import { File, Paths } from 'expo-file-system';
+import * as IntentLauncher from 'expo-intent-launcher';
+import * as Sharing from 'expo-sharing';
+import { useState } from 'react';
+import { Alert, Image, Platform, ScrollView, View, Button, StyleSheet } from 'react-native';
+
+import { BodyText } from '../../components/BodyText';
+
+export default function CameraScreenDocumentScanner() {
+  const [result, setResult] = useState<DocumentScanningResult | null | undefined>(undefined);
+  const [requestPdf, setRequestPdf] = useState(false);
+
+  async function saveAndOpenPdf(pdfUri: string) {
+    try {
+      const dest = new File(Paths.document, 'scanned-document.pdf');
+      await new File(pdfUri).copy(dest, { overwrite: true });
+
+      if (Platform.OS === 'android') {
+        await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
+          data: dest.contentUri,
+          flags: 1,
+          type: 'application/pdf',
+        });
+      } else {
+        await Sharing.shareAsync(dest.uri, { mimeType: 'application/pdf', UTI: 'com.adobe.pdf' });
+      }
+    } catch (error: any) {
+      Alert.alert('Could not open PDF', error.message);
+    }
+  }
+
+  async function scanDocument() {
+    const options: DocumentScanningOptions = { requestPdf };
+    try {
+      const scanResult = await CameraView.scanDocumentAsync(options);
+      setResult(scanResult);
+    } catch (error) {
+      console.error('Error scanning document:', error);
+    }
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={{
+        flexGrow: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 20,
+        gap: 20,
+      }}>
+      <View style={{ gap: 20 }}>
+        <Button
+          title="Scan Document"
+          onPress={scanDocument}
+          disabled={!CameraView.isDocumentScannerAvailable}
+        />
+        {!CameraView.isDocumentScannerAvailable && (
+          <BodyText>Document scanner is unavailable on this device.</BodyText>
+        )}
+        <View style={styles.optionRow}>
+          <BodyText style={styles.optionsText}>Generate PDF</BodyText>
+          <Checkbox value={requestPdf} onValueChange={setRequestPdf} />
+        </View>
+      </View>
+      {result === null && <BodyText>Scan cancelled.</BodyText>}
+      {result != null && (
+        <View style={{ alignItems: 'center', marginTop: 20 }}>
+          <BodyText>Pages: {result.pages.length}</BodyText>
+          {result.pdfUri != null && (
+            <View style={{ alignItems: 'center', gap: 10, marginVertical: 10 }}>
+              <BodyText>PDF: {result.pdfUri}</BodyText>
+              <Button title="Save & Open PDF" onPress={() => saveAndOpenPdf(result.pdfUri!)} />
+            </View>
+          )}
+          <ScrollView horizontal style={{ marginTop: 10, height: 140, flexGrow: 0 }}>
+            {result.pages.map((uri, i) => (
+              <Image key={i} source={{ uri }} style={styles.thumbnail} resizeMode="contain" />
+            ))}
+          </ScrollView>
+        </View>
+      )}
+      {result !== undefined && (
+        <View style={{ marginTop: 16 }}>
+          <Button title="Reset" onPress={() => setResult(undefined)} />
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  optionRow: {
+    width: '55%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  optionsText: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  thumbnail: {
+    width: 100,
+    height: 140,
+    marginHorizontal: 4,
+  },
+});

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -13,6 +13,7 @@ struct ScannerContext {
 
 public final class CameraViewModule: Module, ScannerResultHandler {
   private var scannerContext: ScannerContext?
+  private var documentScannerDelegate: DocumentScannerDelegate?
 
   public func definition() -> ModuleDefinition {
     Name("ExpoCamera")
@@ -32,6 +33,10 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
     Property("isModernBarcodeScannerAvailable") {
       if #available(iOS 16.0, *) { true } else { false }
+    }
+
+    Property("isDocumentScannerAvailable") {
+      return VNDocumentCameraViewController.isSupported
     }
 
     Property("toggleRecordingAsyncAvailable") {
@@ -352,6 +357,10 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
     }
 
+    AsyncFunction("scanDocumentAsync") { (options: DocumentScannerOptions?) -> [String: Any]? in
+      try await self.scanDocument(options: options ?? DocumentScannerOptions())
+    }
+
     AsyncFunction("getCameraPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
         self.appContext?.permissions,
@@ -425,6 +434,28 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     }
     controller.dismiss(animated: true) { [weak self] in
       self?.onScannerDismissed()
+    }
+  }
+
+  @available(iOS 13.0, *)
+  @MainActor
+  private func scanDocument(options: DocumentScannerOptions) async throws -> [String: Any]? {
+    guard VNDocumentCameraViewController.isSupported else {
+      throw DocumentScannerUnavailableException()
+    }
+    guard documentScannerDelegate == nil else {
+      throw DocumentScanFailedException("a document scan is already in progress")
+    }
+    guard let presenter = appContext?.utilities?.currentViewController() else {
+      throw DocumentScanFailedException("no view controller to present from")
+    }
+    defer { documentScannerDelegate = nil }
+    return try await withCheckedThrowingContinuation { continuation in
+      let delegate = DocumentScannerDelegate(appContext: appContext, options: options, continuation: continuation)
+      documentScannerDelegate = delegate
+      let controller = VNDocumentCameraViewController()
+      controller.delegate = delegate
+      presenter.present(controller, animated: true)
     }
   }
 

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -1,67 +1,79 @@
 import ExpoModulesCore
 
-internal final class CameraUnmountedException: Exception {
+internal final class CameraUnmountedException: Exception, @unchecked Sendable {
   override var reason: String {
     "Camera unmounted during taking photo process"
   }
 }
 
-internal final class CameraNotReadyException: Exception {
+internal final class CameraNotReadyException: Exception, @unchecked Sendable {
   override var reason: String {
     "Camera is not ready yet"
   }
 }
 
-internal final class CameraOutputNotReadyException: Exception {
+internal final class CameraOutputNotReadyException: Exception, @unchecked Sendable {
   override var reason: String {
     "Camera is not ready yet. Wait for 'onCameraReady' callback"
   }
 }
 
-internal final class CameraImageCaptureException: Exception {
+internal final class CameraImageCaptureException: Exception, @unchecked Sendable {
   override var reason: String {
     "Image could not be captured"
   }
 }
 
-internal final class CameraSavingImageException: GenericException<String> {
+internal final class CameraSavingImageException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     "Failed to save image: \(param)"
   }
 }
 
-internal final class CameraRecordingException: GenericException<String?> {
+internal final class CameraRecordingException: GenericException<String?>, @unchecked Sendable {
   override var reason: String {
     "Video Codec '\(String(describing: param))' is not supported on this device"
   }
 }
 
-internal final class CameraRecordingFailedException: Exception {
+internal final class CameraRecordingFailedException: Exception, @unchecked Sendable {
   override var reason: String {
     "An error occurred while recording a video"
   }
 }
 
-internal final class CameraMetadataDecodingException: Exception {
+internal final class CameraMetadataDecodingException: Exception, @unchecked Sendable {
   override var reason: String {
     "Could not decode image metadata"
   }
 }
 
-internal final class CameraInvalidPhotoData: Exception {
+internal final class CameraInvalidPhotoData: Exception, @unchecked Sendable {
   override var reason: String {
     "An error occured while generating photo data"
   }
 }
 
-internal final class CameraToggleRecordingException: Exception {
+internal final class CameraToggleRecordingException: Exception, @unchecked Sendable {
   override var reason: String {
     "`toggleRecording()` is only supported on iOS 18.0 or later"
   }
 }
 
-internal final class CameraScannerUnavailableException: Exception {
+internal final class CameraScannerUnavailableException: Exception, @unchecked Sendable {
   override var reason: String {
     "Modern barcode scanner is not available on this device"
+  }
+}
+
+internal final class DocumentScannerUnavailableException: Exception, @unchecked Sendable {
+  override var reason: String {
+    "Document scanning is unavailable on this device. Check `CameraView.isDocumentScannerAvailable` before calling `scanDocumentAsync`"
+  }
+}
+
+internal final class DocumentScanFailedException: GenericException<String>, @unchecked Sendable {
+  override var reason: String {
+    "The document scan could not be completed: \(param)"
   }
 }

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -4,7 +4,7 @@ import Vision
 
 class BarcodeScannerUtils {
   static func getDefaultSettings() -> [String: [AVMetadataObject.ObjectType]] {
-    var validTypes = [
+    let validTypes = [
       "upc_e": AVMetadataObject.ObjectType.upce,
       "upc_a": AVMetadataObject.ObjectType.ean13,
       "code39": AVMetadataObject.ObjectType.code39,

--- a/packages/expo-camera/ios/Current/DocumentScannerDelegate.swift
+++ b/packages/expo-camera/ios/Current/DocumentScannerDelegate.swift
@@ -1,0 +1,92 @@
+import ExpoModulesCore
+import VisionKit
+import PDFKit
+
+internal final class DocumentScannerDelegate: NSObject, VNDocumentCameraViewControllerDelegate {
+  private weak var appContext: AppContext?
+  private let options: DocumentScannerOptions
+  private var continuation: CheckedContinuation<[String: Any]?, Error>?
+
+  init(appContext: AppContext?, options: DocumentScannerOptions, continuation: CheckedContinuation<[String: Any]?, Error>) {
+    self.appContext = appContext
+    self.options = options
+    self.continuation = continuation
+  }
+
+  func documentCameraViewController(
+    _ controller: VNDocumentCameraViewController,
+    didFinishWith scan: VNDocumentCameraScan
+  ) {
+    let quality = CGFloat(max(0.0, min(1.0, options.quality)))
+    let images = (0..<scan.pageCount).map {
+      scan.imageOfPage(at: $0)
+    }
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      var pageUris: [String] = []
+
+      for (index, image) in images.enumerated() {
+        guard let data = image.jpegData(compressionQuality: quality) else {
+          return self.finish(controller, with: .failure(DocumentScanFailedException("could not encode page \(index)")))
+        }
+        let path = FileSystemUtilities.generatePathInCache(self.appContext, in: "DocumentScanner", extension: ".jpg")
+        do {
+          try data.write(to: URL(fileURLWithPath: path))
+          pageUris.append(URL(fileURLWithPath: path).absoluteString)
+        } catch {
+          return self.finish(controller, with: .failure(DocumentScanFailedException("could not save page \(index): \(error.localizedDescription)")))
+        }
+      }
+
+      var result: [String: Any] = ["pages": pageUris]
+      if self.options.requestPdf {
+        do {
+          result["pdfUri"] = try self.writePdf(images: images)
+        } catch {
+          return self.finish(controller, with: .failure(DocumentScanFailedException("could not generate PDF: \(error.localizedDescription)")))
+        }
+      }
+
+      self.finish(controller, with: .success(result))
+    }
+  }
+
+  func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
+    finish(controller, with: .success(nil))
+  }
+
+  func documentCameraViewController(
+    _ controller: VNDocumentCameraViewController,
+    didFailWithError error: Error
+  ) {
+    finish(controller, with: .failure(DocumentScanFailedException(error.localizedDescription)))
+  }
+
+  private func finish(_ controller: VNDocumentCameraViewController, with result: Result<[String: Any]?, Error>) {
+    DispatchQueue.main.async {
+      guard let continuation = self.continuation else { return }
+      self.continuation = nil
+      controller.dismiss(animated: true) {
+        continuation.resume(with: result)
+      }
+    }
+  }
+
+  private func writePdf(images: [UIImage]) throws -> String {
+    let path = FileSystemUtilities.generatePathInCache(appContext, in: "DocumentScanner", extension: ".pdf")
+    let documentPath = URL(fileURLWithPath: path)
+    let document = PDFDocument()
+
+    for (index, image) in images.enumerated() {
+      guard let page = PDFPage(image: image) else {
+        throw DocumentScanFailedException("could not create PDF page \(index)")
+      }
+      document.insert(page, at: index)
+    }
+
+    guard document.write(to: documentPath) else {
+      throw DocumentScanFailedException("could not write the PDF file")
+    }
+    return URL(fileURLWithPath: path).absoluteString
+  }
+}

--- a/packages/expo-camera/ios/Current/DocumentScannerOptions.swift
+++ b/packages/expo-camera/ios/Current/DocumentScannerOptions.swift
@@ -1,0 +1,6 @@
+import ExpoModulesCore
+
+internal struct DocumentScannerOptions: Record {
+  @Field var requestPdf: Bool = false
+  @Field var quality: Double = 1
+}


### PR DESCRIPTION
# Why

 Adds the iOS part of `scanDocumentAsync`. Provides the same system document scanner used by Notes and Files.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Presents a VNDocumentCameraViewController. Each scanned page is saved as a JPEG, and an optional multi-page PDF is rendered with PDFKit when `requestPdf` is set. Availability is reported through `VNDocumentCameraViewController.isSupported`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare expo