### PR TITLE
[router] Prevent crash on malformed percent-encoded deep link URLs:

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent a crash on malformed percent-encoded deep link URLs (e.g. `%GG`) by falling back to the raw value instead of throwing.
+- Prevent a crash on malformed percent-encoded deep link URLs (e.g. `%GG`) by falling back to the raw value instead of throwing. ([#47566](https://github.com/expo/expo/pull/47566) by [@Pravenn18](https://github.com/Pravenn18))
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent a crash on malformed percent-encoded deep link URLs (e.g. `%GG`) by falling back to the raw value instead of throwing.
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))

--- a/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
+++ b/packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts
@@ -82,6 +82,20 @@ describe(extractExpoPathFromURL, () => {
     delete expo.modules.ExpoGo;
     expect(extractExpoPathFromURL([], `custom:///?x=%20%2B%2F`)).toEqual('?x= +/');
   });
+  it(`does not throw on malformed percent-encoding, passes raw value through`, () => {
+    delete expo.modules.ExpoGo;
+    expect(extractExpoPathFromURL([], `custom:///?q=%GG`)).toEqual('?q=%GG');
+    // A truncated multi-byte UTF-8 sequence: `URLSearchParams` itself already
+    // decodes this losslessly (to a replacement char) without throwing, so
+    // the only requirement here is that it still doesn't crash.
+    expect(() => extractExpoPathFromURL([], `custom:///?q=%E0%A4%A`)).not.toThrow();
+    // Exercises the dev-client `?url=` path (`safeDecodeURI`, line ~102):
+    // the outer query decodes cleanly to `path?q=%GG`, which itself contains
+    // malformed percent-encoding.
+    expect(
+      extractExpoPathFromURL([], `scheme://expo-development-client/?url=path%3Fq%3D%25GG`)
+    ).toEqual('path?q=%GG');
+  });
   it(`decodes query params in Expo Go`, () => {
     expo.modules.ExpoGo = {};
     expect(extractExpoPathFromURL([], `custom:///?x=%20%2B%2F`)).toEqual('?x= +/');

--- a/packages/expo-router/src/fork/extractPathFromURL.ts
+++ b/packages/expo-router/src/fork/extractPathFromURL.ts
@@ -69,6 +69,25 @@ function isExpoDevelopmentClient(url: URL): boolean {
   return url.hostname === 'expo-development-client';
 }
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Malformed percent-encoding (e.g. `%GG`, or a truncated multi-byte
+    // sequence) — pass the raw value through instead of throwing, so one
+    // bad query param doesn't drop the whole deep link.
+    return value;
+  }
+}
+
+function safeDecodeURI(value: string): string {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}
+
 function fromDeepLink(url: string): string {
   let res: URL | null;
   try {
@@ -99,7 +118,7 @@ function fromDeepLink(url: string): string {
       return '';
     }
     const incomingUrl = res.searchParams.get('url')!;
-    return extractExactPathFromURL(decodeURI(incomingUrl));
+    return extractExactPathFromURL(safeDecodeURI(incomingUrl));
   }
 
   let results = '';
@@ -115,7 +134,9 @@ function fromDeepLink(url: string): string {
   const qs = !res.search
     ? ''
     : // @ts-ignore: `entries` is not on `URLSearchParams` in some typechecks.
-      [...res.searchParams.entries()].map(([k, v]) => `${k}=${decodeURIComponent(v)}`).join('&');
+      [...res.searchParams.entries()]
+        .map(([k, v]) => `${k}=${safeDecodeURIComponent(v)}`)
+        .join('&');
 
   if (qs) {
     results += '?' + qs;


### PR DESCRIPTION
# Why

`decodeURIComponent`/`decodeURI` throw on malformed percent-encoding (e.g. `%GG`). Because this runs inside expo-router's async URL event handler, the throw surfaced as an unhandled promise rejection — a LogBox toast in dev, and a silently dropped deep link in release builds. Wrap both decode calls to fall back to the raw value instead.

Fixes #47525

# How

Added two small helpers in `packages/expo-router/src/fork/extractPathFromURL.ts`:

- `safeDecodeURIComponent` — wraps `decodeURIComponent` in try/catch, falling back to the raw (still-encoded) value on `URIError`.
- `safeDecodeURI` — same pattern for `decodeURI`.

Swapped in at the two call sites that prections unguarded:
- The dev-client `?url=` param decode (wa
- The per-query-param decode when buildinline 118).

For any well-formed URL, both helpers behal calls — the `try` branch always succeeds
and returns the same value. Only genuineltakes the new `catch` branch, so this isadditive and doesn't change behavior for existing valid deep links.

# Test Plan

Reproduced the crash first: called `extractExpoPathFromURL([], 'custom:///?q=%GG')` before the fix and confirmed Jest surfaced the exact `URIError: URI malformed` at `extractPathFromURL.ts:118`, matching the crash described in the issue.

Added test cases to `packages/expo-router/src/fork/__tests__/extractPathFromURL.test.ios.ts` covering:
- Malformed query param encoding (`%GG`) — resolves to the raw value instead of throwing.
- A truncated multi-byte UTF-8 sequence — confirmed no throw.
- The dev-client `?url=` decode path (`saormed value resolves without throwing.

Ran the full suite for this file:
Test Suites: 1 passed, 1 total
Tests:       120 passed, 120 total
Snapshots:   87 passed, 87 total
All pre-existing tests and snapshots pass unchanged, confirming no regression for valid URLs.

Also ran `et check-packages expo-router` (build, typecheck, lint, format) — all checks passed.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/ion%20Writing%20Style%20Guide.md)