### PR TITLE
[SDK-57] fix(jest-preset): Bump peer to `@react-native/jest-preset@^0.86.0`

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix incorrect peer dependency range on `@react-native/jest-preset` ([#47440](https://github.com/expo/expo/pull/47440) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 57.0.0 — 2026-06-25

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "expo": "*",
     "react-native": "*",
-    "@react-native/jest-preset": "^0.85.0",
+    "@react-native/jest-preset": "^0.86.0",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
# Why

Resolves #47435

This seems to be missing from the 0.86 bump on `sdk-57`

# How

- Bump peer to `@react-native/jest-preset@^0.86.0`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
