### PR TITLE
[docs] Update additional resources & fix hydration warning

### DIFF
--- a/docs/common/suppress-trailing-slash-warning.test.ts
+++ b/docs/common/suppress-trailing-slash-warning.test.ts
@@ -1,0 +1,69 @@
+import { isTrailingSlashHydrationWarning } from './suppress-trailing-slash-warning';
+
+const HEADER = "A tree hydrated but some attributes of the server rendered HTML didn't match";
+
+function message(...diffLines: string[]) {
+  return [HEADER, '', '  <a', ...diffLines.map(line => `    ${line}`), '  >'].join('\n');
+}
+
+describe(isTrailingSlashHydrationWarning, () => {
+  it('suppresses plain trailing-slash pairs', () => {
+    const msg = message('+ href="/guides/overview/"', '- href="/guides/overview"');
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(true);
+  });
+
+  it('suppresses trailing-slash pairs before a hash', () => {
+    const msg = message('+ href="/workflow/foo/#section"', '- href="/workflow/foo#section"');
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(true);
+  });
+
+  it('suppresses pairs React truncated at shifted offsets', () => {
+    const msg = message(
+      '+ href="/workflow/upgrading-expo-sdk-walkthrough/#how-to-upgrade-to-the-latest-sdk-v..."',
+      '- href="/workflow/upgrading-expo-sdk-walkthrough#how-to-upgrade-to-the-latest-sdk-ve..."'
+    );
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(true);
+  });
+
+  it('suppresses hash links that inherited the query string on the client', () => {
+    const msg = message(
+      '+ href={"/bare/upgrade/?fromSdk=56&toSdk=57#packagejson"}',
+      '- href="/bare/upgrade/#packagejson"'
+    );
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(true);
+  });
+
+  it('does not suppress pairs pointing at different targets', () => {
+    const withQuery = message(
+      '+ href={"/bare/upgrade/?fromSdk=56&toSdk=57#packagejson"}',
+      '- href="/bare/upgrade/#dependencies"'
+    );
+    expect(isTrailingSlashHydrationWarning(withQuery)).toBe(false);
+
+    const differentPaths = message('+ href="/guides/overview/"', '- href="/guides/routing"');
+    expect(isTrailingSlashHydrationWarning(differentPaths)).toBe(false);
+  });
+
+  it('does not suppress truncated pairs with different prefixes', () => {
+    const msg = message('+ href="/workflow/aaa..."', '- href="/workflow/bbb..."');
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(false);
+  });
+
+  it('does not suppress the hard hydration failure', () => {
+    const msg = [
+      "Hydration failed because the server rendered HTML didn't match the client.",
+      '+ href="/guides/overview/"',
+      '- href="/guides/overview"',
+    ].join('\n');
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(false);
+  });
+
+  it('does not suppress messages with unmatched href counts', () => {
+    const msg = message('+ href="/guides/overview/"');
+    expect(isTrailingSlashHydrationWarning(msg)).toBe(false);
+  });
+
+  it('does not suppress messages without href diffs', () => {
+    expect(isTrailingSlashHydrationWarning(message('+ <span className="flex">'))).toBe(false);
+  });
+});

--- a/docs/common/suppress-trailing-slash-warning.ts
+++ b/docs/common/suppress-trailing-slash-warning.ts
@@ -1,25 +1,43 @@
 /**
- * Suppress the dev-mode hydration warning caused by next/link normalizing
- * trailing slashes differently during SSR vs client hydration.
- * See: next.config.ts `trailingSlash: true` + next/link internal resolveHref.
+ * Suppress the dev-mode hydration warning caused by next/link resolving hrefs
+ * differently during SSR vs client hydration: trailing slashes are normalized
+ * on the client only (`trailingSlash: true`), and hash-only hrefs inherit the
+ * current URL's query string on the client (see TableOfContentsLink).
  */
 
 const isDev = process.env.NODE_ENV === 'development';
 
