### PR TITLE
fix(expo-sqlite): make SQLiteStorage migration idempotent to heal sync/async race

### DIFF
--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -384,14 +384,15 @@ export class SQLiteStorage {
     return db.withTransactionAsync(async () => {
       const result = await db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
       let currentDbVersion = result?.user_version ?? 0;
-      if (currentDbVersion >= DATABASE_VERSION) {
-        return;
+      // Always run the migration statement even when user_version is already at
+      // DATABASE_VERSION. MIGRATION_STATEMENT_0 uses IF NOT EXISTS, so it is a
+      // no-op when the table exists. This self-heals a DB that was left with
+      // user_version = 1 but no storage table (possible when getDbSync() raced
+      // a concurrent getDbAsync() call before this lock was introduced).
+      await db.execAsync(MIGRATION_STATEMENT_0);
+      if (currentDbVersion < DATABASE_VERSION) {
+        await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
       }
-      if (currentDbVersion === 0) {
-        await db.execAsync(MIGRATION_STATEMENT_0);
-        currentDbVersion = 1;
-      }
-      await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 
@@ -399,14 +400,15 @@ export class SQLiteStorage {
     db.withTransactionSync(() => {
       const result = db.getFirstSync<{ user_version: number }>('PRAGMA user_version');
       let currentDbVersion = result?.user_version ?? 0;
-      if (currentDbVersion >= DATABASE_VERSION) {
-        return;
+      // Always run the migration statement even when user_version is already at
+      // DATABASE_VERSION. MIGRATION_STATEMENT_0 uses IF NOT EXISTS, so it is a
+      // no-op when the table exists. This self-heals a DB that was left with
+      // user_version = 1 but no storage table because getDbSync() raced a
+      // concurrent getDbAsync() call during first launch.
+      db.execSync(MIGRATION_STATEMENT_0);
+      if (currentDbVersion < DATABASE_VERSION) {
+        db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
       }
-      if (currentDbVersion === 0) {
-        db.execSync(MIGRATION_STATEMENT_0);
-        currentDbVersion = 1;
-      }
-      db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 


### PR DESCRIPTION
Fixes #47448.

## Root cause

`getDbSync()` and `getDbAsync()` can both trigger the first-run migration concurrently. `getDbAsync()` serializes through `awaitLock` (added in #33834), but `getDbSync()` has no shared lock with the async path. When they race:

1. `getDbAsync()` starts `withTransactionAsync`: reads `user_version = 0`, executes `CREATE TABLE IF NOT EXISTS storage`, bumps `user_version = 1`, commits.
2. `getDbSync()` starts `withTransactionSync` concurrently: depending on timing it may read `user_version = 1` from the snapshot already committed by step 1, hit the early-return guard (`currentDbVersion >= DATABASE_VERSION`), **skip `CREATE TABLE`**, and complete.

This leaves the database with `user_version = 1` but no `storage` table. All subsequent `getItemSync`/`setItemSync`/`getItemAsync`/… calls throw `no such table: storage` permanently — the version guard ensures migration is never retried.

## Fix

Remove the early-return guard and unconditionally run `MIGRATION_STATEMENT_0`. The statement uses `IF NOT EXISTS`, so it is always a no-op when the table already exists. The `PRAGMA user_version` bump remains conditional on being below `DATABASE_VERSION`.

Both `maybeMigrateDbSync` and `maybeMigrateDbAsync` receive the same treatment:
- **Sync**: prevents future races.
- **Async**: self-heals any database already corrupted by the race on a user's device (avoids requiring a reinstall).