### PR TITLE
feat(expo-router): allow specifying path-specific headers

### DIFF
--- a/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
+++ b/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
@@ -1,0 +1,13 @@
+import { Text, View } from 'react-native';
+
+export async function loader() {
+  return { data: 'blog' };
+}
+
+export default function Blog() {
+  return (
+    <View>
+      <Text>Blog</Text>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/server-headers/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-headers/workerd/config.capnp
@@ -11,10 +11,9 @@ const serverConfig :Workerd.Config = (
 const server :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workerd.js"),
-    (name = "_sitemap.html", text = embed "_sitemap.html"),
-    (name = "index.html", text = embed "index.html"),
-    (name = "+not-found.html", text = embed "+not-found.html"),
+    (name = "_expo/server/render.js", commonJsModule = embed "_expo/server/render.js"),
     (name = "_expo/functions/api+api.js", commonJsModule = embed "_expo/functions/api+api.js"),
+    (name = "_expo/loaders/blog.js", commonJsModule = embed "_expo/loaders/blog.js"),
     (name = "_expo/routes.json", text = embed "_expo/routes.json"),
   ],
   compatibilityDate = "2025-05-05",

--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -86,6 +86,9 @@ module.exports = {
                 'Set-Cookie': ['session=123', 'token=xyz'],
               }
             : undefined,
+        pageHeaders: process.env.E2E_ROUTER_PAGE_HEADERS
+          ? JSON.parse(process.env.E2E_ROUTER_PAGE_HEADERS)
+          : undefined,
         unstable_useServerDataLoaders: process.env.E2E_ROUTER_SERVER_LOADERS === 'true',
         unstable_useServerMiddleware: process.env.E2E_ROUTER_SERVER_MIDDLEWARE === 'true',
         unstable_useServerRendering: process.env.E2E_ROUTER_SERVER_RENDERING === 'true',

--- a/docs/pages/versions/unversioned/sdk/router/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/index.mdx
@@ -114,6 +114,12 @@ If you are using the [default](/more/create-expo/#--template) template to create
       default: 'undefined',
     },
     {
+      name: 'pageHeaders',
+      description:
+        "An array of header rules that are set on a specific page's response from the server. Each rule should have `source` and `headers`. Rules only apply to page responses, not API routes or data loaders.",
+      default: 'undefined',
+    },
+    {
       name: 'disableSynchronousScreensUpdates',
       description:
         'Disable synchronous layout updates for native screens. This can help with performance in some cases.',

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
+- Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
@@ -12,35 +12,57 @@ import {
 
 runExportSideEffects();
 
-describe('export server with custom headers', () => {
+const GLOBAL_HEADERS = {
+  'X-Powered-By': 'expo-server',
+  'X-Global': 'global',
+  'Set-Cookie': ['session=1', 'session=2'],
+  'Content-Type': 'application/pdf',
+};
+
+const PAGE_HEADERS = [
+  { source: '/', headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } },
+  { source: '/api', headers: { 'Set-Cookie': ['page=1'], 'Content-Type': 'text/should-not-apply' } },
+  { source: '/blog', headers: { 'X-Page-Rule': 'blog' } },
+];
+
+const EXPECTED_PAGE_HEADERS = [
+  {
+    namedRegex: '^/(?:/)?$',
+    headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' },
+  },
+  {
+    namedRegex: '^/api(?:/)?$',
+    headers: { 'Set-Cookie': ['page=1'], 'Content-Type': 'text/should-not-apply' },
+  },
+  {
+    namedRegex: '^/blog(?:/)?$',
+    headers: { 'X-Page-Rule': 'blog' },
+  },
+];
+
+describe('export server with headers', () => {
   describe.each(
     prepareServers([RUNTIME_EXPO_SERVE, RUNTIME_WORKERD], {
       fixtureName: 'server-headers',
       export: {
         env: {
-          E2E_ROUTER_HEADERS: JSON.stringify({
-            'X-Powered-By': 'expo-server',
-            'Set-Cookie': ['hello=world', 'foo=bar'],
-            'Content-Type': 'application/pdf',
-          }),
-          E2E_ROUTER_REWRITES: JSON.stringify([
-            { source: '/rewrite/api', destination: '/api' },
-          ]),
+          E2E_ROUTER_HEADERS: JSON.stringify(GLOBAL_HEADERS),
+          E2E_ROUTER_REWRITES: JSON.stringify([{ source: '/rewrite/api', destination: '/api' }]),
+          E2E_ROUTER_PAGE_HEADERS: JSON.stringify(PAGE_HEADERS),
+          E2E_ROUTER_SERVER_LOADERS: 'true',
+          E2E_ROUTER_SERVER_RENDERING: 'true',
         },
       },
     })
   )('$name requests', (config) => {
     const server = setupServer(config);
 
-    it('includes headers in routes.json manifest', () => {
+    it('includes `headers` and `pageHeaders` in the export manifest', () => {
       const routesJson = JSON.parse(
         fs.readFileSync(path.resolve(server.outputDir, 'server/_expo/routes.json'), 'utf8')
       );
-      expect(routesJson.headers).toEqual({
-        'X-Powered-By': 'expo-server',
-        'Set-Cookie': ['hello=world', 'foo=bar'],
-        'Content-Type': 'application/pdf',
-      });
+      expect(routesJson.headers).toEqual(GLOBAL_HEADERS);
+      expect(routesJson.pageHeaders).toEqual(EXPECTED_PAGE_HEADERS);
     });
 
     it.each([
@@ -48,35 +70,64 @@ describe('export server with custom headers', () => {
         path: '/',
         status: 200,
         contentType: 'text/html',
+        poweredBy: 'page-override',
+        pageRule: 'index',
+        setCookie: 'session=1, session=2',
       },
       {
+        // API routes only apply global headers
         path: '/api',
         status: 200,
         contentType: 'application/json',
+        poweredBy: 'expo-server',
+        pageRule: null,
+        setCookie: 'session=1, session=2',
       },
       {
         path: '/rewrite/api',
         status: 200,
         contentType: 'application/json',
+        poweredBy: 'expo-server',
+        pageRule: null,
+        setCookie: 'session=1, session=2',
+      },
+      {
+        path: '/blog',
+        status: 200,
+        contentType: 'text/html',
+        poweredBy: 'expo-server',
+        pageRule: 'blog',
+        setCookie: 'session=1, session=2',
+      },
+      {
+        // Loader routes only apply global headers
+        path: '/_expo/loaders/blog',
+        status: 200,
+        contentType: 'application/json',
+        poweredBy: 'expo-server',
+        pageRule: null,
+        setCookie: 'session=1, session=2',
       },
       {
         path: '/not-a-route',
         status: 404,
         contentType: 'text/html',
+        poweredBy: 'expo-server',
+        pageRule: null,
+        setCookie: 'session=1, session=2',
       },
-    ])('applies custom headers to $path', async ({ path, status, contentType }) => {
-      const response = await server.fetchAsync(path);
+    ])(
+      'applies `headers` and matching `pageHeaders` to $path',
+      async ({ path, status, contentType, poweredBy, pageRule, setCookie }) => {
+        const response = await server.fetchAsync(path);
 
-      expect(response.status).toBe(status);
-
-      // Check that existing Content-Type header is not overridden
-      expect(response.headers.get('Content-Type')).toBe(contentType);
-
-      // Check single-value custom header
-      expect(response.headers.get('X-Powered-By')).toBe('expo-server');
-
-      // Check array-value custom headers
-      expect(response.headers.get('Set-Cookie')).toBe('hello=world, foo=bar');
-    });
+        expect(response.status).toBe(status);
+        expect(response.headers.get('Content-Type')).toBe(contentType);
+        expect(response.headers.get('X-Global')).toBe('global');
+        expect(response.headers.get('X-Powered-By')).toBe(poweredBy);
+        expect(response.headers.get('X-Page-Rule')).toBe(pageRule);
+        expect(response.headers.get('Set-Cookie')).toBe(setCookie);
+      }
+    );
   });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { runExportSideEffects } from './export-side-effects';
+import { executeExpoAsync } from '../../utils/expo';
+import { getRouterE2ERoot } from '../utils';
+
+runExportSideEffects();
+
+const GLOBAL_HEADERS = {
+  'X-Powered-By': 'expo-server',
+  'X-Global': 'global',
+  'Set-Cookie': ['session=1'],
+};
+
+const PAGE_HEADERS = [
+  { source: '/', headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } },
+  { source: '/api', headers: { 'Set-Cookie': ['page=1'] } },
+];
+
+const EXPECTED_PAGE_HEADERS = [
+  {
+    namedRegex: '^/(?:/)?$',
+    headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' },
+  },
+  {
+    namedRegex: '^/api(?:/)?$',
+    headers: { 'Set-Cookie': ['page=1'] },
+  },
+];
+
+describe('export static with headers', () => {
+  const projectRoot = getRouterE2ERoot();
+  const outputName = 'dist-static-headers';
+  const outputDir = path.join(projectRoot, outputName);
+
+  beforeAll(async () => {
+    await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
+      env: {
+        NODE_ENV: 'production',
+        EXPO_USE_STATIC: 'static',
+        E2E_ROUTER_SRC: 'server-headers',
+        E2E_ROUTER_ASYNC: '',
+        E2E_ROUTER_HEADERS: JSON.stringify(GLOBAL_HEADERS),
+        E2E_ROUTER_PAGE_HEADERS: JSON.stringify(PAGE_HEADERS),
+      },
+    });
+  });
+
+  it('writes global headers and pageHeaders into the export manifest', () => {
+    const routesJson = JSON.parse(
+      fs.readFileSync(path.join(outputDir, '_expo/.routes.json'), 'utf8')
+    );
+    expect(routesJson.headers).toEqual(GLOBAL_HEADERS);
+    expect(routesJson.pageHeaders).toEqual(EXPECTED_PAGE_HEADERS);
+  });
+});

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -118,9 +118,10 @@ export async function getFilesToExportFromServerAsync(
 ): Promise<ExportAssetMap> {
   if (!exportServer && serverManifest) {
     // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
-    // EAS Hosting to recognize the `headers` and `redirects` configs
+    // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
     const subsetServerManifest = {
       headers: serverManifest.headers,
+      pageHeaders: serverManifest.pageHeaders,
       redirects: serverManifest.redirects,
     };
     files.set('_expo/.routes.json', {

--- a/packages/@expo/cli/src/start/server/metro/fetchRouterManifest.ts
+++ b/packages/@expo/cli/src/start/server/metro/fetchRouterManifest.ts
@@ -53,6 +53,8 @@ async function fetchManifest(
 
 export { fetchManifest };
 
+// TODO(@hassankhan): This should be a re-export of `initManifestRegExp()` from
+// `expo-server`
 // Convert the serialized manifest to a usable format
 export function inflateManifest(json: RoutesManifest<string>): RoutesManifest<RegExp> {
   return {
@@ -83,6 +85,12 @@ export function inflateManifest(json: RoutesManifest<string>): RoutesManifest<Re
       };
     }),
     rewrites: json.rewrites?.map((value: any) => {
+      return {
+        ...value,
+        namedRegex: new RegExp(value.namedRegex),
+      };
+    }),
+    pageHeaders: json.pageHeaders?.map((value) => {
       return {
         ...value,
         namedRegex: new RegExp(value.namedRegex),

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Compile `pageHeaders` rules into the routes manifest ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+
 ### 🐛 Bug fixes
 
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/router-server/src/__tests__/getServerManifest.test.node.ts
+++ b/packages/@expo/router-server/src/__tests__/getServerManifest.test.node.ts
@@ -606,3 +606,57 @@ describe('headers', () => {
     });
   });
 });
+
+describe('pageHeaders', () => {
+  it('applies custom `pageHeaders` to manifest', () => {
+    const manifest = getServerManifest(getRoutesFor(['./home.js']), {
+      pageHeaders: [
+        { source: '/blog', headers: { 'Cache-Control': 'public, max-age=3600' } },
+        { source: '/blog/[slug]', headers: { 'X-Test': 'a' } },
+        { source: '/admin/[...rest]', headers: { 'X-Frame-Options': 'DENY' } },
+        { source: '/array-header', headers: { 'Set-Cookie': ['a=1', 'b=2'] } }
+      ],
+    });
+    expect(manifest.pageHeaders).toEqual([
+      {
+        namedRegex: '^/blog(?:/)?$',
+        headers: { 'Cache-Control': 'public, max-age=3600' },
+      },
+      {
+        namedRegex: '^/blog/(?<slug>[^/]+?)(?:/)?$',
+        headers: { 'X-Test': 'a' },
+      },
+      {
+        namedRegex: '^/admin(?:/(?<rest>.+?))?(?:/)?$',
+        headers: { 'X-Frame-Options': 'DENY' },
+      },
+      {
+        namedRegex: '^/array\\-header(?:/)?$',
+        headers: { 'Set-Cookie': ['a=1', 'b=2'] },
+      }
+    ]);
+  });
+
+  it('normalizes a trailing `/index` in `pageHeaders` sources', () => {
+    const manifest = getServerManifest(getRoutesFor(['./home.js']), {
+      pageHeaders: [
+        { source: '/index', headers: { 'X-Index': '1' } },
+        { source: '/blog/index', headers: { 'X-Blog': '2' } },
+      ],
+    });
+    expect(manifest.pageHeaders).toEqual([
+      { namedRegex: '^/(?:/)?$', headers: { 'X-Index': '1' } },
+      { namedRegex: '^/blog(?:/)?$', headers: { 'X-Blog': '2' } },
+    ]);
+  });
+
+  it('omits `pageHeaders` from the manifest when none are configured', () => {
+    const manifest = getServerManifest(getRoutesFor(['./home.js']));
+    expect(manifest.pageHeaders).toBeUndefined();
+  });
+
+  it('omits `pageHeaders` from the manifest when the list is empty', () => {
+    const manifest = getServerManifest(getRoutesFor(['./home.js']), { pageHeaders: [] });
+    expect(manifest.pageHeaders).toBeUndefined();
+  });
+});

--- a/packages/@expo/router-server/src/getServerManifest.ts
+++ b/packages/@expo/router-server/src/getServerManifest.ts
@@ -1,8 +1,14 @@
-import { getContextKey, sortRoutes, type RouteNode } from 'expo-router/internal/routing';
+import {
+  getContextKey,
+  sortRoutes,
+  type RouteNode,
+  type PageHeadersConfig,
+} from 'expo-router/internal/routing';
 import { shouldLinkExternally } from 'expo-router/internal/utils';
-import type { RouteInfo, RoutesManifest } from 'expo-server/private';
+import type { PageHeaderInfo, RouteInfo, RoutesManifest } from 'expo-server/private';
 
 import { getNamedParametrizedRoute } from './getNamedParametrizedRoute';
+import type { Options } from './getRoutesSSR';
 
 export interface Group {
   pos: number;
@@ -40,9 +46,7 @@ type FlatNode = {
   route: RouteNode;
 };
 
-type GetServerManifestOptions = {
-  headers?: Record<string, string | string[]>;
-};
+type GetServerManifestOptions = Pick<Options, 'headers' | 'pageHeaders'>;
 
 // Given a nested route tree, return a flattened array of all routes that can be matched.
 export function getServerManifest(
@@ -150,7 +154,27 @@ export function getServerManifest(
     manifest.headers = options.headers;
   }
 
+  if (options?.pageHeaders?.length) {
+    manifest.pageHeaders = getMatchableManifestForPageHeaders(options.pageHeaders);
+  }
+
   return manifest;
+}
+
+function getMatchableManifestForPageHeaders(
+  pageHeaders: PageHeadersConfig[]
+): PageHeaderInfo<string>[] {
+  return pageHeaders.map(({ source, headers }) => {
+    const prefixedSource = source.startsWith('/') ? source : `/${source}`;
+    const normalizedSource = prefixedSource.replace(/\/index$/, '');
+
+    const { namedParameterizedRoute } = getNamedParametrizedRoute(normalizedSource);
+
+    return {
+      headers,
+      namedRegex: `^${namedParameterizedRoute}(?:/)?$`,
+    };
+  });
 }
 
 function getMatchableManifestForPaths(paths: FlatNode[]): RouteInfo<string>[] {

--- a/packages/@expo/router-server/src/routes-manifest.ts
+++ b/packages/@expo/router-server/src/routes-manifest.ts
@@ -35,5 +35,5 @@ export function createRoutesManifest(
   if (!routeTree) {
     return null;
   }
-  return getServerManifest(routeTree, { headers: options.headers });
+  return getServerManifest(routeTree, options);
 }

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Re-export drawer content components and types (`DrawerContentScrollView`, `DrawerItem`, `DrawerItemList`, `DrawerContentComponentProps`, `DrawerNavigationProp`, and more) from `expo-router/drawer` ([#46635](https://github.com/expo/expo/pull/46635) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Emit a `tabPress` event with `isPrevented: true` when a `disabled` tab is tapped, without selecting it. ([#46445](https://github.com/expo/expo/pull/46445) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Add `testID` and `accessibilityLabel` props to `NativeTabs.Trigger`. ([#47472](https://github.com/expo/expo/pull/47472) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Add `pageHeaders` config plugin option for declaring per-path response headers ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/plugin/options.json
+++ b/packages/expo-router/plugin/options.json
@@ -153,6 +153,37 @@
             ]
           }
         },
+        "pageHeaders": {
+          "description": "A list of headers that are set on a specific path's response from the server",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source", "headers"],
+            "properties": {
+              "source": {
+                "description": "The path to match for the headers to apply",
+                "type": "string"
+              },
+              "headers": {
+                "description": "Response headers to apply for matching paths",
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
         "unstable_useServerMiddleware": {
           "description": "Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config.",
           "type": "boolean",

--- a/packages/expo-router/plugin/src/withRouter.ts
+++ b/packages/expo-router/plugin/src/withRouter.ts
@@ -56,6 +56,13 @@ type RewriteConfig = {
   methods?: HttpMethod[];
 };
 
+type PageHeadersConfig = {
+  /** The path to match for the headers to apply. */
+  source: string;
+  /** Response headers to apply for matching paths. */
+  headers: Record<string, string | string[]>;
+};
+
 export type Props = {
   /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
   origin?: string | boolean;
@@ -84,6 +91,8 @@ export type Props = {
   rewrites?: RewriteConfig[];
   /** A list of headers that are set on every route response from the server */
   headers?: Record<string, string | string[]>;
+  /** A list of headers that are set on a specific path's response from the server. */
+  pageHeaders?: PageHeadersConfig[];
   /** Enable experimental server middleware support with a `+middleware.ts` file. Requires `web.output: 'server'` to be set in app config. */
   unstable_useServerMiddleware?: boolean;
   /** Enable experimental data loader support. Requires `web.output: 'static' | 'server'` to be set in app config. */

--- a/packages/expo-router/src/getRoutesCore.ts
+++ b/packages/expo-router/src/getRoutesCore.ts
@@ -31,9 +31,14 @@ export type Options = {
   platformRoutes?: boolean;
   sitemap?: boolean;
   platform?: string;
+  /** Redirect rules declared in config plugin options */
   redirects?: RedirectConfig[];
+  /** Rewrite rules declared in config plugin options */
   rewrites?: RewriteConfig[];
+  /** Global headers declared in config plugin options */
   headers?: Record<string, string | string[]>;
+  /** Per-path header rules declared in config plugin options */
+  pageHeaders?: PageHeadersConfig[];
   /* Keep redirects as valid routes within the RouteConfig tree */
   preserveRedirectAndRewrites?: boolean;
 
@@ -67,6 +72,11 @@ export type RewriteConfig = {
   destination: string;
   destinationContextKey: string;
   methods?: string[];
+};
+
+export type PageHeadersConfig = {
+  source: string;
+  headers: Record<string, string | string[]>;
 };
 
 const validPlatforms = new Set(['android', 'ios', 'native', 'web']);

--- a/packages/expo-router/src/internal/routing.ts
+++ b/packages/expo-router/src/internal/routing.ts
@@ -6,6 +6,7 @@ export {
   getRoutes as getRoutesCore,
   type Options as GetRoutesCoreOptions,
   type RewriteConfig,
+  type PageHeadersConfig,
 } from '../getRoutesCore';
 export {
   getContextKey,

--- a/packages/expo-server/CHANGELOG.md
+++ b/packages/expo-server/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Apply per-path `pageHeaders` to matching page responses ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+
 ### 🐛 Bug fixes
 
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/expo-server/src/manifest.ts
+++ b/packages/expo-server/src/manifest.ts
@@ -72,6 +72,29 @@ export interface RouteInfo<TRegex = RegExp | string> {
   assets?: AssetInfo;
 }
 
+/**
+ * A per-path header rule, applied to matching page responses only.
+ *
+ * For scalar headers, the order is headers already on the response (set by
+ * `expo-server` or declared by the route itself), then matching rules, then
+ * global `headers`. When multiple rules match a path, the rule declared last
+ * in the `pageHeaders` array takes precedence.
+ *
+ * For array headers, always append. Values from `headers` come first,
+ * then `pageHeaders`.
+ */
+export interface PageHeaderInfo<TRegex = RegExp | string> {
+  /**
+   * Regex for matching the requested path against this rule.
+   */
+  namedRegex: TRegex;
+  /**
+   * Headers to apply to matching responses. Scalar values are set unless the response already
+   * carries the header; array values always append.
+   */
+  headers: Record<string, string | string[]>;
+}
+
 export interface RoutesManifest<TRegex = RegExp | string> {
   /**
    * Middleware function that runs before any route matching.
@@ -82,6 +105,10 @@ export interface RoutesManifest<TRegex = RegExp | string> {
    * Headers to be applied to all responses from the server.
    */
   headers?: Record<string, string | string[]>;
+  /**
+   * Headers to be applied to path-specific responses from the server.
+   */
+  pageHeaders?: PageHeaderInfo<TRegex>[];
   /**
    * Routes that are matched after HTML routes and invoke WinterCG-compliant functions.
    */

--- a/packages/expo-server/src/utils/__tests__/headers.test.ts
+++ b/packages/expo-server/src/utils/__tests__/headers.test.ts
@@ -1,0 +1,79 @@
+import { appendHeadersRecord, mergeHeaderInputs } from '../headers';
+
+describe(appendHeadersRecord, () => {
+  it('sets scalars only when absent without `shouldOverwrite`', () => {
+    const headers = new Headers({ 'X-A': 'existing' });
+
+    appendHeadersRecord(headers, { 'X-A': 'update', 'X-B': 'new' }, false);
+
+    expect(headers.get('X-A')).toBe('existing');
+    expect(headers.get('X-B')).toBe('new');
+  });
+
+  it('replaces scalars with `shouldOverwrite`', () => {
+    const headers = new Headers({ 'X-A': 'existing' });
+
+    appendHeadersRecord(headers, { 'X-A': 'update' }, true);
+
+    expect(headers.get('X-A')).toBe('update');
+  });
+
+  it('always appends array values', () => {
+    const headers = new Headers({ 'Set-Cookie': 'route=1' });
+
+    appendHeadersRecord(headers, { 'Set-Cookie': ['a=1'] }, false);
+
+    expect(headers.get('Set-Cookie')).toBe('route=1, a=1');
+  });
+
+  it('ignores null values', () => {
+    const headers = new Headers();
+
+    appendHeadersRecord(headers, { 'X-A': null as unknown as string }, true);
+
+    expect(headers.get('X-A')).toBeNull();
+  });
+});
+
+describe(mergeHeaderInputs, () => {
+  it('replaces a base scalar with an update scalar', () => {
+    expect(mergeHeaderInputs({ 'X-A': 'base' }, { 'X-A': 'update' })).toEqual({ 'x-a': 'update' });
+  });
+
+  it('concatenates arrays across layers, base first', () => {
+    expect(mergeHeaderInputs({ 'Set-Cookie': ['a=1'] }, { 'Set-Cookie': ['b=2'] })).toEqual({
+      'set-cookie': ['a=1', 'b=2'],
+    });
+  });
+
+  it('absorbs a base scalar into an update array', () => {
+    expect(mergeHeaderInputs({ 'Set-Cookie': 'a=1' }, { 'Set-Cookie': ['b=2'] })).toEqual({
+      'set-cookie': ['a=1', 'b=2'],
+    });
+  });
+
+  it('replaces a base array with an update scalar', () => {
+    expect(mergeHeaderInputs({ 'X-A': ['a', 'b'] }, { 'X-A': 'c' })).toEqual({ 'x-a': 'c' });
+  });
+
+  it('collides header names case-insensitively', () => {
+    expect(mergeHeaderInputs({ 'x-powered-by': 'base' }, { 'X-Powered-By': 'update' })).toEqual({
+      'x-powered-by': 'update',
+    });
+  });
+
+  it('ignores a null update value instead of unsetting the base value', () => {
+    expect(mergeHeaderInputs({ 'X-A': 'base' }, { 'X-A': null as unknown as string })).toEqual({
+      'x-a': 'base',
+    });
+  });
+
+  it('copies arrays instead of aliasing the inputs', () => {
+    const base = { 'Set-Cookie': ['a=1'] };
+    const merged = mergeHeaderInputs(base, {});
+
+    (merged['set-cookie'] as string[]).push('b=2');
+
+    expect(base['Set-Cookie']).toEqual(['a=1']);
+  });
+});

--- a/packages/expo-server/src/utils/headers.ts
+++ b/packages/expo-server/src/utils/headers.ts
@@ -15,3 +15,33 @@ export const appendHeadersRecord = (
     }
   }
 };
+
+export const mergeHeaderInputs = (
+  base: Record<string, string | string[]>,
+  update: Record<string, string | string[]>
+): Record<string, string | string[]> => {
+  const merged: Record<string, string | string[]> = {};
+
+  for (const [headerName, value] of Object.entries(base)) {
+    merged[headerName.toLowerCase()] = Array.isArray(value) ? [...value] : value;
+  }
+
+  for (const headerName in update) {
+    const value = update[headerName];
+    if (value == null) {
+      continue;
+    }
+    const key = headerName.toLowerCase();
+    if (Array.isArray(value)) {
+      const existing = merged[key];
+      merged[key] =
+        existing != null
+          ? [...(Array.isArray(existing) ? existing : [existing]), ...value]
+          : [...value];
+    } else {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+};

--- a/packages/expo-server/src/vendor/__tests__/abstract.test.ts
+++ b/packages/expo-server/src/vendor/__tests__/abstract.test.ts
@@ -1,5 +1,5 @@
 import type { Manifest } from '../../manifest';
-import { createRequestHandler } from '../abstract';
+import { createRequestHandler, type RequestHandlerInput } from '../abstract';
 
 describe(createRequestHandler, () => {
   it('returns streamed HTML responses for matched routes', async () => {
@@ -104,6 +104,33 @@ describe(createRequestHandler, () => {
 
     // Check array-value custom headers
     expect(response.headers.get('Set-Cookie')).toBe('hello=world, foo=bar');
+  });
+
+  it('does not mutate the API route response when applying headers', async () => {
+    const manifest: Manifest = {
+      htmlRoutes: [],
+      apiRoutes: [{ file: 'api.js', page: '/api', namedRegex: /^\/api\/?$/, routeKeys: {} }],
+      notFoundRoutes: [],
+      redirects: [],
+      rewrites: [],
+      headers: { 'X-Global': 'global' },
+    };
+    const apiResponse = new Response('{}', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const handler = createRequestHandler({
+      getRoutesManifest: jest.fn(async () => manifest),
+      getHtml: jest.fn(),
+      getApiRoute: jest.fn(async () => ({ GET: async () => apiResponse })),
+      getMiddleware: jest.fn(),
+      getLoaderData: jest.fn(),
+    });
+
+    const response = await handler(new Request('http://localhost/api'));
+
+    expect(response.headers.get('X-Global')).toBe('global');
+    expect(apiResponse.headers.get('X-Global')).toBeNull();
   });
 
   describe('loader requests', () => {
@@ -389,6 +416,242 @@ describe(createRequestHandler, () => {
 
       const [loaderRequest] = getLoaderData.mock.calls[0]!;
       expect(new URL(loaderRequest.url).pathname).toBe('/nested/');
+    });
+  });
+
+  describe('pageHeaders', () => {
+    function createHandler(manifest: Manifest, overrides: Partial<RequestHandlerInput> = {}) {
+      return createRequestHandler({
+        getRoutesManifest: jest.fn(async () => manifest),
+        getHtml: jest.fn(async () => '<html></html>'),
+        getApiRoute: jest.fn(),
+        getMiddleware: jest.fn(),
+        getLoaderData: jest.fn(),
+        ...overrides,
+      });
+    }
+
+    const indexRoute = {
+      file: 'index',
+      page: '/',
+      namedRegex: /^\/$/,
+      routeKeys: {},
+    };
+
+    it('applies matching `pageHeaders` to response', async () => {
+      const handler = createHandler({
+        htmlRoutes: [indexRoute],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [],
+        pageHeaders: [
+          { namedRegex: /^\/$/, headers: { 'X-Frame-Options': 'DENY' } },
+          { namedRegex: /^\/other$/, headers: { 'X-Frame-Options': 'SAMEORIGIN' } },
+        ],
+      });
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    });
+
+    it('leaves response untouched when no rule matches', async () => {
+      const handler = createHandler({
+        htmlRoutes: [indexRoute],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [],
+        pageHeaders: [{ namedRegex: /^\/other$/, headers: { 'X-Test': 'no' } }],
+      });
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.headers.get('X-Test')).toBeNull();
+    });
+
+    it('applies scalar precedence: route-authored, later rules, earlier rules, globals', async () => {
+      const handler = createHandler({
+        htmlRoutes: [indexRoute],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [],
+        headers: { 'X-Powered-By': 'expo-server', 'X-Global': 'global' },
+        pageHeaders: [
+          {
+            namedRegex: /^\/$/,
+            headers: {
+              'X-Rule': 'first',
+              'X-Powered-By': 'page-override',
+              'Content-Type': 'text/plain',
+            },
+          },
+          { namedRegex: /^\/$/, headers: { 'X-Rule': 'second' } },
+        ],
+      });
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.headers.get('Content-Type')).toBe('text/html');
+      expect(response.headers.get('X-Rule')).toBe('second');
+      expect(response.headers.get('X-Powered-By')).toBe('page-override');
+      expect(response.headers.get('X-Global')).toBe('global');
+    });
+
+    it('appends array headers in global, page-rule order', async () => {
+      const handler = createHandler({
+        htmlRoutes: [indexRoute],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [],
+        headers: { 'Set-Cookie': ['global=1'] },
+        pageHeaders: [
+          { namedRegex: /^\/$/, headers: { 'Set-Cookie': ['page1=1'] } },
+          { namedRegex: /^\/$/, headers: { 'Set-Cookie': ['page2=1'] } },
+        ],
+      });
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.headers.get('Set-Cookie')).toBe('global=1, page1=1, page2=1');
+    });
+
+    it('accumulates array headers', async () => {
+      const handler = createHandler({
+        htmlRoutes: [indexRoute],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [],
+        headers: { 'Set-Cookie': ['session=1'] },
+        pageHeaders: [
+          { namedRegex: /^\/$/, headers: { 'Set-Cookie': ['a=1', 'b=2'] } },
+        ],
+      });
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.headers.get('Set-Cookie')).toBe('session=1, a=1, b=2');
+    });
+
+    it('applies only global headers to API routes and loader requests, and none to redirects', async () => {
+      const handler = createHandler(
+        {
+          htmlRoutes: [
+            {
+              file: 'blog.js',
+              page: '/blog',
+              namedRegex: /^\/blog\/?$/,
+              routeKeys: {},
+              loader: '_expo/loaders/blog.js',
+            },
+          ],
+          apiRoutes: [{ file: 'api.js', page: '/api', namedRegex: /^\/api\/?$/, routeKeys: {} }],
+          notFoundRoutes: [],
+          redirects: [{ file: '', page: '/new', namedRegex: /^\/red\/?$/, routeKeys: {} }],
+          rewrites: [],
+          headers: {
+            'X-Global': 'global',
+            'Set-Cookie': ['global=1'],
+            'Cache-Control': 'public, max-age=60',
+          },
+          pageHeaders: [
+            { namedRegex: /^\/api\/?$/, headers: { 'X-Rule': 'set', 'Set-Cookie': ['page=1'] } },
+            { namedRegex: /^\/blog\/?$/, headers: { 'X-Rule': 'set' } },
+            { namedRegex: /^\/red\/?$/, headers: { 'X-Rule': 'set' } },
+          ],
+        },
+        {
+          getApiRoute: jest.fn(async () => ({
+            GET: async () =>
+              new Response('{}', {
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Set-Cookie': 'route=1',
+                  'Cache-Control': 'max-age=10',
+                },
+              }),
+          })),
+          getLoaderData: jest.fn(
+            async () =>
+              new Response('{}', {
+                headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+              })
+          ),
+        }
+      );
+
+      // API routes only receive global headers, and route-declared headers win over them
+      const apiResponse = await handler(new Request('http://localhost/api'));
+      expect(apiResponse.headers.get('X-Rule')).toBeNull();
+      expect(apiResponse.headers.get('X-Global')).toBe('global');
+      expect(apiResponse.headers.get('Set-Cookie')).toBe('route=1, global=1');
+      expect(apiResponse.headers.get('Content-Type')).toBe('application/json');
+      expect(apiResponse.headers.get('Cache-Control')).toBe('max-age=10');
+
+      // Loader requests only receive global headers, and loader-declared headers win over them
+      const loaderResponse = await handler(new Request('http://localhost/_expo/loaders/blog'));
+      expect(loaderResponse.status).toBe(200);
+      expect(loaderResponse.headers.get('X-Rule')).toBeNull();
+      expect(loaderResponse.headers.get('X-Global')).toBe('global');
+      expect(loaderResponse.headers.get('Cache-Control')).toBe('no-store');
+
+      // Redirects receive neither global nor page headers
+      const redirectResponse = await handler(new Request('http://localhost/red'));
+      expect(redirectResponse.status).toBe(302);
+      expect(redirectResponse.headers.get('Location')).toBe('/new');
+      expect(redirectResponse.headers.get('X-Rule')).toBeNull();
+      expect(redirectResponse.headers.get('X-Global')).toBeNull();
+    });
+
+    it('matches the requested path, not the rewritten target', async () => {
+      const handler = createHandler({
+        htmlRoutes: [{ file: 'new', page: '/new', namedRegex: /^\/new\/?$/, routeKeys: {} }],
+        apiRoutes: [],
+        notFoundRoutes: [],
+        redirects: [],
+        rewrites: [{ file: '', page: '/new', namedRegex: /^\/old\/?$/, routeKeys: {} }],
+        pageHeaders: [
+          { namedRegex: /^\/old\/?$/, headers: { 'X-Matched': 'old' } },
+          { namedRegex: /^\/new\/?$/, headers: { 'X-Matched': 'new' } },
+        ],
+      });
+
+      const response = await handler(new Request('http://localhost/old'));
+
+      expect(response.headers.get('X-Matched')).toBe('old');
+    });
+
+    it('leaves passthrough dev error responses untouched', async () => {
+      const handler = createHandler(
+        {
+          htmlRoutes: [indexRoute],
+          apiRoutes: [],
+          notFoundRoutes: [],
+          redirects: [],
+          rewrites: [],
+          headers: { 'X-Global': 'global' },
+          pageHeaders: [{ namedRegex: /^\/$/, headers: { 'X-Page': 'page' } }],
+        },
+        {
+          getHtml: jest.fn(
+            async () =>
+              new Response('<html>error</html>', {
+                status: 500,
+                headers: { 'Content-Type': 'text/html' },
+              })
+          ),
+        }
+      );
+
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get('X-Global')).toBeNull();
+      expect(response.headers.get('X-Page')).toBeNull();
     });
   });
 });

--- a/packages/expo-server/src/vendor/abstract.ts
+++ b/packages/expo-server/src/vendor/abstract.ts
@@ -2,6 +2,7 @@ import { ImmutableRequest } from '../ImmutableRequest';
 import type { Manifest, MiddlewareInfo, Route } from '../manifest';
 import { getRedirectRewriteLocation, isResponse, parseParams } from '../utils/matchers';
 import { MiddlewareModule, shouldRunMiddleware } from '../utils/middleware';
+import { appendHeadersRecord, mergeHeaderInputs } from '../utils/headers';
 
 const LOADER_PREFIX = '/_expo/loaders';
 
@@ -27,6 +28,7 @@ type ResponseInitLike = Omit<ResponseInit, 'headers'> & {
   cf?: unknown;
   webSocket?: unknown;
 };
+type ResponseOverrides = { headers: Record<string, string | string[]> };
 type CallbackRouteType = 'html' | 'api' | 'notFoundHtml' | 'notAllowedApi';
 type CallbackRoute = (Route & { type: CallbackRouteType }) | { type: null };
 // NOTE(@krystofwoldrich): For better general usability of the callback bodyInit could be also passed as arg.
@@ -94,6 +96,9 @@ export function createRequestHandler({
 
     let request = incomingRequest;
     let url = new URL(request.url);
+    const globalOverrides = manifest.headers ? { headers: manifest.headers } : undefined;
+    // `pageHeaders` rules only apply to HTML responses
+    const pageOverrides = { headers: resolveRouteHeaders(url.pathname) };
 
     if (manifest.middleware) {
       const middleware = await getMiddleware(manifest.middleware);
@@ -161,11 +166,16 @@ export function createRequestHandler({
           // NOTE(@hassankhan): Relocate the request rewriting logic from here
           url.pathname = matchedPath;
           const loaderRequest = new Request(url, request);
-          return createResponseFrom('api', route, await getLoaderData(loaderRequest, route));
+          return createResponseFrom(
+            'api',
+            route,
+            await getLoaderData(loaderRequest, route),
+            globalOverrides
+          );
         }
 
         const html = await getHtml(request, route);
-        return respondHTML(html, route);
+        return respondHTML(html, route, pageOverrides);
       }
     }
 
@@ -175,7 +185,7 @@ export function createRequestHandler({
         continue;
       }
       const mod = await getApiRoute(route);
-      return await respondAPI(mod, request, route);
+      return await respondAPI(mod, request, route, globalOverrides);
     }
 
     // Finally, test 404 routes
@@ -187,7 +197,7 @@ export function createRequestHandler({
 
         try {
           const contents = await getHtml(request, route);
-          return respondNotFoundHTML(contents, route);
+          return respondNotFoundHTML(contents, route, pageOverrides);
         } catch {
           // NOTE(@krystofwoldrich): Should we show a dismissible RedBox in development?
           // Handle missing/corrupted not found route files
@@ -197,17 +207,24 @@ export function createRequestHandler({
     }
 
     // 404
-    return createResponse(null, null, 'Not found', {
-      status: 404,
-      headers: new Headers({ 'Content-Type': 'text/plain' }),
-    });
+    return createResponse(
+      null,
+      null,
+      'Not found',
+      {
+        status: 404,
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+      },
+      globalOverrides
+    );
   }
 
   function createResponse(
     routeType: CallbackRouteType | null = null,
     route: (Route & { type?: CallbackRouteType }) | null,
     bodyInit: BodyInit | null,
-    responseInit: ResponseInitLike
+    responseInit: ResponseInitLike,
+    overrides?: ResponseOverrides
   ): Response {
     const originalStatus = responseInit.status;
     let callbackRoute: CallbackRoute;
@@ -220,20 +237,10 @@ export function createRequestHandler({
 
     let modifiedResponseInit = responseInit;
 
-    // Apply user-defined headers, if provided
-    if (manifest?.headers) {
-      for (const headerName in manifest.headers) {
-        if (Array.isArray(manifest.headers[headerName])) {
-          for (const headerValue of manifest.headers[headerName]) {
-            modifiedResponseInit.headers.append(headerName, headerValue);
-          }
-        } else if (
-          manifest.headers[headerName] != null &&
-          !modifiedResponseInit.headers.has(headerName)
-        ) {
-          modifiedResponseInit.headers.set(headerName, manifest.headers[headerName]);
-        }
-      }
+    // Headers already set on the response are never replaced (see `PageHeaderInfo` for the
+    // full precedence order)
+    if (overrides?.headers) {
+      appendHeadersRecord(modifiedResponseInit.headers, overrides.headers, false);
     }
 
     // Callback call order matters, general rule is to call more specific callbacks first.
@@ -264,7 +271,8 @@ export function createRequestHandler({
   function createResponseFrom(
     routeType: CallbackRouteType | null = null,
     route: (Route & { type?: CallbackRouteType }) | null,
-    response: Response
+    response: Response,
+    overrides?: ResponseOverrides
   ): Response {
     const modifiedResponseInit: ResponseInitLike = {
       headers: new Headers(response.headers),
@@ -274,20 +282,27 @@ export function createRequestHandler({
       cf: (response as Response & { cf?: unknown }).cf,
       webSocket: (response as Response & { webSocket?: unknown }).webSocket,
     };
-    return createResponse(routeType, route, response.body, modifiedResponseInit);
+    return createResponse(routeType, route, response.body, modifiedResponseInit, overrides);
   }
 
   async function respondNotFoundHTML(
     html: string | ReadableStream | Response | null,
-    route: Route
+    route: Route,
+    overrides?: ResponseOverrides
   ): Promise<Response> {
     if (typeof html === 'string') {
-      return createResponse('notFoundHtml', route, html, {
-        status: 404,
-        headers: new Headers({
-          'Content-Type': 'text/html',
-        }),
-      });
+      return createResponse(
+        'notFoundHtml',
+        route,
+        html,
+        {
+          status: 404,
+          headers: new Headers({
+            'Content-Type': 'text/html',
+          }),
+        },
+        overrides
+      );
     }
 
     if (isResponse(html)) {
@@ -296,18 +311,24 @@ export function createRequestHandler({
     }
 
     if (html != null) {
-      return createResponse('notFoundHtml', route, html, {
-        status: 404,
-        headers: new Headers({
-          'Content-Type': 'text/html',
-        }),
-      });
+      return createResponse(
+        'notFoundHtml',
+        route,
+        html,
+        {
+          status: 404,
+          headers: new Headers({
+            'Content-Type': 'text/html',
+          }),
+        },
+        overrides
+      );
     }
 
     throw new ExpoError(`HTML route file ${route.page}.html could not be loaded`);
   }
 
-  async function respondAPI(mod: any, request: Request, route: Route): Promise<Response> {
+  async function respondAPI(mod: any, request: Request, route: Route, overrides?: ResponseOverrides): Promise<Response> {
     if (!mod || typeof mod !== 'object') {
       throw new ExpoError(`API route module ${route.page} could not be loaded`);
     }
@@ -319,12 +340,18 @@ export function createRequestHandler({
 
     const handler = mod[request.method];
     if (!handler || typeof handler !== 'function') {
-      return createResponse('notAllowedApi', route, 'Method not allowed', {
-        status: 405,
-        headers: new Headers({
-          'Content-Type': 'text/plain',
-        }),
-      });
+      return createResponse(
+        'notAllowedApi',
+        route,
+        'Method not allowed',
+        {
+          status: 405,
+          headers: new Headers({
+            'Content-Type': 'text/plain',
+          }),
+        },
+        overrides
+      );
     }
 
     const params = parseParams(request, route);
@@ -335,17 +362,27 @@ export function createRequestHandler({
       );
     }
 
-    return createResponseFrom('api', route, response);
+    return createResponseFrom('api', route, response, overrides);
   }
 
-  function respondHTML(html: string | ReadableStream | Response | null, route: Route): Response {
+  function respondHTML(
+    html: string | ReadableStream | Response | null,
+    route: Route,
+    overrides?: ResponseOverrides
+  ): Response {
     if (typeof html === 'string') {
-      return createResponse('html', route, html, {
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'text/html',
-        }),
-      });
+      return createResponse(
+        'html',
+        route,
+        html,
+        {
+          status: 200,
+          headers: new Headers({
+            'Content-Type': 'text/html',
+          }),
+        },
+        overrides
+      );
     }
 
     if (isResponse(html)) {
@@ -354,12 +391,18 @@ export function createRequestHandler({
     }
 
     if (html != null) {
-      return createResponse('html', route, html, {
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'text/html',
-        }),
-      });
+      return createResponse(
+        'html',
+        route,
+        html,
+        {
+          status: 200,
+          headers: new Headers({
+            'Content-Type': 'text/html',
+          }),
+        },
+        overrides
+      );
     }
 
     throw new ExpoError(`HTML route file ${route.page}.html could not be loaded`);
@@ -381,5 +424,17 @@ export function createRequestHandler({
       status,
       headers: { Location: target },
     });
+  }
+
+  function resolveRouteHeaders(pathname: string): Record<string, string | string[]> {
+    const pageHeaderRules = (manifest?.pageHeaders ?? []).filter((rule) =>
+      rule.namedRegex.test(pathname)
+    );
+
+    let mergedHeaders = manifest?.headers ?? {};
+    for (const rule of pageHeaderRules) {
+      mergedHeaders = mergeHeaderInputs(mergedHeaders, rule.headers);
+    }
+    return mergedHeaders;
   }
 }

--- a/packages/expo-server/src/vendor/environment/common.ts
+++ b/packages/expo-server/src/vendor/environment/common.ts
@@ -31,6 +31,10 @@ function initManifestRegExp(manifest: RawManifest): Manifest {
         ...route,
         namedRegex: new RegExp(route.namedRegex),
       })) ?? [],
+    pageHeaders: manifest.pageHeaders?.map((rule) => ({
+      ...rule,
+      namedRegex: new RegExp(rule.namedRegex),
+    }))
   };
 }
 


### PR DESCRIPTION
# Why

Allow users to specify headers that only apply to specific paths via the `expo-router` config plugin options via a pattern similar to redirects/rewrites:

```js
{
  pageHeaders: [
    { 
      source: '/',
      headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } 
    },
  ]
}
```

The precedence order for header application is:

- Route-level (typically declared in `expo-server` to set the `Content-Type`)
- `pageHeaders` from the config plugin
- `headers` from the config plugin

If multiple `pageHeaders` rules are found for a path, then the last-declared rule will take precedence:

```js
{
  pageHeaders: [
    { 
      source: '/',
      headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } 
    },
    { 
      source: '/',
      headers: { 'X-Page-Rule': 'second'}  // For a request to `/`, the `X-Page-Rule` header will have the value `second`
    },
  ]
}
```

# How

- Added a new `pageHeaders` property to the `expo-router` config plugin options
- Thread the `pageHeaders` through to the export manifests for both SSG and SSR
- Make `expo-server` handle `pageHeaders` with the correct precedence order

# Test Plan

- Added unit tests to cover header merging precedence and behavior
- Added E2E tests to ensure headers are set correctly when served

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
