### PR TITLE
[ci] Trigger iOS Unit Tests for `/apple/` package sources

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - .github/workflows/ios-unit-tests.yml
       - apps/expo-go/ios/**
-      - packages/**/ios/**
+      - 'packages/**/{ios,apple}/**'
       - apps/native-tests/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
@@ -21,7 +21,7 @@ on:
     paths:
       - .github/workflows/ios-unit-tests.yml
       - apps/expo-go/ios/**
-      - packages/**/ios/**
+      - 'packages/**/{ios,apple}/**'
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
       - tools/src/commands/IosNativeUnitTests.ts


### PR DESCRIPTION
## Why

The **iOS Unit Tests** workflow filters on `packages/**/ios/**`, but `expo-modules-jsi` is the one package that keeps its Apple sources under `apple/` rather than `ios/` (it's a standalone SwiftPM package shipped as a prebuilt xcframework). As a result, a PR that only touches `packages/expo-modules-jsi/apple/**` never triggers the workflow, so its Swift test suite goes unrun in CI, even though `expo-modules-jsi` has real native tests and the `native-tests` host app already builds `ExpoModulesJSI/Tests`.

Noticed on #47511, whose only source changes are under `apple/` and which got no iOS Unit Tests check at all.

## How

Widen the existing `packages/**/ios/**` entry to `packages/**/{ios,apple}/**` in both the `pull_request` and `push` path filters of `.github/workflows/ios-unit-tests.yml`. Brace expansion is supported by the minimatch glob used for path filters and is already used elsewhere in the repo (`test-suite.yml` uses `!packages/**/{ios,android}/**`).

I audited the other workflows using this glob:

- `test-suite.yml` `detect-platform-change` inputs also use `packages/**/ios/**`, but `apple/` changes still fall into that workflow's `common-paths` bucket (via `packages/**`, and the `!packages/**/{ios,android}/**` negation does not strip `apple/`), so they already get coverage there. The negations were deliberately left untouched — adding `apple` to them would *exclude* these Swift changes from the common bucket.
- No other workflow references `apple/` or needed changes.

## Test Plan

Path-filter-only change; there's no runtime behavior to exercise. Verified the target workflow already runs `pnpm expotools native-unit-tests --platform ios` and that `apps/native-tests/ios/Podfile.lock` pulls `ExpoModulesJSI` and `ExpoModulesJSI/Tests` from `../../../packages/expo-modules-jsi/apple`, so matching the path is sufficient to build and run the suite. This will be confirmed once a PR touching `packages/expo-modules-jsi/apple/**` (e.g. #47511, after rebasing on this) shows the iOS Unit Tests check running.
