### PR TITLE
[expo-go] Fix cli commands not responding

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -25,6 +25,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDevSettings.h>
+#import <React/RCTPackagerConnection.h>
 #import <React/RCTRootView.h>
 
 #if __has_include(<ExpoModulesCore-Swift.h>)
@@ -203,6 +204,8 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
     _reactRootView = nil;
   }
   if (_expoAppInstance) {
+    [[[self _devSettings] packagerConnection] stop];
+
     _expoAppInstance = nil;
     if (_delegate) {
       [_delegate reactAppManagerDidInvalidate:self];
@@ -452,51 +455,56 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (void)setupWebSocketControls
 {
-  if ([self enablesDeveloperTools]) {
-    if ([_versionManager respondsToSelector:@selector(addWebSocketNotificationHandler:queue:forMethod:)]) {
-      __weak __typeof(self) weakSelf = self;
+  if (![self enablesDeveloperTools]) {
+    return;
+  }
 
-      // Attach listeners to the bundler's dev server web socket connection.
-      // This enables tools to automatically reload the client remotely (i.e. in expo-cli).
+  RCTDevSettings *devSettings = [self _devSettings];
+  if (!devSettings) {
+    return;
+  }
 
-      // Enable a lot of tools under the same command namespace
-      [_versionManager addWebSocketNotificationHandler:^(id params) {
-        if (params != [NSNull null] && (NSDictionary *)params) {
-          NSDictionary *_params = (NSDictionary *)params;
-          if (_params[@"name"] != nil && (NSString *)_params[@"name"]) {
-            NSString *name = _params[@"name"];
-            if ([name isEqualToString:@"reload"]) {
-              [[EXKernel sharedInstance] reloadVisibleApp];
-            } else if ([name isEqualToString:@"toggleDevMenu"]) {
-              [weakSelf toggleDevMenu];
-            } else if ([name isEqualToString:@"toggleElementInspector"]) {
-              [weakSelf toggleElementInspector];
-            } else if ([name isEqualToString:@"togglePerformanceMonitor"]) {
-              [weakSelf togglePerformanceMonitor];
-            }
-          }
+  __weak __typeof(self) weakSelf = self;
+
+  // Attach listeners to the bundler's dev server web socket connection.
+  // This enables tools to automatically reload the client remotely (i.e. in expo-cli).
+
+  // Enable a lot of tools under the same command namespace
+  [devSettings addNotificationHandler:^(id params) {
+    if (params != [NSNull null] && (NSDictionary *)params) {
+      NSDictionary *_params = (NSDictionary *)params;
+      if (_params[@"name"] != nil && (NSString *)_params[@"name"]) {
+        NSString *name = _params[@"name"];
+        if ([name isEqualToString:@"reload"]) {
+          [[EXKernel sharedInstance] reloadVisibleApp];
+        } else if ([name isEqualToString:@"toggleDevMenu"]) {
+          [weakSelf toggleDevMenu];
+        } else if ([name isEqualToString:@"toggleElementInspector"]) {
+          [weakSelf toggleElementInspector];
+        } else if ([name isEqualToString:@"togglePerformanceMonitor"]) {
+          [weakSelf togglePerformanceMonitor];
         }
       }
-                                                 queue:dispatch_get_main_queue()
-                                             forMethod:@"sendDevCommand"];
-
-      // These (reload and devMenu) are here to match RN dev tooling.
-
-      // Reload the app on "reload"
-      [_versionManager addWebSocketNotificationHandler:^(id params) {
-        [[EXKernel sharedInstance] reloadVisibleApp];
-      }
-                                                 queue:dispatch_get_main_queue()
-                                             forMethod:@"reload"];
-
-      // Open the dev menu on "devMenu"
-      [_versionManager addWebSocketNotificationHandler:^(id params) {
-        [weakSelf toggleDevMenu];
-      }
-                                                 queue:dispatch_get_main_queue()
-                                             forMethod:@"devMenu"];
     }
   }
+                                queue:dispatch_get_main_queue()
+                            forMethod:@"sendDevCommand"];
+
+  // These (reload and devMenu) are here to match RN dev tooling.
+
+  // Reload the app on "reload"
+  [devSettings addNotificationHandler:^(id params) {
+    [[EXKernel sharedInstance] reloadVisibleApp];
+  }
+                                queue:dispatch_get_main_queue()
+                            forMethod:@"reload"];
+
+  // Open the dev menu on "devMenu"
+  [devSettings addNotificationHandler:^(id params) {
+    [weakSelf toggleDevMenu];
+  }
+                                queue:dispatch_get_main_queue()
+                            forMethod:@"devMenu"];
 }
 
 - (NSDictionary<NSString *, NSString *> *)devMenuItems
@@ -513,7 +521,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (RCTDevSettings *)_devSettings
 {
-  return (RCTDevSettings *)[self.reactModuleRegistry moduleForName:"DevSettings"];
+  return (RCTDevSettings *)[self.reactModuleRegistry moduleForName:"DevSettings" lazilyLoadIfNecessary:YES];
 }
 
 - (BOOL)isHotLoadingEnabled

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
@@ -22,9 +22,6 @@
 - (void)showDevMenuForHost:(id)host;
 - (void)togglePerformanceMonitorForHost:(id)host;
 - (void)toggleElementInspectorForHost:(id)host;
-- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
-                         queue:(dispatch_queue_t)queue
-                     forMethod:(NSString *)method;
 
 - (NSDictionary<NSString *, NSString *> *)devMenuItemsForHost:(id)host;
 - (void)selectDevMenuItemWithKey:(NSString *)key host:(id)host bundleURL:(NSURL *)bundleURL;

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
@@ -114,18 +114,9 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
 - (void)hostDidStart:(NSURL *)bundleURL
 {
   if ([self _isDevModeEnabledForHost:bundleURL]) {
-    // Set the bundle url for the packager connection manually
-    NSString *packagerServerHostPort = [NSString stringWithFormat:@"%@:%@", bundleURL.host, bundleURL.port];
     RCTBundleURLProvider *settings = [RCTBundleURLProvider sharedSettings];
     settings.packagerScheme = ([bundleURL.scheme isEqualToString:@"https"] || [bundleURL.scheme isEqualToString:@"exps"]) ? @"https" : @"http";
-    
-    RCTDevSettings* devSettings = (RCTDevSettings*)[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]];
-    if (devSettings == nil) {
-      RCTLogWarn(@"Couldn't find the devSettings module when setting packager port; packager connection will not be updated.");
-    } else {
-      [[devSettings packagerConnection] reconnect:packagerServerHostPort];
-    }
-    
+
     RCTInspectorPackagerConnection *inspectorPackagerConnection = [RCTInspectorDevServerHelper connectWithBundleURL:bundleURL];
 
     NSDictionary<NSString *, id> *buildProps = [self.manifest getPluginPropertiesWithPackageName:@"expo-build-properties"];
@@ -266,18 +257,6 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
 {
   RCTDevSettings *devSettings = [self devSettings:host];
   [devSettings toggleElementInspector];
-}
-
-- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
-                                    queue:(dispatch_queue_t)queue
-                                forMethod:(NSString *)method
-{
-  RCTDevSettings* devSettings = (RCTDevSettings*)[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]];
-  if (devSettings == nil) {
-    RCTLogWarn(@"Couldn't find the devSettings module when setting packager port");
-  }
-  
-  return [[devSettings packagerConnection] addNotificationHandler:handler queue:queue forMethod:method];
 }
 
 #pragma mark - internal


### PR DESCRIPTION
# Why
The CLI dev commands stopped reaching Expo Go on iOS. The CLI reported the commands as sent but nothing happened in the app.

This is a regression from React Native [#54258 ](https://github.com/facebook/react-native/pull/54258) which changed RCTPackagerConnection from a process-wide singleton to a per-RCTDevSettings instance created in init.

Expo Go's EXDevSettings initializes through the designated initializer initWithDataSource: so it can inject a scoped data source. That path bypasses init, which is now the only place the connection is created, so `packagerConnection` was always nil. The command handlers ended up registered on a nil connection, while the live socket that actually received the CLI broadcasts had no handlers attached.

# How
In the fork, create the packager connection in the designated initializer initWithDataSource, so every construction path gets one, not just init. 

Expo Go:
- Register the reload, devMenu, and sendDevCommand handlers on the live DevSettings module from the host module registry, instead of a throwaway instance from the module factory that was never connected.
- Stop the packager connection on teardown so a previous app's connection does not linger for a reload cycle and double dispatch commands.
- Remove the dead hostDidStart reconnect and the unused addWebSocketNotificationHandler, which were spawning a packager connection on every reload.

# Test Plan
Tested in expo go in 56, 57, and main
