### PR TITLE
[patch-project] Fix CNG patch paths not applying in monorepos

### DIFF
--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix CNG patch paths not applying in monorepos due to git worktree path resolution. ([#47574](https://github.com/expo/expo/issues/47574))
+
 ### 💡 Others
 
 ## 56.0.16 — 2026-05-26

--- a/packages/patch-project/src/__tests__/gitPatch-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatch-test.ts
@@ -1,12 +1,65 @@
 import spawnAsync from '@expo/spawn-async';
 
-import { applyPatchAsync, getPatchChangedLinesAsync } from '../gitPatch';
+import { applyPatchAsync, getGitRootAsync, getPatchChangedLinesAsync } from '../gitPatch';
 
 jest.mock('@expo/spawn-async');
 jest.mock('fs');
 const mockedSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
 
+describe(getGitRootAsync, () => {
+  it('should return git root from rev-parse', async () => {
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '/repo\n', stderr: '' });
+    const root = await getGitRootAsync('/repo/apps/mobile');
+    expect(root).toBe('/repo');
+  });
+
+  it('should fallback to projectRoot when git is not available', async () => {
+    const error = new Error('spawn git ENOENT');
+    // @ts-expect-error: Simulate spawn error
+    error.code = 'ENOENT';
+    mockedSpawnAsync.mockRejectedValueOnce(error);
+    const root = await getGitRootAsync('/app');
+    expect(root).toBe('/app');
+  });
+});
+
 describe(applyPatchAsync, () => {
+  it('should pass --directory when projectRoot is nested in git repo (monorepo)', async () => {
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '/repo\n', stderr: '' });
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await applyPatchAsync('/repo/apps/mobile', '/repo/apps/mobile/cng-patches/ios+.patch');
+
+    expect(mockedSpawnAsync).toHaveBeenCalledTimes(2);
+    const applyCall = mockedSpawnAsync.mock.calls[1];
+    expect(applyCall[0]).toEqual('git');
+    expect(applyCall[1]).toEqual([
+      'apply',
+      '--ignore-whitespace',
+      '--directory',
+      'apps/mobile',
+      '/repo/apps/mobile/cng-patches/ios+.patch',
+    ]);
+    expect(applyCall[2]).toEqual({ cwd: '/repo/apps/mobile' });
+  });
+
+  it('should not pass --directory when projectRoot is git root', async () => {
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '/app\n', stderr: '' });
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await applyPatchAsync('/app', '/app/cng-patches/ios+.patch');
+
+    expect(mockedSpawnAsync).toHaveBeenCalledTimes(2);
+    const applyCall = mockedSpawnAsync.mock.calls[1];
+    expect(applyCall[0]).toEqual('git');
+    expect(applyCall[1]).toEqual([
+      'apply',
+      '--ignore-whitespace',
+      '/app/cng-patches/ios+.patch',
+    ]);
+    expect(applyCall[2]).toEqual({ cwd: '/app' });
+  });
+
   it('should throw if git is not installed', async () => {
     const error = new Error('spawn git ENOENT');
     // @ts-expect-error: Simulate spawn error
@@ -18,15 +71,15 @@ describe(applyPatchAsync, () => {
   });
 
   it('should throw from git apply errors', async () => {
-    mockedSpawnAsync.mockRejectedValue(new Error('git apply failed'));
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '/app\n', stderr: '' });
+    mockedSpawnAsync.mockRejectedValueOnce(new Error('git apply failed'));
     await expect(() => applyPatchAsync('/app', '/app/cng-patches/ios+.patch')).rejects.toThrow();
   });
 });
 
 describe(getPatchChangedLinesAsync, () => {
   it('should return changed lines', async () => {
-    const mockPatchContent = `\
-1\t1\tandroid/app/build.gradle
+    const mockPatchContent = `\n1\t1\tandroid/app/build.gradle
 1\t3\tandroid/app/src/main/java/com/helloworld/MainApplication.kt`;
     // @ts-expect-error
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: mockPatchContent, stderr: '' });

--- a/packages/patch-project/src/cli/patchProjectAsync.ts
+++ b/packages/patch-project/src/cli/patchProjectAsync.ts
@@ -5,7 +5,7 @@ import fs from 'fs/promises';
 import { glob as globAsync } from 'glob';
 import path from 'path';
 
-import { addAllToGitIndexAsync, commitAsync, diffAsync, initializeGitRepoAsync } from '../gitPatch';
+import { addAllToGitIndexAsync, commitAsync, diffAsync, getGitRootAsync, initializeGitRepoAsync } from '../gitPatch';
 import { moveAsync } from './dir';
 import { generateNativeProjectsAsync, platformSanityCheckAsync } from './generateNativeProjects';
 import * as logger from './logger';
@@ -121,7 +121,11 @@ async function patchProjectForPlatformAsync({
   });
 
   debug(`Initializing git repo for diff - diffDir[${diffDir}]`);
-  const platformDiffDir = path.join(diffDir, platform);
+  const gitRoot = await getGitRootAsync(projectRoot);
+  const relPath = path.relative(gitRoot, projectRoot);
+  const platformDiffDir = relPath
+    ? path.join(diffDir, relPath, platform)
+    : path.join(diffDir, platform);
   await initializeGitRepoAsync(diffDir);
   await moveAsync(path.join(projectRoot, platform), platformDiffDir);
   await addAllToGitIndexAsync(diffDir);

--- a/packages/patch-project/src/gitPatch.ts
+++ b/packages/patch-project/src/gitPatch.ts
@@ -52,8 +52,27 @@ export async function diffAsync(
   );
 }
 
+export async function getGitRootAsync(projectRoot: string): Promise<string> {
+  try {
+    const result = await runGitAsync(['rev-parse', '--show-toplevel'], { cwd: projectRoot });
+    return result;
+  } catch {
+    return projectRoot;
+  }
+}
+
 export async function applyPatchAsync(projectRoot: string, patchFilePath: string) {
-  return await runGitAsync(['apply', '--ignore-whitespace', patchFilePath], { cwd: projectRoot });
+  const gitRoot = await getGitRootAsync(projectRoot);
+  const relPath = path.relative(gitRoot, projectRoot);
+
+  const args = ['apply', '--ignore-whitespace'];
+  if (relPath) {
+    // Normalize to forward slashes; git expects / on all platforms
+    args.push('--directory', relPath.replace(/\\/g, '/'));
+  }
+  args.push(patchFilePath);
+
+  return await runGitAsync(args, { cwd: projectRoot });
 }
 
 export async function getPatchChangedLinesAsync(patchFilePath: string): Promise<number> {


### PR DESCRIPTION
## Description

```markdown
Fix git apply path resolution for CNG patches in monorepo setups. `git apply` resolves paths relative to the git **worktree root**, not the current working directory. In monorepos where the Expo app is nested (e.g., `apps/mobile/`), patch paths like `a/ios/mobile/Info.plist` resolve to `<repo-root>/ios/mobile/Info.plist` instead of `<repo-root>/apps/mobile/ios/mobile/Info.plist`, causing `git apply` to silently skip the patch.

Closes #47574

# Why

When an Expo app lives inside a monorepo (e.g., `apps/mobile/`), `patch-project` generates CNG patches with app-relative paths (`a/ios/...`). But `git apply` resolves paths from the git worktree root — the monorepo root — not from the cwd. The result is `Skipped patch 'ios/mobile/Info.plist'.` and the patch silently does nothing. Manually editing every patch to add the monorepo prefix (`apps/mobile/ios/...`) is not viable.

See the minimal repro: https://github.com/Yash-Singh1/patch-project-monorepo-repro

# How

Two complementary fixes:

**Application side** (`src/gitPatch.ts` — `applyPatchAsync`):
- Added `getGitRootAsync()` helper that runs `git rev-parse --show-toplevel` to find the worktree root, falling back to `projectRoot` if git isn't available
- `applyPatchAsync()` now computes the relative path from the git worktree root to `projectRoot` and passes `--directory=<relPath>` to `git apply`. This tells git to prepend the monorepo nesting prefix before resolving paths from the worktree root. Path separators are normalized to `/` for cross-platform compatibility.

**Generation side** (`src/cli/patchProjectAsync.ts` — `patchProjectForPlatformAsync`):
- The diff repo directory structure now mirrors the monorepo path. Instead of `diffDir/ios/...`, it creates `diffDir/apps/mobile/ios/...`. This makes newly generated patches contain worktree-relative paths out of the box, so they're self-contained and work regardless of which directory they're applied from.

In non-monorepo projects (`gitRoot === projectRoot`), `relPath` is empty and `--directory` is not added — behavior is unchanged.

# Test Plan

**Unit tests** (`src/__tests__/gitPatch-test.ts`):
- `getGitRootAsync`: returns git root from `rev-parse --show-toplevel`; falls back to `projectRoot` when git is unavailable
- `applyPatchAsync` monorepo: passes `--directory apps/mobile` when projectRoot is nested
- `applyPatchAsync` non-monorepo: does NOT pass `--directory` when projectRoot is at git root
- `applyPatchAsync` error cases: throws when git is not installed or `git apply` fails (mock updated for two-step flow)

**Manual monorepo test:**
```sh
# Create monorepo with nested Expo app
mkdir test-monorepo && cd test-monorepo && git init
pnpm create expo-app@latest apps/mobile --template blank-typescript

# Setup and verify
cd apps/mobile
pnpm add patch-project
# Add "patch-project" to app.json plugins
pnpm exec expo prebuild --platform ios
echo '<key>TestKey</key><string>TestValue</string>' >> ios/mobile/Info.plist

# Generate patches and verify they apply
pnpm exec patch-project --platform ios --clean
pnpm exec expo prebuild --platform ios --no-install
grep -q 'TestKey' ios/mobile/Info.plist && echo "PASS" || echo "FAIL"
```

This mirrors the repro at https://github.com/Yash-Singh1/patch-project-monorepo-repro

**Run CI checks:**
```sh
cd packages/patch-project
pnpm test           # unit tests
pnpm test:e2e       # e2e tests
pnpm typecheck      # TypeScript
pnpm lint           # lint
pnpm format --check # formatting
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)