### PR TITLE
[ios][core] Expand JavaScriptCodable and macro integration test coverage

### DIFF
--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableArrayBufferTests.swift
@@ -128,6 +128,44 @@ struct JavaScriptCodableArrayBufferTests {
     #expect(Array(decoded[0].data) == [10, 11])
   }
 
+  // MARK: - Error paths
+
+  @Test
+  func `decode throws for a non-object value`() throws {
+    let runtime = try runtime
+    #expect(throws: ArrayBufferJavaScriptValueConversionException.self) {
+      _ = try ArrayBuffer.decode(runtime.eval("42"), in: runtime)
+    }
+  }
+
+  @Test
+  func `decode throws for an object that is neither ArrayBuffer nor typed array`() throws {
+    let runtime = try runtime
+    #expect(throws: ArrayBufferJavaScriptValueConversionException.self) {
+      _ = try ArrayBuffer.decode(runtime.eval("({})"), in: runtime)
+    }
+  }
+
+  // MARK: - Empty and wide-element buffers
+
+  @Test
+  func `decodes an empty ArrayBuffer`() throws {
+    // A zero-length buffer short-circuits the borrow/copy logic; it must not touch a base address.
+    let runtime = try runtime
+    let decoded = try ArrayBuffer.decode(runtime.eval("new Uint8Array([]).buffer"), in: runtime)
+    #expect(decoded.byteLength == 0)
+    #expect(decoded.isNativeBacked == true)
+  }
+
+  @Test
+  func `decodes the raw bytes of a wide-element typed array buffer`() throws {
+    // `ArrayBuffer` is byte-oriented; a `Float64Array.buffer` is 8 bytes per element, so `byteLength`
+    // must reflect bytes (16), not element count (2) — a element-vs-byte confusion would fail here.
+    let runtime = try runtime
+    let decoded = try ArrayBuffer.decode(runtime.eval("new Float64Array([1.5, -2.5]).buffer"), in: runtime)
+    #expect(decoded.byteLength == 16)
+  }
+
   private func makeArrayBuffer(bytes: [UInt8]) throws -> ArrayBuffer {
     return try ArrayBuffer.copy(data: Data(bytes))
   }

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableEnumerableTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableEnumerableTests.swift
@@ -48,13 +48,60 @@ struct JavaScriptCodableEnumerableTests {
     #expect(encoded.getInt() == 1)
   }
 
+  // MARK: - Round-trips
+
+  @Test
+  func `round-trips a string enum`() throws {
+    let runtime = try runtime
+    for color in [CodableColor.red, .green] {
+      let roundTripped = try CodableColor.decode(CodableColor.encode(color, in: runtime), in: runtime)
+      #expect(roundTripped == color)
+    }
+  }
+
+  @Test
+  func `round-trips an int enum`() throws {
+    let runtime = try runtime
+    for priority in [CodablePriority.low, .high] {
+      let roundTripped = try CodablePriority.decode(CodablePriority.encode(priority, in: runtime), in: runtime)
+      #expect(roundTripped == priority)
+    }
+  }
+
+  // MARK: - Encoded primitive kind
+
+  @Test
+  func `encodes a string enum to a JS string and an int enum to a JS number`() throws {
+    let runtime = try runtime
+    #expect(try CodableColor.encode(.red, in: runtime).isString())
+    #expect(try CodablePriority.encode(.low, in: runtime).isNumber())
+  }
+
   // MARK: - Error paths
 
   @Test
