### PR TITLE
[config-plugins][updates] Honor ios.version/android.version in Updates helpers (sdk-56 backport)

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@tlenahan](https://github.com/tlenahan))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-07-01

--- a/packages/@expo/config-plugins/src/utils/Updates.ts
+++ b/packages/@expo/config-plugins/src/utils/Updates.ts
@@ -29,24 +29,37 @@ export function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'updates'>): string
   return config.updates?.url ?? null;
 }
 
-export function getAppVersion(config: Pick<ExpoConfig, 'version'>): string {
+export function getAppVersion(
+  config: Pick<ExpoConfig, 'version'> & {
+    android?: Pick<Android, 'version'>;
+    ios?: Pick<IOS, 'version'>;
+  },
+  platform?: 'android' | 'ios'
+): string {
+  if (platform === 'ios' && config.ios?.version) {
+    return config.ios.version;
+  }
+  if (platform === 'android' && config.android?.version) {
+    return config.android.version;
+  }
   return config.version ?? '1.0.0';
 }
 
 export function getNativeVersion(
   config: Pick<ExpoConfig, 'version'> & {
-    android?: Pick<Android, 'versionCode'>;
-    ios?: Pick<IOS, 'buildNumber'>;
+    android?: Pick<Android, 'version' | 'versionCode'>;
+    ios?: Pick<IOS, 'version' | 'buildNumber'>;
   },
   platform: 'android' | 'ios'
 ): string {
-  const version = IOSVersion.getVersion(config);
   switch (platform) {
     case 'ios': {
+      const version = IOSVersion.getVersion(config);
       const buildNumber = IOSVersion.getBuildNumber(config);
       return `${version}(${buildNumber})`;
     }
     case 'android': {
+      const version = AndroidVersion.getVersionName(config) ?? '1.0.0';
       const versionCode = AndroidVersion.getVersionCode(config);
       return `${version}(${versionCode})`;
     }
@@ -74,8 +87,8 @@ export async function getRuntimeVersionNullableAsync(
 export async function getRuntimeVersionAsync(
   projectRoot: string,
   config: Pick<ExpoConfig, 'version' | 'runtimeVersion' | 'sdkVersion'> & {
-    android?: Pick<Android, 'versionCode' | 'runtimeVersion'>;
-    ios?: Pick<IOS, 'buildNumber' | 'runtimeVersion'>;
+    android?: Pick<Android, 'version' | 'versionCode' | 'runtimeVersion'>;
+    ios?: Pick<IOS, 'version' | 'buildNumber' | 'runtimeVersion'>;
   },
   platform: 'android' | 'ios'
 ): Promise<string | null> {
@@ -105,13 +118,13 @@ export async function getRuntimeVersionAsync(
 export async function resolveRuntimeVersionPolicyAsync(
   policy: 'appVersion' | 'nativeVersion' | 'sdkVersion',
   config: Pick<ExpoConfig, 'version' | 'sdkVersion'> & {
-    android?: Pick<Android, 'versionCode'>;
-    ios?: Pick<IOS, 'buildNumber'>;
+    android?: Pick<Android, 'version' | 'versionCode'>;
+    ios?: Pick<IOS, 'version' | 'buildNumber'>;
   },
   platform: 'android' | 'ios'
 ): Promise<string> {
   if (policy === 'appVersion') {
-    return getAppVersion(config);
+    return getAppVersion(config, platform);
   } else if (policy === 'nativeVersion') {
     return getNativeVersion(config, platform);
   } else if (policy === 'sdkVersion') {

--- a/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import path from 'path';
 
 import {
+  getAppVersion,
   getNativeVersion,
   getRuntimeVersionAsync,
   getSDKVersion,
@@ -144,6 +145,35 @@ describe(getUpdateUrl, () => {
   });
 });
 
+describe(getAppVersion, () => {
+  it('returns the top-level version when no platform is provided', () => {
+    expect(getAppVersion({ version: '2.0.0' })).toBe('2.0.0');
+  });
+  it('returns the platform-specific version when it is set', () => {
+    expect(getAppVersion({ version: '2.0.0', ios: { version: '3.1.0' } }, 'ios')).toBe('3.1.0');
+    expect(
+      getAppVersion({ version: '2.0.0', android: { version: '4.2.0' } }, 'android')
+    ).toBe('4.2.0');
+  });
+  it('falls back to top-level version when the platform-specific override is unset', () => {
+    expect(getAppVersion({ version: '2.0.0' }, 'ios')).toBe('2.0.0');
+    expect(getAppVersion({ version: '2.0.0' }, 'android')).toBe('2.0.0');
+  });
+  it('does not cross platforms — ios override does not affect android and vice versa', () => {
+    expect(getAppVersion({ version: '2.0.0', ios: { version: '3.1.0' } }, 'android')).toBe(
+      '2.0.0'
+    );
+    expect(
+      getAppVersion({ version: '2.0.0', android: { version: '4.2.0' } }, 'ios')
+    ).toBe('2.0.0');
+  });
+  it('falls back to 1.0.0 when nothing is set', () => {
+    expect(getAppVersion({})).toBe('1.0.0');
+    expect(getAppVersion({}, 'ios')).toBe('1.0.0');
+    expect(getAppVersion({}, 'android')).toBe('1.0.0');
+  });
+});
+
 describe(getNativeVersion, () => {
   const version = '2.0.0';
   const versionCode = 42;
@@ -158,6 +188,30 @@ describe(getNativeVersion, () => {
       `${version}(${buildNumber})`
     );
   });
+  it('prefers ios.version over the top-level version on ios', () => {
+    expect(
+      getNativeVersion(
+        { version, ios: { version: '3.1.0', buildNumber } },
+        'ios'
+      )
+    ).toBe(`3.1.0(${buildNumber})`);
+  });
+  it('prefers android.version over the top-level version on android', () => {
+    expect(
+      getNativeVersion(
+        { version, android: { version: '4.2.0', versionCode } },
+        'android'
+      )
+    ).toBe(`4.2.0(${versionCode})`);
+  });
+  it('does not use ios.version when computing the android native version', () => {
+    expect(
+      getNativeVersion(
+        { version, ios: { version: '3.1.0' }, android: { versionCode } },
+        'android'
+      )
+    ).toBe(`${version}(${versionCode})`);
+  });
   it('throws an error if platform is not recognized', () => {
     const fakePlatform = 'doesnotexist';
     expect(() => {
@@ -166,6 +220,7 @@ describe(getNativeVersion, () => {
   });
   it('uses the default version if the version is missing', () => {
     expect(getNativeVersion({}, 'ios')).toBe('1.0.0(1)');
+    expect(getNativeVersion({}, 'android')).toBe('1.0.0(1)');
   });
   it('uses the default buildNumber if the platform is ios and the buildNumber is missing', () => {
     expect(getNativeVersion({ version }, 'ios')).toBe(`${version}(1)`);
@@ -224,6 +279,34 @@ describe(getRuntimeVersionAsync, () => {
         'ios'
       )
     ).toBe(version);
+  });
+
+  it('honors ios.version for the appVersion policy on ios', async () => {
+    expect(
+      await getRuntimeVersionAsync(
+        '',
+        {
+          version: '1.0.0',
+          runtimeVersion: { policy: 'appVersion' },
+          ios: { version: '3.1.0' },
+        },
+        'ios'
+      )
+    ).toBe('3.1.0');
+  });
+
+  it('honors android.version for the appVersion policy on android', async () => {
+    expect(
+      await getRuntimeVersionAsync(
+        '',
+        {
+          version: '1.0.0',
+          runtimeVersion: { policy: 'appVersion' },
+          android: { version: '4.2.0' },
+        },
+        'android'
+      )
+    ).toBe('4.2.0');
   });
 
   it('works if the runtimeVersion is a fingerprint policy', async () => {


### PR DESCRIPTION
# Why

Backport of [expo#47416](https://github.com/expo/expo/pull/47416) to `sdk-56`.

The runtime-version helpers in `@expo/config-plugins` silently ignore the platform-specific version overrides `ios.version` and `android.version`. Projects that put their versions **only** in the platform keys (with no top-level `version` in `app.json`) fall into the `pkg.version` fallback in `ensureConfigHasDefaultValues` — and if `package.json` has no `version` either, the fallback resolves to `"1.0.0"`.

Every consumer downstream of these helpers then sees `"1.0.0"` (or the `package.json` version) rather than the platform-specific override the user configured — including the `appVersion` runtime version policy and `Updates.getNativeVersion`. On Android, `getNativeVersion` also had a latent bug: it used the iOS version for the `${version}` component of the returned `${version}(${versionCode})` string.

The `ios.version` and `android.version` fields are documented as taking precedence over top-level `version` — and the prebuild writers (`IOSVersion.getVersion`, `AndroidVersion.getVersionName`) already honor them. This PR aligns the `Updates` helpers with that documented contract.

# How

Three targeted changes in `packages/@expo/config-plugins/src/utils/Updates.ts`:

1. **`getAppVersion` becomes platform-aware.** Adds an optional `platform` argument. When provided and the corresponding `ios.version` / `android.version` is set, that value is returned. When absent, the previous top-level-only behavior is preserved, so existing external callers keep working unchanged.
2. **`getNativeVersion` uses per-platform helpers.** The ios branch keeps `IOSVersion.getVersion` (which already reads `ios.version`), and the android branch now uses `AndroidVersion.getVersionName` (which reads `android.version`). This also fixes the latent Android-uses-iOS-version bug.
3. **`resolveRuntimeVersionPolicyAsync` threads `platform` into `getAppVersion`.** With the appVersion policy, `ios.version`/`android.version` is now honored instead of quietly falling back.

The `Pick<Android, …>` / `Pick<IOS, …>` types in the affected signatures are widened to also read the `version` field. This is additive — existing callers passing a superset (like the full `ExpoConfig`) continue to typecheck.

# Test Plan

This PR is a clean cherry-pick of the `main`-targeting change (commit `2619c4676cf`). The starting file contents in `packages/@expo/config-plugins/src/utils/Updates.ts` were byte-identical between `main` and `sdk-56` before the fix, so the resulting code is the same on both branches. The dependency helpers (`IOSVersion.getVersion`, `IOSVersion.getBuildNumber`, `AndroidVersion.getVersionName`, `AndroidVersion.getVersionCode`) and the `ios.version` / `android.version` fields in `@expo/config-types` exist with the same signatures on this branch as on `main`.

On the `main`-targeting PR, verification included:

- `turbo test --filter=@expo/config-plugins` → **68 suites, 437 passed, 2 skipped, 0 failed**
- `turbo typecheck --filter=@expo/config-plugins` → clean
- `turbo lint --filter=@expo/config-plugins` → clean (0 warnings, 0 errors)
- `turbo depscheck --filter=@expo/config-plugins` → clean
- `turbo typecheck --filter=@expo/prebuild-config` → clean (downstream sanity check)
- `turbo typecheck --filter=@expo/cli` → clean (downstream sanity check — calls `Updates.getRuntimeVersionAsync` from server middleware)
- `turbo typecheck --filter=expo-updates` → clean (downstream sanity check — calls `Updates.resolveRuntimeVersionPolicyAsync`)

Included 9 new unit tests in `packages/@expo/config-plugins/src/utils/__tests__/Updates-test.ts` (5 for `getAppVersion`, 3 for `getNativeVersion`, and 2 for the `appVersion` runtime policy honoring `ios.version`/`android.version`).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)