### PR TITLE
[ios][config-plugins] Sanitize CFBundleName to match PRODUCT_NAME

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Sanitize `CFBundleName` to a valid identifier via the shared `sanitizedName` helper, matching `PRODUCT_NAME`. Prevents dead `ExpoModulesProvider` class-name candidates when `config.name` contains non-identifier characters (e.g. `æ`, whitespace). `CFBundleDisplayName` remains the user-visible name. ([#47383](https://github.com/expo/expo/pull/47383) by [@rolfb](https://github.com/rolfb))
+
 ### 💡 Others
 
 ## 56.0.8 — 2026-05-23

--- a/packages/@expo/config-plugins/src/ios/Name.ts
+++ b/packages/@expo/config-plugins/src/ios/Name.ts
@@ -80,6 +80,7 @@ export function setName(
   return {
     ...infoPlist,
     CFBundleName: sanitizedName(name),
+    CFBundleExecutable: sanitizedName(name),
   };
 }
 

--- a/packages/@expo/config-plugins/src/ios/Name.ts
+++ b/packages/@expo/config-plugins/src/ios/Name.ts
@@ -77,9 +77,13 @@ export function setName(
     return infoPlist;
   }
 
+  // `CFBundleName` is used as a fallback to resolve the app's `ExpoModulesProvider`
+  // class name (`AppContext.modulesProvider`), so it must be a valid identifier —
+  // mirroring `setProductName`, which sanitizes `PRODUCT_NAME` for the same lookup.
+  // `CFBundleDisplayName` (set raw by `setDisplayName`) remains the user-visible name.
   return {
     ...infoPlist,
-    CFBundleName: name,
+    CFBundleName: sanitizedName(name),
   };
 }
 

--- a/packages/@expo/config-plugins/src/ios/Name.ts
+++ b/packages/@expo/config-plugins/src/ios/Name.ts
@@ -77,10 +77,6 @@ export function setName(
     return infoPlist;
   }
 
-  // `CFBundleName` is used as a fallback to resolve the app's `ExpoModulesProvider`
-  // class name (`AppContext.modulesProvider`), so it must be a valid identifier —
-  // mirroring `setProductName`, which sanitizes `PRODUCT_NAME` for the same lookup.
-  // `CFBundleDisplayName` (set raw by `setDisplayName`) remains the user-visible name.
   return {
     ...infoPlist,
     CFBundleName: sanitizedName(name),

--- a/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
@@ -28,6 +28,21 @@ describe(setName, () => {
   it(`makes no changes to the infoPlist no name is provided`, () => {
     expect(setName({} as any, {})).toMatchObject({});
   });
+
+  it(`sanitizes CFBundleName to a valid identifier, mirroring PRODUCT_NAME`, () => {
+    // CFBundleName feeds the ExpoModulesProvider class-name lookup as a fallback
+    // for CFBundleExecutable, so it must be identifier-safe. The user-visible name
+    // is CFBundleDisplayName (set raw by setDisplayName), not CFBundleName.
+    for (const [input, output] of [
+      ['My Appæ', 'MyApp'],
+      ['My Cool Thing', 'MyCoolThing'],
+      ['h"&<world/>🚀', 'hworld'],
+    ] as [string, string][]) {
+      expect(setName({ name: input }, {})).toMatchObject({
+        CFBundleName: output,
+      });
+    }
+  });
 });
 describe(setProductName, () => {
   const projectRoot = '/';

--- a/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
@@ -30,9 +30,6 @@ describe(setName, () => {
   });
 
   it(`sanitizes CFBundleName to a valid identifier, mirroring PRODUCT_NAME`, () => {
-    // CFBundleName feeds the ExpoModulesProvider class-name lookup as a fallback
-    // for CFBundleExecutable, so it must be identifier-safe. The user-visible name
-    // is CFBundleDisplayName (set raw by setDisplayName), not CFBundleName.
     for (const [input, output] of [
       ['My Appæ', 'MyApp'],
       ['My Cool Thing', 'MyCoolThing'],


### PR DESCRIPTION
## Summary

`CFBundleName` is used as a fallback to resolve the app's `ExpoModulesProvider` class name (`AppContext.modulesProvider` on iOS), so it must be a valid identifier. `setProductName` already sanitizes `PRODUCT_NAME` for the same lookup via the shared `sanitizedName` helper, but `setName` wrote `config.name` raw into `CFBundleName` — so a name like `\"My Appæ\"` produced a candidate (`My Appæ.ExpoModulesProvider`) that can never resolve via `NSClassFromString`.

- Route `setName` through the existing `sanitizedName` helper so `CFBundleName` and `PRODUCT_NAME` stay consistent.
- `CFBundleDisplayName` (set raw by `setDisplayName`) remains the user-visible name, so the home screen is unaffected.
- Added a test mirroring the existing `setProductName` test, covering `æ`+whitespace and other non-identifier characters.

## Test plan

- [x] `jest` in `@expo/config-plugins` — `Name-test` (10/10) and `withDefaultPlugins` snapshot (3/3, no churn)
- [x] `ExpoModulesCore-Unit-Tests/AppContextTests` iOS simulator — 15/15 pass