### PR TITLE
[brownfield] fix flaky cli e2e (#47431)

### DIFF
--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -131,7 +131,9 @@ describe('tasks:android command', () => {
   describe('with prebuild', () => {
     beforeAll(async () => {
       TEMP_DIR_PREBUILD = await createTempProject('tasksandroidpb', true);
-    }, 600000);
+      // Run once to warm up Gradle — the first run downloads all dependencies and is slow.
+      await tasksAndroidTest({ directory: TEMP_DIR_PREBUILD });
+    }, 3600000);
 
     afterAll(async () => {
       await cleanUpProject('tasksandroidpb');

--- a/packages/expo-brownfield/e2e/scripts/global-setup.js
+++ b/packages/expo-brownfield/e2e/scripts/global-setup.js
@@ -1,4 +1,10 @@
 const { execSync } = require('child_process');
+const spawnAsync = require('@expo/spawn-async');
+const { glob } = require('glob');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEMPLATE_DIR = path.resolve(__dirname, '../../../../templates/expo-template-default');
 
 module.exports = async () => {
   console.log('\nRunning pre-test commands...\n');
@@ -6,4 +12,9 @@ module.exports = async () => {
   execSync('pnpm run --filter expo-build-properties build', { stdio: 'inherit' });
   execSync('pnpm run --filter expo-brownfield build:plugin', { stdio: 'inherit' });
   execSync('pnpm run --filter expo-brownfield build:cli', { stdio: 'inherit' });
+
+  // Prepare the template tarball once, before Jest forks its parallel workers.
+  const staleTarballs = await glob('*.tgz', { cwd: TEMPLATE_DIR, absolute: true });
+  await Promise.all(staleTarballs.map((tarball) => fs.promises.rm(tarball, { force: true })));
+  await spawnAsync('pnpm', ['pack'], { cwd: TEMPLATE_DIR, stdio: 'inherit' });
 };

--- a/packages/expo-brownfield/e2e/utils/process.ts
+++ b/packages/expo-brownfield/e2e/utils/process.ts
@@ -1,10 +1,14 @@
 import spawnAsync, { SpawnResult } from '@expo/spawn-async';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 export const CLI_PATH = require.resolve('../../bin/cli.js');
 export const CREATE_EXPO_BIN = require.resolve('create-expo/bin/create-expo.js');
 
 export interface ExecuteCLIOptions {
   ignoreErrors?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -32,12 +36,21 @@ export const executeExpoCLIAsync = (
 /**
  * Execute Create Expo CLI
  */
-export const executeCreateExpoCLIAsync = (
+export const executeCreateExpoCLIAsync = async (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  return executeCommandAsync(cwd, CREATE_EXPO_BIN, args, options);
+  // Isolate create-expo's tmpdir template cache because `create-expo --template` doesn't support parallel work
+  const cacheDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'create-expo-cache-'));
+  try {
+    return await executeCommandAsync(cwd, CREATE_EXPO_BIN, args, {
+      ...options,
+      env: { ...process.env, TMPDIR: cacheDir, TMP: cacheDir, TEMP: cacheDir },
+    });
+  } finally {
+    await fs.promises.rm(cacheDir, { recursive: true, force: true });
+  }
 };
 
 /**
@@ -53,6 +66,7 @@ export const executeCommandAsync = async (
     const { stdout, stderr, status } = await spawnAsync(command, args, {
       cwd,
       stdio: 'pipe',
+      env: options.env,
     });
 
     return processOutput({ stdout, stderr, status });

--- a/packages/expo-brownfield/e2e/utils/project.ts
+++ b/packages/expo-brownfield/e2e/utils/project.ts
@@ -4,12 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import {
-  executeCommandAsync,
-  executeCreateExpoCLIAsync,
-  executeExpoCLIAsync,
-  sleep,
-} from './process';
+import { executeCreateExpoCLIAsync, executeExpoCLIAsync, sleep } from './process';
 import type { PluginProps, TemplateEntry } from './types';
 
 const PROJECT_NAME = 'testapp';
@@ -117,13 +112,9 @@ const createProjectWithTemplate = async (at: string, projectName: string) => {
     throw new Error(`Template directory not found at: ${templatePath}`);
   }
 
-  let tarballs = await glob('*.tgz', { cwd: templatePath });
+  const tarballs = await glob('*.tgz', { cwd: templatePath });
   if (tarballs.length === 0) {
-    await executeCommandAsync(templatePath, 'pnpm', ['pack', '--json']);
-    tarballs = await glob('*.tgz', { cwd: templatePath });
-    if (tarballs.length === 0) {
-      throw new Error(`No tarballs found in template directory: ${templatePath}`);
-    }
+    throw new Error(`No template tarball found in ${templatePath}.`);
   }
 
   await executeCreateExpoCLIAsync(at, [


### PR DESCRIPTION
# Why

cherry-pick #47431 onto main

# How

cherry-pick #47431 and resolve conflicts

# Test Plan

ci passed

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - no user faced changes
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
