### PR TITLE
[ui][ios] - Fix Host centering content instead of top-aligning

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `<Host>` centering its content instead of top-aligning it, so a `flex: 1` host matches Android's top-leading layout. ([#47561](https://github.com/expo/expo/pull/47561) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - [universal][android] Use `BasicTextField` component instead of Filled Material TextField. ([#46442](https://github.com/expo/expo/pull/46442) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix `<Host>` centering its content instead of top-aligning it, so a `flex: 1` host matches Android's top-leading layout. ([#47561](https://github.com/expo/expo/pull/47561) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 🎉 New features
 
@@ -39,7 +40,6 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `<Host>` centering its content instead of top-aligning it, so a `flex: 1` host matches Android's top-leading layout. ([#47561](https://github.com/expo/expo/pull/47561) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/HostView.swift
+++ b/packages/expo-ui/ios/HostView.swift
@@ -49,6 +49,8 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
   var body: some View {
     let layoutDirection = props.layoutDirection.toLayoutDirection()
     let alignment: Alignment = layoutDirection == .rightToLeft ? .topTrailing : .topLeading
+    let fillHorizontal = !props.useViewportSizeMeasurement && !props.matchContentsHorizontal
+    let fillVertical = !props.useViewportSizeMeasurement && !props.matchContentsVertical
 
     if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
       // swiftlint:disable:next identifier_name
@@ -68,6 +70,7 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
         globalEventDispatcher: props.globalEventDispatcher
       )
       .modifier(GeometryChangeModifier(props: props))
+      .modifier(FillAlignmentModifier(alignment: alignment, fillHorizontal: fillHorizontal, fillVertical: fillVertical))
     } else {
       ZStack(alignment: alignment) {
         Children()
@@ -82,6 +85,7 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
         globalEventDispatcher: props.globalEventDispatcher
       )
       .modifier(GeometryChangeModifier(props: props))
+      .modifier(FillAlignmentModifier(alignment: alignment, fillHorizontal: fillHorizontal, fillVertical: fillVertical))
     }
   }
 
@@ -199,6 +203,26 @@ private struct GeometryChangeModifier: ViewModifier {
             .onChange(of: geometry.size) { dispatchOnLayoutContent($0) }
         }
       }
+    }
+  }
+}
+
+private struct FillAlignmentModifier: ViewModifier {
+  let alignment: Alignment
+  let fillHorizontal: Bool
+  let fillVertical: Bool
+
+  func body(content: Content) -> some View {
+    if fillHorizontal || fillVertical {
+      content.frame(
+        maxWidth: fillHorizontal ? .infinity : nil,
+        maxHeight: fillVertical ? .infinity : nil,
+        alignment: alignment
+      )
+    } else {
+      // Leave the view untouched (e.g. useViewportSizeMeasurement / full matchContents) so the
+      // layout proposal reaches the content's own layout unmodified.
+      content
     }
   }
 }


### PR DESCRIPTION
# Why

`<Host style={{ flex: 1 }}>` centered its content on iOS but top-aligned it on Android, so the same tree rendered differently across platforms.


<img width="300" height="auto" alt="Screenshot 2026-07-06 at 16 14 15" src="https://github.com/user-attachments/assets/55500159-0ad0-4994-93ab-10764e596578" />

# How

Fill content frame when user has not passed `matchContents`, matching android's behaviour.

# Test Plan

Tested in bare-expo: `<Host style={{ flex: 1 }}><Text>Hello world</Text></Host>` now renders top-leading on iOS, matching Android. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
