### PR TITLE
[ui][docs] - Use useCallback instead of useEffectEvent in TextInput examples

### DIFF
--- a/docs/pages/versions/v57.0.0/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/universal/textinput.mdx
@@ -52,15 +52,18 @@ Pass [`value`](#value) to drive the field from a `useNativeState` observable. Th
 
 ```tsx ControlledTextInputExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function ControlledTextInputExample() {
   const text = useNativeState('');
 
-  const handleChangeText = useEffectEvent((value: string) => {
-    'worklet';
-    text.value = value === 'Hello' ? 'World' : value;
-  });
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value === 'Hello' ? 'World' : value;
+    },
+    [text]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>
@@ -78,7 +81,7 @@ Add the `'worklet'` directive to [`onChangeText`](#onchangetext) for synchronous
 
 ```tsx PhoneMaskExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 function formatPhone(input: string) {
   'worklet';
@@ -92,15 +95,18 @@ export default function PhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleChangeText = useEffectEvent((value: string) => {
-    'worklet';
-    const formatted = formatPhone(value);
-    if (formatted !== value) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  });
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      const formatted = formatPhone(value);
+      if (formatted !== value) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>


### PR DESCRIPTION
## Why

The universal `TextInput` docs used `useEffectEvent` in the controlled and worklet-masking examples. `useEffectEvent` does not work well with worklets, it returns a non worklet callback.

## How

Swapped both examples to `useCallback` with the captured `useNativeState` observables as deps (stable refs, so identity is unchanged). Kept the `'worklet'` directives intact.

## Test Plan

Tested docs