### PR TITLE
[docs] Update default template commands to use SDK 57

### DIFF
--- a/docs/checks/ja/source-hashes.json
+++ b/docs/checks/ja/source-hashes.json
@@ -4,7 +4,7 @@
   "tutorial/configuration.mdx": "e2873f8fad4e2acd",
   "tutorial/create-a-modal.mdx": "3c47ffc2f8d27dc8",
   "tutorial/create-your-first-app.mdx": "46fb768673e4e44a",
-  "tutorial/follow-up.mdx": "84cc41c29b4c3e2b",
+  "tutorial/follow-up.mdx": "4271c3bae2bcbf0c",
   "tutorial/gestures.mdx": "beac2cdecce76d7e",
   "tutorial/image-picker.mdx": "777d0067241d8943",
   "tutorial/introduction.mdx": "787b2c32b532fa9e",

--- a/docs/pages/agents/claude.mdx
+++ b/docs/pages/agents/claude.mdx
@@ -33,10 +33,10 @@ Create a project with the following command or ensure your existing project has 
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/agents/codex.mdx
+++ b/docs/pages/agents/codex.mdx
@@ -32,10 +32,10 @@ Create a project with the following command or ensure your existing project has 
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/agents/cursor.mdx
+++ b/docs/pages/agents/cursor.mdx
@@ -30,10 +30,10 @@ Create a project with the following command or ensure your existing project has 
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -45,10 +45,10 @@ First, create an Expo project inside your existing native project's root directo
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app my-project --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-56'],
-    bun: ['$ bun create expo my-project --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app my-project --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-57'],
+    bun: ['$ bun create expo my-project --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -41,10 +41,10 @@ Run the following command to create a new directory named **my-project** that co
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app my-project --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-56'],
-    bun: ['$ bun create expo my-project --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app my-project --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-57'],
+    bun: ['$ bun create expo my-project --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -24,10 +24,10 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
-        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
-        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
-        bun: ['$ bun create expo my-app --template default@sdk-56'],
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-57'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-57'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-57'],
+        bun: ['$ bun create expo my-app --template default@sdk-57'],
       }}
     />
 

--- a/docs/pages/develop/app-navigation.mdx
+++ b/docs/pages/develop/app-navigation.mdx
@@ -31,7 +31,7 @@ The library offers platform-specific look-and-feel with smooth animations and ge
 
 Expo Router is a file-based routing library for Expo and React Native projects. By following the **app** directory convention, it turns files into routes and is integrated with Expo for [Expo CLI](/more/expo-cli/) and bundling without additional setup. The library also adds features such as typed routes, dynamic routes, lazy bundling in development, static rendering for the web, and automatic deep linking.
 
