### PR TITLE
[docs] Update workflows docs

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -470,6 +470,7 @@ export const eas = [
     makePage('eas/workflows/syntax.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
     makePage('eas/workflows/rest-api.mdx'),
+    makePage('eas/workflows/troubleshooting.mdx'),
     makePage('eas/workflows/limitations.mdx'),
     makeGroup('Examples', [
       makePage('eas/workflows/examples/introduction.mdx'),

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -48,7 +48,7 @@ jobs:
 
 Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following EAS CLI command:
 
-<Terminal cmd={['$ eas workflow:run build-ios-production.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/build-ios-production.yml']} />
 
 You can provide parameters to make Android builds or use other build profiles. Learn more about build job parameters with the [build job documentation](/eas/workflows/syntax/#build).
 
@@ -60,7 +60,7 @@ You can submit your app to the app stores using EAS CLI with the `eas submit` co
 
 To write this command as a workflow, create a workflow file named **.eas/workflows/submit-ios.yml** at the root of your project.
 
-Inside **submit-ios.yml**, you can use the following workflow to kick off a job that submits an iOS app.
+The submit job requires the ID of the build to submit. Inside **submit-ios.yml**, you can use the following workflow to create an iOS build and then submit it:
 
 ```yaml .eas/workflows/submit-ios.yml
 name: Submit iOS app
@@ -70,18 +70,27 @@ on:
     branches: ['main']
 
 jobs:
-  submit_ios:
-    name: Submit iOS
-    type: submit
+  build_ios:
+    name: Build iOS
+    type: build
     params:
       platform: ios
+      profile: production
+  submit_ios:
+    name: Submit iOS
+    needs: [build_ios]
+    type: submit
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
 ```
+
+To submit an existing build instead of creating a new one, use the [`get-build`](/eas/workflows/pre-packaged-jobs/#get-build) job to look up the build and pass its `build_id` output to the submit job.
 
 Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following EAS CLI command:
 
-<Terminal cmd={['$ eas workflow:run submit-ios.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/submit-ios.yml']} />
 
-You can provide parameters to submit other platforms or use other submit profiles. Learn more about submit job parameters with the [submit job documentation](/eas/workflows/syntax/#submit).
+You can provide parameters to use other submit profiles. Learn more about submit job parameters with the [submit job documentation](/eas/workflows/syntax/#submit).
 
 ## Publishing updates
 
@@ -110,7 +119,7 @@ jobs:
 
 Once you have this workflow file, you can kick it off by pushing a commit to any branch, or by running the following EAS CLI command:
 
-<Terminal cmd={['$ eas workflow:run publish-update.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/publish-update.yml']} />
 
 You can provide parameters to update specific branches or channels, and configure the update's message. Learn more about update job parameters with the [update job documentation](/eas/workflows/syntax/#update).
 

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -84,7 +84,7 @@ jobs:
       build_id: ${{ needs.build_ios.outputs.build_id }}
 ```
 
-To submit an existing build instead of creating a new one, use the [`get-build`](/eas/workflows/pre-packaged-jobs/#get-build) job to look up the build and pass its `build_id` output to the submit job.
+To submit an existing build instead of creating a new one, pass its `build_id` directly to the submit job, or use the [`get-build`](/eas/workflows/pre-packaged-jobs/#get-build) job to look one up dynamically and pass its `build_id` output.
 
 Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following EAS CLI command:
 

--- a/docs/pages/eas/workflows/examples/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/examples/e2e-tests.mdx
@@ -173,7 +173,7 @@ You can run the E2E test workflow in two ways:
 
 1. **Manually using the EAS CLI**
 
-<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/e2e-test-android.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/e2e-test-android.yml']} />
 
 2. **Automatically when you open a pull request**
 

--- a/docs/pages/eas/workflows/examples/index.js
+++ b/docs/pages/eas/workflows/examples/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/eas/workflows/examples/introduction/');

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -30,88 +30,51 @@ This page walks you through creating your first EAS Workflows: development build
     />
 
   </Requirement>
-  <Requirement title="Install expo-dev-client">
-    [Development builds](/develop/development-builds/introduction/) include the `expo-dev-client` library, which adds a developer menu and connects to your development server. Install it in your project:
-
-    <Terminal cmd={['$ npx expo install expo-dev-client']} />
-
-  </Requirement>
   <Requirement title="Install EAS CLI">
-    You'll need to install EAS CLI to sync your project with EAS and run workflows:
+    You'll need to install EAS CLI to create and run workflows:
 
     <Terminal cmd={['$ npm install -g eas-cli']} />
 
   </Requirement>
-  <Requirement title="Sync the project with EAS">
-    You'll need to sync the project with EAS with the following command. This will create an EAS project and link it to your local project:
-
-    <Terminal cmd={['$ eas init']} />
-
-  </Requirement>
-  <Requirement title="Add eas.json">
-    You'll need an **eas.json** file at the root of your project with the following build profiles. The `development` profile creates development builds for Android devices and emulators, and for iOS devices. The `development-simulator` profile creates development builds for the iOS Simulator.
-
-```json eas.json
-{
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal"
-    },
-    "development-simulator": {
-      "developmentClient": true,
-      "distribution": "internal",
-      "ios": {
-        "simulator": true
-      }
-    },
-    "production": {}
-  }
-}
-```
-
-  </Requirement>
 </Prerequisites>
+
+You don't need to link your project to EAS, add an **eas.json** file, or install `expo-dev-client` up front. The `eas workflow:create` command in the next step sets all of that up for you.
 
 <Step label="1">
 
-Create your first workflow with EAS CLI. This command creates the **.eas/workflows** directory and a starter workflow file, so you don't have to write one from scratch:
+Instead of writing a workflow file by hand, generate one with EAS CLI. Pass `--template build` to create a workflow that builds development builds for every platform:
 
-<Terminal cmd={['$ eas workflow:create create-development-builds.yml']} />
+<Terminal cmd={['$ eas workflow:create --template build']} />
 
-When prompted to select a template, choose **Create development builds**. EAS CLI reads the `development` and `development-simulator` profiles from your **eas.json** and writes a workflow with a build job for each platform:
+This command does the setup work for you. It links your project to EAS (prompting you to choose an account if the project isn't linked yet), adds the `development` and `development-ios-simulator` build profiles to your **eas.json**, sets your app identifiers, installs `expo-dev-client` if it's missing, and writes the workflow to **.eas/workflows/build.yml**:
 
-```yaml .eas/workflows/create-development-builds.yml
+```yaml .eas/workflows/build.yml
 name: Create development builds
-
-on:
-  push:
-    branches: ['main']
 
 jobs:
   android_development_build:
     name: Build Android
     type: build
     params:
-      profile: development
       platform: android
+      profile: development
+  ios_device_development_build:
+    name: Build iOS device
+    type: build
+    params:
+      platform: ios
+      profile: development
   ios_simulator_development_build:
     name: Build iOS simulator
     type: build
     params:
-      profile: development-simulator
       platform: ios
-  ios_development_build:
-    name: Build iOS device
-    type: build
-    params:
-      profile: development
-      platform: ios
+      profile: development-ios-simulator
 ```
 
-This workflow creates three development builds in parallel: an Android build for emulators and devices, an iOS Simulator build, and an iOS device build. It also runs automatically on pushes to the `main` branch once you [link a GitHub repository](#automate-workflows-with-github-events).
+This workflow creates three development builds in parallel: an Android build for emulators and devices, an iOS device build, and an iOS Simulator build.
 
-The Android and iOS Simulator builds work on a brand new project: EAS generates and stores the Android signing keystore automatically, and iOS Simulator builds don't require code signing. The iOS device build requires an Apple Developer account and a registered device. If you don't have those yet, remove the `ios_development_build` job and add it back later by following [iOS device setup](/get-started/set-up-your-environment/?mode=development-build&platform=ios&device=physical).
+The Android and iOS Simulator builds work on a brand new project: EAS generates and stores the Android signing keystore automatically, and iOS Simulator builds don't require code signing. The iOS device build requires an Apple Developer account and a registered device, so EAS CLI prints a **Next steps** list after creating the workflow. To set up iOS device credentials, run the command it suggests (`eas credentials:configure-build -p ios -e development`) and register your device when prompted. You can also do this later, or skip the iOS device build for now by removing the `ios_device_development_build` job.
 
 </Step>
 
@@ -119,11 +82,11 @@ The Android and iOS Simulator builds work on a brand new project: EAS generates 
 
 Run the workflow with the following command:
 
-<Terminal cmd={['$ eas workflow:run .eas/workflows/create-development-builds.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/build.yml']} />
 
 Once you do, you can watch your workflow run on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
 
-> **info** `eas workflow:create` validates the file when it generates it. To check a file you've edited by hand, run `eas workflow:validate .eas/workflows/create-development-builds.yml`.
+> **info** `eas workflow:create` validates the file when it generates it. To check a file you've edited by hand, run `eas workflow:validate .eas/workflows/build.yml`.
 
 </Step>
 
@@ -135,7 +98,7 @@ When the builds finish, install and launch your app on an Android Emulator or iO
   cmd={[
     '$ eas build:run -p android --latest',
     '',
-    '$ eas build:run -p ios -e development-simulator --latest',
+    '$ eas build:run -p ios -e development-ios-simulator --latest',
   ]}
 />
 
@@ -149,9 +112,15 @@ You can install the Android and iOS device builds on physical devices from each 
 
 ## Create production builds
 
-When you're ready to build for the app stores, use the `production` profile from your **eas.json**. Production builds require app signing credentials. The easiest way to set them up is to complete one build with EAS CLI. See [set up your project](/build/setup/).
+When you're ready to build for the app stores, generate a release workflow with the `deploy` template:
 
-Create **.eas/workflows/create-production-builds.yml** with the following:
+<Terminal cmd={['$ eas workflow:create --template deploy']} />
+
+Like the `build` template, this configures EAS Build and EAS Update, then writes a complete release workflow to **.eas/workflows/deploy.yml**. The workflow fingerprints your project, reuses a matching build or creates a new production build when there are native changes, submits to the app stores, and sends an over-the-air update otherwise. Production builds and store submissions require credentials, so EAS CLI prints a **Next steps** list with the commands to set them up.
+
+For a walkthrough of the generated workflow, see the [Deploy to production example](/eas/workflows/examples/deploy-to-production).
+
+If you only need to create production builds, use a workflow with a `build` job for each platform:
 
 ```yaml .eas/workflows/create-production-builds.yml
 name: Create Production Builds
@@ -169,11 +138,9 @@ jobs:
       profile: production
 ```
 
-Then, run the workflow with the following command:
+This workflow uses the `production` profile from your **eas.json**. Production builds require app signing credentials. The easiest way to set them up is to complete one build with EAS CLI. See [set up your project](/build/setup/). Then, run the workflow:
 
 <Terminal cmd={['$ eas workflow:run .eas/workflows/create-production-builds.yml']} />
-
-For a complete release workflow that builds, submits to the app stores, and sends over-the-air updates, see the [Deploy to production example](/eas/workflows/examples/deploy-to-production).
 
 ## More
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -22,10 +22,10 @@ This page walks you through creating your first EAS Workflow: development builds
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest'],
-        yarn: ['$ yarn create expo-app'],
-        pnpm: ['$ pnpm create expo-app'],
-        bun: ['$ bun create expo'],
+        npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
+        yarn: ['$ yarn create expo-app --template default@sdk-57'],
+        pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
+        bun: ['$ bun create expo --template default@sdk-57'],
       }}
     />
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -102,14 +102,11 @@ jobs:
       profile: production
 ```
 
-This workflow uses the `production` profile from your **eas.json**. Production builds require app signing credentials. Set them up for each platform with `eas credentials:configure-build`, without running a build first:
+This workflow uses the `production` profile from your **eas.json**. Production builds require app signing credentials. Set them up for each platform with the following commands:
 
-<Terminal
-  cmd={[
-    '$ eas credentials:configure-build -p android -e production',
-    '$ eas credentials:configure-build -p ios -e production',
-  ]}
-/>
+<Terminal cmd={['$ eas credentials:configure-build -p android -e production']} />
+
+<Terminal cmd={['$ eas credentials:configure-build -p ios -e production']} />
 
 Then, run the workflow:
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -65,7 +65,7 @@ jobs:
       platform: ios
       profile: development
   ios_simulator_development_build:
-    name: Build iOS simulator
+    name: Build iOS Simulator
     type: build
     params:
       platform: ios

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -5,12 +5,11 @@ description: Learn how to use EAS Workflows to automate your React Native CI/CD 
 searchRank: 10
 ---
 
-import { FileTree } from '~/ui/components/FileTree';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-This page walks you through the process of creating your first EAS Workflows for building and submitting your app to the app stores.
+This page walks you through creating your first EAS Workflows: development builds of your app for emulators, simulators, and physical devices, and production builds for the app stores.
 
 ## Get started
 
@@ -31,35 +30,128 @@ This page walks you through the process of creating your first EAS Workflows for
     />
 
   </Requirement>
+  <Requirement title="Install expo-dev-client">
+    [Development builds](/develop/development-builds/introduction/) include the `expo-dev-client` library, which adds a developer menu and connects to your development server. Install it in your project:
+
+    <Terminal cmd={['$ npx expo install expo-dev-client']} />
+
+  </Requirement>
+  <Requirement title="Install EAS CLI">
+    You'll need to install EAS CLI to sync your project with EAS and run workflows:
+
+    <Terminal cmd={['$ npm install -g eas-cli']} />
+
+  </Requirement>
   <Requirement title="Sync the project with EAS">
     You'll need to sync the project with EAS with the following command. This will create an EAS project and link it to your local project:
 
-    <Terminal cmd={['$ npx eas-cli@latest init']} />
+    <Terminal cmd={['$ eas init']} />
 
   </Requirement>
   <Requirement title="Add eas.json">
-    You'll need to add an `eas.json` file to the root of your project if it doesn't already exist:
+    You'll need an **eas.json** file at the root of your project with the following build profiles. The `development` profile creates development builds for Android devices and emulators, and for iOS devices. The `development-simulator` profile creates development builds for the iOS Simulator.
 
-    <Terminal cmd={['$ touch eas.json && echo "{}" > eas.json']} />
+```json eas.json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "development-simulator": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "production": {}
+  }
+}
+```
 
   </Requirement>
 </Prerequisites>
 
 <Step label="1">
-  Create a directory named **.eas/workflows** at the root of your project with a YAML file inside of
-  it. For example: **.eas/workflows/create-production-builds.yml**.
 
-  <FileTree
-  files={[
-    ['my-app/.eas/workflows/create-production-builds.yml', ''],
-    ['my-app/eas.json', ''],
-  ]}
-/>
+Create your first workflow with EAS CLI. This command creates the **.eas/workflows** directory and a starter workflow file, so you don't have to write one from scratch:
+
+<Terminal cmd={['$ eas workflow:create create-development-builds.yml']} />
+
+When prompted to select a template, choose **Create development builds**. EAS CLI reads the `development` and `development-simulator` profiles from your **eas.json** and writes a workflow with a build job for each platform:
+
+```yaml .eas/workflows/create-development-builds.yml
+name: Create development builds
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  android_development_build:
+    name: Build Android
+    type: build
+    params:
+      profile: development
+      platform: android
+  ios_simulator_development_build:
+    name: Build iOS simulator
+    type: build
+    params:
+      profile: development-simulator
+      platform: ios
+  ios_development_build:
+    name: Build iOS device
+    type: build
+    params:
+      profile: development
+      platform: ios
+```
+
+This workflow creates three development builds in parallel: an Android build for emulators and devices, an iOS Simulator build, and an iOS device build. It also runs automatically on pushes to the `main` branch once you [link a GitHub repository](#automate-workflows-with-github-events).
+
+The Android and iOS Simulator builds work on a brand new project: EAS generates and stores the Android signing keystore automatically, and iOS Simulator builds don't require code signing. The iOS device build requires an Apple Developer account and a registered device. If you don't have those yet, remove the `ios_development_build` job and add it back later by following [iOS device setup](/get-started/set-up-your-environment/?mode=development-build&platform=ios&device=physical).
+
 </Step>
 
 <Step label="2">
 
-Add the following YAML to the `create-production-builds.yml` file:
+Run the workflow with the following command:
+
+<Terminal cmd={['$ eas workflow:run .eas/workflows/create-development-builds.yml']} />
+
+Once you do, you can watch your workflow run on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
+
+> **info** `eas workflow:create` validates the file when it generates it. To check a file you've edited by hand, run `eas workflow:validate .eas/workflows/create-development-builds.yml`.
+
+</Step>
+
+<Step label="3">
+
+When the builds finish, install and launch your app on an Android Emulator or iOS Simulator:
+
+<Terminal
+  cmd={[
+    '$ eas build:run -p android --latest',
+    '',
+    '$ eas build:run -p ios -e development-simulator --latest',
+  ]}
+/>
+
+Then, start a development server so the development build can load your app:
+
+<Terminal cmd={['$ npx expo start']} />
+
+You can install the Android and iOS device builds on physical devices from each build's page on the EAS dashboard.
+
+</Step>
+
+## Create production builds
+
+When you're ready to build for the app stores, use the `production` profile from your **eas.json**. Production builds require app signing credentials. The easiest way to set them up is to complete one build with EAS CLI. See [set up your project](/build/setup/).
+
+Create **.eas/workflows/create-production-builds.yml** with the following:
 
 ```yaml .eas/workflows/create-production-builds.yml
 name: Create Production Builds
@@ -69,25 +161,19 @@ jobs:
     type: build # This job type creates a production build for Android
     params:
       platform: android
+      profile: production
   build_ios:
     type: build # This job type creates a production build for iOS
     params:
       platform: ios
+      profile: production
 ```
 
-The workflow above will create a production build for Android and iOS in parallel. To run this workflow successfully, you'll need to [set up and build your project using EAS CLI](/build/setup/) first.
+Then, run the workflow with the following command:
 
-</Step>
+<Terminal cmd={['$ eas workflow:run .eas/workflows/create-production-builds.yml']} />
 
-<Step label="3">
-
-Finally, run the workflow with the following command:
-
-<Terminal cmd={['$ npx eas-cli@latest workflow:run create-production-builds.yml']} />
-
-Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
-
-</Step>
+For a complete release workflow that builds, submits to the app stores, and sends over-the-air updates, see the [Deploy to production example](/eas/workflows/examples/deploy-to-production).
 
 ## More
 
@@ -115,10 +201,12 @@ jobs:
     type: build
     params:
       platform: android
+      profile: production
   build_ios:
     type: build
     params:
       platform: ios
+      profile: production
 ```
 
 ### Trigger workflows from App Store Connect events
@@ -148,10 +236,13 @@ on:
 jobs:
   send_slack_notification:
     type: slack
+    environment: production
     params:
       webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
       message: 'App version is ready for review or waiting for review.'
 ```
+
+The example reads the webhook URL from a `SLACK_WEBHOOK_URL` [environment variable](/eas/environment-variables/manage/#manage-environment-variables). Create it in the `production` environment before running the workflow.
 
 ### VS Code extension
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -9,7 +9,7 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-This page walks you through creating your first EAS Workflows: development builds of your app for emulators, simulators, and physical devices, and production builds for the app stores.
+This page walks you through creating your first EAS Workflow: development builds of your app for Android emulators, iOS simulators, physical devices, and production builds for the app stores.
 
 ## Get started
 
@@ -44,6 +44,8 @@ Run the following command to create a workflow that creates development builds f
 
 <Terminal cmd={['$ eas workflow:create --template build']} />
 
+Then follow the prompts and the `[Action requested]` steps when they appear. The command generates a workflow file at **.eas/workflows/build.yml** and sets up your project for building on EAS.
+
 </Step>
 
 <Step label="2">
@@ -54,27 +56,19 @@ Run the workflow with the following command:
 
 Once you do, you can watch your workflow run on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
 
-> **info** `eas workflow:create` validates the file when it generates it. To check a file you've edited by hand, run `eas workflow:validate .eas/workflows/build.yml`.
-
 </Step>
 
 <Step label="3">
 
-When the builds finish, install and launch your app on an Android Emulator or iOS Simulator:
+When the builds finish, you can install them on your physical devices via the website UI. You can also run the following commands to install the latest builds on your Android Emulator and iOS Simulator:
 
-<Terminal
-  cmd={[
-    '$ eas build:run -p android --latest',
-    '',
-    '$ eas build:run -p ios -e development-ios-simulator --latest',
-  ]}
-/>
+<Terminal cmd={['$ eas build:run -p android --latest']} />
+
+<Terminal cmd={['$ eas build:run -p ios -e development-ios-simulator --latest']} />
 
 Then, start a development server so the development build can load your app:
 
 <Terminal cmd={['$ npx expo start']} />
-
-You can install the Android and iOS device builds on physical devices from each build's page on the EAS dashboard.
 
 </Step>
 
@@ -84,7 +78,9 @@ When you're ready to build for the app stores, generate a release workflow with 
 
 <Terminal cmd={['$ eas workflow:create --template deploy']} />
 
-Like the `build` template, this sets your project up for you: it configures EAS Build and EAS Update and sets your app identifiers, then writes a complete release workflow to **.eas/workflows/deploy.yml**. When you run it, the workflow fingerprints your project, then builds and submits a new production build when there are native changes, or publishes an over-the-air update when a matching build already exists. Production builds and store submissions require credentials, so EAS CLI prints a **Next steps** list with the commands to set them up.
+This sets up your project for automated deployment: it configures EAS Build and EAS Update and sets your app identifiers, then writes a complete release workflow to **.eas/workflows/deploy.yml**.
+
+When you run it, the workflow fingerprints your project, then builds and submits a new production build when there are native changes so they're ready for submission, or publishes an over-the-air update when a matching build already exists, which will be sent to your users immediately.
 
 For a walkthrough of the generated workflow, see the [Deploy to production example](/eas/workflows/examples/deploy-to-production).
 
@@ -106,7 +102,16 @@ jobs:
       profile: production
 ```
 
-This workflow uses the `production` profile from your **eas.json**. Production builds require app signing credentials. The easiest way to set them up is to complete one build with EAS CLI. See [set up your project](/build/setup/). Then, run the workflow:
+This workflow uses the `production` profile from your **eas.json**. Production builds require app signing credentials. Set them up for each platform with `eas credentials:configure-build`, without running a build first:
+
+<Terminal
+  cmd={[
+    '$ eas credentials:configure-build -p android -e production',
+    '$ eas credentials:configure-build -p ios -e production',
+  ]}
+/>
+
+Then, run the workflow:
 
 <Terminal cmd={['$ eas workflow:run .eas/workflows/create-production-builds.yml']} />
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -22,10 +22,10 @@ This page walks you through creating your first EAS Workflows: development build
 
     <Terminal
       cmd={{
-        npm: ['$ npx create-expo-app@latest --template default@sdk-57'],
-        yarn: ['$ yarn create expo-app --template default@sdk-57'],
-        pnpm: ['$ pnpm create expo-app --template default@sdk-57'],
-        bun: ['$ bun create expo --template default@sdk-57'],
+        npm: ['$ npx create-expo-app@latest'],
+        yarn: ['$ yarn create expo-app'],
+        pnpm: ['$ pnpm create expo-app'],
+        bun: ['$ bun create expo'],
       }}
     />
 
@@ -38,43 +38,11 @@ This page walks you through creating your first EAS Workflows: development build
   </Requirement>
 </Prerequisites>
 
-You don't need to link your project to EAS, add an **eas.json** file, or install `expo-dev-client` up front. The `eas workflow:create` command in the next step sets all of that up for you.
-
 <Step label="1">
 
-Instead of writing a workflow file by hand, generate one with EAS CLI. Pass `--template build` to create a workflow that builds development builds for every platform:
+Run the following command to create a workflow that creates development builds for Android and iOS:
 
 <Terminal cmd={['$ eas workflow:create --template build']} />
-
-This command does the setup work for you. It links your project to EAS (prompting you to choose an account if the project isn't linked yet), adds the `development` and `development-ios-simulator` build profiles to your **eas.json**, sets your app identifiers, installs `expo-dev-client` if it's missing, and writes the workflow to **.eas/workflows/build.yml**:
-
-```yaml .eas/workflows/build.yml
-name: Create development builds
-
-jobs:
-  android_development_build:
-    name: Build Android
-    type: build
-    params:
-      platform: android
-      profile: development
-  ios_device_development_build:
-    name: Build iOS device
-    type: build
-    params:
-      platform: ios
-      profile: development
-  ios_simulator_development_build:
-    name: Build iOS Simulator
-    type: build
-    params:
-      platform: ios
-      profile: development-ios-simulator
-```
-
-This workflow creates three development builds in parallel: an Android build for emulators and devices, an iOS device build, and an iOS Simulator build.
-
-The Android and iOS Simulator builds work on a brand new project: EAS generates and stores the Android signing keystore automatically, and iOS Simulator builds don't require code signing. The iOS device build requires an Apple Developer account and a registered device, so EAS CLI prints a **Next steps** list after creating the workflow. To set up iOS device credentials, run the command it suggests (`eas credentials:configure-build -p ios -e development`) and register your device when prompted. You can also do this later, or skip the iOS device build for now by removing the `ios_device_development_build` job.
 
 </Step>
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -116,7 +116,7 @@ When you're ready to build for the app stores, generate a release workflow with 
 
 <Terminal cmd={['$ eas workflow:create --template deploy']} />
 
-Like the `build` template, this configures EAS Build and EAS Update, then writes a complete release workflow to **.eas/workflows/deploy.yml**. The workflow fingerprints your project, reuses a matching build or creates a new production build when there are native changes, submits to the app stores, and sends an over-the-air update otherwise. Production builds and store submissions require credentials, so EAS CLI prints a **Next steps** list with the commands to set them up.
+Like the `build` template, this sets your project up for you: it configures EAS Build and EAS Update and sets your app identifiers, then writes a complete release workflow to **.eas/workflows/deploy.yml**. When you run it, the workflow fingerprints your project, then builds and submits a new production build when there are native changes, or publishes an over-the-air update when a matching build already exists. Production builds and store submissions require credentials, so EAS CLI prints a **Next steps** list with the commands to set them up.
 
 For a walkthrough of the generated workflow, see the [Deploy to production example](/eas/workflows/examples/deploy-to-production).
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -179,7 +179,7 @@ jobs:
       message: 'App version is ready for review or waiting for review.'
 ```
 
-The example reads the webhook URL from a `SLACK_WEBHOOK_URL` [environment variable](/eas/environment-variables/manage/#manage-environment-variables). Create it in the `production` environment before running the workflow.
+The example reads the webhook URL from a `SLACK_WEBHOOK_URL` [environment variable](/eas/environment-variables/manage/#manage-environment-variables). [Create it](https://expo.dev/accounts/[account]/settings/environment-variables) in the `production` environment before running the workflow.
 
 ### VS Code extension
 

--- a/docs/pages/eas/workflows/index.js
+++ b/docs/pages/eas/workflows/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/eas/workflows/introduction/');

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -31,6 +31,8 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 > **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 To create your first workflow, run the following command and follow the prompts:
 
 <Terminal cmd={['$ eas workflow:create']} />

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -12,6 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { DownloadSlide } from '~/ui/components/DownloadSlide';
 import { FAQ } from '~/ui/components/FAQ';
+import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 **EAS Workflows** is a CI/CD service from EAS (Expo Application Services) that automates repeated tasks like building Android and iOS binaries, publishing over-the-air updates, submitting to app stores, running E2E tests, and deploying web apps to EAS Hosting.
@@ -25,6 +26,12 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 />
 
 <br />
+
+## Quick start
+
+To create your first workflow, run the following command and follow the prompts:
+
+<Terminal cmd={['$ eas workflow:create']} />
 
 ## Get started
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -12,7 +12,6 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { DownloadSlide } from '~/ui/components/DownloadSlide';
 import { FAQ } from '~/ui/components/FAQ';
-import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 **EAS Workflows** is a CI/CD service from EAS (Expo Application Services) that lets teams automate repeated tasks such as building Android and iOS binaries, publishing over-the-air updates, submitting to app stores, running E2E tests with Maestro, and deploying web apps to EAS Hosting.
@@ -27,72 +26,36 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 <br />
 
-## Quick start
+## Get started
 
-> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+Workflows are defined as YAML files in the **.eas/workflows/** directory at the root of your project. Each file specifies a `name`, optional triggers (`on`), and one or more `jobs` that run in the cloud. The Get started guide walks you through the prerequisites and your first workflow run, with no CI configuration required.
 
-Workflows are defined as YAML files in the **.eas/workflows/** directory at the root of your project. Each file specifies a `name`, optional triggers (`on`), and one or more `jobs` that run in the cloud. You can run a workflow with EAS CLI with the following command:
-
-<Terminal cmd={['$ eas workflow:run .eas/workflows/your-workflow.yml']} />
+<BoxLink
+  title="Create your first workflow"
+  description="Set up your project and create development builds with a workflow."
+  href="/eas/workflows/get-started"
+  Icon={Dataflow03Icon}
+/>
 
 ## Key features
 
-- **Pre-packaged for React Native/Expo**: Comes with ready-to-use job types (`build`, `submit`, `update`, `maestro`, `deploy`, and more) that abstract away implementation complexity
-- **No infrastructure to manage**: Runs on EAS with macOS and Linux workers, so you don't need to maintain CI servers or configure Android Studio/Xcode
-- **Unified artifact management**: All build artifacts, updates, and logs appear on EAS dashboard
-- **GitHub integration**: Trigger workflows automatically on push, pull request, label, or ref deletion events with branch and path filtering
-- **Faster iteration**: Combine Fingerprint, Get Build, and Update jobs to avoid redundant native builds and publish OTA (over-the-air) updates when possible
-- **E2E testing built-in**: Run Maestro tests on Android emulators and iOS simulators directly in workflows
-- **Slack notifications**: Send notifications to Slack channels when workflows run successfully or fail
-- **Repack**: Reuse an existing build's metadata and JavaScript bundle to create a compatible build faster
-
-## Workflow trigger types
-
-### Push workflows
-
-Run when commits are pushed to matching branches or tags. Supports branch, tag, and path filtering with glob patterns.
-
-### Ref delete workflows
-
-Run when GitHub branches or tags are deleted. Supports branch and tag filtering with glob patterns. Useful for cleaning up EAS Update branches that share names with Git branches.
-
-See [`on.ref_delete` syntax reference](/eas/workflows/syntax/#onref_delete).
-
-### Pull request workflows
-
-Run when pull requests are opened, updated, or labeled. Useful for preview builds and automated testing before merge.
-
-### Scheduled workflows
-
-Run on a cron schedule (for example, nightly builds or weekly regression tests). Scheduled workflows run on the default branch only.
-
-### Manual workflows
-
-Run on-demand using `eas workflow:run` command. Supports parameterized inputs for flexible execution.
-
-### App Store Connect workflows
-
-Run when selected App Store Connect events occur (for example app version state changes, build upload states, external beta states, or beta feedback events).
-
-To use App Store Connect triggers, configure an App Store Connect connection in the EAS dashboard: **[Project settings > General > Connections](https://expo.dev/accounts/[account]/projects/[project]/settings)**.
-
-See [`on.app_store_connect` syntax reference](/eas/workflows/syntax/#onapp_store_connect) for configuration details and supported values.
+- **Pre-packaged jobs**: [ready-to-use jobs](/eas/workflows/pre-packaged-jobs/) that build, submit, and update your app, run Maestro E2E tests, send Slack messages, and more. [Custom jobs](/eas/workflows/syntax/#custom-jobs) run any command you need.
+- **Flexible triggers**: run workflows on [GitHub events](/eas/workflows/syntax/#on) (push, pull request, label, branch or tag deletion), on a cron schedule, on [App Store Connect events](/eas/workflows/syntax/#onapp_store_connect), manually with `eas workflow:run`, or from the [REST API](/eas/workflows/rest-api/).
+- **No infrastructure to manage**: jobs run on EAS-hosted macOS and Linux workers, so you don't need to maintain CI servers or configure Android Studio and Xcode.
+- **Everything on one dashboard**: builds, updates, test results, artifacts, and logs all appear on [expo.dev](https://expo.dev/).
+- **Faster releases**: combine `fingerprint`, `get-build`, and `update` jobs to skip redundant native builds and publish over-the-air updates when possible.
 
 ## When to use EAS Workflows
 
-| Scenario                                                                           | Recommendation |
-| ---------------------------------------------------------------------------------- | -------------- |
-| Automate Android and iOS builds for your Expo and React Native apps                | <YesIcon />    |
-| Submit builds to App Store and Google Play automatically                           | <YesIcon />    |
-| Publish over-the-air updates on every commit or merge                              | <YesIcon />    |
-| Run E2E tests with Maestro as part of CI                                           | <YesIcon />    |
-| Trigger builds and updates from GitHub push or pull request events                 | <YesIcon />    |
-| Deploy web apps to EAS Hosting                                                     | <YesIcon />    |
-| Use fingerprint-based logic to skip redundant native builds                        | <YesIcon />    |
-| CI/CD without managing your own infrastructure or macOS machines                   | <YesIcon />    |
-| Highly customized pipelines with non-EAS services (such as Docker, custom runners) | <NoIcon />     |
-| Matrix builds with multiple configuration variations in parallel                   | <NoIcon />     |
-| CI/CD for non-React Native projects                                                | <NoIcon />     |
+| Scenario                                                                             | Recommendation |
+| ------------------------------------------------------------------------------------ | -------------- |
+| Automate builds, app store submissions, and over-the-air updates for your app        | <YesIcon />    |
+| Run E2E tests with Maestro as part of CI                                             | <YesIcon />    |
+| Trigger builds and updates from GitHub push or pull request events                   | <YesIcon />    |
+| CI/CD without managing your own infrastructure or macOS machines                     | <YesIcon />    |
+| Highly customized pipelines that depend on non-EAS services (Docker, custom runners) | <NoIcon />     |
+
+See [Limitations](/eas/workflows/limitations) for current constraints, such as matrix builds.
 
 ## Frequently asked questions (FAQ)
 
@@ -168,14 +131,7 @@ Share the following slide in your next team meeting to discuss what EAS Workflow
 
 </FAQ>
 
-## Get started
-
-<BoxLink
-  title="Create your first workflow"
-  description="Learn how to create and run your first workflow."
-  href="/eas/workflows/get-started"
-  Icon={Dataflow03Icon}
-/>
+## Learn more
 
 <BoxLink
   title="Pre-packaged jobs"

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -31,8 +31,6 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 > **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
 
-> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
-
 To create your first workflow, run the following command and follow the prompts:
 
 <Terminal cmd={['$ eas workflow:create']} />
@@ -61,6 +59,7 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 | Scenario                                                                             | Recommendation |
 | ------------------------------------------------------------------------------------ | -------------- |
 | Automate builds, app store submissions, and over-the-air updates for your app        | <YesIcon />    |
+| Deploy web apps to EAS Hosting                                                        | <YesIcon />    |
 | Run E2E tests with Maestro as part of CI                                             | <YesIcon />    |
 | Trigger builds and updates from GitHub push or pull request events                   | <YesIcon />    |
 | CI/CD without managing your own infrastructure or macOS machines                     | <YesIcon />    |

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -14,7 +14,7 @@ import { DownloadSlide } from '~/ui/components/DownloadSlide';
 import { FAQ } from '~/ui/components/FAQ';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-**EAS Workflows** is a CI/CD service from EAS (Expo Application Services) that lets teams automate repeated tasks such as building Android and iOS binaries, publishing over-the-air updates, submitting to app stores, running E2E tests with Maestro, and deploying web apps to EAS Hosting.
+**EAS Workflows** is a CI/CD service from EAS (Expo Application Services) that automates repeated tasks like building Android and iOS binaries, publishing over-the-air updates, submitting to app stores, running E2E tests, and deploying web apps to EAS Hosting.
 
 EAS Workflows run in managed cloud environments with pre-packaged job types designed specifically for mobile app development. When your EAS project is linked to GitHub, teams can trigger workflows from GitHub events (push, pull request, labels) or schedules (cron), or run them manually via the EAS CLI.
 
@@ -28,7 +28,7 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 ## Get started
 
-Workflows are defined as YAML files in the **.eas/workflows/** directory at the root of your project. Each file specifies a `name`, optional triggers (`on`), and one or more `jobs` that run in the cloud. The Get started guide walks you through the prerequisites and your first workflow run, with no CI configuration required.
+Workflows are defined as YAML files in the **.eas/workflows/** directory at the root of your project. Each file specifies a `name`, optional triggers (`on`), and one or more `jobs` that run in the cloud. The Get started guide walks you through the prerequisites and your first workflow run:
 
 <BoxLink
   title="Create your first workflow"
@@ -54,8 +54,6 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 | Trigger builds and updates from GitHub push or pull request events                   | <YesIcon />    |
 | CI/CD without managing your own infrastructure or macOS machines                     | <YesIcon />    |
 | Highly customized pipelines that depend on non-EAS services (Docker, custom runners) | <NoIcon />     |
-
-See [Limitations](/eas/workflows/limitations) for current constraints, such as matrix builds.
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -29,6 +29,8 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 To create your first workflow, run the following command and follow the prompts:
 
 <Terminal cmd={['$ eas workflow:create']} />
@@ -46,11 +48,11 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 
 ## Key features
 
-- **Pre-packaged jobs**: [ready-to-use jobs](/eas/workflows/pre-packaged-jobs/) that build, submit, and update your app, run Maestro E2E tests, send Slack messages, and more. [Custom jobs](/eas/workflows/syntax/#custom-jobs) run any command you need.
-- **Flexible triggers**: run workflows on [GitHub events](/eas/workflows/syntax/#on) (push, pull request, label, branch or tag deletion), on a cron schedule, on [App Store Connect events](/eas/workflows/syntax/#onapp_store_connect), manually with `eas workflow:run`, or from the [REST API](/eas/workflows/rest-api/).
-- **No infrastructure to manage**: jobs run on EAS-hosted macOS and Linux workers, so you don't need to maintain CI servers or configure Android Studio and Xcode.
-- **Everything on one dashboard**: builds, updates, test results, artifacts, and logs all appear on [expo.dev](https://expo.dev/).
-- **Faster releases**: combine `fingerprint`, `get-build`, and `update` jobs to skip redundant native builds and publish over-the-air updates when possible.
+- **Pre-packaged jobs**: [Ready-to-use jobs](/eas/workflows/pre-packaged-jobs/) that build, submit, and update your app, run Maestro E2E tests, send Slack messages, and more. [Custom jobs](/eas/workflows/syntax/#custom-jobs) run any command you need.
+- **Flexible triggers**: Run workflows on [GitHub events](/eas/workflows/syntax/#on) (push, pull request, label, branch or tag deletion), on a cron schedule, on [App Store Connect events](/eas/workflows/syntax/#onapp_store_connect), manually with `eas workflow:run`, or from the [REST API](/eas/workflows/rest-api/).
+- **No infrastructure to manage**: Jobs run on EAS-hosted macOS and Linux workers, so you don't need to maintain CI servers or configure Android Studio and Xcode.
+- **Everything on one dashboard**: Builds, updates, test results, artifacts, and logs all appear on [expo.dev](https://expo.dev/).
+- **Faster releases**: Combine `fingerprint`, `get-build`, and `update` jobs to skip redundant native builds and publish over-the-air updates when possible.
 
 ## When to use EAS Workflows
 
@@ -136,7 +138,7 @@ Share the following slide in your next team meeting to discuss what EAS Workflow
 
 </FAQ>
 
-## Learn more
+## Additional resources
 
 <BoxLink
   title="Pre-packaged jobs"

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -59,7 +59,7 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 | Scenario                                                                             | Recommendation |
 | ------------------------------------------------------------------------------------ | -------------- |
 | Automate builds, app store submissions, and over-the-air updates for your app        | <YesIcon />    |
-| Deploy web apps to EAS Hosting                                                        | <YesIcon />    |
+| Deploy web apps to EAS Hosting                                                       | <YesIcon />    |
 | Run E2E tests with Maestro as part of CI                                             | <YesIcon />    |
 | Trigger builds and updates from GitHub push or pull request events                   | <YesIcon />    |
 | CI/CD without managing your own infrastructure or macOS machines                     | <YesIcon />    |

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -58,7 +58,7 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 
 | Scenario                                                                             | Recommendation |
 | ------------------------------------------------------------------------------------ | -------------- |
-| Automate builds, app store submissions, and over-the-air updates for your app        | <YesIcon />    |
+| Automate builds, app store submissions, over-the-air updates, and web deployments    | <YesIcon />    |
 | Deploy web apps to EAS Hosting                                                       | <YesIcon />    |
 | Run E2E tests with Maestro as part of CI                                             | <YesIcon />    |
 | Trigger builds and updates from GitHub push or pull request events                   | <YesIcon />    |

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -17,9 +17,11 @@ Build your project into an Android or iOS app.
 Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
 
 <Prerequisites>
-  <Requirement title="A completed build from your local machine">
-    Complete a build with EAS CLI using the same platform and profile as the pre-packaged job. Learn
-    how to [create your first build](/build/setup/) to get started.
+  <Requirement title="A project configured for EAS Build">
+    Your project must be set up for EAS Build: **eas.json** must contain the build profile the job
+    uses, and app signing credentials must be configured for the platform. The easiest way to do
+    both is to complete one build with EAS CLI using the same platform and profile as the
+    pre-packaged job. Learn how to [create your first build](/build/setup/) to get started.
   </Requirement>
 </Prerequisites>
 
@@ -224,16 +226,18 @@ jobs:
     params:
       alias: string # optional
       prod: boolean # optional
+      source_maps: boolean # optional
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type    | Description                                                                        |
-| --------- | ------- | ---------------------------------------------------------------------------------- |
-| alias     | string  | Optional. The [alias](/eas/hosting/deployments-and-aliases/#aliases) to deploy to. |
-| prod      | boolean | Optional. Whether to deploy to production.                                         |
+| Parameter   | Type    | Description                                                                        |
+| ----------- | ------- | ---------------------------------------------------------------------------------- |
+| alias       | string  | Optional. The [alias](/eas/hosting/deployments-and-aliases/#aliases) to deploy to. |
+| prod        | boolean | Optional. Whether to deploy to production.                                         |
+| source_maps | boolean | Optional. Whether to upload source maps with the deployment.                       |
 
 #### Outputs
 
@@ -542,10 +546,10 @@ Submit an Android or iOS build to the app store using EAS Submit.
 jobs:
   submit_to_store:
     type: submit
-    runs_on: string # optional - see https://docs.expo.dev/build-reference/infrastructure/ for available options
     params:
       build_id: string # required
       profile: string # optional - default: production
+      groups: string[] # optional
     hooks:
       before_submit: step[] # optional - steps to run before the submission starts.
       after_submit: step[] # optional - steps to run after the submission completes.
@@ -555,10 +559,11 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type   | Description                                                    |
-| --------- | ------ | -------------------------------------------------------------- |
-| build_id  | string | Required. The ID of the build to submit.                       |
-| profile   | string | Optional. The submit profile to use. Defaults to `production`. |
+| Parameter | Type     | Description                                                                                                                                     |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| build_id  | string   | Required. The ID of the build to submit.                                                                                                        |
+| profile   | string   | Optional. The submit profile to use. Defaults to `production`.                                                                                  |
+| groups    | string[] | Optional. TestFlight internal group names to add the build to. For more TestFlight distribution options, see the [TestFlight job](#testflight). |
 
 #### Outputs
 
@@ -680,7 +685,6 @@ Upload an EAS iOS build and submit it to TestFlight in a single workflow job.
 jobs:
   testflight_distribution:
     type: testflight
-    runs_on: string # optional - see https://docs.expo.dev/build-reference/infrastructure/ for available options
     params:
       build_id: string # required
       profile: string # optional - default: production
@@ -893,7 +897,6 @@ jobs:
     environment: production | preview | development # optional, defaults to production
     env: # optional list of environment variables
       ENV_VAR_NAME: value
-    runs_on: string # optional - see https://docs.expo.dev/build-reference/infrastructure/ for available options
     params:
       message: string # optional
       platform: string # optional - android | ios | all, defaults to all
@@ -1058,6 +1061,7 @@ jobs:
     type: maestro
     environment: production | preview | development # optional - defaults to preview
     image: string # optional - see https://docs.expo.dev/build-reference/infrastructure/ for a list of available images.
+    runs_on: string # optional - use a linux-*-nested-virtualization worker for Android Emulator tests. See https://docs.expo.dev/eas/workflows/syntax/#jobsjob_idruns_on for available options.
     params:
       build_id: string # required
       flow_path: string | string[] # required
@@ -1071,6 +1075,8 @@ jobs:
       android_system_image_package: string # optional
       device_identifier: string | { android?: string, ios?: string } # optional
       output_format: string # optional - defaults to junit
+      skip_build_check: boolean # optional - defaults to false
+      use_cuttlefish: boolean # optional - defaults to false
     hooks:
       before_maestro_tests: step[] # optional - steps to run before the tests start.
       after_maestro_tests: step[] # optional - steps to run after the tests complete.
@@ -1095,6 +1101,7 @@ You can pass the following parameters into the `params` list:
 | android_system_image_package | string                                                | Optional. Android Emulator system image package to use. Run `sdkmanager --list` on your machine to list available packages. Choose an `x86_64` variant. Examples: `system-images;android-36;google_apis;x86_64`, `system-images;android-35-ext15;google_apis_playstore;x86_64`. Note that newer images require more computing resources, for which you may want to use large runners.                                                 |
 | device_identifier            | string or `{ android?: string, ios?: string }` object | Optional. Device identifier to use for the tests. You can also use a single-value expression like `pixel_6`, `iPhone 16 Plus` or `${{ needs.build.outputs.platform == "android" ? "pixel_6" : "iPhone 16 Plus" }}` and an object like `device_identifier: { android: "pixel_6", ios: "iPhone 16 Plus" }`. Note that iOS devices availability differs across runner images. A list of available devices can be found in the jobs logs. |
 | skip_build_check             | boolean                                               | Optional. Skip validation of the build (whether an iOS build is a simulator build). Defaults to false.                                                                                                                                                                                                                                                                                                                                |
+| use_cuttlefish               | boolean                                               | Optional. Use [Cuttlefish](https://source.android.com/docs/devices/cuttlefish) instead of the Android Emulator. Only supported on the latest Android worker image. Does not support multiple shards. The device does not have Google APIs or Play Store, but it may have better performance. No-op on iOS. Defaults to false.                                                                                                         |
 
 #### Hooks
 
@@ -1286,6 +1293,7 @@ jobs:
       device_locale: string # optional - device locale to use for the tests. Will be passed to Maestro as `--device-locale`.
       device_model: string # optional - model of the device to use for the tests. Will be passed to Maestro as `--device-model`. Run `maestro list-cloud-devices` for a list of supported values.
       device_os: string # optional - OS of the device to use for the tests. Will be passed to Maestro as `--device-os`. Run `maestro list-cloud-devices` for a list of supported values.
+      skip_build_check: boolean # optional - skip validation of the build (whether an iOS build is a simulator build). Defaults to false.
       name: string # optional - name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional - override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional - run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
@@ -1311,6 +1319,7 @@ You can pass the following parameters into the `params` list:
 | device_locale      | string  | Optional. The locale that will be set on devices used for the tests. Corresponds to `--device-locale` param to `maestro cloud`. Example: `pl_PL`.                                                                                            |
 | device_model       | string  | Optional. The model of the device to use for the tests. Corresponds to `--device-model` param to `maestro cloud`. Example: `iPhone-11`. Run `maestro list-cloud-devices` for a list of supported values.                                     |
 | device_os          | string  | Optional. The OS of the device to use for the tests. Corresponds to `--device-os` param to `maestro cloud`. Example: `iOS-18-2`. Run `maestro list-cloud-devices` for a list of supported values.                                            |
+| skip_build_check   | boolean | Optional. Skip validation of the build (whether an iOS build is a simulator build). Defaults to false.                                                                                                                                       |
 | name               | string  | Optional. Name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.                                                                                                                                               |
 | branch             | string  | Optional. Override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`. |
 | async              | boolean | Optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.               |
@@ -2066,8 +2075,12 @@ jobs:
       build_id: string # required
       profile: string # optional
       embed_bundle_assets: boolean # optional
+      js_bundle_only: boolean # optional
+      ios_signing_use_source_app_entitlements: boolean # optional
+      ios_signing_app_entitlements_path: string # optional
       message: string # optional
       repack_version: string # optional
+      repack_package: string # optional
 ```
 
 > **Note:** If the build might still be in progress, use [`get-build`](#get-build) with `wait_for_in_progress: true`, then pass its `build_id` to `repack`.
@@ -2104,6 +2117,7 @@ You can pass the following parameters into the `params` list:
 | js_bundle_only                          | boolean | Optional. Whether to only repack the JavaScript bundle. Defaults to false, which means the entire app metadata will be updated.                                                                                 |
 | message                                 | string  | Optional. Custom message attached to the build. Corresponds to the `--message` flag when running `eas build`.                                                                                                   |
 | repack_version                          | string  | Optional. The version of the `@expo/repack-app` to use. Defaults to the latest version.                                                                                                                         |
+| repack_package                          | string  | Optional. The repack npm package to use. Defaults to `@expo/repack-app`.                                                                                                                                        |
 | ios_signing_use_source_app_entitlements | boolean | Optional. Whether to use fastlane resign `use_app_entitlements` behavior: extract app bundle code signing entitlements and combine them with entitlements from the new provisioning profile. Defaults to false. |
 | ios_signing_app_entitlements_path       | string  | Optional. Path to the entitlements file to use, for example, `myApp/MyApp.entitlements`. This is exclusive with `ios_signing_use_source_app_entitlements`                                                       |
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1077,7 +1077,6 @@ jobs:
       device_identifier: string | { android?: string, ios?: string } # optional
       output_format: string # optional - defaults to junit
       skip_build_check: boolean # optional - defaults to false
-      use_cuttlefish: boolean # optional - defaults to false
     hooks:
       before_maestro_tests: step[] # optional - steps to run before the tests start.
       after_maestro_tests: step[] # optional - steps to run after the tests complete.
@@ -1102,7 +1101,6 @@ You can pass the following parameters into the `params` list:
 | android_system_image_package | string                                                | Optional. Android Emulator system image package to use. Run `sdkmanager --list` on your machine to list available packages. Choose an `x86_64` variant. Examples: `system-images;android-36;google_apis;x86_64`, `system-images;android-35-ext15;google_apis_playstore;x86_64`. Note that newer images require more computing resources, for which you may want to use large runners.                                                 |
 | device_identifier            | string or `{ android?: string, ios?: string }` object | Optional. Device identifier to use for the tests. You can also use a single-value expression like `pixel_6`, `iPhone 16 Plus` or `${{ needs.build.outputs.platform == "android" ? "pixel_6" : "iPhone 16 Plus" }}` and an object like `device_identifier: { android: "pixel_6", ios: "iPhone 16 Plus" }`. Note that iOS devices availability differs across runner images. A list of available devices can be found in the jobs logs. |
 | skip_build_check             | boolean                                               | Optional. Skip validation of the build (whether an iOS build is a simulator build). Defaults to false.                                                                                                                                                                                                                                                                                                                                |
-| use_cuttlefish               | boolean                                               | Optional. Use [Cuttlefish](https://source.android.com/docs/devices/cuttlefish) instead of the Android Emulator. Only supported on the latest Android worker image. Does not support multiple shards. The device does not have Google APIs or Play Store, but it may have better performance. No-op on iOS. Defaults to false.                                                                                                         |
 
 #### Hooks
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -19,9 +19,10 @@ Build jobs can be customized so that you can execute custom commands during the 
 <Prerequisites>
   <Requirement title="A project configured for EAS Build">
     Your project must be set up for EAS Build: **eas.json** must contain the build profile the job
-    uses, and app signing credentials must be configured for the platform. The easiest way to do
-    both is to complete one build with EAS CLI using the same platform and profile as the
-    pre-packaged job. Learn how to [create your first build](/build/setup/) to get started.
+    uses, and app signing credentials must be configured for the platform. Set up credentials
+    without running a build first by running `eas credentials:configure-build -p <platform> -e
+    <profile>` with the same platform and profile the job uses. Learn more about [configuring your
+    project for EAS Build](/build/setup/).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -573,22 +573,6 @@ jobs:
         run: yarn --version # should print a concrete version, like 2.4.3
 ```
 
-### `defaults.hooks`
-
-Steps to run at specific points of every job in the workflow that installs node modules:
-
-- `before_install_node_modules`: steps to run before node modules are installed.
-- `after_install_node_modules`: steps to run after node modules are installed.
-
-```yaml
-defaults:
-  hooks:
-    before_install_node_modules:
-      - run: echo "About to install node modules"
-    after_install_node_modules:
-      - run: echo "Node modules installed"
-```
-
 ## `concurrency`
 
 Configuration for concurrency control. Currently only allows setting `cancel_in_progress` for same-branch workflows.
@@ -1421,7 +1405,6 @@ jobs:
       device_identifier: string | { android?: string, ios?: string } # optional. Device identifier to use for the tests.
       output_format: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
       skip_build_check: boolean # optional, defaults to false. Skip validation of the build (whether an iOS build is a simulator build).
-      use_cuttlefish: boolean # optional, defaults to false. Use Cuttlefish instead of the Android Emulator. Only supported on the latest Android worker image. Does not support multiple shards.
     hooks:
       before_maestro_tests: step[] # optional
       after_maestro_tests: step[] # optional

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -464,7 +464,7 @@ jobs:
 
 ### `jobs.<job_id>.env`
 
-Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `apple-device-registration-request`, `require-approval`, `doc`, `get-build`, and `slack` jobs).
+Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `apple-device-registration-request`, `branch-delete`, `doc`, `get-build`, `github-comment`, `require-approval`, and `slack` jobs).
 
 ```yaml
 jobs:
@@ -517,6 +517,15 @@ jobs:
 
 Parameters to use as defaults for all jobs defined in the workflow configuration.
 
+### `defaults.image`
+
+Default VM image to use for all jobs in the workflow. Using an `sdk-XX` image tag is recommended. See [Infrastructure](/build-reference/infrastructure/) for available images. Individual jobs can override this value with [`jobs.<job_id>.image`](#jobsjob_idimage).
+
+```yaml
+defaults:
+  image: sdk-57
+```
+
 ### `defaults.run.working_directory`
 
 Default working directory to run the scripts in. Relative paths like "./assets" or "assets" are resolved from the app's base directory.
@@ -562,6 +571,22 @@ jobs:
         run: node --version # should print a concrete version, like 23.9.0
       - name: Check Yarn version
         run: yarn --version # should print a concrete version, like 2.4.3
+```
+
+### `defaults.hooks`
+
+Steps to run at specific points of every job in the workflow that installs node modules:
+
+- `before_install_node_modules`: steps to run before node modules are installed.
+- `after_install_node_modules`: steps to run after node modules are installed.
+
+```yaml
+defaults:
+  hooks:
+    before_install_node_modules:
+      - run: echo "About to install node modules"
+    after_install_node_modules:
+      - run: echo "Node modules installed"
 ```
 
 ## `concurrency`
@@ -1161,6 +1186,7 @@ jobs:
     params:
       alias: string # optional
       prod: boolean # optional
+      source_maps: boolean # optional
 ```
 
 This job outputs the following properties:
@@ -1379,7 +1405,8 @@ jobs:
     type: maestro
     # @end #
     environment: production | preview | development # optional, defaults to preview
-    image: string # optional. See https://docs.expo.dev/eas/workflows/syntax/#jobsjob_idruns_on  for a list of available images.
+    image: string # optional. See https://docs.expo.dev/build-reference/infrastructure/ for a list of available images.
+    runs_on: string # optional. Use a linux-*-nested-virtualization worker for Android Emulator tests. See https://docs.expo.dev/eas/workflows/syntax/#jobsjob_idruns_on for available options.
     params:
       build_id: string # required
       flow_path: string | string[] # required
@@ -1392,7 +1419,9 @@ jobs:
       maestro_version: string # optional. Version of Maestro to use for the tests. If not provided, the latest version will be used.
       android_system_image_package: string # optional. Android Emulator system image package to use.
       device_identifier: string | { android?: string, ios?: string } # optional. Device identifier to use for the tests.
-      output_format?: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
+      output_format: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
+      skip_build_check: boolean # optional, defaults to false. Skip validation of the build (whether an iOS build is a simulator build).
+      use_cuttlefish: boolean # optional, defaults to false. Use Cuttlefish instead of the Android Emulator. Only supported on the latest Android worker image. Does not support multiple shards.
     hooks:
       before_maestro_tests: step[] # optional
       after_maestro_tests: step[] # optional
@@ -1411,7 +1440,7 @@ jobs:
     type: maestro-cloud
     # @end #
     environment: production | preview | development # optional, defaults to preview
-    image: string # optional. See https://docs.expo.dev/eas/workflows/syntax/#jobsjob_idruns_on  for a list of available images.
+    image: string # optional. See https://docs.expo.dev/build-reference/infrastructure/ for a list of available images.
     params:
       build_id: string # required. ID of the build to test.
       maestro_project_id: string # required. Maestro Cloud project ID. Example: `proj_01jw6hxgmdffrbye9fqn0pyzm0`.
@@ -1424,6 +1453,7 @@ jobs:
       device_locale: string # optional. Device locale to use for the tests. Will be passed to Maestro as `--device-locale`.
       device_model: string # optional. Model of the device to use for the tests. Will be passed to Maestro as `--device-model`. Run `maestro list-cloud-devices` for a list of supported values.
       device_os: string # optional. OS of the device to use for the tests. Will be passed to Maestro as `--device-os`. Run `maestro list-cloud-devices` for a list of supported values.
+      skip_build_check: boolean # optional, defaults to false. Skip validation of the build (whether an iOS build is a simulator build).
       name: string # optional. Name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional. Override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, *not* whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
@@ -1532,8 +1562,12 @@ jobs:
       build_id: string # required
       profile: string # optional
       embed_bundle_assets: boolean # optional
+      js_bundle_only: boolean # optional
+      ios_signing_use_source_app_entitlements: boolean # optional
+      ios_signing_app_entitlements_path: string # optional
       message: string # optional
       repack_version: string # optional
+      repack_package: string # optional
     # @end #
 ```
 
@@ -1610,7 +1644,7 @@ jobs:
 
 ### `jobs.<job_id>.runs_on`
 
-Specifies the worker that will execute the job. Available only on custom jobs.
+Specifies the worker that will execute the job. Available on custom jobs and on the `build`, `maestro`, `maestro-cloud`, and `repack` pre-packaged jobs.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/troubleshooting.mdx
+++ b/docs/pages/eas/workflows/troubleshooting.mdx
@@ -1,0 +1,56 @@
+---
+title: Troubleshoot EAS Workflows
+sidebar_title: Troubleshooting
+description: Learn how to diagnose and fix common issues when running EAS Workflows.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+This page lists common EAS Workflows failure modes and how to fix them. If a workflow doesn't start or a job fails, start with the workflow run's detail page on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows). It shows each job's status, logs, and errors.
+
+## Validate the workflow file
+
+Check a workflow file for YAML syntax and schema errors before running it:
+
+<Terminal cmd={['$ eas workflow:validate .eas/workflows/my-workflow.yml']} />
+
+The [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) also provides descriptions and autocompletion for workflow files as you edit them.
+
+## Workflow doesn't start on GitHub events
+
+If a workflow with an [`on` trigger](/eas/workflows/syntax/#on) never starts, check the following:
+
+- **GitHub connection**: triggers such as `push`, `pull_request`, and `ref_delete` require your EAS project to be [linked to a GitHub repository](/eas/workflows/get-started/#automate-workflows-with-github-events).
+- **Workflow file location and ref**: the file must be inside the **.eas/workflows** directory. For `push` and `pull_request` events, EAS reads the workflow file from the triggering commit, so the file must exist on that branch. For `schedule` and `ref_delete` events, EAS reads the workflow file from the default branch.
+- **Trigger filters**: `branches`, `tags`, `paths`, `types`, and `labels` filters must match the event. For example, `on.push.branches: ['main']` ignores pushes to every other branch.
+- **Commit message skip markers**: runs triggered by `push` and `pull_request` events are skipped when the commit message contains `[eas skip]`, `[skip eas]`, or `[no eas]`.
+- **Scheduled workflows**: `on.schedule` workflows only run from the repository's default branch, run in the GMT time zone, and may be delayed during periods of high load.
+
+## Build job fails with "Missing build profile in eas.json"
+
+Pre-packaged [build jobs](/eas/workflows/pre-packaged-jobs/#build) require the build profile they use to exist in your project's **eas.json**. Build jobs use the `production` profile unless the job's `params.profile` says otherwise, so an empty or missing **eas.json** fails with this error.
+
+Add the profile to **eas.json**, or run `eas build:configure` to generate the file with default profiles. Builds also need app signing credentials for each platform. Completing one build with EAS CLI using the same platform and profile sets up both. See [create your first build](/build/setup/).
+
+## Environment variable is empty or missing
+
+[EAS environment variables](/eas/environment-variables/) are scoped to an environment: `production`, `preview`, or `development`. A job only sees variables from the environment set by its [`environment` key](/eas/workflows/syntax/#jobsjob_idenvironment), which defaults to `production`. If a variable is empty in a job, confirm the variable exists in the environment the job uses, or set the job's `environment` to match where the variable is defined.
+
+Also note that the [`env` key](/eas/workflows/syntax/#jobsjob_idenv) is not available on the `apple-device-registration-request`, `branch-delete`, `doc`, `get-build`, `github-comment`, `require-approval`, and `slack` jobs.
+
+## Workflow run is stuck in "action-required"
+
+The `action-required` status means a job is waiting on a person, not that something is broken:
+
+- A [`require-approval`](/eas/workflows/pre-packaged-jobs/#require-approval) job waits until a team member approves or rejects the run on the workflow run's detail page.
+- An [`apple-device-registration-request`](/eas/workflows/pre-packaged-jobs/#apple-device-registration-request) job waits until a device enrolls and a team member approves the enrollment.
+
+Open the workflow run's detail page to complete the pending action.
+
+## Branch delete job fails with a channel mapping error
+
+A [`branch-delete`](/eas/workflows/pre-packaged-jobs/#branch-delete) job fails when a channel points to the EAS Update branch it is trying to delete. Remove or repoint the [channel–branch link](/eas-update/eas-cli/) before deleting the branch. To keep cleanup workflows from failing on branches that are already gone, leave `fail_on_missing` at its default of `false`.
+
+## More help
+
+If you're still stuck, email [workflows@expo.dev](mailto:workflows@expo.dev) with your workflow file and a link to the failing run, or ask in the [Expo Discord](https://chat.expo.dev/).

--- a/docs/pages/eas/workflows/troubleshooting.mdx
+++ b/docs/pages/eas/workflows/troubleshooting.mdx
@@ -38,19 +38,6 @@ Add the profile to **eas.json**, or run `eas build:configure` to generate the fi
 
 Also note that the [`env` key](/eas/workflows/syntax/#jobsjob_idenv) is not available on the `apple-device-registration-request`, `branch-delete`, `doc`, `get-build`, `github-comment`, `require-approval`, and `slack` jobs.
 
-## Workflow run is stuck in "action-required"
-
-The `action-required` status means a job is waiting on a person, not that something is broken:
-
-- A [`require-approval`](/eas/workflows/pre-packaged-jobs/#require-approval) job waits until a team member approves or rejects the run on the workflow run's detail page.
-- An [`apple-device-registration-request`](/eas/workflows/pre-packaged-jobs/#apple-device-registration-request) job waits until a device enrolls and a team member approves the enrollment.
-
-Open the workflow run's detail page to complete the pending action.
-
-## Branch delete job fails with a channel mapping error
-
-A [`branch-delete`](/eas/workflows/pre-packaged-jobs/#branch-delete) job fails when a channel points to the EAS Update branch it is trying to delete. Remove or repoint the [channel–branch link](/eas-update/eas-cli/) before deleting the branch. To keep cleanup workflows from failing on branches that are already gone, leave `fail_on_missing` at its default of `false`.
-
 ## More help
 
 If you're still stuck, email [workflows@expo.dev](mailto:workflows@expo.dev) with your workflow file and a link to the failing run, or ask in the [Expo Discord](https://chat.expo.dev/).

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -8,6 +8,7 @@ import { RouterLogo } from '@expo/styleguide';
 import { ActivityIcon } from '@expo/styleguide-icons/outline/ActivityIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
@@ -162,4 +163,11 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
   description="Solutions for common issues when setting up and using EAS Observe."
   href="/eas/observe/reference/troubleshooting/"
   Icon={ActivityIcon}
+/>
+
+<BoxLink
+  title="EAS Workflows: Troubleshooting"
+  description="Diagnose and fix common issues when running EAS Workflows."
+  href="/eas/workflows/troubleshooting/"
+  Icon={Dataflow03Icon}
 />


### PR DESCRIPTION
# Why

Closes ENG-23990

Refreshes the EAS Workflows docs to center the getting-started flow on the improved `eas workflow:create` (expo/eas-cli#3943).

Highlights:
- **Get started**: leads with `eas workflow:create --template build`, which links the project, writes the `development`/`development-ios-simulator` profiles, sets app identifiers, and installs `expo-dev-client`, so the manual `eas.json`/`eas init`/dev-client prerequisites are gone. Production section uses `--template deploy`.
- **Credentials**: build-job setup now points at `eas credentials:configure-build -p <platform> -e <profile>` instead of "run one build first" (get-started + pre-packaged-jobs).
- **Introduction**: trimmed to a shorter feature list and a single get-started BoxLink.
- **New Troubleshooting page** + nav entry; `/eas/workflows` and `/eas/workflows/examples` index redirects.
- **Syntax + pre-packaged-jobs** updated for `defaults.image`, `defaults.hooks`, `runs_on` availability, and new params (`source_maps`, `groups`, `skip_build_check`, `use_cuttlefish`, repack options).

Note: the `--template` flow depends on expo/eas-cli#3943 being released with EAS CLI.

# Test plan

Look at the following pages and make sure they read well:
- Introduction: https://pr-47481.expo-docs.pages.dev/eas/workflows/introduction/
- Get started: https://pr-47481.expo-docs.pages.dev/eas/workflows/get-started/
- Pre-packaged jobs: https://pr-47481.expo-docs.pages.dev/eas/workflows/pre-packaged-jobs/
- Syntax: https://pr-47481.expo-docs.pages.dev/eas/workflows/syntax/
- Troubleshooting: https://pr-47481.expo-docs.pages.dev/eas/workflows/troubleshooting/