### PR TITLE
[JSI][iOS] Fix JavaScriptPromise not propagating error code correctly to JS

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47453](https://github.com/expo/expo/pull/47453) by [@HubertBer](https://github.com/HubertBer))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-06-15

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -102,9 +102,13 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       guard let rejecter = rejectFunction.take() else {
         return
       }
-      // Create a JS error from any (native) error.
-      let errorMessage = String(describing: error)
-      let errorValue = JavaScriptError(runtime, message: errorMessage).asValue()
+
+      let errorValue: JavaScriptValue
+      if let throwable = error as? JavaScriptThrowable {
+        errorValue = JavaScriptError(runtime, from: throwable).asValue()
+      } else {
+        errorValue = JavaScriptError(runtime, message: String(describing: error)).asValue()
+      }
 
       // Call the actual rejecter given in the Promise setup.
       // This will also call `deferredPromise.reject` in the `then` handler.


### PR DESCRIPTION
# Why
In the issue https://github.com/expo/expo/issues/47372 there is a problem that in the newest expo release error codes are not propagated through promise reject to the JS from the Swift modules. This was fixed on main in #47259, however cherry-picking that change would require cherry-picking other changes as well like #47154 as it depends on `JavaScriptError` changes, which are not on sdk-56. 

# How
I've added a minimal change required for this fix, that is construct a JavaScriptError differently based on whether the error was a JavaScriptThrowable or not, similar to the synchronous path.

# Test Plan
I've checked it manually in an example modue taken from the #47372 repro.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
