### PR TITLE
[fingerprint] fix e2e test errors

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Added more default `getConfig` exclusion packages. ([#47503](https://github.com/expo/expo/pull/47503) by [@kudo](https://github.com/kudo))
+
 ## 0.19.3 — 2026-05-26
 
 ### 🐛 Bug fixes

--- a/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
@@ -4,12 +4,17 @@ import os from 'os';
 import path from 'path';
 
 import { createFingerprintAsync } from '../../src/Fingerprint';
-import { E2E_EXPECTED_3RD_PARTY_MODULES, E2E_TEMPLATE_SDK_VERSION } from './utils/constants';
+import {
+  E2E_EXPECTED_3RD_PARTY_MODULES,
+  E2E_TEMPLATE_SDK_VERSION,
+} from './utils/constants';
 
 jest.mock('../../src/ExpoConfigLoader', () => ({
   // Mock the getExpoConfigLoaderPath to use the built version rather than the typescript version from src
   getExpoConfigLoaderPath: jest.fn(() =>
-    jest.requireActual('path').resolve(__dirname, '..', '..', 'build', 'ExpoConfigLoader.js')
+    jest
+      .requireActual('path')
+      .resolve(__dirname, '..', '..', 'build', 'ExpoConfigLoader.js'),
   ),
 }));
 
@@ -25,7 +30,12 @@ describe('default template ignore paths', () => {
     await fs.rm(projectRoot, { force: true, recursive: true });
     await spawnAsync(
       'bunx',
-      ['create-expo-app', '-t', `default@${E2E_TEMPLATE_SDK_VERSION}`, projectName],
+      [
+        'create-expo-app',
+        '-t',
+        `default@${E2E_TEMPLATE_SDK_VERSION}`,
+        projectName,
+      ],
       {
         stdio: 'inherit',
         cwd: tmpDir,
@@ -34,7 +44,7 @@ describe('default template ignore paths', () => {
           // Do not inherit the package manager from this repository
           npm_config_user_agent: undefined,
         },
-      }
+      },
     );
   });
 
@@ -57,7 +67,11 @@ describe('default template ignore paths', () => {
 
       // Heuristic to check if it's a native module
       // We ignore expo modules first and then check react-native- prefix.
-      if (moduleName === 'expo' || moduleName === '@expo' || moduleName.startsWith('expo-')) {
+      if (
+        moduleName === 'expo' ||
+        moduleName === '@expo' ||
+        moduleName.startsWith('expo-')
+      ) {
         continue;
       }
 
@@ -85,7 +99,7 @@ export default ({ config }) => {
       (source) =>
         source.type === 'file' &&
         source.filePath === 'package.json' &&
-        source.reasons.includes('expoConfigPlugins')
+        source.reasons.includes('expoConfigPlugins'),
     );
     expect(packageJsonSource).toBeUndefined();
     await fs.rm(appConfigPath, { force: true });
@@ -101,7 +115,12 @@ macosDescribe('CocoaPods generated files', () => {
     await fs.rm(projectRoot, { force: true, recursive: true });
     await spawnAsync(
       'bunx',
-      ['create-expo-app', '-t', `default@${E2E_TEMPLATE_SDK_VERSION}`, projectName],
+      [
+        'create-expo-app',
+        '-t',
+        `default@${E2E_TEMPLATE_SDK_VERSION}`,
+        projectName,
+      ],
       {
         stdio: 'inherit',
         cwd: tmpDir,
@@ -110,7 +129,7 @@ macosDescribe('CocoaPods generated files', () => {
           // Do not inherit the package manager from this repository
           npm_config_user_agent: undefined,
         },
-      }
+      },
     );
     const appJsonPath = path.join(projectRoot, 'app.json');
     const config = JSON.parse(await fs.readFile(appJsonPath, 'utf8'));
@@ -122,7 +141,7 @@ macosDescribe('CocoaPods generated files', () => {
       `\
 android/**/*
 ios/**/*
-`
+`,
     );
   });
 
@@ -134,15 +153,23 @@ ios/**/*
     // expo-sqlite and expo-updates have dynamic copied files, which should be ignored by fingerprinting.
     // https://github.com/expo/expo/blob/d0e39858ead9a194d90990f89903e773b9d33582/packages/expo-sqlite/ios/ExpoSQLite.podspec#L25-L36
     // https://github.com/expo/expo/blob/d0e39858ead9a194d90990f89903e773b9d33582/packages/expo-updates/ios/EXUpdates.podspec#L51-L58
-    await spawnAsync('npx', ['expo', 'install', 'expo-sqlite', 'expo-updates'], {
-      stdio: 'ignore',
-      cwd: projectRoot,
-    });
+    await spawnAsync(
+      'npx',
+      ['expo', 'install', 'expo-sqlite', 'expo-updates'],
+      {
+        stdio: 'ignore',
+        cwd: projectRoot,
+      },
+    );
     const fingerprint = await createFingerprintAsync(projectRoot);
-    await spawnAsync('npx', ['expo', 'prebuild', '--platform', 'ios', '--no-install'], {
-      stdio: 'ignore',
-      cwd: projectRoot,
-    });
+    await spawnAsync(
+      'npx',
+      ['expo', 'prebuild', '--platform', 'ios', '--no-install'],
+      {
+        stdio: 'ignore',
+        cwd: projectRoot,
+      },
+    );
     await spawnAsync('npx', ['pod-install'], {
       stdio: 'ignore',
       cwd: projectRoot,

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -26,7 +26,9 @@ async function runAsync(programName: string, args: string[] = []) {
   const loadedModulesBefore = new Set(Object.keys(module._cache));
 
   const { getConfig } = require(resolveFrom(path.resolve(projectRoot), 'expo/config'));
-  const config = await getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const config = await getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+  });
 
   const virtualModuleNames = new Set<string>();
   const loadedModules: string[] = [];
@@ -91,7 +93,10 @@ async function runAsync(programName: string, args: string[] = []) {
     )
   ).filter((modulePath) => modulePath != null);
 
-  const result = JSON.stringify({ config, loadedModules: existingLoadedModules });
+  const result = JSON.stringify({
+    config,
+    loadedModules: existingLoadedModules,
+  });
 
   if (process.send) {
     process.send(result);
@@ -179,6 +184,9 @@ const DEFAULT_CONFIG_LOADING_IGNORE_PATHS = [
     'ajv-formats',
     'ajv-keywords',
     'ansi-styles',
+    'base64-js',
+    'big-integer',
+    'bplist-creator',
     'chalk',
     'debug',
     'dotenv',
@@ -198,6 +206,7 @@ const DEFAULT_CONFIG_LOADING_IGNORE_PATHS = [
     'parse-png',
     'path-key',
     'picocolors',
+    'plist',
     'pngjs',
     'lines-and-columns',
     'require-from-string',
@@ -205,6 +214,8 @@ const DEFAULT_CONFIG_LOADING_IGNORE_PATHS = [
     'sax',
     'schema-utils',
     'signal-exit',
+    'simple-plist',
+    'stream-buffers',
     'sucrase',
     'supports-color',
     'ts-interface-checker',
@@ -212,5 +223,7 @@ const DEFAULT_CONFIG_LOADING_IGNORE_PATHS = [
     'xml2js',
     'xmlbuilder',
     'which',
+    'uuid',
+    'xcode',
   ].join(',')}}/**/*`,
 ];


### PR DESCRIPTION
# Why

fix fingerprint e2e error: https://github.com/expo/expo/actions/runs/28655646441

# How

add more exclude `getConfig` list from cli

# Test Plan

fingerprint e2e ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
