### PR TITLE
[jsi] Clear long-lived objects on runtime teardown

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Add `JavaScriptUnownedValue`, a non-owning, non-copyable value that borrows a `jsi::Value` for the zero-copy argument-decode fast path. ([#46616](https://github.com/expo/expo/pull/46616) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Conform `JavaScriptRuntime` to `Identifiable` with an `id` based on the underlying runtime, equal across multiple wrappers of the same runtime. ([#47068](https://github.com/expo/expo/pull/47068) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRef.withValue`, a non-consuming borrow accessor that reads the referenced value without taking it, so a long-lived reference can be read repeatedly. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -64,6 +64,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
@@ -74,6 +75,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = true
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
@@ -85,6 +87,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
@@ -107,6 +110,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler(scheduler, fn)
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   deinit {
@@ -663,6 +667,42 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   /// JavaScript thread while the runtime is still valid.
   @JavaScriptActor
   public let longLivedObjects = LongLivedObjectCollection()
+
+  /// Property name under which the teardown object is pinned on `global` (see
+  /// ``installLongLivedObjectsTeardown()``).
+  private static let teardownObjectPropertyName = "__expo_long_lived_objects_teardown__"
+
+  /// Attaches a native state to a dedicated JS object whose deallocator clears ``longLivedObjects``
+  /// when the runtime is torn down. The object is pinned by storing it as a property on `global`, so
+  /// it stays reachable within the JavaScript heap for the runtime's whole life (no Swift-side strong
+  /// reference) and its native state drops only when the runtime's object graph is destroyed. That
+  /// fires the deallocator on the JavaScript thread while the runtime is still valid, the point at
+  /// which any surviving long-lived objects can safely release their JSI state.
+  private func installLongLivedObjectsTeardown() {
+    // Runtime initializers run on the JavaScript thread but aren't actor-isolated, so reach the
+    // isolated object/native-state/`clear()` APIs through the actor.
+    JavaScriptActor.assumeIsolated {
+      // Capture the collection strongly, not `self`: teardown may run as the runtime itself
+      // deallocates, and the sweep must still call `allowRelease()` on survivors. Holding the
+      // collection keeps it alive for the sweep; it does not retain the runtime.
+      let longLivedObjects = self.longLivedObjects
+      let nativeState = JavaScriptNativeState()
+      nativeState.setDeallocator { nativeState in
+        // Fires as the teardown object is released on the JavaScript thread with the runtime still
+        // valid, so releasing JSI state here is safe. Mirrors the caveat on `AppContext.NativeState`:
+        // a future cross-runtime path that could drop this state from another thread would have to
+        // hop back to the JavaScript thread first.
+        JavaScriptActor.assumeIsolated {
+          longLivedObjects.clear()
+        }
+      }
+      let object = createObject()
+      object.setNativeState(nativeState)
+      // Pin via a JS-heap reference on `global` rather than a Swift property, so the object's
+      // lifetime is governed by the runtime's object graph.
+      global().setProperty(JavaScriptRuntime.teardownObjectPropertyName, value: object.asValue())
+    }
+  }
 }
 
 private func createFunctionClosure(

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -637,6 +637,14 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
 
   @JavaScriptActor
   internal var propNameIdsRegistry: [String: JavaScriptPropNameID] = [:]
+
+  // MARK: - Long-lived objects
+
+  /// Registry of JSI objects (such as in-flight promises) that must outlive the native call that
+  /// created them. Cleared when the runtime is torn down so their JSI state is released on the
+  /// JavaScript thread while the runtime is still valid.
+  @JavaScriptActor
+  public let longLivedObjects = LongLivedObjectCollection()
 }
 
 private func createFunctionClosure(

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/LongLivedObjectCollection.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/LongLivedObjectCollection.swift
@@ -1,0 +1,46 @@
+/// An object whose lifetime must extend past the native call that created it, such as an in-flight
+/// promise holding its resolve/reject state. Register it with a ``LongLivedObjectCollection``.
+@JavaScriptActor
+public protocol LongLivedObject: AnyObject {
+  /// Called on the JavaScript thread when the runtime tears down while this object is still
+  /// registered, to release any held JSI state. Not called on the normal completion path, where the
+  /// object removes itself after releasing its own state.
+  func allowRelease()
+}
+
+/// Keeps ``LongLivedObject``s alive across asynchronous boundaries and releases any that remain when
+/// the runtime is torn down. Isolated to ``JavaScriptActor``, so it needs no lock.
+@JavaScriptActor
+public final class LongLivedObjectCollection {
+  // Keyed by identity, effectively a set. A dictionary rather than a `Set` because
+  // `any LongLivedObject` is an existential and cannot conform to `Hashable`.
+  private var registeredObjects: [ObjectIdentifier: any LongLivedObject] = [:]
+
+  // `nonisolated` so ``JavaScriptRuntime`` can create one as a stored-property default.
+  internal nonisolated init() {}
+
+  /// Registers an object, keeping it alive until it is removed or the collection is cleared.
+  public func add(_ object: any LongLivedObject) {
+    registeredObjects[ObjectIdentifier(object)] = object
+  }
+
+  /// Removes an object that finished on its own, without calling ``LongLivedObject/allowRelease()``.
+  public func remove(_ object: any LongLivedObject) {
+    registeredObjects[ObjectIdentifier(object)] = nil
+  }
+
+  /// Teardown sweep: calls ``LongLivedObject/allowRelease()`` on every remaining object and empties
+  /// the collection. Must run on the JavaScript thread while the runtime is still valid.
+  public func clear() {
+    let survivors = registeredObjects.values
+    registeredObjects.removeAll()
+    for object in survivors {
+      object.allowRelease()
+    }
+  }
+
+  /// Number of currently registered objects.
+  public var count: Int {
+    return registeredObjects.count
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -801,6 +801,46 @@ struct JavaScriptRuntimeTests {
       #expect(try localRuntime.eval("1 + \(index)").getInt() == 1 + index)
     }
   }
+
+  // MARK: - Long-lived objects teardown
+
+  /// Records whether `allowRelease()` was called.
+  final class TrackedObject: LongLivedObject {
+    private(set) var released = false
+
+    func allowRelease() {
+      released = true
+    }
+  }
+
+  @Test
+  func `tearing down the runtime clears its long-lived objects`() {
+    let tracked = TrackedObject()
+
+    do {
+      let localRuntime = JavaScriptRuntime()
+      localRuntime.longLivedObjects.add(tracked)
+      #expect(localRuntime.longLivedObjects.count == 1)
+      // Leaving the scope releases the runtime. Its `deinit` destroys the owned Hermes runtime,
+      // tearing down the JS heap, which drops the teardown object's native state and fires its
+      // deallocator, sweeping the collection.
+    }
+
+    #expect(tracked.released == true)
+  }
+
+  @Test
+  func `an object removed before teardown is not released by the sweep`() {
+    let tracked = TrackedObject()
+
+    do {
+      let localRuntime = JavaScriptRuntime()
+      localRuntime.longLivedObjects.add(tracked)
+      localRuntime.longLivedObjects.remove(tracked)
+    }
+
+    #expect(tracked.released == false)
+  }
 }
 
 /// Runs `body` on a freshly spawned synchronous thread and bridges the result back into the

--- a/packages/expo-modules-jsi/apple/Tests/LongLivedObjectCollectionTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/LongLivedObjectCollectionTests.swift
@@ -1,0 +1,228 @@
+import ExpoModulesJSI
+import Testing
+
+@Suite
+@JavaScriptActor
+struct LongLivedObjectCollectionTests {
+  /// Minimal conformer that counts how many times `allowRelease()` was called, so tests can assert
+  /// it fires exactly once (and not at all on the remove path).
+  final class TrackedObject: LongLivedObject {
+    private(set) var releaseCount = 0
+
+    func allowRelease() {
+      releaseCount += 1
+    }
+  }
+
+  // MARK: - add / remove
+
+  @Test
+  func `a new collection is empty`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `add registers the object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 1)
+  }
+
+  @Test
+  func `remove deregisters the object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `remove does not call allowRelease`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+
+    #expect(object.releaseCount == 0)
+  }
+
+  @Test
+  func `removing an object that was never added is a no-op`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let added = TrackedObject()
+    let neverAdded = TrackedObject()
+
+    collection.add(added)
+    collection.remove(neverAdded)
+
+    #expect(collection.count == 1)
+    #expect(neverAdded.releaseCount == 0)
+  }
+
+  @Test
+  func `removing one object leaves the others registered`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let first = TrackedObject()
+    let second = TrackedObject()
+
+    collection.add(first)
+    collection.add(second)
+    collection.remove(first)
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - identity semantics
+
+  @Test
+  func `distinct objects are distinct entries`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 2)
+  }
+
+  @Test
+  func `adding the same object twice keeps a single entry`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.add(object)
+
+    #expect(collection.count == 1)
+  }
+
+  @Test
+  func `re-adding after remove registers again`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let object = TrackedObject()
+
+    collection.add(object)
+    collection.remove(object)
+    collection.add(object)
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - clear
+
+  @Test
+  func `clear empties the collection`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.add(TrackedObject())
+    collection.clear()
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `clear calls allowRelease exactly once on every survivor`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let first = TrackedObject()
+    let second = TrackedObject()
+
+    collection.add(first)
+    collection.add(second)
+    collection.clear()
+
+    #expect(first.releaseCount == 1)
+    #expect(second.releaseCount == 1)
+  }
+
+  @Test
+  func `clear does not call allowRelease on a removed object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    let removed = TrackedObject()
+    let survivor = TrackedObject()
+
+    collection.add(removed)
+    collection.add(survivor)
+    collection.remove(removed)
+    collection.clear()
+
+    #expect(removed.releaseCount == 0)
+    #expect(survivor.releaseCount == 1)
+  }
+
+  @Test
+  func `clear on an empty collection is a no-op`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.clear()
+
+    #expect(collection.count == 0)
+  }
+
+  @Test
+  func `the collection is reusable after clear`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+
+    collection.add(TrackedObject())
+    collection.clear()
+    collection.add(TrackedObject())
+
+    #expect(collection.count == 1)
+  }
+
+  // MARK: - ownership
+
+  @Test
+  func `the collection stops retaining an object after clear`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+      collection.clear()
+    }
+
+    // With no external strong reference and the collection's own reference dropped by `clear()`,
+    // the object must have been deallocated.
+    #expect(weakObject == nil)
+  }
+
+  @Test
+  func `the collection stops retaining an object after remove`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+      collection.remove(object)
+    }
+
+    #expect(weakObject == nil)
+  }
+
+  @Test
+  func `the collection retains a registered object`() {
+    let collection = JavaScriptRuntime().longLivedObjects
+    weak var weakObject: TrackedObject?
+
+    do {
+      let object = TrackedObject()
+      weakObject = object
+      collection.add(object)
+    }
+
+    // The external strong reference is gone, but the collection still holds one.
+    #expect(weakObject != nil)
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of two other PRs. The diff will only show this PR's changes once both land:
> - #47515 — `[jsi] Destroy the owned Hermes runtime on deinit` (this PR's base; the teardown sweep can't fire without it)
> - #47511 — `[jsi] Add LongLivedObjectCollection` (the collection this wires up)

## Why

`LongLivedObjectCollection` (#47511) keeps JSI state (such as in-flight promises) alive across async boundaries, and its documented contract is that survivors are released when the runtime is torn down. This PR provides that teardown sweep. Without it, anything still registered at teardown would leak its JSI state.

## How

Each runtime installs a `JavaScriptNativeState` on a dedicated JS object pinned as a property on `global`. Its deallocator calls `longLivedObjects.clear()`. Because the object is reachable only from the runtime's own JS heap (no Swift-side strong reference), its native state drops precisely when the runtime's object graph is destroyed, firing the deallocator on the JavaScript thread while the runtime is still valid — the safe point to release the survivors' JSI state. This mirrors how `AppContext` on iOS drives its own teardown via a `global.expo` native state.

This depends on the runtime actually being destroyed at end of life, which is why #47515 (destroying the owned Hermes runtime on `deinit`) is a prerequisite: without it a standalone runtime leaks and the deallocator never fires.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-jsi` (via `pnpm test:integration`). Added, in `JavaScriptRuntimeTests`:
- `tearing down the runtime clears its long-lived objects` — registers an object, drops the runtime, and verifies the object's `allowRelease()` ran (i.e. the deallocator fired `clear()` at real teardown).
- `an object removed before teardown is not released by the sweep` — verifies the remove path is not swept.

Both suites pass:

```
✔ Test "tearing down the runtime clears its long-lived objects" passed after 0.014 seconds.
✔ Test "an object removed before teardown is not released by the sweep" passed after 0.014 seconds.
✔ Test run with 77 tests in 2 suites passed after 0.033 seconds.
** TEST SUCCEEDED **
```
