### PR TITLE
[docs] Translate reset button in the sidebar

### DIFF
--- a/docs/messages/en.json
+++ b/docs/messages/en.json
@@ -43,5 +43,7 @@
   "progressTrackerNext": "Next: {title}",
   "prerequisitesHeading": "Prerequisites",
   "prerequisitesRequirementSingular": "requirement",
-  "prerequisitesRequirementPlural": "requirements"
+  "prerequisitesRequirementPlural": "requirements",
+  "sidebarResetTutorial": "Reset tutorial",
+  "sidebarTutorialProgress": "{completed} of {total}"
 }

--- a/docs/messages/ja.json
+++ b/docs/messages/ja.json
@@ -43,5 +43,7 @@
   "progressTrackerNext": "次へ：{title}",
   "prerequisitesHeading": "前提条件",
   "prerequisitesRequirementSingular": "件",
-  "prerequisitesRequirementPlural": "件"
+  "prerequisitesRequirementPlural": "件",
+  "sidebarResetTutorial": "チュートリアルをリセット",
+  "sidebarTutorialProgress": "{completed} / {total}"
 }

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -22,6 +22,7 @@ import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
 import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
 import { TerminalBrowserIcon } from '@expo/styleguide-icons/outline/TerminalBrowserIcon';
 import { useRouter } from 'next/compat/router';
+import { useIntl } from 'react-intl';
 
 import {
   buildLocalePath,
@@ -45,6 +46,7 @@ import { SidebarNodeProps } from './types';
 export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
   const { getChapters, isCompleted, resetTutorial } = useTutorialChapterCompletion();
   const router = useRouter();
+  const intl = useIntl();
 
   const title = route.sidebarTitle ?? route.name;
   const Icon = route.hideIcon ? undefined : getIconElement(route.name);
@@ -111,7 +113,12 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="ml-2 text-sm text-tertiary">{`${completedChaptersCount} of ${totalChapters}`}</p>
+              <p className="ml-2 text-sm text-tertiary">
+                {intl.formatMessage(
+                  { id: 'sidebarTutorialProgress' },
+                  { completed: completedChaptersCount, total: totalChapters }
+                )}
+              </p>
             </div>
           </div>
         )}
@@ -150,7 +157,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             theme="secondary"
             className="flex w-full items-center justify-center"
             href={localizedResetHref}>
-            Reset tutorial
+            {intl.formatMessage({ id: 'sidebarResetTutorial' })}
           </Button>
         )}
       </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-23563

Stacked on https://github.com/expo/expo/pull/47559

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="161" height="226" alt="CleanShot 2026-07-07 at 19 58 36@2x" src="https://github.com/user-attachments/assets/9825fbfc-e256-40cb-94bc-c12b810ade6c" />


<img width="173" height="257" alt="CleanShot 2026-07-07 at 19 58 29@2x" src="https://github.com/user-attachments/assets/260210ee-3878-44f8-8a8c-e4f0a1c4fe8c" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
