### PR TITLE
[gha] Bump SDK branch for template sync workflow

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [sdk-56]
+    branches: [sdk-57]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22290

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update sync-template.yml to trigger on sdk-57 instead of sdk-56
- This syncs the changes to https://github.com/expo/expo-template-default

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

We should see the template [`expo/expo-template-default`](https://github.com/expo/expo-template-default) sync to the latest version once this is bumped.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
