### PR TITLE
[expo][jest-expo] remove vector-icons aliasing from jest-preset

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove `react-native-vector-icons` → `@expo/vector-icons` aliasing from the Jest preset, since it broke module resolution in monorepos (e.g. Nx) for projects without `@expo/vector-icons` installed. ([#47567](https://github.com/expo/expo/pull/47567) by [@matinzd](https://github.com/matinzd))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-20

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -26,13 +26,6 @@ jestPreset = cloneDeep(jestPreset);
 const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
 const { resolveBabelOptions } = require('./src/resolveBabelOptions');
 
-// Emulate the alias behavior of Expo's Metro resolver.
-jestPreset.moduleNameMapper = {
-  ...(jestPreset.moduleNameMapper || {}),
-  '^react-native-vector-icons$': '@expo/vector-icons',
-  '^react-native-vector-icons/(.*)': '@expo/vector-icons/$1',
-};
-
 const upstreamBabelJest = Object.keys(jestPreset.transform).find(
   (key) => jestPreset.transform[key] === 'babel-jest'
 );


### PR DESCRIPTION
**BREAKING CHANGE**
 
Removed the `react-native-vector-icons` → `@expo/vector-icons` alias from the Jest preset.

# Why

`@expo/vector-icons` [is being deprecated and is no longer recommended](https://docs.expo.dev/guides/icons/), with Expo recommending a migration to `react-native-vector-icons` directly (see the [migration blog post](https://expo.dev/blog/moving-away-from-expo-vector-icons)).

The `jest-preset.js` alias that mapped `react-native-vector-icons` imports to `@expo/vector-icons` causes problems in monorepos, particularly with Nx. Nx resolves module aliases eagerly across the workspace graph, so it tries to resolve `@expo/vector-icons` even for projects that do not depend on either `@expo/vector-icons` or `react-native-vector-icons`. This breaks the build/test graph for those projects.

Since this alias only emulated Metro's resolver behavior for a package that's now on its way out, keeping it in the Jest preset does more harm than good.

There are more changes introduced in https://github.com/expo/expo/pull/25512 which we need to address now that `@expo/vector-icons` will not be around. Personally I feel that all changes introduced in that PR needs to be reverted.

# How

Removed the `moduleNameMapper` entries in `packages/jest-expo/jest-preset.js` that aliased `react-native-vector-icons` (and its subpaths) to `@expo/vector-icons`. Projects using `react-native-vector-icons` will now resolve it directly, matching the non-deprecated, recommended path.

# Test Plan

Ran `et check-packages jest-expo` to confirm the preset still builds, type-checks, and passes existing tests.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
