### PR TITLE
[store-review][android] Fix requestReview crash when no current Activity is available

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `requestReview` crashing when no `Activity` is available. ([#47436](https://github.com/expo/expo/pull/47436) by [@gursheyss](https://github.com/gursheyss))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewExceptions.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewExceptions.kt
@@ -7,3 +7,6 @@ internal class RMTaskException :
 
 internal class RMUnsuccessfulTaskException :
   CodedException("Android ReviewManager task was not successful")
+
+internal class RMMissingActivityException :
+  CodedException("Android ReviewManager cannot launch without a current Activity")

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -34,7 +34,9 @@ class StoreReviewModule : Module() {
       if (task.isSuccessful) {
         val reviewInfo = task.result
         reviewInfo?.let {
-          val flow = manager.launchReviewFlow(appContext.throwingActivity, it)
+          val activity = appContext.currentActivity
+            ?: return@addOnCompleteListener promise.reject(RMMissingActivityException())
+          val flow = manager.launchReviewFlow(activity, it)
           flow.addOnCompleteListener { result ->
             if (result.isSuccessful) {
               promise.resolve(null)


### PR DESCRIPTION
# Why

`StoreReview.requestReview()` on Android calls `manager.launchReviewFlow(appContext.throwingActivity, it)` inside the `requestReviewFlow` completion listener. The listener fires asynchronously, so if the app was backgrounded (or the Activity was otherwise destroyed) between the JS call and the completion callback, `throwingActivity` throws `Exceptions.MissingActivity` and the promise is rejected with a crash-like generic error. We see this in production via Sentry whenever a review prompt races an app background.

# How

Resolve the Activity with `appContext.currentActivity` in the completion listener and reject the promise with a typed `RMMissingActivityException` ("Android ReviewManager cannot launch without a current Activity") when it is gone, instead of throwing. This matches how the surrounding code already reports `RMTaskException`/`RMUnsuccessfulTaskException` as coded promise rejections.

# Test Plan

- Patched the identical change into our production app (Expo SDK 56 and 57) via a pnpm patch; the `MissingActivity` crash reports stopped while review prompts continue to work when the Activity is present.
- Call `StoreReview.requestReview()` and immediately background the app: the promise now rejects with `RMMissingActivityException` instead of throwing `Exceptions.MissingActivity`.

# Checklist

- [x] Documentation is up to date to reflect these changes (no docs changes needed — error behavior only).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).