### PR TITLE
[jsi] Own promise JSI values as a long-lived object

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a use-after-free when a `JavaScriptPromise` outlives its runtime (e.g. an async function's promise held by a completion handler that fires after `reloadAsync()`) by having the runtime's `LongLivedObjectCollection` own its JSI values and release them on the JavaScript thread when the wrapper is dropped or at teardown, instead of against a freed runtime. ([#47521](https://github.com/expo/expo/pull/47521) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a standalone `JavaScriptRuntime` leaking its underlying Hermes runtime: a runtime it creates itself is now destroyed on `deinit`, while runtimes adopted from elsewhere (e.g. React Native) are left untouched. ([#47515](https://github.com/expo/expo/pull/47515) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed `Build ExpoModulesJSI xcframework` build phase failing on Xcode 26 because the nested SwiftPM build ignored `-derivedDataPath` and wrote products outside the expected location. ([#46326](https://github.com/expo/expo/issues/46326) by [@Kurogoma4D](https://github.com/Kurogoma4D))
 - [iOS] Fixed the xcframework build failing with a `sed` error when building in an environment that uses GNU `sed` instead of BSD `sed` (e.g. a Nix shell). ([#46389](https://github.com/expo/expo/pull/46389) by [@niteshbalusu11](https://github.com/niteshbalusu11))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -11,46 +11,93 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
   private weak let runtime: JavaScriptRuntime?
-  private var object: JavaScriptObject
   private let deferredPromise = DeferredPromise()
 
-  // Create refs for resolve and reject functions.
-  // They will be set in the Promise setup function.
-  private let resolveFunction = JavaScriptValue.Ref()
-  private let rejectFunction = JavaScriptValue.Ref()
+  /// Owns the promise's JSI values (the object and, for a deferred promise, its resolve/reject
+  /// functions). Registered with the runtime's ``LongLivedObjectCollection`` so they're released on
+  /// the JS thread rather than against a freed runtime when a wrapper outlives its runtime (e.g. an
+  /// async function's promise held by a URLSession delegate).
+  ///
+  /// There are two release paths, both on the JS thread while the runtime is alive:
+  /// - When the ``JavaScriptPromise`` wrapper is dropped, its `deinit` schedules a job that
+  ///   deregisters this state and releases the values, so a stream of promises doesn't pin their
+  ///   objects (and resolution values) until teardown.
+  /// - If the wrapper outlives the runtime, the teardown sweep (``allowRelease()``) releases whatever
+  ///   is still registered before the runtime is destroyed.
+  ///
+  /// The state stays registered for as long as the wrapper is alive, even after the promise settles,
+  /// so ``asValue()`` keeps returning a valid object. Settling only releases the resolve/reject
+  /// functions, which can no longer be called and are the bulk of a deferred promise's held state.
+  @JavaScriptActor
+  private final class LongLivedState: LongLivedObject {
+    // Stored as `JavaScriptValue` (a reference type), not `JavaScriptObject`: a `Copyable` value read
+    // back through `JavaScriptRef.withValue` avoids the copy a borrowed `~Copyable` object would trap on.
+    let object = JavaScriptValue.Ref()
+    let resolveFunction = JavaScriptValue.Ref()
+    let rejectFunction = JavaScriptValue.Ref()
+
+    func allowRelease() {
+      object.release()
+      resolveFunction.release()
+      rejectFunction.release()
+    }
+  }
+
+  private let longLivedState = LongLivedState()
+
+  /// Dropping the wrapper means no native code can settle or read this promise anymore, so release
+  /// its long-lived state. The values can only be touched on the JS thread while the runtime is
+  /// alive, so schedule the work there; if the runtime is already gone, the teardown sweep has
+  /// released everything and there is nothing to do (this is the `#47454` off-thread-drop case).
+  deinit {
+    guard let runtime else {
+      return
+    }
+    // Capture the collection, not the runtime, so a wrapper's deinit can't prolong the runtime's
+    // lifetime by keeping it alive until the scheduled job drains.
+    let longLivedObjects = runtime.longLivedObjects
+    runtime.schedule { [longLivedState] in
+      longLivedObjects.remove(longLivedState)
+      longLivedState.allowRelease()
+    }
+  }
 
   /// Initializes a promise from the existing object. The promise may already be settled.
   /// It cannot be resolved/rejected from the outside, i.e. `resolve` and `reject` functions are no-op.
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) throws {
     self.runtime = runtime
-    self.object = object
+    longLivedState.object.reset(object.asValue())
     try setUpCallbacks()
+    // Register only after setup succeeds, so a failed initializer (e.g. `then` unavailable) doesn't
+    // leave the state pinned in the collection until teardown. Owns the promise's JSI values from
+    // here until teardown (see `LongLivedState`).
+    runtime.longLivedObjects.add(longLivedState)
   }
 
   /// Creates a new promise whose resolver or rejecter must be called from the outside (also known as a deferred promise).
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
-    // Initialize the non-copyable field before any throwing work. Swift requires a
-    // consistently initialized value on every throwing initializer path.
-    self.object = runtime.createObject()
 
     // Create function that is the promise setup. It is called immediately on `callAsConstructor`.
-    let setup = runtime.createFunction { [weak resolveFunction, weak rejectFunction] this, arguments in
-      resolveFunction?.reset(arguments[0])
-      rejectFunction?.reset(arguments[1])
+    let setup = runtime.createFunction { [weak longLivedState] this, arguments in
+      longLivedState?.resolveFunction.reset(arguments[0])
+      longLivedState?.rejectFunction.reset(arguments[1])
       return .undefined
     }
 
-    self.object =
+    let object =
       try runtime
       .global()
       .getPropertyAsFunction(.cached(runtime, "Promise"))
       .callAsConstructor(setup.asValue())
-      .getObject()
-
+    longLivedState.object.reset(object)
     try setUpCallbacks()
+    // Register only after setup succeeds, so a failed initializer (e.g. `then` unavailable) doesn't
+    // leave the state pinned in the collection until teardown. Owns the promise's JSI values from
+    // here until teardown (see `LongLivedState`).
+    runtime.longLivedObjects.add(longLivedState)
   }
 
   @JavaScriptActor
@@ -59,7 +106,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   }
 
   public var isDeferred: Bool {
-    return !resolveFunction.isEmpty && !rejectFunction.isEmpty
+    return !longLivedState.resolveFunction.isEmpty && !longLivedState.rejectFunction.isEmpty
   }
 
   @JavaScriptActor
@@ -68,7 +115,10 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   }
 
   public func asValue() -> JavaScriptValue {
-    return object.asValue()
+    // Read without consuming, so the state keeps owning the object (unlike `Ref.asValue()`).
+    return longLivedState.object.withValue { object in
+      return object
+    } ?? .undefined
   }
 
   public func resolve<V: JavaScriptRepresentable>(_ value: V) {
@@ -77,17 +127,18 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     }
 
     // `resolve` is not isolated, so make sure to jump to JS thread.
-    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+    runtime.schedule(priority: .immediate) { [longLivedState] in
       // If the promise is already settled, do nothing.
-      guard let resolver = resolveFunction.take() else {
+      guard let resolver = longLivedState.resolveFunction.take() else {
         return
       }
       // Call the actual resolver given in the Promise setup.
       // This will also call `deferredPromise.resolve` in the `then` handler.
       _ = try! resolver.getFunction().call(arguments: value)
 
-      // Release the rejecter, we cannot call it anymore.
-      rejectFunction.release()
+      // The rejecter can't be called anymore. The state stays registered so it keeps owning the
+      // object until the wrapper is dropped (or the teardown sweep runs).
+      longLivedState.rejectFunction.release()
     }
   }
 
@@ -97,9 +148,9 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     }
 
     // `reject` is not isolated, so make sure to jump to JS thread.
-    runtime.schedule(priority: .immediate) { [resolveFunction, rejectFunction] in
+    runtime.schedule(priority: .immediate) { [longLivedState] in
       // If the promise is already settled, do nothing.
-      guard let rejecter = rejectFunction.take() else {
+      guard let rejecter = longLivedState.rejectFunction.take() else {
         return
       }
       // Convert the error to its JavaScript representation. This preserves an existing
@@ -112,8 +163,9 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       // This will also call `deferredPromise.reject` in the `then` handler.
       _ = try! rejecter.getFunction().call(arguments: errorValue)
 
-      // Release the resolver, we cannot call it anymore.
-      resolveFunction.release()
+      // The resolver can't be called anymore. The state stays registered so it keeps owning the
+      // object until the wrapper is dropped (or the teardown sweep runs).
+      longLivedState.resolveFunction.release()
     }
   }
 
@@ -140,6 +192,12 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       }
       return .undefined
     }
