### PR TITLE
[expo] Add expo-eas-client to bundledNativeModules.json

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -41,6 +41,7 @@
   "expo-dev-client": "~56.0.16",
   "expo-device": "~56.0.4",
   "expo-document-picker": "~56.0.4",
+  "expo-eas-client": "~56.0.1",
   "expo-file-system": "~56.0.7",
   "expo-font": "~56.0.5",
   "expo-gl": "~56.0.5",


### PR DESCRIPTION
# Why

`expo-eas-client` doesn't usually need to be directly installed, but we identified a use case for Observe where you could use the EAS Client ID to cross-reference a user/device install history or session to an actual user in your system, and that would require importing this package.