### PR TITLE
[tools] Add label author to cherry picks

### DIFF
--- a/tools/src/commands/CheckSdkPrs.test.ts
+++ b/tools/src/commands/CheckSdkPrs.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { getLabelAuthor, renderRows } from './CheckSdkPrsCommand';
+
+describe('getLabelAuthor', () => {
+  it('returns the actor of a matching labeled event', () => {
+    const events = [
+      {
+        event: 'labeled',
+        actor: { login: 'brentvatne' },
+        label: { name: 'sdk-55' },
+        created_at: '2026-06-01T00:00:00Z',
+      },
+    ];
+    assert.equal(getLabelAuthor(events, 'sdk-55'), 'brentvatne');
+  });
+
+  it('ignores labeled events for other labels', () => {
+    const events = [
+      {
+        event: 'labeled',
+        actor: { login: 'someone' },
+        label: { name: 'bug' },
+        created_at: '2026-06-01T00:00:00Z',
+      },
+    ];
+    assert.equal(getLabelAuthor(events, 'sdk-55'), null);
+  });
+
+  it('ignores non-label timeline events', () => {
+    const events = [
+      { event: 'commented', actor: { login: 'someone' }, created_at: '2026-06-01T00:00:00Z' },
+    ];
+    assert.equal(getLabelAuthor(events, 'sdk-55'), null);
+  });
+
+  it('returns the most recent actor when the label was applied more than once', () => {
+    const events = [
+      {
+        event: 'labeled',
+        actor: { login: 'first' },
+        label: { name: 'sdk-55' },
+        created_at: '2026-06-01T00:00:00Z',
+      },
+      {
+        event: 'unlabeled',
+        actor: { login: 'first' },
+        label: { name: 'sdk-55' },
+        created_at: '2026-06-02T00:00:00Z',
+      },
+      {
+        event: 'labeled',
+        actor: { login: 'second' },
+        label: { name: 'sdk-55' },
+        created_at: '2026-06-03T00:00:00Z',
+      },
+    ];
+    assert.equal(getLabelAuthor(events, 'sdk-55'), 'second');
+  });
+
+  it('returns null when there are no events', () => {
+    assert.equal(getLabelAuthor([], 'sdk-55'), null);
+  });
+
+  it('tolerates a missing actor', () => {
+    const events = [
+      {
+        event: 'labeled',
+        actor: null,
+        label: { name: 'sdk-55' },
+        created_at: '2026-06-01T00:00:00Z',
+      },
+    ];
+    assert.equal(getLabelAuthor(events, 'sdk-55'), null);
+  });
+});
+
+describe('renderRows', () => {
+  it('drops columns that are empty in every row and pads to the widest cell', () => {
+    const rows = [
+      ['#1', '', 'a', 'today'],
+      ['#22', '', 'bb', '1d'],
+    ];
+    assert.deepEqual(renderRows(rows), ['  #1   a   today', '  #22  bb  1d']);
+  });
+
+  it('keeps a column that is populated in only some rows', () => {
+    const rows = [
+      ['#1', 'published', 'title'],
+      ['#2', '', 'other'],
+    ];
+    assert.deepEqual(renderRows(rows), ['  #1  published  title', '  #2             other']);
+  });
+});

