### PR TITLE
[ios][task-manager] Make task request callback fire exactly once

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a crash when a task execution request is evaluated re-entrantly, by making its completion callback fire exactly once. ([#47594](https://github.com/expo/expo/pull/47594) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.15 — 2026-05-26

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
@@ -56,10 +56,17 @@
     // due to this fact `_callback = nil;` was crashing on older versions of iOS (below 12.0).
     __strong EXTaskExecutionRequest *strongSelf = self;
 
-    _callback(_results);
+    // Capture the callback and results, then clear the request state before invoking. The callback is a
+    // one-shot completion that unregisters this request and breaks the retain cycle keeping its captured
+    // state alive, so a re-entrant or duplicated evaluation (e.g. a task finishing during a foreground
+    // transition) must not pass the `_callback` guard again and fire against freed memory.
+    void (^callback)(NSArray *) = _callback;
+    NSArray *results = _results;
     _callback = nil;
     _tasks = nil;
     _results = nil;
+
+    callback(results);
     strongSelf = nil;
   }
 }


### PR DESCRIPTION
## Why

Fixes #47572. In production apps using background tasks (e.g. `startLocationUpdatesAsync`), we've seen intermittent `EXC_BAD_ACCESS` / `SIGSEGV` crashes in `EXTaskExecutionRequest._maybeExecuteCallback`. This also plausibly explains the earlier crash reports #44709 and #47316, which were closed for lacking a deterministic repro.

`_maybeExecuteCallback` invoked the completion callback *before* clearing `_callback`:

```objc
_callback(_results);
_callback = nil;
_tasks = nil;
_results = nil;
```

The `if (_callback)` guard is meant to give the callback one-shot semantics, but because the state was cleared only *after* the call returned, a re-entrant or duplicated evaluation of the same request that reached `_maybeExecuteCallback` while `_callback(...)` was still on the stack passed the guard a second time. The callback is `EXTaskService`'s per-request completion block, which unregisters the request and breaks the retain cycle keeping its captured state alive, so the second invocation fired against already-freed memory. The re-entry is reachable when a background task finishes during a foreground transition (the completion block's work drains more task-finish notifications for a task still in the same request's set).

## How

Capture the callback and results into locals, clear all request state (`_callback`, `_tasks`, `_results`), then invoke. Now the `if (_callback)` guard genuinely fires once: a re-entrant `_maybeExecuteCallback` sees `_callback == nil` and no-ops instead of firing against freed memory. The `__strong strongSelf` reference is kept, since the callback removes the request from `EXTaskService._requests` and can drop the last strong reference to `self` mid-call.

This matches the fix reported in #47572, which the reporter has been shipping as a local patch of `expo-task-manager`.

## Test Plan

There is no automated test: the crash is a use-after-free race in Objective-C completion plumbing with no JSI surface, and `EXTaskExecutionRequest` has no native unit-test target. The fix is verified by source inspection (the reorder makes the guard fire-once) and by the reporter running the identical reorder in a production app that previously crashed. `et check-packages expo-task-manager` passes (build, lint, format).
