### PR TITLE
[expo-observe] ENG-22120 Fix non-serializable route params issue

### DIFF
--- a/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
@@ -13,10 +13,19 @@ type FilteredParamsRoute = {
     accountId?: string;
     firstName?: string;
     tab?: string;
+    p1?: string;
+    p2?: string;
+    q1?: string;
+    q2?: string;
+    onPress?: () => void;
   };
 };
 
-function IndexScreen() {
+function IndexScreen({
+  navigation,
+}: {
+  navigation: { navigate: (screen: string, params?: object) => void };
+}) {
   const { theme } = useTheme();
   const { markInteractive } = useObserve();
 
@@ -34,12 +43,24 @@ function IndexScreen() {
         }>
         <Text style={[styles.button, { color: theme.text.link }]}>Open filtered params</Text>
       </TouchableOpacity>
+      <TouchableOpacity
+        onPress={() =>
+          navigation.navigate('filteredParams', {
+            p1: 'p1',
+            p2: 'p2',
+            onPress: () => {},
+          })
+        }>
+        <Text style={[styles.button, { color: theme.text.link }]}>
+          Navigate with function param
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }
 
 function FilteredParamsScreen({ route }: { route: FilteredParamsRoute }) {
-  const { userId, accountId, firstName, tab } = route.params ?? {};
+  const { userId, accountId, firstName, tab, p1, p2, onPress } = route.params ?? {};
   const { theme } = useTheme();
   const { markInteractive } = useObserve();
 
@@ -52,6 +73,9 @@ function FilteredParamsScreen({ route }: { route: FilteredParamsRoute }) {
       <Text style={[styles.label, { color: theme.text.secondary }]}>Route params</Text>
       <Text style={[styles.value, { color: theme.text.default }]}>userId: {userId}</Text>
       <Text style={[styles.value, { color: theme.text.default }]}>accountId: {accountId}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>p1: {p1}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>p2: {p2}</Text>
+      <Text style={[styles.value, { color: theme.text.default }]}>onPress: {typeof onPress}</Text>
       <Text style={[styles.label, { color: theme.text.secondary }]}>Query params</Text>
       <Text style={[styles.value, { color: theme.text.default }]}>firstName: {firstName}</Text>
       <Text style={[styles.value, { color: theme.text.default }]}>tab: {tab}</Text>

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix non-serializable route params issue ([#47497](https://github.com/expo/expo/pull/47497) by [@Ubax](https://github.com/Ubax))
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
 - [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder)) ([#47160](https://github.com/expo/expo/pull/47160) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
@@ -146,13 +146,18 @@ describe('initListeners', () => {
 
   it('filters route params from cold_ttr, warm_ttr, and deferred tti metrics', async () => {
     setRouterConfig({ filteredParams: ['userId', 'token'] });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
     storage.screenTimes['b'] = { lastInteractiveCall: performance.now() };
 
-    focus(events, 'a', { params: { userId: '1', tab: 'home' } });
+    focus(events, 'a', { params: { userId: '1', tab: 'home', callback: () => {}, circular } });
     await flushAsync();
 
     dispatch(events, 'NAVIGATE');
-    focus(events, 'b', { pathname: '/b?token=secret', params: { token: 'secret', q: 'ok' } });
+    focus(events, 'b', {
+      pathname: '/b?token=secret',
+      params: { token: 'secret', q: 'ok', callback: () => {}, circular },
+    });
     await flushAsync();
 
     expect(mockAddMetric.mock.calls[0][0].params).toEqual({

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/navigationConfig.test.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/navigationConfig.test.ts
@@ -1,14 +1,14 @@
-import {
-  getNavigationMetricParams,
-  getNavigationRouteParams,
-} from '../../navigationConfig';
+import { getNavigationMetricParams, getNavigationRouteParams } from '../../navigationConfig';
 
 describe('expo-router navigation config', () => {
   it('filters configured route and query param keys', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
     expect(
       getNavigationRouteParams(
         { filteredParams: ['userId', 'token', 42 as unknown as string] },
-        { userId: '1', tab: 'posts', token: 'secret' }
+        { userId: '1', tab: 'posts', token: circular }
       ).routeParams
     ).toEqual({ tab: 'posts' });
   });
@@ -19,9 +19,27 @@ describe('expo-router navigation config', () => {
     ).toEqual({});
   });
 
+  it('omits only route param values that cannot be serialized', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const symbol = Symbol('value');
+
+    expect(
+      getNavigationRouteParams(true, {
+        id: '42',
+        callback: () => {},
+        circular,
+        nested: { ok: true, callback: () => {} },
+        none: null,
+        symbol,
+        unset: undefined,
+      })
+    ).toEqual({ routeParams: { id: '42', nested: { ok: true }, none: null } });
+  });
+
   it('keeps params and URL visible by default', () => {
     const params = { userId: '1' };
-    expect(getNavigationRouteParams(true, params).routeParams).toBe(params);
+    expect(getNavigationRouteParams(true, params).routeParams).toEqual(params);
     expect(getNavigationMetricParams(true, params, '/users/1')).toEqual({
       routeParams: params,
       url: '/users/1',
@@ -45,5 +63,15 @@ describe('expo-router navigation config', () => {
         '/u?token=secret'
       )
     ).toEqual({ routeParams: { tab: 'posts' }, urlHidden: true });
+  });
+
+  it('keeps the URL visible when a route param cannot be serialized', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(getNavigationMetricParams(true, { id: '42', circular }, '/users/42')).toEqual({
+      routeParams: { id: '42' },
+      url: '/users/42',
+    });
   });
 });

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/useObserveForRouter.test.native.tsx
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/useObserveForRouter.test.native.tsx
@@ -182,6 +182,33 @@ describe('useObserveForRouter', () => {
     );
   });
 
+  it('omits non-serializable route params from markInteractive and hook-emitted TTI', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    mockUseCurrentRouteInfo.mockReturnValue({
+      pathname: '/test',
+      params: { id: '42', callback: () => {}, circular },
+      segments: ['test'],
+    });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };
+    jest.spyOn(performance, 'now').mockReturnValue(1300);
+
+    const { result } = renderHook(() => useObserveForRouter(), { wrapper: wrapper(storage) });
+    await act(async () => {
+      await result.current!();
+    });
+
+    expect(AppMetrics.markInteractive).toHaveBeenCalledWith({
+      routeName: '/test',
+      params: { routeParams: { id: '42' }, url: '/test' },
+    });
+    expect(mockAddMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { isAppLaunch: false, routeParams: { id: '42' }, url: '/test' },
+      })
+    );
+  });
+
   it('hides URL for markInteractive and hook-emitted TTI when a route param is filtered', async () => {
     initModule.getRouterIntegrationConfig.mockReturnValue({ filteredParams: ['x'] });
     storage.screenTimes['screen-a'] = { dispatchTime: 1000, isAppLaunch: false };

--- a/packages/expo-observe/src/integrations/navigationConfig.ts
+++ b/packages/expo-observe/src/integrations/navigationConfig.ts
@@ -1,15 +1,11 @@
 import type { ObserveNavigationIntegrationConfig } from '../types';
 
 type NavigationIntegrationConfig = boolean | ObserveNavigationIntegrationConfig | undefined;
-type NavigationMetricParams<T extends object | undefined> = {
-  routeParams: T | Record<string, never>;
+type NavigationMetricParams = {
+  routeParams: Record<string, unknown>;
 } & ({ url: string | undefined; urlHidden?: false } | { url?: undefined; urlHidden: true });
-type FilteredNavigationParams<T extends object | undefined> = {
-  routeParams: T | Record<string, never>;
-  ignoredParam: boolean;
-};
-type NavigationRouteParams<T extends object | undefined> = {
-  routeParams: T | Record<string, never>;
+type NavigationRouteParams = {
+  routeParams: Record<string, unknown>;
   urlHidden?: true;
 };
 
@@ -21,40 +17,56 @@ function getFilteredParamKeys(config: NavigationIntegrationConfig): Set<string> 
   return keys.size > 0 ? keys : null;
 }
 
-export function getNavigationRouteParams<T extends object | undefined>(
+function prepareNavigationRouteParams(
   config: NavigationIntegrationConfig,
-  params: T
-): NavigationRouteParams<T> {
-  const { routeParams, ignoredParam } = getFilteredNavigationParams(config, params);
+  params: object | undefined
+): NavigationRouteParams {
+  const filteredKeys = getFilteredParamKeys(config);
+  let urlHidden = false;
+  const routeParams = Object.fromEntries(
+    Object.entries(params ?? {})
+      .filter(([key]) => {
+        const keep = !filteredKeys?.has(key);
+        urlHidden ||= !keep;
+        return keep;
+      })
+      .map(([key, value]) => {
+        try {
+          if (value === undefined) return null;
+
+          const serialized = JSON.stringify(value);
+          if (serialized === undefined) return null;
+
+          return [key, JSON.parse(serialized)] as const;
+        } catch {
+          // Ignore only the individual param value that cannot cross the native boundary.
+          return null;
+        }
+      })
+      .filter((entry): entry is readonly [string, unknown] => entry != null)
+  );
+
   return {
     routeParams,
-    ...(ignoredParam ? { urlHidden: true as const } : {}),
+    ...(urlHidden ? { urlHidden: true as const } : {}),
   };
 }
 
-function getFilteredNavigationParams<T extends object | undefined>(
+export function getNavigationRouteParams(
   config: NavigationIntegrationConfig,
-  params: T
-): FilteredNavigationParams<T> {
-  const filteredKeys = getFilteredParamKeys(config);
-  if (!params || !filteredKeys) return { routeParams: params, ignoredParam: false };
-
-  let ignoredParam = false;
-  const filtered = Object.fromEntries(
-    Object.entries(params).filter(([key]) => {
-      const keep = !filteredKeys.has(key);
-      ignoredParam ||= !keep;
-      return keep;
-    })
-  );
-  return { routeParams: filtered as T | Record<string, never>, ignoredParam };
+  params: object | undefined
+): NavigationRouteParams {
+  const navigationParams = prepareNavigationRouteParams(config, params);
+  return navigationParams.urlHidden
+    ? { routeParams: navigationParams.routeParams, urlHidden: true }
+    : { routeParams: navigationParams.routeParams };
 }
 
-export function getNavigationMetricParams<T extends object | undefined>(
+export function getNavigationMetricParams(
   config: NavigationIntegrationConfig,
-  routeParams: T,
+  routeParams: object | undefined,
   url: string | undefined
-): NavigationMetricParams<T> {
+): NavigationMetricParams {
   const navigationParams = getNavigationRouteParams(config, routeParams);
 
   return navigationParams.urlHidden

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
@@ -201,9 +201,18 @@ describe('createStateChangeHandler', () => {
     initModule.getReactNavigationIntegrationConfig.mockReturnValue({
       filteredParams: ['userId', 'token'],
     });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
     storage.screenTimes['a'] = { lastInteractiveCall: performance.now() };
 
-    handle(stackState([{ key: 'a', params: { userId: '1', tab: 'home' } }]));
+    handle(
+      stackState([
+        {
+          key: 'a',
+          params: { userId: '1', tab: 'home', callback: () => {}, circular },
+        },
+      ])
+    );
     await flushAsync();
 
     expect(mockAddMetric).toHaveBeenCalledTimes(2);

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/navigationConfig.test.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/navigationConfig.test.ts
@@ -2,10 +2,13 @@ import { getNavigationRouteParams } from '../../navigationConfig';
 
 describe('react-navigation navigation config', () => {
   it('filters configured route param keys', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
     expect(
       getNavigationRouteParams(
         { filteredParams: ['userId', 'token', null as unknown as string] },
-        { userId: '1', tab: 'posts', token: 'secret' }
+        { userId: '1', tab: 'posts', token: circular }
       ).routeParams
     ).toEqual({ tab: 'posts' });
   });
@@ -16,8 +19,33 @@ describe('react-navigation navigation config', () => {
     ).toEqual({});
   });
 
+  it('omits only route param values that cannot be serialized', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const symbol = Symbol('value');
+
+    expect(
+      getNavigationRouteParams(true, {
+        id: '42',
+        callback: () => {},
+        circular,
+        nested: { ok: true, callback: () => {} },
+        none: null,
+        symbol,
+        unset: undefined,
+      })
+    ).toEqual({ routeParams: { id: '42', nested: { ok: true }, none: null } });
+  });
+
   it('keeps params by default', () => {
     const params = { userId: '1' };
-    expect(getNavigationRouteParams(true, params).routeParams).toBe(params);
+    expect(getNavigationRouteParams(true, params).routeParams).toEqual(params);
+  });
+
+  it('sets urlHidden when a route param is filtered', () => {
+    expect(getNavigationRouteParams({ filteredParams: ['token'] }, { token: 'secret', tab: 'posts' })).toEqual({
+      routeParams: { tab: 'posts' },
+      urlHidden: true,
+    });
   });
 });

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/useObserveForReactNavigation.test.native.tsx
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/useObserveForReactNavigation.test.native.tsx
@@ -145,6 +145,29 @@ describe('useObserveForReactNavigation', () => {
     );
   });
 
+  it('omits non-serializable route params from hook-emitted TTI', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    mockUseRoute.mockReturnValue({
+      key: 'screen-a',
+      name: 'A',
+      params: { id: '42', callback: () => {}, circular },
+    });
+    storage.screenTimes['screen-a'] = { dispatchTime: 1000 };
+    jest.spyOn(performance, 'now').mockReturnValue(1300);
+
+    const { result } = renderHook(() => useObserveForReactNavigation(), {
+      wrapper: wrapper({ storage }),
+    });
+    await act(async () => {
+      await result.current!();
+    });
+
+    expect(mockAddMetric).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { routeParams: { id: '42' } } })
+    );
+  });
+
   it('still records lastInteractiveCall when the screen is not focused (skips markInteractive and TTI)', async () => {
     mockUseNavigation.mockReturnValue({ isFocused: () => false });
     storage.screenTimes['screen-a'] = { dispatchTime: 1000 };


### PR DESCRIPTION
# Why

See https://linear.app/expo/issue/ENG-22120/investigate-crash-with-non-serializable-navigation-event-params

# How

1. `JSON.parse(JSON.stringify(value))` value before passing to native. Catch and don't save on exception

# Test Plan

1. CI
2. Bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
