### PR TITLE
[core][fetch] Support react-native Blob in Response.blob()

### DIFF
--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -33,6 +33,25 @@ export function test({ describe, expect, it, ...t }) {
       expect(buffer.byteLength).toBe(20);
     });
 
+    it('should process blob with size and type', async () => {
+      const resp = await fetch('https://httpbin.io/bytes/20');
+      const blob = await resp.blob();
+      expect(blob.size).toBe(20);
+      expect(blob.type).toBe('application/octet-stream');
+    });
+
+    it('should read blob content back through FileReader', async () => {
+      const resp = await fetch('https://httpbin.io/base64/aGVsbG8gYmxvYg==');
+      const blob = await resp.blob();
+      const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as ArrayBuffer);
+        reader.onerror = reject;
+        reader.readAsArrayBuffer(blob);
+      });
+      expect(new TextDecoder().decode(buffer)).toBe('hello blob');
+    });
+
     it('should process response in readablestream from late get reader call', async () => {
       const resp = await fetch('https://httpbin.io/get');
       expect(resp.ok).toBe(true);

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Adopted the UIKit scene-based life cycle on iOS so apps built with the iOS 27 SDK launch correctly. ([#46733](https://github.com/expo/expo/pull/46733) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in extensions. ([#46799](https://github.com/expo/expo/pull/46799) by [@jakex7](https://github.com/jakex7))
 - Fix `asyncRoutes` failing on Android and iOS with `Requiring unknown module` ([#46870](https://github.com/expo/expo/pull/46870) by [@hassankhan](https://github.com/hassankhan))
+- Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
@@ -4,6 +4,7 @@ package expo.modules.fetch
 
 import android.util.Log
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.blob.BlobModule
 import com.facebook.react.modules.network.CookieJarContainer
 import com.facebook.react.modules.network.ForwardingCookieHandler
 import com.facebook.react.modules.network.OkHttpClientProvider
@@ -47,6 +48,13 @@ class ExpoFetchModule : Module() {
 
     OnCreate {
       cookieJarContainer.setCookieJar(JavaNetCookieJar(cookieHandler))
+    }
+
+    // TODO(kudo,20260706): remove this when we install expo-blob as globalThis.Blob
+    AsyncFunction("unstable_createBlobData") { data: ByteArray ->
+      val blobModule = reactContext.getNativeModule(BlobModule::class.java)
+        ?: throw FetchBlobModuleUnavailableException()
+      return@AsyncFunction blobModule.store(data)
     }
 
     OnDestroy {

--- a/packages/expo/android/src/main/java/expo/modules/fetch/FetchExceptions.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/FetchExceptions.kt
@@ -15,3 +15,9 @@ internal class FetchAndroidContextLostException :
 
 internal class FetchRedirectException :
   CodedException("Redirect is not allowed when redirect mode is 'error'")
+
+internal class FetchBlobModuleUnavailableException :
+  CodedException(
+    "Unable to store the response body as a blob because React Native's BlobModule is not available. " +
+      "Make sure your app includes the React Native blob support or read the body with arrayBuffer() instead"
+  )

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -24,6 +24,19 @@ public final class ExpoFetchModule: Module {
       urlSession.invalidateAndCancel()
     }
 
+    // TODO(kudo,20260706): remove this when we install expo-blob as globalThis.Blob
+    AsyncFunction("unstable_createBlobData") { (data: Data) -> String in
+      guard let blobManager: NSObject = self.appContext?.nativeModule(named: "BlobModule") else {
+        throw FetchBlobModuleUnavailableException()
+      }
+      let store = NSSelectorFromString("store:")
+      guard blobManager.responds(to: store),
+        let blobId = blobManager.perform(store, with: data as NSData)?.takeUnretainedValue() as? String else {
+        throw FetchBlobModuleUnavailableException()
+      }
+      return blobId
+    }
+
     // swiftlint:disable:next closure_body_length
     Class(NativeResponse.self) {
       Constructor {

--- a/packages/expo/ios/Fetch/FetchExceptions.swift
+++ b/packages/expo/ios/Fetch/FetchExceptions.swift
@@ -19,3 +19,10 @@ internal final class FetchRedirectException: Exception {
     "Redirect is not allowed when redirect mode is 'error'"
   }
 }
+
+internal final class FetchBlobModuleUnavailableException: Exception {
+  override var reason: String {
+    "Unable to store the response body as a blob because React Native's BlobModule is not available. " +
+    "Make sure your app includes the React Native blob support (React-RCTBlob) or read the body with arrayBuffer() instead"
+  }
+}

--- a/packages/expo/src/winter/fetch/FetchResponse.ts
+++ b/packages/expo/src/winter/fetch/FetchResponse.ts
@@ -1,5 +1,6 @@
 import { ExpoFetchModule } from './ExpoFetchModule';
 import type { NativeHeadersType, NativeResponse } from './NativeRequest';
+import { createReactNativeBlobAsync, isReactNativeBlobGlobal } from './createBlob';
 
 const ConcreteNativeResponse = ExpoFetchModule.NativeResponse as typeof NativeResponse;
 export type AbortSubscriptionCleanupFunction = () => void;
@@ -19,6 +20,8 @@ interface ResponseMetadata {
 }
 
 const stateKey = Symbol('FetchResponse.state');
+
+let hasWarnedAboutReactNativeBlob = false;
 
 interface ConsumptionWrapper {
   stream: ReadableStream<Uint8Array<ArrayBuffer>>;
@@ -280,13 +283,22 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
     return this.status >= 200 && this.status < 300;
   }
 
-  /**
-   * This method is not currently supported by react-native's Blob constructor.
-   */
   async blob(): Promise<Blob> {
     this.checkBodyUsedError('blob');
+    const type = this.headers.get('content-type') ?? '';
     const buffer = await this.arrayBuffer();
-    return new Blob([buffer]);
+
+    if (isReactNativeBlobGlobal()) {
+      if (__DEV__ && !hasWarnedAboutReactNativeBlob) {
+        hasWarnedAboutReactNativeBlob = true;
+        console.warn(
+          "Response.blob() is using React Native's Blob, which copies the response into the native blob store and reads it back through base64 encoding. This may be slow for large responses. Add the `expo-blob` package to your app to avoid the performance overhead."
+        );
+      }
+      return createReactNativeBlobAsync(buffer, type);
+    }
+
+    return new Blob([buffer], { type });
   }
 
   async formData(): Promise<UniversalFormData> {

--- a/packages/expo/src/winter/fetch/__tests__/FetchResponse-blob-test.native.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchResponse-blob-test.native.ts
@@ -1,0 +1,88 @@
+import { FetchResponse } from '../FetchResponse';
+
+jest.mock('../ExpoFetchModule', () => {
+  const helloWorld = new TextEncoder().encode('hello world');
+
+  class StubNativeResponse {
+    // Getters on the prototype, like the real native binding, so super.x works.
+    get _rawHeaders(): [string, string][] {
+      return [['content-type', 'text/plain']];
+    }
+
+    addListener() {}
+    removeListener() {}
+    removeAllListeners() {}
+
+    async arrayBuffer(): Promise<ArrayBuffer> {
+      return helloWorld.buffer.slice(
+        helloWorld.byteOffset,
+        helloWorld.byteOffset + helloWorld.byteLength
+      ) as ArrayBuffer;
+    }
+  }
+
+  return {
+    ExpoFetchModule: {
+      NativeResponse: StubNativeResponse,
+      unstable_createBlobData: jest.fn(async () => 'mock-blob-id'),
+    },
+  };
+});
+
+describe('FetchResponse blob() with react-native Blob', () => {
+  const originalBlob = globalThis.Blob;
+  const RNBlob = require('react-native/Libraries/Blob/Blob').default;
+  const { ExpoFetchModule } = require('../ExpoFetchModule');
+
+  beforeEach(() => {
+    globalThis.Blob = RNBlob;
+    ExpoFetchModule.unstable_createBlobData.mockClear();
+  });
+
+  afterEach(() => {
+    globalThis.Blob = originalBlob;
+  });
+
+  function makeResponse(): FetchResponse {
+    return new FetchResponse(() => {});
+  }
+
+  it('should warn about the performance overhead only once', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await makeResponse().blob();
+      await makeResponse().blob();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('expo-blob'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('should return a react-native blob backed by the native blob store', async () => {
+    const response = makeResponse();
+    const blob = await response.blob();
+
+    expect(blob).toBeInstanceOf(RNBlob);
+    expect((blob as any).data.blobId).toBe('mock-blob-id');
+    expect(blob.size).toBe(11);
+    expect(blob.type).toBe('text/plain');
+  });
+
+  it('should store the body bytes in the native blob store', async () => {
+    const response = makeResponse();
+    await response.blob();
+
+    expect(ExpoFetchModule.unstable_createBlobData).toHaveBeenCalledTimes(1);
+    const bytes = ExpoFetchModule.unstable_createBlobData.mock.calls[0][0] as Uint8Array;
+    expect(new TextDecoder().decode(bytes)).toBe('hello world');
+  });
+
+  it('should reject a second blob() call with TypeError', async () => {
+    const response = makeResponse();
+    await response.blob();
+    await expect(response.blob()).rejects.toThrow(TypeError);
+  });
+});

--- a/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
@@ -89,6 +89,7 @@ jest.mock('../ExpoFetchModule', () => {
     ExpoFetchModule: {
       NativeRequest: StubNativeRequest,
       NativeResponse: StubNativeResponse,
+      unstable_createBlobData: jest.fn(async () => 'mock-blob-id'),
     },
   };
 });
@@ -251,6 +252,15 @@ describe('FetchResponse', () => {
       const cloned = response.clone();
       const formData = await cloned.formData();
       expect(formData.get('hello world')).toBe('');
+    });
+  });
+
+  describe('blob()', () => {
+    it('should create a blob with type from the content-type header', async () => {
+      const response = makeResponse();
+      const blob = await response.blob();
+      expect(blob.size).toBe(11);
+      expect(blob.type).toBe('text/plain');
     });
   });
 

--- a/packages/expo/src/winter/fetch/createBlob.ts
+++ b/packages/expo/src/winter/fetch/createBlob.ts
@@ -1,0 +1,26 @@
+import { ExpoFetchModule } from './ExpoFetchModule';
+
+export function isReactNativeBlobGlobal(): boolean {
+  try {
+    return globalThis.Blob === require('react-native/Libraries/Blob/Blob').default;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * react-native's `Blob` cannot be created from binary data in JS, so store the
+ * bytes in its native blob store and reference them, like XHR responses do.
+ * TODO(kudo,20260706): remove this when we install expo-blob as globalThis.Blob
+ */
+export async function createReactNativeBlobAsync(buffer: ArrayBuffer, type: string): Promise<Blob> {
+  const BlobManager = require('react-native/Libraries/Blob/BlobManager').default;
+  const blobId: string = await ExpoFetchModule.unstable_createBlobData(new Uint8Array(buffer));
+  return BlobManager.createFromOptions({
+    blobId,
+    offset: 0,
+    size: buffer.byteLength,
+    type,
+    lastModified: Date.now(),
+  });
+}


### PR DESCRIPTION
# Why

`Response.blob()` from `expo/fetch` throws on native because react-native's `Blob` can't be created from an `ArrayBuffer`.

Fixes #47468

# How

Store the response bytes in react-native's native blob store and create the `Blob` from there, like react-native's own XHR does. Also set `Blob.type` from the `Content-Type` header, and show a dev-only warning that recommends `expo-blob` for better performance.

# Test Plan

- New unit tests and test-suite cases for `blob()`.
- Android and iOS native sources build in bare-expo.
- Test repro from https://github.com/janicduplessis/expo-fetch-blob-repro

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)