### PR TITLE
[speech][Android] Migrate from `Locale()` to `Locale.Builder()`

### DIFF
--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -13,3 +13,8 @@ android {
     versionName "56.0.3"
   }
 }
+
+dependencies {
+  testImplementation 'io.mockk:mockk:1.14.9'
+  testImplementation 'junit:junit:4.13.2'
+}

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
@@ -6,13 +6,13 @@ import java.util.*
 object LanguageUtils {
   private val countryISOCodes: Map<String, Locale> by lazy {
     Locale.getISOCountries().associate { country ->
-      val locale = Locale("", country)
+      val locale = Locale.Builder().setRegion(country).build()
       locale.isO3Country.uppercase(locale) to locale
     }
   }
   private val languageISOCodes: Map<String, Locale> by lazy {
     Locale.getISOLanguages().associate { language ->
-      val locale = Locale(language)
+      val locale = Locale.Builder().setLanguage(language).build()
       locale.isO3Language to locale
     }
   }

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.util.ArrayDeque
+import java.util.IllformedLocaleException
 import java.util.Locale
 import java.util.Queue
 
@@ -104,15 +105,19 @@ class SpeechModule : Module() {
     options.rate?.let(textToSpeech::setSpeechRate)
 
     textToSpeech.language = options.language?.let {
-      val locale = Locale(it)
-      val languageAvailable = textToSpeech.isLanguageAvailable(locale)
+      try {
+        val locale = Locale.Builder().setLanguage(it).build()
+        val languageAvailable = textToSpeech.isLanguageAvailable(locale)
 
-      return@let if (
-        languageAvailable != TextToSpeech.LANG_MISSING_DATA &&
-        languageAvailable != TextToSpeech.LANG_NOT_SUPPORTED
-      ) {
-        locale
-      } else {
+        return@let if (
+          languageAvailable != TextToSpeech.LANG_MISSING_DATA &&
+          languageAvailable != TextToSpeech.LANG_NOT_SUPPORTED
+        ) {
+          locale
+        } else {
+          Locale.getDefault()
+        }
+      } catch (_: IllformedLocaleException) {
         Locale.getDefault()
       }
     } ?: Locale.getDefault()

--- a/packages/expo-speech/android/src/test/java/expo/modules/speech/LocaleBuilderCompatibilityTest.kt
+++ b/packages/expo-speech/android/src/test/java/expo/modules/speech/LocaleBuilderCompatibilityTest.kt
@@ -1,0 +1,25 @@
+package expo.modules.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+// These tests were added to ensure that the deprecated Locale constructors and the new Locale.Builder produce the same results.
+// TODO: Remove these tests after one full release (SDK 59)
+class LocaleBuilderCompatibilityTest {
+  @Test
+  @Suppress("DEPRECATION")
+  fun countryBuilderMatchesConstructor() {
+    Locale.getISOCountries().forEach { country ->
+      assertEquals(Locale("", country), Locale.Builder().setRegion(country).build())
+    }
+  }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun languageBuilderMatchesConstructor() {
+    Locale.getISOLanguages().forEach { language ->
+      assertEquals(Locale(language), Locale.Builder().setLanguage(language).build())
+    }
+  }
+}

--- a/packages/expo-speech/android/src/test/java/expo/modules/speech/SpeechModuleTest.kt
+++ b/packages/expo-speech/android/src/test/java/expo/modules/speech/SpeechModuleTest.kt
@@ -1,0 +1,40 @@
+package expo.modules.speech
+
+import android.speech.tts.TextToSpeech
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import java.util.Locale
+
+class SpeechModuleTest {
+  @Test
+  fun malformedLanguageFallsBackToDefaultLocale() {
+    val module = SpeechModule()
+    val textToSpeech = mockk<TextToSpeech>(relaxed = true)
+
+    setTextToSpeech(module, textToSpeech)
+
+    speakOut(module, SpeechOptions("malformed", null, null, null, null))
+
+    verify { textToSpeech.language = Locale.getDefault() }
+  }
+
+  private fun speakOut(module: SpeechModule, options: SpeechOptions) {
+    SpeechModule::class.java.getDeclaredMethod(
+      "speakOut",
+      String::class.java,
+      String::class.java,
+      SpeechOptions::class.java
+    ).apply { isAccessible = true }
+      .invoke(module, "id", "text", options)
+  }
+
+  private fun setTextToSpeech(module: SpeechModule, textToSpeech: TextToSpeech) {
+    val delegate = SpeechModule::class.java.getDeclaredField("textToSpeech\$delegate")
+      .apply { isAccessible = true }
+      .get(module)
+    delegate.javaClass.getDeclaredField("_value")
+      .apply { isAccessible = true }
+      .set(delegate, textToSpeech)
+  }
+}


### PR DESCRIPTION
# Why

`Locale` constructors were deprecated. This PR replaces them with the recommended path forward `Locale.Builder()`

# How

- Updates `speakOut` to use `Locale.Builder()`. Unlike the constructor, the builder validates language codes and can throw `IllformedLocaleException`, so we catch this exception and fall back to the default locale to preserve the previous behavior
- Modifies `LanguageUtils.countryISOCodes` to use `setRegion(country)` instead of `Locale("", country)`, since both paths require the same two-letter ISO 3166 value
- Modifies `LanguageUtils.languageISOCodes` to use `setLanguage(language)`

# Test Plan

Adds two native compatibility tests for the migration (they might be removed after one full release), plus one business-logic test to ensure `speakOut` falls back to the default locale instead of throwing