### PR TITLE
[tools][android] Remove Prettier from the publish flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lint-staged": "^17.0.8",
     "oxfmt": "^0.55.0",
     "oxlint": "^1.70.0",
-    "prettier": "~3.8.3",
     "ts-node": "^10.9.2",
     "turbo": "2.10.0",
     "typescript": "^6.0.2"

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### 💡 Others
 
+- [Android] `expoPublish` no longer shells out to `pnpm prettier` after updating `expo-module.config.json`, so it works regardless of the package manager and without prettier installed. ([#47438](https://github.com/expo/expo/pull/47438) by [@hassankhan](https://github.com/hassankhan))
 - Allow `react-native-worklets` `^0.9.0` in peer dependencies. ([#46950](https://github.com/expo/expo/pull/46950) by [@zoontek](https://github.com/zoontek))
 - [Android] Make `expo-module-gradle-plugin` compatible with Android Gradle Plugin 9. ([#46769](https://github.com/expo/expo/pull/46769) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added `JavaScriptDecodable` / `JavaScriptEncodable` (composed as `JavaScriptCodable`), a statically-dispatched, non-erasing conversion path between JavaScript and native values for Expo Modules v2, with conformances for primitives, containers, records, enumerables and `Data`. ([#46893](https://github.com/expo/expo/pull/46893) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -200,12 +200,7 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, expoModule
 
   logger.quiet("Updating 'expo-module.config.json' in ${expoModuleConfig.parent}")
 
-  expoModuleConfig.writeText(newJsonString)
-  providers.exec { env ->
-    env.workingDir(layout.projectDirectory.file(".."))
-    // TODO(@lukmccall): support other package managers
-    env.commandLine("pnpm", "prettier", "--write", "expo-module.config.json")
-  }.result.get()
+  expoModuleConfig.writeText(newJsonString + "\n")
 }
 
 private fun Project.validateProjectConfiguration(expoModulesExtension: ExpoModuleExtension) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       oxlint:
         specifier: ^1.70.0
         version: 1.70.0
-      prettier:
-        specifier: ~3.8.3
-        version: 3.8.3
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -5,13 +5,13 @@ import { glob } from 'glob';
 import inquirer from 'inquirer';
 import path from 'path';
 
-import { ensureBareExpoDependencies } from './ensureBareExpoDependencies';
-import { updateAndroidProjects } from './updateAndroidProjects';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { ExpoModuleConfig, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import type { CommandOptions, Parcel, TaskArgs } from '../types';
+import { ensureBareExpoDependencies } from './ensureBareExpoDependencies';
+import { updateAndroidProjects } from './updateAndroidProjects';
 
 const EXCLUDE = ['expo-module-template'];
 
@@ -199,10 +199,7 @@ async function removeExistingPublications(pkg: Package) {
 
   const stringifyConfig = JSON.stringify(pkg.expoModuleConfig, null, 2);
 
-  await fs.writeFile(pkg.expoModulesConfigPath, stringifyConfig, 'utf-8');
-  return spawnAsync('pnpm', ['prettier', '--write', pkg.expoModulesConfigPath], {
-    cwd: pkg.path,
-  });
+  await fs.writeFile(pkg.expoModulesConfigPath, stringifyConfig + '\n', 'utf-8');
 }
 
 /**


### PR DESCRIPTION
# Why

Follow-up to #47326. 

The nightly Publish Canaries workflow broke because the Android publish flow shells out to `pnpm prettier --write expo-module.config.json`, which only resolves when `prettier` is hoisted to the workspace root. #47326 fixed it by re-adding `prettier` as a root dev dependency, but that keeps the publish flow coupled to a formatter the repo no longer uses (we migrated to oxfmt).

# How

- `tools/src/publish-packages/tasks/publishAndroidPackages.ts`: dropped the `pnpm prettier --write` spawn after writing `expo-module.config.json`. The file is already written with `JSON.stringify(config, null, 2)`; the only thing prettier added was a trailing newline, which is now appended directly.
- `expo-module-gradle-plugin` (`MavenPublicationExtension.kt`): dropped the `providers.exec` prettier call after `expoPublish` rewrites `expo-module.config.json`. The JSON is already pretty-printed by kotlinx-serialization with 2-space indent; a trailing newline is appended directly.
- Removed `prettier` from the root `package.json` again. The `prettier` dev dependency in `tools/package.json` remains since `eslint-config-universe/flat/node` runs `eslint-plugin-prettier`, which needs it for `tools/` linting.

# Test Plan

- `tools`: `pnpm build` and `pnpm test` pass (309 tests), `pnpm lint` clean on the changed file.
- Gradle plugin: `./gradlew :expo-module-gradle-plugin:compileKotlin` succeeds from `apps/bare-expo/android`.
- Verified these were the only two `prettier` invocations in the publish flow (`grep` across `tools/`, `packages/**/*.{kt,gradle,kts}`, and workflows).
- No automated test covers `removeExistingPublications`/`expoPublishBody` (they are fs/Gradle glue without an existing harness); the nightly Publish Canaries run will exercise the full path.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).