### PR TITLE
[expo-observe] ENG-22118: Add filteredParams configuration option to navigation integrations

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -1,9 +1,9 @@
 import { ThemeProvider } from 'ThemeProvider';
 import BenchmarkHelper from 'benchmark-helper';
+import * as DevMenu from 'expo-dev-menu';
 import { Observe, ObserveRoot } from 'expo-observe';
 import * as Splashscreen from 'expo-splash-screen';
 import React from 'react';
-import * as DevMenu from 'expo-dev-menu';
 
 import MainNavigator, { optionalRequire } from './MainNavigator';
 
@@ -70,7 +70,7 @@ Observe.configure({
   dispatchingEnabled: true,
   sampleRate: 0.9,
   integrations: {
-    'react-navigation': true,
+    'react-navigation': { filteredParams: ['accountId', 'firstName'] },
   },
 });
 

--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -7,13 +7,13 @@ import { LinkingOptions } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as Linking from 'expo-linking';
+import { AppMetrics } from 'expo-observe';
+import { ObserveNavigationContainer } from 'expo-observe/integrations/react-navigation';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { Platform } from 'react-native';
-import { TestStackNavigator } from 'test-suite/TestStackNavigator';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { AppMetrics } from 'expo-observe';
-import { ObserveNavigationContainer } from 'expo-observe/integrations/react-navigation';
+import { TestStackNavigator } from 'test-suite/TestStackNavigator';
 
 import Playground from './Playground';
 

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -123,6 +123,21 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/ExpoObserveScreen'));
+    },
+    name: 'ExpoObserve',
+    options: { headerShown: false, title: 'Expo Observe' },
+    route: 'expo-observe',
+    linking: {
+      path: 'expo-observe',
+      screens: {
+        index: '',
+        filteredParams: 'filtered/:userId/:accountId',
+      },
+    },
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/AsyncStorageScreen'));
     },
     name: 'AsyncStorage',

--- a/apps/native-component-list/src/navigation/MainNavigators.tsx
+++ b/apps/native-component-list/src/navigation/MainNavigators.tsx
@@ -31,7 +31,7 @@ const apis: ScreenConfig = {
       ...APIScreens.reduce(
         (prev, curr) => ({
           ...prev,
-          [curr.name]: getScreenIdForLinking(curr),
+          [curr.name]: curr.linking ?? getScreenIdForLinking(curr),
         }),
         {}
       ),

--- a/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
@@ -1,0 +1,102 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useTheme } from 'ThemeProvider';
+import * as Linking from 'expo-linking';
+import { useObserve } from 'expo-observe';
+import { useEffect } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+const Stack = createNativeStackNavigator();
+
+type FilteredParamsRoute = {
+  params?: {
+    userId?: string;
+    accountId?: string;
+    firstName?: string;
+    tab?: string;
+  };
+};
+
+function IndexScreen() {
+  const { theme } = useTheme();
+  const { markInteractive } = useObserve();
+
+  useEffect(() => {
+    markInteractive();
+  }, [markInteractive]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background.screen }]}>
+      <TouchableOpacity
+        onPress={() =>
+          Linking.openURL(
+            Linking.createURL('apis/expo-observe/filtered/42/acct-123?firstName=Ada&tab=posts')
+          )
+        }>
+        <Text style={[styles.button, { color: theme.text.link }]}>Open filtered params</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function FilteredParamsScreen({ route }: { route: FilteredParamsRoute }) {
+  const { userId, accountId, firstName, tab } = route.params ?? {};
+  const { theme } = useTheme();
+  const { markInteractive } = useObserve();
+
+  useEffect(() => {
+    markInteractive();
+  }, [markInteractive]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background.screen }]}>
+      <Text style={[styles.label, { color: theme.text.secondary }]}>Route params</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>userId: {userId}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>accountId: {accountId}</Text>
+      <Text style={[styles.label, { color: theme.text.secondary }]}>Query params</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>firstName: {firstName}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>tab: {tab}</Text>
+    </View>
+  );
+}
+
+export default function ExpoObserveScreen() {
+  const { theme } = useTheme();
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.background.default },
+        headerTintColor: theme.icon.info,
+        headerTitleStyle: { color: theme.text.default },
+      }}>
+      <Stack.Screen name="index" component={IndexScreen} options={{ title: 'Expo Observe' }} />
+      <Stack.Screen
+        name="filteredParams"
+        component={FilteredParamsScreen}
+        options={{ title: 'Filtered Params' }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  button: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  label: {
+    fontSize: 13,
+    letterSpacing: 0.5,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+  },
+  value: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 16,
+  },
+});

--- a/apps/native-component-list/src/types/ScreenConfig.ts
+++ b/apps/native-component-list/src/types/ScreenConfig.ts
@@ -1,8 +1,10 @@
+import { type PathConfig } from '@react-navigation/native';
 import React from 'react';
 
 export type ScreenConfig = {
   getComponent(): React.ComponentType<object> | (() => React.ReactElement);
   name: string;
   route?: string;
+  linking?: PathConfig<object>;
   options?: object;
 };

