### PR TITLE
[jsi] Clear long-lived objects on runtime teardown

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -64,6 +64,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
@@ -74,6 +75,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = true
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
@@ -85,6 +87,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   /// Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
@@ -107,6 +110,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler(scheduler, fn)
     self.ownsRuntime = false
+    installLongLivedObjectsTeardown()
   }
 
   deinit {
@@ -674,6 +678,43 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   /// JavaScript thread while the runtime is still valid.
   @JavaScriptActor
   public let longLivedObjects = LongLivedObjectCollection()
+
+  /// Attaches a native state to a dedicated JS object whose deallocator clears ``longLivedObjects``
+  /// when the runtime is torn down. The object is pinned by storing it as a property on `global`, so
+  /// it stays reachable within the JavaScript heap for the runtime's whole life (no Swift-side strong
+  /// reference) and its native state drops only when the runtime's object graph is destroyed. That
+  /// fires the deallocator on the JavaScript thread while the runtime is still valid, the point at
+  /// which any surviving long-lived objects can safely release their JSI state.
+  private func installLongLivedObjectsTeardown() {
+    // Runtime initializers run on the JavaScript thread but aren't actor-isolated, so reach the
+    // isolated object/native-state/`clear()` APIs through the actor.
+    JavaScriptActor.assumeIsolated {
+      // Capture the collection strongly, not `self`: teardown may run as the runtime itself
+      // deallocates, and the sweep must still call `allowRelease()` on survivors. Holding the
+      // collection keeps it alive for the sweep; it does not retain the runtime.
+      let longLivedObjects = self.longLivedObjects
+      let nativeState = JavaScriptNativeState()
+      nativeState.setDeallocator { nativeState in
+        // Fires as the teardown object is released on the JavaScript thread with the runtime still
+        // valid, so releasing JSI state here is safe. Mirrors the caveat on `AppContext.NativeState`:
+        // a future cross-runtime path that could drop this state from another thread would have to
+        // hop back to the JavaScript thread first.
+        JavaScriptActor.assumeIsolated {
+          longLivedObjects.clear()
+        }
+      }
+      let object = createObject()
+      object.setNativeState(nativeState)
+      // Pin via a JS-heap reference on `global` rather than a Swift property, so the object's
+      // lifetime is governed by the runtime's object graph. The property name is unique per wrapper
+      // (keyed by this wrapper's address), so several wrappers of the same underlying runtime (e.g.
+      // via `init(unsafePointer:)`) each pin their own teardown object instead of overwriting a
+      // shared slot, which would let one wrapper's collection be swept early while the runtime is
+      // still alive.
+      let wrapperAddress = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
+      global().setProperty("__expo_long_lived_objects_teardown_\(wrapperAddress)__", value: object.asValue())
+    }
+  }
 }
 
 private func createFunctionClosure(

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -805,6 +805,58 @@ struct JavaScriptRuntimeTests {
       #expect(value.getObject().getProperty("index").getInt() == index)
     }
   }
+
+  // MARK: - Long-lived objects teardown
+
+  /// Records whether `allowRelease()` was called.
+  final class TrackedObject: LongLivedObject {
+    private(set) var released = false
+
+    func allowRelease() {
+      released = true
+    }
+  }
+
+  @Test
+  func `tearing down the runtime clears its long-lived objects`() {
+    let tracked = TrackedObject()
+
+    do {
+      let localRuntime = JavaScriptRuntime()
+      localRuntime.longLivedObjects.add(tracked)
+      #expect(localRuntime.longLivedObjects.count == 1)
+      // Leaving the scope releases the runtime. Its `deinit` destroys the owned Hermes runtime,
+      // tearing down the JS heap, which drops the teardown object's native state and fires its
+      // deallocator, sweeping the collection.
+    }
+
+    #expect(tracked.released == true)
+  }
+
+  @Test
+  func `an object removed before teardown is not released by the sweep`() {
+    let tracked = TrackedObject()
+
+    do {
+      let localRuntime = JavaScriptRuntime()
+      localRuntime.longLivedObjects.add(tracked)
+      localRuntime.longLivedObjects.remove(tracked)
+    }
+
+    #expect(tracked.released == false)
+  }
+
+  @Test
+  func `wrapping the same runtime again does not sweep the first wrapper's objects`() {
+    // Each wrapper pins its own teardown object under a per-wrapper property name. A second wrapper
+    // of the same underlying runtime must not overwrite the first's pinned object (which would let
+    // it be collected early and sweep the first wrapper's collection while the runtime is alive).
+    let tracked = TrackedObject()
+    runtime.longLivedObjects.add(tracked)
+    _ = runtime.withUnsafePointee { JavaScriptRuntime(unsafePointer: $0) }
+    #expect(tracked.released == false)
+    #expect(runtime.longLivedObjects.count == 1)
+  }
 }
 
 /// Runs `body` on a freshly spawned synchronous thread and bridges the result back into the


### PR DESCRIPTION
## Why

`LongLivedObjectCollection` (added in #47511) keeps JSI state (such as in-flight promises) alive across async boundaries, and its documented contract is that survivors are released when the runtime is torn down. This PR provides that teardown sweep. Without it, anything still registered at teardown would leak its JSI state.

## How

Each runtime installs a `JavaScriptNativeState` on a dedicated JS object pinned as a property on `global`. Its deallocator calls `longLivedObjects.clear()`. Because the object is reachable only from the runtime's own JS heap (no Swift-side strong reference), its native state drops precisely when the runtime's object graph is destroyed, firing the deallocator on the JavaScript thread while the runtime is still valid, the safe point to release the survivors' JSI state. This mirrors how `AppContext` on iOS drives its own teardown via a `global.expo` native state.

This relies on the runtime actually being destroyed at end of life, provided for standalone runtimes by #47515 (destroying the owned Hermes runtime on `deinit`); adopted runtimes (e.g. React Native's) are torn down by their owner, which drops the pinned object and fires the same deallocator.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-jsi` (via `pnpm test:integration`). Added, in `JavaScriptRuntimeTests`:
- `tearing down the runtime clears its long-lived objects`: registers an object, drops the runtime, and verifies the object's `allowRelease()` ran (i.e. the deallocator fired `clear()` at real teardown).
- `an object removed before teardown is not released by the sweep`: verifies the remove path is not swept.

The collection's own sweep semantics (clearing every survivor exactly once, skipping removed objects, not self-registering) are covered by `LongLivedObjectCollectionTests`. Full suite passes:

```
✔ Test run with 555 tests in 30 suites passed
** TEST SUCCEEDED **
```
