### PR TITLE
[ios][autolinking] Raise resource bundle targets to their pod's deployment target

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Align the `react-native-reanimated` precompile config with `react-native-reanimated@4.5.0`'s generated component and native view sources. ([#47201](https://github.com/expo/expo/pull/47201) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`. ([#47478](https://github.com/expo/expo/pull/47478) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Under precompiled modules, preserve a dynamic-framework subgraph set up by an earlier `pre_install` hook (e.g. `@rnmapbox/maps`) — both the dynamic frameworks and the pods that link against them — instead of forcing them back to static libraries. ([#47500](https://github.com/expo/expo/pull/47500) by [@kudo](https://github.com/kudo))
+- [iOS] Raise resource bundle targets to their pod's effective deployment target, fixing builds failing on Xcode 27 for pods whose podspec declares a deployment target below iOS 15.0 (e.g. `ReachabilitySwift`). ([#47562](https://github.com/expo/expo/pull/47562) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -66,6 +66,16 @@ module Pod
       # "Compiling for iOS 15.1, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4"
       # type of message
       reconcile_expo_module_deployment_targets()
+
+      # Raise each pod's resource bundle targets to the pod's effective
+      # deployment target. CocoaPods generates resource bundle targets with
+      # the deployment target declared by the pod's own podspec, and
+      # `react_native_post_install` raises only the pods' library targets,
+      # so a bundle can be left below the minimum supported by the Xcode SDK
+      # (e.g. ReachabilitySwift's privacy manifest bundle at iOS 12.0),
+      # which fails the build on Xcode 27. Runs after the reconciliation
+      # above so bundles of Expo modules pick up the reconciled values.
+      reconcile_resource_bundle_deployment_targets()
     end
 
     define_method(:run_podfile_pre_install_hooks) do
@@ -157,6 +167,50 @@ module Pod
           summary = platforms.map { |label| "#{label}=#{versions_by_label[label]}" }.join(' ')
           Pod::UI.puts "  #{pod_name} (#{summary})".yellow
         end
+        self.pods_project.save
+      end
+    end
+
+    # See call site in perform_post_install_actions for rationale.
+    # Bundle targets are only ever raised to their owning pod's library
+    # target value, never lowered, so a bundle already declaring a higher
+    # deployment target keeps it.
+    def reconcile_resource_bundle_deployment_targets
+      deployment_target_keys = [
+        'IPHONEOS_DEPLOYMENT_TARGET',
+        'MACOSX_DEPLOYMENT_TARGET',
+        'TVOS_DEPLOYMENT_TARGET',
+      ]
+
+      bumped = [] # names of bumped resource bundle targets
+      self.target_installation_results.pod_target_installation_results.each_value do |result|
+        library_settings_by_config = result.native_target.build_configurations
+          .map { |config| [config.name, config.build_settings] }
+          .to_h
+
+        result.resource_bundle_targets.each do |bundle_target|
+          bundle_target.build_configurations.each do |config|
+            library_settings = library_settings_by_config[config.name]
+            next if library_settings.nil?
+
+            deployment_target_keys.each do |key|
+              current = config.build_settings[key]
+              effective = library_settings[key]
+              # nil means the target doesn't build for that platform. Empty
+              # strings and xcconfig references (e.g. `$(inherited)`) can't be
+              # compared as versions, so leave those alone.
+              next if current.nil? || current.empty? || current.start_with?('$')
+              next if effective.nil? || effective.empty? || effective.start_with?('$')
+              next unless Gem::Version.new(current) < Gem::Version.new(effective)
+              config.build_settings[key] = effective
+              bumped << bundle_target.name unless bumped.include?(bundle_target.name)
+            end
+          end
+        end
+      end
+
+      unless bumped.empty?
+        Pod::UI.puts "[Expo] ".blue + "Raised resource bundle deployment targets to match their pods: #{bumped.join(', ')}".yellow
         self.pods_project.save
       end
     end

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -149,9 +149,11 @@ module Pod
           required.each do |key, info|
             current = config.build_settings[key]
             # nil means the pod doesn't target this platform — don't create a setting for it.
-            # Empty string or an xcconfig reference (e.g. `$(inherited)`) means we can't
-            # compare versions, so leave it alone.
-            next if current.nil? || current.empty? || current.start_with?('$')
+            # Empty string, an xcconfig reference (e.g. `$(inherited)`), or a malformed
+            # value written by another post_install hook means we can't compare versions,
+            # so leave it alone.
+            next if current.nil? || current.empty?
+            next unless Gem::Version.correct?(current)
             next unless Gem::Version.new(current) < Gem::Version.new(info[:version])
             config.build_settings[key] = info[:version]
             bumped_platforms << info[:label] unless bumped_platforms.include?(info[:label])
@@ -183,6 +185,7 @@ module Pod
       ]
 
       bumped = [] # names of bumped resource bundle targets