--- a/apps/observe-tester/app/(tabs)/examples/nested-stack/[userId]/[accountId].tsx
+++ b/apps/observe-tester/app/(tabs)/examples/nested-stack/[userId]/[accountId].tsx
@@ -1,0 +1,50 @@
+import { ObserveInteractiveMarker } from 'expo-observe';
+import { useLocalSearchParams } from 'expo-router';
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from '@/utils/theme';
+
+export default function FilteredParamsScreen() {
+  const { userId, accountId, firstName, tab } = useLocalSearchParams<{
+    userId: string;
+    accountId: string;
+    firstName?: string;
+    tab?: string;
+  }>();
+  const theme = useTheme();
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      <ObserveInteractiveMarker />
+      <Text style={[styles.label, { color: theme.text.secondary }]}>Route params</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>userId: {userId}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>accountId: {accountId}</Text>
+      <Text style={[styles.label, { color: theme.text.secondary }]}>Query params</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>firstName: {firstName}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>tab: {tab}</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  label: {
+    fontSize: 13,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  value: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 16,
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/nested-stack/_layout.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/nested-stack/_layout.tsx
@@ -14,6 +14,7 @@ export default function NestedStackLayout() {
       <Stack.Screen name="network" options={{ title: 'Network' }} />
       <Stack.Screen name="heavy" options={{ title: 'Heavy render' }} />
       <Stack.Screen name="[id]" options={{ title: 'Param' }} />
+      <Stack.Screen name="[userId]/[accountId]" options={{ title: 'Filtered params' }} />
       <Stack.Screen name="nested" options={{ headerShown: false }} />
     </Stack>
   );

--- a/apps/observe-tester/app/(tabs)/examples/nested-stack/index.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/nested-stack/index.tsx
@@ -29,6 +29,11 @@ export default function NestedStackIndex() {
         onPress={() => router.push('/examples/nested-stack/foo')}
       />
       <Button
+        title="Filtered params"
+        description="Open [userId]/[accountId]?firstName=Ada&tab=posts with accountId and firstName filtered"
+        onPress={() => router.push('/examples/nested-stack/42/acct-123?firstName=Ada&tab=posts')}
+      />
+      <Button
         title="Nested → modal"
         description="Push into a nested stack that opens a modal"
         onPress={() => router.push('/examples/nested-stack/nested')}

--- a/apps/observe-tester/app/_layout.tsx
+++ b/apps/observe-tester/app/_layout.tsx
@@ -8,7 +8,7 @@ Observe.configure({
   dispatchingEnabled: true,
   dispatchInDebug: true,
   integrations: {
-    'expo-router': true,
+    'expo-router': { filteredParams: ['accountId', 'firstName'] },
     'expo-image': {
       oversizeThreshold: 1.5,
     },

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
 - Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))
+- Add `filteredParams` configuration option to navigation integrations ([#47488](https://github.com/expo/expo/pull/47488) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -31,6 +31,7 @@ jest.mock('../integrations/expo-router/router', () => ({
 jest.mock('../integrations/expo-router/init', () => ({
   initRouterIntegration: jest.fn(),
   isInitialized: jest.fn(() => false),
+  getRouterIntegrationConfig: jest.fn(() => undefined),
   initListeners: jest.fn(() => () => {}),
 }));
 
@@ -42,6 +43,7 @@ jest.mock('../integrations/react-navigation/reactNavigation', () => ({
 jest.mock('../integrations/react-navigation/init', () => ({
   initReactNavigationIntegration: jest.fn(),
   isInitialized: jest.fn(() => false),
+  getReactNavigationIntegrationConfig: jest.fn(() => undefined),
 }));
 
 let warnSpy: jest.SpyInstance;
@@ -59,6 +61,7 @@ beforeEach(() => {
   jest.doMock('../integrations/expo-router/init', () => ({
     initRouterIntegration: jest.fn(),
     isInitialized: jest.fn(() => false),
+    getRouterIntegrationConfig: jest.fn(() => undefined),
     initListeners: jest.fn(() => () => {}),
   }));
   jest.doMock('../integrations/react-navigation/reactNavigation', () => ({
@@ -68,6 +71,7 @@ beforeEach(() => {
   jest.doMock('../integrations/react-navigation/init', () => ({
     initReactNavigationIntegration: jest.fn(),
     isInitialized: jest.fn(() => false),
+    getReactNavigationIntegrationConfig: jest.fn(() => undefined),
   }));
 });
 
@@ -100,6 +104,31 @@ describe('module Proxy', () => {
     }
   );
 
+  it('forwards object integration config to native unchanged', () => {
+    const Observe = loadModule();
+    const { initRouterIntegration } = loadInit();
+    const { initReactNavigationIntegration } = loadReactNavigationInit();
+    const routerConfig = { filteredParams: ['userId', 'token'] };
+    const reactNavigationConfig = { filteredParams: ['userIdRN', 'Rtoken'] };
+    Observe.configure({
+      environment: 'test',
+      integrations: {
+        'expo-router': routerConfig,
+        'react-navigation': reactNavigationConfig,
+      },
+    });
+
+    expect(mockNative.configure).toHaveBeenCalledWith({
+      environment: 'test',
+      integrations: {
+        'expo-router': routerConfig,
+        'react-navigation': reactNavigationConfig,
+      },
+    });
+    expect(initRouterIntegration).toHaveBeenCalledWith(routerConfig);
+    expect(initReactNavigationIntegration).not.toHaveBeenCalled();
+  });
+
   it("calls initRouterIntegration when router is installed and integrations['expo-router'] is true", () => {
     const Observe = loadModule();
     const { initRouterIntegration } = loadInit();
@@ -108,6 +137,7 @@ describe('module Proxy', () => {
       integrations: { 'expo-router': true },
     });
     expect(initRouterIntegration).toHaveBeenCalledTimes(1);
+    expect(initRouterIntegration).toHaveBeenCalledWith(true);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -221,6 +251,20 @@ describe('module Proxy', () => {
       integrations: { 'react-navigation': true },
     });
     expect(initReactNavigationIntegration).toHaveBeenCalledTimes(1);
+    expect(initReactNavigationIntegration).toHaveBeenCalledWith(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes integrations['react-navigation'] object config to initReactNavigationIntegration", () => {
+    const Observe = loadModule();
+    const { initReactNavigationIntegration } = loadReactNavigationInit();
+    const config = { filteredParams: ['userId', 'token'] };
+    Observe.configure({
+      environment: 'test',
+      integrations: { 'react-navigation': config },
+    });
+    expect(initReactNavigationIntegration).toHaveBeenCalledTimes(1);
+    expect(initReactNavigationIntegration).toHaveBeenCalledWith(config);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import AppMetrics from 'expo-app-metrics';
 
-import { initListeners } from '../init';
+import { initListeners, initRouterIntegration } from '../init';
 import { createRouterIntegrationStorage, type RouterIntegrationStorage } from '../storage';
 
 // These are `expo-router`'s event types, but importing them here would pull expo-router's source
@@ -105,12 +105,19 @@ let warnSpy: jest.SpyInstance;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  initRouterIntegration(undefined);
   logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   storage = createRouterIntegrationStorage();
   events = createFakeNavigationEvents();
   cleanup = initListeners(storage, events as any);
 });
+
+function setRouterConfig(config: Parameters<typeof initRouterIntegration>[0]) {
+  cleanup?.();
+  initRouterIntegration(config);
+  cleanup = initListeners(storage, events as any);
+}
 
 afterEach(() => {
   cleanup?.();
@@ -134,6 +141,54 @@ describe('initListeners', () => {
       routeName: '/a',
       value: expect.closeTo(0.1, 2),
       params: { isAppLaunch: true, routeParams: {}, url: '/a' },
+    });
+  });
+
+  it('filters route params from cold_ttr, warm_ttr, and deferred tti metrics', async () => {
+    setRouterConfig({ filteredParams: ['userId', 'token'] });
+    storage.screenTimes['b'] = { lastInteractiveCall: performance.now() };
+
+    focus(events, 'a', { params: { userId: '1', tab: 'home' } });
+    await flushAsync();
+
+    dispatch(events, 'NAVIGATE');
+    focus(events, 'b', { pathname: '/b?token=secret', params: { token: 'secret', q: 'ok' } });
+    await flushAsync();
+
+    expect(mockAddMetric.mock.calls[0][0].params).toEqual({
+      isAppLaunch: true,
+      routeParams: { tab: 'home' },
+      urlHidden: true,
+    });
+    expect(mockAddMetric.mock.calls[1][0].params).toEqual({
+      isAppLaunch: false,
+      routeParams: { q: 'ok' },
+      urlHidden: true,
+    });
+    expect(mockAddMetric.mock.calls[2][0].params).toEqual({
+      isAppLaunch: false,
+      routeParams: { q: 'ok' },
+      urlHidden: true,
+    });
+  });
+
+  it('keeps URL visible when filteredParams does not remove any route param', async () => {
+    setRouterConfig({ filteredParams: ['userId'] });
+    storage.screenTimes['a'] = { lastInteractiveCall: performance.now() };
+
+    focus(events, 'a', { pathname: '/a?token=secret', params: { token: 'secret' } });
+    await flushAsync();
+
+    expect(mockAddMetric).toHaveBeenCalledTimes(2);
+    expect(mockAddMetric.mock.calls[0][0].params).toEqual({
+      isAppLaunch: true,
+      routeParams: { token: 'secret' },
+      url: '/a?token=secret',
+    });
+    expect(mockAddMetric.mock.calls[1][0].params).toEqual({
+      isAppLaunch: true,
+      routeParams: { token: 'secret' },
+      url: '/a?token=secret',
     });
   });
 

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/navigationConfig.test.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/navigationConfig.test.ts
@@ -1,0 +1,49 @@
+import {
+  getNavigationMetricParams,
+  getNavigationRouteParams,
+} from '../../navigationConfig';
+
+describe('expo-router navigation config', () => {
+  it('filters configured route and query param keys', () => {
+    expect(
+      getNavigationRouteParams(
+        { filteredParams: ['userId', 'token', 42 as unknown as string] },
+        { userId: '1', tab: 'posts', token: 'secret' }
+      ).routeParams
+    ).toEqual({ tab: 'posts' });
+  });
+
+  it('returns an empty object when every param is filtered', () => {
+    expect(
+      getNavigationRouteParams({ filteredParams: ['userId'] }, { userId: '1' }).routeParams
+    ).toEqual({});
+  });
+
+  it('keeps params and URL visible by default', () => {
+    const params = { userId: '1' };
+    expect(getNavigationRouteParams(true, params).routeParams).toBe(params);
+    expect(getNavigationMetricParams(true, params, '/users/1')).toEqual({
+      routeParams: params,
+      url: '/users/1',
+    });
+  });
+
+  it('keeps the URL visible when no route param is filtered', () => {
+    expect(
+      getNavigationMetricParams({ filteredParams: ['token'] }, { tab: 'posts' }, '/users/1')
+    ).toEqual({
+      routeParams: { tab: 'posts' },
+      url: '/users/1',
+    });
+  });
+
+  it('hides the URL when a route param is filtered', () => {
+    expect(
+      getNavigationMetricParams(
+        { filteredParams: ['token'] },
+        { token: 'secret', tab: 'posts' },
+        '/u?token=secret'
+      )
+    ).toEqual({ routeParams: { tab: 'posts' }, urlHidden: true });
+  });
+});

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/useObserveForRouter.test.native.tsx
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/useObserveForRouter.test.native.tsx
@@ -27,6 +27,7 @@ jest.mock('expo-app-metrics', () => {
 jest.mock('../init', () => ({
   __esModule: true,
   isInitialized: jest.fn(() => true),
+  getRouterIntegrationConfig: jest.fn(() => undefined),
   initListeners: jest.fn(() => () => {}),
   initRouterIntegration: jest.fn(),
 }));
@@ -59,6 +60,7 @@ const mockUseNavigation = (routerModule as unknown as { __useNavigation: jest.Mo
   .__useNavigation;
 const mockUseCurrentRouteInfo = (routerModule as unknown as { __useCurrentRouteInfo: jest.Mock })
   .__useCurrentRouteInfo;
+const initModule = require('../init') as { getRouterIntegrationConfig: jest.Mock };
 
 function wrapper(storage: RouterIntegrationStorage | null) {
   return ({ children }: { children: ReactNode }) => (
@@ -72,6 +74,7 @@ let storage: RouterIntegrationStorage;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  initModule.getRouterIntegrationConfig.mockReturnValue(undefined);
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   mockUseRoute.mockReturnValue({ key: 'screen-a' });
@@ -131,7 +134,7 @@ describe('useObserveForRouter', () => {
 
       expect(AppMetrics.markInteractive).toHaveBeenCalledWith({
         routeName: expectedRouteName,
-        params: { url: pathname },
+        params: { routeParams, url: pathname },
       });
       expect(mockAddMetric).toHaveBeenCalledWith({
         timestamp: expect.any(String),
@@ -162,6 +165,44 @@ describe('useObserveForRouter', () => {
     );
   });
 
+  it('filters route params from hook-emitted TTI', async () => {
+    initModule.getRouterIntegrationConfig.mockReturnValue({ filteredParams: ['x'] });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };
+    jest.spyOn(performance, 'now').mockReturnValue(1300);
+
+    const { result } = renderHook(() => useObserveForRouter(), { wrapper: wrapper(storage) });
+    await act(async () => {
+      await result.current!();
+    });
+
+    expect(mockAddMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { isAppLaunch: false, routeParams: {}, urlHidden: true },
+      })
+    );
+  });
+
+  it('hides URL for markInteractive and hook-emitted TTI when a route param is filtered', async () => {
+    initModule.getRouterIntegrationConfig.mockReturnValue({ filteredParams: ['x'] });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };
+    jest.spyOn(performance, 'now').mockReturnValue(1300);
+
+    const { result } = renderHook(() => useObserveForRouter(), { wrapper: wrapper(storage) });
+    await act(async () => {
+      await result.current!();
+    });
+
+    expect(AppMetrics.markInteractive).toHaveBeenCalledWith({
+      routeName: '/test',
+      params: { routeParams: {}, urlHidden: true },
+    });
+    expect(mockAddMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { isAppLaunch: false, routeParams: {}, urlHidden: true },
+      })
+    );
+  });
+
   it('calls AppMetrics.markInteractive when the screen is focused', async () => {
     storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };
     const { result } = renderHook(() => useObserveForRouter(), { wrapper: wrapper(storage) });
@@ -170,7 +211,22 @@ describe('useObserveForRouter', () => {
       await result.current!({ ...arg });
     });
     expect(AppMetrics.markInteractive).toHaveBeenCalledWith({
-      params: { x: 'payload', url: '/test' },
+      params: { x: 'payload', routeParams: { x: '1' }, url: '/test' },
+      routeName: '/test',
+    });
+  });
+
+  it('drops caller-provided URL from markInteractive params when a route param is filtered', async () => {
+    initModule.getRouterIntegrationConfig.mockReturnValue({ filteredParams: ['x'] });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };
+    const { result } = renderHook(() => useObserveForRouter(), { wrapper: wrapper(storage) });
+
+    await act(async () => {
+      await result.current!({ params: { url: '/unsafe', custom: 'value' } });
+    });
+
+    expect(AppMetrics.markInteractive).toHaveBeenCalledWith({
+      params: { custom: 'value', routeParams: {}, urlHidden: true },
       routeName: '/test',
     });
   });

--- a/packages/expo-observe/src/integrations/expo-router/emitTTI.ts
+++ b/packages/expo-observe/src/integrations/expo-router/emitTTI.ts
@@ -1,5 +1,8 @@
 import type { Session } from 'expo-app-metrics';
 
+import type { ObserveIntegrationsConfig } from '../../types';
+import { getNavigationMetricParams } from '../navigationConfig';
+
 export function emitTTI(args: {
   session: Pick<Session, 'addMetric'>;
   timestamp: string;
@@ -8,6 +11,7 @@ export function emitTTI(args: {
   isAppLaunch: boolean;
   routeParams: object | undefined;
   url: string | undefined;
+  config?: ObserveIntegrationsConfig['expo-router'];
 }): Promise<void> {
   return args.session.addMetric({
     timestamp: args.timestamp,
@@ -15,6 +19,9 @@ export function emitTTI(args: {
     name: 'tti',
     routeName: args.routeName,
     value: args.value,
-    params: { isAppLaunch: args.isAppLaunch, routeParams: args.routeParams, url: args.url },
+    params: {
+      isAppLaunch: args.isAppLaunch,
+      ...getNavigationMetricParams(args.config, args.routeParams, args.url),
+    },
   });
 }

--- a/packages/expo-observe/src/integrations/expo-router/init.ts
+++ b/packages/expo-observe/src/integrations/expo-router/init.ts
@@ -1,5 +1,7 @@
 import AppMetrics from 'expo-app-metrics';
 
+import type { ObserveIntegrationsConfig } from '../../types';
+import { getNavigationMetricParams } from '../navigationConfig';
 import { emitTTI } from './emitTTI';
 import { buildRoutePattern } from './routeName';
 import { optionalRouter } from './router';
@@ -11,11 +13,14 @@ import { type RouterIntegrationStorage } from './storage';
 // relying on the web stubs in `expo-app-metrics/module.web.ts`.
 
 let initialized = false;
+let routerIntegrationConfig: ObserveIntegrationsConfig['expo-router'];
 
 export const isInitialized = () => initialized;
+export const getRouterIntegrationConfig = () => routerIntegrationConfig;
 
-export function initRouterIntegration() {
+export function initRouterIntegration(config?: ObserveIntegrationsConfig['expo-router']) {
   initialized = true;
+  routerIntegrationConfig = config;
   optionalRouter?.unstable_navigationEvents.enable();
 }
 
@@ -101,6 +106,11 @@ export function initListeners(
     }
 
     const mainSession = AppMetrics.getMainSession();
+    const navigationParams = getNavigationMetricParams(
+      routerIntegrationConfig,
+      e.params,
+      e.pathname
+    );
 
     mainSession.addMetric({
       timestamp,
@@ -108,7 +118,7 @@ export function initListeners(
       name,
       routeName: routePattern,
       value: ttrSeconds,
-      params: { isAppLaunch, routeParams: e.params, url: e.pathname },
+      params: { isAppLaunch, ...navigationParams },
     });
     if (hasPendingInteractive) {
       await emitTTI({
@@ -119,6 +129,7 @@ export function initListeners(
         isAppLaunch,
         routeParams: e.params,
         url: e.pathname,
+        config: routerIntegrationConfig,
       });
     }
   });

--- a/packages/expo-observe/src/integrations/expo-router/useObserveForRouter.ts
+++ b/packages/expo-observe/src/integrations/expo-router/useObserveForRouter.ts
@@ -2,9 +2,10 @@ import AppMetrics, { type MetricAttributes } from 'expo-app-metrics';
 import { use, useCallback, useEffect, useRef } from 'react';
 
 import { useAssertValueDoesNotChange } from '../../useAssertValueDoesNotChange';
+import { getNavigationMetricParams } from '../navigationConfig';
 import { ObserveRouterIntegrationContext } from './ObserveRouterIntegrationProvider';
 import { emitTTI } from './emitTTI';
-import { isInitialized } from './init';
+import { getRouterIntegrationConfig, isInitialized } from './init';
 import { buildRoutePattern } from './routeName';
 import { optionalRouter } from './router';
 
@@ -19,6 +20,7 @@ export function useObserveForRouter(): MarkInteractive | null {
   const routeInfo = optionalRouter?.useCurrentRouteInfo();
   const { pathname, params: routeParams, segments } = routeInfo ?? {};
   const routePattern = buildRoutePattern(segments);
+  const routerIntegrationConfig = getRouterIntegrationConfig();
 
   useAssertValueDoesNotChange(
     initialized,
@@ -68,6 +70,11 @@ export function useObserveForRouter(): MarkInteractive | null {
       // Snapshot BEFORE the write below so the deferred-TTI check sees the
       // pre-write state (lastInteractiveCall undefined until this call).
       const currentScreenData = storage.screenTimes[screenId];
+      const navigationParams = getNavigationMetricParams(
+        routerIntegrationConfig,
+        routeParams,
+        pathname
+      );
 
       // Record lastInteractiveCall regardless of focus so the `pageFocused`
       // listener can emit `tti = ttr` on our behalf when this call lands
@@ -88,10 +95,17 @@ export function useObserveForRouter(): MarkInteractive | null {
 
       // All async work happens after storage is updated, so a concurrent
       // pageFocused observes our writes before its own awaited writes.
+      const attributeParams = attributes?.params ?? {};
+      const safeAttributeParams = navigationParams.urlHidden
+        ? Object.fromEntries(Object.entries(attributeParams).filter(([key]) => key !== 'url'))
+        : attributeParams;
       AppMetrics.markInteractive({
         ...(attributes ?? {}),
         routeName: routePattern,
-        params: { ...(attributes?.params ?? {}), url: pathname },
+        params: {
+          ...safeAttributeParams,
+          ...navigationParams,
+        },
       });
 
       if (wasAlreadyInteractive) return;
@@ -114,9 +128,10 @@ export function useObserveForRouter(): MarkInteractive | null {
         isAppLaunch: !!currentScreenData.isAppLaunch,
         routeParams,
         url: pathname,
+        config: routerIntegrationConfig,
       });
     },
-    [screenId, navigation, pathname, routePattern, storage, routeParams]
+    [screenId, navigation, pathname, routePattern, storage, routeParams, routerIntegrationConfig]
   );
 
   return initialized ? markInteractive : null;

--- a/packages/expo-observe/src/integrations/navigationConfig.ts
+++ b/packages/expo-observe/src/integrations/navigationConfig.ts
@@ -1,0 +1,63 @@
+import type { ObserveNavigationIntegrationConfig } from '../types';
+
+type NavigationIntegrationConfig = boolean | ObserveNavigationIntegrationConfig | undefined;
+type NavigationMetricParams<T extends object | undefined> = {
+  routeParams: T | Record<string, never>;
+} & ({ url: string | undefined; urlHidden?: false } | { url?: undefined; urlHidden: true });
+type FilteredNavigationParams<T extends object | undefined> = {
+  routeParams: T | Record<string, never>;
+  ignoredParam: boolean;
+};
+type NavigationRouteParams<T extends object | undefined> = {
+  routeParams: T | Record<string, never>;
+  urlHidden?: true;
+};
+
+function getFilteredParamKeys(config: NavigationIntegrationConfig): Set<string> | null {
+  const filteredParams = config && typeof config === 'object' ? config.filteredParams : undefined;
+  if (!Array.isArray(filteredParams)) return null;
+
+  const keys = new Set(filteredParams.filter((key): key is string => typeof key === 'string'));
+  return keys.size > 0 ? keys : null;
+}
+
+export function getNavigationRouteParams<T extends object | undefined>(
+  config: NavigationIntegrationConfig,
+  params: T
+): NavigationRouteParams<T> {
+  const { routeParams, ignoredParam } = getFilteredNavigationParams(config, params);
+  return {
+    routeParams,
+    ...(ignoredParam ? { urlHidden: true as const } : {}),
+  };
+}
+
+function getFilteredNavigationParams<T extends object | undefined>(
+  config: NavigationIntegrationConfig,
+  params: T
+): FilteredNavigationParams<T> {
+  const filteredKeys = getFilteredParamKeys(config);
+  if (!params || !filteredKeys) return { routeParams: params, ignoredParam: false };
+
+  let ignoredParam = false;
+  const filtered = Object.fromEntries(
+    Object.entries(params).filter(([key]) => {
+      const keep = !filteredKeys.has(key);
+      ignoredParam ||= !keep;
+      return keep;
+    })
+  );
+  return { routeParams: filtered as T | Record<string, never>, ignoredParam };
+}
+
+export function getNavigationMetricParams<T extends object | undefined>(
+  config: NavigationIntegrationConfig,
+  routeParams: T,
+  url: string | undefined
+): NavigationMetricParams<T> {
+  const navigationParams = getNavigationRouteParams(config, routeParams);
+
+  return navigationParams.urlHidden
+    ? { routeParams: navigationParams.routeParams, urlHidden: true }
+    : { routeParams: navigationParams.routeParams, url };
+}

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/ObserveNavigationProvider.test.native.tsx
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/ObserveNavigationProvider.test.native.tsx
@@ -27,6 +27,7 @@ jest.mock('expo-app-metrics', () => {
 
 jest.mock('../init', () => ({
   __esModule: true,
+  getReactNavigationIntegrationConfig: jest.fn(() => undefined),
   isInitialized: jest.fn(() => true),
   initReactNavigationIntegration: jest.fn(),
 }));

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
@@ -23,7 +23,13 @@ jest.mock('expo-app-metrics', () => {
   };
 });
 
+jest.mock('../init', () => ({
+  __esModule: true,
+  getReactNavigationIntegrationConfig: jest.fn(() => undefined),
+}));
+
 const mockAddMetric = AppMetrics.getMainSession().addMetric as jest.Mock;
+const initModule = require('../init') as { getReactNavigationIntegrationConfig: jest.Mock };
 
 function stackState(
   routes: { key: string; name?: string; params?: object }[],
@@ -62,6 +68,7 @@ let warnSpy: jest.SpyInstance;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  initModule.getReactNavigationIntegrationConfig.mockReturnValue(undefined);
   logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   storage = createReactNavigationIntegrationStorage();
@@ -187,6 +194,27 @@ describe('createStateChangeHandler', () => {
     expect(mockAddMetric.mock.calls[0][0].params).toEqual({
       isAppLaunch: true,
       routeParams: { id: '42' },
+    });
+  });
+
+  it('filters focused route params from TTR and deferred TTI metrics', async () => {
+    initModule.getReactNavigationIntegrationConfig.mockReturnValue({
+      filteredParams: ['userId', 'token'],
+    });
+    storage.screenTimes['a'] = { lastInteractiveCall: performance.now() };
+
+    handle(stackState([{ key: 'a', params: { userId: '1', tab: 'home' } }]));
+    await flushAsync();
+
+    expect(mockAddMetric).toHaveBeenCalledTimes(2);
+    expect(mockAddMetric.mock.calls[0][0].params).toEqual({
+      isAppLaunch: true,
+      routeParams: { tab: 'home' },
+      urlHidden: true,
+    });
+    expect(mockAddMetric.mock.calls[1][0].params).toEqual({
+      routeParams: { tab: 'home' },
+      urlHidden: true,
     });
   });
 

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/integration.test.native.tsx
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/integration.test.native.tsx
@@ -37,11 +37,13 @@ jest.mock('expo-app-metrics', () => {
 jest.mock('../init', () => ({
   __esModule: true,
   isInitialized: jest.fn(() => true),
+  getReactNavigationIntegrationConfig: jest.fn(() => undefined),
   initReactNavigationIntegration: jest.fn(),
 }));
 
 const mockAddMetric = AppMetrics.getMainSession().addMetric as jest.Mock;
 const mockMarkInteractive = AppMetrics.markInteractive as jest.Mock;
+const initModule = require('../init') as { getReactNavigationIntegrationConfig: jest.Mock };
 
 type EmittedMetric = {
   name: string;
@@ -168,6 +170,7 @@ async function navigate(ref: React.RefObject<ContainerRef | null>, name: string,
 
 beforeEach(() => {
   jest.clearAllMocks();
+  initModule.getReactNavigationIntegrationConfig.mockReturnValue(undefined);
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
@@ -208,6 +211,21 @@ describe('react-navigation integration (real navigation tree)', () => {
       expect(metric.routeName).toBe('/Details');
       expect(metric.routeName).not.toContain('abc');
       expect(metric.params).toEqual({ isAppLaunch: false, routeParams: { id: 'abc' } });
+    });
+
+    it('filters route params from real navigation metrics', async () => {
+      initModule.getReactNavigationIntegrationConfig.mockReturnValue({ filteredParams: ['id'] });
+      const { ref } = await app();
+
+      await navigate(ref, 'Details', { id: 'abc', tab: 'posts' });
+
+      const metric = emittedMetrics().at(-1)!;
+      expect(metric.routeName).toBe('/Details');
+      expect(metric.params).toEqual({
+        isAppLaunch: false,
+        routeParams: { tab: 'posts' },
+        urlHidden: true,
+      });
     });
 
     it('emits warm_ttr with a params-free routeName when revisiting a screen', async () => {

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/navigationConfig.test.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/navigationConfig.test.ts
@@ -1,0 +1,23 @@
+import { getNavigationRouteParams } from '../../navigationConfig';
+
+describe('react-navigation navigation config', () => {
+  it('filters configured route param keys', () => {
+    expect(
+      getNavigationRouteParams(
+        { filteredParams: ['userId', 'token', null as unknown as string] },
+        { userId: '1', tab: 'posts', token: 'secret' }
+      ).routeParams
+    ).toEqual({ tab: 'posts' });
+  });
+
+  it('returns an empty object when every param is filtered', () => {
+    expect(
+      getNavigationRouteParams({ filteredParams: ['token'] }, { token: 'secret' }).routeParams
+    ).toEqual({});
+  });
+
+  it('keeps params by default', () => {
+    const params = { userId: '1' };
+    expect(getNavigationRouteParams(true, params).routeParams).toBe(params);
+  });
+});

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/useObserveForReactNavigation.test.native.tsx
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/useObserveForReactNavigation.test.native.tsx
@@ -29,6 +29,7 @@ jest.mock('expo-app-metrics', () => {
 jest.mock('../init', () => ({
   __esModule: true,
   isInitialized: jest.fn(() => true),
+  getReactNavigationIntegrationConfig: jest.fn(() => undefined),
   initReactNavigationIntegration: jest.fn(),
 }));
 
@@ -57,7 +58,10 @@ const reactNavigationModule = require('@react-navigation/native') as {
 const mockUseRoute = reactNavigationModule.__useRoute;
 const mockUseNavigation = reactNavigationModule.__useNavigation;
 const mockUseStateForPath = reactNavigationModule.useStateForPath;
-const initModule = require('../init') as { isInitialized: jest.Mock };
+const initModule = require('../init') as {
+  isInitialized: jest.Mock;
+  getReactNavigationIntegrationConfig: jest.Mock;
+};
 
 const mockAddMetric = AppMetrics.getMainSession().addMetric as jest.Mock;
 
@@ -74,6 +78,7 @@ let storage: ReactNavigationIntegrationStorage;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  initModule.getReactNavigationIntegrationConfig.mockReturnValue(undefined);
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   initModule.isInitialized.mockReturnValue(true);
@@ -121,6 +126,23 @@ describe('useObserveForReactNavigation', () => {
       params: { x: 'payload' },
       routeName: '/A',
     });
+  });
+
+  it('filters route params from hook-emitted TTI', async () => {
+    initModule.getReactNavigationIntegrationConfig.mockReturnValue({ filteredParams: ['x'] });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000 };
+    jest.spyOn(performance, 'now').mockReturnValue(1300);
+
+    const { result } = renderHook(() => useObserveForReactNavigation(), {
+      wrapper: wrapper({ storage }),
+    });
+    await act(async () => {
+      await result.current!();
+    });
+
+    expect(mockAddMetric).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { routeParams: {}, urlHidden: true } })
+    );
   });
 
   it('still records lastInteractiveCall when the screen is not focused (skips markInteractive and TTI)', async () => {

--- a/packages/expo-observe/src/integrations/react-navigation/emitTTI.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/emitTTI.ts
@@ -6,6 +6,7 @@ export function emitTTI(args: {
   routeName: string | undefined;
   value: number;
   routeParams: object;
+  urlHidden?: true;
 }): Promise<void> {
   return args.session.addMetric({
     timestamp: args.timestamp,
@@ -13,6 +14,6 @@ export function emitTTI(args: {
     name: 'tti',
     routeName: args.routeName,
     value: args.value,
-    params: { routeParams: args.routeParams },
+    params: { routeParams: args.routeParams, ...(args.urlHidden ? { urlHidden: true } : {}) },
   });
 }

--- a/packages/expo-observe/src/integrations/react-navigation/handleStateChange.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/handleStateChange.ts
@@ -1,7 +1,9 @@
 import AppMetrics from 'expo-app-metrics';
 
+import { getNavigationRouteParams } from '../navigationConfig';
 import { emitTTI } from './emitTTI';
 import { getPathname } from './getPathname';
+import { getReactNavigationIntegrationConfig } from './init';
 import { collectMountedKeys, findFocusedLeaf } from './stateTraversal';
 import type { ReactNavigationIntegrationStorage } from './storage';
 import type { NavigationStateLike } from './types';
@@ -61,7 +63,10 @@ export function createStateChangeHandler(
     previousFocusedKey = focused.key;
 
     const pathname = getPathname(state) ?? focused.route.name;
-    const routeParams = focused.route.params ?? {};
+    const navigationParams = getNavigationRouteParams(
+      getReactNavigationIntegrationConfig(),
+      focused.route.params ?? {}
+    );
     const name = isInitial ? 'cold_ttr' : 'warm_ttr';
 
     // The main session is a static shared object, available synchronously and
@@ -83,7 +88,7 @@ export function createStateChangeHandler(
         name,
         routeName: pathname,
         value: appLaunchTtrSeconds,
-        params: { isAppLaunch: true, routeParams },
+        params: { isAppLaunch: true, ...navigationParams },
       });
       if (hasPendingInteractive) {
         await emitTTI({
@@ -91,7 +96,7 @@ export function createStateChangeHandler(
           timestamp,
           routeName: pathname,
           value: appLaunchTtrSeconds,
-          routeParams,
+          ...navigationParams,
         });
       }
       storage.pendingActions.length = 0;
@@ -113,7 +118,7 @@ export function createStateChangeHandler(
       name,
       routeName: pathname,
       value: ttrSeconds,
-      params: { isAppLaunch: false, routeParams },
+      params: { isAppLaunch: false, ...navigationParams },
     });
     if (hasPendingInteractive) {
       await emitTTI({
@@ -121,7 +126,7 @@ export function createStateChangeHandler(
         timestamp,
         routeName: pathname,
         value: ttrSeconds,
-        routeParams,
+        ...navigationParams,
       });
     }
     storage.pendingActions.length = 0;

--- a/packages/expo-observe/src/integrations/react-navigation/init.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/init.ts
@@ -1,7 +1,14 @@
+import type { ObserveIntegrationsConfig } from '../../types';
+
 let initialized = false;
+let reactNavigationIntegrationConfig: ObserveIntegrationsConfig['react-navigation'];
 
 export const isInitialized = () => initialized;
+export const getReactNavigationIntegrationConfig = () => reactNavigationIntegrationConfig;
 
-export function initReactNavigationIntegration() {
+export function initReactNavigationIntegration(
+  config?: ObserveIntegrationsConfig['react-navigation']
+) {
   initialized = true;
+  reactNavigationIntegrationConfig = config;
 }

--- a/packages/expo-observe/src/integrations/react-navigation/useObserveForReactNavigation.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/useObserveForReactNavigation.ts
@@ -2,10 +2,11 @@ import AppMetrics, { type MetricAttributes } from 'expo-app-metrics';
 import { use, useCallback, useEffect, useRef } from 'react';
 
 import { useAssertValueDoesNotChange } from '../../useAssertValueDoesNotChange';
+import { getNavigationRouteParams } from '../navigationConfig';
 import { ObserveReactNavigationIntegrationContext } from './context';
 import { emitTTI } from './emitTTI';
 import { getPathname } from './getPathname';
-import { isInitialized } from './init';
+import { getReactNavigationIntegrationConfig, isInitialized } from './init';
 import { optionalReactNavigation } from './reactNavigation';
 import type { NavigationStateLike } from './types';
 
@@ -18,6 +19,7 @@ export function useObserveForReactNavigation(): MarkInteractive | null {
   const route = optionalReactNavigation?.useRoute();
   const navigation = optionalReactNavigation?.useNavigation();
   const stateForPath = optionalReactNavigation?.useStateForPath();
+  const reactNavigationIntegrationConfig = getReactNavigationIntegrationConfig();
 
   useAssertValueDoesNotChange(
     initialized,
@@ -74,7 +76,10 @@ export function useObserveForReactNavigation(): MarkInteractive | null {
       // it the subtree produces the same pathname as the full state without
       // requiring access to the root navigation state from inside a leaf hook.
       const pathname = getPathname(stateForPath as NavigationStateLike | undefined) ?? route.name;
-      const routeParams = (route.params as object | undefined) ?? {};
+      const navigationParams = getNavigationRouteParams(
+        reactNavigationIntegrationConfig,
+        (route.params as object | undefined) ?? {}
+      );
 
       // Snapshot times BEFORE writing the new interactive timestamp so the
       // duplicate-detection logic below sees the previous call, not this one.
@@ -117,10 +122,10 @@ export function useObserveForReactNavigation(): MarkInteractive | null {
         timestamp,
         routeName: pathname,
         value: interactiveTimeSeconds,
-        routeParams,
+        ...navigationParams,
       });
     },
-    [screenId, navigation, route, contextValue, stateForPath]
+    [screenId, navigation, route, contextValue, stateForPath, reactNavigationIntegrationConfig]
   );
 
   return initialized ? markInteractive : null;

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -39,9 +39,9 @@ const Observe: ObserveModule = new Proxy(native, {
         }
 
         if (shouldInitRouterIntegration) {
-          initRouterIntegration();
+          initRouterIntegration(config.integrations?.['expo-router']);
         } else if (shouldInitReactNavigationIntegration) {
-          initReactNavigationIntegration();
+          initReactNavigationIntegration(config.integrations?.['react-navigation']);
         }
         return target.configure(config);
       };

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -67,6 +67,16 @@ export type ObserveConfig = {
   integrations?: ObserveIntegrationsConfig;
 };
 
+export type ObserveNavigationIntegrationConfig = {
+  /**
+   * Route or query parameter keys to remove from exported navigation metric
+   * `routeParams`. When any configured parameter is removed from a metric,
+   * the exported resolved URL/path is replaced with `urlHidden: true`.
+   * Does not affect `routeName`.
+   */
+  filteredParams?: string[];
+};
+
 export interface ObserveIntegrationsConfig {
   /**
    * Enables the `expo-router` integration, which records navigation metrics
@@ -74,9 +84,11 @@ export interface ObserveIntegrationsConfig {
    *
    * Requires `expo-router` to be installed.
    *
+   * Pass an object to filter exported route/query params.
+   *
    * @default false
    */
-  'expo-router'?: boolean;
+  'expo-router'?: boolean | ObserveNavigationIntegrationConfig;
   /**
    * Enables the `@react-navigation/native` integration, which records
    * navigation metrics (`cold_ttr`, `warm_ttr`, `tti`).
@@ -85,9 +97,11 @@ export interface ObserveIntegrationsConfig {
    * to be wrapped in `<ObserveNavigationContainer>` instead of the stock
    * `<NavigationContainer>`.
    *
+   * Pass an object to filter exported route/query params.
+   *
    * @default false
    */
-  'react-navigation'?: boolean;
+  'react-navigation'?: boolean | ObserveNavigationIntegrationConfig;
 }
 
 /**


### PR DESCRIPTION
# Why

Route and query params can include sensitive information, which apps may want to ignore when sending data to observe

# How

1. Add `filteredParams` property to specify which params should be filtered. When params are filtered then the `url` for that entry will not be sent. 

# Test Plan

1. CI
2. Observe tester

<img width="387" height="429" alt="image" src="https://github.com/user-attachments/assets/9ed15907-0a55-4143-8686-9b30612ce8ee" />

3. Bare expo

<img width="413" height="206" alt="image" src="https://github.com/user-attachments/assets/b772c155-474b-4f1e-936e-54ab8a669bea" />

`p2` and `q1` are filtered

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
