### PR TITLE
[android][templates] Add assetsPaths to MainActivity configChanges to avoid recreation on dynamic-color changes

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
   </queries>
 
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize|assetsPaths" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
# Why

On Android, a Material You **dynamic-color change** (e.g. the user changes wallpaper/accent) — and any runtime resource-overlay swap — reports the `CONFIG_ASSETS_PATHS` (`0x80000000`) configuration change. `MainActivity` doesn't declare it in `configChanges`, so the OS **recreates the activity while the JS process survives**, resetting navigation state on Android 12+. This is the root cause behind reports like #42500.

`assetsPaths` was added as a `configChanges` token in **API 36** (Expo's current default `compileSdk`), documented as "a runtime overlay is installed and enabled." Declaring it makes the OS deliver the change to the running app instead of relaunching the activity.

# How

Add `assetsPaths` to `MainActivity`'s `android:configChanges` in the prebuild template manifest (`expo-template-bare-minimum`).

**Verified empirically** on emulators with a control/treatment activity pair:
- Without the flag: the overlay/dynamic-color change relaunches the activity (`wm_relaunch_resume_activity […,80000000]`).
- With the flag: the change applies but the activity is **not** recreated.
- Confirmed on **API 31** (minimum SDK for dynamic colors) through **API 36**. The runtime honors the bit as far back as API 31; only the manifest *token* requires `compileSdk 36` to compile (it's ignored harmlessly on older runtimes / `minSdk 24`).

# Test Plan

- `aapt2 link` against `android-36` accepts `assetsPaths` (a bogus flag is rejected, and the error lists `assetsPaths=2147483648`), so it builds with the default `compileSdk 36`.
- Runtime A/B on API 31 and API 35 emulators: control activity recreates on an overlay/assets-path change; the activity declaring `assetsPaths` does not.

# Notes / follow-ups

- Requires `compileSdk >= 36` to compile the token — which is the current Expo default (`ExpoModulesCorePlugin.gradle`).
- `@expo/config-plugins`' `withAndroidBaseMods.getAndroidManifestTemplate` carries an identical in-memory default used only for **introspection** (not real prebuild output). Happy to sync it in this PR if preferred; left out to keep the change to the actual template that prebuild copies.
- Suppressing the recreate means the app is responsible for reflecting new dynamic colors on `onConfigurationChanged` rather than via a full restart (React Native forwards the config change to JS). This is the desired behavior for preserving navigation state.

# Checklist

- [x] Verified the change builds (`aapt2` against compileSdk 36) and works at runtime (API 31 & 35).
- [ ] N/A: no CHANGELOG for the bare-minimum template.