### PR TITLE
fix(expo-modules-autolinking): Honor explicit `null` platform overrides

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Respect explicit per-platform null overrides from project `react-native.config.js` files when merging dependency config from packages that ship their own config. ([#47545](https://github.com/expo/expo/pull/47545) by [@chownation](https://github.com/chownation))
 - [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.4.1` upstream defaults, adding the `CSS/core/transition` and `PseudoStyles` header mappings along with the missing `IOS_CSS_CORE_ANIMATION` and `USE_ANIMATION_BACKEND` feature flags so its XCFramework builds. ([#46950](https://github.com/expo/expo/pull/46950) by [@zoontek](https://github.com/zoontek))
 - Fixed build error for unresolvable `expo-modules-macros-plugin`. ([#46294](https://github.com/expo/expo/pull/46294) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] Stop discarding xcconfig changes made by other `post_install` hooks, which broke builds against React Native nightlies with `include of non-modular header inside framework module 'React.…'`. ([#49038](https://github.com/expo/expo/pull/49038) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `'React/RCTBridge.h' file not found` with `ios.useFrameworks: "dynamic"` by reverting the dynamic-framework linkage guard from [#47500](https://github.com/expo/expo/pull/47500). Under `:dynamic` linkage every pod target is already a dynamic framework, so the guard skipped the whole `USE_FRAMEWORKS` downgrade. `@rnmapbox/maps` 10.3.2 no longer needs the guard because it skips its own dynamic flip when precompiled modules are enabled. ([#48869](https://github.com/expo/expo/pull/48869) by [@kudo](https://github.com/kudo))
 - [iOS] Pull a 3rd-party pod's prebuilt XCFramework to source when a dependent 3rd-party pod builds from source, fixing `'worklets/Compat/StableApi.h' file not found`. ([#49147](https://github.com/expo/expo/pull/49147) by [@chrfalch](https://github.com/chrfalch))
+- Respect explicit per-platform `null` overrides from project `react-native.config.js` files ([#47545](https://github.com/expo/expo/pull/47545) by [@chownation](https://github.com/chownation))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/reactNativeConfig-test.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/reactNativeConfig-test.ts
@@ -516,13 +516,19 @@ describe(resolveReactNativeModule, () => {
   });
 
   itWithMemoize(
-    'should preserve library config when project config sets platform to null (deep merge)',
+    'should honor project config null platform overrides when library config has platform data',
     async () => {
+      const androidResolver = require('../androidResolver');
+      const mockPlatformResolverAndroid = jest.spyOn(
+        androidResolver,
+        'resolveDependencyConfigImplAndroidAsync'
+      );
+      mockPlatformResolverAndroid.mockResolvedValueOnce(null);
       const projectConfig: RNConfigReactNativeProjectConfig = {
         dependencies: {
           'react-native-test': {
             platforms: {
-              ios: null,
+              android: null,
             },
           },
         },
@@ -530,9 +536,9 @@ describe(resolveReactNativeModule, () => {
       const libraryConfig: RNConfigReactNativeLibraryConfig = {
         dependency: {
           platforms: {
-            ios: {
-              configurations: ['Debug'],
-              scriptPhases: [{ name: 'test', path: './test.js' }],
+            android: {
+              sourceDir: './android',
+              cmakeListsPath: './src/main/jni/CMakeLists.txt',
             },
           },
         },
@@ -550,20 +556,16 @@ describe(resolveReactNativeModule, () => {
           depth: 0,
         },
         projectConfig,
-        'ios',
+        'android',
         new Set()
       );
 
-      // Deep merge preserves the target object when the source is null,
-      // so the library's ios config is kept.
-      expect(mockPlatformResolverIos).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/app/node_modules/react-native-test' }),
-        {
-          configurations: ['Debug'],
-          scriptPhases: [{ name: 'test', path: './test.js' }],
-        },
+      expect(mockPlatformResolverAndroid).toHaveBeenCalledWith(
+        '/app/node_modules/react-native-test',
+        null,
         undefined
       );
+      mockPlatformResolverAndroid.mockRestore();
     }
   );
 

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/reactNativeConfig-test.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/reactNativeConfig-test.ts
@@ -556,13 +556,19 @@ describe(resolveReactNativeModule, () => {
   });
 
   itWithMemoize(
-    'should preserve library config when project config sets platform to null (deep merge)',
+    'should honor project config null platform overrides when library config has platform data',
     async () => {
+      const androidResolver = require('../androidResolver');
+      const mockPlatformResolverAndroid = jest.spyOn(
+        androidResolver,
+        'resolveDependencyConfigImplAndroidAsync'
+      );
+      mockPlatformResolverAndroid.mockResolvedValueOnce(null);
       const projectConfig: RNConfigReactNativeProjectConfig = {
         dependencies: {
           'react-native-test': {
             platforms: {
-              ios: null,
+              android: null,
             },
           },
         },
@@ -570,9 +576,9 @@ describe(resolveReactNativeModule, () => {
       const libraryConfig: RNConfigReactNativeLibraryConfig = {
         dependency: {
           platforms: {
-            ios: {
-              configurations: ['Debug'],
-              scriptPhases: [{ name: 'test', path: './test.js' }],
+            android: {
+              sourceDir: './android',
+              cmakeListsPath: './src/main/jni/CMakeLists.txt',
             },
           },
         },
@@ -590,20 +596,16 @@ describe(resolveReactNativeModule, () => {
           depth: 0,
         },
         projectConfig,
-        'ios',
+        'android',
         new Set()
       );
 
-      // Deep merge preserves the target object when the source is null,
-      // so the library's ios config is kept.
-      expect(mockPlatformResolverIos).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/app/node_modules/react-native-test' }),
-        {
-          configurations: ['Debug'],
-          scriptPhases: [{ name: 'test', path: './test.js' }],
-        },
+      expect(mockPlatformResolverAndroid).toHaveBeenCalledWith(
+        '/app/node_modules/react-native-test',
+        null,
         undefined
       );
+      mockPlatformResolverAndroid.mockRestore();
     }
   );
 

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/reactNativeConfig.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/reactNativeConfig.ts
@@ -36,6 +36,7 @@ import { checkDependencyWebAsync } from './webResolver';
 const deepObjectMerge = (target: any, source: any): any => {
   if (
     source !== undefined &&
+    source !== null &&
     typeof target === 'object' &&
     target != null &&
     !Array.isArray(target) &&


### PR DESCRIPTION
# Why

Fixes #47544.

Project-level `react-native.config.js` can use `platforms.<platform>: null` to disable autolinking for one platform. `expo-modules-autolinking` already treats an explicit `null` as a skip once it reaches the platform resolver, but the deep merge between a library config and a project override swallowed `null` when the library already had a plain object at that path.

# How

Treat explicit `null` as a leaf override in `deepObjectMerge` instead of entering the object-merge branch. This lets the project override replace the library platform config with `null`, while preserving the existing deep-merge behavior for object overrides.

I also updated the existing regression test that encoded the previous behavior so Android `platforms.android: null` is passed through to the resolver as `null`, and left the adjacent nested-object merge coverage intact.

# Test Plan

- `pnpm run test -- src/reactNativeConfig/__tests__/reactNativeConfig-test.ts`
  - `Test Suites: 1 passed, 1 total`
  - `Tests: 21 passed, 21 total`
- `pnpm run test`
  - `Test Suites: 21 passed, 21 total`
  - `Tests: 241 passed, 241 total`
- `pnpm run typecheck`
- `pnpm run lint`

Before opening this PR, I also checked open PRs for `deepObjectMerge expo-modules-autolinking`, `platforms.android null autolinking`, and `react-native.config null autolinking`; all returned no matches.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
