### PR TITLE
[expo-router] fix press detection with android bottom toolbar

### DIFF
--- a/apps/router-e2e/__e2e__/toolbar-press/__tests__/close-warning.yml
+++ b/apps/router-e2e/__e2e__/toolbar-press/__tests__/close-warning.yml
@@ -1,0 +1,10 @@
+appId: dev.expo.routere2e
+---
+# Dismiss the React Native dev warning toast if it is showing.
+- runFlow:
+    when:
+      visible: "!, Open debugger to view warnings."
+    commands:
+      - tapOn:
+          point: 96%,93%
+      - assertNotVisible: "!, Open debugger to view warnings."

--- a/apps/router-e2e/__e2e__/toolbar-press/__tests__/press-blocked.yml
+++ b/apps/router-e2e/__e2e__/toolbar-press/__tests__/press-blocked.yml
@@ -1,0 +1,18 @@
+appId: dev.expo.routere2e
+name: Screen pressable works under bottom toolbar (ENG-22124)
+---
+# Reproduces ENG-22124: on Android the bottom Stack.Toolbar renders inside a full-screen
+# Compose host that swallows touches, so this screen Pressable never fires. This test asserts
+# the CORRECT behavior, so it FAILS on the current build (counter stays at 0) — that failure
+# is the reproduction. It will pass once the toolbar stops blocking touches.
+- stopApp: dev.expo.routere2e
+- openLink: router-e2e://
+- runFlow: close-warning.yml
+- assertVisible:
+    id: "press-count"
+    text: "Pressed: 0"
+- tapOn:
+    id: "press-target"
+- assertVisible:
+    id: "press-count"
+    text: "Pressed: 1"

--- a/apps/router-e2e/__e2e__/toolbar-press/__tests__/toolbar-button-works.yml
+++ b/apps/router-e2e/__e2e__/toolbar-press/__tests__/toolbar-button-works.yml
@@ -1,0 +1,18 @@
+appId: dev.expo.routere2e
+name: Bottom toolbar button is tappable (ENG-22124 control)
+---
+# Control for ENG-22124: the toolbar button itself receives touches today. This passes on the
+# current build, isolating the bug to screen content underneath the Compose host (see
+# press-blocked.yml).
+- stopApp: dev.expo.routere2e
+- openLink: router-e2e://
+- runFlow: close-warning.yml
+- assertVisible:
+    id: "toolbar-count"
+    text: "Toolbar: 0"
+# The toolbar button is a Compose IconButton; accessibilityLabel maps to its content-desc
+# (not a resource-id), so match it by accessibility text rather than `id`.
+- tapOn: "toolbar-add-button"
+- assertVisible:
+    id: "toolbar-count"
+    text: "Toolbar: 1"

--- a/apps/router-e2e/__e2e__/toolbar-press/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/toolbar-press/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return <Stack />;
+}

--- a/apps/router-e2e/__e2e__/toolbar-press/app/index.tsx
+++ b/apps/router-e2e/__e2e__/toolbar-press/app/index.tsx
@@ -1,0 +1,68 @@
+import { Stack } from 'expo-router';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+// Android needs an xml drawable; iOS uses an SF Symbol. See ENG-22124.
+const addIcon = require('@expo/material-symbols/add.xml');
+
+/**
+ * Minimal repro for ENG-22124: on Android the bottom `Stack.Toolbar` renders inside a
+ * full-screen Jetpack Compose host that swallows touches, so the screen `Pressable` below
+ * never fires. The toolbar button itself still works.
+ */
+export default function ToolbarPress() {
+  const [pressed, setPressed] = useState(0);
+  const [toolbarPressed, setToolbarPressed] = useState(0);
+
+  return (
+    <>
+      <View style={styles.container}>
+        <Pressable
+          testID="press-target"
+          style={styles.button}
+          onPress={() => setPressed((n) => n + 1)}>
+          <Text testID="press-count" style={styles.buttonText}>
+            Pressed: {pressed}
+          </Text>
+        </Pressable>
+        <Text testID="toolbar-count" style={styles.toolbarCount}>
+          Toolbar: {toolbarPressed}
+        </Text>
+      </View>
+
+      <Stack.Toolbar>
+        <Stack.Toolbar.Spacer />
+        <Stack.Toolbar.Button
+          accessibilityLabel="toolbar-add-button"
+          icon={process.env.EXPO_OS === 'ios' ? 'plus' : addIcon}
+          onPress={() => setToolbarPressed((n) => n + 1)}
+        />
+        <Stack.Toolbar.Spacer />
+      </Stack.Toolbar>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 24,
+  },
+  button: {
+    paddingVertical: 24,
+    paddingHorizontal: 48,
+    backgroundColor: '#4630eb',
+    borderRadius: 12,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  toolbarCount: {
+    fontSize: 18,
+    color: '#333',
+  },
+});

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -53,6 +53,9 @@
     "start:stack": "E2E_ROUTER_SRC=stack expo start",
     "ios:stack": "E2E_ROUTER_SRC=stack expo run:ios",
     "android:stack": "E2E_ROUTER_SRC=stack expo run:android",
+    "start:toolbar-press": "E2E_ROUTER_SRC=toolbar-press expo start",
+    "ios:toolbar-press": "E2E_ROUTER_SRC=toolbar-press expo run:ios",
+    "android:toolbar-press": "E2E_ROUTER_JS_ENGINE=hermes E2E_ROUTER_SRC=toolbar-press expo run:android",
     "start:helmet": "E2E_ROUTER_SRC=helmet expo start",
     "export:helmet": "E2E_ROUTER_SRC=helmet expo export -p web",
     "lint": "expo lint __e2e__",
