### PR TITLE
[expo-observe] expose configure event

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
+- Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
@@ -17,7 +17,8 @@ class Config(
   @Field val environment: String? = null,
   @Field val dispatchingEnabled: Boolean? = null,
   @Field val dispatchInDebug: Boolean? = null,
-  @Field val sampleRate: Double? = null
+  @Field val sampleRate: Double? = null,
+  @Field val integrations: Map<String, Any?>? = null
 ) : Record
 
 @OptimizedRecord
@@ -33,9 +34,13 @@ class ObserveModule : Module() {
   private lateinit var observabilityManager: ObservabilityManager
   private lateinit var appMetricsModule: AppMetricsModule
 
+  private var lastIntegrations: Map<String, Any?> = emptyMap()
+
   override fun definition() =
     ModuleDefinition {
       Name("ExpoObserve")
+
+      Events("configure")
 
       OnCreate {
         appMetricsModule = checkNotNull(appContext.registry.getModule<AppMetricsModule>()) {
@@ -72,6 +77,14 @@ class ObserveModule : Module() {
         val resolvedEnvironment = config.environment
           ?: ObservePreferences.getBundleDefaults(context)?.environment
         resolvedEnvironment?.let { appMetricsModule.setEnvironment(it) }
+
+        // Broadcast the integrations config so integration libraries (e.g. expo-image) can activate.
+        lastIntegrations = config.integrations ?: emptyMap()
+        this@ObserveModule.sendEvent("configure", mapOf("integrations" to lastIntegrations))
+      }
+
+      Function("getIntegrations") {
+        lastIntegrations
       }
 
       Function("setBundleDefaults") { defaults: BundleDefaults ->

--- a/packages/expo-observe/ios/ObserveModule.swift
+++ b/packages/expo-observe/ios/ObserveModule.swift
@@ -10,6 +10,7 @@ internal struct Config: Record {
   @Field var dispatchingEnabled: Bool?
   @Field var dispatchInDebug: Bool?
   @Field var sampleRate: Double?
+  @Field var integrations: [String: Any]?
 }
 
 internal struct BundleDefaults: Record {
@@ -18,8 +19,12 @@ internal struct BundleDefaults: Record {
 }
 
 public final class ObserveModule: Module {
+  private var lastIntegrations: [String: Any] = [:]
+
   public func definition() -> ModuleDefinition {
     Name("ExpoObserve")
+
+    Events("configure")
 
     OnCreate {
       // The observability manager needs to know the project id. Currently it's available only through `expo-constants`,
@@ -49,6 +54,14 @@ public final class ObserveModule: Module {
           AppMetrics.setEnvironment(resolvedEnvironment)
         }
       }
+
+      // Broadcast the integrations config so integration libraries (e.g. expo-image) can activate.
+      self.lastIntegrations = config.integrations ?? [:]
+      self.emit(event: "configure", payload: ["integrations": self.lastIntegrations])
+    }
+
+    Function("getIntegrations") {
+      return self.lastIntegrations
     }
 
     Function("setBundleDefaults") { (defaults: BundleDefaults) in

--- a/packages/expo-observe/src/index.ts
+++ b/packages/expo-observe/src/index.ts
@@ -20,5 +20,7 @@ export type {
   ObserveAttributes,
   ObserveConfig,
   ObserveIntegrationsConfig,
+  ObserveModule,
+  ObserveModuleEvents,
 } from './types';
 export { useObserve } from './useObserve';

--- a/packages/expo-observe/src/module.web.ts
+++ b/packages/expo-observe/src/module.web.ts
@@ -1,11 +1,20 @@
 import { NativeModule, registerWebModule } from 'expo';
 import AppMetrics, { type LogEventOptions, type MetricAttributes } from 'expo-app-metrics';
 
-import type { ObserveConfig, ObserveModule, ObserveAttributes } from './types';
+import type {
+  ObserveConfig,
+  ObserveIntegrationsConfig,
+  ObserveModule,
+  ObserveModuleEvents,
+  ObserveAttributes,
+} from './types';
 
-class ExpoObserveModule extends NativeModule implements ObserveModule {
+class ExpoObserveModule extends NativeModule<ObserveModuleEvents> implements ObserveModule {
   async dispatchEvents() {}
   configure(config: ObserveConfig): void {}
+  getIntegrations(): ObserveIntegrationsConfig {
+    return {};
+  }
   logEvent(name: string, options?: LogEventOptions): void {
     AppMetrics.logEvent(name, options);
   }

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -67,7 +67,7 @@ export type ObserveConfig = {
   integrations?: ObserveIntegrationsConfig;
 };
 
-export type ObserveIntegrationsConfig = {
+export interface ObserveIntegrationsConfig {
   /**
    * Enables the `expo-router` integration, which records navigation metrics
    * (`cold_ttr`, `warm_ttr`, `tti`) from router state changes.
@@ -88,14 +88,30 @@ export type ObserveIntegrationsConfig = {
    * @default false
    */
   'react-navigation'?: boolean;
+}
+
+/**
+ * Events emitted by the native `ExpoObserve` module.
+ */
+export type ObserveModuleEvents = {
+  /**
+   * Fired on every `configure(...)` call, carrying the resolved `integrations`
+   * config
+   */
+  configure: (payload: { integrations: ObserveIntegrationsConfig }) => void;
 };
 
-export declare class ObserveModule extends NativeModule {
+export declare class ObserveModule extends NativeModule<ObserveModuleEvents> {
   dispatchEvents(): Promise<void>;
   /**
    * Configures observability settings.
    */
   configure(config: ObserveConfig): void;
+  /**
+   * Returns the `integrations` config from the most recent `configure(...)`
+   * call, or an empty object if `configure` has not run yet.
+   */
+  getIntegrations(): ObserveIntegrationsConfig;
   /**
    * Records a log event against the current main session. The event is
    * persisted locally and dispatched on the next `dispatchEvents()` flush.


### PR DESCRIPTION
# Why

Prerequisite for 3rd party integrations. 

# How

1. Adds `configure` event in observe module for configuration changes
2. Turns `ObserveIntegrationsConfig` into interface, so that it can be modified via `declare module` from other packages

# Test Plan

Follow-up PR with expo-image integration

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
