### PR TITLE
[linear-gradient][ios] Render gradients on the GPU with CAGradientLayer

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Render gradients on the GPU with `CAGradientLayer` instead of CPU-rasterizing bitmaps on the main thread — fixes multi-second main-thread hangs on gradient-heavy screens, the `UIGraphics` invalid-size crash, and a division by zero with single-color gradients. ([#47554](https://github.com/expo/expo/pull/47554) by [@Eduard-R-Code](https://github.com/Eduard-R-Code))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-07

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -4,144 +4,141 @@ import QuartzCore
 import CoreGraphics
 import ExpoModulesCore
 
-var defaultStartPoint = CGPoint(x: 0.5, y: 0.0)
-var defaultEndPoint = CGPoint(x: 0.5, y: 1.0)
-var defaultLocations: [CGFloat] = []
+let defaultStartPoint = CGPoint(x: 0.5, y: 0.0) // == CAGradientLayer's own default
+let defaultEndPoint = CGPoint(x: 0.5, y: 1.0)   // == CAGradientLayer's own default
 
-final class LinearGradientLayer: CALayer {
-  var colors = [UIColor]()
-  var startPoint = defaultStartPoint
-  var endPoint = defaultEndPoint
-  var locations = defaultLocations
+/**
+ A `CAGradientLayer` subclass fed by the props of `LinearGradientModule`.
+
+ Previous implementations subclassed `CALayer` and CPU-rasterized the gradient
+ into a full-resolution bitmap on the main thread on every `display()`
+ (`UIGraphicsBeginImageContextWithOptions` → `CGContextDrawLinearGradient`).
+ Screens composing many gradients re-rasterized all of them inside a single
+ CA transaction whenever bounds or traits changed (rotation, foregrounding,
+ appearance switches), which shows up in the field as multi-second main-thread
+ hangs on thermally-throttled devices, and as crashes when the bounds were
+ non-finite (UIGraphics size assertions).
+
+ `CAGradientLayer` shades on the render server instead: no main-thread raster
+ work, no backing-store bitmap, and bounds changes are free because the
+ endpoints live in the unit coordinate space. Visual output is unchanged: the
+ default axis, the even-spacing locations fallback and the edge clamping
+ (`drawsBefore/AfterStartLocation`) all match CAGradientLayer's semantics.
+
+ Platform orientation note: the unit coordinate space follows each platform's
+ layer geometry — top-left origin on iOS/tvOS, bottom-left on macOS — which
+ reproduces the previous CPU implementation exactly (its UIKit image context
+ was flipped on iOS/tvOS while its hand-built macOS `CGContext` was not).
+ */
+final class LinearGradientLayer: CAGradientLayer {
+  // `CAGradientLayer` already declares `colors`, `startPoint`, `endPoint` and
+  // `locations`, so the JS-provided values are retained under different names.
+  // Keeping the UIColors (not just their CGColor projections) lets `display()`
+  // re-resolve dynamic colors against the current traits when the hosting view
+  // calls `setNeedsDisplay()` from `traitCollectionDidChange` /
+  // `viewDidChangeEffectiveAppearance`.
+  private var sourceColors: [UIColor] = []
+  private var sourceLocations: [CGFloat] = []
 
   override init() {
     super.init()
-    self.needsDisplayOnBoundsChange = true
     self.masksToBounds = true
+    // Intentionally NOT setting `needsDisplayOnBoundsChange`: resizing a
+    // CAGradientLayer requires no redisplay (unit-space endpoints).
+    self.startPoint = defaultStartPoint
+    self.endPoint = defaultEndPoint
   }
-  
+
   override init(layer: Any) {
+    // Presentation/model copies: super copies all CAGradientLayer properties
+    // (colors, locations, start/end points, masksToBounds); only the custom
+    // stored state needs copying here. Do not re-apply defaults — that would
+    // clobber the copied values.
     super.init(layer: layer)
-    self.needsDisplayOnBoundsChange = true
-    self.masksToBounds = true
+    if let layer = layer as? LinearGradientLayer {
+      self.sourceColors = layer.sourceColors
+      self.sourceLocations = layer.sourceLocations
+    }
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func setColors(_ colors: [UIColor]) {
-    self.colors = colors
-    setNeedsDisplay()
+  // The set* methods below are plain Swift methods (final class, no @objc
+  // inference), so they cannot collide with the Objective-C setters of the
+  // superclass properties (`setColors:`, `setLocations:`, ...). @nonobjc
+  // makes that guarantee explicit.
+
+  @nonobjc func setColors(_ colors: [UIColor]) {
+    sourceColors = colors
+    applyGradient()
   }
 
-  func setStartPoint(_ startPoint: CGPoint?) {
-    self.startPoint = startPoint ?? defaultStartPoint
-    setNeedsDisplay()
+  @nonobjc func setStartPoint(_ startPoint: CGPoint?) {
+    withDisabledActions {
+      self.startPoint = startPoint ?? defaultStartPoint
+    }
   }
 
-  func setEndPoint(_ endPoint: CGPoint?) {
-    self.endPoint = endPoint ?? defaultEndPoint
-    setNeedsDisplay()
+  @nonobjc func setEndPoint(_ endPoint: CGPoint?) {
+    withDisabledActions {
+      self.endPoint = endPoint ?? defaultEndPoint
+    }
   }
 
-  func setLocations(_ locations: [CGFloat]?) {
-    self.locations = locations ?? defaultLocations
-    setNeedsDisplay()
+  @nonobjc func setLocations(_ locations: [CGFloat]?) {
+    sourceLocations = locations ?? []
+    applyGradient()
   }
 
+  // `LinearGradientView` calls `layer.setNeedsDisplay()` on trait/appearance
+  // changes. A CAGradientLayer has no backing store to redraw, so `display()`
+  // is repurposed to re-resolve possibly-dynamic colors under the new traits.
+  // Deliberately does NOT call super: CALayer's default `display()` would walk
+  // the delegate drawing path and could allocate a useless backing store.
   override func display() {
-    super.display()
-
-    if colors.isEmpty || bounds.size.width.isZero || bounds.size.height.isZero {
-      return
-    }
-    let hasAlpha = colors.reduce(false) { result, color in
-      return result || color.cgColor.alpha < 1.0
-    }
-
-    #if os(macOS)
-    setLayerContentsMacOS(hasAlpha: hasAlpha)
-    #else
-    setLayerContents(hasAlpha: hasAlpha)
-    #endif
+    applyGradient()
   }
 
-  #if !os(macOS)
-  private func setLayerContents(hasAlpha: Bool) {
-    UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
-
-    guard let contextRef = UIGraphicsGetCurrentContext() else {
-      return
-    }
-
-    draw(in: contextRef)
-
-    guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
-      return
-    }
-
-    self.contents = image.cgImage
-    self.contentsScale = image.scale
-
-    UIGraphicsEndImageContext()
-  }
-  #else
-  private func setLayerContentsMacOS(hasAlpha: Bool) {
-    let scale = contentsScale > 0 ? contentsScale : (NSScreen.main?.backingScaleFactor ?? 2.0)
-    let pixelWidth = Int(bounds.size.width * scale)
-    let pixelHeight = Int(bounds.size.height * scale)
-    if pixelWidth == 0 || pixelHeight == 0 {
-      return
-    }
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bitmapInfo: UInt32 = hasAlpha
-      ? CGImageAlphaInfo.premultipliedLast.rawValue
-      : CGImageAlphaInfo.noneSkipLast.rawValue
-    guard let ctx = CGContext(
-      data: nil,
-      width: pixelWidth,
-      height: pixelHeight,
-      bitsPerComponent: 8,
-      bytesPerRow: 0,
-      space: colorSpace,
-      bitmapInfo: bitmapInfo
-    ) else {
-      return
-    }
-    ctx.scaleBy(x: scale, y: scale)
-    draw(in: ctx)
-    self.contents = ctx.makeImage()
-    self.contentsScale = scale
-  }
-  #endif
-
-  override func draw(in ctx: CGContext) {
-    super.draw(in: ctx)
-
-    ctx.saveGState()
-
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let locations = colors.enumerated().map { (offset: Int, _: UIColor) -> CGFloat in
-      if self.locations.count > offset {
-        return self.locations[offset]
-      } else {
-        return CGFloat(offset) / CGFloat(colors.count - 1)
+  private func applyGradient() {
+    withDisabledActions {
+      if sourceColors.isEmpty {
+        self.colors = nil
+        self.locations = nil
+        return
       }
+      self.colors = sourceColors.map { $0.cgColor }
+      self.locations = effectiveLocations()
     }
-    let cgColors = colors.map { $0.cgColor } as CFArray
+  }
 
-    if let gradient = CGGradient(colorsSpace: colorSpace, colors: cgColors, locations: locations) {
-      let size = bounds.size
-
-      ctx.drawLinearGradient(
-        gradient,
-        start: CGPoint(x: startPoint.x * size.width, y: startPoint.y * size.height),
-        end: CGPoint(x: endPoint.x * size.width, y: endPoint.y * size.height),
-        options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
-      )
+  // Mirrors the previous implementation's semantics exactly: entries missing
+  // from the `locations` prop fall back to an even distribution (i / (n - 1));
+  // extra entries beyond `colors.count` are ignored. Returning nil means
+  // "uniform", which is CAGradientLayer's native behavior and equals the
+  // fallback formula. (Also fixes the previous n == 1 division by zero.)
+  private func effectiveLocations() -> [NSNumber]? {
+    if sourceLocations.isEmpty || sourceColors.count < 2 {
+      return nil
     }
+    return sourceColors.enumerated().map { offset, _ in
+      if sourceLocations.count > offset {
+        return NSNumber(value: Double(sourceLocations[offset]))
+      }
+      return NSNumber(value: Double(offset) / Double(sourceColors.count - 1))
+    }
+  }
 
-    ctx.restoreGState()
+  // colors/locations/startPoint/endPoint are all implicitly animatable. UIKit
+  // suppresses implicit actions for a view's backing layer outside UIView
+  // animation blocks, but not inside them, and AppKit backing layers behave
+  // differently — so actions are disabled explicitly on every mutation path
+  // for deterministic, animation-free prop application.
+  private func withDisabledActions(_ body: () -> Void) {
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    body()
+    CATransaction.commit()
   }
 }


### PR DESCRIPTION
# Why

`LinearGradientLayer` subclasses `CALayer` and CPU-rasterizes every gradient into a full-resolution bitmap **on the main thread** inside `display()` (`UIGraphicsBeginImageContextWithOptions` → `CGContextDrawLinearGradient` → `argb32_shade_axial_RGB`), at device scale — cost ∝ width × height × scale². Because the layer sets `needsDisplayOnBoundsChange = true` and the view calls `setNeedsDisplay()` from `traitCollectionDidChange`, any bounds change, foreground restore, or appearance change re-rasterizes **every gradient on screen inside one CA transaction**.

In production (a fitness app with ~20 gradient layers per screen, including a full-screen one) this surfaced as Sentry **"App Hang Fully Blocked"** events of 3.6–5.3 s on an iPhone 16 Pro Max foregrounding under `thermal_state: serious` — the main thread pegged shading gradient pixels while the watchdog counted down:

<details>
<summary>Production main-thread stack (Sentry AppHang, iOS 26.5)</summary>

```
LinearGradientLayer.display
  → LinearGradientLayer.setLayerContents(hasAlpha:)
    → LinearGradientLayer.draw(in:)
      → CGContextDrawLinearGradient
        → argb32_shade_axial_RGB   ← 3.6–5.3 s of main-thread CPU shading
```

</details>

The same CPU path is the root cause of the invalid-size crash class tracked in #46110 (the `bounds.size.width.isZero` guard lets NaN/negative/∞ through to `UIGraphicsBeginImageContextWithOptions`), which #38221 and #47553 mitigate while keeping CPU rasterization.

# How

Rewrite `LinearGradientLayer` as a **`CAGradientLayer`** subclass, so the gradient is shaded by the render server (GPU):

- **Zero main-thread raster work** — `display()` becomes a cheap dynamic-color re-resolution hook (no `super` call, so CALayer never allocates a useless backing store).
- **No backing-store bitmap** — saves `w × h × 4 × scale²` bytes per gradient.
- **Bounds changes are free** — endpoints live in the unit coordinate space, so `needsDisplayOnBoundsChange` is gone entirely.
- **The `UIGraphics` invalid-size crash class disappears** — there is no image context left to assert on.
- Fixes a latent division by zero in the locations fallback when `colors.count == 1`.

The public surface consumed by `LinearGradientModule` / `LinearGradientView` (`setColors` / `setStartPoint` / `setEndPoint` / `setLocations`, the `gradientLayer` cast) is unchanged — no JS or module/view edits. The setters are `@nonobjc` so they cannot collide with the ObjC setters of the inherited `colors`/`locations`/`startPoint`/`endPoint` properties; JS values are retained as `sourceColors`/`sourceLocations` so dynamic colors (e.g. `PlatformColor`) still re-resolve on trait/appearance changes.

## Semantics preserved

| Behavior | Before (CPU raster) | After (CAGradientLayer) |
|---|---|---|
| Default axis | `(0.5, 0) → (0.5, 1)` | identical (CAGradientLayer's own default) |
| Missing `locations` entries | filled as `i / (n − 1)` | `nil` locations = uniform spacing (same formula); explicit arrays honored per-index |
| Edge extension | `.drawsBeforeStartLocation` / `.drawsAfterEndLocation` | CAGradientLayer's native edge clamping (equivalent) |
| `masksToBounds` | `true` | `true` |
| Trait/appearance change | full re-raster | color re-resolution only |
| Implicit animations | none (bitmap swap) | explicitly disabled via `CATransaction.setDisableActions` on every mutation |
| macOS orientation | hand-built `CGContext` (unflipped, bottom-origin) | CAGradientLayer's macOS unit space is also bottom-origin — output unchanged |

**Platform note:** the unit coordinate space follows each platform's layer geometry (top-left origin on iOS/tvOS, bottom-left on macOS), which reproduces the current implementation's per-platform output exactly — the UIKit image context was flipped while the macOS `CGContext` was not. If unifying macOS orientation with iOS is ever desired, that should be a deliberate follow-up, not a side effect of this PR.

# Test Plan

- Running in production via `patch-package` in a React Native app with 110 `LinearGradient` call sites (~20 layers per screen commit): output is visually identical across glass-card overlays (3-stop translucent gradients), full-screen backgrounds, buttons, and tab bars; dark-mode toggles snap with no implicit crossfades.
- App's full test suite (16k+ tests) green; `ExpoLinearGradient` pod target compiles clean against `ExpoModulesCore`.
- Instruments Time Profiler: `argb32_shade_axial_RGB` / `CGContextDrawLinearGradient` / `LinearGradientLayer.display` gone from the main thread after the change; foreground-cycling under Thermal State: Critical no longer hangs.
- tvOS/macOS: `CAGradientLayer` is available on all targeted platforms (tvOS 9+/macOS 10.6+; podspec floors are 16.4/13.4) with no availability guards required — compile-level validation via CI.

# Related

- Fixes the crash class described in #46110.
- Overlaps with #47553 and #38221 (both replace the deprecated `UIGraphicsBeginImageContextWithOptions` with `UIGraphicsImageRenderer` but keep CPU rasterization) — this PR removes the image context altogether, which resolves the same crash while also eliminating the rasterization cost.

# Checklist

- [x] Documentation is up to date to reflect these changes — no public API change.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: no addition of custom native code).
