### PR TITLE
[android][expo-router] Remove navigation state restoration across activity recreation

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
 - [ios] Fix white flash behind screens during the interactive swipe-back gesture by forwarding the theme background to the native stack container. ([#47121](https://github.com/expo/expo/pull/47121) by [@kevenleone](https://github.com/kevenleone))
 - [ios] Fix memory leaks in the native toolbar and link preview from strong-reference cycles and closures that strongly captured `self`. ([#47378](https://github.com/expo/expo/pull/47378) by [@Ubax](https://github.com/Ubax))
+- [android] Remove navigation state restoration across activity recreation. ([#47422](https://github.com/expo/expo/pull/47422) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -62,7 +62,7 @@ export function useLinking(
       return undefined;
     }
 
-    if (enabled !== false && linkingHandlers.length && process.env.EXPO_OS !== 'android') {
+    if (enabled !== false && linkingHandlers.length) {
       // TODO(@ubax): This check should be removed
       if (linkingHandlers.length > 1) {
         console.error(

--- a/packages/expo-router/src/global-state/store.ts
+++ b/packages/expo-router/src/global-state/store.ts
@@ -4,7 +4,7 @@ import type { RouteNode } from '../Route';
 import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import { resolveHref, resolveHrefStringWithSegments } from '../link/href';
 import type { NavigationContainerRefWithCurrent } from '../react-navigation/native';
-import type { RequireContext, Href } from '../types';
+import type { Href } from '../types';
 import * as SplashScreen from '../views/Splash';
 import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { getCachedRouteInfo, routeInfoSubscribers } from './routeInfoCache';
@@ -26,7 +26,6 @@ type StoreRef = {
   config: any;
   redirects: StoreRedirects[];
   routeInfo?: UrlObject;
-  context?: RequireContext;
 };
 
 export const storeRef = {

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -92,10 +92,6 @@ export function useStore(
     rootComponent = Fragment;
   }
 
-  if (Platform.OS === 'android' && storeRef.current.state && storeRef.current.context === context) {
-    initialState = storeRef.current.state;
-  }
-
   storeRef.current = {
     navigationRef,
     routeNode,
@@ -104,7 +100,6 @@ export function useStore(
     linking,
     redirects,
     state: initialState,
-    context,
   };
 
   if (initialState) {


### PR DESCRIPTION
# Why

In order to restore navigation state after dynamic color configuration change, the state-restoration block added in #42644. This however caused different issues, like #44879.

Recently Android team added a new config change option - `assetsPath` - which prevents activity recreation - see https://github.com/expo/expo/pull/47427. This makes the state restoration redundant and fixes the #44879.

# How

- Remove the Android state-restoration
- Remove the unused param

# Test Plan

- CI
- manual check of router e2e native navigation app

https://github.com/user-attachments/assets/990cdc36-0816-4e7a-ae7a-3d8341d0f789

# Checklist

- [x] Added a `CHANGELOG.md` entry.