### PR TITLE
[macos] Fix CI

### DIFF
--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native-screens.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native-screens.patch
@@ -1,0 +1,13 @@
+diff --git a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+index 945a75bebe089b8b6798e659031fbd91060d52eb..549fca693645bd3e61b11dfbff22b21f9e2e5f9f 100644
+--- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
++++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
+@@ -81,7 +81,7 @@ export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
+ 
+ export interface NativeCommands {
+   setToolbarMenuItemOptions: (
+-    viewRef: React.ComponentRef<ComponentType>,
++    viewRef: React.ElementRef<ComponentType>,
+     id: string,
+     // We use the array here only due to codegen limitation. We're using only
+     // the first index of the array.


### PR DESCRIPTION
# Why
Macos CI job is failing after bumping to the rn-screens nightly

# How
Add a codegen patch

# Test Plan
Manual macos build run on this branch passes https://github.com/expo/expo/actions/runs/28446976905/job/84298799505
