### PR TITLE
[ui][ios] Fix TextField selection crash on iOS 18

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][Android] Fix a scrollable child (e.g. `FlatList`, `ScrollView`) inside `@expo/ui/community/bottom-sheet` not scrolling to the end when using fixed snap points. ([#47245](https://github.com/expo/expo/pull/47245) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix universal `ListItem` stretching a fixed-size raw RN view in its leading/trailing slot to fill the row instead of honoring its size, matching Android. ([#46883](https://github.com/expo/expo/issues/46883) by [@david-videau-ortega](https://github.com/david-videau-ortega)) ([#47236](https://github.com/expo/expo/pull/47236) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix the `@expo-ui/community/datetime-picker` dialog ignoring `minimumDate`/`maximumDate` for its year range, so the calendar and year picker no longer always span 1900–2100. ([#47206](https://github.com/expo/expo/issues/47206) by [@vioodle](https://github.com/vioodle)) ([#47213](https://github.com/expo/expo/pull/47213) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/TextFieldView.swift
+++ b/packages/expo-ui/ios/TextFieldView.swift
@@ -219,11 +219,39 @@ private struct StatefulSelectableTextField: View {
     )
   }
 
+  private var selectionBinding: Binding<SwiftUI.TextSelection?> {
+    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
+      return $localSelection
+    }
+    return clampedSelectionBinding
+  }
+
+  // iOS 18 SwiftUI can throw an out-of-bounds exception when selection becomes invalid after text is changed programmatically.
+  // Resetting to nil avoids passing SwiftUI the stale selection.
+  // https://github.com/expo/expo/issues/47434
+  // https://github.com/swiftlang/swift/issues/82359#issuecomment-3038538035
+  private var clampedSelectionBinding: Binding<SwiftUI.TextSelection?> {
+    Binding(
+      get: {
+        guard let selection = localSelection,
+              case let .selection(range) = selection.indices else {
+          return localSelection
+        }
+        let text = (state.value as? String) ?? ""
+        if range.lowerBound > text.endIndex || range.upperBound > text.endIndex {
+          return nil
+        }
+        return localSelection
+      },
+      set: { localSelection = $0 }
+    )
+  }
+
   var body: some View {
     TextField(
       promptText == nil ? props.placeholder : "",
       text: textBinding,
-      selection: $localSelection,
+      selection: selectionBinding,
       prompt: promptText,
       axis: swiftUIAxis
     )


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/47434

Bug is coming from SwiftUI on iOS 18. https://github.com/swiftlang/swift/issues/82359

SwiftUI `TextField` can crash with `String index is out of bounds` on iOS 18 when JS programmatically writes shorter text into a focused field that still has an active selection. The local `TextSelection` can point past the new string's `endIndex`, and passing that stale selection back into SwiftUI triggers the crash.



# How

- Route the `TextField` selection through a clamped binding on iOS 18-era SwiftUI.
- Return `nil` from that binding when the stored selection range is outside the current text, so SwiftUI clears the stale selection instead of reading invalid indices.
- Keep the direct `$localSelection` binding on iOS/macOS/tvOS 26+, where this workaround is not needed.

# Test Plan

Tested the repro.

# Checklist

- [x] I added a `CHANGELOG.md` entry.
- [ ] This diff includes tests covering the change (manual SwiftUI selection regression; no automated native selection test added).