-New Expo projects created with `npx create-expo-app@latest --template default@sdk-56` include Expo Router by default.
+New Expo projects created with `npx create-expo-app@latest --template default@sdk-57` include Expo Router by default.
 
 <BoxLink
   title="Introduction to Expo Router"

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -29,10 +29,10 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
-        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
-        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
-        bun: ['$ bun create expo my-app --template default@sdk-56'],
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-57'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-57'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-57'],
+        bun: ['$ bun create expo my-app --template default@sdk-57'],
       }}
     />
 

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -35,10 +35,10 @@ This guide will walk you through the process of creating your first web deployme
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
-        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
-        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
-        bun: ['$ bun create expo my-app --template default@sdk-56'],
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-57'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-57'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-57'],
+        bun: ['$ bun create expo my-app --template default@sdk-57'],
       }}
     />
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -23,10 +23,10 @@ This page walks you through the process of creating your first EAS Workflows for
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-        yarn: ['$ yarn create expo-app --template default@sdk-56'],
-        pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-        bun: ['$ bun create expo --template default@sdk-56'],
+        npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+        yarn: ['$ yarn create expo-app --template default@sdk-57'],
+        pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+        bun: ['$ bun create expo --template default@sdk-57'],
       }}
     />
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -25,14 +25,14 @@ To create a new project, run the following command:
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 
-> **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
+> **Note:** During the SDK 57 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-57` to create an SDK 57 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 
 ## Start from an example
 

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -40,7 +40,7 @@ Create or navigate to your Expo project:
   cmd={{
     npm: [
       '# Create a new project (if needed)',
-      '$ npx create-expo-app@latest example-app --template default@sdk-56',
+      '$ npx create-expo-app@latest example-app --template default@sdk-57',
       '$ cd example-app',
       '',
       '# Or navigate to existing project',
@@ -48,7 +48,7 @@ Create or navigate to your Expo project:
     ],
     yarn: [
       '# Create a new project (if needed)',
-      '$ yarn create expo-app example-app --template default@sdk-56',
+      '$ yarn create expo-app example-app --template default@sdk-57',
       '$ cd example-app',
       '',
       '# Or navigate to existing project',
@@ -56,7 +56,7 @@ Create or navigate to your Expo project:
     ],
     pnpm: [
       '# Create a new project (if needed)',
-      '$ pnpm create expo-app example-app --template default@sdk-56',
+      '$ pnpm create expo-app example-app --template default@sdk-57',
       '$ cd example-app',
       '',
       '# Or navigate to existing project',
@@ -64,7 +64,7 @@ Create or navigate to your Expo project:
     ],
     bun: [
       '# Create a new project (if needed)',
-      '$ bun create expo example-app --template default@sdk-56',
+      '$ bun create expo example-app --template default@sdk-57',
       '$ cd example-app',
       '',
       '# Or navigate to existing project',

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -99,10 +99,10 @@ Before you create your app, you have to create the **apps** directory. This dire
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56 apps/cool-app'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56 apps/cool-app'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56 apps/cool-app'],
-    bun: ['$ bun create expo --template default@sdk-56 apps/cool-app'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57 apps/cool-app'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57 apps/cool-app'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57 apps/cool-app'],
+    bun: ['$ bun create expo --template default@sdk-57 apps/cool-app'],
   }}
 />
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -94,10 +94,10 @@ You can configure the React Native Directory check in your **package.json** file
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -21,10 +21,10 @@ To create a new project, use the default template which includes base TypeScript
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 

--- a/docs/pages/ja/tutorial/follow-up.mdx
+++ b/docs/pages/ja/tutorial/follow-up.mdx
@@ -9,9 +9,9 @@ import { A } from '~/ui/components/Text';
 
 ## プロジェクトをアプリとして構築する
 
-自分のマシンで新しいアプリの作成を始めるには、`npx create-expo-app@latest --template default@sdk-55` を使い、続けて [開発環境のセットアップ](/get-started/set-up-your-environment/) を行います。
+自分のマシンで新しいアプリの作成を始めるには、`npx create-expo-app@latest --template default@sdk-57` を使い、続けて [開発環境のセットアップ](/get-started/set-up-your-environment/) を行います。
 
-> **注：** SDK 55 への移行期間中は、`--template` フラグを付けずに `create-expo-app@latest` を実行すると SDK 54 のプロジェクトが作成されます。実機で Expo Go を使用する予定がある場合は、SDK 54 のプロジェクトを使用してください。そうでない場合は、`--template default@sdk-55` を指定して SDK 55 のプロジェクトを作成してください。
+> **注：** SDK 57 への移行期間中は、`--template` フラグを付けずに `create-expo-app@latest` を実行すると SDK 54 のプロジェクトが作成されます。実機で Expo Go を使用する予定がある場合は、SDK 54 のプロジェクトを使用してください。そうでない場合は、`--template default@sdk-57` を指定して SDK 57 のプロジェクトを作成してください。
 
 ### おすすめのリソース
 
@@ -19,7 +19,7 @@ import { A } from '~/ui/components/Text';
 
 - [開発ツール](/develop/tools/)：アプリ構築のさまざまな場面で役立つ Expo ツールのリファレンスです。
 - [開発ビルド](/develop/development-builds/introduction/)：開発ビルドを使用すると、アプリのビルドプロセスを完全にコントロールでき、デバイスやシミュレーターでアプリをテストできます。
-- [開発の概要](/workflow/overview/)：Expo でアプリを開発するうえでの重要な概念や、コア開発ループの流れを高レベルで解説しています。
+- [開発の概要](/workflow/overview/): Expo でアプリを開発するうえでの重要な概念や、コア開発ループの流れを高レベルで解説しています。
 - [Expo Router](/router/introduction/)：チュートリアルでは Expo Router の基本を扱い、タブナビゲーターを実装しました。ライブラリの詳細についてはドキュメントを参照してみてください。
 - [アプリアイコン](/develop/user-interface/splash-screen-and-app-icon/#app-icon) と [スプラッシュスクリーン](/develop/user-interface/splash-screen-and-app-icon/#splash-screen)：アプリアイコンとスプラッシュスクリーンのカスタマイズについて、ガイドで詳しく学べます。また、**app.json** ファイルで設定できるプロパティについては、[アプリ設定リファレンス](/workflow/configuration) を参照してみてください。
 - アプリストアへの [アプリ配信](/deploy/build-project/) と [提出](/deploy/submit-to-app-stores/)：アプリのリリース準備が整った後、アプリストアへの公開や提出方法について学べるリソースです。

--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -64,7 +64,7 @@ The complete table of [MCP capabilities](#available-mcp-capabilities) documents 
     An Expo account is required to use Expo MCP Server.
   </Requirement>
   <Requirement title="An Expo project on the latest SDK">
-    Create a project with `npx create-expo-app@latest --template default@sdk-56`, or ensure your
+    Create a project with `npx create-expo-app@latest --template default@sdk-57`, or ensure your
     existing project has the latest `expo` package installed.
   </Requirement>
   <Requirement title="An AI-assisted tool with remote MCP support">

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -254,22 +254,22 @@ To test the published module in a new project, create a new app and install the 
 <Terminal
   cmd={{
     npm: [
-      '$ npx create-expo-app@latest my-app --template default@sdk-56',
+      '$ npx create-expo-app@latest my-app --template default@sdk-57',
       '$ cd my-app',
       '$ npx expo install expo-settings',
     ],
     yarn: [
-      '$ yarn create expo-app my-app --template default@sdk-56',
+      '$ yarn create expo-app my-app --template default@sdk-57',
       '$ cd my-app',
       '$ yarn expo install expo-settings',
     ],
     pnpm: [
-      '$ pnpm create expo-app my-app --template default@sdk-56',
+      '$ pnpm create expo-app my-app --template default@sdk-57',
       '$ cd my-app',
       '$ pnpm expo install expo-settings',
     ],
     bun: [
-      '$ bun create expo my-app --template default@sdk-56',
+      '$ bun create expo my-app --template default@sdk-57',
       '$ cd my-app',
       '$ bun expo install expo-settings',
     ],

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -14,14 +14,14 @@ To create a new project, run the following command:
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 
-> **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project.
+> **Note:** During the SDK 57 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-57` to create an SDK 57 project.
 
 Running the above command will prompt you to enter the app name of your project. This app name is also used in the app config's [`name`](/versions/latest/config/app/#name) property.
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -29,14 +29,14 @@ We recommend creating a new Expo app using `create-expo-app` to create a project
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
-    yarn: ['$ yarn create expo-app --template default@sdk-56'],
-    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
-    bun: ['$ bun create expo --template default@sdk-56'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+    yarn: ['$ yarn create expo-app --template default@sdk-57'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+    bun: ['$ bun create expo --template default@sdk-57'],
   }}
 />
 
