### PR TITLE
[ci] Add gradle plugins to ccache key

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -171,7 +171,8 @@ runs:
         # ccache tracks these files without any sloppiness issues.
         # - C/C++ source files
         # - Gradle files: see https://github.com/expo/expo/pull/44884
-        key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle', 'apps/bare-expo/android/app/src/main/jni/pch.h') }}
+        # - Gradle plugin files: see https://github.com/expo/expo/pull/47455
+        key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle', 'apps/bare-expo/android/app/src/main/jni/pch.h', 'packages/expo-modules-autolinking/android/expo-gradle-plugin/**/*.kt', 'packages/expo-modules-autolinking/android/expo-gradle-plugin/**/*.kts', 'packages/expo-modules-core/expo-module-gradle-plugin/**/*.kt', 'packages/expo-modules-core/expo-module-gradle-plugin/**/*.kts', 'packages/expo-updates/expo-updates-gradle-plugin/**/*.kt', 'packages/expo-updates/expo-updates-gradle-plugin/**/*.kts', 'packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/**/*.kt', 'packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/**/*.kts', 'packages/expo-network-addons/expo-network-addons-gradle-plugin/**/*.kt', 'packages/expo-network-addons/expo-network-addons-gradle-plugin/**/*.kts') }}
         restore-keys: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}
 
     - name: 🛠 Setup "REACT_NATIVE_DOWNLOADS_DIR" environment variable


### PR DESCRIPTION
# Why

Changes in Gradle plugins cause the Android ccache hit rate to drop: https://github.com/expo/expo/actions/runs/28445779939/job/84294761381?pr=47377

Gradle plugin sources are compiled into JARs. When they change, Gradle/AGP can place transformed dependency artifacts under paths with new hashes:
`~/.gradle/caches/.../transforms/<hash>/transformed/...`
Those paths are passed to `clang++` as include paths, causing ccache to miss

# How
Added `.kt/.kts` paths for the main `expo-gradle-plugin` (in expo-autolinking) and for every package declaring `gradlePlugins` in its `expo-module.config.json`, which `expo-gradle-plugin` includeBuilds during the Android compilation

# Test Plan

Green CI