### PR TITLE
fix(require-utils): Detect unreducable module syntax and evaluate as ESM

### DIFF
--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### 🐛 Bug fixes
 
+- Automatically switch to ESM mode when evaluated module contains non-qualifying module syntax, like `import.meta` or top-level await ([#47441](https://github.com/expo/expo/pull/47441) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
+
+- Annotate more top-level errors when evaluating modules ([#47441](https://github.com/expo/expo/pull/47441) by [@kitten](https://github.com/kitten))
 
 ## 56.1.3 — 2026-05-23
 

--- a/packages/@expo/require-utils/src/__tests__/codeframe-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/codeframe-test.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import url from 'node:url';
+
+import { annotateError } from '../codeframe';
+
+const filename = path.join(__dirname, 'fixtures', 'eval.js');
+const fileHref = url.pathToFileURL(filename).href;
+const code = ['const value = undefined;', 'value.missingMethod();', ''].join('\n');
+
+function errorWithStack(name: string, message: string, frames: string[]) {
+  const error = new Error(message);
+  error.name = name;
+  error.stack = [`${name}: ${message}`, ...frames.map((frame) => `    at ${frame}`)].join('\n');
+  return error;
+}
+
+describe('annotateError', () => {
+  it('annotates a TypeError whose top frame matches the module', () => {
+    const error = errorWithStack(
+      'TypeError',
+      "Cannot read properties of undefined (reading 'missingMethod')",
+      [`${fileHref}:2:7`, 'Module._compile (node:internal/modules/cjs/loader:1234:14)']
+    );
+
+    const result = annotateError(code, filename, error) as (Error & { codeFrame: string }) | null;
+    expect(result).toBe(error);
+    expect(typeof result?.codeFrame).toBe('string');
+    expect(result?.codeFrame).toContain('missingMethod');
+    expect(result?.message).toContain('missingMethod');
+  });
+
+  it('does not annotate when the top frame is a different file', () => {
+    const otherHref = url.pathToFileURL(path.join(__dirname, 'fixtures', 'other.js')).href;
+    const error = errorWithStack('TypeError', 'boom', [`${otherHref}:1:1`, `${fileHref}:2:7`]);
+
+    expect(annotateError(code, filename, error)).toBeNull();
+  });
+
+  it('returns null for a non-Error thrown value without crashing', () => {
+    expect(annotateError(code, filename, { code: 'CUSTOM_THROW' } as any)).toBeNull();
+  });
+});

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -110,4 +110,15 @@ describe('evalModule', () => {
 
     expect(mod).toBe('import.meta.dirname');
   });
+
+  it('rethrows a non-Error thrown value without crashing the annotator', () => {
+    let caught: any;
+    try {
+      evalModule(`throw { code: 'CUSTOM_THROW' };`, path.join(basepath, 'eval.js'));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toEqual({ code: 'CUSTOM_THROW' });
+  });
 });

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -76,4 +76,38 @@ describe('evalModule', () => {
       default: 'test',
     });
   });
+
+  it('evaluates .js using import.meta as ESM instead of CommonJS', () => {
+    const mod = evalModule(
+      `
+      export const dir = import.meta.dirname;
+      export default dir;
+    `,
+      path.join(basepath, 'eval.js')
+    );
+
+    expect(mod.dir).toBe(basepath);
+    expect(mod.default).toBe(basepath);
+  });
+
+  it('evaluates .ts using import.meta as ESM instead of CommonJS', () => {
+    const mod = evalModule(
+      `
+      const dir: string = import.meta.dirname;
+      export default dir;
+    `,
+      path.join(basepath, 'eval.ts')
+    );
+
+    expect(mod.default).toBe(basepath);
+  });
+
+  it('does not treat import.meta inside a string literal as ESM', () => {
+    const mod = evalModule(
+      `module.exports = 'import.meta.dirname';`,
+      path.join(basepath, 'eval.js')
+    );
+
+    expect(mod).toBe('import.meta.dirname');
+  });
 });

