### PR TITLE
[cli] Support trusted dev server proxy CIDRs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
+- Support trusted reverse proxy CIDRs for native development server control endpoints. ([#47430](https://github.com/expo/expo/pull/47430) by [@kebr0m](https://github.com/kebr0m))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/__tests__/createDebugMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/__tests__/createDebugMiddleware.test.ts
@@ -1,0 +1,137 @@
+import type { NextHandleFunction } from 'connect';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import { WebSocketServer } from 'ws';
+
+import type { SocketRemoteFamily } from '../../../../../utils/net';
+import { createDebugMiddleware } from '../createDebugMiddleware';
+
+const devMiddleware = jest.fn<ReturnType<NextHandleFunction>, Parameters<NextHandleFunction>>(
+  (_req, _res, next) => next()
+);
+let debuggerWebsocketEndpoint: WebSocketServer;
+
+jest.mock('@react-native/dev-middleware', () => ({
+  createDevMiddleware: jest.fn(() => {
+    debuggerWebsocketEndpoint = new WebSocketServer({ noServer: true });
+
+    return {
+      middleware: devMiddleware,
+      websocketEndpoints: {
+        '/inspector/debug': debuggerWebsocketEndpoint,
+      },
+    };
+  }),
+}));
+
+function createSocket({
+  remoteAddress,
+  remoteFamily,
+}: {
+  remoteAddress: string;
+  remoteFamily: SocketRemoteFamily;
+}): Socket {
+  const socket = new Socket();
+  Object.defineProperty(socket, 'remoteAddress', { configurable: true, value: remoteAddress });
+  Object.defineProperty(socket, 'remoteFamily', { configurable: true, value: remoteFamily });
+  return socket;
+}
+
+function createRequest({
+  remoteAddress,
+  remoteFamily = 'IPv4',
+  origin,
+}: {
+  remoteAddress: string;
+  remoteFamily?: SocketRemoteFamily;
+  origin?: string;
+}): IncomingMessage {
+  const request = new IncomingMessage(createSocket({ remoteAddress, remoteFamily }));
+  if (origin) {
+    request.headers.origin = origin;
+  }
+  return request;
+}
+
+function createReporter() {
+  return {
+    update: jest.fn(),
+  };
+}
+
+function getDebuggerEndpoint(endpoints: Record<string, WebSocketServer>): WebSocketServer {
+  const endpoint = endpoints['/inspector/debug'];
+  if (!endpoint) {
+    throw new Error('Expected /inspector/debug websocket endpoint');
+  }
+  return endpoint;
+}
+
+describe(createDebugMiddleware, () => {
+  beforeEach(() => {
+    devMiddleware.mockClear();
+  });
+
+  it('skips React Native debug middleware for untrusted proxy sockets', () => {
+    const { debugMiddleware } = createDebugMiddleware({
+      serverBaseUrl: 'http://localhost:8081',
+      reporter: createReporter(),
+    });
+    const request = createRequest({ remoteAddress: '172.18.0.8' });
+    const response = new ServerResponse(request);
+    const next = jest.fn();
+
+    debugMiddleware(request, response, next);
+
+    expect(devMiddleware).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses React Native debug middleware for trusted proxy sockets', () => {
+    const { debugMiddleware } = createDebugMiddleware({
+      serverBaseUrl: 'http://localhost:8081',
+      reporter: createReporter(),
+      socketTrustOptions: { trustedProxyCIDRs: ['172.18.0.0/16'] },
+    });
+    const request = createRequest({ remoteAddress: '172.18.0.8' });
+    const response = new ServerResponse(request);
+    const next = jest.fn();
+
+    debugMiddleware(request, response, next);
+
+    expect(devMiddleware).toHaveBeenCalledWith(request, response, next);
+  });
+
+  it('terminates debugger websocket connections from untrusted proxy sockets', () => {
+    const { debugWebsocketEndpoints } = createDebugMiddleware({
+      serverBaseUrl: 'http://localhost:8081',
+      reporter: createReporter(),
+    });
+    const socket = { terminate: jest.fn() };
+    const request = createRequest({
+      remoteAddress: '172.18.0.8',
+      origin: 'http://localhost:8081',
+    });
+
+    getDebuggerEndpoint(debugWebsocketEndpoints).emit('connection', socket, request);
+
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps debugger websocket connections from trusted proxy sockets', () => {
+    const { debugWebsocketEndpoints } = createDebugMiddleware({
+      serverBaseUrl: 'http://localhost:8081',
+      reporter: createReporter(),
+      socketTrustOptions: { trustedProxyCIDRs: ['172.18.0.0/16'] },
+    });
+    const socket = { terminate: jest.fn() };
+    const request = createRequest({
+      remoteAddress: '172.18.0.8',
+      origin: 'http://localhost:8081',
+    });
+
+    getDebuggerEndpoint(debugWebsocketEndpoints).emit('connection', socket, request);
+
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,7 +2,11 @@ import type { NextHandleFunction } from 'connect';
 import { WebSocketServer } from 'ws';
 
 import { env, envIsHeadless } from '../../../../utils/env';
-import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
+import {
+  isMatchingOrigin,
+  isTrustedDevServerSocket,
+  type SocketTrustOptions,
+} from '../../../../utils/net';
 import type { TerminalReporter } from '../TerminalReporter';
 import { createHandlersFactory } from './createHandlersFactory';
 import { recordNetworkResponse } from './messageHandlers/NetworkResponse';
@@ -16,12 +20,14 @@ interface DebugMiddleware {
 
 interface DebugMiddlewareParams {
   serverBaseUrl: string;
-  reporter: TerminalReporter;
+  reporter: Pick<TerminalReporter, 'update'>;
+  socketTrustOptions?: SocketTrustOptions;
 }
 
 export function createDebugMiddleware({
   serverBaseUrl,
   reporter,
+  socketTrustOptions,
 }: DebugMiddlewareParams): DebugMiddleware {
   // Load the React Native debugging tools from project
   // TODO: check if this works with isolated modules
@@ -61,7 +67,10 @@ export function createDebugMiddleware({
 
   // Explicitly limit debugger websocket to loopback requests
   debuggerWebsocketEndpoint.on('connection', (socket, request) => {
-    if (!isLocalSocket(request.socket) || !isMatchingOrigin(request, serverBaseUrl)) {
+    if (
+      !isTrustedDevServerSocket(request.socket, socketTrustOptions) ||
+      !isMatchingOrigin(request, serverBaseUrl)
+    ) {
       // NOTE: `socket.close` nicely closes the websocket, which will still allow incoming messages
       // `socket.terminate` instead forcefully closes down the socket
       socket.terminate();
@@ -71,7 +80,7 @@ export function createDebugMiddleware({
   return {
     debugMiddleware(req, res, next) {
       // The debugger middleware is skipped entirely if the connection isn't a loopback request
-      if (isLocalSocket(req.socket)) {
+      if (isTrustedDevServerSocket(req.socket, socketTrustOptions)) {
         return middleware(req, res, next);
       } else {
         return next();
@@ -82,7 +91,7 @@ export function createDebugMiddleware({
 }
 
 function createLogger(
-  reporter: TerminalReporter
+  reporter: Pick<TerminalReporter, 'update'>
 ): Parameters<typeof import('@react-native/dev-middleware').createDevMiddleware>[0]['logger'] {
   return {
     info: makeLogger(reporter, 'info'),
@@ -91,7 +100,7 @@ function createLogger(
   };
 }
 
-function makeLogger(reporter: TerminalReporter, level: 'info' | 'warn' | 'error') {
+function makeLogger(reporter: Pick<TerminalReporter, 'update'>, level: 'info' | 'warn' | 'error') {
   return (...data: any[]) =>
     reporter.update({
       type: 'unstable_server_log',

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
@@ -230,6 +230,50 @@ describe(createMessagesSocket, () => {
   });
 });
 
+describe(`${createMessagesSocket} trusted proxy sockets`, () => {
+  const untrustedProxy = withMetroServer('/project', {
+    socketRemoteAddress: '172.18.0.8',
+  });
+  const trustedProxy = withMetroServer('/project', {
+    socketRemoteAddress: '172.18.0.8',
+    socketTrustOptions: { trustedProxyCIDRs: ['172.18.0.0/16'] },
+  });
+
+  it('drops client-originated broadcasts from untrusted proxy sockets', async () => {
+    const client1 = untrustedProxy.server.connect('/message');
+    const client2 = untrustedProxy.server.connect('/message');
+
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    const client2Listener = jest.fn();
+    client2.on('message', client2Listener);
+
+    client1.send(serializeMessage({ method: 'reload' }));
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(client2Listener).not.toHaveBeenCalled();
+  });
+
+  it('allows client-originated broadcasts from trusted proxy sockets', async () => {
+    const client1 = trustedProxy.server.connect('/message');
+    const client2 = trustedProxy.server.connect('/message');
+
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    const client2Listener = jest.fn();
+    client2.on('message', client2Listener);
+
+    const message = serializeMessage({ method: 'reload' });
+    client1.send(message);
+
+    await waitForExpect(() => {
+      expect(client2Listener).toHaveBeenCalled();
+      expect(client2Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(client2Listener.mock.calls[0][0].toString()).toBe(message);
+    });
+  });
+});
+
 async function requestClientId(client: WebSocket, testId = 'requestclientid') {
   // Send the `getid` server request
   client.send(serializeMessage({ id: testId, method: 'getid', target: 'server' }));

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
@@ -5,9 +5,18 @@ import { promisify } from 'node:util';
 import type { ClientOptions } from 'ws';
 import { WebSocket } from 'ws';
 
+import type { SocketTrustOptions } from '../../../../../utils/net';
 import { createMetroMiddleware } from '../createMetroMiddleware';
 
-export function withMetroServer(projectRoot = '/project'): {
+interface MetroServerTestOptions {
+  socketRemoteAddress?: string;
+  socketTrustOptions?: SocketTrustOptions;
+}
+
+export function withMetroServer(
+  projectRoot = '/project',
+  options: MetroServerTestOptions = {}
+): {
   projectRoot: string;
   metro: ReturnType<typeof createMetroMiddleware>;
   server: ReturnType<typeof createServer> & {
@@ -23,6 +32,7 @@ export function withMetroServer(projectRoot = '/project'): {
           ready: () => Promise.resolve(),
         }) as any,
       serverBaseUrl: 'http://localhost',
+      socketTrustOptions: options.socketTrustOptions,
     }
   );
 
@@ -41,6 +51,13 @@ export function withMetroServer(projectRoot = '/project'): {
 
   // Ensure the websockets can be tested
   server.on('upgrade', (request, socket, head) => {
+    if (options.socketRemoteAddress) {
+      Object.defineProperty(request.socket, 'remoteAddress', {
+        configurable: true,
+        value: options.socketRemoteAddress,
+      });
+    }
+
     const { pathname } = parse(request.url!);
     const endpoint =
       pathname != null

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -1,7 +1,11 @@
 import { parse } from 'node:url';
 import { type WebSocket, WebSocketServer, type RawData as WebSocketRawData } from 'ws';
 
-import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
+import {
+  isMatchingOrigin,
+  isTrustedDevServerSocket,
+  type SocketTrustOptions,
+} from '../../../../utils/net';
 import { createBroadcaster } from './utils/createSocketBroadcaster';
 import { createSocketMap, type SocketId } from './utils/createSocketMap';
 import { parseRawMessage, serializeMessage } from './utils/socketMessages';
@@ -11,6 +15,7 @@ type MessageSocketOptions = {
     warn: (message: string) => any;
   };
   serverBaseUrl: string;
+  socketTrustOptions?: SocketTrustOptions;
 };
 
 const debug = require('debug')('expo:metro:devserver:messageSocket') as typeof console.log;
@@ -30,7 +35,8 @@ export function createMessagesSocket(options: MessageSocketOptions) {
   server.on('connection', (socket, req) => {
     const client = clients.registerSocket(socket);
     const isTrustedClient =
-      isLocalSocket(req.socket) && isMatchingOrigin(req, options.serverBaseUrl);
+      isTrustedDevServerSocket(req.socket, options.socketTrustOptions) &&
+      isMatchingOrigin(req, options.serverBaseUrl);
 
     // Assign the query parameters to the socket, used for `getpeers` requests
     // NOTE(cedric): this looks like a legacy feature, might be able to drop it

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { Log } from '../../../../log';
 import { isPathInside } from '../../../../utils/dir';
 import { openInEditorAsync } from '../../../../utils/editor';
-import { shouldThrottleRemoteDevCall } from '../../../../utils/net';
+import { shouldThrottleRemoteDevCall, type SocketTrustOptions } from '../../../../utils/net';
 import { compression } from './compression';
 import { createEventsSocket } from './createEventSocket';
 import { createMessagesSocket } from './createMessageSocket';
@@ -17,6 +17,7 @@ import { createMessagesSocket } from './createMessageSocket';
 interface MetroMiddlewareOptions {
   getMetroBundler(): MetroBundler;
   serverBaseUrl: string;
+  socketTrustOptions?: SocketTrustOptions;
 }
 
 interface StackFrame {
@@ -28,7 +29,11 @@ export function createMetroMiddleware(
   metroConfig: Pick<MetroConfig, 'projectRoot'>,
   options: MetroMiddlewareOptions
 ) {
-  const messages = createMessagesSocket({ logger: Log, serverBaseUrl: options.serverBaseUrl });
+  const messages = createMessagesSocket({
+    logger: Log,
+    serverBaseUrl: options.serverBaseUrl,
+    socketTrustOptions: options.socketTrustOptions,
+  });
   const events = createEventsSocket(messages);
 
   const middleware = connect()

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -381,11 +381,15 @@ export async function instantiateMetroAsync(
   const serverBaseUrl = metroBundler
     .getUrlCreator()
     .constructUrl({ scheme: 'http', hostType: 'localhost' });
+  const trustedProxyCIDRs = env.EXPO_UNSTABLE_DEV_SERVER_TRUSTED_PROXY_CIDRS.split(',')
+    .map((cidr) => cidr.trim())
+    .filter(Boolean);
+  const socketTrustOptions = trustedProxyCIDRs.length > 0 ? { trustedProxyCIDRs } : undefined;
 
   // Create the core middleware stack for Metro, including websocket listeners
   const { middleware, messagesSocket, eventsSocket, websocketEndpoints } = createMetroMiddleware(
     metroConfig,
-    { getMetroBundler, serverBaseUrl }
+    { getMetroBundler, serverBaseUrl, socketTrustOptions }
   );
 
   if (!isExporting) {
@@ -396,6 +400,7 @@ export async function instantiateMetroAsync(
     const { debugMiddleware, debugWebsocketEndpoints } = createDebugMiddleware({
       serverBaseUrl,
       reporter,
+      socketTrustOptions,
     });
     Object.assign(websocketEndpoints, debugWebsocketEndpoints);
     middleware.use(debugMiddleware);

--- a/packages/@expo/cli/src/utils/__tests__/net-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/net-test.ts
@@ -1,37 +1,141 @@
-import { isLocalSocket as _isLocalSocket, isMatchingOrigin } from '../net';
+import { Socket } from 'node:net';
 
-const isLocalSocket = _isLocalSocket as (x: any) => boolean;
+import {
+  isLocalSocket,
+  isMatchingOrigin,
+  isTrustedDevServerSocket,
+  type SocketRemoteFamily,
+} from '../net';
+
+function createSocket({
+  localAddress,
+  remoteAddress,
+  remoteFamily,
+}: {
+  localAddress?: string;
+  remoteAddress?: string;
+  remoteFamily?: SocketRemoteFamily;
+}): Socket {
+  const socket = new Socket();
+  if (localAddress != null) {
+    Object.defineProperty(socket, 'localAddress', { configurable: true, value: localAddress });
+  }
+  if (remoteAddress != null) {
+    Object.defineProperty(socket, 'remoteAddress', { configurable: true, value: remoteAddress });
+  }
+  if (remoteFamily != null) {
+    Object.defineProperty(socket, 'remoteFamily', { configurable: true, value: remoteFamily });
+  }
+  return socket;
+}
 
 describe(isLocalSocket, () => {
   it('detects loopback sockets', () => {
-    expect(isLocalSocket({ localAddress: '127.0.0.1', remoteAddress: '127.0.0.1' })).toBe(true);
-    expect(isLocalSocket({ remoteFamily: 'IPv4', remoteAddress: '127.0.0.1' })).toBe(true);
-    expect(isLocalSocket({ remoteFamily: 'IPv6', remoteAddress: '::ffff:127.0.0.1' })).toBe(true);
-    expect(isLocalSocket({ remoteFamily: 'IPv6', remoteAddress: '::1' })).toBe(true);
-    expect(isLocalSocket({ localAddress: '::1', remoteAddress: '::1', remoteFamily: 'IPv6' })).toBe(
+    expect(
+      isLocalSocket(createSocket({ localAddress: '127.0.0.1', remoteAddress: '127.0.0.1' }))
+    ).toBe(true);
+    expect(isLocalSocket(createSocket({ remoteAddress: '127.0.0.1', remoteFamily: 'IPv4' }))).toBe(
       true
     );
+    expect(isLocalSocket(createSocket({ localAddress: '::1', remoteAddress: '::1' }))).toBe(true);
     expect(
-      isLocalSocket({ localAddress: '::ffff:127.0.0.1', remoteAddress: '::ffff:127.0.0.1' })
+      isLocalSocket(createSocket({ remoteAddress: '::ffff:127.0.0.1', remoteFamily: 'IPv6' }))
     ).toBe(true);
+    expect(isLocalSocket(createSocket({ remoteAddress: '::1', remoteFamily: 'IPv6' }))).toBe(true);
     expect(
-      isLocalSocket({ localAddress: '::ffff:127.0.0.1', remoteAddress: '::ffff:127.0.0.1' })
+      isLocalSocket(
+        createSocket({
+          localAddress: '::ffff:127.0.0.1',
+          remoteAddress: '::ffff:127.0.0.1',
+        })
+      )
     ).toBe(true);
   });
 
   it('rejects other connections', () => {
     expect(
-      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '10.0.0.2' })
+      isLocalSocket(
+        createSocket({
+          localAddress: '127.0.0.1',
+          remoteAddress: '10.0.0.2',
+          remoteFamily: 'IPv4',
+        })
+      )
     ).toBe(false);
     expect(
-      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '100.0.0.1' })
+      isLocalSocket(
+        createSocket({
+          localAddress: '127.0.0.1',
+          remoteAddress: '100.0.0.1',
+          remoteFamily: 'IPv4',
+        })
+      )
     ).toBe(false);
     expect(
-      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '1.1.1.1' })
+      isLocalSocket(
+        createSocket({
+          localAddress: '127.0.0.1',
+          remoteAddress: '1.1.1.1',
+          remoteFamily: 'IPv4',
+        })
+      )
     ).toBe(false);
-    expect(isLocalSocket({ remoteFamily: 'IPv4', localAddress: '::1', remoteAddress: '::2' })).toBe(
-      false
+    expect(
+      isLocalSocket(createSocket({ localAddress: '::1', remoteAddress: '::2', remoteFamily: 'IPv6' }))
+    ).toBe(false);
+  });
+});
+
+describe(isTrustedDevServerSocket, () => {
+  it('detects loopback sockets without trusted proxy CIDRs', () => {
+    expect(isTrustedDevServerSocket(createSocket({ remoteAddress: '127.0.0.1', remoteFamily: 'IPv4' }))).toBe(
+      true
     );
+  });
+
+  it('detects trusted proxy sockets by IPv4 CIDR', () => {
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: '172.18.0.8' }),
+        { trustedProxyCIDRs: ['172.18.0.0/16'] }
+      )
+    ).toBe(true);
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: '::ffff:172.18.0.8' }),
+        { trustedProxyCIDRs: ['172.18.0.0/16'] }
+      )
+    ).toBe(true);
+  });
+
+  it('detects trusted proxy sockets by IPv6 CIDR', () => {
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: 'fd00::8' }),
+        { trustedProxyCIDRs: ['fd00::/8'] }
+      )
+    ).toBe(true);
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: 'fd01::8' }),
+        { trustedProxyCIDRs: ['fd00::/16'] }
+      )
+    ).toBe(false);
+  });
+
+  it('rejects untrusted and malformed proxy CIDRs', () => {
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: '172.19.0.8' }),
+        { trustedProxyCIDRs: ['172.18.0.0/16'] }
+      )
+    ).toBe(false);
+    expect(
+      isTrustedDevServerSocket(
+        createSocket({ remoteAddress: '172.18.0.8' }),
+        { trustedProxyCIDRs: ['not-a-cidr'] }
+      )
+    ).toBe(false);
   });
 });
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -328,6 +328,15 @@ class Env {
     return boolish('EXPO_UNSTABLE_BONJOUR', !envIsHeadless());
   }
 
+  /**
+   * Trust reverse proxy socket addresses for native development control endpoints.
+   * This enables React Native debugging endpoints when the dev server is intentionally
+   * reached through a local proxy. Values are comma-separated IPv4 or IPv6 CIDRs.
+   */
+  get EXPO_UNSTABLE_DEV_SERVER_TRUSTED_PROXY_CIDRS(): string {
+    return getOriginalEnvValue('EXPO_UNSTABLE_DEV_SERVER_TRUSTED_PROXY_CIDRS') || '';
+  }
+
   /** @internal Configure other environment variables for headless operations */
   get EXPO_UNSTABLE_HEADLESS() {
     return boolish('EXPO_UNSTABLE_HEADLESS', envIsWebcontainer());

--- a/packages/@expo/cli/src/utils/net.ts
+++ b/packages/@expo/cli/src/utils/net.ts
@@ -1,7 +1,13 @@
 import type { IncomingHttpHeaders } from 'node:http';
-import type { Socket } from 'node:net';
+import { BlockList, isIP, type Socket } from 'node:net';
 
 const ipv6To4Prefix = '::ffff:';
+
+export type SocketRemoteFamily = 'IPv4' | 'IPv6';
+
+export interface SocketTrustOptions {
+  trustedProxyCIDRs?: readonly string[];
+}
 
 export const isLocalSocket = (socket: Socket): boolean => {
   let { localAddress, remoteAddress, remoteFamily } = socket;
@@ -19,6 +25,61 @@ export const isLocalSocket = (socket: Socket): boolean => {
 
   return remoteAddress === '::1' || remoteAddress.startsWith('127.');
 };
+
+export const isTrustedDevServerSocket = (
+  socket: Socket,
+  options: SocketTrustOptions = {}
+): boolean => {
+  return isLocalSocket(socket) || isTrustedProxySocket(socket, options);
+};
+
+function isTrustedProxySocket(socket: Socket, options: SocketTrustOptions): boolean {
+  if (!socket.remoteAddress || !options.trustedProxyCIDRs?.length) {
+    return false;
+  }
+
+  const blockList = createTrustedProxyBlockList(options.trustedProxyCIDRs);
+  if (!blockList) {
+    return false;
+  }
+
+  const ipVersion = isIP(socket.remoteAddress);
+  if (ipVersion === 0) {
+    return false;
+  }
+
+  try {
+    return blockList.check(socket.remoteAddress, ipVersion === 4 ? 'ipv4' : 'ipv6');
+  } catch {
+    return false;
+  }
+}
+
+function createTrustedProxyBlockList(cidrs: readonly string[]): BlockList | null {
+  const blockList = new BlockList();
+  let hasValidCIDR = false;
+
+  for (const cidr of cidrs) {
+    const [address, prefixLengthString] = cidr.trim().split('/');
+    const prefixLength = Number(prefixLengthString);
+    const ipVersion = isIP(address ?? '');
+
+    if (
+      !address ||
+      !Number.isInteger(prefixLength) ||
+      ipVersion === 0 ||
+      prefixLength < 0 ||
+      prefixLength > (ipVersion === 4 ? 32 : 128)
+    ) {
+      continue;
+    }
+
+    blockList.addSubnet(address, prefixLength, ipVersion === 4 ? 'ipv4' : 'ipv6');
+    hasValidCIDR = true;
+  }
+
+  return hasValidCIDR ? blockList : null;
+}
 
 interface AbstractIncomingMessage {
   headers: IncomingHttpHeaders | Record<string, string | string[]>;


### PR DESCRIPTION
## Summary

Adds an unstable `EXPO_UNSTABLE_DEV_SERVER_TRUSTED_PROXY_CIDRS` option for native development server control endpoints when an Expo development server is intentionally accessed through a trusted reverse proxy.

Today, several native development endpoints rely on `isLocalSocket(req.socket)` so React Native debugger middleware, `/inspector/debug`, and trusted `/message` broadcasts only work when the TCP peer is loopback. That is a good default, but it means custom-domain development setups that terminate through a local reverse proxy can serve the bundle while still losing parts of the native dev control plane because the final peer address is the proxy instead of `127.0.0.1`.

This is intended for local development setups where the proxy address range is controlled by the developer, such as a local reverse proxy or container bridge network.

This keeps `isLocalSocket()` local-only and adds a separate trusted-dev-server socket check for the specific native dev-server surfaces that need proxy awareness:

- `/message` trusted client broadcasts
- React Native debug middleware
- `/inspector/debug` websocket gating

CIDR matching uses Node's native `BlockList`, supporting IPv4 and IPv6 CIDRs. Same-device-only surfaces that still call `isLocalSocket()` directly, such as `POST /_expo/open`, remain loopback-only.

## Tests Added

The new tests cover both the network utility boundary and the dev-server call sites that opt into trusted proxy handling:

- `isLocalSocket()` remains loopback-only.
- `isTrustedDevServerSocket()` accepts configured IPv4 and IPv6 proxy CIDRs and rejects malformed or untrusted CIDRs.
- `/message` still drops privileged client broadcasts from untrusted proxy sockets and allows them only when the proxy CIDR is trusted.
- React Native debug middleware and `/inspector/debug` websocket gating follow the same trusted-proxy behavior.

## Test Plan

Fully bootstrapped the workspace with:

```bash
pnpm install
```

Then ran the package check required by the contributing guide:

```bash
et check-packages @expo/cli
```
