### PR TITLE
[expo-blur] Fix gestures being cancelled under a BlurTargetView on Android

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `BlurView` not applying border radius styles to the native blur layer. ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong)) and [@behenate](https://github.com/behenate)
-- [Android] Fixed `ExpoBlurTargetView.indexOfChild()` returning `-1` for its own child, which made gesture handlers (e.g. `react-native-gesture-handler`) treat views under a `BlurTargetView` as detached and cancel their gestures. ([#47402](https://github.com/expo/expo/issues/47402) by [@efstathiosntonas](https://github.com/efstathiosntonas))
+- [Android] Fix gesture handlers treating views under a `BlurTargetView` as detached and cancelling their gestures. ([#47404](https://github.com/expo/expo/pull/47404) by [@efstathiosntonas](https://github.com/efstathiosntonas))
 
 ### 💡 Others
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `BlurView` not applying border radius styles to the native blur layer. ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong)) and [@behenate](https://github.com/behenate)
+- [Android] Fixed `ExpoBlurTargetView.indexOfChild()` returning `-1` for its own child, which made gesture handlers (e.g. `react-native-gesture-handler`) treat views under a `BlurTargetView` as detached and cancel their gestures. ([#47402](https://github.com/expo/expo/issues/47402) by [@efstathiosntonas](https://github.com/efstathiosntonas))
 
 ### 💡 Others
 

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
@@ -95,7 +95,19 @@ class ExpoBlurTargetView(context: Context, appContext: AppContext) : ExpoView(co
 
   override fun getChildAt(index: Int): View? = blurTargetView.getChildAt(index)
 
-  override fun indexOfChild(child: View?): Int = blurTargetView.indexOfChild(child)
+  override fun indexOfChild(child: View?): Int {
+    // `blurTargetView` is our own real child (added via `super.addView` in `init`); every other
+    // child is proxied to it. Without this guard `indexOfChild(blurTargetView)` delegates to
+    // `blurTargetView.indexOfChild(blurTargetView)`, which is always -1 (a view can't be its own
+    // child) even though `blurTargetView.parent === this`. Consumers relying on the View
+    // parent/child contract — e.g. react-native-gesture-handler's attached-view walk — then treat
+    // everything under the blur target as detached and cancel their gestures. Mirror the
+    // add/remove overrides above.
+    if (child === blurTargetView) {
+      return super.indexOfChild(child)
+    }
+    return blurTargetView.indexOfChild(child)
+  }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     val width = MeasureSpec.getSize(widthMeasureSpec)


### PR DESCRIPTION
# Why

Fixes #47402.

On Android, `ExpoBlurTargetView` proxies child operations to its inner `blurTargetView`. The `indexOfChild` override did this unconditionally:

```kotlin
override fun indexOfChild(child: View?): Int = blurTargetView.indexOfChild(child)
```

`blurTargetView` is itself a real child of `ExpoBlurTargetView` (added via `super.addView` in `init`). So `ExpoBlurTargetView.indexOfChild(blurTargetView)` is delegated to `blurTargetView.indexOfChild(blurTargetView)`, which is always `-1` (a view cannot be its own child) — even though `blurTargetView.parent === ExpoBlurTargetView`.

This breaks the `View`/`ViewGroup` parent↔child contract. `react-native-gesture-handler` 3.0.x relies on that contract (v2 works fine) in `GestureHandlerOrchestrator.isViewAttachedUnderWrapper` to detect detached views (software-mansion/react-native-gesture-handler#4177). Its walk goes bottom-up, reaches `blurTargetView`, asks its parent (`ExpoBlurTargetView`) for the index, gets `-1`, and concludes the fully on-screen view is detached — so it cancels **every** gesture rendered under a `BlurTargetView` on Android (long-press, pan, swipeables, …).

# How

Give `indexOfChild` the same `child === blurTargetView` guard that the `addView`/`removeView` overrides already use: return the real index of the blur target view (`super.indexOfChild`) instead of delegating to it. Content children keep resolving through `blurTargetView`, so the proxy stays transparent.

# Test Plan

- Minimal repro (`react-native-gesture-handler` `useLongPressGesture` inside a `FlashList` inside a `BlurTargetView`): long-press was cancelled on Android before this change and works after — https://github.com/efstathiosntonas/rngh-long-press-repro
- Verified in a production app: with stock `react-native-gesture-handler` 3.0.2 (no patches), gestures under the app's app-wide blur target were dead on Android before this change and work after applying it.
- iOS is unaffected

# Notes

After this change `indexOfChild(blurTargetView) == 0` while `getChildAt(0)` returns the first *content* child (the intentionally-proxied set). This minor internal inconsistency is harmless — nothing does `getChildAt(indexOfChild(blurTargetView))`, and contract walkers only check the sign — and it matches the existing `addView`/`removeView` guard behavior.
