### PR TITLE
[cli] make expo login default to browser auth

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
+- Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
 - Make `expo prebuild` clear and regenerate the native folders by default. Pass `--no-clean` to apply changes to the existing folders instead. ([#47209](https://github.com/expo/expo/pull/47209) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -54,13 +54,13 @@ it('throws on invalid project root', async () => {
   ).rejects.toThrow(/^Invalid project root: .*very---invalid$/m);
 });
 
-it('runs `npx expo login` and throws due to CI', async () => {
-  await expect(executeExpoAsync(projectRoot, ['login'], { verbose: false })).rejects.toThrow(
-    /Input is required/
-  );
-  await expect(executeExpoAsync(projectRoot, ['login'], { verbose: false })).rejects.toThrow(
-    /Use the EXPO_TOKEN environment variable to authenticate in CI/
-  );
+it('runs `npx expo login --no-browser` and throws due to CI', async () => {
+  await expect(
+    executeExpoAsync(projectRoot, ['login', '--no-browser'], { verbose: false })
+  ).rejects.toThrow(/Input is required/);
+  await expect(
+    executeExpoAsync(projectRoot, ['login', '--no-browser'], { verbose: false })
+  ).rejects.toThrow(/Use the EXPO_TOKEN environment variable to authenticate in CI/);
 });
 
 it('runs `npx expo login` and throws due to invalid credentials', async () => {

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -42,7 +42,15 @@ export const expoLogin: Command = async (argv) => {
 
   const password = args['--password'] === '-' ? await readWordFromStdin() : args['--password'];
 
-  const browser = args['--no-browser'] ? false : args['--browser'] ? true : undefined;
+  const browser = (() => {
+    if (args['--browser']) {
+      return true;
+    }
+    if (args['--no-browser'] || args['--username'] || password) {
+      return false;
+    }
+    return true;
+  })();
 
   const { showLoginPromptAsync } = await import('../api/user/actions.js');
   return showLoginPromptAsync({


### PR DESCRIPTION
Makes plain `expo login` pass `browser: true` by default instead of leaving the login action to infer browser usage from interactivity. Keeps `--no-browser` and username/password flags on the username/password path, and updates the e2e CI expectation to use `--no-browser`. Updates the changelog wording to remove the old CI exception.\n\nTests: not run locally because this workspace is missing `node_modules` and `jest` is unavailable.