### PR TITLE
[docs] Update markdown generation to account native upgrade helper diffs

### DIFF
--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -1,24 +1,48 @@
+function upgradeHelperPairPath(url) {
+  if (!/^\/bare\/upgrade\/?$/.test(url.pathname)) return null;
+
+  const from = (url.searchParams.get("fromSdk") || "").replace(/\.md$/, "");
+  const to = (url.searchParams.get("toSdk") || "").replace(/\.md$/, "");
+  const version = /^(\d+|unversioned)$/;
+  if (!from || !to || from === to || !version.test(from) || !version.test(to)) {
+    return null;
+  }
+
+  return `/bare/upgrade/${from}-to-${to}/index.md`;
+}
+
 export default {
   async fetch(request, env) {
     const accept = request.headers.get("Accept") || "";
+    const url = new URL(request.url);
+    const pairPath = upgradeHelperPairPath(url);
 
-    if (accept.includes("text/markdown")) {
-      const url = new URL(request.url);
+    const wantsMarkdown =
+      accept.includes("text/markdown") ||
+      (pairPath !== null && /\.md$/.test(url.searchParams.get("toSdk") || ""));
+
+    if (wantsMarkdown) {
       let mdPath = url.pathname;
       if (!mdPath.endsWith("/")) mdPath += "/";
       mdPath += "index.md";
 
-      url.pathname = mdPath;
-      const mdResponse = await env.ASSETS.fetch(new Request(url, request));
+      const candidates = [];
+      if (pairPath) candidates.push(pairPath);
+      candidates.push(mdPath);
 
-      const contentType = mdResponse.headers.get("Content-Type") || "";
-      if (mdResponse.ok && contentType.includes("text/markdown")) {
-        return new Response(mdResponse.body, {
-          status: 200,
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-          },
-        });
+      for (const candidate of candidates) {
+        url.pathname = candidate;
+        const mdResponse = await env.ASSETS.fetch(new Request(url, request));
+
+        const contentType = mdResponse.headers.get("Content-Type") || "";
+        if (mdResponse.ok && contentType.includes("text/markdown")) {
+          return new Response(mdResponse.body, {
+            status: 200,
+            headers: {
+              "Content-Type": "text/markdown; charset=utf-8",
+            },
+          });
+        }
       }
 
       return new Response("Not found\n", { status: 404 });

--- a/docs/scripts/check-markdown-pages.ts
+++ b/docs/scripts/check-markdown-pages.ts
@@ -32,6 +32,7 @@ import {
   findMarkdownPages,
   findMdxSource,
 } from './generate-markdown-pages-utils.ts';
+import { isUpgradePairMarkdownPath } from './generate-upgrade-diff-pages.ts';
 
 const OUT_DIR = path.join(process.cwd(), 'out');
 const PAGES_DIR = path.join(process.cwd(), 'pages');
@@ -72,7 +73,9 @@ function tabPanelHeadingDeficit(markdown: string, htmlPath: string): number {
 
 if (fs.existsSync(OUT_DIR)) {
   const htmlFiles = findHtmlPages(OUT_DIR);
-  const mdFiles = findMarkdownPages(OUT_DIR);
+  const mdFiles = findMarkdownPages(OUT_DIR).filter(
+    mdPath => !isUpgradePairMarkdownPath(path.relative(OUT_DIR, mdPath))
+  );
 
   if (mdFiles.length === 0) {
     console.error('No markdown files found in out/. Did generate-markdown-pages run?');

--- a/docs/scripts/generate-markdown-pages.ts
+++ b/docs/scripts/generate-markdown-pages.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 
 import { findHtmlPages, findMarkdownPages } from './generate-markdown-pages-utils.ts';
+import { generateUpgradeDiffPages } from './generate-upgrade-diff-pages.ts';
 
 const OUT_DIR = path.join(process.cwd(), 'out');
 const PAGES_DIR = path.join(process.cwd(), 'pages');
@@ -106,6 +107,27 @@ try {
   console.error(`\x1b[31m✗\x1b[0m ${(err as Error).message}`);
   process.exit(1);
 }
+
+const diffInfo = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), 'public', 'static', 'diffs', 'template-bare-minimum', 'diffInfo.json'),
+    'utf-8'
+  )
+);
+const { VERSIONS } = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), 'public', 'static', 'constants', 'versions.json'),
+    'utf-8'
+  )
+);
+const upgradeDiffPages = generateUpgradeDiffPages({
+  outDir: OUT_DIR,
+  diffInfo,
+  includeUnversioned: VERSIONS.includes('unversioned'),
+});
+console.warn(
+  ` \x1b[1m\x1b[32m✓\x1b[0m Generated ${upgradeDiffPages.length} upgrade helper diff pages`
+);
 
 const parts: string[] = [];
 if (warned) {

--- a/docs/scripts/generate-upgrade-diff-pages.test.ts
+++ b/docs/scripts/generate-upgrade-diff-pages.test.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildUpgradeDiffMarkdown,
+  generateUpgradeDiffPages,
+  isUpgradePairMarkdownPath,
+  listUpgradePairs,
+  upgradeDiffPagePath,
+} from './generate-upgrade-diff-pages.ts';
+
+const DIFF_52_53 = `diff --git a/templates/expo-template-bare-minimum/package.json b/templates/expo-template-bare-minimum/package.json
+index 1111111..2222222 100644
+--- a/templates/expo-template-bare-minimum/package.json
++++ b/templates/expo-template-bare-minimum/package.json
+@@ -1,3 +1,3 @@
+ {
+-  "version": "52.0.0",
++  "version": "53.0.0",
+ }`;
+
+const DIFF_52_UNVERSIONED = DIFF_52_53.replace('53.0.0', '54.0.0-canary');
+const DIFF_53_UNVERSIONED = DIFF_52_53.replace('"version": "52.0.0",', '"version": "53.0.0",');
+
+const diffInfo = {
+  versions: ['52', '53', '54', 'unversioned'],
+  diffs: {
+    '52..52': '',
+    '52..53': DIFF_52_53,
+    '53..53': '',
+    '53..54': '   \n',
+    '52..unversioned': DIFF_52_UNVERSIONED,
+    '53..unversioned': DIFF_53_UNVERSIONED,
+    'unversioned..unversioned': '',
+  },
+};
+
+describe(listUpgradePairs, () => {
+  it('skips identity pairs', () => {
+    const pairs = listUpgradePairs(diffInfo, { includeUnversioned: true });
+    expect(pairs).not.toContainEqual({ from: '52', to: '52' });
+    expect(pairs).not.toContainEqual({ from: 'unversioned', to: 'unversioned' });
+  });
+
+  it('skips pairs whose diff content is empty', () => {
+    const pairs = listUpgradePairs(diffInfo, { includeUnversioned: true });
+    expect(pairs).not.toContainEqual({ from: '53', to: '54' });
+  });
+
+  it('includes unversioned pairs when unversioned is shown in this environment', () => {
+    const pairs = listUpgradePairs(diffInfo, { includeUnversioned: true });
+    expect(pairs).toContainEqual({ from: '52', to: 'unversioned' });
+    expect(pairs).toContainEqual({ from: '53', to: 'unversioned' });
+  });
+
+  it('excludes unversioned pairs when unversioned is hidden, as on production', () => {
+    const pairs = listUpgradePairs(diffInfo, { includeUnversioned: false });
+    expect(pairs).toEqual([{ from: '52', to: '53' }]);
+  });
+});
+
+describe(upgradeDiffPagePath, () => {
+  it('places each pair in its own directory so the /<slug>.md rewrite resolves it', () => {
+    expect(upgradeDiffPagePath('52', '57')).toBe('52-to-57/index.md');
+    expect(upgradeDiffPagePath('52', 'unversioned')).toBe('52-to-unversioned/index.md');
+  });
+});
+
+describe(isUpgradePairMarkdownPath, () => {
+  it('matches generated pair pages', () => {
+    expect(isUpgradePairMarkdownPath('bare/upgrade/52-to-57/index.md')).toBe(true);
+    expect(isUpgradePairMarkdownPath('bare/upgrade/52-to-unversioned/index.md')).toBe(true);
+  });
+
+  it('does not match the page itself or other pages', () => {
+    expect(isUpgradePairMarkdownPath('bare/upgrade/index.md')).toBe(false);
+    expect(isUpgradePairMarkdownPath('bare/overview/index.md')).toBe(false);
+    expect(isUpgradePairMarkdownPath('guides/how-to/index.md')).toBe(false);
+  });
+});
+
+describe(buildUpgradeDiffMarkdown, () => {
+  const markdown = buildUpgradeDiffMarkdown({ from: '52', to: '53', diff: DIFF_52_53 });
+
+  it('starts with frontmatter naming both SDK versions', () => {
+    expect(markdown.startsWith('---\n')).toBe(true);
+    const frontmatter = markdown.split('---\n')[1];
+    expect(frontmatter).toContain('title: ');
+    expect(frontmatter).toContain('SDK 52 to SDK 53');
+    expect(frontmatter).toContain('description: ');
+  });
+
+  it('includes the same apply instructions as the Copy prompt action', () => {
+    expect(markdown).toContain('from SDK 52 to SDK 53');
+    expect(markdown).toContain('My project is NOT identical to the template');
+    expect(markdown).toContain('do not assume a clean `git apply`');
+  });
+
+  it('wraps the raw diff in a diff code fence', () => {
+    expect(markdown).toContain('```diff\n' + DIFF_52_53 + '\n```');
+  });
+
+  it('uses a longer fence when the diff itself contains triple backticks', () => {
+    const trickyDiff = DIFF_52_53 + '\n+```\n+code\n+```';
+    const tricky = buildUpgradeDiffMarkdown({ from: '52', to: '53', diff: trickyDiff });
+    expect(tricky).toContain('````diff\n');
+    expect(tricky).toContain('\n````');
+  });
+
+  it('links back to the upgrade helper pinned to the same version pair', () => {
+    expect(markdown).toContain('https://docs.expo.dev/bare/upgrade/?fromSdk=52&toSdk=53');
+  });
+
+  it('ends with a single trailing newline', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+    expect(markdown.endsWith('\n\n')).toBe(false);
+  });
+});
+
+describe(generateUpgradeDiffPages, () => {
+  it('writes one markdown file per eligible pair under bare/upgrade', () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-diff-pages-'));
+    try {
+      const written = generateUpgradeDiffPages({
+        outDir,
+        diffInfo,
+        includeUnversioned: false,
+      });
+
+      expect(written).toEqual(['52-to-53/index.md']);
+      const filePath = path.join(outDir, 'bare', 'upgrade', '52-to-53', 'index.md');
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe(
+        buildUpgradeDiffMarkdown({ from: '52', to: '53', diff: DIFF_52_53 })
+      );
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes unversioned pairs only when unversioned is shown', () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-diff-pages-'));
+    try {
+      const written = generateUpgradeDiffPages({
+        outDir,
+        diffInfo,
+        includeUnversioned: true,
+      });
+
+      expect(written).toEqual([
+        '52-to-53/index.md',
+        '52-to-unversioned/index.md',
+        '53-to-unversioned/index.md',
+      ]);
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale pair pages and legacy flat pair files from a previous run', () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-diff-pages-'));
+    try {
+      const pageDir = path.join(outDir, 'bare', 'upgrade');
+      fs.mkdirSync(path.join(pageDir, '50-to-51'), { recursive: true });
+      fs.writeFileSync(path.join(pageDir, '50-to-51', 'index.md'), 'stale');
+      fs.writeFileSync(path.join(pageDir, '50-to-51.md'), 'stale flat file');
+      fs.writeFileSync(path.join(pageDir, 'index.md'), 'converted page');
+
+      generateUpgradeDiffPages({ outDir, diffInfo, includeUnversioned: false });
+
+      expect(fs.existsSync(path.join(pageDir, '50-to-51'))).toBe(false);
+      expect(fs.existsSync(path.join(pageDir, '50-to-51.md'))).toBe(false);
+      expect(fs.readFileSync(path.join(pageDir, 'index.md'), 'utf-8')).toBe('converted page');
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/docs/scripts/generate-upgrade-diff-pages.ts
+++ b/docs/scripts/generate-upgrade-diff-pages.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  buildUpgradeHelperAttribution,
+  buildUpgradeInstructions,
+} from '../ui/components/TemplateBareMinimumDiffViewer/buildUpgradePrompt.ts';
+
+type UpgradeDiffInfo = {
+  versions: string[];
+  diffs: Record<string, string>;
+};
+
+type UpgradePair = { from: string; to: string };
+
+const PAIR_DIR_PATTERN = /^[^/]+-to-[^/]+$/;
+const LEGACY_FLAT_PAIR_FILE_PATTERN = /^.+-to-.+\.md$/;
+
+function versionRank(version: string): number {
+  return version === 'unversioned' ? Number.POSITIVE_INFINITY : Number(version);
+}
+
+function compareVersions(a: string, b: string): number {
+  const rankA = versionRank(a);
+  const rankB = versionRank(b);
+  return rankA === rankB ? 0 : rankA < rankB ? -1 : 1;
+}
+
+export function listUpgradePairs(
+  diffInfo: UpgradeDiffInfo,
+  { includeUnversioned }: { includeUnversioned: boolean }
+): UpgradePair[] {
+  const pairs: UpgradePair[] = [];
+
+  for (const [diffName, diff] of Object.entries(diffInfo.diffs)) {
+    const [from, to] = diffName.split('..');
+    if (!from || !to || !diff.trim()) {
+      continue;
+    }
+    if (!includeUnversioned && (from === 'unversioned' || to === 'unversioned')) {
+      continue;
+    }
+    if (compareVersions(from, to) >= 0) {
+      continue;
+    }
+    pairs.push({ from, to });
+  }
+
+  return pairs.sort((a, b) => compareVersions(a.from, b.from) || compareVersions(a.to, b.to));
+}
+
+export function upgradeDiffPagePath(from: string, to: string): string {
+  return `${from}-to-${to}/index.md`;
+}
+
+/**
+ * Whether an out/-relative markdown path is a generated upgrade pair page.
+ * Pair pages have no HTML sibling, so check-markdown-pages skips them.
+ */
+export function isUpgradePairMarkdownPath(relPath: string): boolean {
+  const posixPath = relPath.split(path.sep).join('/');
+  const match = posixPath.match(/^bare\/upgrade\/([^/]+)\/index\.md$/);
+  return match ? PAIR_DIR_PATTERN.test(match[1]) : false;
+}
+
+export function buildUpgradeDiffMarkdown({ from, to, diff }: UpgradePair & { diff: string }) {
+  const fence = diff.includes('```') ? '````' : '```';
+  const helperUrl = `https://docs.expo.dev/bare/upgrade/?fromSdk=${from}&toSdk=${to}`;
+
+  return [
+    '---',
+    `title: Upgrade native projects from SDK ${from} to SDK ${to}`,
+    `description: Ready-to-run prompt with the full expo-template-bare-minimum diff to upgrade native projects from SDK ${from} to SDK ${to}.`,
+    '---',
+    '',
+    buildUpgradeInstructions(from, to),
+    '',
+    `${fence}diff`,
+    diff,
+    fence,
+    '',
+    buildUpgradeHelperAttribution(helperUrl),
+    '',
+  ].join('\n');
+}
+
+export function generateUpgradeDiffPages({
+  outDir,
+  diffInfo,
+  includeUnversioned,
+}: {
+  outDir: string;
+  diffInfo: UpgradeDiffInfo;
+  includeUnversioned: boolean;
+}): string[] {
+  const pageDir = path.join(outDir, 'bare', 'upgrade');
+  fs.mkdirSync(pageDir, { recursive: true });
+
+  for (const entry of fs.readdirSync(pageDir, { withFileTypes: true })) {
+    if (entry.isDirectory() && PAIR_DIR_PATTERN.test(entry.name)) {
+      fs.rmSync(path.join(pageDir, entry.name), { recursive: true, force: true });
+    } else if (entry.isFile() && LEGACY_FLAT_PAIR_FILE_PATTERN.test(entry.name)) {
+      fs.unlinkSync(path.join(pageDir, entry.name));
+    }
+  }
+
+  const written: string[] = [];
+  for (const { from, to } of listUpgradePairs(diffInfo, { includeUnversioned })) {
+    const pagePath = upgradeDiffPagePath(from, to);
+    const markdown = buildUpgradeDiffMarkdown({ from, to, diff: diffInfo.diffs[`${from}..${to}`] });
+    fs.mkdirSync(path.dirname(path.join(pageDir, pagePath)), { recursive: true });
+    fs.writeFileSync(path.join(pageDir, pagePath), markdown);
+    written.push(pagePath);
+  }
+
+  return written;
+}

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -56,13 +56,17 @@ function setupTestDirectory(): void {
   fs.mkdirSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(`${TEST_DIR}/test-page`, { recursive: true });
   fs.mkdirSync(`${TEST_DIR}/html-only-page`, { recursive: true });
+  fs.mkdirSync(`${TEST_DIR}/bare/upgrade/52-to-57`, { recursive: true });
 
-  // Copy worker files
+  // Copy worker files, including the real _redirects: its /*.md wildcard
+  // rewrite shapes how .md URLs resolve, so tests must run against it
   const routesContent = fs.readFileSync('public/_routes.json', 'utf8');
   const workerContent = fs.readFileSync('public/_worker.js', 'utf8');
+  const redirectsContent = fs.readFileSync('public/_redirects', 'utf8');
 
   fs.writeFileSync(`${TEST_DIR}/_routes.json`, routesContent);
   fs.writeFileSync(`${TEST_DIR}/_worker.js`, workerContent);
+  fs.writeFileSync(`${TEST_DIR}/_redirects`, redirectsContent);
   fs.writeFileSync(`${TEST_DIR}/index.html`, '<html><body><h1>Test Page</h1></body></html>');
   fs.writeFileSync(
     `${TEST_DIR}/test-page/index.html`,
@@ -77,6 +81,13 @@ function setupTestDirectory(): void {
     `${TEST_DIR}/html-only-page/index.html`,
     '<html><body><h1>HTML Only Page</h1></body></html>'
   );
+  // Upgrade helper page with a default index.md and one version-pair file
+  fs.writeFileSync(
+    `${TEST_DIR}/bare/upgrade/index.html`,
+    '<html><body><h1>Upgrade Helper HTML</h1></body></html>'
+  );
+  fs.writeFileSync(`${TEST_DIR}/bare/upgrade/index.md`, '# Default Upgrade Markdown');
+  fs.writeFileSync(`${TEST_DIR}/bare/upgrade/52-to-57/index.md`, '# Upgrade Pair 52 To 57');
 
   console.log('✓ Test directory created');
 }
@@ -176,6 +187,116 @@ async function testMarkdownNotFoundAsync(): Promise<void> {
   console.log('✓ Nonexistent page returns 404');
 }
 
+async function testUpgradePairNegotiationAsync(): Promise<void> {
+  console.log('\n--- Testing upgrade helper version-pair negotiation ---');
+
+  // Valid pair params should serve the pair-specific markdown
+  const pairResponse = await fetch(`${BASE_URL}/bare/upgrade/?fromSdk=52&toSdk=57`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  const pairBody = await pairResponse.text();
+
+  if (!pairBody.includes('Upgrade Pair 52 To 57')) {
+    throw new Error(
+      'Expected pair markdown for fromSdk=52&toSdk=57, got: ' + pairBody.slice(0, 200)
+    );
+  }
+  console.log('✓ Valid version pair serves pair-specific markdown');
+
+  // Missing pair file should fall back to the default index.md
+  const missingPair = await fetch(`${BASE_URL}/bare/upgrade/?fromSdk=52&toSdk=99`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  const missingPairBody = await missingPair.text();
+
+  if (!missingPairBody.includes('Default Upgrade Markdown')) {
+    throw new Error('Expected fallback to default markdown for a missing pair');
+  }
+  console.log('✓ Missing pair file falls back to default markdown');
+
+  // No query params should serve the default index.md
+  const noQuery = await fetch(`${BASE_URL}/bare/upgrade/`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  const noQueryBody = await noQuery.text();
+
+  if (!noQueryBody.includes('Default Upgrade Markdown')) {
+    throw new Error('Expected default markdown when no version pair is selected');
+  }
+  console.log('✓ No version pair serves default markdown');
+
+  // Path-traversal style params must be rejected, not resolved as paths
+  const traversal = await fetch(
+    `${BASE_URL}/bare/upgrade/?fromSdk=${encodeURIComponent('../secret')}&toSdk=57`,
+    { headers: { Accept: 'text/markdown' } }
+  );
+  const traversalBody = await traversal.text();
+
+  if (traversal.status >= 500) {
+    throw new Error(`Server error for traversal params: HTTP ${traversal.status}`);
+  }
+  if (!traversalBody.includes('Default Upgrade Markdown')) {
+    throw new Error('Expected traversal params to fall back to default markdown');
+  }
+  console.log('✓ Invalid version params fall back to default markdown');
+
+  // The /<slug>.md convention resolves pair pages via the _redirects wildcard
+  const slugUrl = await fetch(`${BASE_URL}/bare/upgrade/52-to-57.md`);
+  const slugBody = await slugUrl.text();
+
+  if (!slugUrl.ok || !slugBody.includes('Upgrade Pair 52 To 57')) {
+    throw new Error('Expected /bare/upgrade/52-to-57.md to serve the pair page');
+  }
+  console.log('✓ Pair page resolves at the /<slug>.md convention');
+
+  // Known limit: .md paths bypass the worker (excluded in _routes.json) and
+  // _redirects cannot read query strings, so a pair query on the .md page
+  // path serves the default markdown, whose top note points at pair URLs.
+  const mdPathWithQuery = await fetch(`${BASE_URL}/bare/upgrade.md?fromSdk=52&toSdk=57`);
+  const mdPathWithQueryBody = await mdPathWithQuery.text();
+
+  if (!mdPathWithQuery.ok || !mdPathWithQueryBody.includes('Default Upgrade Markdown')) {
+    throw new Error('Expected /bare/upgrade.md with a pair query to serve the default markdown');
+  }
+  console.log('✓ .md page path with pair query serves default markdown (documented limit)');
+
+  // Appending .md to the page path without a query serves the default
+  const mdPathPlain = await fetch(`${BASE_URL}/bare/upgrade.md`);
+  const mdPathPlainBody = await mdPathPlain.text();
+
+  if (!mdPathPlain.ok || !mdPathPlainBody.includes('Default Upgrade Markdown')) {
+    throw new Error('Expected /bare/upgrade.md to serve the default markdown');
+  }
+  console.log('✓ .md page path without query serves default markdown');
+
+  // Appending .md to the last query value (the copy-paste gesture) also works
+  const mdSuffixParam = await fetch(`${BASE_URL}/bare/upgrade/?fromSdk=52&toSdk=57.md`);
+  const mdSuffixParamBody = await mdSuffixParam.text();
+
+  if (!mdSuffixParam.ok || !mdSuffixParamBody.includes('Upgrade Pair 52 To 57')) {
+    throw new Error('Expected ?fromSdk=52&toSdk=57.md to serve the pair page');
+  }
+  console.log('✓ .md suffix on the toSdk value serves pair markdown');
+
+  // The /<slug>.md convention on regular pages still works through the worker
+  const regularSlug = await fetch(`${BASE_URL}/test-page.md`);
+  const regularSlugBody = await regularSlug.text();
+
+  if (!regularSlug.ok || !regularSlugBody.includes('Test Markdown Content')) {
+    throw new Error('Expected /test-page.md to serve the page markdown');
+  }
+  console.log('✓ Regular /<slug>.md path serves markdown through the worker');
+
+  // The canonical index.md file path serves directly (bypassing the worker)
+  const direct = await fetch(`${BASE_URL}/bare/upgrade/52-to-57/index.md`);
+  const directBody = await direct.text();
+
+  if (!direct.ok || !directBody.includes('Upgrade Pair 52 To 57')) {
+    throw new Error('Expected direct pair index.md request to serve the static file');
+  }
+  console.log('✓ Direct pair index.md request serves content correctly');
+}
+
 async function testHtmlNotFoundAsync(): Promise<void> {
   console.log('\n--- Testing HTML 404 responses ---');
 
@@ -198,6 +319,7 @@ async function mainAsync(): Promise<void> {
     await testDirectMarkdownAccessAsync();
     await testMarkdownContentNegotiationAsync();
     await testMarkdownNotFoundAsync();
+    await testUpgradePairNegotiationAsync();
     await testHtmlNotFoundAsync();
 
     console.log('\n=== All tests passed! ===');

--- a/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
+++ b/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
@@ -16,6 +16,8 @@ import { MarkdownIcon } from '~/ui/components/CustomIcons/MarkdownIcon';
 import * as Dropdown from '~/ui/components/Dropdown';
 import { FOOTNOTE } from '~/ui/components/Text';
 
+import { getVersionedMarkdownPath } from './paths';
+
 const getPrompt = (url: string) =>
   encodeURIComponent(`Read this documentation page, so I can ask questions about it:\n\n${url}`);
 
@@ -30,6 +32,11 @@ export function MarkdownActionsDropdown() {
   const markdownViewUrl = useMemo(() => {
     if (!pagePath) {
       return null;
+    }
+
+    const versionedPath = getVersionedMarkdownPath(pagePath);
+    if (versionedPath) {
+      return versionedPath;
     }
 
     const path = pagePath.split(/[#?]/)[0].replace(/\/$/, '');

--- a/docs/ui/components/MarkdownActions/paths.test.ts
+++ b/docs/ui/components/MarkdownActions/paths.test.ts
@@ -1,4 +1,9 @@
-import { hasDynamicData, normalizePath, shouldShowMarkdownActions } from './paths';
+import {
+  getVersionedMarkdownPath,
+  hasDynamicData,
+  normalizePath,
+  shouldShowMarkdownActions,
+} from './paths';
 
 describe(normalizePath, () => {
   it('strips trailing slashes', () => {
@@ -36,6 +41,51 @@ describe(hasDynamicData, () => {
   });
 });
 
+describe(getVersionedMarkdownPath, () => {
+  it('resolves the pair markdown path from the upgrade helper query', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52&toSdk=57')).toBe(
+      '/bare/upgrade/52-to-57/index.md'
+    );
+  });
+
+  it('resolves without a trailing slash and with a hash fragment', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade?fromSdk=52&toSdk=57')).toBe(
+      '/bare/upgrade/52-to-57/index.md'
+    );
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52&toSdk=57#packagejson')).toBe(
+      '/bare/upgrade/52-to-57/index.md'
+    );
+  });
+
+  it('allows unversioned as the target version', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52&toSdk=unversioned')).toBe(
+      '/bare/upgrade/52-to-unversioned/index.md'
+    );
+  });
+
+  it('returns null when either version is missing', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade/')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?toSdk=57')).toBeNull();
+  });
+
+  it('returns null on other pages carrying the same query', () => {
+    expect(getVersionedMarkdownPath('/guides/overview/?fromSdk=52&toSdk=57')).toBeNull();
+  });
+
+  it('rejects versions that are not plain numbers or unversioned', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=..%2F52&toSdk=57')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52abc&toSdk=57')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=&toSdk=57')).toBeNull();
+  });
+
+  it('rejects pairs that do not upgrade to a newer version', () => {
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=57&toSdk=52')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=52&toSdk=52')).toBeNull();
+    expect(getVersionedMarkdownPath('/bare/upgrade/?fromSdk=unversioned&toSdk=57')).toBeNull();
+  });
+});
+
 describe(shouldShowMarkdownActions, () => {
   it('agrees between server and client paths for the same page', () => {
     const server = shouldShowMarkdownActions({ path: '/additional-resources/' });
@@ -48,5 +98,23 @@ describe(shouldShowMarkdownActions, () => {
     expect(shouldShowMarkdownActions({ packageName: 'expo-video', path: '/guides/x/' })).toBe(
       false
     );
+  });
+
+  it('hides actions on the upgrade helper without a version pair', () => {
+    expect(shouldShowMarkdownActions({ path: '/bare/upgrade/' })).toBe(false);
+    expect(shouldShowMarkdownActions({ path: '/bare/upgrade/?fromSdk=57&toSdk=52' })).toBe(false);
+  });
+
+  it('shows actions on the upgrade helper once a version pair is selected', () => {
+    expect(shouldShowMarkdownActions({ path: '/bare/upgrade/?fromSdk=52&toSdk=57' })).toBe(true);
+  });
+
+  it('keeps package pages hidden even with a version pair selected', () => {
+    expect(
+      shouldShowMarkdownActions({
+        packageName: 'expo-video',
+        path: '/bare/upgrade/?fromSdk=52&toSdk=57',
+      })
+    ).toBe(false);
   });
 });

--- a/docs/ui/components/MarkdownActions/paths.ts
+++ b/docs/ui/components/MarkdownActions/paths.ts
@@ -4,6 +4,9 @@ const DYNAMIC_DATA_PATHS = [
   /^\/bare\/upgrade\/?$/,
 ];
 
+const UPGRADE_HELPER_PATH = '/bare/upgrade';
+const SDK_VERSION_PARAM = /^(\d+|unversioned)$/;
+
 export function normalizePath(path?: string) {
   if (!path) {
     return '';
@@ -18,6 +21,36 @@ export function hasDynamicData(path?: string) {
   return normalized ? DYNAMIC_DATA_PATHS.some(pattern => pattern.test(normalized)) : false;
 }
 
+function versionRank(version: string) {
+  return version === 'unversioned' ? Number.POSITIVE_INFINITY : Number(version);
+}
+
+export function getVersionedMarkdownPath(path?: string) {
+  if (!path || normalizePath(path) !== UPGRADE_HELPER_PATH) {
+    return null;
+  }
+
+  const query = path.split('#')[0].split('?')[1];
+  if (!query) {
+    return null;
+  }
+
+  const params = new URLSearchParams(query);
+  const from = params.get('fromSdk');
+  const to = params.get('toSdk');
+  if (
+    !from ||
+    !to ||
+    !SDK_VERSION_PARAM.test(from) ||
+    !SDK_VERSION_PARAM.test(to) ||
+    versionRank(from) >= versionRank(to)
+  ) {
+    return null;
+  }
+
+  return `${UPGRADE_HELPER_PATH}/${from}-to-${to}/index.md`;
+}
+
 export function shouldShowMarkdownActions({
   packageName,
   path,
@@ -27,6 +60,10 @@ export function shouldShowMarkdownActions({
 }) {
   if (packageName) {
     return false;
+  }
+
+  if (getVersionedMarkdownPath(path)) {
+    return true;
   }
 
   return !hasDynamicData(path);

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/buildUpgradePrompt.ts
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/buildUpgradePrompt.ts
@@ -5,14 +5,20 @@ type BuildNativeUpgradePromptParams = {
   url?: string;
 };
 
-export function buildNativeUpgradePrompt({ from, to, diff, url }: BuildNativeUpgradePromptParams) {
-  const instructions = `Upgrade my Expo React Native project from SDK ${from} to SDK ${to}. Below is the unified diff of every file that changed in the expo-template-bare-minimum template between these two SDK versions. It covers the native android/ and ios/ directories as well as project-root files such as package.json. Apply every change in this diff to the corresponding file in my project. My project is NOT identical to the template, so adapt file paths, reconcile conflicts, skip changes already present, preserve my custom code, and do not assume a clean \`git apply\`. When done, summarize what you changed.`;
+export function buildUpgradeInstructions(from: string, to: string) {
+  return `Upgrade my Expo React Native project from SDK ${from} to SDK ${to}. Below is the unified diff of every file that changed in the expo-template-bare-minimum template between these two SDK versions. It covers the native android/ and ios/ directories as well as project-root files such as package.json. Apply every change in this diff to the corresponding file in my project. My project is NOT identical to the template, so adapt file paths, reconcile conflicts, skip changes already present, preserve my custom code, and do not assume a clean \`git apply\`. When done, summarize what you changed.`;
+}
 
-  const prompt = `${instructions}\n\n${diff}`;
+export function buildUpgradeHelperAttribution(url: string) {
+  return `Generated with the Expo native upgrade helper: ${url}`;
+}
+
+export function buildNativeUpgradePrompt({ from, to, diff, url }: BuildNativeUpgradePromptParams) {
+  const prompt = `${buildUpgradeInstructions(from, to)}\n\n${diff}`;
 
   if (!url) {
     return prompt;
   }
 
-  return `${prompt}\n\nGenerated with the Expo native upgrade helper: ${url}`;
+  return `${prompt}\n\n${buildUpgradeHelperAttribution(url)}`;
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-22652

# How

- Add `scripts/generate-upgrade-diff-pages.ts` to write a markdown page per SDK version pair (`out/bare/upgrade/<from>-to-<to>/index.md`) from `diffInfo.json` during `generate-markdown-pages`, skipping `unversioned` pairs when the environment hides them
- Resolve version-pinned markdown requests in `public/_worker.js` (`?fromSdk`/`?toSdk`, including a trailing `.md` on the value) to the pair file, falling back to the default `index.md`
- Show the Copy page dropdown on `/bare/upgrade` once a pair is selected and point its actions at the pair file via `getVersionedMarkdownPath` in `MarkdownActions/paths.ts`
- Export the prompt instructions from `buildUpgradePrompt.ts` for reuse, and cover the above in jest and `test-worker.ts` (fixture now runs against the real `_redirects`)

# Test Plan

On the preview:

- Open **/bare/upgrade/**, select from SDK 52 to SDK 57, and confirm the Copy page dropdown appears in the header
- Use **View markdown** from the dropdown and confirm it opens the markdown titled "Upgrade native projects from SDK 52 to SDK 57", then change the selectors and confirm the link follows
- Use **Copy markdown** and paste somewhere to confirm the prompt and diff match the selected pair
- Visit **/bare/upgrade/52-to-57.md** directly and confirm the same pair markdown renders
- Visit **/bare/upgrade/?fromSdk=52&toSdk=57.md** (the append-.md gesture on a pinned URL) and confirm the pair markdown renders

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).