### PR TITLE
[ios][core] Fix CSS color regexes not matching on the iOS 27.0 beta runtime

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `hsl()`/`hsla()` color strings failing to parse on some OS versions (observed on the iOS 27.0 beta), caused by regex-literal fragments composed in `RegexBuilder` blocks. The CSS color patterns are now built from `RegexBuilder` primitives only. ([#47543](https://github.com/expo/expo/pull/47543) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fix a reload deadlock on the new architecture where reloading (from pressing `r` in the iOS simulator) would freeze the app until the watchdog killed it. `reloadAppAsync` now triggers the reload synchronously when already on the main thread instead of always deferring via `DispatchQueue.main.async`. ([#47392](https://github.com/expo/expo/pull/47392) by [@brentvatne](https://github.com/brentvatne))
 - [iOS] Pair a native shared object with one JavaScript object per runtime, so a shared object exposed to several runtimes (e.g. the main and UI runtimes, or worklet contexts) keeps a live pairing in each instead of only the one paired last. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
 - [Android][compose] Guard `onLayout` against detached window to prevent `LayoutNode should be attached to an owner` crash. ([#47085](https://github.com/expo/expo/pull/47085) by [@roitium](https://github.com/roitium))

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -28,7 +28,8 @@ extension UIColor: Convertible {
     // Handle `PlatformColor` and `DynamicColorIOS`
     if let opaqueValue = value as? [String: Any] {
       if let semanticName = opaqueValue["semantic"] as? String,
-        let color = resolveNamedColor(name: semanticName) {
+        let color = resolveNamedColor(name: semanticName)
+      {
         return color as! Self
       }
       if let semanticArray = opaqueValue["semantic"] as? [String] {
@@ -40,7 +41,8 @@ extension UIColor: Convertible {
       }
       if let appearances = opaqueValue["dynamic"] as? [String: Any],
         let lightColor = try appearances["light"].map({ try UIColor.convert(from: $0) }),
-        let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0) }) {
+        let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0) })
+      {
         let highContrastLightColor = try appearances["highContrastLight"].map({ try UIColor.convert(from: $0) })
         let highContrastDarkColor = try appearances["highContrastDark"].map({ try UIColor.convert(from: $0) })
 
@@ -166,9 +168,7 @@ private func uiColorWithComponents(_ components: [Double]) throws -> UIColor {
 
 // MARK: - Color String Parsing
 
-/**
- Parses a color string (hex, rgb, hsl, hwb) into a UIColor.
- */
+/// Parses a color string (hex, rgb, hsl, hwb) into a UIColor.
 private func colorFromString(_ value: String) throws -> UIColor {
   let input = value.trimmingCharacters(in: .whitespacesAndNewlines)
   let lowercased = input.lowercased()
@@ -233,80 +233,183 @@ private func colorFromRgba(_ rgba: UInt64) throws -> UIColor {
 
 // MARK: - CSS Color Function Regex Patterns
 
-nonisolated(unsafe) private let cssNumber = /[-+]?\d*\.?\d+/
-nonisolated(unsafe) private let cssNumberOrPercent = /[-+]?\d*\.?\d+%?/
+// These are built from RegexBuilder primitives only. Composing regex-literal fragments
+// (e.g. /hsla?\(\s*/) inside a builder miscompiles on some OS runtime versions
+// (observed on the iOS 27.0 beta simulator) and the patterns silently stop matching.
+
+/// A CSS number like `-12`, `+1.5`, `.5` or `100`.
+nonisolated(unsafe) private let cssNumber = Regex {
+  Optionally {
+    CharacterClass.anyOf("-+")
+  }
+  ZeroOrMore(.digit)
+  Optionally {
+    "."
+  }
+  OneOrMore(.digit)
+}
+
+nonisolated(unsafe) private let cssNumberOrPercent = Regex {
+  cssNumber
+  Optionally {
+    "%"
+  }
+}
+
+nonisolated(unsafe) private let commaSeparator = Regex {
+  ZeroOrMore(.whitespace)
+  ","
+  ZeroOrMore(.whitespace)
+}
 
 nonisolated(unsafe) private let rgbCommaRegex = Regex {
-  /rgba?\(\s*/
-  Capture { cssNumberOrPercent }
-  /\s*,\s*/
-  Capture { cssNumberOrPercent }
-  /\s*,\s*/
-  Capture { cssNumberOrPercent }
+  "rgb"
   Optionally {
-    /\s*,\s*/
-    Capture { cssNumberOrPercent }
+    "a"
   }
-  /\s*\)/
+  "("
+  ZeroOrMore(.whitespace)
+  Capture {
+    cssNumberOrPercent
+  }
+  commaSeparator
+  Capture {
+    cssNumberOrPercent
+  }
+  commaSeparator
+  Capture {
+    cssNumberOrPercent
+  }
+  Optionally {
+    commaSeparator
+    Capture {
+      cssNumberOrPercent
+    }
+  }
+  ZeroOrMore(.whitespace)
+  ")"
 }.ignoresCase()
 
 nonisolated(unsafe) private let rgbSpaceRegex = Regex {
-  /rgba?\(\s*/
-  Capture { cssNumberOrPercent }
-  /\s+/
-  Capture { cssNumberOrPercent }
-  /\s+/
-  Capture { cssNumberOrPercent }
+  "rgb"
   Optionally {
-    /\s*\/\s*/
-    Capture { cssNumberOrPercent }
+    "a"
   }
-  /\s*\)/
+  "("
+  ZeroOrMore(.whitespace)
+  Capture {
+    cssNumberOrPercent
+  }
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumberOrPercent
+  }
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumberOrPercent
+  }
+  Optionally {
+    ZeroOrMore(.whitespace)
+    "/"
+    ZeroOrMore(.whitespace)
+    Capture {
+      cssNumberOrPercent
+    }
+  }
+  ZeroOrMore(.whitespace)
+  ")"
 }.ignoresCase()
 
 nonisolated(unsafe) private let hslCommaRegex = Regex {
-  /hsla?\(\s*/
-  Capture { cssNumber }
-  /\s*,\s*/
-  Capture { cssNumber }
-  /%\s*,\s*/
-  Capture { cssNumber }
-  /%\s*/
+  "hsl"
   Optionally {
-    /,\s*/
-    Capture { cssNumberOrPercent }
+    "a"
   }
-  /\s*\)/
+  "("
+  ZeroOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  commaSeparator
+  Capture {
+    cssNumber
+  }
+  "%"
+  commaSeparator
+  Capture {
+    cssNumber
+  }
+  "%"
+  ZeroOrMore(.whitespace)
+  Optionally {
+    ","
+    ZeroOrMore(.whitespace)
+    Capture {
+      cssNumberOrPercent
+    }
+  }
+  ZeroOrMore(.whitespace)
+  ")"
 }.ignoresCase()
 
 nonisolated(unsafe) private let hslSpaceRegex = Regex {
-  /hsla?\(\s*/
-  Capture { cssNumber }
-  /\s+/
-  Capture { cssNumber }
-  /%\s+/
-  Capture { cssNumber }
-  /%\s*/
+  "hsl"
   Optionally {
-    /\/\s*/
-    Capture { cssNumberOrPercent }
+    "a"
   }
-  /\s*\)/
+  "("
+  ZeroOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  "%"
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  "%"
+  ZeroOrMore(.whitespace)
+  Optionally {
+    "/"
+    ZeroOrMore(.whitespace)
+    Capture {
+      cssNumberOrPercent
+    }
+  }
+  ZeroOrMore(.whitespace)
+  ")"
 }.ignoresCase()
 
 nonisolated(unsafe) private let hwbRegex = Regex {
-  /hwb\(\s*/
-  Capture { cssNumber }
-  /\s+/
-  Capture { cssNumber }
-  /%\s+/
-  Capture { cssNumber }
-  /%\s*/
-  Optionally {
-    /\/\s*/
-    Capture { cssNumberOrPercent }
+  "hwb("
+  ZeroOrMore(.whitespace)
+  Capture {
+    cssNumber
   }
-  /\s*\)/
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  "%"
+  OneOrMore(.whitespace)
+  Capture {
+    cssNumber
+  }
+  "%"
+  ZeroOrMore(.whitespace)
+  Optionally {
+    "/"
+    ZeroOrMore(.whitespace)
+    Capture {
+      cssNumberOrPercent
+    }
+  }
+  ZeroOrMore(.whitespace)
+  ")"
 }.ignoresCase()
 
 // MARK: - CSS Color Function Parsers
@@ -387,8 +490,7 @@ private func hwbToUIColor(h: CGFloat, w: CGFloat, b: CGFloat, a: CGFloat) -> UIC
 }
 
 private func colorFromRGBString(_ rgbString: String) throws -> UIColor {
-  if let match = rgbString.wholeMatch(of: rgbCommaRegex) ?? rgbString.wholeMatch(of: rgbSpaceRegex)
-  {
+  if let match = rgbString.wholeMatch(of: rgbCommaRegex) ?? rgbString.wholeMatch(of: rgbSpaceRegex) {
     let r = parseRgbComponent(match.1)
     let g = parseRgbComponent(match.2)
     let b = parseRgbComponent(match.3)
@@ -399,8 +501,7 @@ private func colorFromRGBString(_ rgbString: String) throws -> UIColor {
 }
 
 private func colorFromHSLString(_ hslString: String) throws -> UIColor {
-  if let match = hslString.wholeMatch(of: hslCommaRegex) ?? hslString.wholeMatch(of: hslSpaceRegex)
-  {
+  if let match = hslString.wholeMatch(of: hslCommaRegex) ?? hslString.wholeMatch(of: hslSpaceRegex) {
     let h = CGFloat(Double(match.1) ?? 0)
     let s = CGFloat(min(max((Double(match.2) ?? 0) / 100.0, 0), 1))
     let l = CGFloat(min(max((Double(match.3) ?? 0) / 100.0, 0), 1))
@@ -421,10 +522,8 @@ private func colorFromHWBString(_ hwbString: String) throws -> UIColor {
   throw InvalidHWBColorException(hwbString)
 }
 
-/**
- Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
- and additionally the transparent color.
- */
+/// Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
+/// and additionally the transparent color.
 private let namedColors: [String: [Double]] = [
   "aliceblue": [240, 248, 255, 255],
   "antiquewhite": [250, 235, 215, 255],


### PR DESCRIPTION
# Why

All nine `hsl()`/`hsla()` tests in `ColorConvertiblesTests` fail when the native test suite runs on the iOS 27.0 beta simulator runtime, throwing `InvalidHSLColorException` for valid inputs like `hsl(0, 100%, 50%)`. CI does not catch this because it runs on a stable runtime, and the Swift regex engine ships with the OS rather than with the app, so the same binary behaves differently per runtime. If the regression ships in the iOS 27 release, `hsl()` color parsing breaks for real apps.

# How

The root cause is a regression in the regex engine of the iOS 27.0 beta: regex-literal fragments composed inside `RegexBuilder` blocks (e.g. `Regex { /hsla?\(\s*/ ... }`) miscompile and silently stop matching. Only some shapes are affected, which is why the `rgb()` and `hwb()` patterns (built the same way) happened to survive: a bisect showed failing shapes directly adjacent to theirs, e.g. `Regex { Capture { /\d+/ }; /%\s*,\s*/ }` no longer matches `100%,`. Flat regex literals and pure builder DSL both work correctly.

Upstream context: this belongs to a known regression family in the Swift 6.4 regex engine (the stdlib the iOS 27 beta ships), tracked in [swiftlang/swift-experimental-string-processing#865](https://github.com/swiftlang/swift-experimental-string-processing/issues/865) and traced there to the DSL flattening/auto-possessification rework ([#849](https://github.com/swiftlang/swift-experimental-string-processing/pull/849)), with related piecemeal fixes in [#851](https://github.com/swiftlang/swift-experimental-string-processing/pull/851), [#859](https://github.com/swiftlang/swift-experimental-string-processing/pull/859) and [#866](https://github.com/swiftlang/swift-experimental-string-processing/pull/866). How builder concatenations are flattened and coalesced is clearly in flux, so this PR moves the patterns off that code path rather than dodging individual broken shapes.

All five CSS color patterns are now built from `RegexBuilder` primitives only (string literals, `Capture`, `Optionally`, `ZeroOrMore(.whitespace)`, `OneOrMore(.whitespace)`), sharing small `cssNumber`, `cssNumberOrPercent` and `commaSeparator` components. A comment on the section documents the constraint so the fragments don't sneak back in.

Isolation of the root cause: one identical test binary spawned via `simctl` passes on the iOS 26.1 and 26.5 simulator runtimes and on macOS 26.5, and fails only on the iOS 27.0 beta (24A5355p). Byte-for-byte copies of the new patterns were verified against the full test input set (including capture contents and negative cases) on all four runtimes before porting.

# Test Plan

`et native-unit-tests -p ios --packages expo-modules-core` on the iOS 27.0 beta simulator: all 696 tests pass, including the nine previously failing `hsl()`/`hsla()` tests and the existing `rgb()`/`hwb()` coverage. Before the fix, the same run failed exactly those nine tests.
