### PR TITLE
[widgets][iOS] Changing widget configuration at runtime

### DIFF
--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -126,7 +126,7 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
         'Makes the widget [configurable](#configurable-widgets). The values the user picks are passed to your widget at runtime through `environment.configuration`. An object with:',
         '* `title` - The title shown when the user edits the widget.',
         '* `description` - An optional description shown when the user edits the widget.',
-        '* `parameters` - A map of parameter keys to parameter definitions. Each parameter has a `title`, a `type` (`string`, `number`, `boolean`, or `enum`), and a `default`. An `enum` parameter additionally takes a `values` array of `{ name, value }` options.',
+        '* `parameters` - A map of parameter keys to parameter definitions. Each parameter has a `title`, a `type` (`string`, `number`, `boolean`, or `enum`), and a `default`. An `enum` parameter additionally takes a `values` array of `{ name, value }` options and can set `dynamic: true` to let the app replace those options at runtime.',
       ].join('\n'),
     },
   ]}
@@ -173,7 +173,8 @@ You can configure `expo-widgets` using its built-in [config plugin](/config-plug
                       "values": [
                         { "name": "San Francisco", "value": "sf" },
                         { "name": "New York", "value": "nyc" }
-                      ]
+                      ],
+                      "dynamic": true
                     }
                   }
                 }
@@ -462,6 +463,18 @@ const WeatherWidget = (
 };
 
 export default createWidget<WeatherProps, WeatherConfiguration>('WeatherWidget', WeatherWidget);