-  func `enum decode throws on an unknown raw value`() throws {
+  func `string enum decode throws no-such-value for an unknown raw value`() throws {
+    let runtime = try runtime
+    #expect(throws: EnumNoSuchValueException.self) {
+      _ = try CodableColor.decode(runtime.eval("'purple'"), in: runtime)
+    }
+  }
+
+  @Test
+  func `int enum decode throws no-such-value for an out-of-range raw value`() throws {
+    let runtime = try runtime
+    #expect(throws: EnumNoSuchValueException.self) {
+      _ = try CodablePriority.decode(runtime.eval("3"), in: runtime)
+    }
+  }
+
+  @Test
+  func `string enum decode throws before create when the JS value is the wrong type`() throws {
+    // A number can't decode into the `String` raw value, so `RawValue.decode` throws before
+    // `create(fromRawValue:)` is ever reached — a distinct failure mode from a no-such-value.
     let runtime = try runtime
     #expect(throws: (any Error).self) {
-      _ = try CodableColor.decode(runtime.eval("'purple'"), in: runtime)
+      _ = try CodableColor.decode(runtime.eval("42"), in: runtime)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableRecordTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableRecordTests.swift
@@ -13,6 +13,43 @@ struct CodablePoint: Equatable {
   var y: Double = 0
 }
 
+// Covers the optional/nullable field shape: `label` is nullable-and-optional, `note` optional with a
+// default. Neither is required, so both may be omitted from the source object.
+@Record
+struct CodableLabeledPoint: Equatable {
+  var x: Double = 0
+  var label: String? = nil
+  var note: String = "unset"
+}
+
+// Covers a required field (non-optional, no default). `from(object:)` throws when it is omitted.
+@Record
+struct CodableRequiredPoint: Equatable {
+  var x: Double
+  var y: Double = 0
+}
+
+// Covers a record whose field is itself a record, exercising nested `from(object:)`/`toObject()`.
+@Record
+struct CodableLine: Equatable {
+  var start: CodablePoint = CodablePoint()
+  var end: CodablePoint = CodablePoint()
+}
+
+// Covers non-`Double` field types in one place: string, int, bool, array, and dictionary.
+@Record
+struct CodableMixed: Equatable {
+  var name: String = ""
+  var count: Int = 0
+  var enabled: Bool = false
+  var tags: [String] = []
+  var scores: [String: Int] = [:]
+}
+
+// Covers the zero-field boundary: the field-iteration loops run over nothing.
+@Record
+struct CodableEmpty: Equatable {}
+
 @Suite("JavaScriptCodable+Record")
 @JavaScriptActor
 struct JavaScriptCodableRecordTests {
@@ -80,5 +117,104 @@ struct JavaScriptCodableRecordTests {
     #expect(throws: Exceptions.AppContextNotFound.self) {
       _ = try CodablePoint.encode(CodablePoint(x: 1, y: 2), in: bareRuntime)
     }
+  }
+
+  // MARK: - Optional and nullable fields
+
+  @Test
+  func `round-trips a record whose optional field is set`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 1, label: 'a', note: 'b' })")
+    let decoded = try CodableLabeledPoint.decode(value, in: runtime)
+    #expect(decoded == CodableLabeledPoint(x: 1, label: "a", note: "b"))
+    let reencoded = try CodableLabeledPoint.encode(decoded, in: runtime)
+    let object = reencoded.getObject()
+    #expect(object.getProperty("label").getString() == "a")
+    #expect(object.getProperty("note").getString() == "b")
+  }
+
+  @Test
+  func `encodes a nil optional field as JS null`() throws {
+    let runtime = try runtime
+    let encoded = try CodableLabeledPoint.encode(CodableLabeledPoint(x: 1, label: nil, note: "b"), in: runtime)
+    #expect(encoded.getObject().getProperty("label").isNull())
+  }
+
+  @Test
+  func `decodes a null optional field as nil`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 1, label: null, note: 'b' })")
+    let decoded = try CodableLabeledPoint.decode(value, in: runtime)
+    #expect(decoded.label == nil)
+  }
+
+  @Test
+  func `keeps the declared default when an optional field is omitted`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 1 })")
+    let decoded = try CodableLabeledPoint.decode(value, in: runtime)
+    #expect(decoded.label == nil)
+    #expect(decoded.note == "unset")
+  }
+
+  // MARK: - Required fields and conversion errors
+
+  @Test
+  func `decode throws when a required field is missing`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ y: 2 })")
+    #expect(throws: (any Error).self) {
+      _ = try CodableRequiredPoint.decode(value, in: runtime)
+    }
+  }
+
+  @Test
+  func `decode throws when a field has the wrong type`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ x: 'not a number', y: 2 })")
+    #expect(throws: (any Error).self) {
+      _ = try CodablePoint.decode(value, in: runtime)
+    }
+  }
+
+  // MARK: - Nested and multi-type fields
+
+  @Test
+  func `round-trips a record containing a nested record`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ start: { x: 1, y: 2 }, end: { x: 3, y: 4 } })")
+    let decoded = try CodableLine.decode(value, in: runtime)
+    #expect(decoded == CodableLine(start: CodablePoint(x: 1, y: 2), end: CodablePoint(x: 3, y: 4)))
+    let reencoded = try CodableLine.encode(decoded, in: runtime)
+    let start = reencoded.getObject().getProperty("start").getObject()
+    #expect(start.getProperty("x").getDouble() == 1)
+    #expect(start.getProperty("y").getDouble() == 2)
+  }
+
+  @Test
+  func `round-trips a record with string, int, bool, array and dictionary fields`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ name: 'a', count: 3, enabled: true, tags: ['x', 'y'], scores: { a: 1 } })")
+    let decoded = try CodableMixed.decode(value, in: runtime)
+    #expect(decoded == CodableMixed(name: "a", count: 3, enabled: true, tags: ["x", "y"], scores: ["a": 1]))
+    let reencoded = try CodableMixed.encode(decoded, in: runtime)
+    let object = reencoded.getObject()
+    #expect(object.getProperty("name").getString() == "a")
+    #expect(object.getProperty("count").getInt() == 3)
+    #expect(object.getProperty("enabled").getBool() == true)
+    #expect(object.getProperty("tags").getArray().length == 2)
+    #expect(object.getProperty("scores").getObject().getProperty("a").getInt() == 1)
+  }
+
+  // MARK: - Empty record
+
+  @Test
+  func `round-trips an empty record`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({})")
+    let decoded = try CodableEmpty.decode(value, in: runtime)
+    #expect(decoded == CodableEmpty())
+    let reencoded = try CodableEmpty.encode(decoded, in: runtime)
+    #expect(reencoded.isObject())
   }
 }

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableTypedArrayTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableTypedArrayTests.swift
@@ -139,4 +139,49 @@ struct JavaScriptCodableTypedArrayTests {
     #expect(decoded.kind == .Uint8Array)
     #expect(decoded[0] == 5)
   }