-    try object.callFunction(.cached(runtime, "then"), arguments: onFulfilled.asValue(), onRejected.asValue())
+    _ = try longLivedState.object.withValue { object in
+      try object?.getObject().callFunction(
+        .cached(runtime, "then"),
+        arguments: onFulfilled.asValue(),
+        onRejected.asValue()
+      )
+    }
   }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -106,6 +106,9 @@ struct JavaScriptPromiseTests {
     #expect(throws: Error.self) {
       _ = try promiseValue.getPromise()
     }
+    // A failed initializer must not leave its state registered, or it would pin the promise object
+    // in the collection until teardown even though no `JavaScriptPromise` escaped.
+    #expect(runtime.longLivedObjects.count == 0)
   }
 
   @Test
@@ -369,5 +372,127 @@ struct JavaScriptPromiseTests {
     let promise = try runtime.eval("Promise.resolve(42)").getPromise()
 
     #expect(promise.isDeferred == false)
+  }
+
+  // MARK: - Long-lived object registration
+
+  @Test
+  func `deferred promise registers as a long-lived object`() throws {
+    let runtime = JavaScriptRuntime()
+    #expect(runtime.longLivedObjects.count == 0)
+
+    let promise = try JavaScriptPromise(runtime)
+    _ = promise.isDeferred
+
+    #expect(runtime.longLivedObjects.count == 1)
+  }
+
+  @Test
+  func `wrapping an existing promise registers to own its object`() throws {
+    let runtime = JavaScriptRuntime()
+    let promise = try runtime.eval("Promise.resolve(42)").getPromise()
+    #expect(promise.isDeferred == false)
+
+    // Even a wrapped promise owns a JSI object that must not be released against a freed runtime,
+    // so it registers to have that object swept at teardown.
+    #expect(runtime.longLivedObjects.count == 1)
+  }
+
+  @Test
+  func `settling keeps the promise registered while the wrapper is alive`() async throws {
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    #expect(runtime.longLivedObjects.count == 1)
+
+    promise.resolve(JavaScriptValue(runtime, 42))
+    _ = try await promise.await()
+
+    // Settling releases the resolve/reject functions, but the state stays registered so it continues
+    // to own the promise object for as long as the wrapper is alive (it is only deregistered when the
+    // wrapper is dropped, see the tests below, or by the teardown sweep).
+    #expect(promise.isDeferred == false)
+    #expect(runtime.longLivedObjects.count == 1)
+  }
+
+  @Test
+  func `dropping a settled promise deregisters its state`() async throws {
+    let runtime = JavaScriptRuntime()
+
+    do {
+      let promise = try JavaScriptPromise(runtime)
+      promise.resolve(JavaScriptValue(runtime, 42))
+      _ = try await promise.await()
+      #expect(runtime.longLivedObjects.count == 1)
+      // Leaving the scope drops the last owner of the wrapper.
+    }
+
+    // Dropping the wrapper deregisters its state and releases the promise object, so a stream of
+    // short-lived promises doesn't pin their objects (and resolution values) until teardown.
+    #expect(runtime.longLivedObjects.count == 0)
+  }
+
+  @Test
+  func `dropping an unsettled promise deregisters its state`() throws {
+    let runtime = JavaScriptRuntime()
+
+    do {
+      let promise = try JavaScriptPromise(runtime)
+      #expect(promise.isDeferred == true)
+      #expect(runtime.longLivedObjects.count == 1)
+      // The promise is never settled; dropping the wrapper here is the only owner going away.
+    }
+
+    // Even an unsettled promise releases its state when its wrapper is dropped: nothing outside can
+    // settle it anymore, so keeping it registered would only pin the object until teardown.
+    #expect(runtime.longLivedObjects.count == 0)
+  }
+
+  @Test
+  func `dropping a wrapped promise deregisters its state`() throws {
+    let runtime = JavaScriptRuntime()
+
+    do {
+      let promise = try runtime.eval("Promise.resolve(42)").getPromise()
+      #expect(promise.isDeferred == false)
+      #expect(runtime.longLivedObjects.count == 1)
+    }
+
+    #expect(runtime.longLivedObjects.count == 0)
+  }
+
+  @Test
+  func `an unsettled deferred promise is released by the teardown sweep`() throws {
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    #expect(runtime.longLivedObjects.count == 1)
+
+    // The promise is never settled; the runtime's teardown sweep must release its long-lived state.
+    runtime.longLivedObjects.clear()
+
+    #expect(runtime.longLivedObjects.count == 0)
+    // After the sweep the settle functions are released, so it can no longer be settled.
+    #expect(promise.isDeferred == false)
+  }
+
+  @Test
+  func `an unsettled deferred promise outliving its runtime does not crash on teardown`() throws {
+    // Reproduces the shape of the promise-teardown crash (#47454): a deferred promise is still in
+    // flight when its runtime is torn down. Before the state was owned by the runtime's
+    // `LongLivedObjectCollection`, its JSI values were released after the Hermes runtime was already
+    // destroyed, a use-after-free. Now the runtime's teardown sweep releases the state on the JS
+    // thread while the runtime is still valid.
+    var promise: JavaScriptPromise? = nil
+
+    do {
+      let runtime = JavaScriptRuntime()
+      promise = try JavaScriptPromise(runtime)
+      #expect(promise?.isDeferred == true)
+      // Leaving the scope releases the runtime while the promise is still unsettled. Its teardown
+      // sweep must release the promise's state before Hermes is destroyed.
+    }
+
+    // Dropping the promise wrapper here must not touch a freed runtime. This is the crash point in
+    // #47454; reaching the end of the test without a crash is the assertion.
+    promise = nil
   }
 }


