### PR TITLE
[autolinking] Respect dynamic framework linkage set by earlier pre_install hooks

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Respect an explicit `ios.usePrecompiledModules: false` even when `EXPO_USE_PRECOMPILED_MODULES` is already set in the environment (e.g. EAS Build). ([#46983](https://github.com/expo/expo/pull/46983) by [@ryanda9910](https://github.com/ryanda9910))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.5.0`'s generated component and native view sources. ([#47201](https://github.com/expo/expo/pull/47201) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`. ([#47478](https://github.com/expo/expo/pull/47478) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Under precompiled modules, preserve a dynamic-framework subgraph set up by an earlier `pre_install` hook (e.g. `@rnmapbox/maps`) — both the dynamic frameworks and the pods that link against them — instead of forcing them back to static libraries. ([#47500](https://github.com/expo/expo/pull/47500) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -205,7 +205,26 @@ module Expo
 
         pods_to_downgrade = Set.new(installer.podfile.framework_modules_to_patch)
 
+        # Pods an earlier pre_install hook already switched to dynamic frameworks —
+        # e.g. @rnmapbox/maps flips its Mapbox binary pods (MapboxCommon,
+        # MapboxCoreMaps, MapboxMaps, Turf) to dynamic. Forcing these back to static
+        # breaks that required linkage and makes CocoaPods abort with "transitive
+        # dependencies that include statically linked binaries".
+        # `build_type` is a private reader on Pod::Target, so read it via `send`;
+        # hooks that override it define a public method, which `send` resolves too.
+        dynamic_framework_pods = installer.pod_targets
+          .select { |t| t.send(:build_type).dynamic_framework? }
+          .map(&:name)
+          .to_set
+
         installer.pod_targets.each do |t|
+          # Leave the dynamic framework itself untouched.
+          next if dynamic_framework_pods.include?(t.name)
+          # Leave a pod that links against one untouched too: a consumer like
+          # rnmapbox-maps is built as a framework under use_frameworks! and imports
+          # the dynamic pod with framework-style headers (#import <Mapbox…/…>), so a
+          # static-library downgrade breaks its compile.
+          next if t.root_spec.dependencies.any? { |d| dynamic_framework_pods.include?(d.name) }
           if has_vendored_xcframeworks?(t)
             pods_to_downgrade.add(t.name)
           elsif t.root_spec.dependencies.any? { |d| d.name.start_with?('React-Core') }


### PR DESCRIPTION
# Why

fixes #47330.

with `useFrameworks: "static"` + `@rnmapbox/maps` + precompiled modules, `pod install` fails:

```
[!] The 'Pods-...' target has transitive dependencies that include statically linked binaries: (MapboxCoreMaps, MapboxCommon, and Turf)
```

rnmapbox flips its mapbox binary pods to dynamic frameworks in its own `pre_install`, but expo's precompiled-module step runs afterwards and forces every use_frameworks pod back to a static library, undoing that. hence the `EXPO_USE_PRECOMPILED_MODULES=0` workaround.

there are actually two failures from the same cause. even after pod install passes, the build still breaks: `rnmapbox-maps` is built as a framework under use_frameworks and imports the dynamic mapbox pods with framework-style headers, but the downgrade turns it into a static library:

```
rnmapbox_maps-Swift.pre.h:10:9: fatal error: 'rnmapbox_maps/rnmapbox_maps-Swift.h' file not found
```

# How

preserve the whole dynamic-framework subgraph an earlier hook sets up, instead of forcing it back to static:

```ruby
dynamic_framework_pods = installer.pod_targets
  .select { |t| t.send(:build_type).dynamic_framework? }
  .map(&:name).to_set

# ...in the downgrade loop:
next if dynamic_framework_pods.include?(t.name)            # the dynamic frameworks
next if t.root_spec.dependencies.any? { |d| dynamic_framework_pods.include?(d.name) }  # + pods that link against them
```

`build_type` is private on `Pod::Target`, so read it via `send`. firebase (`forceStaticLinking`) and expo's own static xcframework pods are untouched — only the subgraph a prior hook made dynamic is preserved.

# Test Plan

ran the reporter's repro on cocoapods 1.16.2, `pod install` **and** `xcodebuild` for the simulator, precompiled modules on:

- before: `pod install` fails with the transitive-static error
- with only the pod-install part fixed: `pod install` passes but `xcodebuild` fails on the `rnmapbox_maps-Swift.h` error above
- after (this pr): `pod install` succeeds (114 pods) and `xcodebuild` → `** BUILD SUCCEEDED **`; mapbox stays dynamic, `rnmapbox-maps` stays a framework, `RNFBApp` stays static

`EXPO_USE_PRECOMPILED_MODULES=0` still builds as before.

# checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
