### PR TITLE
[docs] Hide markdown actions until the router is ready to fix hydration mismatch

### DIFF
--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -132,4 +132,44 @@ describe(PageHeader, () => {
     );
     expect(linkElement.getAttribute('aria-label')).toEqual('Edit content of this page on GitHub');
   });
+
+  test('hides markdown actions on the hydration render even when the URL has a version pair', () => {
+    renderWithTestRouter(<PageHeader title="Upgrade native project" />, {
+      pathname: '/bare/upgrade',
+      asPath: '/bare/upgrade/?fromSdk=56&toSdk=57',
+      isReady: false,
+    });
+
+    expect(screen.queryAllByText('Copy page')).toHaveLength(0);
+  });
+
+  test('shows markdown actions once the router is ready with a version pair', () => {
+    renderWithTestRouter(<PageHeader title="Upgrade native project" />, {
+      pathname: '/bare/upgrade',
+      asPath: '/bare/upgrade/?fromSdk=56&toSdk=57',
+      isReady: true,
+    });
+
+    expect(screen.queryAllByText('Copy page').length).toBeGreaterThan(0);
+  });
+
+  test('keeps markdown actions hidden on the upgrade helper without a version pair', () => {
+    renderWithTestRouter(<PageHeader title="Upgrade native project" />, {
+      pathname: '/bare/upgrade',
+      asPath: '/bare/upgrade/',
+      isReady: true,
+    });
+
+    expect(screen.queryAllByText('Copy page')).toHaveLength(0);
+  });
+
+  test('shows markdown actions on regular pages during the hydration render', () => {
+    renderWithTestRouter(<PageHeader title="Overview" />, {
+      pathname: '/guides/overview',
+      asPath: '/guides/overview/',
+      isReady: false,
+    });
+
+    expect(screen.queryAllByText('Copy page').length).toBeGreaterThan(0);
+  });
 });

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -3,7 +3,11 @@ import { useRouter } from 'next/compat/router';
 
 import { WithTestRequire } from '~/types/common';
 import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/MarkdownActionsDropdown';
-import { hasDynamicData, shouldShowMarkdownActions } from '~/ui/components/MarkdownActions/paths';
+import {
+  hasDynamicData,
+  normalizePath,
+  shouldShowMarkdownActions,
+} from '~/ui/components/MarkdownActions/paths';
 import { H1, P } from '~/ui/components/Text';
 
 import { AskPageAIConfigTrigger, AskPageAITrigger } from '../AskPageAI/AskPageAITrigger';
@@ -44,7 +48,7 @@ export function PageHeader({
   const currentPath = router?.asPath ?? router?.pathname ?? '';
   const showMarkdownActions = shouldShowMarkdownActions({
     packageName,
-    path: currentPath,
+    path: router?.isReady ? currentPath : normalizePath(currentPath),
   });
   const showPackageMarkdown = packageName ? !hasDynamicData(currentPath) : false;
   const isSdkPage = currentPath.includes('/sdk/');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://github.com/expo/expo/pull/47498#pullrequestreview-4635314272

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix `PageHeader` to ignore the URL query until `router.isReady`, so the first client render matches the server-rendered HTML and the markdown actions reveal after hydration instead of triggering React error `#418` on `/bare/upgrade`.
- Add `PageHeader` tests covering the hydration render with a version pair in the URL, the post-ready reveal, and regular pages keeping their actions during hydration.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview and/or run locally and verify that opening http://localhost:3002/bare/upgrade/ or https://pr-47555.expo-docs.pages.dev/bare/upgrade/?fromSdk=55&toSdk=56, the hydration mismatch issue doesn't show up.

`pnpm test` should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