-> **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project.
+> **Note:** During the SDK 57 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-57` to create an SDK 57 project.
 
 </Step>
 

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -9,9 +9,9 @@ Now that the example app is done, let's learn more about the technologies we use
 
 ## Build your project into an app
 
-To start creating a new app on your machine you can use `npx create-expo-app@latest --template default@sdk-56` and [set up your development environment](/get-started/set-up-your-environment/) sequentially.
+To start creating a new app on your machine you can use `npx create-expo-app@latest --template default@sdk-57` and [set up your development environment](/get-started/set-up-your-environment/) sequentially.
 
-> **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project.
+> **Note:** During the SDK 57 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-57` to create an SDK 57 project.
 
 ### Recommended resources
 

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -56,29 +56,29 @@ You can create a project with the desired SDK version and open it in a simulator
 <Terminal
   cmd={{
     npm: [
-      '# Bootstrap an SDK 56 project',
-      '$ npx create-expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ npx create-expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ npx expo start --android',
     ],
     yarn: [
-      '# Bootstrap an SDK 56 project',
-      '$ yarn create expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ yarn create expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ yarn expo start --android',
     ],
     pnpm: [
-      '# Bootstrap an SDK 56 project',
-      '$ pnpm create expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ pnpm create expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ pnpm expo start --android',
     ],
     bun: [
-      '# Bootstrap an SDK 56 project',
-      '$ bun create expo --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ bun create expo --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ bun expo start --android',

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -87,29 +87,29 @@ You can create a project with the desired SDK version and open it in a simulator
 <Terminal
   cmd={{
     npm: [
-      '# Bootstrap an SDK 56 project',
-      '$ npx create-expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ npx create-expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ npx expo start --ios',
     ],
     yarn: [
-      '# Bootstrap an SDK 56 project',
-      '$ yarn create expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ yarn create expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ yarn expo start --ios',
     ],
     pnpm: [
-      '# Bootstrap an SDK 56 project',
-      '$ pnpm create expo-app --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ pnpm create expo-app --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ pnpm expo start --ios',
     ],
     bun: [
-      '# Bootstrap an SDK 56 project',
-      '$ bun create expo --template blank@56',
+      '# Bootstrap an SDK 57 project',
+      '$ bun create expo --template blank@57',
       '',
       '# Open the app on a simulator to install the required Expo Go app',
       '$ bun expo start --ios',

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -106,28 +106,28 @@ The following three commands result in more or less the same project:
 <Terminal
   cmd={{
     npm: [
-      '$ npx create-expo-app@latest --template default@sdk-56 MyApp && cd MyApp && npx expo prebuild',
+      '$ npx create-expo-app@latest --template default@sdk-57 MyApp && cd MyApp && npx expo prebuild',
       '',
       '$ npx create-expo-app --template bare-minimum',
       '',
       '$ npx @react-native-community/cli@latest init MyApp && cd MyApp && npx install-expo-modules',
     ],
     yarn: [
-      '$ yarn create expo-app --template default@sdk-56 MyApp && cd MyApp && yarn expo prebuild',
+      '$ yarn create expo-app --template default@sdk-57 MyApp && cd MyApp && yarn expo prebuild',
       '',
       '$ yarn create expo-app --template bare-minimum',
       '',
       '$ yarn dlx @react-native-community/cli@latest init MyApp && cd MyApp && yarn dlx install-expo-modules',
     ],
     pnpm: [
-      '$ pnpm create expo-app --template default@sdk-56 MyApp && cd MyApp && pnpm expo prebuild',
+      '$ pnpm create expo-app --template default@sdk-57 MyApp && cd MyApp && pnpm expo prebuild',
       '',
       '$ pnpm create expo-app --template bare-minimum',
       '',
       '$ pnpm dlx @react-native-community/cli@latest init MyApp && cd MyApp && pnpm dlx install-expo-modules',
     ],
     bun: [
-      '$ bun create expo --template default@sdk-56 MyApp && cd MyApp && bun expo prebuild',
+      '$ bun create expo --template default@sdk-57 MyApp && cd MyApp && bun expo prebuild',
       '',
       '$ bun create expo --template bare-minimum',
       '',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22291

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Bump all `create-expo-app` entry-point commands across the docs from `default@sdk-56` to `default@sdk-57`.
- Update the SDK transition-period notes to SDK 57, keeping the Expo Go fallback at SDK 54 (tutorial steps and EAS build-image aliases left unchanged).
- Sync the Japanese `tutorial/follow-up.mdx` mirror and re-stamp `checks/ja/source-hashes.json` so the ja-sync check passes.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
