### PR TITLE
[expo-navigation-bar] Polyfill enforceNavigationBarContrast on Android 8 and 9

### DIFF
--- a/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
@@ -51,7 +51,7 @@ You can configure `expo-navigation-bar` using its built-in [config plugin](/conf
     {
       name: 'enforceContrast',
       description:
-        'Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content. Has no effect on Android 9 and below.',
+        'Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content. Has no effect on Android 7.1 and below.',
       default: 'true',
       platform: 'android',
     },

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Polyfill `enforceContrast` on Android 8 and 9. ([#47382](https://github.com/expo/expo/pull/47382) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -37,11 +37,12 @@ internal fun Window.setNavigationBarStyle(
     return // isAppearanceLightNavigationBars is not available below Android O.
   }
 
-  // android:enforceNavigationBarContrast is not available below Android Q.
-  // This means the button style is not automatically adjusted for contrast,
-  // so we set an explicit navigation bar color to avoid invisible buttons.
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-    navigationBarColor = if (hasLightBackground) LightNavigationBarColor else DarkNavigationBarColor
+    navigationBarColor = when {
+      !isContrastEnforced -> Color.TRANSPARENT
+      hasLightBackground -> LightNavigationBarColor
+      else -> DarkNavigationBarColor
+    }
   } else {
     isNavigationBarContrastEnforced = isContrastEnforced
   }
@@ -67,18 +68,19 @@ class NavigationBarModule : Module(), ExtraWindowEventListener {
   private val reactContext get() = appContext.reactContext as? ReactApplicationContext
 
   private val isContrastEnforced: Boolean by lazy {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      true
-    } else {
-      val theme = currentActivity.theme
-      val resId = android.R.attr.enforceNavigationBarContrast
-      val value = TypedValue()
+    val theme = currentActivity.theme
+    val value = TypedValue()
 
-      if (theme.resolveAttribute(resId, value, true)) {
-        value.data != 0
-      } else {
-        true
-      }
+    val resId = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      R.attr.expoEnforceNavigationBarContrast
+    } else {
+      android.R.attr.enforceNavigationBarContrast
+    }
+
+    if (theme.resolveAttribute(resId, value, true)) {
+      value.data != 0
+    } else {
+      true
     }
   }
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -39,7 +39,13 @@ class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListen
     val theme = activity.theme
     val window = activity.window
 
-    if (!theme.getBooleanAttribute(R.attr.expoEnforceNavigationBarContrast, true)) {
+    val resId = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      R.attr.expoEnforceNavigationBarContrast
+    } else {
+      android.R.attr.enforceNavigationBarContrast
+    }
+
+    if (!theme.getBooleanAttribute(resId, true)) {
       window.disableNavigationBarContrast()
     }
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -2,29 +2,48 @@ package expo.modules.navigationbar
 
 import android.app.Activity
 import android.content.res.Resources
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.view.Window
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
-class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
-  private fun isNavigationBarHidden(theme: Resources.Theme): Boolean {
-    // This value is defined via config plugins
-    val attrs = intArrayOf(R.attr.expoNavigationBarHidden)
-    val typedArray = theme.obtainStyledAttributes(attrs)
+internal fun Resources.Theme.getBooleanAttribute(attr: Int, defValue: Boolean): Boolean {
+  val typedArray = obtainStyledAttributes(intArrayOf(attr))
 
-    return try {
-      typedArray.getBoolean(0, false)
-    } finally {
-      typedArray.recycle()
-    }
+  return try {
+    typedArray.getBoolean(0, defValue)
+  } finally {
+    typedArray.recycle()
+  }
+}
+
+@Suppress("DEPRECATION")
+internal fun Window.disableNavigationBarContrast() {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+    return // isAppearanceLightNavigationBars is not available below Android O.
   }
 
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+    navigationBarColor = Color.TRANSPARENT
+  } else {
+    isNavigationBarContrastEnforced = false
+  }
+}
+
+class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
     // Execute static tasks before the JS engine starts
