### PR TITLE
[docs] Add floating copy button for code block selections

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -18,6 +18,7 @@ import { CodeBlockSettingsProvider } from '~/providers/CodeBlockSettingsProvider
 import { TutorialChapterCompletionProvider } from '~/providers/TutorialChapterCompletionProvider';
 import { HreflangAlternates } from '~/ui/components/HreflangAlternates';
 import { markdownComponents } from '~/ui/components/Markdown';
+import { CodeSelectionCopy } from '~/ui/components/Snippet/CodeSelectionCopy';
 import { StructuredData } from '~/ui/components/StructuredData';
 import * as Tooltip from '~/ui/components/Tooltip';
 import '~/common/suppress-trailing-slash-warning';
@@ -99,6 +100,7 @@ export default function App({ Component, pageProps }: AppProps) {
                   <MDXProvider components={rootMarkdownComponents}>
                     <Tooltip.Provider>
                       <Component {...pageProps} />
+                      <CodeSelectionCopy />
                     </Tooltip.Provider>
                   </MDXProvider>
                 </CodeBlockSettingsProvider>

--- a/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
+++ b/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
@@ -56,7 +56,7 @@ export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownCompone
       };
 
       return (
-        <div className="relative">
+        <div className="relative" data-selection-copy-ignore>
           <PreComponent {...preProps} className={mergeClasses('px-3 py-2', preProps.className)} />
           <Button
             type="button"

--- a/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
@@ -1,0 +1,229 @@
+import { jest } from '@jest/globals';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { CodeSelectionCopy } from './CodeSelectionCopy';
+
+const CODE_BLOCK = `
+  <pre data-md-lang="json"><code id="code">{
+  "expo": { "userInterfaceStyle": "automatic" }
+}</code></pre>`;
+
+const HIDDEN_CODE_BLOCK = `
+  <pre data-md-lang="java"><code id="code">visible start
+<span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">...</span><span class="code-hidden">hidden code</span>visible end</code></pre>`;
+
+const DIFF_BLOCK = `
+  <table class="diff-unified"><tbody id="diff-body">
+    <tr><td class="diff-gutter">1</td><td class="diff-code">package com.myapp</td></tr>
+    <tr><td class="diff-gutter">2</td><td class="diff-code">import expo.modules.Wrapper</td></tr>
+  </tbody></table>`;
+
+const PROSE = '<p><span id="prose">Some regular paragraph text on the page.</span></p>';
+
+let fixture: HTMLDivElement;
+let writeText: jest.Mock<() => Promise<void>>;
+
+function renderWithFixture(html: string) {
+  render(<CodeSelectionCopy />);
+  fixture.innerHTML = html;
+  return fixture;
+}
+
+function mockSelection({
+  startNode,
+  startOffset = 0,
+  endNode = startNode,
+  endOffset = 0,
+  text,
+  isCollapsed = false,
+}: {
+  startNode: Node;
+  startOffset?: number;
+  endNode?: Node;
+  endOffset?: number;
+  text?: string;
+  isCollapsed?: boolean;
+}) {
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  const selection = {
+    isCollapsed,
+    rangeCount: 1,
+    anchorNode: startNode,
+    anchorOffset: startOffset,
+    focusNode: endNode,
+    focusOffset: endOffset,
+    toString: () => text ?? range.toString(),
+    getRangeAt: () => range,
+  } as unknown as Selection;
+  jest.spyOn(window, 'getSelection').mockReturnValue(selection);
+  return selection;
+}
+
+function rect(left: number, top: number, width: number, height: number) {
+  return { left, top, width, height, right: left + width, bottom: top + height } as DOMRect;
+}
+
+function stubRects(caretRectFor: (container: Node) => DOMRect, selectionRect: DOMRect) {
+  jest.spyOn(Range.prototype, 'getClientRects').mockImplementation(function (this: Range) {
+    const rect = this.collapsed ? caretRectFor(this.startContainer) : null;
+    const rects = rect && rect.height > 0 ? [rect] : [];
+    return { length: rects.length, item: (i: number) => rects[i] ?? null } as DOMRectList;
+  });
+  jest.spyOn(Range.prototype, 'getBoundingClientRect').mockImplementation(function (this: Range) {
+    return this.collapsed ? caretRectFor(this.startContainer) : selectionRect;
+  });
+}
+
+function showButton(node: Node, endNode?: Node, endOffset?: number) {
+  mockSelection({ startNode: node, endNode: endNode ?? node, endOffset: endOffset ?? 0 });
+  fireEvent.mouseUp(document.body);
+  return screen.getByRole('button', { name: /copy/i });
+}
+
+beforeAll(() => {
+  Range.prototype.getClientRects = () =>
+    ({ length: 0, item: () => null }) as unknown as DOMRectList;
+  Range.prototype.getBoundingClientRect = () => rect(0, 0, 0, 0);
+});
+
+beforeEach(() => {
+  fixture = document.createElement('div');
+  document.body.append(fixture);
+  writeText = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+});
+
+afterEach(() => {
+  fixture.remove();
+  jest.restoreAllMocks();
+});
+
+describe(CodeSelectionCopy, () => {
+  it('shows a Copy button above the selection midpoint in a code block', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!.firstChild!;
+    stubRects(
+      container => (container === code ? rect(100, 200, 0, 16) : rect(300, 240, 0, 16)),
+      rect(100, 200, 200, 56)
+    );
+    mockSelection({ startNode: code, startOffset: 0, endNode: code.parentElement!, endOffset: 1 });
+    fireEvent.mouseUp(document.body);
+
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toHaveStyle({ top: '160px', left: '200px' });
+  });
+
+  it('falls back to the selection rect when a caret rect is degenerate', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!.firstChild!;
+    stubRects(
+      container => (container === code ? rect(0, 0, 0, 0) : rect(350, 420, 0, 16)),
+      rect(300, 400, 200, 36)
+    );
+    mockSelection({ startNode: code, startOffset: 0, endNode: code.parentElement!, endOffset: 1 });
+    fireEvent.mouseUp(document.body);
+
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toHaveStyle({ top: '360px', left: '325px' });
+  });
+
+  it('copies the selection without hidden code or placeholders, then flips to Copied!', async () => {
+    renderWithFixture(HIDDEN_CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    const button = showButton(code.firstChild!, code, code.childNodes.length);
+
+    fireEvent.click(button);
+
+    expect(writeText).toHaveBeenCalledWith('visible start\nvisible end');
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+    await act(() => new Promise(resolve => requestAnimationFrame(() => resolve(null))));
+    expect(screen.getByRole('status')).toHaveTextContent('Copied!');
+  });
+
+  it('copies diff selections as clean joined lines without gutters', () => {
+    renderWithFixture(DIFF_BLOCK);
+    const body = document.getElementById('diff-body')!;
+    const button = showButton(body.firstChild!, body, body.childNodes.length);
+
+    fireEvent.click(button);
+
+    expect(writeText).toHaveBeenCalledWith('package com.myapp\nimport expo.modules.Wrapper');
+  });
+
+  it('does not appear for selections outside code blocks', () => {
+    renderWithFixture(PROSE);
+    mockSelection({ startNode: document.getElementById('prose')!.firstChild!, endOffset: 10 });
+    fireEvent.mouseUp(document.body);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('does not appear inside data-selection-copy-ignore containers', () => {
+    renderWithFixture(`<div data-selection-copy-ignore>${CODE_BLOCK}</div>`);
+    const code = document.getElementById('code')!;
+    mockSelection({ startNode: code.firstChild!, endNode: code, endOffset: 1 });
+    fireEvent.mouseUp(document.body);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('ignores collapsed and whitespace-only selections', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!.firstChild!;
+
+    mockSelection({ startNode: code, isCollapsed: true });
+    fireEvent.mouseUp(document.body);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    mockSelection({ startNode: code, text: '  \n  ' });
+    fireEvent.mouseUp(document.body);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('survives clicks landing on the SVG icon inside the button', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    const button = showButton(code.firstChild!, code, 1);
+    const icon = button.querySelector('svg')!;
+
+    fireEvent.mouseDown(icon);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+
+    fireEvent.click(icon);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+  });
+
+  it('dismisses on Escape', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    showButton(code.firstChild!, code, 1);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('dismisses on mousedown outside the button', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    showButton(code.firstChild!, code, 1);
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('dismisses on scroll and resize', () => {
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    showButton(code.firstChild!, code, 1);
+
+    fireEvent.scroll(document.body);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    showButton(code.firstChild!, code, 1);
+    fireEvent(window, new Event('resize'));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable testing-library/no-node-access */
 import { jest } from '@jest/globals';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
@@ -138,7 +139,14 @@ describe(CodeSelectionCopy, () => {
 
     expect(writeText).toHaveBeenCalledWith('visible start\nvisible end');
     expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument();
-    await act(() => new Promise(resolve => requestAnimationFrame(() => resolve(null))));
+    await act(
+      () =>
+        new Promise(resolve => {
+          requestAnimationFrame(() => {
+            resolve(null);
+          });
+        })
+    );
     expect(screen.getByRole('status')).toHaveTextContent('Copied!');
   });
 

--- a/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.test.tsx
@@ -234,4 +234,52 @@ describe(CodeSelectionCopy, () => {
     fireEvent(window, new Event('resize'));
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
+
+  it('disappears on its own shortly after copying', () => {
+    jest.useFakeTimers();
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    const button = showButton(code.firstChild!, code, 1);
+
+    fireEvent.click(button);
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('does not hide a fresh selection because of an earlier copy timer', () => {
+    jest.useFakeTimers();
+    renderWithFixture(CODE_BLOCK);
+    const code = document.getElementById('code')!;
+    const button = showButton(code.firstChild!, code, 1);
+
+    fireEvent.click(button);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    showButton(code.firstChild!, code, 1);
+
+    act(() => {
+      jest.advanceTimersByTime(1400);
+    });
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('hides the button when the selection collapses instead of leaving a dead button', () => {
+    renderWithFixture(DIFF_BLOCK);
+    const body = document.getElementById('diff-body')!;
+    showButton(body.firstChild!, body, body.childNodes.length);
+
+    fireEvent(document, new Event('selectionchange'));
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+
+    mockSelection({ startNode: body.firstChild!, isCollapsed: true });
+    fireEvent(document, new Event('selectionchange'));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
 });

--- a/docs/ui/components/Snippet/CodeSelectionCopy.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.tsx
@@ -1,0 +1,158 @@
+import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useIntl } from 'react-intl';
+
+const CODE_BLOCK_SELECTOR = 'pre[data-md-lang], .diff-unified';
+
+type Position = { top: number; left: number };
+
+function isNodeInCodeBlock(node: Node | null) {
+  const element = node instanceof Element ? node : node?.parentElement;
+  const codeBlock = element?.closest(CODE_BLOCK_SELECTOR);
+  return Boolean(codeBlock && !codeBlock.closest('[data-selection-copy-ignore]'));
+}
+
+function isOnCopyButton(target: EventTarget | null) {
+  return target instanceof Element && Boolean(target.closest('[data-selection-copy]'));
+}
+
+function getCleanSelectionText(selection: Selection) {
+  const container = document.createElement('div');
+  for (let index = 0; index < selection.rangeCount; index++) {
+    container.append(selection.getRangeAt(index).cloneContents());
+  }
+  for (const node of container.querySelectorAll('.code-hidden, .code-placeholder')) {
+    node.remove();
+  }
+  const diffCells = container.querySelectorAll('.diff-code');
+  if (diffCells.length > 0) {
+    return Array.from(diffCells, cell => cell.textContent ?? '').join('\n');
+  }
+  return container.textContent ?? '';
+}
+
+function getCaretRect(node: Node | null, offset: number) {
+  if (!node) {
+    return null;
+  }
+  const range = document.createRange();
+  range.setStart(node, offset);
+  range.collapse(true);
+  const rect = range.getClientRects().item(0) ?? range.getBoundingClientRect();
+  return rect.height > 0 ? rect : null;
+}
+
+export function CodeSelectionCopy() {
+  const intl = useIntl();
+  const [position, setPosition] = useState<Position | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    const onMouseUp = (event: MouseEvent) => {
+      if (isOnCopyButton(event.target)) {
+        return;
+      }
+      const selection = window.getSelection();
+      if (
+        !selection ||
+        selection.isCollapsed ||
+        selection.rangeCount === 0 ||
+        !selection.toString().trim()
+      ) {
+        setPosition(null);
+        return;
+      }
+      if (!isNodeInCodeBlock(selection.anchorNode) && !isNodeInCodeBlock(selection.focusNode)) {
+        setPosition(null);
+        return;
+      }
+      const fallback = selection.getRangeAt(0).getBoundingClientRect();
+      const startRect = getCaretRect(selection.anchorNode, selection.anchorOffset) ?? fallback;
+      const endRect = getCaretRect(selection.focusNode, selection.focusOffset) ?? fallback;
+      setPosition({
+        top: Math.max(8, Math.min(startRect.top, endRect.top) - 40),
+        left: Math.min(Math.max(60, (startRect.left + endRect.left) / 2), window.innerWidth - 60),
+      });
+      setCopied(false);
+    };
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!position) {
+      return;
+    }
+    const dismiss = () => {
+      setPosition(null);
+    };
+    const onMouseDown = (event: MouseEvent) => {
+      if (!isOnCopyButton(event.target)) {
+        setPosition(null);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setPosition(null);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    window.addEventListener('scroll', dismiss, true);
+    window.addEventListener('resize', dismiss);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', dismiss, true);
+      window.removeEventListener('resize', dismiss);
+    };
+  }, [position]);
+
+  if (!position) {
+    return null;
+  }
+
+  const onCopy = () => {
+    const selection = window.getSelection();
+    const text = selection ? getCleanSelectionText(selection) : '';
+    if (!text.trim()) {
+      return;
+    }
+    void navigator.clipboard?.writeText(text);
+    setCopied(true);
+    setAnnouncement('');
+    window.requestAnimationFrame(() => {
+      setAnnouncement(intl.formatMessage({ id: 'codeCopied' }));
+    });
+  };
+
+  return createPortal(
+    <>
+      <span className="sr-only" role="status" aria-live="polite">
+        {announcement}
+      </span>
+      <button
+        type="button"
+        data-selection-copy
+        onMouseDown={event => {
+          event.preventDefault();
+        }}
+        onClick={onCopy}
+        style={{
+          position: 'fixed',
+          top: position.top,
+          left: position.left,
+          transform: 'translateX(-50%)',
+        }}
+        className="z-50 inline-flex items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default">
+        <ClipboardIcon aria-hidden="true" className="icon-xs text-icon-secondary" />
+        {intl.formatMessage({ id: copied ? 'codeCopied' : 'codeCopy' })}
+      </button>
+    </>,
+    document.body
+  );
+}

--- a/docs/ui/components/Snippet/CodeSelectionCopy.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.tsx
@@ -170,7 +170,7 @@ export function CodeSelectionCopy() {
           left: position.left,
           transform: 'translateX(-50%)',
         }}
-        className="z-50 inline-flex items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default cursor-pointer">
+        className="z-50 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default">
         <ClipboardIcon aria-hidden="true" className="icon-xs text-icon-secondary" />
         {intl.formatMessage({ id: copied ? 'codeCopied' : 'codeCopy' })}
       </button>

--- a/docs/ui/components/Snippet/CodeSelectionCopy.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.tsx
@@ -170,7 +170,7 @@ export function CodeSelectionCopy() {
           left: position.left,
           transform: 'translateX(-50%)',
         }}
-        className="z-50 inline-flex items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default">
+        className="z-50 inline-flex items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default cursor-pointer">
         <ClipboardIcon aria-hidden="true" className="icon-xs text-icon-secondary" />
         {intl.formatMessage({ id: copied ? 'codeCopied' : 'codeCopy' })}
       </button>

--- a/docs/ui/components/Snippet/CodeSelectionCopy.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { useIntl } from 'react-intl';
 
 const CODE_BLOCK_SELECTOR = 'pre[data-md-lang], .diff-unified';
+const COPIED_DISMISS_MS = 1200;
 
 type Position = { top: number; left: number };
 
@@ -100,17 +101,38 @@ export function CodeSelectionCopy() {
         setPosition(null);
       }
     };
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || !selection.toString().trim()) {
+        setPosition(null);
+      }
+    };
     document.addEventListener('mousedown', onMouseDown);
     document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('selectionchange', onSelectionChange);
     window.addEventListener('scroll', dismiss, true);
     window.addEventListener('resize', dismiss);
     return () => {
       document.removeEventListener('mousedown', onMouseDown);
       document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('selectionchange', onSelectionChange);
       window.removeEventListener('scroll', dismiss, true);
       window.removeEventListener('resize', dismiss);
     };
   }, [position]);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setPosition(null);
+      setCopied(false);
+    }, COPIED_DISMISS_MS);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [copied]);
 
   if (!position) {
     return null;


### PR DESCRIPTION
# Why

**Proposal:** Allow copying a portion of a code block or diff by hand drags along line numbers, hidden `@hide` code, and placeholder markers, so partial copies need manual cleanup after pasting.

# How

- Add `CodeSelectionCopy` (`ui/components/Snippet`): a floating Copy button that appears above text selections in `pre[data-md-lang]` and `.diff-unified` blocks and copies the cleaned selection (drops `.code-hidden` and `.code-placeholder` spans, joins `.diff-code` cells without gutters).
- Mount it once in `pages/_app.tsx`.
- Mark Ask AI chat code blocks with `data-selection-copy-ignore` in `useChatMarkdownComponents.tsx` since they ship their own copy button.
- Add unit tests covering positioning (including the degenerate caret rect fallback), copy cleaning, ignore gating, and dismissal behaviors.

# Test plan


https://github.com/user-attachments/assets/6783f0d8-9e72-4ff5-be9a-f57c4d5da690

