### PR TITLE
[ci] Split iOS/apple path filters instead of brace expansion

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - .github/workflows/ios-unit-tests.yml
       - apps/expo-go/ios/**
-      - 'packages/**/{ios,apple}/**'
+      - packages/**/ios/**
+      - packages/**/apple/**
       - apps/native-tests/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
@@ -21,7 +22,8 @@ on:
     paths:
       - .github/workflows/ios-unit-tests.yml
       - apps/expo-go/ios/**
-      - 'packages/**/{ios,apple}/**'
+      - packages/**/ios/**
+      - packages/**/apple/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
       - tools/src/commands/IosNativeUnitTests.ts


### PR DESCRIPTION
## Why

Follow-up to #47512. That PR collapsed the iOS Unit Tests path filter to `packages/**/{ios,apple}/**`, but GitHub's native `on.<event>.paths` filter **does not support brace expansion** — the [filter pattern cheat sheet](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet) lists `*`, `**`, `?`, `+`, `[]`, and leading `!`, but not `{}`. So the brace pattern matches nothing, which not only fails to cover the intended `apple/` sources but also **regresses the existing `packages/**/ios/**` matching**: a normal change under e.g. `packages/expo-camera/ios/...` no longer triggers the workflow.

The brace globs used elsewhere in the repo (e.g. `!packages/**/{ios,android}/**` in `test-suite.yml`) are passed to `tj-actions/changed-files`, which does support brace expansion — a different matcher than the event trigger. I conflated the two in #47512.

Caught by an automated review comment on #47512.

## How

Split the pattern into two literal entries, `packages/**/ios/**` and `packages/**/apple/**`, in both the `pull_request` and `push` path filters.

## Test Plan

Path-filter-only change. The literal `**` globs are the documented, supported form; `packages/**/ios/**` restores the pre-#47512 behavior and `packages/**/apple/**` adds the `expo-modules-jsi` coverage that motivated the original change. Verified against the workflow syntax cheat sheet linked above.
