### PR TITLE
[docs] revise iOS permissions for calendar access

### DIFF
--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -83,7 +83,11 @@ You can configure `expo-calendar` using its built-in [config plugin](/config-plu
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **ios** project manually), then you need to configure following permissions in your native project:
 
-- For iOS, add `NSCalendarsUsageDescription`, `NSCalendarsFullAccessUsageDescription`, and `NSRemindersUsageDescription` to your project's **ios/[app]/Info.plist**:
+- For iOS, add the following keys to your project's **ios/[app]/Info.plist**:
+
+  > **warning** On iOS 17+, the app will crash on startup if these keys are missing. The module checks for these permissions during initialization, not just when calendar methods are called.
+
+  **For full calendar and reminders access:**
 
   ```xml
   <key>NSCalendarsUsageDescription</key>
@@ -92,13 +96,23 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
   <string>Allow $(PRODUCT_NAME) to access your calendar</string>
   <key>NSRemindersUsageDescription</key>
   <string>Allow $(PRODUCT_NAME) to access your reminders</string>
+  <key>NSRemindersFullAccessUsageDescription</key>
+  <string>Allow $(PRODUCT_NAME) to access your reminders</string>
   ```
 
-  When requesting write-only calendar access on iOS 17+, add `NSCalendarsWriteOnlyAccessUsageDescription` instead of `NSCalendarsFullAccessUsageDescription`:
+  **For write-only calendar access (iOS 17+):**
+
+  When requesting write-only calendar access on iOS 17+, add `NSCalendarsWriteOnlyAccessUsageDescription` instead of `NSCalendarsFullAccessUsageDescription`. Note that you still need `NSRemindersFullAccessUsageDescription` if your app accesses reminders:
 
   ```xml
+  <key>NSCalendarsUsageDescription</key>
+  <string>Allow $(PRODUCT_NAME) to access your calendar</string>
   <key>NSCalendarsWriteOnlyAccessUsageDescription</key>
   <string>Allow $(PRODUCT_NAME) to add events to your calendars</string>
+  <key>NSRemindersUsageDescription</key>
+  <string>Allow $(PRODUCT_NAME) to access your reminders</string>
+  <key>NSRemindersFullAccessUsageDescription</key>
+  <string>Allow $(PRODUCT_NAME) to access your reminders</string>
   ```
 
 </ConfigReactNative>
@@ -195,5 +209,10 @@ The following usage description keys are used by this library:
         "A message that tells the user why the app is requesting write-only access to the user's calendar data.",
     },
     'NSRemindersUsageDescription',
+    {
+      name: 'NSRemindersFullAccessUsageDescription',
+      description:
+        "A message that tells the user why the app is requesting full access to the user's reminders data. Required on iOS 17+.",
+    },
   ]}
 />


### PR DESCRIPTION
**Note:** PR description is AI-generated with human check and verification.

Updated iOS permissions documentation for calendar and reminders access, including new keys for iOS 17+.

# Why

Apps using `expo-calendar` crash immediately on launch on iOS 17+ with the error: `ExpoCalendar.MissingCalendarPlistValueException error 1`

The current documentation is missing `NSRemindersFullAccessUsageDescription`, which is **required** on iOS 17+ and checked during module initialization (not just when calendar methods are called). This causes apps to crash on startup before any user interaction.

**Source code reference:**

[`RemindersPermissionRequester.swift` (line 20-32)](https://github.com/expo/expo/blob/main/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift#L20-L32) checks for `NSRemindersFullAccessUsageDescription` on iOS 17+ and if the key is missing, it calls `RCTFatal()` during the `OnCreate` lifecycle event

This issue affects any app using `expo-calendar` on iOS 17+ that accesses reminders or initializes the calendar module.

# How

1. Added `NSRemindersFullAccessUsageDescription` to the manual configuration examples for both full access and write-only access scenarios
2. Added prominent warnings explaining that apps will crash on iOS 17+ if these keys are missing
3. Updated the iOS Permissions section to include `NSRemindersFullAccessUsageDescription` with proper description
4. Clarified that permission checks happen during module initialization, not just when methods are called


# Test Plan

1. Create a React Native app with `expo-calendar` v55.x
2. Add only the old permissions: `NSCalendarsUsageDescription`, `NSCalendarsFullAccessUsageDescription`, `NSRemindersUsageDescription`
3. Run on iOS 17+ simulator/device
4. App crashes immediately on launch with a release build and shows a red error modal in debug mode with `MissingCalendarPlistValueException`
<img width="200" alt="SCR-20260707-kvsj" src="https://github.com/user-attachments/assets/5c3bb60a-c4c4-43db-9c48-7e5c509967ed" />


**Verification of the fix:**
1. Add `NSRemindersFullAccessUsageDescription` to Info.plist
2. Rebuild the app
3. App launches successfully without crashes


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
