### PR TITLE
[ios][video] Change iOS audioMixingMode default to .auto (as documented)

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback. ([#46753](https://github.com/expo/expo/pull/46753) by [@zoontek](https://github.com/zoontek))
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))
 - Recover failed players to fix broken playback placeholder ([#46681](https://github.com/expo/expo/pull/46681) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -15,7 +15,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   private var tracksLoadingTask: Task<(), Never>?
 
   var loop = false
-  var audioMixingMode: AudioMixingMode = .doNotMix {
+  var audioMixingMode: AudioMixingMode = .auto {
     didSet {
       if oldValue != audioMixingMode {
         VideoManager.shared.setAppropriateAudioSessionOrWarn()


### PR DESCRIPTION
# Why

See #47363: the [documented default](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode) for audioMixingMode is auto, which should not interrupt music when the video player is muted. But the [iOS implementation sets the default to doNotMix](https://github.com/expo/expo/blob/main/packages/expo-video/ios/VideoPlayer.swift#L18), not auto.

The Android and Web implementations set the default to auto as documented.

# How

I just changed the iOS default to `.auto` from `.doNotFix`.

# Test Plan

1. On iOS, use some app to play audio.
2. Run [the repro app from #47363](https://github.com/andymatuschak/expo/tree/patch-2) against these changes.
3. Without this patch, the playing audio stops when the app is launched. With the patch, it does not.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
