### PR TITLE
[fix][bare-expo] Fix inline modules screen on bare-expo

### DIFF
--- a/apps/bare-expo/ios/Podfile.properties.json
+++ b/apps/bare-expo/ios/Podfile.properties.json
@@ -3,6 +3,7 @@
   "newArchEnabled": "true",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "expo.inlineModules.watchedDirectories": "[\"../native-component-list/src/screens/inlineModules/inlineModulesExamples\"]",
+  "expo.inlineModules.xcodeProjectTargets": "{\"mainTarget\":\"BareExpoMain-BareExpo\",\"targets\":[]}",
   "ios.buildReactNativeFromSource": "false",
   "EXPO_USE_PRECOMPILED_MODULES": "false"
 }


### PR DESCRIPTION
# Why
After added option to specify xcode project targets for inline modules #46698, bare-expo wasn't properly updated which lead to inline modules not autolinking and inline modules API screen crashing.

# How
Specified the main target in the `Podfile.properties.json` of bare-expo

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
