### PR TITLE
Fix expo-widgets typed config ios fields

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))
+- Fix typed config plugin requiring deprecated root-level widget fields when using `ios.supportedFamilies`. ([#47473](https://github.com/expo/expo/pull/47473) by [@eliotgevers](https://github.com/eliotgevers))
 - [iOS][plugin] Only add the `aps-environment` entitlement when `enablePushNotifications` is enabled, and keep a pre-existing value. ([#47645](https://github.com/expo/expo/pull/47645) by [@kadikraman](https://github.com/kadikraman))
 - [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
 

--- a/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
+++ b/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
@@ -5,9 +5,9 @@ export type WidgetConfig = {
   displayName: string;
   description: string;
   // @deprecated: use `ios.supportedFamilies` instead.
-  supportedFamilies: WidgetFamily[];
+  supportedFamilies?: WidgetFamily[];
   // @deprecated: use `ios.contentMarginsDisabled` instead.
-  contentMarginsDisabled: boolean;
+  contentMarginsDisabled?: boolean;
   // @deprecated: use `ios.configuration` instead.
   configuration?: {
     title: string;
@@ -15,7 +15,7 @@ export type WidgetConfig = {
     parameters: Record<string, WidgetParameter>;
   };
   ios?: {
-    supportedFamilies: WidgetFamily[];
+    supportedFamilies?: WidgetFamily[];
     contentMarginsDisabled?: boolean;
     initialLayout?: string;
     configuration?: {
@@ -32,7 +32,10 @@ export type WidgetConfig = {
     resizeMode?: 'none' | 'horizontal' | 'vertical' | 'both';
     initialLayout?: string;
   } | null;
-};
+} & (
+  | { supportedFamilies: WidgetFamily[] }
+  | { ios: { supportedFamilies: WidgetFamily[] } }
+);
 
 export type WidgetParameterString = {
   title: string;


### PR DESCRIPTION
# Why

The `expo-widgets` config plugin runtime already supports reading supported widget families from `ios.supportedFamilies` and only falls back to the deprecated root-level `supportedFamilies` field.

It also only emits `.contentMarginsDisabled()` when the resolved value is truthy, so typed configs should not need to pass `contentMarginsDisabled: false`.

The current `WidgetConfig` type still requires both deprecated root-level fields, which makes the typed config plugin reject the iOS-specific shape that the runtime accepts.

# What changed

- Allows `WidgetConfig` to provide supported families through `ios.supportedFamilies` without duplicating them at the root.
- Keeps type safety by still requiring supported families either on `ios.supportedFamilies` or the existing root field.
- Makes `contentMarginsDisabled` optional so callers do not need to pass the default `false` value.
- Adds an `expo-widgets` changelog entry.

# Test plan

Ran a focused TypeScript repro against `packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts`:

- verified a widget using only `ios.supportedFamilies` type-checks
- verified a widget with no supported families still fails type-checking
- ran `git diff --check`
