### PR TITLE
[docs] Fix broken link

### DIFF
--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -13,7 +13,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Whether you have built a native app binary using [EAS](/build/setup/) or [locally](/guides/local-app-development/), the next step in your app development journey is to submit your app to the stores. To do so, you need to create a **production build**.
 
-Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight. This guide explains how to create production builds with [EAS](#production-builds-using-eas) and [locally](#production-builds-locally). It is also possible to create production builds for Expo apps with any CI service capable of compiling Android and iOS apps.
+Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight. This guide explains how to create production builds with [EAS](#production-builds-using-eas) and [locally](#release-builds-locally). It is also possible to create production builds for Expo apps with any CI service capable of compiling Android and iOS apps.
 
 ## Production builds using EAS
 


### PR DESCRIPTION
# Why

The link points to a non-existent section, so i doesn't work.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Change the link target to the "Relase builds locally" section.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI passes. check link manually with `pnpm dev`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)