### PR TITLE
[inline-modules][expo-modules-autolinking] Use proper target name for checking inline modules targets

### DIFF
--- a/apps/bare-expo/ios/Podfile.properties.json
+++ b/apps/bare-expo/ios/Podfile.properties.json
@@ -3,7 +3,7 @@
   "newArchEnabled": "true",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "expo.inlineModules.watchedDirectories": "[\"../native-component-list/src/screens/inlineModules/inlineModulesExamples\",\"../native-component-list/src/screens/ModulesCore\"]",
-  "expo.inlineModules.xcodeProjectTargets": "{\"mainTarget\":\"BareExpoMain-BareExpo\",\"targets\":[]}",
+  "expo.inlineModules.xcodeProjectTargets": "{\"mainTarget\":\"BareExpo\",\"targets\":[]}",
   "ios.buildReactNativeFromSource": "false",
   "EXPO_USE_PRECOMPILED_MODULES": "false"
 }

--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -55,6 +55,25 @@ A directory in `watchedDirectories`:
 
 </PaddedAPIBox>
 
+<PaddedAPIBox header="expo.experiments.inlineModules.xcodeProjectTargets" platforms={["ios"]}>
+Configures which Xcode targets the inline module files are added to. When omitted, inline modules are added to your app's main target only.
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "inlineModules": {
+        "xcodeProjectTargets": ["MyApp", "MyAppWidgets"]
+      }
+    }
+  }
+}
+```
+
+Each entry is the name of a target as it appears in your Xcode project (and in the `target` blocks of your **ios/Podfile**). Use the target name only — even when the target is nested inside an `abstract_target`, do not include the abstract target's name.
+
+</PaddedAPIBox>
+
 > **Warning** You need to run `npx expo prebuild` after changing the [app config](/workflow/configuration/), for it to take effect.
 
 ## Naming convention

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target.
+- [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))
 - [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.4.1` upstream defaults, adding the `CSS/core/transition` and `PseudoStyles` header mappings along with the missing `IOS_CSS_CORE_ANIMATION` and `USE_ANIMATION_BACKEND` feature flags so its XCFramework builds. ([#46950](https://github.com/expo/expo/pull/46950) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target.
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))
 - [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.4.1` upstream defaults, adding the `CSS/core/transition` and `PseudoStyles` header mappings along with the missing `IOS_CSS_CORE_ANIMATION` and `USE_ANIMATION_BACKEND` feature flags so its XCFramework builds. ([#46950](https://github.com/expo/expo/pull/46950) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -145,7 +145,7 @@ module Expo
 
     # Spawns `expo-module-autolinking generate-modules-provider` command.
     public def generate_modules_provider(target_name, target_path)
-      Process.wait IO.popen(generate_modules_provider_command_args(target_path)).pid
+      Process.wait IO.popen(generate_modules_provider_command_args(target_name, target_path)).pid
     end
 
     # If there is any package to autolink.
@@ -253,8 +253,8 @@ module Expo
       node_command_args('resolve').concat(resolve_command_args)
     end
 
-    public def generate_modules_provider_command_args(target_path)
-      command_args = ['--target', target_path, "--podfile-properties-file-path", "\"#{@podfile_properties_path}\""]
+    public def generate_modules_provider_command_args(target_name, target_path)
+      command_args = ['--target', target_path, '--target-name', target_name, "--podfile-properties-file-path", "\"#{@podfile_properties_path}\""]
 
       if !custom_app_root.nil?
         command_args.concat(['--app-root', custom_app_root])

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -261,7 +261,7 @@ module Expo
       # Write to the shell script so it's always in-sync with the autolinking configuration
       IO.write(
         support_script_path,
-        generate_support_script(autolinking_manager, modules_provider_path, entitlement_path)
+        generate_support_script(autolinking_manager, target.target_definition.name, modules_provider_path, entitlement_path)
       )
 
       # Make the support script executable
@@ -303,7 +303,7 @@ module Expo
     end
 
     # Generates the support script that is executed by the build script phase.
-    def self.generate_support_script(autolinking_manager, modules_provider_path, entitlement_path)
+    def self.generate_support_script(autolinking_manager, target_name, modules_provider_path, entitlement_path)
       args = autolinking_manager.base_command_args.map { |arg| "\"#{arg}\"" }
       platform = autolinking_manager.platform_name.downcase
       package_names = autolinking_manager.packages_to_generate.map { |package| "\"#{package.name}\"" }
@@ -361,6 +361,7 @@ module Expo
         expo-modules-autolinking \\
         generate-modules-provider #{args.join(' ')} \\
         --target "#{modules_provider_path}" \\
+        --target-name "#{target_name}" \\
         #{entitlement_param} \\
         #{app_root_param} \\
         #{podfile_properties_param} \\

--- a/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
+++ b/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
@@ -447,60 +447,138 @@ describe('androidInlineModules.ts', () => {
 });
 
 describe('isTargetInInlineModulesTargets', () => {
-  it('should return true if mainTarget matches the extracted target from the path', () => {
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-AppTarget/ExpoModulesProvider.swift';
-    const inlineModulesTargets = { mainTarget: 'AppTarget', targets: [] };
+  describe('with an explicit targetName', () => {
+    it('should return true if targetName matches the mainTarget', () => {
+      const targetName = 'AppTarget';
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-AppTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { mainTarget: 'AppTarget', targets: [] };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(true);
+      const result = isTargetInInlineModulesTargets({
+        targetName,
+        targetPath,
+        inlineModulesTargets,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return true if mainTarget is not provided and targetName is in the targets array', () => {
+      const targetName = 'ExpoWidgetsTarget';
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['SomeOtherTarget', 'ExpoWidgetsTarget'] };
+
+      const result = isTargetInInlineModulesTargets({
+        targetName,
+        targetPath,
+        inlineModulesTargets,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should use targetName even when the path contains an abstract target prefix', () => {
+      // With an abstract target the provider lives under `Pods-<abstract>-<target>`,
+      // so the path-derived name would be `MyAbstractTarget-ExpoWidgetsTarget` and fail
+      // to match. The explicit target name resolves this.
+      const targetName = 'ExpoWidgetsTarget';
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-MyAbstractTarget-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['ExpoWidgetsTarget'] };
+
+      const result = isTargetInInlineModulesTargets({
+        targetName,
+        targetPath,
+        inlineModulesTargets,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should prefer targetName over the path when the abstract-prefixed path would match a different target', () => {
+      // The path-derived name `MainApp-Widget` must not be mistaken for the `MainApp` main target.
+      const targetName = 'Widget';
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-MainApp-Widget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { mainTarget: 'MainApp', targets: [] };
+
+      const result = isTargetInInlineModulesTargets({
+        targetName,
+        targetPath,
+        inlineModulesTargets,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('should return false if targetName is not in the targets array', () => {
+      const targetName = 'ExpoWidgetsTarget';
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['expo56c', 'SomeOtherTarget'] };
+
+      const result = isTargetInInlineModulesTargets({
+        targetName,
+        targetPath,
+        inlineModulesTargets,
+      });
+      expect(result).toBe(false);
+    });
   });
 
-  it('should return true if mainTarget is not provided and the extracted target is in the targets array', () => {
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-    const inlineModulesTargets = {
-      targets: ['SomeOtherTarget', 'ExpoWidgetsTarget'],
-    };
+  describe('falling back to the target extracted from the path', () => {
+    it('should return true if mainTarget matches the extracted target from the path', () => {
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-AppTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { mainTarget: 'AppTarget', targets: [] };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(true);
-  });
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(true);
+    });
 
-  it('should return false if mainTarget is not provided and the extracted target is not in the targets array', () => {
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-    const inlineModulesTargets = { targets: ['expo56c', 'SomeOtherTarget'] };
+    it('should return true if mainTarget is not provided and the extracted target is in the targets array', () => {
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = {
+        targets: ['SomeOtherTarget', 'ExpoWidgetsTarget'],
+      };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(false);
-  });
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(true);
+    });
 
-  it('should return false if mainTarget is not provided and the targets array is empty', () => {
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-expo56c/ExpoModulesProvider.swift';
-    const inlineModulesTargets = { targets: [] };
+    it('should return false if mainTarget is not provided and the extracted target is not in the targets array', () => {
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['expo56c', 'SomeOtherTarget'] };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(false);
-  });
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(false);
+    });
 
-  it('should return false if the path format does not match the expected Pods layout', () => {
-    // Missing the "/Pods-" prefix before the target name
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/MyTarget/ExpoModulesProvider.swift';
-    const inlineModulesTargets = { targets: ['MyTarget'] };
+    it('should return false if mainTarget is not provided and the targets array is empty', () => {
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-expo56c/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: [] };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(false);
-  });
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(false);
+    });
 
-  it('should return false if the target matches but has a different casing structure', () => {
-    const targetPath =
-      '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-    const inlineModulesTargets = { targets: ['expowidgetstarget'] };
+    it('should return false if the path format does not match the expected Pods layout', () => {
+      // Missing the "/Pods-" prefix before the target name
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/MyTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['MyTarget'] };
 
-    const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-    expect(result).toBe(false);
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the target matches but has a different casing structure', () => {
+      const targetPath =
+        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
+      const inlineModulesTargets = { targets: ['expowidgetstarget'] };
+
+      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
+++ b/packages/expo-modules-autolinking/src/__tests__/inlineModules.test.ts
@@ -493,21 +493,6 @@ describe('isTargetInInlineModulesTargets', () => {
       expect(result).toBe(true);
     });
 
-    it('should prefer targetName over the path when the abstract-prefixed path would match a different target', () => {
-      // The path-derived name `MainApp-Widget` must not be mistaken for the `MainApp` main target.
-      const targetName = 'Widget';
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-MainApp-Widget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { mainTarget: 'MainApp', targets: [] };
-
-      const result = isTargetInInlineModulesTargets({
-        targetName,
-        targetPath,
-        inlineModulesTargets,
-      });
-      expect(result).toBe(false);
-    });
-
     it('should return false if targetName is not in the targets array', () => {
       const targetName = 'ExpoWidgetsTarget';
       const targetPath =
@@ -519,65 +504,6 @@ describe('isTargetInInlineModulesTargets', () => {
         targetPath,
         inlineModulesTargets,
       });
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('falling back to the target extracted from the path', () => {
-    it('should return true if mainTarget matches the extracted target from the path', () => {
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-AppTarget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { mainTarget: 'AppTarget', targets: [] };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-      expect(result).toBe(true);
-    });
-
-    it('should return true if mainTarget is not provided and the extracted target is in the targets array', () => {
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = {
-        targets: ['SomeOtherTarget', 'ExpoWidgetsTarget'],
-      };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-      expect(result).toBe(true);
-    });
-
-    it('should return false if mainTarget is not provided and the extracted target is not in the targets array', () => {
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { targets: ['expo56c', 'SomeOtherTarget'] };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-      expect(result).toBe(false);
-    });
-
-    it('should return false if mainTarget is not provided and the targets array is empty', () => {
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-expo56c/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { targets: [] };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-      expect(result).toBe(false);
-    });
-
-    it('should return false if the path format does not match the expected Pods layout', () => {
-      // Missing the "/Pods-" prefix before the target name
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/MyTarget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { targets: ['MyTarget'] };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
-      expect(result).toBe(false);
-    });
-
-    it('should return false if the target matches but has a different casing structure', () => {
-      const targetPath =
-        '/Users/user1/Projects/apps/ios/Pods/Target Support Files/Pods-ExpoWidgetsTarget/ExpoModulesProvider.swift';
-      const inlineModulesTargets = { targets: ['expowidgetstarget'] };
-
-      const result = isTargetInInlineModulesTargets({ targetPath, inlineModulesTargets });
       expect(result).toBe(false);
     });
   });

--- a/packages/expo-modules-autolinking/src/autolinking/generatePackageList.ts
+++ b/packages/expo-modules-autolinking/src/autolinking/generatePackageList.ts
@@ -4,6 +4,7 @@ import type { ModuleDescriptor, ModuleDescriptorIos, SupportedPlatform } from '.
 interface GenerateModulesProviderParams {
   platform: SupportedPlatform;
   targetPath: string;
+  targetName?: string;
   entitlementPath: string | null;
   watchedDirectories: string[];
   inlineModulesTargets: { mainTarget?: string; targets: string[] };

--- a/packages/expo-modules-autolinking/src/commands/generateModulesProviderCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/generateModulesProviderCommand.ts
@@ -9,6 +9,7 @@ import { createAutolinkingOptionsLoader, registerAutolinkingArguments } from './
 
 interface GenerateModulesProviderArguments extends AutolinkingCommonArguments {
   target: string;
+  targetName?: string;
   podfilePropertiesFilePath: string;
   entitlement?: string;
   packages?: string[] | null;
@@ -26,6 +27,10 @@ export function generateModulesProviderCommand(cli: commander.CommanderStatic) {
     .option(
       '-t, --target <path>',
       'Path to the target file, where the package list should be written to.'
+    )
+    .option(
+      '--target-name <name>',
+      'Name of the user target the package list is generated for. Used to match against the inline modules targets.'
     )
     .option('--entitlement <path>', 'Path to the Apple code signing entitlements file.')
     .option(
@@ -76,6 +81,7 @@ export function generateModulesProviderCommand(cli: commander.CommanderStatic) {
         await generateModulesProviderAsync(filteredModules, {
           platform,
           targetPath: commandArguments.target,
+          targetName: commandArguments.targetName,
           entitlementPath: commandArguments.entitlement ?? null,
           watchedDirectories,
           inlineModulesTargets,

--- a/packages/expo-modules-autolinking/src/inlineModules/iosInlineModules.ts
+++ b/packages/expo-modules-autolinking/src/inlineModules/iosInlineModules.ts
@@ -14,24 +14,26 @@ export async function getIosInlineModulesClassNames(
   });
 }
 
+function extractTargetNameFromPath(targetPath: string): string | undefined {
+  const targetRegex = /\/Pods-(.+?)\/ExpoModulesProvider\.swift$/;
+  return targetPath.match(targetRegex)?.[1];
+}
+
 export function isTargetInInlineModulesTargets({
+  targetName,
   targetPath,
   inlineModulesTargets,
 }: {
+  targetName?: string;
   targetPath: string;
   inlineModulesTargets: { mainTarget?: string; targets: string[] };
 }): boolean {
-  const targetRegex = /\/Pods-(.+?)\/ExpoModulesProvider\.swift$/;
-  const match = targetPath.match(targetRegex);
-  if (!match) {
-    return false;
-  }
-  const targetName = match[1];
-  if (targetName === undefined) {
+  const resolvedTargetName = targetName ?? extractTargetNameFromPath(targetPath);
+  if (resolvedTargetName === undefined) {
     return false;
   }
   if (inlineModulesTargets.mainTarget) {
-    return targetName === inlineModulesTargets.mainTarget;
+    return resolvedTargetName === inlineModulesTargets.mainTarget;
   }
-  return inlineModulesTargets.targets.includes(targetName);
+  return inlineModulesTargets.targets.includes(resolvedTargetName);
 }

--- a/packages/expo-modules-autolinking/src/platforms/apple/apple.ts
+++ b/packages/expo-modules-autolinking/src/platforms/apple/apple.ts
@@ -109,6 +109,7 @@ interface GenerateModulesProviderParams {
   watchedDirectories: string[];
   inlineModulesTargets: { mainTarget?: string; targets: string[] };
   targetPath: string;
+  targetName?: string;
   appRoot: string;
 }
 /**


### PR DESCRIPTION


# Why
When checking inline modules target names in expo-modules-autolinking we're currently retrieving the target name from the path to the `ExpoModulesProvider.swift`. But the path may also contain the abstract-target, and we can just propagate the actual target-name to the `generate-modules-provider` command.

# How
added `--target-name` argument to the `generate-modules-provider` command, changed the inline modules target check to verify against the provided `targetName` instead of the target retrieved from the path to `ExpoModulesProvider.swift`
# Test Plan
- [x] added new unit tests
- [x] updated and checked the bare-expo
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
