### PR TITLE
[tools] Add prepare-branch command

### DIFF
--- a/tools/bin/expotools.js
+++ b/tools/bin/expotools.js
@@ -138,6 +138,7 @@ async function loadAllCommandsAsync(callback) {
   const commandFiles = await glob('build/commands/*.js', {
     cwd: ROOT_PATH,
     absolute: true,
+    ignore: '**/*.test.js',
   });
 
   for (const commandFile of commandFiles) {

--- a/tools/src/commands/PodInstallCommand.ts
+++ b/tools/src/commands/PodInstallCommand.ts
@@ -17,7 +17,7 @@ type ActionOptions = {
 const importantProjects = ['apps/bare-expo/ios', 'apps/expo-go/ios'];
 const otherProjects = ['apps/minimal-tester/ios', 'apps/native-tests/ios'];
 
-async function action(options: ActionOptions) {
+export async function action(options: ActionOptions): Promise<boolean> {
   if (process.platform !== 'darwin') {
     throw new Error('This command is not supported on this platform.');
   }
@@ -41,11 +41,12 @@ async function action(options: ActionOptions) {
           // In this case, the output has already been printed.
           logger.error(`💥 Installation failed with output: ${e.output}`);
         }
-        return;
+        return false;
       }
     }
   }
   logger.success('🥳 All iOS projects have up-to-date local pods');
+  return true;
 }
 
 async function md5(path: string): Promise<string | null> {

--- a/tools/src/commands/PrepareBranch.test.ts
+++ b/tools/src/commands/PrepareBranch.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { validatePreconditions } from './PrepareBranchCommand';
+
+describe('validatePreconditions', () => {
+  it('passes on a clean tree on an sdk branch', () => {
+    const result = validatePreconditions({ branchName: 'sdk-56', dirtyFiles: [], force: false });
+    assert.equal(result.warning, null);
+    assert.equal(result.error, null);
+  });
+
+  it('errors when the tree is dirty and force is off', () => {
+    const result = validatePreconditions({
+      branchName: 'sdk-56',
+      dirtyFiles: [' M pnpm-lock.yaml'],
+      force: false,
+    });
+    assert.match(result.error ?? '', /pnpm-lock\.yaml/);
+  });
+
+  it('does not error when the tree is dirty and force is on', () => {
+    const result = validatePreconditions({
+      branchName: 'sdk-56',
+      dirtyFiles: [' M pnpm-lock.yaml'],
+      force: true,
+    });
+    assert.equal(result.error, null);
+  });
+
+  it('warns on a non-sdk branch without erroring', () => {
+    const result = validatePreconditions({ branchName: 'main', dirtyFiles: [], force: false });
+    assert.match(result.warning ?? '', /main/);
+    assert.equal(result.error, null);
+  });
+});

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -1,0 +1,180 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { EXPO_DIR } from '../Constants';
+import * as Directories from '../Directories';
+import Git, { GitDirectory } from '../Git';
+import logger from '../Logger';
+import { spawnAsync } from '../Utils';
+import { action as podInstallAsync } from './PodInstallCommand';
+
+type PreconditionsInput = {
+  branchName: string;
+  dirtyFiles: string[];
+  force: boolean;
+};
+
+type PreconditionsResult = {
+  warning: string | null;
+  error: string | null;
+};
+
+export function validatePreconditions({
+  branchName,
+  dirtyFiles,
+  force,
+}: PreconditionsInput): PreconditionsResult {
+  const warning = /^sdk-\d+/.test(branchName)
+    ? null
+    : `Current branch "${branchName}" is not an SDK branch. Proceeding anyway.`;
+
+  const error =
+    dirtyFiles.length > 0 && !force
+      ? `The working tree has uncommitted changes that this command would discard:\n${dirtyFiles.join(
+          '\n'
+        )}\nCommit or stash them first, or re-run with --force to discard them.`
+      : null;
+
+  return { warning, error };
+}
+
+type ActionOptions = {
+  force: boolean;
+};
+
+type Step = {
+  title: string;
+  runAsync: () => Promise<void>;
+};
+
+const PODS_PATHS = [
+  'apps/bare-expo/ios/Pods',
+  'apps/bare-expo/ios/build',
+  'apps/expo-go/ios/Pods',
+  'apps/expo-go/ios/build',
+];
+
+function createSteps(): Step[] {
+  const reactNativeDir = Directories.getReactNativeSubmoduleDir();
+  const jsiAppleDir = path.join(Directories.getPackagesDir(), 'expo-modules-jsi', 'apple');
+  const precompileDir = Directories.getPrecompileDir();
+
+  return [
+    {
+      // Deleting the root node_modules breaks the pnpm virtual store that tools/ resolves from,
+      // so every dependency must be imported at module top level. A lazy require after this point fails.
+      title: 'Removing node_modules and resetting tracked files',
+      async runAsync() {
+        const nodeModulesDirs = [
+          path.join(EXPO_DIR, 'node_modules'),
+          path.join(reactNativeDir, 'node_modules'),
+        ];
+
+        for (const dir of nodeModulesDirs) {
+          logger.info(`   Removing ${chalk.yellow(path.relative(EXPO_DIR, dir))}`);
+          await fs.remove(dir);
+        }
+        await Git.runAsync(['checkout', '.']);
+      },
+    },
+    {
+      title: 'Cleaning react-native-lab and reinstalling its dependencies',
+      async runAsync() {
+        const reactNativeGit = new GitDirectory(reactNativeDir);
+        await reactNativeGit.runAsync(['clean', '-fdx'], { stdio: 'inherit' });
+        await spawnAsync('yarn', [], { cwd: reactNativeDir, stdio: 'inherit' });
+      },
+    },
+    {
+      title: 'Installing workspace dependencies',
+      async runAsync() {
+        await spawnAsync('pnpm', ['install'], { cwd: EXPO_DIR, stdio: 'inherit' });
+      },
+    },
+    {
+      title: 'Resyncing pods with the native projects',
+      async runAsync() {
+        if (process.platform !== 'darwin') {
+          logger.warn('Skipping pods resync (macOS only).');
+          return;
+        }
+        for (const podsPath of PODS_PATHS) {
+          await fs.remove(path.join(EXPO_DIR, podsPath));
+        }
+        const success = await podInstallAsync({ force: true, verbose: false, all: false });
+
+        if (!success) {
+          throw new Error('pod install failed. See the output above.');
+        }
+      },
+    },
+    {
+      title: 'Removing expo-modules-jsi build artifacts',
+      async runAsync() {
+        for (const name of ['.DerivedData', '.generated', '.swiftpm', 'Products']) {
+          await fs.remove(path.join(jsiAppleDir, name));
+        }
+      },
+    },
+    {
+      title: 'Removing precompile caches',
+      async runAsync() {
+        for (const name of ['.build', '.cache']) {
+          await fs.remove(path.join(precompileDir, name));
+        }
+      },
+    },
+  ];
+}
+
+async function action(options: ActionOptions) {
+  const branchName = await Git.getCurrentBranchNameAsync();
+  const { stdout } = await Git.runAsync(['status', '--porcelain', '--untracked-files=no']);
+  const dirtyFiles = stdout.trim().split('\n').filter(Boolean);
+
+  const { warning, error } = validatePreconditions({
+    branchName,
+    dirtyFiles,
+    force: options.force,
+  });
+
+  if (warning) {
+    logger.warn(`⚠️  ${warning}`);
+  }
+  if (error) {
+    throw new Error(error);
+  }
+
+  const steps = createSteps();
+
+  for (const [index, step] of steps.entries()) {
+    logger.info(chalk.bold(`\n[${index + 1}/${steps.length}]`), step.title);
+
+    try {
+      await step.runAsync();
+    } catch (e) {
+      logger.error(
+        `💥 Step "${step.title}" failed. Fix the issue above and re-run \`et prepare-branch -f\`.`
+      );
+      throw e;
+    }
+  }
+  logger.success('\n🧹 Branch is clean and ready for publishing');
+}
+
+export default (program: Command) => {
+  program
+    .command('prepare-branch')
+    .alias('pb')
+    .description(
+      'Cleans and reinstalls dependencies, pods and build caches before publishing from an SDK branch'
+    )
+    .option(
+      '-f, --force',
+      'Whether to proceed even if the working tree has uncommitted changes',
+      false
+    )
+    .asyncAction(action);
+};

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -84,6 +84,23 @@ function createSteps(): Step[] {
       },
     },
     {
+      title: 'Removing expo-modules-jsi build artifacts',
+      async runAsync() {
+        for (const name of ['.DerivedData', '.generated', '.swiftpm', 'Products']) {
+          await fs.remove(path.join(jsiAppleDir, name));
+        }
+      },
+    },
+    {
+      title: 'Removing precompile caches',
+      async runAsync() {
+        for (const name of ['.build', '.cache']) {
+          await fs.remove(path.join(precompileDir, name));
+        }
+      },
+    },
+    {
+      // Runs after the expo-modules-jsi cleanup so pod install recreates the stub xcframework.
       title: 'Resyncing pods with the native projects',
       async runAsync() {
         if (process.platform !== 'darwin') {
@@ -97,22 +114,6 @@ function createSteps(): Step[] {
 
         if (!success) {
           throw new Error('pod install failed. See the output above.');
-        }
-      },
-    },
-    {
-      title: 'Removing expo-modules-jsi build artifacts',
-      async runAsync() {
-        for (const name of ['.DerivedData', '.generated', '.swiftpm', 'Products']) {
-          await fs.remove(path.join(jsiAppleDir, name));
-        }
-      },
-    },
-    {
-      title: 'Removing precompile caches',
-      async runAsync() {
-        for (const name of ['.build', '.cache']) {
-          await fs.remove(path.join(precompileDir, name));
         }
       },
     },

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -67,15 +67,8 @@ function createSteps(): Step[] {
       // so every dependency must be imported at module top level. A lazy require after this point fails.
       title: 'Removing node_modules and resetting tracked files',
       async runAsync() {
-        const nodeModulesDirs = [
-          path.join(EXPO_DIR, 'node_modules'),
-          path.join(reactNativeDir, 'node_modules'),
-        ];
-
-        for (const dir of nodeModulesDirs) {
-          logger.info(`   Removing ${chalk.yellow(path.relative(EXPO_DIR, dir))}`);
-          await fs.remove(dir);
-        }
+        logger.info(`   Removing ${chalk.yellow('node_modules')}`);
+        await fs.remove(path.join(EXPO_DIR, 'node_modules'));
         await Git.runAsync(['checkout', '.']);
       },
     },

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -65,7 +65,6 @@ function createSteps(): Step[] {
     {
       title: 'Removing node_modules and resetting tracked files',
       async runAsync() {
-        logger.info(`   Removing ${chalk.yellow('node_modules')}`);
         await fs.remove(path.join(EXPO_DIR, 'node_modules'));
         await Git.runAsync(['checkout', '.']);
       },

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -63,8 +63,6 @@ function createSteps(): Step[] {
 
   return [
     {
-      // Deleting the root node_modules breaks the pnpm virtual store that tools/ resolves from,
-      // so every dependency must be imported at module top level. A lazy require after this point fails.
       title: 'Removing node_modules and resetting tracked files',
       async runAsync() {
         logger.info(`   Removing ${chalk.yellow('node_modules')}`);


### PR DESCRIPTION
# Why
Before publishing from an SDK branch, for most consistent results, I've found these steps necessary. Clean install node_modules, a clean react-native-lab checkout, resync pods in the native projects, and no stale build caches. Doing this by hand is a series of easy-to-forget commands, so this adds `et prepare-branch` to automate it.

# How
The command runs six steps in order, stopping on the first failure:

1. Remove the root `node_modules` and run `git checkout .` to reset tracked files.
2. `git clean -fdx` in `react-native-lab/react-native`, then `yarn`.
3. `pnpm install` at the repo root.
4. Remove `Pods` and `build` for bare-expo and Expo Go, then force a pod install to resync them with the native projects.
5. Remove `.DerivedData`, `.generated`, `.swiftpm` and `Products` from `packages/expo-modules-jsi/apple`.
6. Remove `.build` and `.cache` from `packages/precompile`.

Since step 1 discards uncommitted changes, the command aborts up front if the working tree is dirty and lists the offending files. Pass `-f` / `--force` to proceed anyway. It also warns (but continues) when the current branch is not an SDK branch.

To reuse the pod install logic in-process, `PodInstallCommand`'s action is now exported and returns a boolean instead of swallowing failures. The `et pods` behavior is unchanged.

# Test Plan
- Unit tests for the guard logic
- On a dirty tree, `et prepare-branch` aborts with the list of dirty files and deletes nothing.
- Ran the full command end to end on this branch: all six steps completed, node_modules reinstalled, react-native-lab clean with dependencies restored, `Podfile.lock` updated in both apps, and all build caches removed.
