### PR TITLE
[app-metrics] Replace deprecated `fallbackToDestructiveMigration()` with `fallbackToDestructiveMigration(false)`

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -49,7 +49,7 @@ abstract class MetricsDatabase : RoomDatabase() {
             "app_metrics"
           )
           // Allow destructive migration for schema changes during development. Replace with proper Migration if desired.
-          .fallbackToDestructiveMigration()
+          .fallbackToDestructiveMigration(false)
           .build()
         INSTANCE = instance
         instance


### PR DESCRIPTION
# Why

The `fallbackToDestructiveMigration()` function was deprecated.
Fixes the following warning:
```gradle
packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt:50:12 - 'fun fallbackToDestructiveMigration(): RoomDatabase.Builder<MetricsDatabase>' is deprecated. Replace by overloaded version with parameter to indicate if all tables should be dropped or not.
```

# How
Replaced the deprecated function with the one recommended in the docs.

# Test Plan
Green CI 