--- a/tools/src/commands/CheckSdkPrsCommand.ts
+++ b/tools/src/commands/CheckSdkPrsCommand.ts
@@ -21,7 +21,46 @@ type GhPr = {
 type ActionOptions = {
   all: boolean;
   links: boolean;
+  who: boolean;
 };
+
+type TimelineEvent = {
+  event: string;
+  actor?: { login: string } | null;
+  label?: { name: string } | null;
+  created_at?: string;
+};
+
+/**
+ * Given a PR's timeline events, returns the login of whoever most recently
+ * applied the given label, or null if it was never applied. A label can be
+ * added, removed, and re-added, so we take the latest matching `labeled` event.
+ */
+export function getLabelAuthor(events: TimelineEvent[], labelName: string): string | null {
+  const labeledEvents = events
+    .filter((event) => event.event === 'labeled' && event.label?.name === labelName)
+    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+  return labeledEvents[labeledEvents.length - 1]?.actor?.login ?? null;
+}
+
+/**
+ * Fetches a PR's timeline and returns whoever most recently applied the label.
+ * The label isn't attributed on the PR object itself, so this is one extra API
+ * request per PR. Returns null if the timeline can't be read.
+ */
+async function fetchLabelAuthor(prNumber: number, labelName: string): Promise<string | null> {
+  try {
+    const pages = await spawnJSONCommandAsync<TimelineEvent[][]>('gh', [
+      'api',
+      `/repos/expo/expo/issues/${prNumber}/timeline`,
+      '--paginate',
+      '--slurp',
+    ]);
+    return getLabelAuthor(pages.flat(), labelName);
+  } catch {
+    return null;
+  }
+}
 
 let linksEnabled = true;
 
@@ -150,9 +189,34 @@ function formatPublishInfo(info: PublishInfo): string {
 
 const ANSI_RE = /\x1b\[[0-9;]*m|\x1b\]8;;[^\x07]*\x07/g;
 
+function visibleWidth(str: string): number {
+  return str.replace(ANSI_RE, '').length;
+}
+
 function pad(str: string, width: number): string {
-  const visible = str.replace(ANSI_RE, '').length;
-  return str + ' '.repeat(Math.max(0, width - visible));
+  return str + ' '.repeat(Math.max(0, width - visibleWidth(str)));
+}
+
+const COLUMN_GAP = '  ';
+
+/**
+ * Renders a grid of cells into aligned, indented lines. Each column is sized to
+ * its widest cell, columns that are empty in every row are dropped (so unused
+ * fields don't leave a gap), and the last kept column is left unpadded.
+ */
+export function renderRows(rows: string[][]): string[] {
+  const columnCount = rows.reduce((max, row) => Math.max(max, row.length), 0);
+  const widths = Array.from({ length: columnCount }, (_, c) =>
+    rows.reduce((max, row) => Math.max(max, visibleWidth(row[c] ?? '')), 0)
+  );
+  const keptColumns = widths.map((_, c) => c).filter((c) => widths[c] > 0);
+  return rows.map((row) => {
+    const cells = keptColumns.map((c, i) => {
+      const cell = row[c] ?? '';
+      return i === keptColumns.length - 1 ? cell : pad(cell, widths[c]);
+    });
+    return COLUMN_GAP + cells.join(COLUMN_GAP);
+  });
 }
 
 function formatReviewDecision(decision: GhPr['reviewDecision']): string {
@@ -168,7 +232,9 @@ function formatReviewDecision(decision: GhPr['reviewDecision']): string {
   }
 }
 
-function formatPrLine(pr: GhPr, publishInfo?: PublishInfo): string {
+// Builds the ordered cells for one PR row. Empty cells are collapsed by
+// `renderRows`, so a column is only shown when at least one row populates it.
+function prCells(pr: GhPr, publishInfo?: PublishInfo, labelAuthor?: string | null): string[] {
   const num = link(chalk.yellow(`#${pr.number}`), pr.url);
   const sha = pr.mergeCommit
     ? link(
@@ -189,7 +255,14 @@ function formatPrLine(pr: GhPr, publishInfo?: PublishInfo): string {
   // For merged PRs show merge age, for open PRs show time since last activity
   const timestamp = pr.mergedAt ?? pr.updatedAt;
   const age = timestamp ? chalk.dim(formatAge(timestamp)) : '';
-  return `  ${pad(num, 8)}  ${pad(sha, 10)}  ${pad(status, 17)}  ${pad(title, 60)}  ${pad(author, 20)}  ${age}`;
+  // `labelAuthor === undefined` means the column is off; `null` means unknown.
+  const labeledBy =
+    labelAuthor === undefined
+      ? ''
+      : labelAuthor
+        ? link(chalk.dim(`labeled by @${labelAuthor}`), `https://github.com/${labelAuthor}`)
+        : chalk.dim('labeled by ?');
+  return [num, sha, status, title, author, labeledBy, age];
 }
 
 async function action(sdk: string | undefined, options: ActionOptions) {
@@ -307,38 +380,54 @@ async function action(sdk: string | undefined, options: ActionOptions) {
     (a, b) => new Date(b.mergedAt!).getTime() - new Date(a.mergedAt!).getTime()
   );
 
+  const labelAuthors = new Map<number, string | null>();
+  if (options.who) {
+    const displayed = options.all
+      ? [...needsCherryPick, ...alreadyCherryPicked, ...openPrs, ...closedPrs]
+      : needsCherryPick;
+    logger.info(
+      `Fetching label authors for ${displayed.length} PR${displayed.length === 1 ? '' : 's'}...`
+    );
+    await Promise.all(
+      displayed.map(async (pr) => {
+        labelAuthors.set(pr.number, await fetchLabelAuthor(pr.number, label));
+      })
+    );
+  }
+  const labelAuthorFor = (pr: GhPr): string | null | undefined =>
+    options.who ? (labelAuthors.get(pr.number) ?? null) : undefined;
+
+  const logPrTable = (prs: GhPr[]) => {
+    const rows = prs.map((pr) => prCells(pr, publishInfos.get(pr.number), labelAuthorFor(pr)));
+    for (const line of renderRows(rows)) {
+      logger.log(line);
+    }
+  };
+
   // Display results
   if (options.all) {
     if (needsCherryPick.length > 0) {
       logger.log('');
       logger.log(chalk.red.bold(`Needs Cherry-Pick (${needsCherryPick.length}):`));
-      for (const pr of needsCherryPick) {
-        logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
-      }
+      logPrTable(needsCherryPick);
     }
 
     if (alreadyCherryPicked.length > 0) {
       logger.log('');
       logger.log(chalk.green.bold(`Already Cherry-Picked (${alreadyCherryPicked.length}):`));
-      for (const pr of alreadyCherryPicked) {
-        logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
-      }
+      logPrTable(alreadyCherryPicked);
     }
 
     if (openPrs.length > 0) {
       logger.log('');
       logger.log(chalk.blue.bold(`Open (${openPrs.length}):`));
-      for (const pr of openPrs) {
-        logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
-      }
+      logPrTable(openPrs);
     }
 
     if (closedPrs.length > 0) {
       logger.log('');
       logger.log(chalk.gray.bold(`Closed without Merge (${closedPrs.length}):`));
-      for (const pr of closedPrs) {
-        logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
-      }
+      logPrTable(closedPrs);
     }
   } else {
     if (needsCherryPick.length === 0) {
@@ -351,9 +440,7 @@ async function action(sdk: string | undefined, options: ActionOptions) {
     logger.log('');
     logger.log(chalk.bold(`PRs that need cherry-picking to ${branch}:`));
     logger.log('');
-    for (const pr of needsCherryPick) {
-      logger.log(formatPrLine(pr, publishInfos.get(pr.number)));
-    }
+    logPrTable(needsCherryPick);
   }
 
   // Summary
@@ -383,6 +470,11 @@ export default (program: Command) => {
   A PR is "published" if all packages it modified have appeared in a publish commit.`
     )
     .option('-a, --all', 'Show all PRs grouped by status', false)
+    .option(
+      '--who',
+      'Show who applied the SDK label to each PR (one extra API request per PR)',
+      false
+    )
     .option('--no-links', 'Disable clickable terminal hyperlinks')
     .asyncAction(action);
 };


### PR DESCRIPTION
# Why
When triaging what still needs cherry-picking to an SDK branch, it helps to know who put each PR on the list, not just that it's there.

# How
Added a --who flag to et csp.
I also changed the table formatting so it's doesn't take up unnecessary space

# Test Plan

<img width="1190" height="400" alt="Screenshot 2026-07-01 at 09 51 31" src="https://github.com/user-attachments/assets/b117715a-58a0-4f33-857b-23ec4ca6d1e1" />
