### PR TITLE
[router-e2e][observe-tester] fix prebuild command

### DIFF
--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "prebuild": "TEMPLATE_DIR=\"../../templates/expo-template-bare-minimum\" && cd \"$TEMPLATE_DIR\" && PACKED_FILE=$(npm pack) && mv \"$PACKED_FILE\" pack.tgz && cd - && npx expo prebuild --clean --template \"$TEMPLATE_DIR/pack.tgz\"",
+    "prebuild": "TEMPLATE_DIR=\"../../templates/expo-template-bare-minimum\" && (cd \"$TEMPLATE_DIR\" && PACKED_FILE=$(npm pack) && mv \"$PACKED_FILE\" pack.tgz) && npx expo prebuild --clean --template \"$TEMPLATE_DIR/pack.tgz\"",
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "prebuild": "TEMPLATE_DIR=\"../../templates/expo-template-bare-minimum\" && cd \"$TEMPLATE_DIR\" && PACKED_FILE=$(npm pack) && mv \"$PACKED_FILE\" pack.tgz && cd - && npx expo prebuild --clean --template \"$TEMPLATE_DIR/pack.tgz\"",
+    "prebuild": "TEMPLATE_DIR=\"../../templates/expo-template-bare-minimum\" && (cd \"$TEMPLATE_DIR\" && PACKED_FILE=$(npm pack) && mv \"$PACKED_FILE\" pack.tgz) && npx expo prebuild --clean --template \"$TEMPLATE_DIR/pack.tgz\"",
     "start:01-rsc": "E2E_RSC_ENABLED=1 E2E_ROUTER_JS_ENGINE=hermes EXPO_USE_STATIC=server E2E_ROUTER_SRC=01-rsc expo start",
     "export:01-rsc": "E2E_RSC_ENABLED=1 E2E_ROUTER_JS_ENGINE=hermes EXPO_USE_STATIC=server E2E_ROUTER_SRC=01-rsc expo export",
     "start:02-server-actions": "E2E_SERVER_FUNCTIONS=1 E2E_RSC_ENABLED=1 E2E_ROUTER_JS_ENGINE=hermes EXPO_USE_STATIC=server E2E_ROUTER_SRC=02-server-actions expo start",


### PR DESCRIPTION
# Why

The `prebuild` script in `router-e2e` and `observe-tester` used `cd "$TEMPLATE_DIR" && ... && cd -` to pack the template. When the packing step failed the `cd -` never ran, leaving the shell in the template directory, and the trailing `npx expo prebuild` resolved its relative `--template` path from the wrong working directory.

# How

Wrap the pack step in a subshell `(cd ... && npm pack && mv ...)` so the directory change is scoped to packing and `npx expo prebuild` always runs from the app directory.

# Test Plan

Ran `npm run prebuild` in both apps and confirmed it packs the template and prebuilds from the app directory.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)