### PR TITLE
[jsi] Add LongLivedObjectCollection

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Conform `JavaScriptRuntime` to `Identifiable` with an `id` based on the underlying runtime, equal across multiple wrappers of the same runtime. ([#47068](https://github.com/expo/expo/pull/47068) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRef.withValue`, a non-consuming borrow accessor that reads the referenced value without taking it, so a long-lived reference can be read repeatedly. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -637,6 +637,14 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
 
   @JavaScriptActor
   internal var propNameIdsRegistry: [String: JavaScriptPropNameID] = [:]
+
+  // MARK: - Long-lived objects
+
+  /// Registry of JSI objects (such as in-flight promises) that must outlive the native call that
+  /// created them. Cleared when the runtime is torn down so their JSI state is released on the
+  /// JavaScript thread while the runtime is still valid.
+  @JavaScriptActor
+  public let longLivedObjects = LongLivedObjectCollection()
 }
 
 private func createFunctionClosure(

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/LongLivedObjectCollection.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/LongLivedObjectCollection.swift
@@ -1,0 +1,46 @@
+/// An object whose lifetime must extend past the native call that created it, such as an in-flight
+/// promise holding its resolve/reject state. Register it with a ``LongLivedObjectCollection``.
+@JavaScriptActor
+public protocol LongLivedObject: AnyObject {
+  /// Called on the JavaScript thread when the runtime tears down while this object is still
+  /// registered, to release any held JSI state. Not called on the normal completion path, where the
+  /// object removes itself after releasing its own state.
+  func allowRelease()
+}
+
+/// Keeps ``LongLivedObject``s alive across asynchronous boundaries and releases any that remain when
+/// the runtime is torn down. Isolated to ``JavaScriptActor``, so it needs no lock.
+@JavaScriptActor
+public final class LongLivedObjectCollection {
+  // Keyed by identity, effectively a set. A dictionary rather than a `Set` because
+  // `any LongLivedObject` is an existential and cannot conform to `Hashable`.
+  private var registeredObjects: [ObjectIdentifier: any LongLivedObject] = [:]
+
+  // `nonisolated` so ``JavaScriptRuntime`` can create one as a stored-property default.
+  internal nonisolated init() {}
+
+  /// Registers an object, keeping it alive until it is removed or the collection is cleared.
+  public func add(_ object: any LongLivedObject) {
+    registeredObjects[ObjectIdentifier(object)] = object
+  }
+
+  /// Removes an object that finished on its own, without calling ``LongLivedObject/allowRelease()``.
+  public func remove(_ object: any LongLivedObject) {
+    registeredObjects[ObjectIdentifier(object)] = nil
+  }
+
+  /// Teardown sweep: calls ``LongLivedObject/allowRelease()`` on every remaining object and empties
+  /// the collection. Must run on the JavaScript thread while the runtime is still valid.
+  public func clear() {
+    let survivors = registeredObjects.values
+    registeredObjects.removeAll()
+    for object in survivors {
+      object.allowRelease()
+    }
+  }
+
+  /// Number of currently registered objects.
+  public var count: Int {
+    return registeredObjects.count
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/LongLivedObjectCollectionTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/LongLivedObjectCollectionTests.swift
@@ -1,0 +1,228 @@
+import ExpoModulesJSI
+import Testing
+
+@Suite
+@JavaScriptActor
+struct LongLivedObjectCollectionTests {
+  /// Minimal conformer that counts how many times `allowRelease()` was called, so tests can assert
+  /// it fires exactly once (and not at all on the remove path).
+  final class TrackedObject: LongLivedObject {
+    private(set) var releaseCount = 0
+
+    func allowRelease() {
+      releaseCount += 1
+    }
+  }
+
+  // MARK: - add / remove
+
+  @Test
+  func `a new collection is empty`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `add registers the object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 1)
+  }
+
+  @Test
+  func `remove deregisters the object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `remove does not call allowRelease`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+
+    #expect(object.releaseCount == 0)
+  }
+
+  @Test
+  func `removing an object that was never added is a no-op`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let added = TrackedObject()
+    let neverAdded = TrackedObject()
+
+    collection.add(added)
+    collection.remove(neverAdded)
+
+    #expect(collection.count == 1)
+    #expect(neverAdded.releaseCount == 0)
+  }
+
+  @Test
+  func `removing one object leaves the others registered`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let first = TrackedObject()
+    let second = TrackedObject()
+
+    collection.add(first)
+    collection.add(second)
+    collection.remove(first)
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - identity semantics
+
+  @Test
+  func `distinct objects are distinct entries`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 2)
+  }
+
+  @Test
+  func `adding the same object twice keeps a single entry`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.add(object)
+
+    #expect(collection.count == 1)
+  }
+
+  @Test
+  func `re-adding after remove registers again`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+    collection.add(object)
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - clear
+
+  @Test
+  func `clear empties the collection`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.add(TrackedObject())
+    collection.clear()
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `clear calls allowRelease exactly once on every survivor`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let first = TrackedObject()
+    let second = TrackedObject()
+
+    collection.add(first)
+    collection.add(second)
+    collection.clear()
+
+    #expect(first.releaseCount == 1)
+    #expect(second.releaseCount == 1)
+  }
+
+  @Test
+  func `clear does not call allowRelease on a removed object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let removed = TrackedObject()
+    let survivor = TrackedObject()
+
+    collection.add(removed)
+    collection.add(survivor)
+    collection.remove(removed)
+    collection.clear()
+
+    #expect(removed.releaseCount == 0)
+    #expect(survivor.releaseCount == 1)
+  }
+
+  @Test
+  func `clear on an empty collection is a no-op`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.clear()
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `the collection is reusable after clear`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.clear()
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - ownership
+
+  @Test
+  func `the collection stops retaining an object after clear`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+      collection.clear()
+    }
+
+    // With no external strong reference and the collection's own reference dropped by `clear()`,
+    // the object must have been deallocated.
+    #expect(weakObject == nil)
+  }
+
+  @Test
+  func `the collection stops retaining an object after remove`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+      collection.remove(object)
+    }
+
+    #expect(weakObject == nil)
+  }
+
+  @Test
+  func `the collection retains a registered object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+    }
+
+    // The external strong reference is gone, but the collection still holds one.
+    #expect(weakObject != nil)
+  }
+}


