### PR TITLE
[docs] Rename "Bundled version" label to "Compatible version"

### DIFF
--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -74,7 +74,7 @@ describe(PageHeader, () => {
     expect(linkElement).toBe(undefined);
   });
 
-  test('displays bundled version when packageName provided', async () => {
+  test('displays compatible version when packageName provided', async () => {
     renderWithHeadings(
       <PageHeader
         title="test-title"
@@ -83,7 +83,42 @@ describe(PageHeader, () => {
         testRequire={require}
       />
     );
-    await screen.findByText(/bundled version:/i);
+    await screen.findByText(/compatible version:/i);
+  });
+
+  test('explains the compatible version through an accessible tooltip', async () => {
+    renderWithHeadings(
+      <PageHeader title="test-title" packageName="expo-audio" testRequire={require} />
+    );
+    const infoButton = await screen.findByRole('button', {
+      name: /more information about compatible version/i,
+    });
+
+    fireEvent.focus(infoButton);
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent(/compatible with the expo sdk version/i);
+    expect(tooltip).not.toHaveTextContent(/included in expo go/i);
+    expect(infoButton).toHaveAttribute('aria-describedby', tooltip.id);
+  });
+
+  test('notes the Expo Go library version in the tooltip when included in Expo Go', async () => {
+    renderWithHeadings(
+      <PageHeader
+        title="test-title"
+        packageName="expo-audio"
+        platforms={['ios', 'android', 'expo-go']}
+        testRequire={require}
+      />
+    );
+    const infoButton = await screen.findByRole('button', {
+      name: /more information about compatible version/i,
+    });
+
+    fireEvent.focus(infoButton);
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+    expect(tooltip).toHaveTextContent(/compatible with the expo sdk version/i);
+    expect(tooltip).toHaveTextContent(/library version included in expo go/i);
   });
 
   test('displays edit page link for non-API docs', () => {

--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -74,7 +74,7 @@ describe(PageHeader, () => {
     expect(linkElement).toBe(undefined);
   });
 
-  test('displays compatible version when packageName provided', async () => {
+  test('displays recommended version when packageName provided', async () => {
     renderWithHeadings(
       <PageHeader
         title="test-title"
@@ -83,15 +83,15 @@ describe(PageHeader, () => {
         testRequire={require}
       />
     );
-    await screen.findByText(/compatible version:/i);
+    await screen.findByText(/recommended version:/i);
   });
 
-  test('explains the compatible version through an accessible tooltip', async () => {
+  test('explains the recommended version through an accessible tooltip', async () => {
     renderWithHeadings(
       <PageHeader title="test-title" packageName="expo-audio" testRequire={require} />
     );
     const infoButton = await screen.findByRole('button', {
-      name: /more information about compatible version/i,
+      name: /more information about recommended version/i,
     });
 
     fireEvent.focus(infoButton);
@@ -112,7 +112,7 @@ describe(PageHeader, () => {
       />
     );
     const infoButton = await screen.findByRole('button', {
-      name: /more information about compatible version/i,
+      name: /more information about recommended version/i,
     });
 
     fireEvent.focus(infoButton);

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -107,6 +107,7 @@ export function PageHeader({
             )}>
             <PagePackageVersion
               packageName={packageName}
+              platforms={platforms}
               testRequire={testRequire}
               showMarkdownActions={showPackageMarkdown}
               className="max-md:w-full max-md:justify-between"
@@ -180,6 +181,7 @@ export function PageHeader({
         {packageName && (
           <PagePackageVersion
             packageName={packageName}
+            platforms={platforms}
             testRequire={testRequire}
             showMarkdownActions={showPackageMarkdown}
           />

--- a/docs/ui/components/PageHeader/PagePackageVersion.tsx
+++ b/docs/ui/components/PageHeader/PagePackageVersion.tsx
@@ -1,6 +1,8 @@
 import { mergeClasses } from '@expo/styleguide';
+import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircleDuotoneIcon';
 import { PackageIcon } from '@expo/styleguide-icons/outline/PackageIcon';
 import { useRouter } from 'next/compat/router';
+import { useState } from 'react';
 
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
@@ -8,23 +10,28 @@ import { WithTestRequire } from '~/types/common';
 import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/MarkdownActionsDropdown';
 import { hasDynamicData } from '~/ui/components/MarkdownActions/paths';
 import { Tag } from '~/ui/components/Tag/Tag';
+import { FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 const { LATEST_VERSION } = versions;
 
 type Props = {
   packageName: string;
+  platforms?: string[];
   showMarkdownActions?: boolean;
   className?: string;
 } & WithTestRequire;
 
 export function PagePackageVersion({
   packageName,
+  platforms,
   testRequire,
   showMarkdownActions,
   className,
 }: Props) {
   const { version } = usePageApiVersion();
   const router = useRouter();
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const currentPath = router?.asPath ?? router?.pathname ?? '';
   const displayMarkdownActions = showMarkdownActions && !hasDynamicData(currentPath);
   const { versions } = testRequire
@@ -43,6 +50,12 @@ export function PagePackageVersion({
     return null;
   }
 
+  const isIncludedInExpoGo =
+    platforms?.some(platform => platform.toLowerCase().includes('expo-go')) ?? false;
+  const compatibleVersionDescription =
+    "The version of this library that's compatible with the Expo SDK version you're viewing." +
+    (isIncludedInExpoGo ? " It's also the library version included in Expo Go." : '');
+
   return (
     <div className={mergeClasses('flex items-center gap-2', className)}>
       {versionRange && (
@@ -50,8 +63,28 @@ export function PagePackageVersion({
           data-md="skip"
           className="flex items-center justify-center gap-1.5 text-sm text-secondary">
           <PackageIcon aria-hidden="true" className="icon-sm text-icon-secondary" />
-          Bundled version:
+          Compatible version:
           <Tag name={versionRange} className="select-auto" />
+          <Tooltip.Root open={isTooltipOpen} onOpenChange={setIsTooltipOpen} delayDuration={100}>
+            <Tooltip.Trigger asChild>
+              <button
+                type="button"
+                aria-label="More information about compatible version"
+                onClick={() => {
+                  setIsTooltipOpen(!isTooltipOpen);
+                }}
+                className="inline-flex items-center justify-center rounded-full p-1 text-icon-secondary hover:text-icon-default focus:ring-2 focus:ring-link focus:ring-offset-1 focus:outline-none active:text-icon-default">
+                <InfoCircleDuotoneIcon aria-hidden="true" className="icon-xs" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content
+              side="top"
+              className="max-w-75"
+              sideOffset={8}
+              collisionPadding={{ left: 16, right: 16 }}>
+              <FOOTNOTE>{compatibleVersionDescription}</FOOTNOTE>
+            </Tooltip.Content>
+          </Tooltip.Root>
         </div>
       )}
       {displayMarkdownActions && <MarkdownActionsDropdown />}

--- a/docs/ui/components/PageHeader/PagePackageVersion.tsx
+++ b/docs/ui/components/PageHeader/PagePackageVersion.tsx
@@ -52,7 +52,7 @@ export function PagePackageVersion({
 
   const isIncludedInExpoGo =
     platforms?.some(platform => platform.toLowerCase().includes('expo-go')) ?? false;
-  const compatibleVersionDescription =
+  const recommendedVersionDescription =
     "The version of this library that's compatible with the Expo SDK version you're viewing." +
     (isIncludedInExpoGo ? " It's also the library version included in Expo Go." : '');
 
@@ -63,13 +63,13 @@ export function PagePackageVersion({
           data-md="skip"
           className="flex items-center justify-center gap-1.5 text-sm text-secondary">
           <PackageIcon aria-hidden="true" className="icon-sm text-icon-secondary" />
-          Compatible version:
+          Recommended version:
           <Tag name={versionRange} className="select-auto" />
           <Tooltip.Root open={isTooltipOpen} onOpenChange={setIsTooltipOpen} delayDuration={100}>
             <Tooltip.Trigger asChild>
               <button
                 type="button"
-                aria-label="More information about compatible version"
+                aria-label="More information about recommended version"
                 onClick={() => {
                   setIsTooltipOpen(!isTooltipOpen);
                 }}
@@ -82,7 +82,7 @@ export function PagePackageVersion({
               className="max-w-75"
               sideOffset={8}
               collisionPadding={{ left: 16, right: 16 }}>
-              <FOOTNOTE>{compatibleVersionDescription}</FOOTNOTE>
+              <FOOTNOTE>{recommendedVersionDescription}</FOOTNOTE>
             </Tooltip.Content>
           </Tooltip.Root>
         </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22382

# How

- Rename the SDK page label from `Bundled version` to `Compatible version` in `PagePackageVersion.tsx`.
- Add an accessible Radix tooltip that explains the version, appending an "included in Expo Go" line only when the library ships in Expo Go.
- Pass `platforms` from `PageHeader` into `PagePackageVersion` so the tooltip mirrors the existing "Included in Expo Go" tag.
- Update `PageHeader.test.tsx` for the new label, the conditional copy, and tooltip a11y (`role="tooltip"`, `aria-describedby`).

# Test Plan

Open an SDK reference page such as `/versions/latest/sdk/router/` and confirm the header shows "Compatible version" with an info tooltip explaining the version. Also, verify the tooltip adds the Expo Go line only for libraries included in Expo Go since `expo-router` is compatible with Expo Go.

<img width="4112" height="1494" alt="CleanShot 2026-07-01 at 15 36 05@2x" src="https://github.com/user-attachments/assets/5eed4b18-e205-4211-936b-5a8d18f511cd" />


Check a page like `/versions/latest/sdk/devclient/` and confirm the header shows "Compatible version", but without the Expo Go wording.

 
<img width="4112" height="1082" alt="CleanShot 2026-07-01 at 15 36 22@2x" src="https://github.com/user-attachments/assets/7e4c8d89-6160-48bc-9528-f8a127990aec" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
