### PR TITLE
[image-picker][Android] Fix `videoMaxDuration` option

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -39,6 +39,7 @@ internal class ImagePickerOptions : Record, Serializable {
   @Field
   var mediaTypes: Array<JSMediaTypes> = arrayOf(JSMediaTypes.IMAGES)
 
+  @Field
   @IntRange(from = 0)
   var videoMaxDuration: Int = 0
 


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/43711
`videoMaxDuration` was defined in the `ImagePickerOptions` type but was missing the field annotation, so it wasn't forwarded to the native side

# How

- Added the missing `@Field` annotation 

# Test Plan
BareExpo ✅
<img width="250" height="600" alt="Screenshot_20260703_165527_Camera" src="https://github.com/user-attachments/assets/9c6b6539-51e8-4bbe-a7fe-06d5740a03ff" />

