### PR TITLE
[android][templates] Add assetsPaths to MainActivity configChanges to avoid recreation on dynamic-color changes

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
   </queries>
 
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize|assetsPaths" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
# Why

On Android, a Material You **dynamic-color change** and any runtime resource-overlay swap — reports the `CONFIG_ASSETS_PATHS` (`0x80000000`) configuration change. `MainActivity` doesn't declare it in `configChanges`, so the OS **recreates the activity while the JS process survives**, resetting navigation state on Android 12+. This is the root cause behind reports like #42500.

`assetsPaths` was added as a `configChanges` token in **API 36**. Declaring it makes the OS deliver the change to the running app instead of relaunching the activity.

# How

Add `assetsPaths` to `MainActivity`'s `android:configChanges` in the prebuild template manifest (`expo-template-bare-minimum`).

# Test Plan

- router-e2e