### PR TITLE
[image-manipulator][ios] Fix crash when passing a shared image ref to manipulate()

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix native crash when passing a shared image ref (e.g. `expo-video`'s `VideoThumbnail`) to `ImageManipulator.manipulate()`. ([#47432](https://github.com/expo/expo/pull/47432) by [@janicduplessis](https://github.com/janicduplessis))
+
 ### 💡 Others
 
 ## 56.0.15 — 2026-05-26

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -10,7 +10,10 @@ public class ImageManipulatorModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoImageManipulator")
 
-    Function("manipulate") { (source: Either<URL, SharedRef<UIImage>>) -> ImageManipulatorContext in
+    // SharedRef is probed before URL: Either casts branches in declaration order, and probing
+    // a shared object against URL converts it through the asserting getAny(), which fatals on
+    // instances with function-valued properties (e.g. expo-video's VideoThumbnail).
+    Function("manipulate") { (source: Either<SharedRef<UIImage>, URL>) -> ImageManipulatorContext in
       let context = ImageManipulatorContext { [weak appContext] in
         guard let appContext else {
           throw Exceptions.AppContextLost()


### PR DESCRIPTION
# Why

Passing a shared image ref to `ImageManipulator.manipulate()` hard-crashes the app on iOS with a Swift `fatalError` (`EXC_BREAKPOINT`, uncatchable from JS). The documented interop of using an `expo-video` `VideoThumbnail` (which is a `SharedRef<UIImage>`) as the manipulator source triggers it reliably:

```ts
const [thumbnail] = await player.generateThumbnailsAsync(times);
const context = ImageManipulator.manipulate(thumbnail); // 💥 native crash
```

Crash stack (SDK 56, iOS simulator):

```
libswiftCore.dylib   _assertionFailure
ExpoModulesJSI       JavaScriptValue.getAny()
ExpoModulesJSI       JavaScriptValue.getAny()
...                  DynamicConvertibleType.cast(jsValue:appContext:)
...                  DynamicEitherType.cast(jsValue:appContext:)
...                  SyncFunctionDefinition.runBody
```

Root cause: `manipulate` takes `Either<URL, SharedRef<UIImage>>`, and `DynamicEitherType.cast` probes the branches in declaration order under `try?`, expecting failures to throw. The `URL` branch (`DynamicConvertibleType.cast`) converts the JS value via the asserting `getAny()`, whose recursive property walk hits `FatalError.unimplemented()` on function-valued properties of the shared-object instance — a trap `try?` cannot catch — so the process dies before the `SharedRef` branch is ever tried.

# How

Swap the `Either` order to `Either<SharedRef<UIImage>, URL>` so shared objects match the first branch directly, never reaching `getAny()`. String/URL sources fail the `SharedRef` probe with a catchable `NativeSharedObjectNotFoundException` (`DynamicSharedObjectType.cast` only throws, never traps) and fall through to the `URL` branch exactly as before, so existing callers — including `manipulateAsync(uri)` — are unchanged. The function body needs no changes since `source.get()` is typed.

This is the minimal targeted fix; the underlying issue (an `Either` probe path that can trap instead of throw via the deprecated `getAny()` in `DynamicConvertibleType.cast`) may be worth a follow-up in `expo-modules-core` / `expo-modules-jsi`, and Android's `EitherOfThree<Uri, ...>` has the same ordering pattern should the Kotlin converter be affected.

# Test Plan

- Reproduced the crash in a real app (SDK 56, iOS simulator): a video-attachment flow generating a poster via `manipulate(videoThumbnail)` crashed with the stack above.
- With this change: the same flow resizes and renders the thumbnail correctly (`resize` → `renderAsync` → `saveAsync`), no crash.
- Regression-checked the string/URI path: image resize on upload through the same module (the `manipulateAsync(uri)`-style path) keeps working.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
