### PR TITLE
[jsi] Destroy the owned Hermes runtime on deinit

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a standalone `JavaScriptRuntime` leaking its underlying Hermes runtime: a runtime it creates itself is now destroyed on `deinit`, while runtimes adopted from elsewhere (e.g. React Native) are left untouched. ([#47515](https://github.com/expo/expo/pull/47515) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed `Build ExpoModulesJSI xcframework` build phase failing on Xcode 26 because the nested SwiftPM build ignored `-derivedDataPath` and wrote products outside the expected location. ([#46326](https://github.com/expo/expo/issues/46326) by [@Kurogoma4D](https://github.com/Kurogoma4D))
 - [iOS] Fixed the xcframework build failing with a `sed` error when building in an environment that uses GNU `sed` instead of BSD `sed` (e.g. a Nix shell). ([#46389](https://github.com/expo/expo/pull/46389) by [@niteshbalusu11](https://github.com/niteshbalusu11))
 - [iOS] Propagate `JavaScriptPromise` setup failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -125,6 +125,16 @@ inline bool isHostObject(jsi::IRuntime &runtime, const jsi::Object &object) {
 
 jsi::Runtime* createHermesRuntime();
 
+/**
+ Destroys a `jsi::Runtime` created by `createHermesRuntime()`. Since the runtime is imported into
+ Swift as an immortal reference type (no ARC-managed lifetime), Swift can't `delete` it directly, so
+ the standalone `JavaScriptRuntime` calls this from its `deinit` to free the runtime it owns. Must
+ not be called on a runtime owned elsewhere (e.g. the React Native-provided one).
+ */
+inline void destroyRuntime(jsi::Runtime &runtime) {
+  delete &runtime;
+}
+
 inline jsi::Value evaluateJavaScript(jsi::IRuntime &runtime, const std::shared_ptr<const jsi::Buffer>& buffer, const std::string& sourceURL) {
   return expo::CppError::tryCatch(runtime, ^{
     return runtime.evaluateJavaScript(buffer, sourceURL);

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -112,9 +112,20 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   deinit {
     // Destroy the runtime only if this wrapper created it (standalone `init()`); adopted runtimes
     // are owned elsewhere (e.g. React Native) and must not be freed here.
-    if ownsRuntime {
-      expo.destroyRuntime(runtimePointee)
+    guard ownsRuntime else {
+      return
     }
+    // Release cached JSI objects (e.g. `PropNameID`s) before the runtime goes away. Swift tears
+    // down stored properties only after `deinit` returns, so leaving them for that phase would
+    // destroy them against an already-freed runtime, which JSI forbids: all objects associated with
+    // a runtime must be destroyed before the runtime itself.
+    //
+    // No thread hop is needed. JSI documents that destructors are safe to call from any thread; the
+    // requirement is only that there is no concurrent access, which holds here since `deinit` runs
+    // when the last reference is gone. `deinit` is `nonisolated`, so it can touch the actor-isolated
+    // registry directly given that exclusive access.
+    propNameIdsRegistry.removeAll()
+    expo.destroyRuntime(runtimePointee)
   }
 
   /// Provides scoped access to a raw pointer to the underlying `facebook.jsi.Runtime`.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -38,6 +38,12 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   internal let runtimePointee: facebook.jsi.Runtime
   internal let scheduler: expo.RuntimeScheduler
 
+  /// Whether this wrapper owns the underlying `jsi::Runtime` and must destroy it on `deinit`. True
+  /// only for the standalone `init()`, which creates the runtime via `createHermesRuntime()`. The
+  /// other initializers adopt a runtime owned elsewhere (e.g. React Native), which must never be
+  /// freed here, matching the immortal (no-op) release semantics of the imported reference type.
+  private let ownsRuntime: Bool
+
   /// Thread ID of the JavaScript thread, captured at construction time. Used by `isOnJavaScriptThread()`
   /// for a fast integer comparison instead of `Thread.current.name == "..."`.
   /// Assumes runtime initializers always run on the JS thread.
@@ -57,6 +63,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.runtimePointee = runtime
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
+    self.ownsRuntime = false
   }
 
   /// Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
@@ -66,6 +73,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.runtimePointee = runtime
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
+    self.ownsRuntime = true
   }
 
   /// Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
@@ -76,6 +84,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.runtimePointee = runtime
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
+    self.ownsRuntime = false
   }
 
   /// Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
@@ -97,6 +106,15 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.runtimePointee = runtime
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler(scheduler, fn)
+    self.ownsRuntime = false
+  }
+
+  deinit {
+    // Destroy the runtime only if this wrapper created it (standalone `init()`); adopted runtimes
+    // are owned elsewhere (e.g. React Native) and must not be freed here.
+    if ownsRuntime {
+      expo.destroyRuntime(runtimePointee)
+    }
   }
 
   /// Provides scoped access to a raw pointer to the underlying `facebook.jsi.Runtime`.

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -790,6 +790,17 @@ struct JavaScriptRuntimeTests {
     let otherRuntime = JavaScriptRuntime()
     #expect(otherRuntime.id != runtime.id)
   }
+
+  @Test
+  func `creating and releasing standalone runtimes repeatedly does not crash`() throws {
+    // Each standalone runtime owns its Hermes runtime and destroys it on `deinit`. Cycling through
+    // many create/use/release rounds exercises that teardown and would surface a use-after-free or
+    // double-free (destroying a runtime must not corrupt a subsequently created one).
+    for index in 0..<20 {
+      let localRuntime = JavaScriptRuntime()
+      #expect(try localRuntime.eval("1 + \(index)").getInt() == 1 + index)
+    }
+  }
 }
 
 /// Runs `body` on a freshly spawned synchronous thread and bridges the result back into the

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -795,10 +795,14 @@ struct JavaScriptRuntimeTests {
   func `creating and releasing standalone runtimes repeatedly does not crash`() throws {
     // Each standalone runtime owns its Hermes runtime and destroys it on `deinit`. Cycling through
     // many create/use/release rounds exercises that teardown and would surface a use-after-free or
-    // double-free (destroying a runtime must not corrupt a subsequently created one).
+    // double-free (destroying a runtime must not corrupt a subsequently created one). Calling `is`
+    // caches a `PropNameID` on the runtime, so this also covers releasing cached JSI objects before
+    // the runtime is freed.
     for index in 0..<20 {
       let localRuntime = JavaScriptRuntime()
-      #expect(try localRuntime.eval("1 + \(index)").getInt() == 1 + index)
+      let value = try localRuntime.eval("({ index: \(index) })")
+      #expect(value.is("Object") == true)
+      #expect(value.getObject().getProperty("index").getInt() == index)
     }
   }
 }


### PR DESCRIPTION
## Why

A standalone `JavaScriptRuntime` (the `public init()` used in tests and standalone contexts) creates its own Hermes runtime via `createHermesRuntime()`, which calls `unique_ptr::release()` and hands back a raw `jsi::Runtime *`. But `jsi::Runtime` is imported into Swift as an *immortal* reference type (`SwiftRetainOp/ReleaseOp: immortal`, i.e. no-ops), and `JavaScriptRuntime` had no `deinit`, so nothing ever destroyed that runtime. Each standalone runtime leaked its entire JS heap.

The immortal-reference import is correct for the React Native-backed initializers, where RN owns the runtime and the wrapper must never free it. Only the standalone `init()` allocates a runtime it is responsible for, and only it leaked.

## How

- Track ownership with a `private let ownsRuntime: Bool`, set `true` only in the standalone `init()` and `false` in the three initializers that adopt an externally-owned runtime.
- Add a `deinit` that destroys the runtime when `ownsRuntime` is `true`.
- Add an `inline destroyRuntime(jsi::Runtime &)` helper in `JSIUtils.h` (`delete &runtime`), since Swift can't `delete` an immortal-reference type directly.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-jsi` (via `pnpm test:integration`). Added `creating and releasing standalone runtimes repeatedly does not crash`, which cycles through many create/use/release rounds; this exercises the new teardown and would surface a use-after-free or double-free (destroying one runtime must not corrupt a subsequently created one). Full `JavaScriptRuntimeTests` suite passes:

```
✔ Test "creating and releasing standalone runtimes repeatedly does not crash" passed after 0.015 seconds.
✔ Test run with 58 tests in 1 suite passed after 0.017 seconds.
** TEST SUCCEEDED **
```
