### PR TITLE
[expo-type-information] Simple static and global values resolution

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -3,7 +3,20 @@ import WebKit
 
 public class TestModule: Module {
   public func definition() -> ModuleDefinition {
-    Events("event1", "event2", "event3")
+    Events(
+      "event1",
+      "event2",
+      "event3",
+      globalEventName,
+      privateGlobalEventName,
+      EventNames.staticLetEvent,
+      EventNames.staticVarEvent,
+      EventStructNamespace.structEvent,
+      EventClassNamespace.classEvent,
+      OuterNamespace.InnerNamespace.nestedEvent,
+      // TODO(@HubertBer) Maybe fix this if this is needed, for now just document we don't support it
+      globalAssignedToGlobal
+    )
 
     Constant("StringConstant") { () -> Int in
       return "Swift constant 1283"
@@ -195,4 +208,28 @@ enum IntBackedEnum1: Int {
 
 enum IntBackedEnum2: Something, Int, SomethingElse {
   case simpleCase
+}
+// Global variable names
+let globalEventName = "onGlobalEvent"
+
+private let privateGlobalEventName = "onPrivateGlobalEvent"
+private let globalAssignedToGlobal = globalEventName
+
+enum EventNames {
+  static let staticLetEvent = "onStaticLetEvent"
+  static var staticVarEvent = "onStaticVarEvent"
+}
+
+struct EventStructNamespace {
+  static let structEvent = "onStructEvent"
+}
+
+class EventClassNamespace {
+  static let classEvent = "onClassEvent"
+}
+
+enum OuterNamespace {
+  enum InnerNamespace {
+    static let nestedEvent = "onNestedEvent"
+  }
 }

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -48,6 +48,8 @@ export enum IntBackedEnum1 {
 export enum IntBackedEnum2 {
   simpleCase
 }
+export enum EventNames {}
+export enum OuterNamespace {}
 
 export declare class TestClassWithConstructor {
   constructor(a: number);
@@ -69,6 +71,13 @@ export type TestModuleEvents = {
   event1: (...args: any[]) => void;
   event2: (...args: any[]) => void;
   event3: (...args: any[]) => void;
+  onClassEvent: (...args: any[]) => void;
+  onGlobalEvent: (...args: any[]) => void;
+  onNestedEvent: (...args: any[]) => void;
+  onPrivateGlobalEvent: (...args: any[]) => void;
+  onStaticLetEvent: (...args: any[]) => void;
+  onStaticVarEvent: (...args: any[]) => void;
+  onStructEvent: (...args: any[]) => void;
 };
 
 export interface ExpoWebViewProps extends ViewProps {
@@ -232,6 +241,8 @@ import {
   TestEnum,
   IntBackedEnum1,
   IntBackedEnum2,
+  EventNames,
+  OuterNamespace,
   TestRecord,
   TestRecord2,
   TestRecordClass,
@@ -338,6 +349,8 @@ export enum IntBackedEnum1 {
 export enum IntBackedEnum2 {
   simpleCase
 }
+export enum EventNames {}
+export enum OuterNamespace {}
 
 export declare class TestClassWithConstructor {
   constructor(a: number);
@@ -359,6 +372,13 @@ export type TestModuleEvents = {
   event1: (...args: any[]) => void;
   event2: (...args: any[]) => void;
   event3: (...args: any[]) => void;
+  onClassEvent: (...args: any[]) => void;
+  onGlobalEvent: (...args: any[]) => void;
+  onNestedEvent: (...args: any[]) => void;
+  onPrivateGlobalEvent: (...args: any[]) => void;
+  onStaticLetEvent: (...args: any[]) => void;
+  onStaticVarEvent: (...args: any[]) => void;
+  onStructEvent: (...args: any[]) => void;
 };
 
 export interface ExpoWebViewProps extends ViewProps {
@@ -444,6 +464,10 @@ export enum IntBackedEnum1 {
 export enum IntBackedEnum2 {
     simpleCase
 }
+export enum EventNames {
+}
+export enum OuterNamespace {
+}
 
 
 export function SimpleFunction(a: number, b: number): number { return 0; }
@@ -524,6 +548,12 @@ export var IntBackedEnum2;
 (function (IntBackedEnum2) {
     IntBackedEnum2[IntBackedEnum2["simpleCase"] = 0] = "simpleCase";
 })(IntBackedEnum2 || (IntBackedEnum2 = {}));
+export var EventNames;
+(function (EventNames) {
+})(EventNames || (EventNames = {}));
+export var OuterNamespace;
+(function (OuterNamespace) {
+})(OuterNamespace || (OuterNamespace = {}));
 export function SimpleFunction(a, b) { return 0; }
 export function TestUntypedFunction() { return ""; }
 export function TestUnicodeCharacters() { return; }
@@ -598,6 +628,8 @@ export enum IntBackedEnum1 {
 export enum IntBackedEnum2 {
   simpleCase
 }
+export enum EventNames {}
+export enum OuterNamespace {}
 
 export declare class TestClassWithConstructor {
   constructor(a: number);
@@ -619,6 +651,13 @@ export type TestModuleEvents = {
   event1: (...args: any[]) => void;
   event2: (...args: any[]) => void;
   event3: (...args: any[]) => void;
+  onClassEvent: (...args: any[]) => void;
+  onGlobalEvent: (...args: any[]) => void;
+  onNestedEvent: (...args: any[]) => void;
+  onPrivateGlobalEvent: (...args: any[]) => void;
+  onStaticLetEvent: (...args: any[]) => void;
+  onStaticVarEvent: (...args: any[]) => void;
+  onStructEvent: (...args: any[]) => void;
 };
 
 export declare class TestModuleNativeModuleType extends NativeModule<TestModuleEvents> {
@@ -696,8 +735,10 @@ export default _default;
 exports[`Same type information 1`] = `
 {
   "declaredTypeIdentifiersList": [
+    "EventNames",
     "IntBackedEnum1",
     "IntBackedEnum2",
+    "OuterNamespace",
     "TestBasicClass",
     "TestClassWithConstructor",
     "TestEmptyClass",
@@ -734,6 +775,16 @@ exports[`Same type information 1`] = `
       "name": "IntBackedEnum2",
       "stringBacked": false,
     },
+    {
+      "cases": [],
+      "name": "EventNames",
+      "stringBacked": true,
+    },
+    {
+      "cases": [],
+      "name": "OuterNamespace",
+      "stringBacked": true,
+    },
   ],
   "inferredTypeParametersCountList": [
     [
@@ -769,7 +820,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 2637,
+          "definitionOffset": 2915,
           "isStatic": false,
           "name": "TestSimpleAsyncFunction",
           "parameters": [],
@@ -798,7 +849,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 2840,
+          "definitionOffset": 3118,
           "isStatic": false,
           "name": "TestUnderscore",
           "parameters": [],
@@ -821,9 +872,9 @@ exports[`Same type information 1`] = `
                 },
               },
             ],
-            "definitionOffset": 2966,
+            "definitionOffset": 3244,
           },
-          "definitionOffset": 2920,
+          "definitionOffset": 3198,
           "methods": [],
           "name": "TestClassWithConstructor",
           "properties": [],
@@ -840,7 +891,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3508,
+              "definitionOffset": 3786,
               "isStatic": false,
               "name": "TestAsyncFunction",
               "parameters": [],
@@ -859,7 +910,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3606,
+              "definitionOffset": 3884,
               "isStatic": true,
               "name": "TestStaticAsyncFunction",
               "parameters": [],
@@ -905,13 +956,13 @@ exports[`Same type information 1`] = `
                 },
               },
             ],
-            "definitionOffset": 3068,
+            "definitionOffset": 3346,
           },
-          "definitionOffset": 3032,
+          "definitionOffset": 3310,
           "methods": [
             {
               "arguments": [],
-              "definitionOffset": 3693,
+              "definitionOffset": 3971,
               "isStatic": true,
               "name": "TestStaticFunction",
               "parameters": [],
@@ -924,7 +975,7 @@ exports[`Same type information 1`] = `
           "name": "TestBasicClass",
           "properties": [
             {
-              "definitionOffset": 3172,
+              "definitionOffset": 3450,
               "name": "TestIntProperty",
               "type": {
                 "kind": 0,
@@ -932,7 +983,7 @@ exports[`Same type information 1`] = `
               },
             },
             {
-              "definitionOffset": 3240,
+              "definitionOffset": 3518,
               "name": "TestEitherProperty",
               "type": {
                 "kind": 2,
@@ -952,7 +1003,7 @@ exports[`Same type information 1`] = `
               },
             },
             {
-              "definitionOffset": 3327,
+              "definitionOffset": 3605,
               "name": "TestEnumProperty",
               "type": {
                 "kind": 1,
@@ -960,7 +1011,7 @@ exports[`Same type information 1`] = `
               },
             },
             {
-              "definitionOffset": 3411,
+              "definitionOffset": 3689,
               "name": "TestRecordProperty",
               "type": {
                 "kind": 1,
@@ -972,7 +1023,7 @@ exports[`Same type information 1`] = `
         {
           "asyncMethods": [],
           "constructor": null,
-          "definitionOffset": 3791,
+          "definitionOffset": 4069,
           "methods": [],
           "name": "TestEmptyClass",
           "properties": [],
@@ -980,7 +1031,7 @@ exports[`Same type information 1`] = `
       ],
       "constants": [
         {
-          "definitionOffset": 167,
+          "definitionOffset": 437,
           "name": "StringConstant",
           "type": {
             "kind": 0,
@@ -988,7 +1039,7 @@ exports[`Same type information 1`] = `
           },
         },
         {
-          "definitionOffset": 338,
+          "definitionOffset": 608,
           "name": "IntConstant",
           "type": {
             "kind": 0,
@@ -996,7 +1047,7 @@ exports[`Same type information 1`] = `
           },
         },
         {
-          "definitionOffset": 488,
+          "definitionOffset": 758,
           "name": "UntypedConstant",
           "type": {
             "kind": 0,
@@ -1010,6 +1061,13 @@ exports[`Same type information 1`] = `
         "event1",
         "event2",
         "event3",
+        "onClassEvent",
+        "onGlobalEvent",
+        "onNestedEvent",
+        "onPrivateGlobalEvent",
+        "onStaticLetEvent",
+        "onStaticVarEvent",
+        "onStructEvent",
       ],
       "functions": [
         {
@@ -1029,7 +1087,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 534,
+          "definitionOffset": 804,
           "isStatic": false,
           "name": "SimpleFunction",
           "parameters": [],
@@ -1040,7 +1098,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 710,
+          "definitionOffset": 980,
           "isStatic": false,
           "name": "TestUntypedFunction",
           "parameters": [],
@@ -1051,7 +1109,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 866,
+          "definitionOffset": 1136,
           "isStatic": false,
           "name": "TestUnicodeCharacters",
           "parameters": [],
@@ -1062,7 +1120,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 1068,
+          "definitionOffset": 1338,
           "isStatic": false,
           "name": "TestUntypedFunction2",
           "parameters": [],
@@ -1073,7 +1131,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 1244,
+          "definitionOffset": 1514,
           "isStatic": false,
           "name": "TestUntypedFunction3",
           "parameters": [],
@@ -1095,7 +1153,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 1422,
+          "definitionOffset": 1696,
           "isStatic": false,
           "name": "TestArrays",
           "parameters": [],
@@ -1154,7 +1212,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 1593,
+          "definitionOffset": 1871,
           "isStatic": false,
           "name": "TestDictionaries",
           "parameters": [],
@@ -1245,7 +1303,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 1802,
+          "definitionOffset": 2080,
           "isStatic": false,
           "name": "TestParametrizedTypes",
           "parameters": [],
@@ -1273,7 +1331,7 @@ exports[`Same type information 1`] = `
               },
             },
           ],
-          "definitionOffset": 2058,
+          "definitionOffset": 2336,
           "isStatic": false,
           "name": "TestTypeCombinations",
           "parameters": [],
@@ -1311,7 +1369,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 2271,
+          "definitionOffset": 2549,
           "isStatic": false,
           "name": "TestFunctionReturningRecord",
           "parameters": [],
@@ -1322,7 +1380,7 @@ exports[`Same type information 1`] = `
         },
         {
           "arguments": [],
-          "definitionOffset": 2448,
+          "definitionOffset": 2726,
           "isStatic": false,
           "name": "TestFunctionReturningEnum",
           "parameters": [],
@@ -1341,7 +1399,7 @@ exports[`Same type information 1`] = `
           "classes": [],
           "constants": [],
           "constructor": null,
-          "definitionOffset": 3854,
+          "definitionOffset": 4132,
           "events": [
             "onEvent1",
             "onEvent2",
@@ -1367,7 +1425,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 3900,
+              "definitionOffset": 4178,
               "name": "url",
             },
             {
@@ -1387,7 +1445,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 4084,
+              "definitionOffset": 4362,
               "name": "testRecord",
             },
             {
@@ -1407,7 +1465,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 4155,
+              "definitionOffset": 4433,
               "name": "testRecord2",
             },
             {
@@ -1427,7 +1485,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 4229,
+              "definitionOffset": 4507,
               "name": "testRecordClass",
             },
             {
@@ -1447,7 +1505,7 @@ exports[`Same type information 1`] = `
                   },
                 },
               ],
-              "definitionOffset": 4315,
+              "definitionOffset": 4593,
               "name": "testEnum",
             },
           ],
@@ -1576,6 +1634,17 @@ exports[`Same type information 1`] = `
   ],
   "typeIdentifierDefinitionList": [
     [
+      "EventNames",
+      {
+        "definition": {
+          "cases": [],
+          "name": "EventNames",
+          "stringBacked": true,
+        },
+        "kind": 1,
+      },
+    ],
+    [
       "IntBackedEnum1",
       {
         "definition": {
@@ -1599,6 +1668,17 @@ exports[`Same type information 1`] = `
           ],
           "name": "IntBackedEnum2",
           "stringBacked": false,
+        },
+        "kind": 1,
+      },
+    ],
+    [
+      "OuterNamespace",
+      {
+        "definition": {
+          "cases": [],
+          "name": "OuterNamespace",
+          "stringBacked": true,
         },
         "kind": 1,
       },

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -47,6 +47,8 @@ const swiftDeclarationKind = {
   varParameter: 'source.lang.swift.decl.var.parameter',
   closure: 'source.lang.swift.expr.closure',
   enumcase: 'source.lang.swift.decl.enumcase',
+  varStatic: 'source.lang.swift.decl.var.static',
+  varGlobal: 'source.lang.swift.decl.var.global',
 };
 
 function isSwiftDictionary(type: string): boolean {
@@ -80,6 +82,14 @@ function isEitherTypeIdentifier(typeIdentifier: string): boolean {
 
 function isEnumStructure(structure: Structure): boolean {
   return structure['key.kind'] === swiftDeclarationKind.enum;
+}
+
+function isClassStructure(structure: Structure): boolean {
+  return structure['key.kind'] === swiftDeclarationKind.class;
+}
+
+function isStructStructure(structure: Structure): boolean {
+  return structure['key.kind'] === swiftDeclarationKind.struct;
 }
 
 function isRecordStructure(structure: Structure): boolean {
@@ -254,6 +264,66 @@ function getIdentifierFromOffsetObject(offsetObject: Structure, file: FileType) 
   const startIndex = offsetObject['key.offset'];
   const endIndex = offsetObject['key.offset'] + offsetObject['key.length'];
   return file.content.substring(startIndex, endIndex).replaceAll('"', '');
+}
+
+function getLiteralOrResolvedIdentifier(offsetObject: Structure, ctx: ParseContext): string {
+  const { namespaces, file } = ctx;
+  const startIndex = offsetObject['key.offset'];
+  const endIndex = offsetObject['key.offset'] + offsetObject['key.length'];
+  const literalOrIdentifier = file.content.substring(startIndex, endIndex);
+
+  if (literalOrIdentifier.startsWith('"')) {
+    return literalOrIdentifier.replaceAll('"', '');
+  }
+
+  const parts = literalOrIdentifier.split('.');
+
+  const traverse = (baseObj: namespace | string | null, keys: string[]) => {
+    let current = baseObj;
+    for (const key of keys) {
+      if (typeof current === 'string' || current === null) {
+        return undefined;
+      }
+      const subNamespace = current[key];
+      if (subNamespace === undefined) {
+        return undefined;
+      }
+      current = subNamespace;
+    }
+    return current;
+  };
+
+  const n0 = traverse(namespaces, parts);
+  if (typeof n0 === 'string') {
+    return n0.replaceAll('"', '');
+  }
+
+  const n1 = traverse(namespaces[''] || {}, parts);
+  if (typeof n1 === 'string') {
+    return n1.replaceAll('"', '');
+  }
+
+  return parts[parts.length - 1] ?? literalOrIdentifier;
+}
+
+function isStringLiteral(str: string): boolean {
+  return str.length > 1 && str[0] == '"' && str[str.length - 1] == '"';
+}
+
+function getInitializerValue(structure: Structure, file: FileType): string | null {
+  const nameEnd = structure['key.nameoffset'] + structure['key.namelength'];
+  const declarationEnd = structure['key.offset'] + structure['key.length'];
+  if (!nameEnd || !declarationEnd) {
+    return null;
+  }
+  const valueSubstring = file.content.substring(nameEnd, declarationEnd);
+  const indexOfInitializerStart = valueSubstring.indexOf('=');
+  const initializer = valueSubstring.slice(indexOfInitializerStart + 1).trim();
+
+  if (!isStringLiteral(initializer)) {
+    return null;
+  }
+  return initializer;
 }
 
 function hasSubstructure(structure: Structure) {
@@ -518,9 +588,10 @@ function getClosureBodyStructure(structure: Structure): Structure | null {
 
 async function parseModuleClassStructure(
   structure: Structure,
-  file: FileType,
-  options: SwiftFileTypeInformationOptions
+  options: SwiftFileTypeInformationOptions,
+  ctx: ParseContext
 ): Promise<ClassDeclaration> {
+  const { file } = ctx;
   const nestedModuleSubstructure = getClosureBodyStructure(structure)?.['key.substructure'];
   const nameSubstrucutre = structure['key.substructure']?.[0];
   const name = nameSubstrucutre
@@ -542,10 +613,10 @@ async function parseModuleClassStructure(
   // `parseModuleStructure` returns `ModuleClassDeclaration` with a found name or with the provided 'UNUSED_NAME', we don't need it here.
   const classTypeInfo = await parseModuleStructure(
     nestedModuleSubstructure,
-    file,
     'UNUSED_NAME',
     structure['key.offset'],
-    options
+    options,
+    ctx
   );
   return {
     name,
@@ -615,9 +686,10 @@ async function parseModulePropDeclaration(
 
 async function parseModuleViewDeclaration(
   substructure: Structure,
-  file: FileType,
-  options: SwiftFileTypeInformationOptions
+  options: SwiftFileTypeInformationOptions,
+  ctx: ParseContext
 ): Promise<ViewDeclaration | null> {
+  const { file } = ctx;
   // The View arguments is a.self for some class a we want.
   const suffixLength = 5;
   const nameSubstrucutre = substructure['key.substructure']?.[0];
@@ -634,17 +706,20 @@ async function parseModuleViewDeclaration(
 
   return await parseModuleStructure(
     viewSubstructure,
-    file,
     name,
     viewStructure['key.offset'],
-    options
+    options,
+    ctx
   );
 }
 
-function parseModuleEventDeclaration(structure: Structure, file: FileType, events: string[]) {
-  structure['key.substructure'].forEach((substructure) =>
-    events.push(getIdentifierFromOffsetObject(substructure, file))
-  );
+function parseModuleEventDeclaration(structure: Structure, events: string[], ctx: ParseContext) {
+  structure['key.substructure'].forEach((substructure) => {
+    const eventName = getLiteralOrResolvedIdentifier(substructure, ctx);
+    if (eventName) {
+      events.push(eventName);
+    }
+  });
 }
 
 function hasFieldAttribute(attributes: Attribute[] | null, file: FileType): boolean {
@@ -740,13 +815,23 @@ function parsePropertyString(
   };
 }
 
+type namespace = {
+  [key: string]: namespace | string | null;
+};
+
+type ParseContext = {
+  file: FileType;
+  namespaces: { [key: string]: namespace };
+};
+
 async function parseModuleStructure(
   moduleStructure: Structure[],
-  file: FileType,
   name: string,
   definitionOffset: number,
-  options: SwiftFileTypeInformationOptions
+  options: SwiftFileTypeInformationOptions,
+  ctx: ParseContext
 ): Promise<ModuleClassDeclaration> {
+  const { file } = ctx;
   const moduleClassDeclaration: ModuleClassDeclaration = {
     name,
     constants: [],
@@ -797,7 +882,7 @@ async function parseModuleStructure(
       }
       case 'Class':
         moduleClassDeclaration.classes.push(
-          await parseModuleClassStructure(structure, file, options)
+          await parseModuleClassStructure(structure, options, ctx)
         );
         break;
       case 'Property': {
@@ -835,14 +920,14 @@ async function parseModuleStructure(
         );
         break;
       case 'View': {
-        const viewDeclaration = await parseModuleViewDeclaration(structure, file, options);
+        const viewDeclaration = await parseModuleViewDeclaration(structure, options, ctx);
         if (viewDeclaration) {
           moduleClassDeclaration.views.push(viewDeclaration);
         }
         break;
       }
       case 'Events':
-        parseModuleEventDeclaration(structure, file, moduleClassDeclaration.events);
+        parseModuleEventDeclaration(structure, moduleClassDeclaration.events, ctx);
         break;
       default:
         console.warn(`Module substructure not supported. ${structure['key.name']}`);
@@ -993,6 +1078,41 @@ function collectModuleTypeIdentifiers(
   });
 }
 
+function parseNamespaces(
+  structure: Structure,
+  namespaces: { [key: string]: namespace },
+  file: FileType,
+  currentNamespace: namespace
+) {
+  if (
+    isModuleStructure(structure) ||
+    isRecordStructure(structure) ||
+    isStructStructure(structure) ||
+    isEnumStructure(structure) ||
+    isClassStructure(structure)
+  ) {
+    const moduleName = structure['key.name'];
+    namespaces[moduleName] = namespaces[moduleName] || {};
+    const ns: namespace = namespaces[moduleName];
+    currentNamespace[moduleName] = ns;
+    structure['key.substructure'].forEach((substructure) => {
+      parseNamespaces(substructure, namespaces, file, ns);
+    });
+    return;
+  }
+  if (
+    structure['key.kind'] === swiftDeclarationKind.varStatic ||
+    structure['key.kind'] === swiftDeclarationKind.varGlobal
+  ) {
+    currentNamespace[structure['key.name']] = getInitializerValue(structure, file);
+    return;
+  }
+  const substructures = structure['key.substructure'];
+  substructures?.forEach((substructure) =>
+    parseNamespaces(substructure, namespaces, file, currentNamespace)
+  );
+}
+
 export type SwiftFileTypeInformationOptions = {
   typeInference: boolean;
 };
@@ -1006,13 +1126,12 @@ export async function getSwiftFileTypeInformation(
   const modulesStructures: { name: string; structure: Structure }[] = [];
   const recordsStructures: Structure[] = [];
   const enumsStructures: Structure[] = [];
-  parseStructure(
-    getStructureFromFile(file),
-    '',
-    modulesStructures,
-    recordsStructures,
-    enumsStructures
-  );
+  const fileStructure = getStructureFromFile(file);
+  parseStructure(fileStructure, '', modulesStructures, recordsStructures, enumsStructures);
+
+  const namespaces: { [key: string]: namespace } = {};
+  namespaces[''] = {};
+  parseNamespaces(fileStructure, namespaces, file, namespaces['']);
 
   const inferredTypeParametersCount = new Map<string, number>();
   const moduleClasses: ModuleClassDeclaration[] = [];
@@ -1034,14 +1153,16 @@ export async function getSwiftFileTypeInformation(
   const recordsPromise = taskAll(recordsStructures, recordMap);
   const moduleClassDeclarationsPromise = taskAll(
     modulesStructures.filter(({ structure }) => hasSubstructure(structure)),
-    ({ structure, name }) =>
-      parseModuleStructure(
+    ({ structure, name }) => {
+      namespaces[name] = namespaces[name] || {};
+      return parseModuleStructure(
         structure['key.substructure'],
-        file,
         name,
         structure['key.offset'],
-        options
-      )
+        options,
+        { namespaces, file }
+      );
+    }
   );
 
   const [records, moduleClassDeclarations] = await Promise.all([

--- a/packages/expo-type-information/src/types.ts
+++ b/packages/expo-type-information/src/types.ts
@@ -17,6 +17,7 @@ export type Structure = {
   'key.offset': number;
   'key.length': number;
   'key.nameoffset': number;
+  'key.namelength': number;
   'key.inheritedtypes': { 'key.name': string }[];
   'key.attributes': Attribute[];
 };


### PR DESCRIPTION
# Why

Sometimes names in expo modules are provided as static / global variable instead of raw strings, and the expo-type-information parser expects them to be strings right now. So if you define
```
Events(someStaticVar)
``` 
The parser will find `someStaticVar` and later in typescript generate
```
type Events = {
	someStaticVar: () => void
}
```

But we want it to actually generate the event name in there! Especially that If the static variable is a static property so you have `Events(SomeModule.SomeVariable)` it will generate:
```
type Events = {
	SomeModule.SomeVariable: () => void
}
```

Which isn't proper typescript so it won't parse.

# How
Added a simple static / global variable storage to the sourcekitten parser. It firsts, before parsing module classes, finds all static / global variables and saves them to a `namespaces` object. This for now is only used when parsing Events, so when parsing event name we instead of just trimming `"` characters, we resolve the variable using `namespaces` object if the event name is not a string literal.

# Test Plan
- [x] tested manually in `expo-contacts`
- [x] added tests, updated snapshot

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