--- a/packages/@expo/require-utils/src/codeframe.ts
+++ b/packages/@expo/require-utils/src/codeframe.ts
@@ -2,9 +2,8 @@ import url from 'node:url';
 import type { Diagnostic } from 'typescript';
 
 function errorToLoc(filename: string, error: Error) {
-  if (error.name === 'ReferenceError' || error.name === 'SyntaxError') {
-    let stack = `${error.stack || ''}`;
-    stack = stack.slice(error.name.length + 2 /* '${name}: ' prefix */);
+  if (typeof error.name === 'string' && typeof error.stack === 'string') {
+    let stack = error.stack.slice(error.name.length + 2 /* '${name}: ' prefix */);
     stack = stack.slice(error.message.length);
     const trace = stack.match(/at ([^\n]+):(\d+):(\d+)/m);
     if (url.pathToFileURL(filename).href === trace?.[1]) {

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -63,26 +63,42 @@ function maybeReadFileSync(filename: string) {
   }
 }
 
-type Format = 'commonjs' | 'module' | 'module-typescript' | 'commonjs-typescript' | 'typescript';
+interface Format {
+  mode:
+    | 'commonjs'
+    | 'module'
+    | 'module-typescript'
+    | 'commonjs-typescript'
+    | 'typescript'
+    | undefined;
+  legacy: boolean;
+}
 
-function toFormat(filename: string, isLegacy: true): Format;
-function toFormat(filename: string, isLegacy: false): Format | null;
-function toFormat(filename: string, isLegacy: boolean): Format | null {
+function toFormat(filename: string, isLegacy: boolean): Format {
+  let mode:
+    | 'commonjs'
+    | 'module'
+    | 'module-typescript'
+    | 'commonjs-typescript'
+    | 'typescript'
+    | undefined;
+  let legacy = false;
   if (filename.endsWith('.cjs')) {
-    return 'commonjs';
+    mode = 'commonjs';
   } else if (filename.endsWith('.mjs')) {
-    return 'module';
+    mode = 'module';
   } else if (filename.endsWith('.js')) {
-    return isLegacy ? 'commonjs' : null;
+    legacy = isLegacy;
+    mode = isLegacy ? 'commonjs' : undefined;
   } else if (filename.endsWith('.mts')) {
-    return 'module-typescript';
+    mode = 'module-typescript';
   } else if (filename.endsWith('.cts')) {
-    return 'commonjs-typescript';
+    mode = 'commonjs-typescript';
   } else if (filename.endsWith('.ts')) {
-    return isLegacy ? 'commonjs-typescript' : 'typescript';
-  } else {
-    return null;
+    legacy = isLegacy;
+    mode = isLegacy ? 'commonjs-typescript' : 'typescript';
   }
+  return { mode, legacy };
 }
 
 export interface ModuleOptions {
@@ -214,7 +230,7 @@ function compileModule(code: string, filename: string, opts: ModuleOptions) {
   }
 
   try {
-    mod._compile(inputCode, compileFilename, format != null ? format : undefined);
+    mod._compile(inputCode, compileFilename, format.mode);
     mod.loaded = true;
     if (shouldCache) {
       require.cache[compileFilename] = mod;
@@ -259,17 +275,17 @@ function evalModule(
   let inputFilename = filename;
   let diagnostic: ts.Diagnostic | undefined;
   if (
-    format === 'typescript' ||
-    format === 'module-typescript' ||
-    format === 'commonjs-typescript'
+    format.mode === 'typescript' ||
+    format.mode === 'module-typescript' ||
+    format.mode === 'commonjs-typescript'
   ) {
     const ts = loadTypescript();
 
     if (ts) {
       let module: ts.ModuleKind;
-      if (format === 'commonjs-typescript') {
+      if (format.mode === 'commonjs-typescript') {
         module = ts.ModuleKind.CommonJS;
-      } else if (format === 'module-typescript') {
+      } else if (format.mode === 'module-typescript') {
         module = ts.ModuleKind.ESNext;
       } else {
         // NOTE(@kitten): We can "preserve" the output, meaning, it can either be ESM or CJS
@@ -313,7 +329,7 @@ function evalModule(
         inputFilename = path.join(path.dirname(filename), path.basename(filename, ext) + inputExt);
       }
     }
-  } else if (format === 'commonjs') {
+  } else if (format.mode === 'commonjs') {
     inputCode = toCommonJS(filename, code);
   }
 
@@ -363,15 +379,17 @@ async function loadModule(filename: string) {
 function loadModuleSync(filename: string) {
   const format = toFormat(filename, true);
   const isTypeScript =
-    format === 'module-typescript' || format === 'commonjs-typescript' || format === 'typescript';
+    format.mode === 'module-typescript' ||
+    format.mode === 'commonjs-typescript' ||
+    format.mode === 'typescript';
   try {
-    if (format !== 'module' && !isTypeScript) {
+    if (format.mode !== 'module' && !isTypeScript) {
       return require(filename);
     }
   } catch (error: any) {
     if (error.code === 'MODULE_NOT_FOUND') {
       throw error;
-    } else if (format == null) {
+    } else if (format.mode == null) {
       const code = maybeReadFileSync(filename);
       throw annotateError(code, filename, error) || error;
     }

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -76,13 +76,7 @@ interface Format {
 }
 
 function toFormat(filename: string, isLegacy: boolean): Format {
-  let mode:
-    | 'commonjs'
-    | 'module'
-    | 'module-typescript'
-    | 'commonjs-typescript'
-    | 'typescript'
-    | undefined;
+  let mode: Format['mode'];
   let legacy = false;
   if (filename.endsWith('.cjs')) {
     mode = 'commonjs';

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -3,6 +3,7 @@ import * as nodeModule from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import url from 'node:url';
+import vm from 'node:vm';
 import type * as ts from 'typescript';
 
 import { annotateError, formatDiagnostic } from './codeframe';
@@ -261,6 +262,20 @@ function compileModule(code: string, filename: string, opts: ModuleOptions) {
   }
 }
 
+function containsModuleSyntax(code: string): boolean {
+  // Fast-path: We can assume that if there's no ESM keyword, we don't need to check at all
+  if (!/\b(?:import|export|await)\b/.test(code)) {
+    return false;
+  }
+  try {
+    const CJS_WRAP_PARAMS = ['exports', 'require', 'module', '__filename', '__dirname'];
+    vm.compileFunction(code, CJS_WRAP_PARAMS);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 const hasStripTypeScriptTypes = typeof nodeModule.stripTypeScriptTypes === 'function';
 
 function evalModule(
@@ -331,6 +346,18 @@ function evalModule(
     }
   } else if (format.mode === 'commonjs') {
     inputCode = toCommonJS(filename, code);
+  }
+
+  // NOTE(@kitten): If we've transpiling to CommonJS ourselves above, we should check if
+  // the output contains module syntax, which prevents us from loading this file as CommonJS.
+  // If it does, we run the non-legacy ESM code path instead
+  if (
+    format.legacy &&
+    (format.mode === 'commonjs' || format.mode === 'commonjs-typescript') &&
+    containsModuleSyntax(inputCode)
+  ) {
+    format = toFormat(filename, false);
+    return evalModule(code, filename, opts, format);
   }
 
   try {


### PR DESCRIPTION
# Why

Resolves #47272

An evaluated module may contain unresolvable module syntax, such as `import.meta` or top-level `await`, which after transpiling to CommonJS remain unaltered. This syntax is detected by Node.js which then runs into a mixed CommonJS/ESM conflict. (Note: We transpile to CommonJS in the first place as part of a "legacy" mode in `loadModuleSync`, rather than `loadModule`, to permit mixed ESM/CJS)

# How

When we're transpiling in "legacy" mode to CommonJS (only for `loadModuleSync`), we should detect residual module syntax, and re-run in the non-legacy mode. This essentially "permits" ESM output and dynamically switches to the working code path.

> [!NOTE]
> The reproduction in the linked issue will still fail since the `lazy` transpilation we apply to `@expo/config-plugins` fails to parse with Node's `cjs-module-lexer`

# Test Plan

- Use reproduction in issue to load the module (it should evaluate as ESM)
- Added tests that check this code-path automatically

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
