### PR TITLE
[docs] Surface llms.txt directive near the top of page HTML

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -371,6 +371,13 @@ export default function DocumentationPage({
           )}
         />
         <main className={mergeClasses('mx-auto px-14 pt-10', 'max-lg:px-4 max-lg:pt-5')}>
+          <p className="sr-only">
+            This documentation is available as Markdown for AI agents and LLMs. See the{' '}
+            <A openInNewTab href="/llms.txt">
+              full Markdown index
+            </A>{' '}
+            or append .md to any documentation URL.
+          </p>
           {version && version === 'unversioned' && (
             <InlineHelp type="default" size="sm" className="mb-5! inline-flex! w-full">
               This is documentation for the next SDK version. For up-to-date documentation, see the{' '}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22584

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add an `sr-only` directive paragraph as the first child of `<main>` in `components/DocumentationPage.tsx`, linking /llms.txt and mentioning that .md is available by appending it to any URL.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
