### PR TITLE
[ios][autolinking] Add missing worklets flag

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed the macro plugin flag not being applied to test targets, so macros couldn't be used in unit tests. ([#46595](https://github.com/expo/expo/pull/46595) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Respect an explicit `ios.usePrecompiledModules: false` even when `EXPO_USE_PRECOMPILED_MODULES` is already set in the environment (e.g. EAS Build). ([#46983](https://github.com/expo/expo/pull/46983) by [@ryanda9910](https://github.com/ryanda9910))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.5.0`'s generated component and native view sources. ([#47201](https://github.com/expo/expo/pull/47201) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`.
+- [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`. ([#47478](https://github.com/expo/expo/pull/47478) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed the macro plugin flag not being applied to test targets, so macros couldn't be used in unit tests. ([#46595](https://github.com/expo/expo/pull/46595) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Respect an explicit `ios.usePrecompiledModules: false` even when `EXPO_USE_PRECOMPILED_MODULES` is already set in the environment (e.g. EAS Build). ([#46983](https://github.com/expo/expo/pull/46983) by [@ryanda9910](https://github.com/ryanda9910))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.5.0`'s generated component and native view sources. ([#47201](https://github.com/expo/expo/pull/47201) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
@@ -47,7 +47,7 @@
                     "compilerFlags": {
                         "common": {
                             "c": [
-                                "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true]\"",
+                                "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true][ENABLE_CROSS_RUNTIME_STACK_TRACES:true]\"",
                                 "-DWORKLETS_VERSION=${PACKAGE_VERSION}",
                                 "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                                 "-DHERMES_V1_ENABLED",
@@ -55,7 +55,7 @@
                             ],
                             "cxx": [
                                 "-fno-cxx-modules",
-                                "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true]\"",
+                                "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true][ENABLE_CROSS_RUNTIME_STACK_TRACES:true]\"",
                                 "-DWORKLETS_VERSION=${PACKAGE_VERSION}",
                                 "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                                 "-DHERMES_V1_ENABLED",
@@ -100,7 +100,7 @@
                         "common": [
                             "-include", "Foundation/Foundation.h",
                             "-include", "UIKit/UIKit.h",
-                            "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true]\"",
+                            "-DWORKLETS_FEATURE_FLAGS=\"[RUNTIME_TEST_FLAG:false][FETCH_PREVIEW_ENABLED:false][IOS_DYNAMIC_FRAMERATE_ENABLED:true][ENABLE_CROSS_RUNTIME_STACK_TRACES:true]\"",
                             "-DWORKLETS_VERSION=${PACKAGE_VERSION}",
                             "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                             "-DHERMES_V1_ENABLED",


### PR DESCRIPTION
# Why
https://exponent-internal.slack.com/archives/C1QP38NQ5/p1783022012537229

# How
 Added the missing ENABLE_CROSS_RUNTIME_STACK_TRACES to all three -DWORKLETS_FEATURE_FLAGS defines

# Test Plan
- Downloaded the published stale tarball and confirmed its compiled string was the three-flag set
- After republish, re-fetch the tarball and verify the four-flag string