-    if (isNavigationBarHidden(activity.theme)) {
-      val window = activity.window
+    val theme = activity.theme
+    val window = activity.window
 
+    if (!theme.getBooleanAttribute(R.attr.expoEnforceNavigationBarContrast, true)) {
+      window.disableNavigationBarContrast()
+    }
+
+    if (theme.getBooleanAttribute(R.attr.expoNavigationBarHidden, false)) {
       WindowInsetsControllerCompat(window, window.decorView)
         .hide(WindowInsetsCompat.Type.navigationBars())
     }

--- a/packages/expo-navigation-bar/android/src/main/res/values/attrs.xml
+++ b/packages/expo-navigation-bar/android/src/main/res/values/attrs.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <attr name="expoEnforceNavigationBarContrast" format="boolean" />
   <attr name="expoNavigationBarHidden" format="boolean" />
 </resources>

--- a/packages/expo-navigation-bar/plugin/src/__tests__/withNavigationBar-test.ts
+++ b/packages/expo-navigation-bar/plugin/src/__tests__/withNavigationBar-test.ts
@@ -152,6 +152,12 @@ describe('applyEnforceNavigationBarContrast', () => {
               "item": [
                 {
                   "$": {
+                    "name": "android:otherSetting",
+                  },
+                  "_": "true",
+                },
+                {
+                  "$": {
                     "name": "android:enforceNavigationBarContrast",
                     "tools:targetApi": "29",
                   },
@@ -159,7 +165,7 @@ describe('applyEnforceNavigationBarContrast', () => {
                 },
                 {
                   "$": {
-                    "name": "android:otherSetting",
+                    "name": "expoEnforceNavigationBarContrast",
                   },
                   "_": "true",
                 },
@@ -217,6 +223,12 @@ describe('applyEnforceNavigationBarContrast', () => {
                   },
                   "_": "true",
                 },
+                {
+                  "$": {
+                    "name": "expoEnforceNavigationBarContrast",
+                  },
+                  "_": "true",
+                },
               ],
             },
           ],
@@ -268,6 +280,12 @@ describe('applyEnforceNavigationBarContrast', () => {
                   "$": {
                     "name": "android:enforceNavigationBarContrast",
                     "tools:targetApi": "29",
+                  },
+                  "_": "false",
+                },
+                {
+                  "$": {
+                    "name": "expoEnforceNavigationBarContrast",
                   },
                   "_": "false",
                 },

--- a/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
+++ b/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
@@ -125,37 +125,25 @@ export function applyEnforceNavigationBarContrast(
   config: ResourceXMLConfig,
   enforceNavigationBarContrast: boolean
 ): ResourceXMLConfig {
-  const enforceNavigationBarContrastItem = {
-    _: enforceNavigationBarContrast ? 'true' : 'false',
-    $: {
-      name: 'android:enforceNavigationBarContrast',
-      'tools:targetApi': '29',
-    },
-  };
-  const { style = [] } = config.modResults.resources;
-  const mainThemeIndex = style.findIndex(({ $ }) => $.name === 'AppTheme');
-  if (mainThemeIndex === -1) {
-    return config;
-  }
-  const mainTheme = style[mainThemeIndex];
+  const androidAttr = 'android:enforceNavigationBarContrast';
+  const expoAttr = 'expoEnforceNavigationBarContrast';
+  const attrs = new Set([androidAttr, expoAttr]);
+  const value = String(enforceNavigationBarContrast);
 
-  if (mainTheme != null) {
-    const enforceIndex = mainTheme.item.findIndex(
-      ({ $ }) => $.name === 'android:enforceNavigationBarContrast'
-    );
-    if (enforceIndex !== -1) {
-      mainTheme.item[enforceIndex] = enforceNavigationBarContrastItem;
-      return config;
+  config.modResults.resources.style = config.modResults.resources.style?.map(
+    (style): typeof style => {
+      if (style.$.name === 'AppTheme') {
+        style.item = style.item.filter((item) => !attrs.has(item.$.name));
+
+        style.item.push(
+          { $: { name: expoAttr }, _: value },
+          { $: { name: androidAttr, 'tools:targetApi': '29' }, _: value }
+        );
+      }
+
+      return style;
     }
-
-    config.modResults.resources.style = [
-      {
-        $: mainTheme.$,
-        item: [enforceNavigationBarContrastItem, ...mainTheme.item],
-      },
-      ...style.filter(({ $ }) => $.name !== 'AppTheme'),
-    ];
-  }
+  );
 
   return config;
 }

--- a/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
+++ b/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
@@ -136,8 +136,8 @@ export function applyEnforceNavigationBarContrast(
         style.item = style.item.filter((item) => !attrs.has(item.$.name));
 
         style.item.push(
-          { $: { name: expoAttr }, _: value },
-          { $: { name: androidAttr, 'tools:targetApi': '29' }, _: value }
+          { $: { name: androidAttr, 'tools:targetApi': '29' }, _: value },
+          { $: { name: expoAttr }, _: value }
         );
       }
 


### PR DESCRIPTION
# Why

`enforceContrast` maps to `android:enforceNavigationBarContrast`, which only exists on Android 10+. On 8 and 9 it was ignored.

# How

- Added an `expoEnforceNavigationBarContrast` theme attribute; the plugin writes it alongside `android:enforceNavigationBarContrast`.
- The activity lifecycle listener reads it before JS starts and disables contrast right away.
- `NavigationBarModule` now honors the attribute below Android 10 (was hardcoded `true`).

# Test Plan

On Android 8 / 9 and 10+ emulators, set `enforceContrast: false` and confirm no scrim at launch; set `true` and confirm the scrim stays.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


# Screenshots

### Android 16

<img width="262" height="490" src="https://github.com/user-attachments/assets/6a984cde-d865-434e-abc8-d7a497ca0ac9" />

### Android 9

<img width="253" height="481" src="https://github.com/user-attachments/assets/715de35e-7455-4405-a179-b2a1c68d813e" />