-if (isDev && typeof window !== 'undefined') {
-  const isTrailingSlashHydrationWarning = (msg: string): boolean => {
-    if (!msg.includes('hydrated but some attributes')) {
-      return false;
-    }
-    const clientHrefs = [...msg.matchAll(/\+\s+href="([^"]*)"/g)].map(m => m[1]);
-    const serverHrefs = [...msg.matchAll(/-\s+href="([^"]*)"/g)].map(m => m[1]);
-    if (clientHrefs.length === 0 || clientHrefs.length !== serverHrefs.length) {
-      return false;
-    }
-    const strip = (h: string) => h.replace(/\/(?=[#?]|$)/g, '');
-    return clientHrefs.every((c, i) => strip(c) === strip(serverHrefs[i]));
-  };
+function isKnownHrefResolutionDiff(client: string, server: string): boolean {
+  const strip = (h: string) => h.replace(/\?[^#]*/, '').replace(/\/(?=#|$)/g, '');
+  const c = strip(client);
+  const s = strip(server);
+  if (!client.endsWith('...') && !server.endsWith('...')) {
+    return c === s;
+  }
+  // React truncates long attribute values in the diff, and the client href is
+  // longer (its extra slash or inherited query), so the two cuts land at
+  // different offsets. Compare the visible common prefix instead.
+  const dropEllipsis = (h: string) => (h.endsWith('...') ? h.slice(0, -3) : h);
+  const cBase = dropEllipsis(c);
+  const sBase = dropEllipsis(s);
+  const length = Math.min(cBase.length, sBase.length);
+  return length > 0 && cBase.slice(0, length) === sBase.slice(0, length);
+}
 
+export function isTrailingSlashHydrationWarning(msg: string): boolean {
+  if (!msg.includes('hydrated but some attributes')) {
+    return false;
+  }
+  // The client side of a pair can print as href="..." or as href={"..."}.
+  const clientHrefs = [...msg.matchAll(/\+\s+href={?"([^"]*)"/g)].map(m => m[1]);
+  const serverHrefs = [...msg.matchAll(/-\s+href={?"([^"]*)"/g)].map(m => m[1]);
+  if (clientHrefs.length === 0 || clientHrefs.length !== serverHrefs.length) {
+    return false;
+  }
+  return clientHrefs.every((c, i) => isKnownHrefResolutionDiff(c, serverHrefs[i]));
+}
+
+if (isDev && typeof window !== 'undefined') {
   // By the time _app.tsx runs, Next.js has already
   // replaced console.error with nextJsHandleConsoleError (in register()).
   // Suppressing here prevents that handler from calling handleError -> overlay.

--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: June 29, 2026
+modificationDate: July 2, 2026
 title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -8,6 +8,14 @@ export const TALKS = [
     home: true,
   },
   {
+    title: 'React Native without Cocoapods',
+    event: 'App.js Conf 2026',
+    description: 'Riccardo Cipolleschi, Christian Falch',
+    videoId: '5nHDA39K4NE',
+    uploadDate: '2026-07-01',
+    home: true,
+  },
+  {
     title: 'Screens & Routers: The Foundation of Navigation in React Native Apps',
     event: 'App.js Conf 2026',
     description: 'Kacper Kafara, Kuba Tkacz',
@@ -29,7 +37,6 @@ export const TALKS = [
     description: 'Evan Bacon',
     videoId: 'GKQ_0VfYweg',
     uploadDate: '2025-06-05',
-    home: true,
   },
   {
     title: 'Embracing Native Code and Capabilities',
@@ -292,6 +299,12 @@ export const PODCASTS = [
 ] as Talk[];
 
 export const LIVE_STREAMS = [
+  {
+    title: 'Closing the loop: How to turn your website into a mobile app with AI',
+    event: 'Expo Live Stream',
+    videoId: '9Sl6VXrj224',
+    uploadDate: '2026-07-02',
+  },
   {
     title: "What's new in Expo SDK 56? Widgets, Expo UI, Router decoupling from React Navigation",
     event: 'Expo Live Stream',

--- a/docs/ui/components/MarkdownActions/paths.test.ts
+++ b/docs/ui/components/MarkdownActions/paths.test.ts
@@ -1,0 +1,52 @@
+import { hasDynamicData, normalizePath, shouldShowMarkdownActions } from './paths';
+
+describe(normalizePath, () => {
+  it('strips trailing slashes', () => {
+    expect(normalizePath('/additional-resources/')).toBe('/additional-resources');
+  });
+
+  it('strips query strings', () => {
+    expect(normalizePath('/additional-resources/?foo=bar')).toBe('/additional-resources');
+  });
+
+  it('strips hash fragments', () => {
+    expect(normalizePath('/additional-resources/#talks')).toBe('/additional-resources');
+    expect(normalizePath('/bare/upgrade/#anchor')).toBe('/bare/upgrade');
+  });
+
+  it('handles empty and root paths', () => {
+    expect(normalizePath('')).toBe('');
+    expect(normalizePath('/')).toBe('/');
+  });
+});
+
+describe(hasDynamicData, () => {
+  it('matches dynamic-data paths regardless of trailing slash', () => {
+    expect(hasDynamicData('/additional-resources')).toBe(true);
+    expect(hasDynamicData('/additional-resources/')).toBe(true);
+  });
+
+  it('matches dynamic-data paths when the client URL carries a hash', () => {
+    expect(hasDynamicData('/additional-resources/#talks')).toBe(true);
+  });
+
+  it('does not match regular pages', () => {
+    expect(hasDynamicData('/guides/overview/')).toBe(false);
+    expect(hasDynamicData('/guides/overview/#section')).toBe(false);
+  });
+});
+
+describe(shouldShowMarkdownActions, () => {
+  it('agrees between server and client paths for the same page', () => {
+    const server = shouldShowMarkdownActions({ path: '/additional-resources/' });
+    const client = shouldShowMarkdownActions({ path: '/additional-resources/#talks' });
+    expect(client).toBe(server);
+    expect(client).toBe(false);
+  });
+
+  it('hides actions for package pages', () => {
+    expect(shouldShowMarkdownActions({ packageName: 'expo-video', path: '/guides/x/' })).toBe(
+      false
+    );
+  });
+});

--- a/docs/ui/components/MarkdownActions/paths.ts
+++ b/docs/ui/components/MarkdownActions/paths.ts
@@ -9,7 +9,7 @@ export function normalizePath(path?: string) {
     return '';
   }
 
-  const [cleanPath] = path.split('?');
+  const [cleanPath] = path.split(/[#?]/);
   return cleanPath.replace(/\/+$/, '') || '/';
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Update additional resources.
- Also fix the following hydration error on pages opened with a URL hash:


<img width="1884" height="2234" alt="CleanShot 2026-07-02 at 13 58 19@2x" src="https://github.com/user-attachments/assets/75dea4bb-c55b-4c36-8cc1-d3116c2b39f7" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2490" height="832" alt="CleanShot 2026-07-02 at 13 34 11@2x" src="https://github.com/user-attachments/assets/f2cb7e51-aa14-4a29-a298-b87e5e152225" />

<img width="2682" height="1002" alt="CleanShot 2026-07-02 at 13 34 15@2x" src="https://github.com/user-attachments/assets/6a9311d3-02ce-428a-aab0-cf0a08003385" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
