### PR TITLE
[expo-router] fix native ios memory leaks

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix type inference for `unstable_createStandardRouterNavigator` ([#46737](https://github.com/expo/expo/pull/46737) by [@Ubax](https://github.com/Ubax))
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
 - [ios] Fix white flash behind screens during the interactive swipe-back gesture by forwarding the theme background to the native stack container. ([#47121](https://github.com/expo/expo/pull/47121) by [@kevenleone](https://github.com/kevenleone))
+- [ios] Fix memory leaks in the native toolbar and link preview from strong-reference cycles and closures that strongly captured `self`. ([#47378](https://github.com/expo/expo/pull/47378) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
@@ -77,7 +77,7 @@ class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatabl
     menuAction = UIMenu(title: "", image: nil, options: [], children: [])
     super.init(appContext: appContext)
     clipsToBounds = true
-    baseUiAction = UIAction(title: "", handler: { _ in self.onSelected() })
+    baseUiAction = UIAction(title: "", handler: { [weak self] _ in self?.onSelected() })
   }
 
   func updateMenu() {

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -166,8 +166,8 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
     animator: UIContextMenuInteractionAnimating?
   ) {
     onPreviewWillClose()
-    animator?.addCompletion {
-      self.onPreviewDidClose()
+    animator?.addCompletion { [weak self] in
+      self?.onPreviewDidClose()
     }
   }
 

--- a/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
@@ -304,7 +304,8 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
       if #available(iOS 18.0, *) {
         let options = UIViewController.Transition.ZoomOptions()
 
-        options.alignmentRectProvider = { context in
+        options.alignmentRectProvider = { [weak self] context in
+          guard let self else { return nil }
           guard
             let sourceInfo = self.sourceRepository?.getSource(
               identifier: self.zoomTransitionSourceIdentifier)
@@ -341,7 +342,8 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
             return true
           }
         }
-        controller.preferredTransition = .zoom(options: options) { _ in
+        controller.preferredTransition = .zoom(options: options) { [weak self] _ in
+          guard let self else { return nil }
           let sourceInfo = self.sourceRepository?.getSource(
             identifier: self.zoomTransitionSourceIdentifier)
           var view: UIView? = sourceInfo?.view

--- a/packages/expo-router/ios/Tests/LinkPreviewMemoryTests.swift
+++ b/packages/expo-router/ios/Tests/LinkPreviewMemoryTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import UIKit
+
+@testable import ExpoRouter
+
+// Records the completion blocks handed to it, mimicking how the system animator
+// retains them for the duration of the context-menu dismiss animation.
+private final class MockContextMenuAnimator: NSObject, UIContextMenuInteractionAnimating {
+  var preferredCommitStyle: UIContextMenuInteractionCommitStyle = .dismiss
+  var previewViewController: UIViewController?
+  var completions: [() -> Void] = []
+
+  func addAnimations(_ animations: @escaping () -> Void) {}
+  func addCompletion(_ completion: @escaping () -> Void) {
+    completions.append(completion)
+  }
+}
+
+@Suite("LinkPreview memory management")
+@MainActor
+struct LinkPreviewMemoryTests {
+
+  // The dismiss completion must not strongly capture the view: the system animator
+  // outlives the interaction, so a strong capture pins the view to the animation.
+  @Test
+  func `preview view is released even while a dismiss completion is pending`() {
+    let animator = MockContextMenuAnimator()
+    weak var weakView: NativeLinkPreviewView?
+
+    autoreleasepool {
+      let view = NativeLinkPreviewView(appContext: nil)
+      let interaction = UIContextMenuInteraction(delegate: view)
+      let configuration = UIContextMenuConfiguration(
+        identifier: nil, previewProvider: nil, actionProvider: nil)
+      view.contextMenuInteraction(
+        interaction, willEndFor: configuration, animator: animator)
+
+      weakView = view
+      #expect(weakView != nil)
+      #expect(!animator.completions.isEmpty)
+    }
+
+    #expect(weakView == nil)
+  }
+}

--- a/packages/expo-router/ios/Tests/ToolbarMemoryTests.swift
+++ b/packages/expo-router/ios/Tests/ToolbarMemoryTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import UIKit
+
+@testable import ExpoRouter
+
+// Guards against strong-reference cycles in the iOS toolbar. Each view is held
+// only by a weak ref; once the strong refs drop, ARC must deallocate it.
+@Suite("Toolbar memory management")
+@MainActor
+struct ToolbarMemoryTests {
+
+  // Leak 1: the host holds each item in `toolbarItemsMap`; the item's `host`
+  // back-pointer must be weak or the pair never deallocates.
+  @Test
+  func `host and item are released together`() {
+    weak var weakHost: RouterToolbarHostView?
+    weak var weakItem: RouterToolbarItemView?
+
+    autoreleasepool {
+      let host = RouterToolbarHostView(appContext: nil)
+      let item = RouterToolbarItemView(appContext: nil)
+      item.identifier = "test-item"
+      host.mountChildComponentView(item, index: 0)
+
+      weakHost = host
+      weakItem = item
+      #expect(weakHost != nil)
+      #expect(weakItem != nil)
+    }
+
+    #expect(weakHost == nil)
+    #expect(weakItem == nil)
+  }
+
+  // Leak 2: the view owns `baseUiAction`, whose handler must not capture self
+  // strongly or the action view never deallocates.
+  @Test
+  func `action view is released`() {
+    weak var weakAction: LinkPreviewNativeActionView?
+
+    autoreleasepool {
+      let action = LinkPreviewNativeActionView(appContext: nil)
+      weakAction = action
+      #expect(weakAction != nil)
+    }
+
+    #expect(weakAction == nil)
+  }
+}

--- a/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
@@ -35,7 +35,7 @@ class RouterToolbarItemView: RouterViewWithLogger {
   // This property is not applied in this component, but read by the host
   @ReactiveProp var routerHidden: Bool = false
 
-  var host: RouterToolbarHostView?
+  weak var host: RouterToolbarHostView?
   private var currentBarButtonItem: UIBarButtonItem?
 
   let onSelected = EventDispatcher()


### PR DESCRIPTION
# Why

There are small risks of memory leaks in toolbar and link preview

# How

Change references to weak references

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
