### PR TITLE
[docs] Add example run command to SDK installation sections

### DIFF
--- a/docs/components/plugins/InstallSection.test.tsx
+++ b/docs/components/plugins/InstallSection.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+
+import { PageApiVersionContext } from '~/providers/page-api-version';
+import { PageMetadataContext } from '~/providers/page-metadata';
+import { type PageMetadata } from '~/types/common';
+
+import { APIInstallSection } from './InstallSection';
+
+function Providers({
+  children,
+  version,
+  meta,
+}: PropsWithChildren<{ version: string; meta: PageMetadata }>) {
+  return (
+    <PageApiVersionContext.Provider
+      value={{
+        version: version as never,
+        hasVersion: true,
+        setVersion: () => {},
+      }}>
+      <PageMetadataContext.Provider value={meta}>{children}</PageMetadataContext.Provider>
+    </PageApiVersionContext.Provider>
+  );
+}
+
+const widgetsMeta: PageMetadata = { packageName: 'expo-widgets', exampleName: 'with-widgets' };
+
+describe(APIInstallSection, () => {
+  it('shows install and example tabs on the latest SDK version', () => {
+    render(
+      <Providers version="v57.0.0" meta={widgetsMeta}>
+        <APIInstallSection />
+      </Providers>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Install library' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Start with an example' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('npx create-expo-app --example with-widgets');
+    expect(document.body).toHaveTextContent('npx expo install expo-widgets');
+    for (const packageManager of ['npm', 'yarn', 'pnpm', 'bun']) {
+      const switchers = screen.getAllByRole('tab', { name: packageManager, hidden: true });
+      expect(switchers.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('shows the tabs when browsing via the latest alias', () => {
+    render(
+      <Providers version="latest" meta={widgetsMeta}>
+        <APIInstallSection />
+      </Providers>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Start with an example' })).toBeInTheDocument();
+  });
+
+  it('hides the example tab on older SDK versions', () => {
+    render(
+      <Providers version="v54.0.0" meta={widgetsMeta}>
+        <APIInstallSection />
+      </Providers>
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Start with an example' })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('create-expo-app');
+    expect(document.body).toHaveTextContent('npx expo install expo-widgets');
+  });
+
+  it('renders the plain install section when the page has no example', () => {
+    render(
+      <Providers version="v57.0.0" meta={{ packageName: 'expo-camera' }}>
+        <APIInstallSection />
+      </Providers>
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Install library' })).not.toBeInTheDocument();
+    expect(document.body).toHaveTextContent('npx expo install expo-camera');
+  });
+});

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -1,7 +1,10 @@
 import { PropsWithChildren } from 'react';
 
+import { usePageApiVersion } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
+import versions from '~/public/static/constants/versions.json';
 import { Terminal, type PackageManagerCommandSet } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 import { A, P, CODE } from '~/ui/components/Text';
 
 type InstallSectionProps = PropsWithChildren<{
@@ -58,7 +61,40 @@ export default function InstallSection({
   );
 }
 
-export const APIInstallSection = (props: InstallSectionProps) => {
-  const { packageName } = usePageMetadata();
-  return <InstallSection {...props} packageName={props.packageName ?? packageName} />;
+type APIInstallSectionProps = Omit<InstallSectionProps, 'packageName'> & { packageName?: string };
+
+export const APIInstallSection = (props: APIInstallSectionProps) => {
+  const { packageName, exampleName } = usePageMetadata();
+  const { version } = usePageApiVersion();
+  const resolvedPackageName = props.packageName ?? packageName ?? '';
+  const isLatestVersion = version === 'latest' || version === versions.LATEST_VERSION;
+
+  if (!exampleName || !isLatestVersion) {
+    return <InstallSection {...props} packageName={resolvedPackageName} />;
+  }
+
+  return (
+    <Tabs>
+      <Tab label="Install library">
+        <InstallSection {...props} packageName={resolvedPackageName} />
+      </Tab>
+      <Tab label="Start with an example">
+        <P className="mb-4">
+          The{' '}
+          <A href={`https://github.com/expo/examples/tree/master/${exampleName}`}>
+            <CODE>{exampleName}</CODE>
+          </A>{' '}
+          example comes with <CODE>{resolvedPackageName}</CODE> already installed and configured:
+        </P>
+        <Terminal
+          cmd={{
+            npm: [`$ npx create-expo-app --example ${exampleName}`],
+            yarn: [`$ yarn create expo-app --example ${exampleName}`],
+            pnpm: [`$ pnpm create expo-app --example ${exampleName}`],
+            bun: [`$ bun create expo --example ${exampleName}`],
+          }}
+        />
+      </Tab>
+    </Tabs>
+  );
 };

--- a/docs/pages/versions/unversioned/sdk/app-integrity.mdx
+++ b/docs/pages/versions/unversioned/sdk/app-integrity.mdx
@@ -3,6 +3,7 @@ title: AppIntegrity
 description: A library that provides access to Google's Play Integrity API on Android and Apple's App Attest service on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-app-integrity'
 packageName: '@expo/app-integrity'
+exampleName: 'with-app-integrity'
 platforms: ['android', 'ios', 'expo-go']
 isAlpha: true
 ---

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -3,6 +3,7 @@ title: Camera
 description: A React component that renders a preview for the device's front or back camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-camera'
 packageName: 'expo-camera'
+exampleName: 'with-camera'
 iconUrl: '/static/images/packages/expo-camera.png'
 platforms: ['android*', 'ios*', 'web', 'expo-go']
 ---

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -3,6 +3,7 @@ title: Maps
 description: A library that provides access to Google Maps on Android and Apple Maps on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-maps'
 packageName: 'expo-maps'
+exampleName: 'with-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
 isAlpha: true

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -3,6 +3,7 @@ title: SplashScreen
 description: A library that provides access to controlling the visibility behavior of native splash screen.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-splash-screen'
 packageName: 'expo-splash-screen'
+exampleName: 'with-splash-screen'
 iconUrl: '/static/images/packages/expo-splash-screen.png'
 platforms: ['android', 'ios', 'tvos']
 ---

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -3,6 +3,7 @@ title: SQLite
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sqlite'
 packageName: 'expo-sqlite'
+exampleName: 'with-sqlite'
 iconUrl: '/static/images/packages/expo-sqlite.png'
 platforms: ['android', 'ios', 'macos', 'tvos', 'web', 'expo-go']
 ---

--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -3,6 +3,7 @@ title: Widgets
 description: A library to build iOS home screen widgets and Live Activities using Expo UI components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-widgets'
 packageName: 'expo-widgets'
+exampleName: 'with-widgets'
 platforms: ['ios']
 ---
 

--- a/docs/pages/versions/v57.0.0/sdk/app-integrity.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/app-integrity.mdx
@@ -3,6 +3,7 @@ title: AppIntegrity
 description: A library that provides access to Google's Play Integrity API on Android and Apple's App Attest service on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-app-integrity'
 packageName: '@expo/app-integrity'
+exampleName: 'with-app-integrity'
 platforms: ['android', 'ios', 'expo-go']
 isAlpha: true
 ---

--- a/docs/pages/versions/v57.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/camera.mdx
@@ -3,6 +3,7 @@ title: Camera
 description: A React component that renders a preview for the device's front or back camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-camera'
 packageName: 'expo-camera'
+exampleName: 'with-camera'
 iconUrl: '/static/images/packages/expo-camera.png'
 platforms: ['android*', 'ios*', 'web', 'expo-go']
 ---

--- a/docs/pages/versions/v57.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/maps.mdx
@@ -3,6 +3,7 @@ title: Maps
 description: A library that provides access to Google Maps on Android and Apple Maps on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-maps'
 packageName: 'expo-maps'
+exampleName: 'with-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
 isAlpha: true

--- a/docs/pages/versions/v57.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/splash-screen.mdx
@@ -3,6 +3,7 @@ title: SplashScreen
 description: A library that provides access to controlling the visibility behavior of native splash screen.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-splash-screen'
 packageName: 'expo-splash-screen'
+exampleName: 'with-splash-screen'
 iconUrl: '/static/images/packages/expo-splash-screen.png'
 platforms: ['android', 'ios', 'tvos']
 ---

--- a/docs/pages/versions/v57.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/sqlite.mdx
@@ -3,6 +3,7 @@ title: SQLite
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-sqlite'
 packageName: 'expo-sqlite'
+exampleName: 'with-sqlite'
 iconUrl: '/static/images/packages/expo-sqlite.png'
 platforms: ['android', 'ios', 'macos', 'tvos', 'web', 'expo-go']
 ---

--- a/docs/pages/versions/v57.0.0/sdk/widgets.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/widgets.mdx
@@ -3,6 +3,7 @@ title: Widgets
 description: A library to build iOS home screen widgets and Live Activities using Expo UI components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-widgets'
 packageName: 'expo-widgets'
+exampleName: 'with-widgets'
 platforms: ['ios']
 ---
 

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -3,6 +3,7 @@ export type PageMetadata = {
   description?: string;
   sourceCodeUrl?: string;
   packageName?: string;
+  exampleName?: string;
   cliVersion?: string;
   maxHeadingDepth?: number;
   iconUrl?: string;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22262

# How

- Add an optional `exampleName` frontmatter key that maps an SDK page to its `expo/examples` project.
- Update `APIInstallSection` to render two tabs when the key is present on the latest SDK version: **Install library** (existing instructions) and **Start with an example**, showing the `create-expo-app --example` command for all four package managers and a link to the example on GitHub.
- Gate the example tab to the latest SDK version, so it disappears from older versions automatically when a new SDK is cut. This is because the examples repo only contains latest SDK examples.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2456" height="1644" alt="CleanShot 2026-07-02 at 16 45 00@2x" src="https://github.com/user-attachments/assets/9ede94a4-27c6-496f-a6a3-1dbb2b092330" />

<img width="2564" height="668" alt="CleanShot 2026-07-02 at 16 45 32@2x" src="https://github.com/user-attachments/assets/6606ae4c-aed8-4458-a3f1-c97278c54007" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
