### PR TITLE
[ios][core] Fix crash passing a SharedRef into an Either argument

### DIFF
--- a/packages/expo-modules-core/ios/Tests/DynamicEitherTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicEitherTypeTests.swift
@@ -122,6 +122,29 @@ struct DynamicEitherTypeTests {
   }
 
   @Test
+  func `supports shared objects passed as a JS value`() throws {
+    class TestSharedObject: SharedObject {}
+
+    let nativeObject = TestSharedObject()
+    let jsObject = appContext.sharedObjectRegistry.createSharedJavaScriptObject(runtime: try runtime, nativeObject: nativeObject)
+
+    let either = try (~Either<URL, TestSharedObject>.self)
+      .cast(jsValue: jsObject.asValue(), appContext: appContext) as! Either<URL, TestSharedObject>
+
+    #expect(either.is(TestSharedObject.self) == true)
+    #expect(either.is(URL.self) == false)
+    #expect(try either.as(TestSharedObject.self).sharedObjectId == nativeObject.sharedObjectId)
+  }
+
+  @Test
+  func `does not crash resolving an Either when a JS object holds a function`() throws {
+    let objectWithFunction = try runtime.eval("({ cb: () => {} })")
+    #expect(throws: NeitherTypeException.self) {
+      try (~Either<URL, Int>.self).cast(jsValue: objectWithFunction, appContext: appContext)
+    }
+  }
+
+  @Test
   func `supports array of either`() throws {
     let eitherArray2 = try (~[Either<String, Int>].self).cast(["bg", 37], appContext: appContext) as! [Either<String, Int>]
     #expect(eitherArray2[0].is(String.self) == true)

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [iOS] Type the host-object setter pointer explicitly so the nil-check conversion type-checks reliably. ([#46736](https://github.com/expo/expo/pull/46736) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Awaiting a `JavaScriptPromise` that is rejected after the await begins now throws instead of resuming with the rejection value as if fulfilled. ([#47154](https://github.com/expo/expo/pull/47154) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47259](https://github.com/expo/expo/pull/47259) by [@wwdrew](https://github.com/wwdrew))
+- [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value.
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -29,7 +29,7 @@
 - [iOS] Type the host-object setter pointer explicitly so the nil-check conversion type-checks reliably. ([#46736](https://github.com/expo/expo/pull/46736) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Awaiting a `JavaScriptPromise` that is rejected after the await begins now throws instead of resuming with the rejection value as if fulfilled. ([#47154](https://github.com/expo/expo/pull/47154) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47259](https://github.com/expo/expo/pull/47259) by [@wwdrew](https://github.com/wwdrew))
-- [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value.
+- [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value. ([#47381](https://github.com/expo/expo/pull/47381) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -208,7 +208,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
         return result
       }
       if object.isFunction() {
-        FatalError.unimplemented()
+        // Don't trap, callers convert speculatively under `try?`, which can't catch a `fatalError`.
+        return NSNull()
       }
       var result = [String: Any]()
 
@@ -222,7 +223,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
       }
       return result
     }
-    fatalError("Unsupported value kind: \(kind)")
+    // Unrepresentable kind (e.g. symbol). Don't trap, for the same reason as above.
+    return NSNull()
   }
 
   /// Returns the value as a boolean, or asserts if not a boolean.


### PR DESCRIPTION
# Why
Closes #47327

Calling `ImageManipulator.manipulate()` with a `SharedRef` crashes immediately on iOS. When resolving the `Either`, `DynamicEitherType` tries each candidate type under `try?`, expecting a recoverable failure so it can fall through to the next one. The `URL` branch is tried first and routes through the deprecated `JavaScriptValue.getAny()`. On a `SharedRef`, `getAny()` walks the object's properties and hits a function-valued one, calling `FatalError.unimplemented()`. A `fatalError` cannot be caught by `try?`, so the app traps instead of falling through to the `SharedRef<UIImage>` branch.

# How
Made `getAny()` return `NSNull()` for function values and otherwise-unrepresentable kinds instead of `fatalError`. `try?` conversions can then fail correctly, so `Either` falls through to the next candidate and the `SharedRef` branch resolves.

# Test Plan
Added tests in `DynamicEitherTypeTests`
Full test suite passes
Tested in with the provided repro