+      dirty_projects = Set.new
       self.target_installation_results.pod_target_installation_results.each_value do |result|
         library_settings_by_config = result.native_target.build_configurations
           .map { |config| [config.name, config.build_settings] }
@@ -197,12 +200,14 @@ module Pod
               current = config.build_settings[key]
               effective = library_settings[key]
               # nil means the target doesn't build for that platform. Empty
-              # strings and xcconfig references (e.g. `$(inherited)`) can't be
-              # compared as versions, so leave those alone.
-              next if current.nil? || current.empty? || current.start_with?('$')
-              next if effective.nil? || effective.empty? || effective.start_with?('$')
+              # strings, xcconfig references (e.g. `$(inherited)`), and
+              # malformed values written by another post_install hook can't
+              # be compared as versions, so leave those alone.
+              next if current.nil? || current.empty? || effective.nil? || effective.empty?
+              next unless Gem::Version.correct?(current) && Gem::Version.correct?(effective)
               next unless Gem::Version.new(current) < Gem::Version.new(effective)
               config.build_settings[key] = effective
+              dirty_projects << bundle_target.project
               bumped << bundle_target.name unless bumped.include?(bundle_target.name)
             end
           end
@@ -211,7 +216,10 @@ module Pod
 
       unless bumped.empty?
         Pod::UI.puts "[Expo] ".blue + "Raised resource bundle deployment targets to match their pods: #{bumped.join(', ')}".yellow
-        self.pods_project.save
+        # Save every project that owns a bumped bundle target; with the
+        # `generate_multiple_pod_projects` install option those are per-pod
+        # projects rather than `pods_project`.
+        dirty_projects.each(&:save)
       end
     end
 


### PR DESCRIPTION
# Why

Fixes #47537.

CocoaPods generates each pod's resource bundle targets with the deployment target declared by the pod's own podspec, while `react_native_post_install` raises only the pods' library targets to React Native's iOS floor (15.1). A pod declaring a low platform version keeps its resource bundle target below that floor: `expo-updates`' `ReachabilitySwift` dependency declares iOS 12.0 and ships a privacy manifest bundle, so the generated `ReachabilitySwift-ReachabilitySwift` target stays at `IPHONEOS_DEPLOYMENT_TARGET = 12.0`. The Xcode 27 iOS SDK rejects deployment targets below 15.0, which fails the build.

The same latent problem exists in other popular pods with privacy manifest bundles: `RNCAsyncStorage`, `RNSVG`, `SDWebImage`, `lottie-ios`, and `lottie-react-native`.

# How

Added a `reconcile_resource_bundle_deployment_targets` step to the autolinking CocoaPods installer patch, running right after the existing Expo module deployment target reconciliation. For every pod, it raises each resource bundle target's deployment target (iOS, macOS, tvOS) to match the owning pod's library target, whose value has already been raised by `react_native_post_install` (and by our Expo module reconciliation) at that point.

The step only ever raises values, never lowers them, and skips settings that can't be compared as versions: empty strings, xcconfig references like `$(inherited)`, and malformed values another `post_install` hook may have written (guarded with `Gem::Version.correct?`, also applied to the existing Expo module reconciliation). It logs which bundles it bumped and saves each project that owns a bumped bundle target, so it also works under the `generate_multiple_pod_projects` install option, where bundle targets live in per-pod projects rather than the main Pods project. There is deliberately no floor of its own: bundles just follow whatever the earlier layers decided for their pod, so the app minimum stays an app-level policy and React Native's floor stays React Native's.

Shipping this in `expo-modules-autolinking` means existing SDK 57 apps pick up the fix via a patch release on their next `pod install`, with no prebuild or template change.

# Test Plan

These installer scripts have no test harness, so I verified against the real generated Pods project in `apps/bare-expo`, temporarily disabling the bare-expo Podfile workaround (which masks the bug) for both runs:

- Without the fix: the `ReachabilitySwift` library target is at 15.1 (React Native's bump), while its resource bundle target is stuck at 12.0, reproducing the report.
- With the fix: `pod install` logs `[Expo] Raised resource bundle deployment targets to match their pods: RNCAsyncStorage-RNCAsyncStorage_resources, RNSVG-RNSVGFilters, ReachabilitySwift-ReachabilitySwift, SDWebImage-SDWebImage, lottie-ios-LottiePrivacyInfo, lottie-react-native-Lottie_React_Native_Privacy`, the bundle target ends up at 15.1, and a scan of the entire generated `Pods.xcodeproj` finds no `IPHONEOS_DEPLOYMENT_TARGET` below 15.0.

To reproduce: in the issue's repro (or any SDK 57 app with `expo-updates`), run `pod install` and check the generated project:

```sh
rg -n "IPHONEOS_DEPLOYMENT_TARGET = 12.0" ios/Pods/Pods.xcodeproj/project.pbxproj
```
