### PR TITLE
[expo-modules-autolinking][iOS] Fix Array HEADER_SEARCH_PATHS corrupting build settings in the precompiled modules hook

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Respect an explicit `ios.usePrecompiledModules: false` even when `EXPO_USE_PRECOMPILED_MODULES` is already set in the environment (e.g. EAS Build). ([#46983](https://github.com/expo/expo/pull/46983) by [@ryanda9910](https://github.com/ryanda9910))
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.5.0`'s generated component and native view sources. ([#47201](https://github.com/expo/expo/pull/47201) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`. ([#47478](https://github.com/expo/expo/pull/47478) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix corrupted `HEADER_SEARCH_PATHS` (stringified Ruby Array) written into every target's build settings by the precompiled modules post-install hook on React Native 0.86. ([#47552](https://github.com/expo/expo/pull/47552) by [@ahmetberkincoglu](https://github.com/ahmetberkincoglu))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -877,6 +877,11 @@ module Expo
         installer.pods_project.targets.each do |target|
           target.build_configurations.each do |config|
             existing = config.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)'
+            # HEADER_SEARCH_PATHS may be an Array (e.g. after React Native's own
+            # per-target header path merge). Interpolating an Array serializes it
+            # as '["$(inherited)", ...]' which Xcode treats as junk paths and
+            # shadows the pod xcconfig. Join to a space-separated string first.
+            existing = existing.join(' ') if existing.is_a?(Array)
             unless existing.include?(paths_string)
               config.build_settings['HEADER_SEARCH_PATHS'] = "#{existing} #{paths_string}"
             end


### PR DESCRIPTION
# Why

When iOS precompiled modules are enabled (the SDK 57 default) on React Native 0.86, `pod install` can write corrupted `HEADER_SEARCH_PATHS` into every target's build configuration, shadowing values from the pod xcconfig files. The first visible casualty in our app was `@shopify/react-native-skia`, which fails to compile with `'third_party/base64.h' file not found` because its `$(PODS_TARGET_SRCROOT)/cpp/**` search path (defined in its xcconfig) gets shadowed.

Root cause: in `precompiled_modules.rb`, the post-install hook assumes `config.build_settings['HEADER_SEARCH_PATHS']` is a String:

```ruby
existing = config.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)'
unless existing.include?(paths_string)
  config.build_settings['HEADER_SEARCH_PATHS'] = "#{existing} #{paths_string}"
end
```

But the value can be a Ruby **Array** (React Native 0.86's per-target header path handling leaves arrays in build settings). Then:

1. `existing.include?(paths_string)` performs Array element-equality membership instead of a substring check → always false
2. `"#{existing} #{paths_string}"` serializes the array via `Array#to_s`, producing literal `["$(inherited)", ...]` junk in the build setting

In a fresh SDK 57 app we counted **104 build configuration blocks** in the Pods project polluted this way after a single `pod install`.

# How

Coerce an Array value to a space-separated string before the membership check and interpolation:

```ruby
existing = existing.join(' ') if existing.is_a?(Array)
```

Before opening this PR I searched open PRs/issues for `HEADER_SEARCH_PATHS` and `precompiled_modules`; no matches for this problem.

# Test Plan

Reproduced in a production Expo SDK 57 / React Native 0.86 app (`EXPO_USE_PRECOMPILED_MODULES` enabled):

- **Before:** 104 config blocks in the generated Pods project contain the stringified-array junk; `@shopify/react-native-skia` fails to compile (`'third_party/base64.h' file not found`).
- **After:** 0 junk blocks; skia and the full app compile successfully.

We have been shipping this exact one-line change as a `yarn patch` against `expo-modules-autolinking@57.0.4` since the SDK 57 upgrade, validated through full device builds.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md). *(no docs impact)*
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
