### PR TITLE
[dev-launcher] Add search to the Updates tab

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add a search input to the Updates tab to filter branches and updates by name. ([#47533](https://github.com/expo/expo/pull/47533) by [@alZyad](https://github.com/alZyad))
 - Add a Settings toggle to switch between auto-launching the most recent app and showing the launcher. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add build's expiration date to Settings. ([#47190](https://github.com/expo/expo/pull/47190) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/BranchesViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/BranchesViewModel.kt
@@ -26,7 +26,8 @@ sealed interface BranchesAction {
 data class BranchesState(
   val branches: List<Branch> = emptyList(),
   val isLoading: Boolean = false,
-  val needToSignIn: Boolean = false
+  val needToSignIn: Boolean = false,
+  val hasMore: Boolean = true
 )
 
 class BranchesViewModel : ViewModel() {
@@ -52,7 +53,8 @@ class BranchesViewModel : ViewModel() {
         hasMore.value = false
         _state.value = _state.value.copy(
           branches = emptyList(),
-          isLoading = false
+          isLoading = false,
+          hasMore = false
         )
       }
 
@@ -61,7 +63,8 @@ class BranchesViewModel : ViewModel() {
           hasMore.value = true
           _state.value = _state.value.copy(
             branches = emptyList(),
-            isLoading = true
+            isLoading = true,
+            hasMore = true
           )
           viewModelScope.launch {
             loadMoreBranches()
@@ -158,7 +161,8 @@ class BranchesViewModel : ViewModel() {
     hasMore.value = branches.size == limit
     _state.value = _state.value.copy(
       isLoading = false,
-      branches = _state.value.branches + branches
+      branches = _state.value.branches + branches,
+      hasMore = hasMore.value
     )
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/routes/Updates.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/routes/Updates.kt
@@ -83,6 +83,7 @@ private fun Branches(onProfileClick: () -> Unit, updatesNavController: NavHostCo
     BranchesScreen(
       branches = state.branches,
       isLoading = state.isLoading,
+      hasMore = state.hasMore,
       needToSignIn = state.needToSignIn,
       onProfileClick = onProfileClick,
       onAction = { action ->

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,8 +40,10 @@ import expo.modules.devlauncher.compose.primitives.CircularProgressBar
 import expo.modules.devlauncher.compose.ui.ActionButton
 import expo.modules.devlauncher.compose.ui.AppHeader
 import expo.modules.devlauncher.compose.ui.DefaultScreenContainer
+import expo.modules.devlauncher.compose.ui.SearchInput
 import expo.modules.devlauncher.compose.ui.LauncherIcons
 import expo.modules.devlauncher.compose.utils.DateFormat
+import expo.modules.devlauncher.compose.utils.fuzzyMatch
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
 import expo.modules.devmenu.compose.primitives.RoundedSurface
@@ -143,6 +147,7 @@ fun BranchesScreen(
   branches: List<Branch> = emptyList(),
   needToSignIn: Boolean = false,
   isLoading: Boolean = false,
+  hasMore: Boolean = true,
   onProfileClick: () -> Unit = {},
   onAction: (BranchesAction) -> Unit = { _ -> }
 ) {
@@ -161,6 +166,28 @@ fun BranchesScreen(
     Spacer(NewAppTheme.spacing.`4`)
 
     Column {
+      var searchQuery by remember { mutableStateOf("") }
+
+      val filteredBranches = remember(branches, searchQuery) {
+        val query = searchQuery.trim()
+        if (query.isEmpty()) {
+          branches
+        } else {
+          branches.filter { branch ->
+            fuzzyMatch(query, branch.name) ||
+              (branch.compatibleUpdate?.name?.let { fuzzyMatch(query, it) } == true)
+          }
+        }
+      }
+
+      SearchInput(
+        value = searchQuery,
+        onValueChange = { searchQuery = it },
+        placeholder = "Search branches and updates"
+      )
+
+      Spacer(NewAppTheme.spacing.`4`)
+
       val lazyListState = rememberLazyListState()
 
       val reachedBottom: Boolean by remember {
@@ -171,8 +198,10 @@ fun BranchesScreen(
         }
       }
 
-      LaunchedEffect(reachedBottom) {
-        if (reachedBottom && !isLoading) {
+      LaunchedEffect(reachedBottom, branches.size, searchQuery) {
+        // While searching, a short filtered list always "reaches bottom", which would burst-load every page
+        // which is why searching pages is driven by the explicit button below instead.
+        if (reachedBottom && !isLoading && searchQuery.isBlank()) {
           onAction(BranchesAction.LoadMoreBranches)
         }
       }
@@ -181,7 +210,7 @@ fun BranchesScreen(
         state = lazyListState,
         verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
       ) {
-        items(items = branches) { branch ->
+        items(items = filteredBranches, key = { it.name }) { branch ->
           RoundedSurface(
             color = NewAppTheme.colors.background.subtle,
             borderRadius = NewAppTheme.borderRadius.xl
@@ -283,7 +312,7 @@ fun BranchesScreen(
               )
             }
           }
-        } else if (branches.isEmpty()) {
+        } else if (filteredBranches.isEmpty()) {
           item {
             Row(
               modifier = Modifier
@@ -293,7 +322,11 @@ fun BranchesScreen(
               verticalAlignment = Alignment.CenterVertically
             ) {
               NewText(
-                "No branches available.",
+                if (searchQuery.isBlank()) {
+                  "No branches available."
+                } else {
+                  "No branches or updates match \"$searchQuery\"."
+                },
                 style = NewAppTheme.font.lg.merge(
                   textAlign = TextAlign.Center,
                   fontWeight = FontWeight.Medium
@@ -301,6 +334,18 @@ fun BranchesScreen(
                 color = NewAppTheme.colors.text.secondary
               )
             }
+          }
+        }
+
+        if (searchQuery.isNotBlank() && hasMore && !isLoading) {
+          item {
+            ActionButton(
+              "Load more to keep searching",
+              foreground = NewAppTheme.colors.text.default,
+              background = NewAppTheme.colors.background.element,
+              modifier = Modifier.padding(vertical = NewAppTheme.spacing.`2`),
+              onClick = { onAction(BranchesAction.LoadMoreBranches) }
+            )
           }
         }
       }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SearchInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SearchInput.kt
@@ -1,0 +1,80 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.composeunstyled.TextInput
+import com.composeunstyled.UnstyledTextField
+import expo.modules.devmenu.compose.newtheme.NewAppTheme
+import expo.modules.devmenu.compose.primitives.NewText
+
+@Composable
+fun SearchInput(
+  value: String,
+  onValueChange: (String) -> Unit,
+  placeholder: String = "Search",
+  modifier: Modifier = Modifier
+) {
+  val keyboardController = LocalSoftwareKeyboardController.current
+  UnstyledTextField(
+    value = value,
+    onValueChange = onValueChange,
+    textColor = NewAppTheme.colors.text.default,
+    textStyle = NewAppTheme.font.md,
+    singleLine = true,
+    modifier = modifier
+      .fillMaxWidth()
+      .border(
+        width = 1.dp,
+        shape = RoundedCornerShape(NewAppTheme.borderRadius.xl),
+        color = NewAppTheme.colors.border.default
+      )
+      .clip(RoundedCornerShape(NewAppTheme.borderRadius.xl))
+      .background(NewAppTheme.colors.background.element)
+      .padding(NewAppTheme.spacing.`3`),
+    keyboardOptions = KeyboardOptions(
+      capitalization = KeyboardCapitalization.None,
+      autoCorrectEnabled = false,
+      keyboardType = KeyboardType.Text,
+      imeAction = ImeAction.Search
+    ),
+    keyboardActions = KeyboardActions(
+      onSearch = { keyboardController?.hide() }
+    ),
+    cursorBrush = SolidColor(NewAppTheme.colors.text.default.copy(alpha = 0.9f))
+  ) {
+    TextInput(
+      placeholder = {
+        NewText(
+          text = placeholder,
+          style = NewAppTheme.font.md,
+          color = NewAppTheme.colors.text.secondary
+        )
+      }
+    )
+  }
+}
+
+@Composable
+@Preview(showBackground = true, widthDp = 300)
+fun SearchInputPreview() {
+  SearchInput(
+    value = "",
+    onValueChange = {},
+    placeholder = "Search branches and updates"
+  )
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/utils/FuzzyMatch.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/utils/FuzzyMatch.kt
@@ -1,0 +1,12 @@
+package expo.modules.devlauncher.compose.utils
+
+/** Case-insensitive subsequence match: is [query] a subsequence of [text]? */
+fun fuzzyMatch(query: String, text: String): Boolean {
+  var i = 0
+  for (character in text) {
+    if (i < query.length && character.equals(query[i], ignoreCase = true)) {
+      i++
+    }
+  }
+  return i == query.length
+}

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/compose/utils/FuzzyMatchTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/compose/utils/FuzzyMatchTest.kt
@@ -1,0 +1,53 @@
+package expo.modules.devlauncher.compose.utils
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FuzzyMatchTest {
+  @Test
+  fun `matches contiguous substrings`() {
+    Truth.assertThat(fuzzyMatch("feat", "feature/search")).isTrue()
+    Truth.assertThat(fuzzyMatch("search", "feature/search")).isTrue()
+  }
+
+  @Test
+  fun `matches are case-insensitive`() {
+    Truth.assertThat(fuzzyMatch("MAIN", "main")).isTrue()
+    Truth.assertThat(fuzzyMatch("main", "MAIN")).isTrue()
+  }
+
+  @Test
+  fun `an empty query matches everything`() {
+    Truth.assertThat(fuzzyMatch("", "anything")).isTrue()
+    Truth.assertThat(fuzzyMatch("", "")).isTrue()
+  }
+
+  @Test
+  fun `matches non-contiguous characters as long as order is preserved`() {
+    Truth.assertThat(fuzzyMatch("fs", "feature/search")).isTrue()
+    Truth.assertThat(fuzzyMatch("ftsh", "feature/search")).isTrue()
+  }
+
+  @Test
+  fun `matches broadly, a tiny query can hit unrelated branch names`() {
+    Truth.assertThat(fuzzyMatch("ee", "feature/search")).isTrue()
+    Truth.assertThat(fuzzyMatch("ee", "release/hotfix")).isTrue()
+    Truth.assertThat(fuzzyMatch("ee", "develop")).isTrue()
+    Truth.assertThat(fuzzyMatch("fresh", "feature/search")).isTrue()
+    Truth.assertThat(fuzzyMatch("sea", "feature/search")).isTrue()
+  }
+
+  @Test
+  fun `returns false when a character is missing`() {
+    Truth.assertThat(fuzzyMatch("z", "feature/search")).isFalse()
+    Truth.assertThat(fuzzyMatch("searchx", "feature/search")).isFalse()
+  }
+
+  @Test
+  fun `returns false when characters are out of order`() {
+    Truth.assertThat(fuzzyMatch("hs", "search")).isFalse()
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateUtils.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateUtils.swift
@@ -3,3 +3,14 @@ func formatUpdateUrl(_ permalink: String, _ message: String) -> String {
   let updateMessage = "updateMessage=\(message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
   return "expo-dev-client://expo-development-client?\(updatePermalink)&\(updateMessage)"
 }
+
+/// Case-insensitive subsequence match: is `query` a subsequence of `text`?
+func fuzzyMatch(_ query: String, in text: String) -> Bool {
+  let query = query.lowercased()
+  let text = text.lowercased()
+  var index = query.startIndex
+  for character in text where index < query.endIndex && character == query[index] {
+    index = query.index(after: index)
+  }
+  return index == query.endIndex
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -8,11 +8,31 @@ struct UpdatesListView: View {
   @State private var filteredUpdates: [(update: Update, branchName: String)] = []
   @State private var filterByCompatibility = false
   @State private var sortByRecency = true
+  @State private var searchQuery = ""
   @State private var isLoading = false
   @State private var errorMessage: String?
 
   var body: some View {
     VStack(spacing: 20) {
+      HStack {
+        Image(systemName: "magnifyingglass")
+          .foregroundColor(.secondary)
+        TextField("Search branches and updates", text: $searchQuery)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled(true)
+        if !searchQuery.isEmpty {
+          Button {
+            searchQuery = ""
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundColor(.secondary)
+          }
+        }
+      }
+      .padding(10)
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
+
       HStack {
         Toggle("Compatible only", isOn: $filterByCompatibility)
         Spacer()
@@ -49,6 +69,9 @@ struct UpdatesListView: View {
       applyFilters()
     }
     .onChange(of: sortByRecency) { _ in
+      applyFilters()
+    }
+    .onChange(of: searchQuery) { _ in
       applyFilters()
     }
     .onAppear {
@@ -125,6 +148,13 @@ struct UpdatesListView: View {
       filtered = filtered.filter { viewModel.isCompatibleRuntime($0.update.runtimeVersion) }
     }
 
+    let query = searchQuery.trimmingCharacters(in: .whitespaces)
+    if !query.isEmpty {
+      filtered = filtered.filter {
+        return fuzzyMatch(query, in: $0.branchName) || fuzzyMatch(query, in: $0.update.message)
+      }
+    }
+
     filtered.sort {
       let formatter = DateFormatter()
       formatter.dateFormat = "MMMM d, yyyy, h:mma"
@@ -179,7 +209,18 @@ struct UpdatesListView: View {
         .frame(width: 44, height: 44)
         .foregroundColor(.gray)
 
-      if filterByCompatibility {
+      if !searchQuery.trimmingCharacters(in: .whitespaces).isEmpty {
+        VStack(spacing: 8) {
+          Text("No matching updates")
+            .font(.headline)
+            .multilineTextAlignment(.center)
+
+          Text("No branches or updates match \"\(searchQuery)\". Only loaded updates are searched.")
+            .font(.system(size: 14))
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+        }
+      } else if filterByCompatibility {
         VStack(spacing: 8) {
           Text("No compatible updates")
             .font(.headline)

--- a/packages/expo-dev-launcher/ios/Tests/FuzzyMatchTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/FuzzyMatchTests.swift
@@ -1,0 +1,44 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import EXDevLauncher
+
+class FuzzyMatchTests: XCTestCase {
+  func testMatchesContiguousSubstrings() {
+    XCTAssertTrue(fuzzyMatch("feat", in: "feature/search"))
+    XCTAssertTrue(fuzzyMatch("search", in: "feature/search"))
+  }
+
+  func testMatchesAreCaseInsensitive() {
+    XCTAssertTrue(fuzzyMatch("MAIN", in: "main"))
+    XCTAssertTrue(fuzzyMatch("main", in: "MAIN"))
+  }
+
+  func testEmptyQueryMatchesEverything() {
+    XCTAssertTrue(fuzzyMatch("", in: "anything"))
+    XCTAssertTrue(fuzzyMatch("", in: ""))
+  }
+
+  func testMatchesNonContiguousCharactersInOrder() {
+    XCTAssertTrue(fuzzyMatch("fs", in: "feature/search"))
+    XCTAssertTrue(fuzzyMatch("ftsh", in: "feature/search"))
+  }
+
+  func testMatchesBroadlyAcrossUnrelatedBranchNames() {
+    XCTAssertTrue(fuzzyMatch("ee", in: "feature/search"))
+    XCTAssertTrue(fuzzyMatch("ee", in: "release/hotfix"))
+    XCTAssertTrue(fuzzyMatch("ee", in: "develop"))
+    XCTAssertTrue(fuzzyMatch("fresh", in: "feature/search"))
+    XCTAssertTrue(fuzzyMatch("sea", in: "feature/search"))
+  }
+
+  func testReturnsFalseWhenACharacterIsMissing() {
+    XCTAssertFalse(fuzzyMatch("z", in: "feature/search"))
+    XCTAssertFalse(fuzzyMatch("searchx", in: "feature/search"))
+  }
+
+  func testReturnsFalseWhenCharactersAreOutOfOrder() {
+    XCTAssertFalse(fuzzyMatch("hs", in: "search"))
+  }
+}


### PR DESCRIPTION
Adds a search field to the Updates tab on Android and iOS that fuzzy-matches branches and updates by name.

I went with a basic fuzzy search method, but i'm open to take any feedback to use a more precise solution or a simpler one.

I kept distinct solutions for ios/android since they were already different, but if you feel it's better to have a common behavior i can make a refactor.

# Why

[Personal feature request](https://expo.canny.io/feature-requests/p/add-search-field-in-the-expo-updates-tab-to-filter-through-branches-updates):
Being able to search for specific branches / updates without having to scroll manually to find them, especially given how branch / update names can be verbose which makes it hard to inspect visually.

# How

By adding a search input + filtering with fuzzy search logic.
For Android, I added a "load more" button at the bottom of the list to avoid spamming backend with requests until all pages are explored because "end of list" would be triggered permanently. (non-issue on iOS because additional results are not fetched)

# Test Plan

Tested manually by building the BareExpo app.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

| Android | iOS |
|--------|--------|
| <img width="300" alt="android-expo-search-new" src="https://github.com/user-attachments/assets/ad5c7d0f-52f3-4c4d-8ee9-a2e915454c36" /> | <img width="300" alt="ios-expo-search" src="https://github.com/user-attachments/assets/a9377643-1d78-40d1-86a9-880a38141106" /> | 