### PR DESCRIPTION
## Why

A `JavaScriptPromise` holds JSI values: the promise object itself and, for a deferred promise, its resolve/reject functions. Until now nothing owned that state past the native call that created it, so when a wrapper outlived its runtime (for example, an async function's promise captured by a `URLSession` delegate that fires after `reloadAsync()` tears the runtime down), those JSI values were released against a freed runtime. That is the use-after-free in `facebook::jsi::Pointer::~Pointer` reported in #47454.

This makes `JavaScriptPromise` the first concrete `LongLivedObject` conformer, the payoff of `LongLivedObjectCollection` (#47511) and its teardown sweep (#47517): the runtime owns the promise's JSI state and releases it on the JavaScript thread while the runtime is still valid.

## How

- The promise's JSI values move into a `LongLivedState: LongLivedObject` reference type (previously the object was stored directly on the `~Copyable` struct and the functions in loose refs).
- Both initializers register the state with `runtime.longLivedObjects` once setup succeeds, so the collection owns those values for as long as the wrapper is alive.
- The state is released on the JavaScript thread through one of two paths:
  - When the wrapper is dropped, its `deinit` schedules a job that deregisters the state and releases its values, so a stream of short-lived promises (e.g. one per `createAsyncFunction` call) doesn't pin their objects and resolution values until teardown. This mirrors React Native's `AsyncPromise`, where the `PromiseHolder` is released when the native handle drops (`~SharedState()` calling `allowRelease()`), except the release is scheduled onto the JS thread instead of running inline on the dropping thread. The scheduled closure captures the collection rather than the runtime, so a wrapper's deinit can't prolong the runtime's lifetime.
  - If the wrapper outlives the runtime (the #47454 shape), the wrapper's weak runtime reference is already nil, its `deinit` is a no-op, and the teardown sweep has released whatever was still registered before the runtime was destroyed.
- Settling releases only the resolve/reject functions (they can no longer be called); the state stays registered while the wrapper is alive so `asValue()` keeps returning a valid object.
- The object is stored as a `JavaScriptValue.Ref` rather than a `JavaScriptObject.Ref`. `JavaScriptValue` is a reference type, so reading it back through `JavaScriptRef.withValue` yields a `Copyable` borrow that callers can use without forcing the copy a borrowed `~Copyable` `JavaScriptObject` would trap on ("attempt to copy a value of a type that cannot be copied").

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-jsi` (via `pnpm test:integration`). Written red first (the registration and deregistration assertions failed against the pre-change code), then green. `JavaScriptPromiseTests` covers:
- `deferred promise registers as a long-lived object`
- `wrapping an existing promise registers to own its object`
- `settling keeps the promise registered while the wrapper is alive`
- `dropping a settled promise deregisters its state`
- `dropping an unsettled promise deregisters its state`
- `dropping a wrapped promise deregisters its state`
- `an unsettled deferred promise is released by the teardown sweep`
- `an unsettled deferred promise outliving its runtime does not crash on teardown` (reproduces the #47454 shape)

All suites pass with no regressions:

```
✔ Test run with 564 tests in 30 suites passed
** TEST SUCCEEDED **
```