+
+  // MARK: - Remaining concrete kinds
+
+  @Test
+  func `decodes the remaining concrete kinds`() throws {
+    let runtime = try runtime
+    #expect(try Int8Array.decode(runtime.eval("new Int8Array([1])"), in: runtime).kind == .Int8Array)
+    #expect(try Uint16Array.decode(runtime.eval("new Uint16Array([1])"), in: runtime).kind == .Uint16Array)
+    #expect(try Uint32Array.decode(runtime.eval("new Uint32Array([1])"), in: runtime).kind == .Uint32Array)
+    #expect(try BigUint64Array.decode(runtime.eval("new BigUint64Array([1n])"), in: runtime).kind == .BigUint64Array)
+  }
+
+  @Test
+  func `decodes a Uint8ClampedArray distinctly from a Uint8Array`() throws {
+    // `Uint8ClampedArray` shares the `UInt8` element type with `Uint8Array`, so its `.kind` is the only
+    // thing distinguishing the two — a copy/paste kind bug would surface here.
+    let runtime = try runtime
+    let decoded = try Uint8ClampedArray.decode(runtime.eval("new Uint8ClampedArray([1, 2])"), in: runtime)
+    #expect(decoded.kind == .Uint8ClampedArray)
+  }
+
+  // MARK: - Element fidelity
+
+  @Test
+  func `decodes signed and wide integer boundary values`() throws {
+    let runtime = try runtime
+    let int8 = try Int8Array.decode(runtime.eval("new Int8Array([-128, 127])"), in: runtime)
+    #expect(int8[0] == -128)
+    #expect(int8[1] == 127)
+    let uint32 = try Uint32Array.decode(runtime.eval("new Uint32Array([4294967295])"), in: runtime)
+    #expect(uint32[0] == 4_294_967_295)
+    let bigInt64 = try BigInt64Array.decode(runtime.eval("new BigInt64Array([-9223372036854775808n])"), in: runtime)
+    #expect(bigInt64[0] == Int64.min)
+  }
+
+  // MARK: - Empty typed array
+
+  @Test
+  func `decodes an empty typed array`() throws {
+    // An empty typed array has no backing storage; the decode must not dereference a nil base address.
+    let runtime = try runtime
+    let decoded = try Uint8Array.decode(runtime.eval("new Uint8Array([])"), in: runtime)
+    #expect(decoded.kind == .Uint8Array)
+    #expect(decoded.length == 0)
+  }
 }

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroEventTests.swift
@@ -11,7 +11,13 @@ private struct ProgressEvent {
   var percent: Int = 0
 }
 
