### PR TITLE
[dev-launcher] Debounce reloads

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -110,6 +110,9 @@ open class DevMenuManager: NSObject {
 
   private var isNavigatingHome = false
 
+  private var isReloading = false
+  private var lastReloadEventAt: Date?
+
   weak var hostDelegate: DevMenuHostDelegate?
 
   @objc
@@ -214,6 +217,8 @@ open class DevMenuManager: NSObject {
   public func setAppContext(_ appContext: AppContext?) {
     currentAppContext = appContext
     if appContext != nil {
+      isReloading = false
+      lastReloadEventAt = Date()
       isNavigatingHome = false
       isReactAppRunning = true
       // Re-run packager connection setup now that the app context (and devSettings) is available.
@@ -223,6 +228,20 @@ open class DevMenuManager: NSObject {
       isReactAppRunning = false
     }
     updateAutoLaunchObserver()
+  }
+
+  /**
+   Clears the app context, but only if `context` is still the active one.
+   On reload the incoming context's `OnCreate` can run before the outgoing context's
+   `OnDestroy`, so an unconditional reset would wipe the new context and leave the dev
+   menu unable to open.
+   */
+  @objc
+  public func clearAppContext(current context: AppContext?) {
+    if currentAppContext != nil && currentAppContext !== context {
+      return
+    }
+    setAppContext(nil)
   }
 
   @objc
@@ -524,6 +543,17 @@ open class DevMenuManager: NSObject {
   }
 
   func reload() {
+    let now = Date()
+    if isReloading || (lastReloadEventAt.map { now.timeIntervalSince($0) < 0.5 } ?? false) {
+      lastReloadEventAt = now
+      return
+    }
+    isReloading = true
+    lastReloadEventAt = now
+    // Clear the guard even if a new app context never registers, for example a failed reload.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+      self?.isReloading = false
+    }
     let devToolsDelegate = getDevToolsDelegate()
     devToolsDelegate?.reload()
   }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -548,14 +548,16 @@ open class DevMenuManager: NSObject {
       lastReloadEventAt = now
       return
     }
+    guard let devToolsDelegate = getDevToolsDelegate() else {
+      return
+    }
     isReloading = true
     lastReloadEventAt = now
     // Clear the guard even if a new app context never registers, for example a failed reload.
     DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
       self?.isReloading = false
     }
-    let devToolsDelegate = getDevToolsDelegate()
-    devToolsDelegate?.reload()
+    devToolsDelegate.reload()
   }
 
   func togglePerformanceMonitor() {

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -92,7 +92,7 @@ class DevMenuPackagerConnectionHandler {
 
     switch command {
     case "reload":
-      devDelegate.reload()
+      manager.reload()
     case "toggleDevMenu":
       self.manager?.toggleMenu()
     case "toggleElementInspector":

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -10,7 +10,7 @@ open class DevMenuModule: Module {
     }
 
     OnDestroy {
-      DevMenuManager.shared.setAppContext(nil)
+      DevMenuManager.shared.clearAppContext(current: self.appContext)
       // Cleanup registered callbacks when the module is destroyed to prevent leaking into other bridges.
       if DevMenuManager.wasInitilized {
         DevMenuManager.shared.registeredCallbacks = []


### PR DESCRIPTION
# Why
On iOS, reloading a dev client could leave the app in a broken state. Depending on timing it would do one of three things: spin in an endless reload loop, freeze completely, or come back up with a dev menu that could no longer be opened and the CLI commands no longer responded. This reproduced on both SDK 56 and 57.

# How
1.  DevMenuManager.reload() now ignores reloads while one is already in flight plus a short window after, which swallows the repeat burst without throttling intentional reloads.

2. Stop the reload deadlock. addressed in #47392

3. Stop the dev menu from being unable to open after a reload. During reload the incoming context's OnCreate can run before the outgoing context's OnDestroy. The unconditional setAppContext(nil) in OnDestroy then wiped the live context, leaving isReactAppRunning false so the menu refused to open. OnDestroy now clears the context only if it is still the active one.

The deadlock is a RCTHost reload race in React Native itself, where the legacy RCTNativeAnimatedTurboModule invalidation overlaps new-instance startup. Running the reload inline removes the interleaving that triggers it.

# Test Plan
New 57 project