+```
+
+#### Dynamic enum options
+
+Set `dynamic: true` on an enum parameter when the list of choices is only known at runtime, such as workspaces loaded after sign-in. The `values` array in app config is used as the fallback list until the app provides runtime options.
+
+```tsx
+WeatherWidget.setConfigurationParameterEnum('city', [
+  { name: 'Current City', value: 'current' },
+  { name: 'San Francisco', value: 'sf' },
+  { name: 'New York', value: 'nyc' },
+]);
 ```
 
 ### Live Activities

--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -467,7 +467,7 @@ export default createWidget<WeatherProps, WeatherConfiguration>('WeatherWidget',
 
 #### Dynamic enum options
 
-Set `dynamic: true` on an enum parameter when the list of choices is only known at runtime, such as workspaces loaded after sign-in. The `values` array in app config is used as the fallback list until the app provides runtime options.
+Set `dynamic: true` on an enum parameter in the [app config](#configuration-in-app-config) when the list of choices is only known at runtime, such as workspaces loaded after sign-in. The `values` array in app config is used as the fallback list until the app provides runtime options as shown below:
 
 ```tsx
 WeatherWidget.setConfigurationParameterEnum('city', [

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] Implement widgets. ([#46961](https://github.com/expo/expo/pull/46961) by [@jakex7](https://github.com/jakex7))
 - [Android] Support interactions. ([#47035](https://github.com/expo/expo/pull/47035) by [@jakex7](https://github.com/jakex7))
 - [iOS][plugin] Fix extension `CFBundleVersion` sync. ([#47061](https://github.com/expo/expo/pull/47061) by [@jakex7](https://github.com/jakex7))
+- [iOS] Changing widget configuration at runtime. ([#47533](https://github.com/expo/expo/pull/47533) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/ios/WidgetObject.swift
+++ b/packages/expo-widgets/ios/WidgetObject.swift
@@ -33,4 +33,16 @@ final class WidgetObject: SharedObject {
     }
     return try entries.map { try WidgetsJSTimelineEntry(from: $0, appContext: appContext) }
   }
+
+  func setConfigurationParameterEnum(parameterName: String, options: [WidgetConfigurationOptionRecord]?) {
+    if let options {
+      WidgetsStorage.set(
+        options.map { $0.toDictionary() },
+        forKey: "__expo_widgets_\(name)_configuration_options_\(parameterName)"
+      )
+    } else {
+      WidgetsStorage.removeObject(forKey: "__expo_widgets_\(name)_configuration_options_\(parameterName)")
+    }
+    self.reload()
+  }
 }

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -2,6 +2,18 @@ import SwiftUI
 import WidgetKit
 import Foundation
 
+public struct WidgetConfigurationOption {
+  public let name: String
+  public let value: String
+  public let subtitle: String?
+
+  public init(name: String, value: String, subtitle: String? = nil) {
+    self.name = name
+    self.value = value
+    self.subtitle = subtitle
+  }
+}
+
 func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [WidgetsTimelineEntry] {
   guard let timeline = WidgetsStorage.getArray(forKey: "__expo_widgets_\(name)_timeline") else {
     return [WidgetsTimelineEntry(date: Date(), name: name, props: WidgetsLayoutRegistry.initialProps(for: name), entryIndex: nil)]
@@ -20,6 +32,26 @@ func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [W
   }
 
   return entries.compactMap(\.self)
+}
+
+public func widgetConfigurationOptions(
+  name: String,
+  parameter: String,
+  fallback: [WidgetConfigurationOption]
+) -> [WidgetConfigurationOption] {
+  guard let options = WidgetsStorage.getArray(forKey: "__expo_widgets_\(name)_configuration_options_\(parameter)") else {
+    return fallback
+  }
+
+  let parsedOptions: [WidgetConfigurationOption] = options.compactMap { option in
+    guard let option = option as? [String: Any],
+          let name = option["name"] as? String,
+          let value = option["value"] as? String else {
+      return nil
+    }
+    return WidgetConfigurationOption(name: name, value: value, subtitle: option["subtitle"] as? String)
+  }
+  return parsedOptions.isEmpty ? fallback : parsedOptions
 }
 
 public func createRedBox(message: String, stack: String? = nil) -> [String: Any] {

--- a/packages/expo-widgets/ios/WidgetsModule.swift
+++ b/packages/expo-widgets/ios/WidgetsModule.swift
@@ -79,6 +79,10 @@ public final class WidgetsModule: Module {
       Function("getTimeline") { (widget: WidgetObject) in
         try widget.getTimeline()
       }
+
+      Function("setConfigurationParameterEnum") { (widget: WidgetObject, parameterName: String, options: [WidgetConfigurationOptionRecord]?) in
+        widget.setConfigurationParameterEnum(parameterName: parameterName, options: options)
+      }
     }
 
     Class("LiveActivityFactory", LiveActivityFactory.self) {

--- a/packages/expo-widgets/ios/WidgetsRecords.swift
+++ b/packages/expo-widgets/ios/WidgetsRecords.swift
@@ -6,6 +6,23 @@ struct WidgetsJSTimelineEntry: Record {
   @Field var props: [String: Any] = [:]
 }
 
+struct WidgetConfigurationOptionRecord: Record {
+  @Field var name: String
+  @Field var value: String
+  @Field var subtitle: String?
+
+  func toDictionary() -> [String: Any] {
+    var result: [String: Any] = [
+      "name": name,
+      "value": value
+    ]
+    if let subtitle {
+      result["subtitle"] = subtitle
+    }
+    return result
+  }
+}
+
 internal enum LiveActivityDismissalPolicy: String, Enumerable {
   case `default`
   case immediate

--- a/packages/expo-widgets/plugin/src/ios/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/ios/withWidgetSourceFiles.ts
@@ -203,6 +203,146 @@ struct ExportWidgets${index}: WidgetBundle {
   }
 }`;
 
+type WidgetParameter = NonNullable<
+  NonNullable<WidgetConfig['ios']>['configuration']
+>['parameters'][string];
+
+const capitalize = (value: string): string => value[0]?.toUpperCase() + value.slice(1);
+
+const enumTypeName = (widgetName: string, parameterName: string): string =>
+  `${widgetName}${capitalize(parameterName)}Enum`;
+
+const optionsProviderName = (widgetName: string, parameterName: string): string =>
+  `${widgetName}${capitalize(parameterName)}OptionsProvider`;
+
+const isDynamicEnumParameter = (
+  parameter: WidgetParameter
+): parameter is Extract<WidgetParameter, { type: 'enum' }> & { dynamic: true } =>
+  parameter.type === 'enum' && parameter.dynamic === true;
+
+const parameterSwiftType = (
+  widgetName: string,
+  parameterName: string,
+  parameter: WidgetParameter
+): string => {
+  switch (parameter.type) {
+    case 'string':
+      return 'String';
+    case 'number':
+      return 'Double';
+    case 'boolean':
+      return 'Bool';
+    case 'enum':
+      return enumTypeName(widgetName, parameterName);
+    default:
+      return 'String';
+  }
+};
+
+const parameterDefaultValue = (
+  widgetName: string,
+  parameterName: string,
+  parameter: WidgetParameter
+): string => {
+  switch (parameter.type) {
+    case 'string':
+    case 'enum':
+      return isDynamicEnumParameter(parameter)
+        ? JSON.stringify(parameter.default)
+        : parameter.type === 'enum'
+          ? `${enumTypeName(widgetName, parameterName)}.${parameter.default}`
+          : JSON.stringify(parameter.default);
+    case 'number':
+    case 'boolean':
+      return String(parameter.default);
+    default:
+      return '""';
+  }
+};
+
+const parameterDeclaration = (
+  widgetName: string,
+  parameterName: string,
+  parameter: WidgetParameter
+): string => {
+  if (isDynamicEnumParameter(parameter)) {
+    return `  @Parameter(title: ${JSON.stringify(parameter.title)}, optionsProvider: ${optionsProviderName(widgetName, parameterName)}())\n  var ${parameterName}: String?`;
+  }
+  return `  @Parameter(title: ${JSON.stringify(parameter.title)}, default: ${parameterDefaultValue(widgetName, parameterName, parameter)})\n  var ${parameterName}: ${parameterSwiftType(widgetName, parameterName, parameter)}`;
+};
+
+const configurationValueExpression = (
+  parameterName: string,
+  parameter: WidgetParameter
+): string => {
+  const rawValueAccess = parameter.type === 'enum' && !isDynamicEnumParameter(parameter) ? '.rawValue' : '';
+  return `      "${parameterName}": entry.configuration.${parameterName}${rawValueAccess}`;
+};
+
+const staticEnumSwift = (
+  widgetName: string,
+  parameterName: string,
+  parameter: Extract<WidgetParameter, { type: 'enum' }>
+): string => {
+  if (isDynamicEnumParameter(parameter)) {
+    return '';
+  }
+  const typeName = enumTypeName(widgetName, parameterName);
+  return `
+enum ${typeName}: String, CaseIterable, AppEnum {
+  ${parameter.values
+    .map((value) => {
+      return `case ${value.value}`;
+    })
+    .join('\n  ')}
+
+  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: ${JSON.stringify(parameter.title)})
+
+  static var caseDisplayRepresentations: [${typeName}: DisplayRepresentation] = [
+    ${parameter.values
+      .map((value) => {
+        return `.${value.value}: DisplayRepresentation(title: ${JSON.stringify(value.name)})`;
+      })
+      .join(',\n    ')}
+  ]
+}`;
+};
+
+const dynamicEnumOptionsProviderSwift = (
+  widgetName: string,
+  parameterName: string,
+  parameter: Extract<WidgetParameter, { type: 'enum' }> & { dynamic: true }
+): string => `
+struct ${optionsProviderName(widgetName, parameterName)}: DynamicOptionsProvider {
+  func results() async throws -> IntentItemCollection<String> {
+    let options = widgetConfigurationOptions(
+      name: ${JSON.stringify(widgetName)},
+      parameter: ${JSON.stringify(parameterName)},
+      fallback: [
+${parameter.values
+  .map((value) => {
+    return `        WidgetConfigurationOption(name: ${JSON.stringify(value.name)}, value: ${JSON.stringify(value.value)})`;
+  })
+  .join(',\n')}
+      ]
+    )
+
+    return IntentItemCollection(sections: [
+      IntentItemSection(items: options.map { option in
+        IntentItem(
+          option.value,
+          title: LocalizedStringResource(stringLiteral: option.name),
+          subtitle: option.subtitle.map { LocalizedStringResource(stringLiteral: $0) }
+        )
+      })
+    ])
+  }
+
+  func defaultResult() async -> String? {
+    return ${JSON.stringify(parameter.default)}
+  }
+}`;
+
 const widgetSwift = (widget: WidgetConfig): string => {
   const configuration = widget.ios?.configuration ?? widget.configuration;
   const supportedFamilies = widget.ios?.supportedFamilies ?? widget.supportedFamilies ?? [];
@@ -236,24 +376,7 @@ struct ${widget.name}ConfigurationAppIntent: WidgetConfigurationIntent {
 ${configuration?.description ? `  static var description: LocalizedStringResource = ${JSON.stringify(configuration.description)}\n` : ''}
 ${Object.entries(configuration?.parameters ?? {})
   .map(([name, param]) => {
-    let paramType: string;
-    switch (param.type) {
-      case 'string':
-        paramType = 'String';
-        break;
-      case 'number':
-        paramType = 'Double';
-        break;
-      case 'boolean':
-        paramType = 'Bool';
-        break;
-      case 'enum':
-        paramType = `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum`;
-        break;
-      default:
-        paramType = 'String';
-    }
-    return `  @Parameter(title: ${JSON.stringify(param.title)}, default: ${param.type === 'string' ? JSON.stringify(param.default) : param.type === 'number' ? param.default : param.type === 'boolean' ? param.default : `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum.${param.default}`})\n  var ${name}: ${paramType}`;
+    return parameterDeclaration(widget.name, name, param);
   })
   .join('\n')}
 
@@ -264,25 +387,9 @@ ${Object.entries(configuration?.parameters ?? {})
 ${Object.entries(configuration?.parameters ?? {})
   .map(([name, param]) => {
     if (param.type !== 'enum') return '';
-    const paramTypeName = `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum`;
-    return `
-enum ${paramTypeName}: String, CaseIterable, AppEnum {
-  ${param.values
-    .map((value) => {
-      return `case ${value.value}`;
-    })
-    .join('\n  ')}
-
-  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: ${JSON.stringify(param.title)})
-
-  static var caseDisplayRepresentations: [${paramTypeName}: DisplayRepresentation] = [
-    ${param.values
-      .map((value) => {
-        return `.${value.value}: DisplayRepresentation(title: ${JSON.stringify(value.name)})`;
-      })
-      .join(',\n    ')}
-  ]
-}`;
+    return isDynamicEnumParameter(param)
+      ? dynamicEnumOptionsProviderSwift(widget.name, name, param)
+      : staticEnumSwift(widget.name, name, param);
   })
   .join('\n')}
 
@@ -343,11 +450,11 @@ struct ${widget.name}EntryView: View {
     var env: [String: Any] = getWidgetEnvironment(environment: environment)
     env["timestamp"] = Int(entry.date.timeIntervalSince1970 * 1000)
     env["configuration"] = [
-${Object.entries(configuration?.parameters ?? {})
-  .map(([name, param]) => {
-    return `      "${name}": entry.configuration.${name}${param.type === 'enum' ? '.rawValue' : ''}`;
-  })
-  .join(',\n')}
+  ${Object.entries(configuration?.parameters ?? {})
+    .map(([name, param]) => {
+      return configurationValueExpression(name, param);
+    })
+    .join(',\n')}
     ]
     return env
   }

--- a/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
+++ b/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
@@ -52,6 +52,7 @@ export type WidgetParameterBoolean = {
 export type WidgetParameterEnum = {
   title: string;
   type: 'enum';
+  dynamic?: boolean;
   values: {
     name: string;
     value: string;

--- a/packages/expo-widgets/src/ExpoWidgets.ts
+++ b/packages/expo-widgets/src/ExpoWidgets.ts
@@ -6,6 +6,7 @@ import type {
   NativeLiveActivity,
   NativeLiveActivityFactory,
   NativeWidgetObject,
+  WidgetConfigurationEnum,
 } from './Widgets.types';
 
 const noopSubscription: EventSubscription = { remove() {} };
@@ -19,6 +20,10 @@ class WidgetStub {
   async getTimeline(): Promise<ExpoTimelineEntry[]> {
     return [];
   }
+  setConfigurationParameterEnum(
+    _parameterName: string,
+    _options?: WidgetConfigurationEnum[]
+  ): void {}
 }
 
 class LiveActivityStub {

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -10,6 +10,7 @@ import type {
   NativeLiveActivityFactory,
   NativeWidgetObject,
   PushTokenEvent,
+  WidgetConfigurationEnum,
   WidgetEnvironment,
   WidgetTimelineEntry,
 } from './Widgets.types';
@@ -78,6 +79,17 @@ export class Widget<
       date: new Date(entry.timestamp),
       props: entry.props as PropsType,
     }));
+  }
+
+  /**
+   * Replaces the runtime options for a dynamic enum configuration parameter.
+   * The app config values remain the fallback when no runtime options are set.
+   */
+  setConfigurationParameterEnum(
+    parameterName: keyof ConfigurationType & string,
+    options?: WidgetConfigurationEnum[]
+  ) {
+    this.nativeWidgetObject.setConfigurationParameterEnum(parameterName, options);
   }
 }
 

--- a/packages/expo-widgets/src/Widgets.types.ts
+++ b/packages/expo-widgets/src/Widgets.types.ts
@@ -145,6 +145,22 @@ export type WidgetTimelineEntry<T extends object = object> = {
   props: T;
 };
 
+export type WidgetConfigurationEnum = {
+  /**
+   * User-visible option label.
+   */
+  name: string;
+  /**
+   * Value available in `environment.configuration`.
+   */
+  value: string;
+  /**
+   * Optional secondary text displayed to user.
+   * @platform iOS
+   */
+  subtitle?: string;
+};
+
 export type ExpoTimelineEntry = {
   timestamp: number;
   props: Record<string, any>;
@@ -281,6 +297,7 @@ export declare class NativeWidgetObject extends SharedObject {
   updateSnapshot(props: Record<string, any>): void;
   updateTimeline(entries: ExpoTimelineEntry[]): void;
   getTimeline(): Promise<ExpoTimelineEntry[]>;
+  setConfigurationParameterEnum(parameterName: string, options?: WidgetConfigurationEnum[]): void;
 }
 
 export declare class NativeLiveActivityFactory extends SharedObject {

--- a/packages/expo-widgets/src/index.ts
+++ b/packages/expo-widgets/src/index.ts
@@ -10,6 +10,7 @@ export type {
   PushTokenEvent,
   PushToStartTokenEvent,
   UserInteractionEvent,
+  WidgetConfigurationEnum,
   WidgetEnvironment,
   WidgetFamily,
   WidgetRenderingMode,


### PR DESCRIPTION
# Why

Some apps may require widget configuration to be provided at runtime. For example, Slack can provide the list of workspaces after the user has authenticated.

# How

Add a `dynamic` option to the `app.json` configuration, that will generate a `DynamicOptionsProvider` instead of a standard enum.

The available values can then be provided at runtime using `setConfigurationParameterEnum(parameterName, options)`.

For example:

```tsx
MyWidget.setConfigurationParameterEnum('workspace', [
  { name: 'Current Workspace', value: 'current', subtitle: 'Follows the app' },
  { name: 'Personal', value: 'personal' },
  { name: 'Expo', value: 'expo' },
  { name: 'SWM.', value: 'swm' },
]);
```

# Test Plan

https://github.com/user-attachments/assets/0a8ad5c6-8702-4f0c-aadb-5ff3fa4ad5c4

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
