### PR TITLE
[ui][ios] Fix graphical DatePicker resize jump

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][Android] Fix a scrollable child (e.g. `FlatList`, `ScrollView`) inside `@expo/ui/community/bottom-sheet` not scrolling to the end when using fixed snap points. ([#47245](https://github.com/expo/expo/pull/47245) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/DatePickerView.swift
+++ b/packages/expo-ui/ios/DatePickerView.swift
@@ -4,12 +4,24 @@ import SwiftUI
 internal struct DatePickerView: ExpoSwiftUI.View {
   @ObservedObject var props: DatePickerProps
   @State private var date = Date()
+  // `.graphical` has some AutoLayout bug (it uses UICalendarView under the hood)
+  // It shrinks height when user taps a date.
+  // https://github.com/expo/expo/issues/47062
+  // https://stackoverflow.com/a/74763440/7070640
+  // Current fix is to add a fixed min width of 320 when `.graphical` style is used.
+  // TODO: Remove if apple fixes the bug in newer versions
+  private var isGraphicalStyle: Bool {
+    props.modifiers?.contains {
+      $0["$type"] as? String == "datePickerStyle" && $0["style"] as? String == "graphical"
+    } ?? false
+  }
 
   var body: some View {
 #if os(tvOS)
     Text("DatePicker is not supported on tvOS")
 #else
     createDatePicker()
+      .frame(minWidth: isGraphicalStyle ? 320 : nil)
       .onChange(of: date) { newDate in
         if props.selection == newDate { return }
         props.onDateChange(["date": newDate.timeIntervalSince1970 * 1000])


### PR DESCRIPTION
# Why

Fixes #47062. The `.graphical` DatePicker style (backed by `UICalendarView`) renders undersized on first layout, then visibly jumps to its correct size on first date tap. Upstream bug when SwiftUI is hosted in UIHostingController - https://stackoverflow.com/questions/73475000/datepicker-with-graphical-style-breaks-layout-constraints-on-ios-16-0

# How

Adds `minWidth` 320 as suggested in the solution. Looks very hacky fix but i couldn't find any better way to make it work 😕. The fix is scoped to graphical datepicker style so it does not have any big regression area. Worst case it will break which is already broken 😄 (It's well tested though!)


Alternate would be to document the issue, but lets see how it works? the change seems to be small.

# Test Plan

Tested on iOS 18 and 26.5.

### Before

https://github.com/user-attachments/assets/8f8f9f9b-13fd-42de-82ec-511268ee6430


### After



https://github.com/user-attachments/assets/3ce9d72c-7f3e-453a-a23c-0a105f7e6959


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)