### PR TITLE
[docs] Add EAS Observe library integration guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -636,6 +636,7 @@ export const eas = [
     makePage('eas/observe/events.mdx'),
     makePage('eas/observe/configuration.mdx'),
     makeGroup('Integrations', [
+      makePage('eas/observe/integrations/libraries.mdx'),
       makePage('eas/observe/integrations/expo-router.mdx'),
       makePage('eas/observe/integrations/react-navigation.mdx'),
     ]),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -636,9 +636,9 @@ export const eas = [
     makePage('eas/observe/events.mdx'),
     makePage('eas/observe/configuration.mdx'),
     makeGroup('Integrations', [
-      makePage('eas/observe/integrations/third-party.mdx'),
       makePage('eas/observe/integrations/expo-router.mdx'),
       makePage('eas/observe/integrations/react-navigation.mdx'),
+      makePage('eas/observe/integrations/third-party.mdx'),
     ]),
     makeGroup('Reference', [
       makePage('eas/observe/reference/metrics.mdx'),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -636,7 +636,7 @@ export const eas = [
     makePage('eas/observe/events.mdx'),
     makePage('eas/observe/configuration.mdx'),
     makeGroup('Integrations', [
-      makePage('eas/observe/integrations/libraries.mdx'),
+      makePage('eas/observe/integrations/third-party.mdx'),
       makePage('eas/observe/integrations/expo-router.mdx'),
       makePage('eas/observe/integrations/react-navigation.mdx'),
     ]),

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -19,12 +19,13 @@ Observe.configure({
 });
 ```
 
-| Option               | Type      | Default                | Description                                                                                        |
-| -------------------- | --------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
-| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                     |
-| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                     |
-| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds. |
-| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).           |
+| Option               | Type      | Default                | Description                                                                                         |
+| -------------------- | --------- | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                      |
+| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                      |
+| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.  |
+| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).            |
+| `integrations`       | `object`  | `undefined`            | Opt-in settings for Observe integrations. See [Integrations](/eas/observe/integrations/libraries/). |
 
 ## `dispatchEvents()`
 

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -25,7 +25,7 @@ Observe.configure({
 | `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                      |
 | `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.  |
 | `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).            |
-| `integrations`       | `object`  | `undefined`            | Opt-in settings for Observe integrations. See [Integrations](/eas/observe/integrations/libraries/). |
+| `integrations`       | `object`  | `undefined`            | Opt-in settings for Observe integrations. See [Integrations](/eas/observe/integrations/third-party/). |
 
 ## `dispatchEvents()`
 

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -19,12 +19,12 @@ Observe.configure({
 });
 ```
 
-| Option               | Type      | Default                | Description                                                                                         |
-| -------------------- | --------- | ---------------------- | --------------------------------------------------------------------------------------------------- |
-| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                      |
-| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                      |
-| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.  |
-| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).            |
+| Option               | Type      | Default                | Description                                                                                           |
+| -------------------- | --------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                        |
+| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                        |
+| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.    |
+| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).              |
 | `integrations`       | `object`  | `undefined`            | Opt-in settings for Observe integrations. See [Integrations](/eas/observe/integrations/third-party/). |
 
 ## `dispatchEvents()`

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -19,13 +19,13 @@ Observe.configure({
 });
 ```
 
-| Option               | Type      | Default                | Description                                                                                           |
-| -------------------- | --------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
-| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                        |
-| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                        |
-| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.    |
-| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).              |
-| `integrations`       | `object`  | `undefined`            | Opt-in settings for Observe integrations. See [Integrations](/eas/observe/integrations/third-party/). |
+| Option               | Type      | Default                | Description                                                                                                                                                                                                                                           |
+| -------------------- | --------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `environment`        | `string`  | `process.env.NODE_ENV` | The environment label for observability events                                                                                                                                                                                                        |
+| `dispatchingEnabled` | `boolean` | `true`                 | Whether to send collected events to the server                                                                                                                                                                                                        |
+| `dispatchInDebug`    | `boolean` | `false`                | Whether to dispatch metrics that were collected in a debug build. Has no effect on release builds.                                                                                                                                                    |
+| `sampleRate`         | `number`  | `undefined`            | Fraction of installations that dispatch metrics, in `[0, 1]`. See [Sampling](#sampling).                                                                                                                                                              |
+| `integrations`       | `object`  | `undefined`            | Opt-in settings for EAS Observe integrations. See [Expo Router](/eas/observe/integrations/expo-router/) and [React Navigation](/eas/observe/integrations/react-navigation/), or [integrate your own package](/eas/observe/integrations/third-party/). |
 
 ## `dispatchEvents()`
 

--- a/docs/pages/eas/observe/integrations/libraries.mdx
+++ b/docs/pages/eas/observe/integrations/libraries.mdx
@@ -1,0 +1,157 @@
+---
+title: Integrate a library with EAS Observe
+sidebar_title: Libraries
+description: Learn how to add an optional EAS Observe integration to a library.
+---
+
+import { Step } from '~/ui/components/Step';
+
+Library integrations let Expo and third-party packages emit observability signals when an app opts in through `expo-observe`. Use this pattern when your library can detect performance or usage issues that are hard for app code to measure directly.
+
+Good library signals point to an actionable fix. For example, your library can log an image decoded much larger than the screen, a long-running background operation, or a slow native resource load.
+
+<Step label="1">
+
+## Choose an actionable signal
+
+Start with a runtime condition that your library understands better than app code. Prefer warnings that help developers fix a problem. Avoid logging normal successful work unless users need that signal in the EAS Observe dashboard.
+
+The `expo-image` integration logs an event when an image decodes to far more pixels than the device screen can display. The event points to a concrete fix: constrain the image decode size with `maxWidth` and `maxHeight`.
+
+</Step>
+
+<Step label="2">
+
+## Define an opt-in integration key
+
+Disable the integration by default. Use the package name as the integration key and keep any options under that key. Document the app-side opt-in as part of your library integration:
+
+```tsx app/_layout.tsx
+import { Observe } from 'expo-observe';
+
+Observe.configure({
+  integrations: {
+    'your-library': true,
+  },
+});
+```
+
+Use object configuration when the integration needs tuning:
+
+```tsx app/_layout.tsx
+Observe.configure({
+  integrations: {
+    'your-library': {
+      threshold: 1.5,
+    },
+  },
+});
+```
+
+If your library ships TypeScript types, register the integration key with `expo-observe` through declaration merging:
+
+```ts
+import type { YourLibraryIntegrationConfig } from './observe';
+
+declare module 'expo-observe' {
+  interface ObserveIntegrationsConfig {
+    'your-library'?: boolean | YourLibraryIntegrationConfig;
+  }
+}
+```
+
+Place the augmentation in a file that is part of your package's public type graph. For example, `expo-image` keeps the augmentation in a public types file that is re-exported from the package entry.
+
+</Step>
+
+<Step label="3">
+
+## Keep the dependency optional
+
+Keep the library working when the host app does not install `expo-observe` or `expo-app-metrics`. Resolve Observe and App Metrics with optional native-module lookups and return early when either module is missing:
+
+```ts
+import { requireOptionalNativeModule } from 'expo';
+import type { ExpoAppMetricsModuleType } from 'expo-app-metrics';
+import type { ObserveModule } from 'expo-observe';
+
+const observe = requireOptionalNativeModule<ObserveModule>('ExpoObserve');
+const appMetrics = requireOptionalNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics');
+
+if (!observe || !appMetrics) {
+  return;
+}
+```
+
+Add `expo-observe` and `expo-app-metrics` as development dependencies for tests and types, not as required runtime dependencies. Import them with `import type` wherever possible.
+
+</Step>
+
+<Step label="4">
+
+## Initialize once and react to configuration
+
+Initialize the integration from the library's entry point after guarding environments that cannot run client-side code. Keep initialization idempotent.
+
+Read the current integrations with `getIntegrations()`. Then subscribe to Observe's `configure` event so later calls to `Observe.configure()` can enable, disable, or retune the integration:
+
+```ts
+let initialized = false;
+
+export function initObserveIntegrationIfNeeded() {
+  if (initialized || typeof window === 'undefined') {
+    return;
+  }
+  initialized = true;
+
+  const observe = requireOptionalNativeModule<ObserveModule>('ExpoObserve');
+  if (!observe) {
+    return;
+  }
+
+  activate(observe.getIntegrations());
+  observe.addListener('configure', ({ integrations }) => activate(integrations));
+}
+```
+
+If enabling the integration creates listeners or native subscriptions, remove them when the integration is disabled.
+
+</Step>
+
+<Step label="5">
+
+## Emit stable events
+
+Log library events with `Observe.logEvent()` or the underlying App Metrics module. Use lowercase, dot-separated names prefixed by the package name:
+
+```ts
+appMetrics.logEvent('your-library.expensive-operation', {
+  displayName: 'Expensive operation detected',
+  severity: 'warn',
+  body: 'The operation exceeded the configured threshold.',
+  attributes: {
+    durationMs,
+    thresholdMs,
+  },
+});
+```
+
+Follow the same event conventions as app code:
+
+- Use stable event names. The dashboard groups events by exact name.
+- Use `displayName` and `body` to explain what happened and how to fix it.
+- Use attributes for values users will filter or inspect.
+- Do not include Personally Identifiable Information (PII) in event names, bodies, or attributes.
+- Treat reporting as best-effort. Catch logging errors so observability never breaks the library's main behavior.
+
+</Step>
+
+## Implementation notes
+
+- Prefer signals derived from actual runtime behavior over configuration alone. The `expo-image` integration listens to the library's image-loaded event. It compares decoded pixel area against the current screen's physical pixel count.
+- Use device-relative thresholds when the same resource can be appropriate on one device and wasteful on another.
+- Deduplicate noisy events within the current configuration. For example, report the same oversized image URL at most once per session, then clear the deduplication set if `Observe.configure()` changes the threshold.
+- Keep event attributes small, structured, and serializable. Strings, numbers, booleans, arrays, and nested objects are supported.
+- Test the integration when `expo-observe` is absent, when the integration is disabled, when it is enabled with `true`, and when it is enabled with object configuration.
+
+For app-level custom events, see [User-defined events](/eas/observe/events/).

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -1,20 +1,20 @@
 ---
-title: Integrate a library with EAS Observe
-sidebar_title: Libraries
-description: Learn how to add an optional EAS Observe integration to a library.
+title: Integrate a third-party package with EAS Observe
+sidebar_title: Third-party
+description: Learn how to add an optional EAS Observe integration to a third-party package.
 ---
 
 import { Step } from '~/ui/components/Step';
 
-Library integrations let Expo and third-party packages emit observability signals when an app opts in through `expo-observe`. Use this pattern when your library can detect performance or usage issues that are hard for app code to measure directly.
+Third-party integrations let packages emit observability signals when an app opts in through `expo-observe`. Use this pattern when your package can detect performance or usage issues that are hard for app code to measure directly.
 
-Good library signals point to an actionable fix. For example, your library can log an image decoded much larger than the screen, a long-running background operation, or a slow native resource load.
+Good signals point to an actionable fix. For example, your package can log an image decoded much larger than the screen, a long-running background operation, or a slow native resource load.
 
 <Step label="1">
 
 ## Choose an actionable signal
 
-Start with a runtime condition that your library understands better than app code. Prefer warnings that help developers fix a problem. Avoid logging normal successful work unless users need that signal in the EAS Observe dashboard.
+Start with a runtime condition that your package understands better than app code. Prefer warnings that help developers fix a problem. Avoid logging normal successful work unless users need that signal in the EAS Observe dashboard.
 
 The `expo-image` integration logs an event when an image decodes to far more pixels than the device screen can display. The event points to a concrete fix: constrain the image decode size with `maxWidth` and `maxHeight`.
 
@@ -24,14 +24,14 @@ The `expo-image` integration logs an event when an image decodes to far more pix
 
 ## Define an opt-in integration key
 
-Disable the integration by default. Use the package name as the integration key and keep any options under that key. Document the app-side opt-in as part of your library integration:
+Disable the integration by default. Use the package name as the integration key and keep any options under that key. Document the app-side opt-in as part of your integration:
 
 ```tsx app/_layout.tsx
 import { Observe } from 'expo-observe';
 
 Observe.configure({
   integrations: {
-    'your-library': true,
+    'your-package': true,
   },
 });
 ```
@@ -41,21 +41,21 @@ Use object configuration when the integration needs tuning:
 ```tsx app/_layout.tsx
 Observe.configure({
   integrations: {
-    'your-library': {
+    'your-package': {
       threshold: 1.5,
     },
   },
 });
 ```
 
-If your library ships TypeScript types, register the integration key with `expo-observe` through declaration merging:
+If your package ships TypeScript types, register the integration key with `expo-observe` through declaration merging:
 
 ```ts
-import type { YourLibraryIntegrationConfig } from './observe';
+import type { YourPackageIntegrationConfig } from './observe';
 
 declare module 'expo-observe' {
   interface ObserveIntegrationsConfig {
-    'your-library'?: boolean | YourLibraryIntegrationConfig;
+    'your-package'?: boolean | YourPackageIntegrationConfig;
   }
 }
 ```
@@ -68,7 +68,7 @@ Place the augmentation in a file that is part of your package's public type grap
 
 ## Keep the dependency optional
 
-Keep the library working when the host app does not install `expo-observe` or `expo-app-metrics`. Resolve Observe and App Metrics with optional native-module lookups and return early when either module is missing:
+Keep the package working when the host app does not install `expo-observe` or `expo-app-metrics`. Resolve Observe and App Metrics with optional native-module lookups and return early when either module is missing:
 
 ```ts
 import { requireOptionalNativeModule } from 'expo';
@@ -91,7 +91,7 @@ Add `expo-observe` and `expo-app-metrics` as development dependencies for tests 
 
 ## Initialize once and react to configuration
 
-Initialize the integration from the library's entry point after guarding environments that cannot run client-side code. Keep initialization idempotent.
+Initialize the integration from the package's entry point after guarding environments that cannot run client-side code. Keep initialization idempotent.
 
 Read the current integrations with `getIntegrations()`. Then subscribe to Observe's `configure` event so later calls to `Observe.configure()` can enable, disable, or retune the integration:
 
@@ -122,10 +122,10 @@ If enabling the integration creates listeners or native subscriptions, remove th
 
 ## Emit stable events
 
-Log library events with `Observe.logEvent()` or the underlying App Metrics module. Use lowercase, dot-separated names prefixed by the package name:
+Log events with `Observe.logEvent()` or the underlying App Metrics module. Use lowercase, dot-separated names prefixed by the package name:
 
 ```ts
-appMetrics.logEvent('your-library.expensive-operation', {
+appMetrics.logEvent('your-package.expensive-operation', {
   displayName: 'Expensive operation detected',
   severity: 'warn',
   body: 'The operation exceeded the configured threshold.',
@@ -142,7 +142,7 @@ Follow the same event conventions as app code:
 - Use `displayName` and `body` to explain what happened and how to fix it.
 - Use attributes for values users will filter or inspect.
 - Do not include Personally Identifiable Information (PII) in event names, bodies, or attributes.
-- Treat reporting as best-effort. Catch logging errors so observability never breaks the library's main behavior.
+- Treat reporting as best-effort. Catch logging errors so observability never breaks the package's main behavior.
 
 </Step>
 

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -117,24 +117,24 @@ Observe.configure({
 Call `initIntegration()` with your integration key. The callback receives the configuration for your integration:
 
 ```ts observe.ts
-import { enableObserveIntegration } from './monitoring';
+export function initObserveIntegration() {
+  if (typeof window !== 'undefined' && observeModule) {
+    const { Observe } = observeModule;
 
-let initialized = false;
-
-export function initObserveIntegrationIfNeeded() {
-  if (initialized || typeof window === 'undefined' || !observeModule) {
-    return;
+    Observe.initIntegration('your-package', config => {
+      if (config) {
+        enableObserveIntegration(config === true ? {} : config);
+      }
+    });
   }
-  initialized = true;
+}
 
-  const { Observe } = observeModule;
+let enabled = false;
 
-  Observe.initIntegration('your-package', config => {
-    if (!config) {
-      return;
-    }
-    enableObserveIntegration(config === true ? {} : config);
-  });
+function enableObserveIntegration() {
+  // Initialize the integration here
+  // For example:
+  enabled = true;
 }
 ```
 
@@ -143,11 +143,11 @@ Implement `enableObserveIntegration()` in your package. The callback does not ru
 Call the initialization function from your package entry point:
 
 ```ts index.ts
-import { initObserveIntegrationIfNeeded } from './observe';
+import { initObserveIntegration } from './observe';
 
 export type { YourPackageIntegrationConfig } from './observe.types';
 
-initObserveIntegrationIfNeeded();
+initObserveIntegration();
 ```
 
 </Step>
@@ -160,11 +160,13 @@ Call `Observe.logEvent()` when your package detects an actionable issue. Use a l
 
 ```ts observe.ts
 export function logExpensiveOperation(durationMs: number, thresholdMs: number) {
-  if (!observeModule) {
+  if (!observeModule || !enabled) {
     return;
   }
 
-  observeModule.Observe.logEvent('your-package.expensive-operation', {
+  const { Observe } = observeModule;
+
+  Observe.logEvent('your-package.expensive-operation', {
     severity: 'warn',
     body: 'Reduce the work performed by this operation or increase the configured threshold.',
     attributes: {

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -6,25 +6,71 @@ description: Learn how to add an optional EAS Observe integration to a third-par
 
 import { Step } from '~/ui/components/Step';
 
-Third-party integrations let packages emit observability signals when an app opts in through `expo-observe`. Use this pattern when your package can detect performance or usage issues that are hard for app code to measure directly.
+Third-party packages can integrate with EAS Observe to send events that help developers identify performance and usage issues, especially problems that are difficult to detect from application code alone.
 
-Good signals point to an actionable fix. For example, your package can log an image decoded much larger than the screen, a long-running background operation, or a slow native resource load.
+Events should describe actionable issues that developers can fix. For example, a package might report:
+
+- An image that is much larger than the device's screen
+- A background task that takes too long to complete
+- A native resource that loads slowly
 
 <Step label="1">
 
-## Choose an actionable signal
+## Add `expo-observe` as an optional dependency
 
-Start with a runtime condition that your package understands better than app code. Prefer warnings that help developers fix a problem. Avoid logging normal successful work unless users need that signal in the EAS Observe dashboard.
+Add `expo-observe` as an optional peer dependency so your package continues to work when it is not installed. Also add it as a development dependency for TypeScript types and tests. Do not add it as a required runtime dependency.
 
-The `expo-image` integration logs an event when an image decodes to far more pixels than the device screen can display. The event points to a concrete fix: constrain the image decode size with `maxWidth` and `maxHeight`.
+```json package.json
+{
+  "peerDependencies": {
+    "expo-observe": ">=56.0.0"
+  },
+  "peerDependenciesMeta": {
+    "expo-observe": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "expo-observe": "^56.0.0"
+  }
+}
+```
+
+Load the package with `require()` inside a `try...catch` block. Use `typeof import()` to preserve its TypeScript types:
+
+```ts observe.ts
+let observeModule: typeof import('expo-observe') | undefined;
+
+try {
+  observeModule = require('expo-observe') as typeof import('expo-observe');
+} catch {
+  // The integration remains disabled when expo-observe is not installed.
+}
+```
 
 </Step>
 
 <Step label="2">
 
-## Define an opt-in integration key
+## Declare the integration configuration
 
-Disable the integration by default. Use the package name as the integration key and keep any options under that key. Document the app-side opt-in as part of your integration:
+Use declaration merging to add your package's integration key to `expo-observe`:
+
+```ts observe.types.ts
+export type YourPackageIntegrationConfig = {
+  thresholdMs?: number;
+};
+
+declare module 'expo-observe' {
+  interface ObserveIntegrationsConfig {
+    'your-package'?: boolean | YourPackageIntegrationConfig;
+  }
+}
+```
+
+Export this declaration from your package entry point so TypeScript loads it when users import your package.
+
+Users can then enable the integration with `Observe.configure()`:
 
 ```tsx app/_layout.tsx
 import { Observe } from 'expo-observe';
@@ -36,122 +82,94 @@ Observe.configure({
 });
 ```
 
-Use object configuration when the integration needs tuning:
+If the integration accepts options, users can pass a configuration object instead of `true`:
 
 ```tsx app/_layout.tsx
 Observe.configure({
   integrations: {
     'your-package': {
-      threshold: 1.5,
+      thresholdMs: 1500,
     },
   },
 });
 ```
 
-If your package ships TypeScript types, register the integration key with `expo-observe` through declaration merging:
-
-```ts
-import type { YourPackageIntegrationConfig } from './observe';
-
-declare module 'expo-observe' {
-  interface ObserveIntegrationsConfig {
-    'your-package'?: boolean | YourPackageIntegrationConfig;
-  }
-}
-```
-
-Place the augmentation in a file that is part of your package's public type graph. For example, `expo-image` keeps the augmentation in a public types file that is re-exported from the package entry.
-
 </Step>
 
 <Step label="3">
 
-## Keep the dependency optional
+## Initialize the integration
 
-Keep the package working when the host app does not install `expo-observe` or `expo-app-metrics`. Resolve Observe and App Metrics with optional native-module lookups and return early when either module is missing:
+Read the current configuration with `getIntegrations()`. Then listen for the `configure` event so the app can enable, disable, or update the integration later:
 
-```ts
-import { requireOptionalNativeModule } from 'expo';
-import type { ExpoAppMetricsModuleType } from 'expo-app-metrics';
-import type { ObserveModule } from 'expo-observe';
+```ts observe.ts
+import type { ObserveIntegrationsConfig } from 'expo-observe';
 
-const observe = requireOptionalNativeModule<ObserveModule>('ExpoObserve');
-const appMetrics = requireOptionalNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics');
+import { disableObserveIntegration, enableObserveIntegration } from './monitoring';
 
-if (!observe || !appMetrics) {
-  return;
+let initialized = false;
+
+function applyConfiguration(integrations: ObserveIntegrationsConfig) {
+  const config = integrations['your-package'];
+
+  if (!config) {
+    disableObserveIntegration();
+    return;
+  }
+
+  enableObserveIntegration(config === true ? {} : config);
+}
+
+export function initObserveIntegrationIfNeeded() {
+  if (initialized || typeof window === 'undefined' || !observeModule) {
+    return;
+  }
+  initialized = true;
+
+  const { Observe } = observeModule;
+
+  applyConfiguration(Observe.getIntegrations());
+  Observe.addListener('configure', ({ integrations }) => applyConfiguration(integrations));
 }
 ```
 
-Add `expo-observe` and `expo-app-metrics` as development dependencies for tests and types, not as required runtime dependencies. Import them with `import type` wherever possible.
+Implement `enableObserveIntegration()` and `disableObserveIntegration()` in your package. Make sure enabling the integration more than once does not add duplicate listeners. Remove any listeners or native subscriptions when the integration is disabled.
+
+Call the initialization function from your package entry point:
+
+```ts index.ts
+import { initObserveIntegrationIfNeeded } from './observe';
+
+export type { YourPackageIntegrationConfig } from './observe.types';
+
+initObserveIntegrationIfNeeded();
+```
 
 </Step>
 
 <Step label="4">
 
-## Initialize once and react to configuration
+## Log events
 
-Initialize the integration from the package's entry point after guarding environments that cannot run client-side code. Keep initialization idempotent.
+Call `Observe.logEvent()` when your package detects an actionable issue. Use a lowercase event name with the package name as the first segment. Separate segments with periods:
 
-Read the current integrations with `getIntegrations()`. Then subscribe to Observe's `configure` event so later calls to `Observe.configure()` can enable, disable, or retune the integration:
-
-```ts
-let initialized = false;
-
-export function initObserveIntegrationIfNeeded() {
-  if (initialized || typeof window === 'undefined') {
-    return;
-  }
-  initialized = true;
-
-  const observe = requireOptionalNativeModule<ObserveModule>('ExpoObserve');
-  if (!observe) {
+```ts observe.ts
+export function logExpensiveOperation(durationMs: number, thresholdMs: number) {
+  if (!observeModule) {
     return;
   }
 
-  activate(observe.getIntegrations());
-  observe.addListener('configure', ({ integrations }) => activate(integrations));
+  observeModule.Observe.logEvent('your-package.expensive-operation', {
+    severity: 'warn',
+    body: 'Reduce the work performed by this operation or increase the configured threshold.',
+    attributes: {
+      durationMs,
+      thresholdMs,
+    },
+  });
 }
 ```
 
-If enabling the integration creates listeners or native subscriptions, remove them when the integration is disabled.
+For more information about naming events and adding details, see [User-defined events](/eas/observe/events/).
 
 </Step>
-
-<Step label="5">
-
-## Emit stable events
-
-Log events with `Observe.logEvent()` or the underlying App Metrics module. Use lowercase, dot-separated names prefixed by the package name:
-
-```ts
-appMetrics.logEvent('your-package.expensive-operation', {
-  displayName: 'Expensive operation detected',
-  severity: 'warn',
-  body: 'The operation exceeded the configured threshold.',
-  attributes: {
-    durationMs,
-    thresholdMs,
-  },
-});
-```
-
-Follow the same event conventions as app code:
-
-- Use stable event names. The dashboard groups events by exact name.
-- Use `displayName` and `body` to explain what happened and how to fix it.
-- Use attributes for values users will filter or inspect.
-- Do not include Personally Identifiable Information (PII) in event names, bodies, or attributes.
-- Treat reporting as best-effort. Catch logging errors so observability never breaks the package's main behavior.
-
-</Step>
-
-## Implementation notes
-
-- Prefer signals derived from actual runtime behavior over configuration alone. The `expo-image` integration listens to the library's image-loaded event. It compares decoded pixel area against the current screen's physical pixel count.
-- Use device-relative thresholds when the same resource can be appropriate on one device and wasteful on another.
-- Deduplicate noisy events within the current configuration. For example, report the same oversized image URL at most once per session, then clear the deduplication set if `Observe.configure()` changes the threshold.
-- Keep event attributes small, structured, and serializable. Strings, numbers, booleans, arrays, and nested objects are supported.
-- Test the integration when `expo-observe` is absent, when the integration is disabled, when it is enabled with `true`, and when it is enabled with object configuration.
-
-For app-level custom events, see [User-defined events](/eas/observe/events/).

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -6,7 +6,7 @@ description: Learn how to add an optional EAS Observe integration to a third-par
 
 import { Step } from '~/ui/components/Step';
 
-Third-party packages can integrate with EAS Observe to send events that help developers identify performance and usage issues, especially problems that are difficult to detect from application code alone.
+Third-party packages can integrate with EAS Observe to send events that help developers identify performance and usage issues. These are often problems that are difficult to detect from application code alone.
 
 Events should describe actionable issues that developers can fix. For example, a package might report:
 
@@ -23,7 +23,7 @@ Add `expo-observe` as an optional peer dependency so your package continues to w
 ```json package.json
 {
   "peerDependencies": {
-    "expo-observe": ">=56.0.0"
+    "expo-observe": ">={{expoSdkVersion}}"
   },
   "peerDependenciesMeta": {
     "expo-observe": {
@@ -31,7 +31,7 @@ Add `expo-observe` as an optional peer dependency so your package continues to w
     }
   },
   "devDependencies": {
-    "expo-observe": "^56.0.0"
+    "expo-observe": "^{{expoSdkVersion}}"
   }
 }
 ```

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -18,9 +18,8 @@ Events should describe actionable issues that developers can fix. For example, a
 ## Prerequisites
 
 <Prerequisites>
-  <Requirement title="Expo SDK 57 or later">
-    Third-party integrations require SDK 57 or later to access `getIntegrations()` and listen for
-    the `configure` event.
+  <Requirement title="Expo SDK 57 and later">
+    Third-party integrations require SDK 57 and later to access `Observe.initIntegration()`.
   </Requirement>
   <Requirement title="An app already using EAS Observe">
     Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
@@ -30,7 +29,7 @@ Events should describe actionable issues that developers can fix. For example, a
 
 <Step label="1">
 
-## Add `expo-observe` as an optional dependency
+## Add `expo-observe` as an optional peer dependency
 
 Add `expo-observe` as an optional peer dependency so your package continues to work when it is not installed. Also, add it as a development dependency for TypeScript types and tests. Do not add it as a required runtime dependency.
 
@@ -114,10 +113,11 @@ Observe.configure({
 
 ## Initialize the integration
 
-Call `initIntegration()` with your integration key. The callback receives the configuration for your integration:
+Call `Observe.initIntegration()` with your integration key. The callback receives the configuration for your integration:
 
 ```ts observe.ts
 export function initObserveIntegration() {
+  // The `typeof window` check skips initialization during server-side rendering on web.
   if (typeof window !== 'undefined' && observeModule) {
     const { Observe } = observeModule;
 

--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -4,6 +4,7 @@ sidebar_title: Third-party
 description: Learn how to add an optional EAS Observe integration to a third-party package.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 
 Third-party packages can integrate with EAS Observe to send events that help developers identify performance and usage issues. These are often problems that are difficult to detect from application code alone.
@@ -14,11 +15,24 @@ Events should describe actionable issues that developers can fix. For example, a
 - A background task that takes too long to complete
 - A native resource that loads slowly
 
+## Prerequisites
+
+<Prerequisites>
+  <Requirement title="Expo SDK 57 or later">
+    Third-party integrations require SDK 57 or later to access `getIntegrations()` and listen for
+    the `configure` event.
+  </Requirement>
+  <Requirement title="An app already using EAS Observe">
+    Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
+    build.
+  </Requirement>
+</Prerequisites>
+
 <Step label="1">
 
 ## Add `expo-observe` as an optional dependency
 
-Add `expo-observe` as an optional peer dependency so your package continues to work when it is not installed. Also add it as a development dependency for TypeScript types and tests. Do not add it as a required runtime dependency.
+Add `expo-observe` as an optional peer dependency so your package continues to work when it is not installed. Also, add it as a development dependency for TypeScript types and tests. Do not add it as a required runtime dependency.
 
 ```json package.json
 {
@@ -36,7 +50,7 @@ Add `expo-observe` as an optional peer dependency so your package continues to w
 }
 ```
 
-Load the package with `require()` inside a `try...catch` block. Use `typeof import()` to preserve its TypeScript types:
+Load the package with `require()` inside a `try/catch` block. Use `typeof import()` to preserve its TypeScript types:
 
 ```ts observe.ts
 let observeModule: typeof import('expo-observe') | undefined;
@@ -70,7 +84,7 @@ declare module 'expo-observe' {
 
 Export this declaration from your package entry point so TypeScript loads it when users import your package.
 
-Users can then enable the integration with `Observe.configure()`:
+Developers using your package can then enable the integration with `Observe.configure()`:
 
 ```tsx app/_layout.tsx
 import { Observe } from 'expo-observe';
@@ -82,7 +96,7 @@ Observe.configure({
 });
 ```
 
-If the integration accepts options, users can pass a configuration object instead of `true`:
+If the integration accepts options, developers can pass a configuration object instead of `true`:
 
 ```tsx app/_layout.tsx
 Observe.configure({
@@ -100,25 +114,12 @@ Observe.configure({
 
 ## Initialize the integration
 
-Read the current configuration with `getIntegrations()`. Then listen for the `configure` event so the app can enable, disable, or update the integration later:
+Call `initIntegration()` with your integration key. The callback receives the configuration for your integration:
 
 ```ts observe.ts
-import type { ObserveIntegrationsConfig } from 'expo-observe';
-
-import { disableObserveIntegration, enableObserveIntegration } from './monitoring';
+import { enableObserveIntegration } from './monitoring';
 
 let initialized = false;
-
-function applyConfiguration(integrations: ObserveIntegrationsConfig) {
-  const config = integrations['your-package'];
-
-  if (!config) {
-    disableObserveIntegration();
-    return;
-  }
-
-  enableObserveIntegration(config === true ? {} : config);
-}
 
 export function initObserveIntegrationIfNeeded() {
   if (initialized || typeof window === 'undefined' || !observeModule) {
@@ -128,12 +129,16 @@ export function initObserveIntegrationIfNeeded() {
 
   const { Observe } = observeModule;
 
-  applyConfiguration(Observe.getIntegrations());
-  Observe.addListener('configure', ({ integrations }) => applyConfiguration(integrations));
+  Observe.initIntegration('your-package', config => {
+    if (!config) {
+      return;
+    }
+    enableObserveIntegration(config === true ? {} : config);
+  });
 }
 ```
 
-Implement `enableObserveIntegration()` and `disableObserveIntegration()` in your package. Make sure enabling the integration more than once does not add duplicate listeners. Remove any listeners or native subscriptions when the integration is disabled.
+Implement `enableObserveIntegration()` in your package. The callback does not run when the integration is omitted or set to `false`.
 
 Call the initialization function from your package entry point:
 


### PR DESCRIPTION
# Why

Add a guide for third-party libraries to integrate with expo-observe

# How


# Test Plan

