### PR TITLE
[android][camera] Add support for document scanning

### DIFF
--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -9,6 +9,9 @@ version = '56.0.7'
 def barcodeScannerEnabled = findProperty('expo.camera.barcode-scanner-enabled')
 def isBarcodeScannerEnabled = (barcodeScannerEnabled ?: "true").toString() != "false"
 
+def documentScannerEnabled = findProperty('expo.camera.document-scanner-enabled')
+def isDocumentScannerEnabled = (documentScannerEnabled ?: "true").toString() != "false"
+
 android {
   namespace "expo.modules.camera"
   defaultConfig {
@@ -43,4 +46,7 @@ dependencies {
   add(barcodeDependencyConfiguration, "com.google.android.gms:play-services-code-scanner:16.1.0")
   add(barcodeDependencyConfiguration, "com.google.mlkit:barcode-scanning:17.3.0")
   add(barcodeDependencyConfiguration, "androidx.camera:camera-mlkit-vision:${camerax_version}")
+
+  def documentScannerDependencyConfiguration = isDocumentScannerEnabled ? "implementation" : "compileOnly"
+  add(documentScannerDependencyConfiguration, "com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1")
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
@@ -23,4 +23,10 @@ class CameraExceptions {
     CodedException("Google Play Services is not available on this device. This feature requires Google Play Services.")
 
   class WriteImageException(cause: String?) : CodedException("Writing image has failed: $cause")
+
+  class DocumentScannerUnavailableException :
+    CodedException("Document scanning is unavailable. It requires Google Play Services and the ML Kit document scanner module. Check `CameraView.isDocumentScannerAvailable` before calling `scanDocumentAsync`.")
+
+  class DocumentScanningFailedException(cause: String?) :
+    CodedException("Document scanning failed: $cause")
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -1,6 +1,8 @@
 package expo.modules.camera
 
 import android.Manifest
+import android.app.Activity
+import android.content.IntentSender
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Bundle
@@ -8,11 +10,18 @@ import android.util.Base64
 import android.util.Log
 import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
 import expo.modules.camera.analyzers.BarCodeScannerResultSerializer
 import expo.modules.camera.analyzers.MLKitBarCodeScanner
+import expo.modules.camera.documentscanner.DocumentScannerActivityResult
+import expo.modules.camera.documentscanner.DocumentScannerContract
+import expo.modules.camera.documentscanner.DocumentScannerContractInput
+import expo.modules.camera.documentscanner.DocumentScannerResultParser
 import expo.modules.camera.records.BarcodeSettings
 import expo.modules.camera.records.BarcodeType
 import expo.modules.camera.records.CameraMode
+import expo.modules.camera.records.DocumentScannerOptions
 import expo.modules.camera.records.CameraRatio
 import expo.modules.camera.records.CameraType
 import expo.modules.camera.records.FlashMode
@@ -29,6 +38,7 @@ import expo.modules.core.utilities.VRUtilities
 import expo.modules.interfaces.imageloader.ImageLoaderInterface
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
@@ -38,6 +48,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.io.File
 
@@ -62,6 +73,11 @@ val cameraPermissions = if (VRUtilities.isQuest()) {
 
 class CameraViewModule : Module() {
   private val moduleScope = CoroutineScope(Dispatchers.Main)
+
+  private var pendingDocumentScanIntentSender: IntentSender? = null
+  private var documentScanPromise: Promise? = null
+  private lateinit var documentScannerLauncher:
+    AppContextActivityResultLauncher<DocumentScannerContractInput, DocumentScannerActivityResult>
 
   override fun definition() = ModuleDefinition {
     Name("ExpoCamera")
@@ -197,6 +213,43 @@ class CameraViewModule : Module() {
 
     AsyncFunction("dismissScanner") {
       // Aligned with iOS, this function is a no-op on Android since the scanner is dismissed automatically
+    }
+
+    Property("isDocumentScannerAvailable") {
+      CameraUtils.isMLKitDocumentScannerAvailable() && CameraUtils.hasGooglePlayServices(appContext.reactContext)
+    }
+
+    RegisterActivityContracts {
+      documentScannerLauncher = registerForActivityResult(
+        DocumentScannerContract { pendingDocumentScanIntentSender }
+      ) { _, _ ->
+        pendingDocumentScanIntentSender = null
+        documentScanPromise?.reject(
+          CameraExceptions.DocumentScanningFailedException("the document scan was interrupted because the screen was recreated")
+        )
+        documentScanPromise = null
+      }
+    }
+
+    AsyncFunction("scanDocumentAsync") { options: DocumentScannerOptions?, promise: Promise ->
+      if (!CameraUtils.isMLKitDocumentScannerAvailable()) {
+        promise.reject(CameraExceptions.DocumentScannerUnavailableException())
+        return@AsyncFunction
+      }
+      if (!CameraUtils.hasGooglePlayServices(appContext.reactContext)) {
+        promise.reject(CameraExceptions.GooglePlayServicesUnavailableException())
+        return@AsyncFunction
+      }
+      val activity = appContext.currentActivity
+      if (activity == null) {
+        promise.reject(Exceptions.MissingActivity())
+        return@AsyncFunction
+      }
+      if (documentScanPromise != null) {
+        promise.reject(CameraExceptions.DocumentScanningFailedException("a document scan is already in progress"))
+        return@AsyncFunction
+      }
+      launchDocumentScanner(activity, options, promise)
     }
 
     OnDestroy {
@@ -482,6 +535,66 @@ class CameraViewModule : Module() {
 
   private val permissionsManager: Permissions
     get() = appContext.permissions ?: throw Exceptions.PermissionsModuleNotFound()
+
+  private fun launchDocumentScanner(activity: Activity, options: DocumentScannerOptions?, promise: Promise) {
+    documentScanPromise = promise
+    try {
+      GmsDocumentScanning.getClient(buildDocumentScannerOptions(options))
+        .getStartScanIntent(activity)
+        .addOnSuccessListener { intentSender ->
+          pendingDocumentScanIntentSender = intentSender
+          documentScannerLauncher.launch(DocumentScannerContractInput()) { result ->
+            handleDocumentScanResult(result)
+          }
+        }
+        .addOnFailureListener { e ->
+          documentScanPromise = null
+          promise.reject(CameraExceptions.DocumentScanningFailedException(e.message))
+        }
+    } catch (e: Exception) {
+      documentScanPromise = null
+      promise.reject(CameraExceptions.DocumentScanningFailedException(e.message))
+    }
+  }
+
+  private fun buildDocumentScannerOptions(options: DocumentScannerOptions?): GmsDocumentScannerOptions {
+    val builder = GmsDocumentScannerOptions.Builder()
+      .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
+    if (options?.requestPdf == true) {
+      builder.setResultFormats(
+        GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
+        GmsDocumentScannerOptions.RESULT_FORMAT_PDF
+      )
+    } else {
+      builder.setResultFormats(GmsDocumentScannerOptions.RESULT_FORMAT_JPEG)
+    }
+    return builder.build()
+  }
+
+  private fun handleDocumentScanResult(activityResult: DocumentScannerActivityResult) {
+    pendingDocumentScanIntentSender = null
+    val promise = documentScanPromise ?: return
+    documentScanPromise = null
+    if (activityResult.cancelled || activityResult.result == null) {
+      promise.resolve(null)
+      return
+    }
+    val reactContext = appContext.reactContext
+    if (reactContext == null) {
+      promise.reject(Exceptions.ReactContextLost())
+      return
+    }
+    moduleScope.launch {
+      try {
+        val bundle = withContext(Dispatchers.IO) {
+          DocumentScannerResultParser.parse(reactContext, activityResult.result, cacheDirectory)
+        }
+        promise.resolve(bundle)
+      } catch (e: Exception) {
+        promise.reject(CameraExceptions.DocumentScanningFailedException(e.message))
+      }
+    }
+  }
 
   companion object {
     internal val TAG = CameraViewModule::class.java.simpleName

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/documentscanner/DocumentScannerContract.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/documentscanner/DocumentScannerContract.kt
@@ -1,0 +1,45 @@
+package expo.modules.camera.documentscanner
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.ACTION_INTENT_SENDER_REQUEST
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.EXTRA_INTENT_SENDER_REQUEST
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+import java.io.Serializable
+
+class DocumentScannerContractInput : Serializable
+
+class DocumentScannerActivityResult(
+  val cancelled: Boolean,
+  val result: GmsDocumentScanningResult?
+)
+
+class DocumentScannerContract(
+  private val intentSenderProvider: () -> IntentSender?
+) : AppContextActivityResultContract<DocumentScannerContractInput, DocumentScannerActivityResult> {
+
+  override fun createIntent(context: Context, input: DocumentScannerContractInput): Intent {
+    val intentSender = intentSenderProvider()
+      ?: throw IllegalStateException("Document scanner IntentSender was not prepared before launch")
+    val request = IntentSenderRequest.Builder(intentSender).build()
+    return Intent(ACTION_INTENT_SENDER_REQUEST).putExtra(EXTRA_INTENT_SENDER_REQUEST, request)
+  }
+
+  override fun parseResult(
+    input: DocumentScannerContractInput,
+    resultCode: Int,
+    intent: Intent?
+  ): DocumentScannerActivityResult {
+    if (resultCode != Activity.RESULT_OK) {
+      return DocumentScannerActivityResult(cancelled = true, result = null)
+    }
+    return DocumentScannerActivityResult(
+      cancelled = false,
+      result = GmsDocumentScanningResult.fromActivityResultIntent(intent)
+    )
+  }
+}

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/documentscanner/DocumentScannerResultParser.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/documentscanner/DocumentScannerResultParser.kt
@@ -1,0 +1,33 @@
+package expo.modules.camera.documentscanner
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
+import expo.modules.camera.utils.FileSystemUtils
+import java.io.File
+import java.io.IOException
+
+object DocumentScannerResultParser {
+  fun parse(context: Context, result: GmsDocumentScanningResult, cacheDir: File): Bundle {
+    val pageUris = result.pages.orEmpty().map { page ->
+      copyToCache(context, page.imageUri, cacheDir, ".jpg")
+    }
+    return Bundle().apply {
+      putStringArray("pages", pageUris.toTypedArray())
+      result.pdf?.let { pdf ->
+        putString("pdfUri", copyToCache(context, pdf.uri, cacheDir, ".pdf"))
+      }
+    }
+  }
+
+  private fun copyToCache(context: Context, source: Uri, cacheDir: File, extension: String): String {
+    val target = FileSystemUtils.generateOutputFile(cacheDir, "DocumentScanner", extension)
+    val input = context.contentResolver.openInputStream(source)
+      ?: throw IOException("Could not open the scanned document at $source")
+    input.use { stream ->
+      target.outputStream().use { output -> stream.copyTo(output) }
+    }
+    return Uri.fromFile(target).toString()
+  }
+}

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/DocumentScannerOptions.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/DocumentScannerOptions.kt
@@ -1,0 +1,13 @@
+package expo.modules.camera.records
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+class DocumentScannerOptions : Record {
+  @Field
+  var requestPdf: Boolean = false
+
+  // Unused on Android.
+  @Field
+  var quality: Double = 1.0
+}

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
@@ -28,6 +28,15 @@ object CameraUtils {
     }
   }
 
+  fun isMLKitDocumentScannerAvailable(): Boolean {
+    return try {
+      Class.forName("com.google.mlkit.vision.documentscanner.GmsDocumentScanning")
+      true
+    } catch (_: ClassNotFoundException) {
+      false
+    }
+  }
+
   fun isMLKitAvailable(context: Context?): Boolean {
     if (!hasGooglePlayServices(context)) {
       return false


### PR DESCRIPTION
# Why

Adds the Android part of `scanDocumentAsync`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Launches ML Kit's scanner through its IntentSender. The result pages and optional PDF are copied out of ML Kit's storage and returned as { pages, pdfUri? }. The ML Kit dependency is gated behind a new gradle property expo.camera.document-scanner-enabled, similar to barcode scanning, so apps that do not need it can opt out and avoid the extra Play Services module. Availability checks for both the ML Kit module and Google Play Services. Also adds the ncl test screen.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare expo