### PR TITLE
[brownfield] fix flaky cli e2e

### DIFF
--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -133,7 +133,7 @@ describe('tasks:android command', () => {
       TEMP_DIR_PREBUILD = await createTempProject('tasksandroidpb', true);
       // Run once to warm up Gradle — the first run downloads all dependencies and is slow.
       await tasksAndroidTest({ directory: TEMP_DIR_PREBUILD });
-    }, 1800000);
+    }, 3600000);
 
     afterAll(async () => {
       await cleanUpProject('tasksandroidpb');

--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -131,6 +131,8 @@ describe('tasks:android command', () => {
   describe('with prebuild', () => {
     beforeAll(async () => {
       TEMP_DIR_PREBUILD = await createTempProject('tasksandroidpb', true);
+      // Run once to warm up Gradle — the first run downloads all dependencies and is slow.
+      await tasksAndroidTest({ directory: TEMP_DIR_PREBUILD });
     }, 1800000);
 
     afterAll(async () => {

--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -131,7 +131,7 @@ describe('tasks:android command', () => {
   describe('with prebuild', () => {
     beforeAll(async () => {
       TEMP_DIR_PREBUILD = await createTempProject('tasksandroidpb', true);
-    }, 600000);
+    }, 1800000);
 
     afterAll(async () => {
       await cleanUpProject('tasksandroidpb');

--- a/packages/expo-brownfield/e2e/scripts/global-setup.js
+++ b/packages/expo-brownfield/e2e/scripts/global-setup.js
@@ -1,6 +1,17 @@
 const { execSync } = require('child_process');
+const spawnAsync = require('@expo/spawn-async');
+const { glob } = require('glob');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEMPLATE_DIR = path.resolve(__dirname, '../../../../templates/expo-template-default');
 
 module.exports = async () => {
   console.log('\nRunning pre-test commands...\n');
   execSync('pnpm run --filter create-expo build:prod', { stdio: 'inherit' });
+
+  // Prepare the template tarball once, before Jest forks its parallel workers.
+  const staleTarballs = await glob('*.tgz', { cwd: TEMPLATE_DIR, absolute: true });
+  await Promise.all(staleTarballs.map((tarball) => fs.promises.rm(tarball, { force: true })));
+  await spawnAsync('pnpm', ['pack'], { cwd: TEMPLATE_DIR, stdio: 'inherit' });
 };

--- a/packages/expo-brownfield/e2e/utils/process.ts
+++ b/packages/expo-brownfield/e2e/utils/process.ts
@@ -1,4 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 export const CLI_PATH = require.resolve('../../bin/cli.js');
 export const CREATE_EXPO_BIN = require.resolve('create-expo/bin/create-expo.js');
@@ -67,10 +70,13 @@ export const executeCreateExpoCLIAsync = async (
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
+  // Isolate create-expo's tmpdir template cache because `create-expo --template` doesn't support parallel work
+  const cacheDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'create-expo-cache-'));
   try {
     const { stdout, stderr, status } = await spawnAsync(CREATE_EXPO_BIN, args, {
       cwd,
       stdio: 'pipe',
+      env: { ...process.env, TMPDIR: cacheDir, TMP: cacheDir, TEMP: cacheDir },
     });
 
     return processOutput({ stdout, stderr, status });
@@ -82,6 +88,8 @@ export const executeCreateExpoCLIAsync = async (
 
     const { stdout, stderr, status } = error;
     return processOutput({ stdout, stderr, status });
+  } finally {
+    await fs.promises.rm(cacheDir, { recursive: true, force: true });
   }
 };
 

--- a/packages/expo-brownfield/e2e/utils/project.ts
+++ b/packages/expo-brownfield/e2e/utils/project.ts
@@ -4,12 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
-import {
-  executeCommandAsync,
-  executeCreateExpoCLIAsync,
-  executeExpoCLIAsync,
-  sleep,
-} from './process';
+import { executeCreateExpoCLIAsync, executeExpoCLIAsync, sleep } from './process';
 import type { PluginProps, TemplateEntry } from './types';
 
 const PROJECT_NAME = 'testapp';
@@ -117,13 +112,9 @@ const createProjectWithTemplate = async (at: string, projectName: string) => {
     throw new Error(`Template directory not found at: ${templatePath}`);
   }
 
-  let tarballs = await glob('*.tgz', { cwd: templatePath });
+  const tarballs = await glob('*.tgz', { cwd: templatePath });
   if (tarballs.length === 0) {
-    await executeCommandAsync(templatePath, 'pnpm', ['pack', '--json']);
-    tarballs = await glob('*.tgz', { cwd: templatePath });
-    if (tarballs.length === 0) {
-      throw new Error(`No tarballs found in template directory: ${templatePath}`);
-    }
+    throw new Error(`No template tarball found in ${templatePath}.`);
   }
 
   await executeCreateExpoCLIAsync(at, [


### PR DESCRIPTION
# Why

fix ci error: https://github.com/expo/expo/actions/runs/28534088001/job/84590855603

# How

fix flaky parallel e2e from jest

# Test Plan

brownfield e2e ci passed

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - no user faced changes
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