### PR DESCRIPTION
## Why

Native code often holds JSI state that must outlive the native call that created it, the clearest case being an in-flight promise whose resolve/reject functions settle asynchronously long after the host function returned. Today nothing on the Swift side owns that state across the gap, and there is no deterministic point at which it gets released when the runtime is torn down. That's the shape behind the promise-teardown lifetime hazards we've been chasing.

React Native solves the same problem in `react/bridging` with a `LongLivedObject` base class and a singleton `LongLivedObjectCollection`. This introduces the equivalent in `expo-modules-jsi`, keeping the mechanism in the JSI layer rather than depending on RN internals, and keeping it runtime-scoped rather than a process-global singleton.

## How

- Add a `LongLivedObject` protocol with a single `allowRelease()` hook, called when the runtime tears down while an object is still registered (on the JS thread, runtime still valid, so held JSI state can be released safely).
- Add `LongLivedObjectCollection` with `add` / `remove` / `clear` / `count`. It's isolated to `@JavaScriptActor` (the JS thread), so unlike RN's mutex-guarded C++ collection it needs no lock. Objects are stored in a dictionary keyed by `ObjectIdentifier` (an identity set; `any LongLivedObject` can't conform to `Hashable`).
- The normal completion path calls `remove(_:)` and does not fire `allowRelease()` (the object already released its own state); only the teardown sweep `clear()` calls `allowRelease()` on survivors before emptying.
- Expose it as `JavaScriptRuntime.longLivedObjects`. The collection's `init` stays `internal` (only the runtime mints one) and `nonisolated` so it can be a stored-property default.

This is the mechanism only. Wiring `JavaScriptPromise` in as the first conformer, and calling `clear()` from the runtime teardown path, are deliberately left for follow-ups.

## Test Plan

New `LongLivedObjectCollectionTests` (17 tests) covering add/remove, identity/dedup, `clear()` calling `allowRelease()` exactly once per survivor while skipping removed objects, reuse after clear, and ownership (a registered object is retained; `remove`/`clear` drop the collection's reference). All pass via `pnpm test:integration -only-testing:Tests/LongLivedObjectCollectionTests`:

```
✔ Test run with 17 tests in 1 suite passed after 0.007 seconds.
** TEST SUCCEEDED **
```
