### PR TITLE
[linear-gradient][ios] Fix crash when displaying the gradient layer with an invalid size

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a crash on iOS when the gradient layer is displayed with a non-finite or negative size. ([#47553](https://github.com/expo/expo/pull/47553) by [@kubilaiswf](https://github.com/kubilaiswf))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-07

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -53,7 +53,13 @@ final class LinearGradientLayer: CALayer {
   override func display() {
     super.display()
 
-    if colors.isEmpty || bounds.size.width.isZero || bounds.size.height.isZero {
+    let size = bounds.size
+    // Layout churn (e.g. recycled list cells) can briefly leave the layer with
+    // NaN or negative bounds, which pass the isZero check but trap in
+    // UIGraphicsBeginImageContextWithOptions on iOS 17+.
+    guard !colors.isEmpty,
+      size.width.isFinite, size.width > 0,
+      size.height.isFinite, size.height > 0 else {
       return
     }
     let hasAlpha = colors.reduce(false) { result, color in
@@ -69,22 +75,15 @@ final class LinearGradientLayer: CALayer {
 
   #if !os(macOS)
   private func setLayerContents(hasAlpha: Bool) {
-    UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
-
-    guard let contextRef = UIGraphicsGetCurrentContext() else {
-      return
-    }
-
-    draw(in: contextRef)
-
-    guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
-      return
+    let format = UIGraphicsImageRendererFormat.preferred()
+    format.opaque = !hasAlpha
+    let renderer = UIGraphicsImageRenderer(size: bounds.size, format: format)
+    let image = renderer.image { context in
+      draw(in: context.cgContext)
     }
 
     self.contents = image.cgImage
     self.contentsScale = image.scale
-
-    UIGraphicsEndImageContext()
   }
   #else
   private func setLayerContentsMacOS(hasAlpha: Bool) {


### PR DESCRIPTION
# Why

My TestFlight build (SDK 54, expo-linear-gradient 15.0.8) started crashing on iOS 26 with an assertion coming from `LinearGradientLayer.display()`:

```
Last Exception Backtrace:
2  Foundation   -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:]
3  UIKitCore    _UIGraphicsBeginImageContextWithOptions + 580 (UIGraphics.m:407)
4  Flompt       LinearGradientLayer.display() + 396 (LinearGradientLayer.swift:62)
5  QuartzCore   CA::Layer::layout_and_display_if_needed(CA::Transaction*)
```

It happened while fast-scrolling a list full of gradient views and switching tabs at the same time, so a recycled layer got displayed while its bounds were transient garbage. The existing guard only checks `isZero`, which lets NaN and negative sizes through, and since iOS 17 `UIGraphicsBeginImageContextWithOptions` raises an assertion for invalid sizes instead of just returning a nil context. Same code is still on `main`, so this affects current versions too.

# How

- Extended the size check in `display()` to also reject non-finite and negative sizes.
- Replaced the deprecated `UIGraphicsBeginImageContextWithOptions` / `UIGraphicsEndImageContext` pair with `UIGraphicsImageRenderer`, which is the recommended replacement and doesn't assert on degenerate sizes. Behavior is otherwise the same: opaque context when no color has alpha, device scale.

The macOS path (`setLayerContentsMacOS`) is untouched, it already builds its `CGContext` manually.

# Test Plan

I applied the same change to my app via patch-package. Gradients render as before, and the crash site is gone by construction: degenerate bounds bail out early, and `UIGraphicsImageRenderer` doesn't trap on unusual sizes the way the deprecated API does. The crash itself is a race during list cell recycling, so I couldn't reproduce it on demand, only in the wild on an iOS 26.6 device.
