### PR TITLE
[ios][expo-ui] Fix SwiftUI Menu/ContextMenu outside-tap dismiss passing through to React Native views

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tapping outside a SwiftUI `Menu`/`ContextMenu` to dismiss it passing the touch through to the React Native view behind it. ([#47413](https://github.com/expo/expo/pull/47413) by [@damselem](https://github.com/damselem))
 - [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/ExpoUIMenuDismissTouchGuard.swift
+++ b/packages/expo-ui/ios/ExpoUIMenuDismissTouchGuard.swift
@@ -1,0 +1,270 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+// iOS-only: ExpoUI.podspec also builds tvOS, and sibling files use `#if os(...)` for
+// platform-divergent behavior. The RN touch pass-through this guard fixes is touch-specific,
+// so the whole guard compiles out on other platforms.
+#if os(iOS)
+
+import UIKit
+import ObjectiveC.runtime
+
+/**
+ Fixes: tapping OUTSIDE an open SwiftUI `Menu` / `.contextMenu` to dismiss it also
+ fires the React Native view under the tap (the dismiss tap "passes through").
+
+ Root cause: when the menu opens, iOS inserts a `_UIContextMenuContainerView` at the
+ window level. UIKit blocks other UIKit controls behind it, but does NOT block React
+ Native's touch handler (`RCTSurfaceTouchHandler` on Fabric / `RCTTouchHandler` on
+ Paper) — it is a `UIGestureRecognizer` on the RN surface, so the tap still reaches RN.
+
+ SwiftUI `Menu` exposes no present/dismiss callback, so we detect the context-menu
+ container being added to the window and disable the RN touch handler(s) in that window
+ while it is presented, re-enabling them the moment the menu commits to dismissal.
+
+ Re-enable timing (why not just wait for the container to be removed): the
+ `_UIContextMenuContainerView` is only removed at the END of the dismissal animation —
+ up to ~1s after the user tapped. If we kept the RN handlers disabled until then, every
+ tap in the window would be silently dropped for that whole animation (e.g. tapping a
+ menu item and then immediately tapping a button would eat the button tap). Instead we
+ re-enable at the earliest SAFE moment: when the container stops being interactive.
+ UIKit sets `container.isUserInteractionEnabled = false` (and disables the container's
+ own pan recognizer) at the very start of the dismissal animation, which is exactly when
+ the menu is no longer accepting input. Re-enabling there is safe for the original
+ pass-through bug: the touch that triggered the dismissal began while our handlers were
+ disabled, and a gesture recognizer re-enabled mid-sequence is never handed a touch
+ sequence already in flight — so that dismiss tap still never reaches RN. Only brand-new
+ touches (which the user genuinely intends) get through.
+
+ Detection is scoped to `UIWindow` only (via isa-scoped method swizzling), so no
+ overhead is added to ordinary view-hierarchy mutations.
+
+ State is tracked PER-WINDOW and re-derived from the actual hierarchy on every container
+ add/remove and on every dismissal-poll tick (self-healing): whether a window's handlers
+ should be disabled is decided by live UIKit state, never by a running counter that could
+ desync. This keeps multiple windows/scenes independent and recovers automatically if an
+ add/remove event is ever missed. `willRemoveSubview` remains a backstop: even if the
+ dismissal poll never observed the interactivity flip, container removal still re-derives
+ and re-enables.
+
+ Detection has two halves with different robustness. Container detection stays string-based
+ (`isContextMenuContainer`) because `_UIContextMenuContainerView` is private with no public
+ class to reference. Recognizer detection is TYPED: `ExpoUITouchHandlerHelper.isReactTouchHandler`
+ matches the concrete RN touch-handler classes and is shared with the create path, so the
+ guard disables exactly the recognizers expo-ui attaches (no substring guesswork).
+
+ KNOWN LIMITATIONS:
+ (a) Disabling a recognizer cancels any in-flight RN touch (`touchesCancelled`). A finger
+     already down on an RN element at the instant a menu opens can be left in a transient
+     stuck-pressed state until the next touch.
+ (b) Re-enable is unconditional: it restores every recognizer the guard disabled. A third
+     party that deliberately set one of those recognizers' `isEnabled = false` mid-presentation
+     would have that override clobbered when the guard re-enables.
+ (c) The guard fires for ANY context-menu container, including UIKit's own
+     `UIContextMenuInteraction` (not just SwiftUI `Menu`/`.contextMenu`), because the RN
+     pass-through bug exists for all of them.
+ */
+@objc public final class ExpoUIMenuDismissTouchGuard: NSObject {
+  // Per-window record of the RN touch handlers we disabled while a menu is presented in
+  // that window. Weak keys so windows/scenes are never retained; the recognizers inside
+  // each table are weak too. A key being present means "this window's handlers are
+  // currently disabled by us".
+  private static let disabledHandlersByWindow =
+    NSMapTable<UIWindow, NSHashTable<UIGestureRecognizer>>.weakToStrongObjects()
+
+  /// Installs the detection once, atomically, no matter how many times it is called
+  /// (e.g. from the module's `OnCreate`). `static let` gives us `dispatch_once` semantics.
+  private static let installOnce: Void = {
+    scopedSwizzle(#selector(UIView.didAddSubview(_:)), #selector(UIWindow.expoui_menuGuard_didAddSubview(_:)))
+    scopedSwizzle(#selector(UIView.willRemoveSubview(_:)), #selector(UIWindow.expoui_menuGuard_willRemoveSubview(_:)))
+  }()
+
+  @objc public static func install() {
+    // UIKit swizzling and every piece of guard state below assume the main queue,
+    // but the module's `OnCreate` is NOT pinned to it (module registration runs on a
+    // background queue in practice — verified in the unified log). So hop rather than
+    // assert: a `dispatchPrecondition` here crashes at boot. `installOnce`'s static-let
+    // once-semantics make the async hop safe against duplicate installs.
+    if Thread.isMainThread {
+      _ = installOnce
+    } else {
+      DispatchQueue.main.async { _ = installOnce }
+    }
+  }
+
+  fileprivate static func isContextMenuContainer(_ view: UIView) -> Bool {
+    return String(describing: type(of: view)).contains("ContextMenuContainer")
+  }
+
+  /// Drive `window`'s handlers to match reality: disabled iff the window still contains a
+  /// context-menu container. Idempotent and self-healing. `ignoring` is the subview about
+  /// to be removed (still present in `window.subviews` during `willRemoveSubview`), so it
+  /// must be excluded from the "is a menu still open?" check.
+  fileprivate static func reevaluate(_ window: UIWindow, ignoring ignored: UIView? = nil) {
+    let menuPresented = windowContainsContextMenuContainer(window, ignoring: ignored)
+    let alreadyDisabled = disabledHandlersByWindow.object(forKey: window) != nil
+
+    if menuPresented, !alreadyDisabled {
+      let disabled = NSHashTable<UIGestureRecognizer>.weakObjects()
+      var handlers = [UIGestureRecognizer]()
+      collectReactTouchHandlers(in: window, into: &handlers)
+      for handler in handlers where handler.isEnabled {
+        handler.isEnabled = false
+        disabled.add(handler)
+      }
+      disabledHandlersByWindow.setObject(disabled, forKey: window)
+    } else if !menuPresented, alreadyDisabled {
+      // Tripwire: reaching this branch means the early dismissal-start poll never fired for
+      // this presentation, so the only thing that re-enabled the handlers was the container
+      // actually leaving the window. That happens only if the `isUserInteractionEnabled`-flip
+      // heuristic the poll relies on never held — our signal that the private-API dismissal
+      // timing this guard depends on has shifted under us.
+      #if DEBUG
+      NSLog("ExpoUIMenuDismissTouchGuard: handlers re-enabled only at container removal — the dismissal-start heuristic never fired; UIKit may have changed the isUserInteractionEnabled timing.")
+      #endif
+      reEnableHandlers(in: window)
+    }
+  }
+
+  /// Re-enable and forget the handlers we disabled for `window`, unconditionally (i.e.
+  /// even while the context-menu container is still present but no longer interactive —
+  /// the early re-enable path). Idempotent: a no-op if nothing is currently disabled.
+  fileprivate static func reEnableHandlers(in window: UIWindow) {
+    guard let disabled = disabledHandlersByWindow.object(forKey: window) else { return }
+    for handler in disabled.allObjects {
+      handler.isEnabled = true
+    }
+    disabledHandlersByWindow.removeObject(forKey: window)
+  }
+
+  /// One frame at 60Hz. The poll only needs to comfortably beat the ~250ms dismissal
+  /// animation for the re-enable to feel instant, and each tick is a cheap shallow scan
+  /// of the window's direct subviews, so a fixed per-frame cadence is plenty on every
+  /// display tier. A `CADisplayLink` would align ticks to the real refresh rate but adds
+  /// lifecycle to manage (invalidation on teardown) for no user-visible benefit at this
+  /// duty cycle.
+  private static let dismissalPollInterval: TimeInterval = 1.0 / 60.0
+
+  /// Watch `window` while a menu is presented and re-enable its RN touch handlers the
+  /// instant NO context-menu container in it remains interactive — UIKit flips
+  /// `isUserInteractionEnabled` to false at the start of the dismissal animation —
+  /// rather than waiting for the container to be removed at the end of the animation.
+  ///
+  /// Deliberately NOT keyed to the single container whose addition scheduled it: if a
+  /// second menu opens while the first is still animating out, a container-keyed check
+  /// would re-enable the handlers while the new menu is interactive (resurrecting the
+  /// pass-through bug for it, since its own poll would then find nothing left to do).
+  /// Re-deriving "is ANY container still interactive?" from the live hierarchy each tick
+  /// cannot be fooled that way; overlapping presentations just mean two idempotent polls,
+  /// the first of which does the work while the other exits on the bookkeeping check.
+  ///
+  /// Implemented as a self-terminating main-queue poll rather than KVO: it holds `window`
+  /// weakly across ticks (no retain cycles, no observer teardown to get wrong), re-derives
+  /// from live state each tick, and runs only while a menu is on screen (a brief,
+  /// user-initiated window). It stops as soon as any of these is true: the window is gone,
+  /// its handlers are no longer ours to re-enable, every container has left the window
+  /// (the removal backstop's job), or the re-enable fired.
+  private static func scheduleEarlyReEnable(in window: UIWindow) {
+    // Opening/dismissing latch, carried across ticks by reference (the nested `poll`
+    // captures it): only re-enable once we have actually SEEN a container be interactive.
+    // Guards against a UIKit that ADDS the container non-interactive and flips it to
+    // interactive a frame later — without the latch the first tick would see
+    // "all non-interactive" mid-OPEN and prematurely re-enable, reopening the pass-through
+    // bug. Requiring a prior interactive observation means "all non-interactive" can only
+    // mean dismissal, never a not-yet-opened menu.
+    var sawInteractive = false
+    func poll(_ window: UIWindow) {
+      // Already re-enabled (early path fired, or removal backstop ran): done.
+      guard disabledHandlersByWindow.object(forKey: window) != nil else { return }
+      let containers = window.subviews.filter(isContextMenuContainer)
+      // Every container is gone: the removal backstop owns re-enabling.
+      guard !containers.isEmpty else { return }
+      if containers.contains(where: { $0.isUserInteractionEnabled }) {
+        sawInteractive = true
+      }
+      // Every menu on screen has committed to dismissal — nothing accepts input anymore —
+      // AND we saw it interactive first, so this is a real dismissal, not a fresh open.
+      if sawInteractive, containers.allSatisfy({ !$0.isUserInteractionEnabled }) {
+        reEnableHandlers(in: window)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + dismissalPollInterval) { [weak window] in
+        guard let window else { return }
+        poll(window)
+      }
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + dismissalPollInterval) { [weak window] in
+      guard let window else { return }
+      poll(window)
+    }
+  }
+
+  // The context-menu container is added as a direct child of the window, so a shallow
+  // scan of the window's own subviews is enough (and cheap).
+  private static func windowContainsContextMenuContainer(_ window: UIWindow, ignoring ignored: UIView?) -> Bool {
+    for subview in window.subviews where subview !== ignored {
+      if isContextMenuContainer(subview) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private static func collectReactTouchHandlers(in view: UIView, into acc: inout [UIGestureRecognizer]) {
+    if let recognizers = view.gestureRecognizers {
+      for recognizer in recognizers where ExpoUITouchHandlerHelper.isReactTouchHandler(recognizer) {
+        acc.append(recognizer)
+      }
+    }
+    for subview in view.subviews {
+      collectReactTouchHandlers(in: subview, into: &acc)
+    }
+  }
+
+  /// Swizzle `original` (declared on `UIView`) with `replacement` (declared on
+  /// `UIWindow`) so ONLY `UIWindow` instances are affected. If `UIView`'s impl is
+  /// inherited (not overridden by `UIWindow`) we first give `UIWindow` its own copy,
+  /// then exchange — leaving every other `UIView` untouched.
+  private static func scopedSwizzle(_ original: Selector, _ replacement: Selector) {
+    let cls = UIWindow.self
+    guard let replacementMethod = class_getInstanceMethod(cls, replacement),
+          let inheritedMethod = class_getInstanceMethod(cls, original) else {
+      return
+    }
+    let added = class_addMethod(
+      cls,
+      original,
+      method_getImplementation(inheritedMethod),
+      method_getTypeEncoding(inheritedMethod)
+    )
+    if added, let ownMethod = class_getInstanceMethod(cls, original) {
+      method_exchangeImplementations(ownMethod, replacementMethod)
+    } else {
+      method_exchangeImplementations(inheritedMethod, replacementMethod)
+    }
+  }
+
+  // Exposed to the UIWindow extension (fileprivate can't reach a private static).
+  fileprivate static func onContextMenuContainerAdded(in window: UIWindow) {
+    reevaluate(window)
+    scheduleEarlyReEnable(in: window)
+  }
+}
+
+private extension UIWindow {
+  @objc func expoui_menuGuard_didAddSubview(_ subview: UIView) {
+    self.expoui_menuGuard_didAddSubview(subview) // calls the original (exchanged) impl
+    if ExpoUIMenuDismissTouchGuard.isContextMenuContainer(subview) {
+      ExpoUIMenuDismissTouchGuard.onContextMenuContainerAdded(in: self)
+    }
+  }
+
+  @objc func expoui_menuGuard_willRemoveSubview(_ subview: UIView) {
+    if ExpoUIMenuDismissTouchGuard.isContextMenuContainer(subview) {
+      // `subview` is still in `self.subviews` here — exclude it from the scan.
+      ExpoUIMenuDismissTouchGuard.reevaluate(self, ignoring: subview)
+    }
+    self.expoui_menuGuard_willRemoveSubview(subview) // calls the original (exchanged) impl
+  }
+}
+
+#endif

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -7,6 +7,15 @@ public final class ExpoUIModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoUI")
 
+    OnCreate {
+      // Consume the outside-tap that dismisses a SwiftUI Menu/ContextMenu so it does
+      // not pass through to the React Native view behind it. Idempotent.
+      // iOS-only: the guard (and the pass-through bug it fixes) is iOS-specific.
+      #if os(iOS)
+      ExpoUIMenuDismissTouchGuard.install()
+      #endif
+    }
+
     View(RNHostView.self)
 
     OnDestroy {

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
@@ -11,6 +11,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable UIGestureRecognizer *)createAndAttachTouchHandlerForView:(UIView *)view;
 
+/// True iff `recognizer` is one of React Native's surface touch handlers: Fabric's
+/// `RCTSurfaceTouchHandler` (compile-time class) or Paper's `RCTTouchHandler` (resolved
+/// at runtime via `NSClassFromString`, since the Paper header may be absent in
+/// Fabric-only builds). Shared by the menu-dismiss guard's disable path and the
+/// create path so both agree on exactly which recognizers count as RN touch handlers.
++ (BOOL)isReactTouchHandler:(UIGestureRecognizer *)recognizer;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
@@ -17,4 +17,18 @@
   return touchHandler;
 }
 
++ (BOOL)isReactTouchHandler:(UIGestureRecognizer *)recognizer {
+  if ([recognizer isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+    return YES;
+  }
+  // Paper's RCTTouchHandler header may be absent in Fabric-only builds, so resolve the
+  // class at runtime (cached) rather than referencing it at compile time.
+  static Class paperTouchHandlerClass;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    paperTouchHandlerClass = NSClassFromString(@"RCTTouchHandler");
+  });
+  return paperTouchHandlerClass != nil && [recognizer isKindOfClass:paperTouchHandlerClass];
+}
+
 @end


### PR DESCRIPTION
# [ios][expo-ui] Fix SwiftUI Menu/ContextMenu outside-tap dismiss passing through to React Native views

## Demo

Before/after with the exact same taps. On published `@expo/ui` the outside-tap dismiss also fires the row underneath (see the log line); with this PR the tap only dismisses the menu.

https://github.com/user-attachments/assets/277f9310-f4f3-4f1d-8dd8-1dd4db710430


## Why

When an `@expo/ui/swift-ui` `Menu` (or `.contextMenu` via `ContextMenu`) is open, tapping **outside** the menu to dismiss it also fires the React Native view under the tap — e.g. it navigates into the list row you tapped. On native iOS the dismiss tap is *consumed* (tapping outside an open menu only closes it; the control underneath is not triggered — see Apple Music, Photos "Filter" menu).

This is the last gap keeping `@expo/ui` menus from matching native menu UX. Keep-open multi-select already works (`menuActionDismissBehavior`, #41087/#41109); this outside-tap pass-through is the remaining difference.

Prior reports: #42068 described this exact behavior but was auto-closed for a missing repro. Distinct from #44144 (a z-index/visual dismiss artifact).

### Root cause

When the SwiftUI `Menu` opens, iOS inserts a `_UIContextMenuContainerView` at the window level. UIKit's event routing blocks other **UIKit** controls behind it, but does **not** block React Native's touch handler (`RCTSurfaceTouchHandler` on Fabric / `RCTTouchHandler` on Paper) — it is a `UIGestureRecognizer` on the RN surface, so the dismiss tap still reaches RN's responder chain and fires the view. (Apple fixed the pure-SwiftUI-gesture case in iOS 18, but RN-hosted touch handling still leaks. Arguably the root deficiency is in React Native's touch handler — it ignores UIKit presentation exclusivity — so this guard is a compensating fix at the expo-ui level; happy to file/link an upstream RN issue if you'd like that tracked.)

## How

SwiftUI `Menu` exposes no present/dismiss callback, so we detect the system context-menu container at the window level and suspend RN touch handling exactly while the menu is interactively presented:

- New file `ios/ExpoUIMenuDismissTouchGuard.swift`: installs an **isa-scoped** swizzle of `UIWindow.didAddSubview(_:)` / `willRemoveSubview(_:)` (only `UIWindow` is affected — no overhead on ordinary view mutations). When a `_UIContextMenuContainerView` appears, it disables the React Native touch handlers found in that window, identified by a **typed predicate** shared with `ExpoUITouchHandlerHelper` (`RCTSurfaceTouchHandler` by class; Paper's `RCTTouchHandler` via cached `NSClassFromString`) — no class-name string matching for the recognizers.
- **Re-enable at dismissal start, not container removal.** The container is only removed at the *end* of the dismissal animation (up to ~1s after the user's tap); re-enabling only then would silently drop every tap in the window for that whole period (e.g. tap a menu item, then immediately tap a button → the button tap is eaten). UIKit flips the container's `isUserInteractionEnabled` to `false` the instant dismissal commits, so a self-terminating per-frame poll re-enables the handlers on that flip. The dismiss tap itself still never reaches RN: it began while the handlers were disabled, and a recognizer re-enabled mid-sequence is never handed an in-flight touch sequence.
- `ios/ExpoUIModule.swift`: one `OnCreate` call, `#if os(iOS)` (the podspec also builds tvOS, where the bug doesn't manifest). `install()` hops to the main queue — module `OnCreate` verifiably runs off the main thread.

No changes to `MenuView`/`ContextMenu`/`Host`, no JS changes, no new public API. Fixes both the tap `Menu` and the long-press `.contextMenu`. A no-op when no menu is open.

Robustness details:
- **Per-window, self-healing state**: on each container add/remove — and on every poll tick — the guard re-derives from the live hierarchy whether the window still contains an *interactive* context-menu container, and drives the handlers to match (no running counter that could desync; robust to overlapping presentations). State is keyed by window in a weak-keyed `NSMapTable`; container removal remains a backstop re-enable path.
- **Opening/dismissing latch**: the poll only honors the all-non-interactive condition after having observed an interactive tick, so an OS that adds the container non-interactive first cannot trigger a premature re-enable mid-open.
- **DEBUG tripwire**: if handlers ever re-enable only via the removal backstop, the dismissal-timing heuristic went inert (private API changed) — a dev-build log makes that fail loudly instead of silently regressing.
- **Weak references** to the disabled recognizers, so a view/window torn down mid-menu is never retained or left as a stale, permanently-disabled handler.
- **Install is idempotent** via `static let` (`dispatch_once` semantics).
- **Known limitations** (documented in the file header): disabling cancels an in-flight RN touch (a transient stuck pressed state is possible if a finger is down at menu-open); re-enable restores exactly what the guard disabled, which would override a third party's deliberate mid-presentation disable of the same recognizer; and the guard deliberately fires for *any* context-menu container (UIKit `UIContextMenuInteraction` included), since the RN pass-through exists for all of them.

The disable/re-enable-the-RN-touch-handler technique matches what [react-native-ios-context-menu fixed for its UIKit menu](https://github.com/dominicstop/react-native-ios-context-menu/pull/141); here it is driven by window-level container detection because SwiftUI `Menu` has no interaction delegate, and re-enables at dismissal start rather than dismissal end.

## Test Plan

Minimal repro (Host + SwiftUI `Menu` over a list of RN `Pressable` rows, with an on-screen "last onPress" log): https://github.com/damselem/expo-ui-menu-passthrough-repro

Validated on **iOS 26 / New Architecture (Fabric)**: on device (iPhone 17 Pro, SDK 57 / RN 0.86) via the repro app, and in a production app under an automated tap harness (simulator, SDK 56 / RN 0.85).

| Step | Before | After (this PR) |
|------|--------|-----------------|
| Open menu, tap a row to dismiss | menu closes **and** row `onPress` fires ❌ | menu closes, row `onPress` does **not** fire ✅ (0/6 leaks, automated) |
| Tap a row directly (menu closed) | fires ✅ | fires ✅ (handler correctly re-enabled — no freeze) |
| Open menu, tap a menu item | fires ✅ | fires ✅ (selection unaffected) |
| Tap a menu item, then a header button 150–300ms later | button tap silently **eaten** for the dismissal duration ❌ | lands first try ✅ (0/36 eaten, automated) |

Also verified:
- The DEBUG tripwire stayed silent across all presentations (the dismissal-start heuristic fired every time; the removal backstop was never needed).
- Multiple menus on one screen — opening, outside-tap-dismiss, and selection all behave, and each menu's per-window state stays independent (no cross-talk, no stuck handlers).
- **Keep-open multi-select** menu (`menuActionDismissBehavior('disabled')` + `Toggle`s): toggling multiple items keeps the menu open with native checkmarks, then an outside tap dismisses it without firing the row behind, and the row is tappable again afterward. This is the primary real-world case, since a keep-open menu is closed *by* an outside tap.

## Coverage / where review is welcome

The mechanism depends on two private behaviors: the `_UIContextMenuContainerView` class name (detection) and its `isUserInteractionEnabled` flip at dismissal start (re-enable timing). If detection fails on some configuration, the guard **degrades to a no-op** (the pre-existing pass-through returns); if only the timing flip changes, re-enable falls back to container removal (taps dropped for the dismissal animation, dev tripwire fires). I have **not** yet verified:
- iOS 16–18,
- iPad (where a `Menu` can present as a popover),
- old-architecture Paper (`RCTTouchHandler`).

Happy to extend testing or adjust the detection for these.

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

Notes:
- Bug fix; iOS only; no breaking changes, no new public API.
- Maintainer note: happy to adjust the detection hook if you prefer a different mechanism (e.g. a `Host`-level present/dismiss lifecycle, which would also address the original #42068 request for menu lifecycle callbacks).
