### PR TITLE
[docs] Exclude redirect stub pages from sitemap.xml

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -206,6 +206,7 @@ const nextConfig: NextConfig = {
       pathMap,
       domain: `https://docs.expo.dev`,
       output: join(outDir, `sitemap.xml`),
+      pagesDirectory: pagesDir,
       // Some of the search engines only track the first N items from the sitemap,
       // this makes sure our starting and general guides are first, and API index last (in order from new to old)
       pathsPriority: [

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -7,6 +7,35 @@ const IGNORED_PAGES = new Set([
   '/versions', // Skip the redirect to latest, use `/versions/latest` instead
 ]);
 
+const REDIRECT_STUB_MARKERS = new Map([
+  ['.js', 'common/redirect'],
+  ['.mdx', 'components/plugins/Redirect'],
+]);
+
+export function findRedirectStubUrls(pagesDirectory, urls) {
+  const stubUrls = urls.filter(url => {
+    const route = url.replace(/^\/+|\/+$/g, '');
+    if (!route) {
+      return false;
+    }
+
+    const candidates = [
+      path.join(pagesDirectory, route, 'index.js'),
+      path.join(pagesDirectory, route, 'index.mdx'),
+      path.join(pagesDirectory, `${route}.mdx`),
+    ];
+    const pageFile = candidates.find(candidate => fs.existsSync(candidate));
+    if (!pageFile) {
+      return false;
+    }
+
+    const marker = REDIRECT_STUB_MARKERS.get(path.extname(pageFile));
+    return marker ? fs.readFileSync(pageFile, 'utf-8').includes(marker) : false;
+  });
+
+  return new Set(stubUrls);
+}
+
 /**
  * Create a sitemap for crawlers like Algolia Docsearch.
  * This allows crawlers to index _all_ pages, without a full page-link-chain.
@@ -17,6 +46,7 @@ export default function createSitemap({
   output,
   pathsPriority,
   pathsHidden,
+  pagesDirectory,
   modificationDates = {},
 }) {
   if (!pathMap) {
@@ -33,9 +63,19 @@ export default function createSitemap({
   pathsPriority = pathsPriority.map(pathWithStartingSlash);
   pathsHidden = pathsHidden.map(pathWithStartingSlash);
 
+  // Sitemaps should only list canonical content URLs, not redirect stubs
+  const redirectStubs = pagesDirectory
+    ? findRedirectStubUrls(pagesDirectory, Object.keys(pathMap))
+    : new Set();
+
   // Get a list of URLs from the pathMap that we can use in the sitemap
   const urls = Object.keys(pathMap)
-    .filter(url => !IGNORED_PAGES.has(url) && !pathsHidden.some(hidden => url.startsWith(hidden)))
+    .filter(
+      url =>
+        !IGNORED_PAGES.has(url) &&
+        !redirectStubs.has(url) &&
+        !pathsHidden.some(hidden => url.startsWith(hidden))
+    )
     .map(pathWithTrailingSlash)
     .sort((a, b) => pathSortedByPriority(a, b, pathsPriority));
 

--- a/docs/scripts/create-sitemap.test.js
+++ b/docs/scripts/create-sitemap.test.js
@@ -1,6 +1,137 @@
-import { pathSortedByPriority } from './create-sitemap.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import createSitemap, { findRedirectStubUrls, pathSortedByPriority } from './create-sitemap.js';
 
 const priorities = ['/get-started', '/guides', '/versions'];
+
+const JS_STUB = `import redirect from '~/common/redirect';
+
+export default redirect('/develop/development-builds/introduction');
+`;
+
+const MDX_STUB = `---
+title: EAS Build
+---
+
+import Redirect from '~/components/plugins/Redirect';
+
+<Redirect path="/build/introduction" />
+`;
+
+const MDX_CONTENT_WITH_REDIRECT_EXAMPLE = `---
+title: Redirects
+---
+
+Use the [\`Redirect\`](https://docs.expo.dev/versions/latest/sdk/router/) component from \`expo-router\`:
+
+\`\`\`tsx
+import { Redirect } from 'expo-router';
+
+export default function Page() {
+  return <Redirect href="/about" />;
+}
+\`\`\`
+`;
+
+const MDX_CONTENT = `---
+title: Overview
+---
+
+Real documentation content.
+`;
+
+let pagesDirectory;
+
+beforeAll(() => {
+  pagesDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'create-sitemap-test-'));
+
+  const files = {
+    'develop/index.js': JS_STUB,
+    'build/index.mdx': MDX_STUB,
+    'moved-page.mdx': MDX_STUB,
+    'router/reference/redirects.mdx': MDX_CONTENT_WITH_REDIRECT_EXAMPLE,
+    'guides/overview.mdx': MDX_CONTENT,
+    'develop/development-builds/introduction.mdx': MDX_CONTENT,
+  };
+
+  for (const [file, contents] of Object.entries(files)) {
+    const filePath = path.join(pagesDirectory, file);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(pagesDirectory, { recursive: true, force: true });
+});
+
+describe('findRedirectStubUrls', () => {
+  test('detects index.js meta-refresh stubs', () => {
+    expect(findRedirectStubUrls(pagesDirectory, ['/develop'])).toEqual(new Set(['/develop']));
+  });
+
+  test('detects mdx pages rendering the Redirect plugin', () => {
+    expect(findRedirectStubUrls(pagesDirectory, ['/build', '/moved-page'])).toEqual(
+      new Set(['/build', '/moved-page'])
+    );
+  });
+
+  test('keeps content pages that only mention Redirect in code examples', () => {
+    expect(findRedirectStubUrls(pagesDirectory, ['/router/reference/redirects'])).toEqual(
+      new Set()
+    );
+  });
+
+  test('keeps regular content pages, the root url, and unresolvable urls', () => {
+    const urls = ['/guides/overview', '/develop/development-builds/introduction', '/', '/unknown'];
+    expect(findRedirectStubUrls(pagesDirectory, urls)).toEqual(new Set());
+  });
+});
+
+describe('createSitemap', () => {
+  test('omits redirect stubs from the generated sitemap when pagesDirectory is set', async () => {
+    const output = path.join(pagesDirectory, 'sitemap.xml');
+    const urls = createSitemap({
+      pathMap: {
+        '/': {},
+        '/develop': {},
+        '/develop/development-builds/introduction': {},
+        '/build': {},
+        '/guides/overview': {},
+      },
+      domain: 'https://docs.expo.dev',
+      output,
+      pathsPriority: [],
+      pathsHidden: [],
+      pagesDirectory,
+    });
+
+    expect(urls).toEqual(['/', '/develop/development-builds/introduction/', '/guides/overview/']);
+
+    const xml = await waitForSitemapFlush(output);
+    expect(xml).toContain(
+      '<loc>https://docs.expo.dev/develop/development-builds/introduction/</loc>'
+    );
+    expect(xml).not.toContain('<loc>https://docs.expo.dev/develop/</loc>');
+    expect(xml).not.toContain('<loc>https://docs.expo.dev/build/</loc>');
+  });
+});
+
+async function waitForSitemapFlush(filePath, timeoutMs = 2000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (fs.existsSync(filePath)) {
+      const contents = fs.readFileSync(filePath, 'utf-8');
+      if (contents.includes('</urlset>')) {
+        return contents;
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error(`Sitemap was not fully written within ${timeoutMs}ms: ${filePath}`);
+}
 
 describe('pathSortedByPriority', () => {
   test('index page sorts first', () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-23559

The generated `sitemap.xml` lists 19 redirect stub pages (`/develop`, `/get-started`, `/build`, ...) that serve an empty shell with a meta refresh, so crawlers that sample them see no content and the pages inflate the llms.txt coverage denominator in agent-docs measurements. Sitemaps should list canonical content URLs only. 

# How

- Add `findRedirectStubUrls` to `scripts/create-sitemap.js` to detect pages backed by a `common/redirect` `index.js` stub or an MDX page importing `components/plugins/Redirect`, and filter them from sitemap entries. The import path is the marker, not the `<Redirect>` tag, since content pages embed that tag in code examples.
- Pass `pagesDirectory` from `next.config.ts` so the export build applies the filter.
- Add tests in `scripts/create-sitemap.test.js` covering both stub kinds, content pages that only mention `<Redirect>` in examples, and the stub-free written XML.

# Test Plan

Run `node --experimental-strip-types --experimental-vm-modules ./node_modules/jest/bin/jest.js scripts/create-sitemap.test.js` (11 passing). 

On the preview deploy, `/sitemap.xml` drops from 1488 to 1469 entries and no longer lists `/develop/` or `/build/` while their redirect targets remain: https://pr-47593.expo-docs.pages.dev/sitemap.xml

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
