### PR TITLE
[expo-router] Guard deep link decode against malformed percent-encoding

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [ios] Fix white flash behind screens during the interactive swipe-back gesture by forwarding the theme background to the native stack container. ([#47121](https://github.com/expo/expo/pull/47121) by [@kevenleone](https://github.com/kevenleone))
 - [ios] Fix memory leaks in the native toolbar and link preview from strong-reference cycles and closures that strongly captured `self`. ([#47378](https://github.com/expo/expo/pull/47378) by [@Ubax](https://github.com/Ubax))
 - [android] Remove navigation state restoration across activity recreation. ([#47422](https://github.com/expo/expo/pull/47422) by [@Ubax](https://github.com/Ubax))
+- Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding, falling back to the raw value instead of throwing `URIError` and dropping the link. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -24,7 +24,7 @@
 - [ios] Fix white flash behind screens during the interactive swipe-back gesture by forwarding the theme background to the native stack container. ([#47121](https://github.com/expo/expo/pull/47121) by [@kevenleone](https://github.com/kevenleone))
 - [ios] Fix memory leaks in the native toolbar and link preview from strong-reference cycles and closures that strongly captured `self`. ([#47378](https://github.com/expo/expo/pull/47378) by [@Ubax](https://github.com/Ubax))
 - [android] Remove navigation state restoration across activity recreation. ([#47422](https://github.com/expo/expo/pull/47422) by [@Ubax](https://github.com/Ubax))
-- Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding, falling back to the raw value instead of throwing `URIError` and dropping the link. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
+- Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -2,6 +2,8 @@ import {
   extractExpoPathFromURL,
   parsePathAndParamsFromExpoGoLink,
   parsePathFromExpoGoLink,
+  safelyDecodeURI,
+  safelyDecodeURIComponent,
 } from '../extractPathFromURL';
 
 describe(extractExpoPathFromURL, () => {
@@ -189,5 +191,31 @@ describe(parsePathAndParamsFromExpoGoLink, () => {
         queryString: '?foo=bar',
       }
     );
+  });
+});
+
+describe(safelyDecodeURI, () => {
+  it(`decodes a well-formed URI`, () => {
+    expect(safelyDecodeURI('http://localhost:8081/example%20path')).toEqual(
+      'http://localhost:8081/example path'
+    );
+  });
+  it(`returns the original string when the URI is malformed`, () => {
+    expect(safelyDecodeURI('http://localhost:8081/%GG')).toEqual('http://localhost:8081/%GG');
+  });
+  it(`does not throw on malformed percent-encoding`, () => {
+    expect(() => safelyDecodeURI('%GG')).not.toThrow();
+  });
+});
+
+describe(safelyDecodeURIComponent, () => {
+  it(`decodes a well-formed URI component`, () => {
+    expect(safelyDecodeURIComponent('%20%2B%2F')).toEqual(' +/');
+  });
+  it(`returns the original string when the URI component is malformed`, () => {
+    expect(safelyDecodeURIComponent('%GG')).toEqual('%GG');
+  });
+  it(`does not throw on malformed percent-encoding`, () => {
+    expect(() => safelyDecodeURIComponent('%GG')).not.toThrow();
   });
 });

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -91,6 +91,18 @@ describe(extractExpoPathFromURL, () => {
     expect(extractExpoPathFromURL([], `exp://x?y=%20%2B%2F`)).toEqual('?y= +/');
   });
 
+  it(`does not throw on malformed percent-encoding in query params`, () => {
+    delete expo.modules.ExpoGo;
+    expect(() => extractExpoPathFromURL([], `custom:///?q=%GG`)).not.toThrow();
+    expect(extractExpoPathFromURL([], `custom:///?q=%GG`)).toEqual('?q=%GG');
+  });
+  it(`does not throw on malformed percent-encoding in dev-client url param`, () => {
+    delete expo.modules.ExpoGo;
+    expect(() =>
+      extractExpoPathFromURL([], `scheme://expo-development-client/?url=http://localhost:8081/%GG`)
+    ).not.toThrow();
+  });
+
   it(`only handles Expo Go URLs in Expo Go`, () => {
     delete expo.modules.ExpoGo;
 

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -2,8 +2,6 @@ import {
   extractExpoPathFromURL,
   parsePathAndParamsFromExpoGoLink,
   parsePathFromExpoGoLink,
-  safelyDecodeURI,
-  safelyDecodeURIComponent,
 } from '../extractPathFromURL';
 
 describe(extractExpoPathFromURL, () => {
@@ -191,31 +189,5 @@ describe(parsePathAndParamsFromExpoGoLink, () => {
         queryString: '?foo=bar',
       }
     );
-  });
-});
-
-describe(safelyDecodeURI, () => {
-  it(`decodes a well-formed URI`, () => {
-    expect(safelyDecodeURI('http://localhost:8081/example%20path')).toEqual(
-      'http://localhost:8081/example path'
-    );
-  });
-  it(`returns the original string when the URI is malformed`, () => {
-    expect(safelyDecodeURI('http://localhost:8081/%GG')).toEqual('http://localhost:8081/%GG');
-  });
-  it(`does not throw on malformed percent-encoding`, () => {
-    expect(() => safelyDecodeURI('%GG')).not.toThrow();
-  });
-});
-
-describe(safelyDecodeURIComponent, () => {
-  it(`decodes a well-formed URI component`, () => {
-    expect(safelyDecodeURIComponent('%20%2B%2F')).toEqual(' +/');
-  });
-  it(`returns the original string when the URI component is malformed`, () => {
-    expect(safelyDecodeURIComponent('%GG')).toEqual('%GG');
-  });
-  it(`does not throw on malformed percent-encoding`, () => {
-    expect(() => safelyDecodeURIComponent('%GG')).not.toThrow();
   });
 });

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -99,7 +99,14 @@ function fromDeepLink(url: string): string {
       return '';
     }
     const incomingUrl = res.searchParams.get('url')!;
-    return extractExactPathFromURL(decodeURI(incomingUrl));
+    let decodedIncomingUrl: string;
+    try {
+      decodedIncomingUrl = decodeURI(incomingUrl);
+    } catch {
+      // Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
+      decodedIncomingUrl = incomingUrl;
+    }
+    return extractExactPathFromURL(decodedIncomingUrl);
   }
 
   let results = '';
@@ -115,7 +122,16 @@ function fromDeepLink(url: string): string {
   const qs = !res.search
     ? ''
     : // @ts-ignore: `entries` is not on `URLSearchParams` in some typechecks.
-      [...res.searchParams.entries()].map(([k, v]) => `${k}=${decodeURIComponent(v)}`).join('&');
+      [...res.searchParams.entries()]
+        .map(([k, v]) => {
+          try {
+            return `${k}=${decodeURIComponent(v)}`;
+          } catch {
+            // Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
+            return `${k}=${v}`;
+          }
+        })
+        .join('&');
 
   if (qs) {
     results += '?' + qs;

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -1,3 +1,5 @@
+import { safeDecodeURI, safeDecodeURIComponent } from '../utils/url';
+
 export function parsePathAndParamsFromExpoGoLink(url: string): {
   pathname: string;
   queryString: string;
@@ -69,23 +71,6 @@ function isExpoDevelopmentClient(url: URL): boolean {
   return url.hostname === 'expo-development-client';
 }
 
-// Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
-export function safelyDecodeURI(uri: string): string {
-  try {
-    return decodeURI(uri);
-  } catch {
-    return uri;
-  }
-}
-
-export function safelyDecodeURIComponent(uriComponent: string): string {
-  try {
-    return decodeURIComponent(uriComponent);
-  } catch {
-    return uriComponent;
-  }
-}
-
 function fromDeepLink(url: string): string {
   let res: URL | null;
   try {
@@ -116,7 +101,7 @@ function fromDeepLink(url: string): string {
       return '';
     }
     const incomingUrl = res.searchParams.get('url')!;
-    return extractExactPathFromURL(safelyDecodeURI(incomingUrl));
+    return extractExactPathFromURL(safeDecodeURI(incomingUrl));
   }
 
   let results = '';
@@ -133,7 +118,7 @@ function fromDeepLink(url: string): string {
     ? ''
     : // @ts-ignore: `entries` is not on `URLSearchParams` in some typechecks.
       [...res.searchParams.entries()]
-        .map(([k, v]) => `${k}=${safelyDecodeURIComponent(v)}`)
+        .map(([k, v]) => `${k}=${safeDecodeURIComponent(v)}`)
         .join('&');
 
   if (qs) {

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -69,6 +69,23 @@ function isExpoDevelopmentClient(url: URL): boolean {
   return url.hostname === 'expo-development-client';
 }
 
+// Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
+export function safelyDecodeURI(uri: string): string {
+  try {
+    return decodeURI(uri);
+  } catch {
+    return uri;
+  }
+}
+
+export function safelyDecodeURIComponent(uriComponent: string): string {
+  try {
+    return decodeURIComponent(uriComponent);
+  } catch {
+    return uriComponent;
+  }
+}
+
 function fromDeepLink(url: string): string {
   let res: URL | null;
   try {
@@ -99,14 +116,7 @@ function fromDeepLink(url: string): string {
       return '';
     }
     const incomingUrl = res.searchParams.get('url')!;
-    let decodedIncomingUrl: string;
-    try {
-      decodedIncomingUrl = decodeURI(incomingUrl);
-    } catch {
-      // Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
-      decodedIncomingUrl = incomingUrl;
-    }
-    return extractExactPathFromURL(decodedIncomingUrl);
+    return extractExactPathFromURL(safelyDecodeURI(incomingUrl));
   }
 
   let results = '';
@@ -123,14 +133,7 @@ function fromDeepLink(url: string): string {
     ? ''
     : // @ts-ignore: `entries` is not on `URLSearchParams` in some typechecks.
       [...res.searchParams.entries()]
-        .map(([k, v]) => {
-          try {
-            return `${k}=${decodeURIComponent(v)}`;
-          } catch {
-            // Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the link.
-            return `${k}=${v}`;
-          }
-        })
+        .map(([k, v]) => `${k}=${safelyDecodeURIComponent(v)}`)
         .join('&');
 
   if (qs) {

--- a/packages/expo-router/src/global-state/getRouteInfoFromState.ts
+++ b/packages/expo-router/src/global-state/getRouteInfoFromState.ts
@@ -1,6 +1,7 @@
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../constants';
 import { appendBaseUrl } from '../fork/getPathFromState-forks';
 import type { NavigationState, PartialState } from '../react-navigation/native';
+import { safeDecodeURIComponent } from '../utils/url';
 import type { FocusedRouteState } from './types';
 
 export type UrlObject = {
@@ -212,13 +213,4 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
     // TODO: Remove this, it is not used anywhere
     isIndex: false,
   };
-}
-
-function safeDecodeURIComponent(value: any) {
-  try {
-    return typeof value === 'string' ? decodeURIComponent(value) : value;
-  } catch {
-    // If the value is not a valid URI component, return it as is
-    return value;
-  }
 }

--- a/packages/expo-router/src/utils/__tests__/url.test.ios.ts
+++ b/packages/expo-router/src/utils/__tests__/url.test.ios.ts
@@ -1,4 +1,4 @@
-import { parseUrlUsingCustomBase } from '../url';
+import { parseUrlUsingCustomBase, safeDecodeURI, safeDecodeURIComponent } from '../url';
 
 describe(parseUrlUsingCustomBase, () => {
   it('should parse relative path', () => {
@@ -44,5 +44,31 @@ describe(parseUrlUsingCustomBase, () => {
   it('should handle special characters in query parameters', () => {
     const url = parseUrlUsingCustomBase('/path?param=value%20with%20spaces');
     expect(url.searchParams.get('param')).toBe('value with spaces');
+  });
+});
+
+describe(safeDecodeURI, () => {
+  it(`decodes a well-formed URI`, () => {
+    expect(safeDecodeURI('http://localhost:8081/example%20path')).toEqual(
+      'http://localhost:8081/example path'
+    );
+  });
+  it(`returns the original string when the URI is malformed`, () => {
+    expect(safeDecodeURI('http://localhost:8081/%GG')).toEqual('http://localhost:8081/%GG');
+  });
+  it(`does not throw on malformed percent-encoding`, () => {
+    expect(() => safeDecodeURI('%GG')).not.toThrow();
+  });
+});
+
+describe(safeDecodeURIComponent, () => {
+  it(`decodes a well-formed URI component`, () => {
+    expect(safeDecodeURIComponent('%20%2B%2F')).toEqual(' +/');
+  });
+  it(`returns the original string when the URI component is malformed`, () => {
+    expect(safeDecodeURIComponent('%GG')).toEqual('%GG');
+  });
+  it(`does not throw on malformed percent-encoding`, () => {
+    expect(() => safeDecodeURIComponent('%GG')).not.toThrow();
   });
 });

--- a/packages/expo-router/src/utils/url.ts
+++ b/packages/expo-router/src/utils/url.ts
@@ -26,3 +26,22 @@ export function parseUrlUsingCustomBase(href: string): URL {
   // dummy URL in the output bytecode
   return new URL(href, 'file:');
 }
+
+// Malformed percent-encoding (e.g. `%GG`) would otherwise throw and drop the value.
+export function safeDecodeURI(value: any) {
+  try {
+    return typeof value === 'string' ? decodeURI(value) : value;
+  } catch {
+    // If the value is not a valid URI, return it as is
+    return value;
+  }
+}
+
+export function safeDecodeURIComponent(value: any) {
+  try {
+    return typeof value === 'string' ? decodeURIComponent(value) : value;
+  } catch {
+    // If the value is not a valid URI component, return it as is
+    return value;
+  }
+}


### PR DESCRIPTION
decodeURI/decodeURIComponent in extractExactPathFromURL throw on malformed percent-encoding (e.g. %GG), which surfaces as an unhandled rejection in the url listener and silently drops the link in release builds. Wraps both decode sites in the same try/catch-with-raw-fallback useLocalSearchParams already uses.

Fixes #47525
