### PR TITLE
[ci] fix test-suite build errors

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -216,6 +216,7 @@ jobs:
           NODE_ENV: production
           RCT_USE_PREBUILT_RNCORE: 1
           RCT_USE_RN_DEP: 1
+          EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK: 1 # Temporary workaround for build error before expo-router migration
         with:
           platform: ios
           fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json
@@ -422,6 +423,7 @@ jobs:
         env:
           EXPO_DEBUG: 1
           NODE_ENV: production
+          EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK: 1 # Temporary workaround for build error before expo-router migration
         with:
           platform: android
           fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json


### PR DESCRIPTION
# Why

fix ci error: https://github.com/expo/expo/actions/runs/28671352313/job/85035176624

# How

failures since https://github.com/expo/expo/commit/5b6deb59451a918ac320ecdebbc6b804b2b7330c before we added expo-router. this pr adds a workaround to disable the check

# Test Plan

ci passed

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