-@ExpoModule
+@SharedObject
+private final class MacroEmittingObject: SharedObject {
+  @Event
+  var onTicked: (ProgressEvent) -> Void
+}
+
+@ExpoModule(classes: [MacroEmittingObject.self])
 private final class MacroEmitter: Module {
   @Event
   var onProgress: (ProgressEvent) -> Void
@@ -59,6 +65,23 @@ private struct MacroEventTests {
     module.onDone()
 
     try await expectResult(equals: 1)
+  }
+
+  @Test
+  func `emits an event from a shared object to a JS listener`() async throws {
+    let object = MacroEmittingObject()
+    // Encoding pairs the native object with a JS object and registers it; stash that on a global so a
+    // listener can be attached from JS.
+    let encoded = try MacroEmittingObject.encode(object, in: runtime)
+    try runtime.global().setProperty("emittingObject", value: encoded)
+    try runtime.eval("""
+      globalThis.result = null
+      emittingObject.addListener('ticked', payload => { globalThis.result = payload.percent })
+      """)
+
+    object.onTicked(ProgressEvent(percent: 30))
+
+    try await expectResult(equals: 30)
   }
 
   nonisolated private func expectResult(equals expected: Int) async throws {

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
@@ -6,6 +6,12 @@ import Testing
 
 // MARK: - Test modules
 
+@Record
+private struct MacroOptions {
+  var label: String = ""
+  var count: Int = 0
+}
+
 @ExpoModule
 private final class MacroGreeter: Module {
   @JS
@@ -21,6 +27,29 @@ private final class MacroGreeter: Module {
   @JS
   var status: String {
     return "ok"
+  }
+
+  // A settable stored property.
+  @JS
+  var nickname: String = ""
+
+  // A `Record` argument and return.
+  @JS
+  func repeated(options: MacroOptions) -> MacroOptions {
+    return MacroOptions(label: options.label, count: options.count + 1)
+  }
+
+  // A throwing function, whose coded error surfaces to JS.
+  @JS
+  func fail() throws {
+    throw TestCodedException()
+  }
+
+  // An async function, which returns a Promise on the JS side.
+  @JS
+  @JavaScriptActor
+  func delayed(value: String) async throws -> String {
+    return value
   }
 }
 
@@ -97,5 +126,56 @@ private struct MacroModuleTests {
   func `binds a @JS property`() throws {
     register(MacroGreeter(appContext: appContext))
     #expect(try runtime.eval("expo.modules.MacroGreeter.status").asString() == "ok")
+  }
+
+  @Test
+  func `binds a settable @JS property, decoding the assigned value`() throws {
+    register(MacroGreeter(appContext: appContext))
+    let value = try runtime.eval(
+      """
+      expo.modules.MacroGreeter.nickname = 'Ada'
+      expo.modules.MacroGreeter.nickname
+      """)
+    #expect(try value.asString() == "Ada")
+  }
+
+  // MARK: - Async functions
+
+  @Test
+  func `binds an async @JS function that returns a promise`() async throws {
+    register(MacroGreeter(appContext: appContext))
+    let result = try await runtime.evalAsync("expo.modules.MacroGreeter.delayed('done')")
+    #expect(try await result.asString() == "done")
+  }
+
+  // MARK: - Non-primitive decode/encode
+
+  @Test
+  func `decodes and encodes a Record across a @JS function`() throws {
+    register(MacroGreeter(appContext: appContext))
+    let result = try runtime.eval("expo.modules.MacroGreeter.repeated({ label: 'a', count: 2 })").asObject()
+    #expect(try result.getProperty("label").asString() == "a")
+    #expect(try result.getProperty("count").asInt() == 3)
+  }
+
+  // MARK: - Error propagation
+
+  @Test
+  func `a throwing @JS function surfaces a coded JS error`() throws {
+    register(MacroGreeter(appContext: appContext))
+    let code = try runtime.eval("try { expo.modules.MacroGreeter.fail() } catch (error) { error.code }")
+    #expect(try code.asString() == "E_TEST_CODE")
+  }
+
+  // MARK: - Argument arity
+
+  @Test
+  func `calling a @JS function with the wrong argument count throws`() throws {
+    register(MacroGreeter(appContext: appContext))
+    // `greet` takes one argument; calling it with none trips the synthesized arity check, whose
+    // message names the function and the argument counts.
+    let message = try runtime.eval("try { expo.modules.MacroGreeter.greet(); '' } catch (error) { error.message }")
+    #expect(try message.asString().contains("greet"))
+    #expect(try message.asString().contains("argument"))
   }
 }


### PR DESCRIPTION
## Why

The `JavaScriptCodable` conversion suites and the macro integration tests had gaps: several conformances and macro-generated bindings were only exercised on the happy path, so error paths, edge shapes, and less-common member kinds were unverified. This adds that coverage. Test-only, no runtime changes.

## How

**JavaScriptCodable conformances** (`packages/expo-modules-core/ios/Tests/JavaScriptCodable*Tests.swift`):
- **Record**: optional/nullable field round-trips (nil to/from JS `null`), omitted-optional keeps its default, missing required field throws, wrong-typed field propagates the error, nested record, mixed field types (string/int/bool/array/dictionary), and empty record.
- **Enumerable**: string- and int-backed round-trips, encoded-primitive kind (`isString`/`isNumber`), and the error paths (no-such-value for both backings, and a wrong JS type failing before the enum case lookup).
- **TypedArray**: the concrete kinds that weren't decoded (`Int8`/`Uint16`/`Uint32`/`BigUint64`), `Uint8ClampedArray` distinct from `Uint8Array`, signed/wide/BigInt boundary values, and an empty typed array.
- **ArrayBuffer**: both decode error paths (non-object, and a plain object), an empty buffer, and a wide-element (`Float64Array.buffer`) byte-length check.

**Macro integration** (`packages/expo-modules-core/ios/Tests/Macros/`):
- **Module**: settable `@JS var`, a `@Record` argument/return, an `async` function returning a promise, a throwing function surfacing a coded JS error, and an argument-arity mismatch.
- **Event**: a shared-object `@Event`, a distinct binding path from module events (the accessor's `self` is the concrete instance).

The async `@JS` module function carries an explicit `@JavaScriptActor` stamp, matching the macro change in expo/expo-modules-macros-plugin#30 that stamps async members automatically.

## Test Plan

`et native-unit-tests -p ios --packages expo-modules-core`: all 5 `JavaScriptCodable` suites and all 3 macro suites (module, shared object, event) pass. The only failures in the run are pre-existing, unrelated `ColorConvertiblesTests` HSL-parsing cases.