@@ -62,6 +65,7 @@
   },
   "dependencies": {
     "@expo/dom-webview": "workspace:*",
+    "@expo/material-symbols": "0.1.1",
     "@expo/vector-icons": "^15.0.2",
     "expo": "workspace:*",
     "expo-asset": "workspace:*",

--- a/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
+++ b/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
@@ -1,0 +1,75 @@
+import { render, within } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { RouterToolbarHost } from '../native';
+
+jest.mock('@expo/ui/jetpack-compose', () => {
+  const { View }: typeof import('react-native') = jest.requireActual('react-native');
+  return {
+    Host: jest.fn((props) => <View testID="Host" {...props} />),
+    Box: jest.fn((props) => <View testID="Box" {...props} />),
+    HorizontalFloatingToolbar: jest.fn((props) => (
+      <View testID="HorizontalFloatingToolbar" {...props} />
+    )),
+  };
+});
+
+jest.mock('@expo/ui/jetpack-compose/modifiers', () => ({
+  fillMaxWidth: jest.fn(() => ({ type: 'fillMaxWidth' })),
+  height: jest.fn((h: number) => ({ type: 'height', height: h })),
+  padding: jest.fn((...args: number[]) => ({ type: 'padding', values: args })),
+  imePadding: jest.fn(() => ({ type: 'imePadding' })),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 12, left: 0, right: 0 }),
+}));
+
+const flatten = (style: unknown) =>
+  Object.assign({}, ...(Array.isArray(style) ? style : [style]).filter(Boolean));
+
+describe('RouterToolbarHost (Android bottom toolbar)', () => {
+  it('does not cover the full screen so touches above the toolbar pass through', () => {
+    const { getByTestId } = render(
+      <RouterToolbarHost>
+        <Text>item</Text>
+      </RouterToolbarHost>
+    );
+
+    const host = getByTestId('Host');
+    const wrapper = getByTestId('RouterToolbarWrapper');
+
+    // The wrapper fills the screen but must not be a touch target itself, and it must pin the
+    // toolbar to the bottom so the Compose host only covers the toolbar area.
+    expect(wrapper.props.pointerEvents).toBe('box-none');
+    expect(flatten(wrapper.props.style).justifyContent).toBe('flex-end');
+
+    expect(host.props.matchContents.vertical).toBe(true);
+  });
+
+  it('renders its children inside the floating toolbar', () => {
+    const { getByTestId } = render(
+      <RouterToolbarHost>
+        <Text testID="toolbar-child">item</Text>
+      </RouterToolbarHost>
+    );
+
+    const toolbar = getByTestId('HorizontalFloatingToolbar');
+    expect(within(toolbar).getByTestId('toolbar-child')).toBeDefined();
+  });
+
+  it.each([
+    [true, true],
+    [false, false],
+    [undefined, false],
+  ])('includes the imePadding modifier only when withImePadding is %s', (withImePadding, expected) => {
+    const { getByTestId } = render(
+      <RouterToolbarHost withImePadding={withImePadding}>
+        <Text>item</Text>
+      </RouterToolbarHost>
+    );
+
+    const modifiers = getByTestId('Box').props.modifiers as { type: string }[];
+    expect(modifiers.some((m) => m.type === 'imePadding')).toBe(expected);
+  });
+});

--- a/packages/expo-router/src/toolbar/native.android.tsx
+++ b/packages/expo-router/src/toolbar/native.android.tsx
@@ -17,10 +17,13 @@ export function RouterToolbarHost(props: RouterToolbarHostProps) {
     return baseModifiers;
   }, [insets.bottom, props.withImePadding]);
 
+  // The wrapper fills the screen so it can pin the toolbar to the bottom, but `box-none` keeps it
+  // from being a touch target. The Compose `Host` then wraps just the toolbar (matchContents), so
+  // only that area swallows touches — taps elsewhere reach the screen content below (ENG-22124).
   return (
-    <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
-      <Host style={styles.host}>
-        <Box modifiers={modifiers} contentAlignment="bottomCenter">
+    <View testID="RouterToolbarWrapper" style={styles.container} pointerEvents="box-none">
+      <Host matchContents={{ vertical: true }} style={styles.host}>
+        <Box modifiers={modifiers} contentAlignment="center">
           <HorizontalFloatingToolbar
             colors={{
               ...(props.backgroundColor ? { toolbarContainerColor: props.backgroundColor } : {}),
@@ -35,5 +38,6 @@ export function RouterToolbarHost(props: RouterToolbarHostProps) {
 }
 
 const styles = StyleSheet.create({
-  host: { width: '100%', height: '100%', paddingHorizontal: 24 },
+  container: { ...StyleSheet.absoluteFill, justifyContent: 'flex-end' },
+  host: { width: '100%', paddingHorizontal: 24 },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,9 @@ importers:
       '@expo/dom-webview':
         specifier: workspace:*
         version: link:../../packages/@expo/dom-webview
+      '@expo/material-symbols':
+        specifier: 0.1.1
+        version: 0.1.1
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.1.1(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -18109,9 +18112,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
# Why

Pressables didn't work when bottom toolbar on android was used.

# How

1. Move the layout logic to `View` - positioning toolbar at the bottom. `Host` cannot have `pointer-events` set to `box-none`

# Test Plan

1. Local maestro tests `maestro test __e2e__/toolbar-press/__tests__/` from `router-e2e` directory
2. CI
3. Router e2e app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
