### PR TITLE
[docs] Split Expo Skills table into framework and EAS sections

### DIFF
--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -85,24 +85,31 @@ Use the [skills CLI](https://skills.sh/docs/cli) to add Expo Skills to any compa
 
 ## Available Expo Skills
 
-The following skills are available in the `expo` plugin:
+The following skills are available in the `expo` plugin. Skill names describe what they cover: `expo-*` skills teach agents the open source framework, and `eas-*` skills cover EAS services.
 
-<ExpoSkillsTable />
+### Expo SDK and framework
+
+<ExpoSkillsTable category="framework" />
+
+### Expo Application Services (EAS)
+
+<ExpoSkillsTable category="eas" />
 
 ## Example prompts
 
 Try the following prompts after installing Expo Skills. Your AI agent will automatically use the appropriate skill:
 
-| Example prompt                                         | Skill used                |
-| ------------------------------------------------------ | ------------------------- |
-| Build a settings screen with a form and navigation     | `building-native-ui`      |
-| Set up Tailwind CSS in my Expo project                 | `expo-tailwind-setup`     |
-| Embed a recharts chart in my native app using web code | `use-dom`                 |
-| Add a SwiftUI picker component to my Expo app          | `expo-ui-swift-ui`        |
-| Use Material Design 3 components with Jetpack Compose  | `expo-ui-jetpack-compose` |
-| How do I deploy my Expo app to the Apple App Store?    | `expo-deployment`         |
-| Create a CI/CD workflow that builds on every PR        | `expo-cicd-workflows`     |
-| Upgrade my project to the latest Expo SDK              | `upgrading-expo`          |
+| Example prompt                                         | Skill used            |
+| ------------------------------------------------------ | --------------------- |
+| Build a settings screen with native-feeling controls   | `expo-native-ui`      |
+| Add tab navigation and a modal to my app               | `expo-router`         |
+| Set up Tailwind CSS in my Expo project                 | `expo-tailwind-setup` |
+| Embed a recharts chart in my native app using web code | `expo-dom`            |
+| Add a SwiftUI picker component to my Expo app          | `expo-ui`             |
+| Use Material Design 3 components with Jetpack Compose  | `expo-ui`             |
+| How do I deploy my Expo app to the Apple App Store?    | `eas-app-stores`      |
+| Create a CI/CD workflow that builds on every PR        | `eas-workflows`       |
+| Upgrade my project to the latest Expo SDK              | `expo-upgrade`        |
 
 ## Additional resources
 

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -85,7 +85,7 @@ Use the [skills CLI](https://skills.sh/docs/cli) to add Expo Skills to any compa
 
 ## Available Expo Skills
 
-The following skills are available in the `expo` plugin. Skill names describe what they cover: `expo-*` skills teach agents the open source framework, and `eas-*` skills cover EAS services.
+The following skills are available in the `expo` plugin. Skills name prefixed with`expo-*` skills are used for the Expo open source framework and `eas-*` skills for the EAS services.
 
 ### Expo SDK and framework
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -17,7 +17,7 @@ If you are looking to install a specific version of Expo Go, visit [expo.dev/go]
 
 ### Upgrade with an AI coding agent
 
-If you use an AI coding agent, install [Expo Skills](/skills/) and use the [`upgrading-expo` skill](/skills/#available-expo-skills). The skill provides guidelines for upgrading Expo SDK versions and fixing dependency issues. Review any proposed changes and check the SDK changelog for version-specific instructions.
+If you use an AI coding agent, install [Expo Skills](/skills/) and use the [`expo-upgrade` skill](/skills/#available-expo-skills). The skill provides guidelines for upgrading Expo SDK versions and fixing dependency issues. Review any proposed changes and check the SDK changelog for version-specific instructions.
 
 ### Upgrade manually
 

--- a/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
+++ b/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
@@ -2,104 +2,123 @@
   "source": {
     "repo": "expo/skills",
     "url": "https://api.github.com/repos/expo/skills/contents/plugins/expo/skills",
-    "fetchedAt": "2026-07-07T09:09:13.631Z"
+    "fetchedAt": "2026-07-07T17:11:30.891Z"
   },
   "totalSkills": 19,
   "skills": [
     {
-      "name": "add-app-clip",
-      "description": "Add an iOS App Clip target to an Expo app. Use when the user mentions App Clip, AASA, apple-app-site-association, appclips, smart app banner, or wants to ship a lightweight iOS Clip invoked from a URL alongside their parent app.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/add-app-clip/SKILL.md"
+      "name": "eas-app-stores",
+      "category": "eas",
+      "description": "Deploy Expo apps to the app stores with EAS - build and submit to the iOS App Store, Google Play Store, and TestFlight, configure eas.json build and submit profiles, manage app versions and build numbers, and publish App Store metadata and ASO. Use whenever the user wants to deploy, release, or ship an app to production or the app stores, is preparing a production build, running eas build or eas submit, shipping to TestFlight, bumping version or build numbers, or setting up store listing metadata. For deploying an Expo website or API routes, use the eas-hosting skill.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-app-stores/SKILL.md"
     },
     {
-      "name": "building-native-ui",
-      "description": "Build beautiful, native-feeling Expo screens. Covers Apple HIG styling, semantic colors, native controls, SF Symbols, media, animations, visual effects, gradients, storage, and responsive layout. For routing and navigation, use the expo-router skill.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/building-native-ui/SKILL.md"
+      "name": "eas-hosting",
+      "category": "eas",
+      "description": "Deploy Expo websites and Expo Router API routes to EAS Hosting - export the web bundle, run eas deploy for production and PR preview URLs, manage environment secrets and custom domains, and work within the Cloudflare Workers runtime. Also covers authoring API routes (+api.ts handlers, HTTP methods, request handling, CORS). Use when deploying an Expo web app or API routes, setting up EAS Hosting, or configuring hosting environments and domains. Not for native builds or store releases - use the eas-app-stores skill for those.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-hosting/SKILL.md"
+    },
+    {
+      "name": "eas-observe",
+      "category": "eas",
+      "description": "Use for anything related to EAS Observe - adding `expo-observe` to an Expo project (AppMetricsRoot/ObserveRoot HOC, markInteractive, the useObserve hook, the Expo Router / React Navigation integrations for per-route metrics, and user-defined events via `Observe.logEvent`), querying via the EAS CLI (`eas observe:metrics-summary`, `observe:metrics`, `observe:routes`, `observe:events`, `observe:versions`), or interpreting the resulting metrics (cold/warm launch, TTR, TTI, navigation cold/warm TTR, update download, and the TTI frameRate params for triaging slow startups).",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-observe/SKILL.md"
     },
     {
       "name": "eas-simulator",
-      "description": "Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Always read before executing any `eas simulator:*` commands — it has the current syntax for this experimental API. Use whenever the user needs a simulator they can't run locally — 'run my app on a cloud simulator', 'use eas simulator to run/install/screenshot my app', 'I'm on Linux/Cursor and need an iOS device', 'no sim on this box / headless CI', 'let an agent click through my app and screenshot it', 'test my dev build on a remote sim with live reload', 'stream a sim's screen to my browser' — even when they don't say 'EAS Simulator' or 'cloud'. On a host WITHOUT a local simulator (Linux, CI, cloud sandbox) it's the default — just use it; on macOS, do NOT auto-trigger for a plain 'run on the simulator' — use it only for a cloud/remote/shareable sim, an iOS version they lack, or an agent-driven session. NOT for local sims (expo run:ios, Xcode, Android Studio), EAS Build/Update, web preview, or physical devices.",
+      "category": "eas",
+      "description": "Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Read before running any `eas simulator:*` commands - it has the current syntax for this experimental API. Use whenever the user needs a simulator they can't run locally - 'run my app on a cloud simulator', 'use eas simulator to run/install/screenshot my app', 'I'm on Linux/Cursor and need an iOS device', 'no sim on this box / headless CI', 'let an agent click through my app and screenshot it', 'test my dev build on a remote sim with live reload', 'stream a sim to my browser' - even when they don't say 'EAS Simulator' or 'cloud'. On a host WITHOUT a local simulator (Linux, CI, cloud sandbox) it's the default; on macOS, do NOT auto-trigger for a plain 'run on the simulator' - use it only for a cloud/remote/shareable sim, an iOS version they lack, or an agent-driven session. NOT for local sims (expo run:ios, Xcode, Android Studio), EAS Build/Update, web preview, or physical devices.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-simulator/SKILL.md"
     },
     {
       "name": "eas-update-insights",
-      "description": "Check the health of published EAS Updates: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel. Use when the user asks how an update is performing, whether a rollout is healthy, how many users are on the embedded build vs OTA, or wants to gate CI on update health.",
+      "category": "eas",
+      "description": "Check the health of published EAS Update: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel. Use when the user asks how an update is performing, whether a rollout is healthy, how many users are on the embedded build vs OTA, or wants to gate CI on update health.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-update-insights/SKILL.md"
     },
     {
-      "name": "expo-api-routes",
-      "description": "Guidelines for creating API routes in Expo Router with EAS Hosting.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-api-routes/SKILL.md"
+      "name": "eas-workflows",
+      "category": "eas",
+      "description": "Helps understand and write EAS workflow YAML files for Expo projects. Use this skill when the user asks about CI/CD or workflows in an Expo or EAS context, mentions .eas/workflows/, or wants help with EAS build pipelines or deployment automation.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-workflows/SKILL.md"
+    },
+    {
+      "name": "expo-app-clip",
+      "category": "framework",
+      "description": "Add an iOS App Clip target to an Expo app. Use when the user mentions App Clip, AASA, apple-app-site-association, appclips, smart app banner, or wants to ship a lightweight iOS Clip invoked from a URL alongside their parent app.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-app-clip/SKILL.md"
     },
     {
       "name": "expo-brownfield",
+      "category": "framework",
       "description": "Integrate Expo and React Native into an existing native iOS or Android app. Use when the user mentions brownfield, embedding React Native in a native app, AAR/XCFramework, or adding Expo to an existing Kotlin/Swift project. Covers both the isolated approach and the integrated approach.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-brownfield/SKILL.md"
     },
     {
-      "name": "expo-cicd-workflows",
-      "description": "Helps understand and write EAS workflow YAML files for Expo projects. Use this skill when the user asks about CI/CD or workflows in an Expo or EAS context, mentions .eas/workflows/, or wants help with EAS build pipelines or deployment automation.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-cicd-workflows/SKILL.md"
-    },
-    {
-      "name": "expo-deployment",
-      "description": "Deploy Expo apps to production with EAS — build and submit to the iOS App Store, Google Play Store, and TestFlight, configure eas.json build and submit profiles, manage app versions and build numbers, publish App Store metadata and ASO, and deploy web bundles and API routes via EAS Hosting. Use whenever the user is preparing a production build, running eas build or eas submit, shipping to TestFlight, releasing or rolling out to the app stores, bumping version or build numbers, or setting up store listing metadata for an Expo app.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-deployment/SKILL.md"
+      "name": "expo-data-fetching",
+      "category": "framework",
+      "description": "Use when implementing or debugging ANY network request, API call, or data fetching. Covers fetch API, React Query, SWR, error handling, caching, offline support, and Expo Router data loaders (`useLoaderData`).",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-data-fetching/SKILL.md"
     },
     {
       "name": "expo-dev-client",
-      "description": "Build Expo app for development.",
+      "category": "framework",
+      "description": "Build and distribute Expo development clients locally or via TestFlight for internal testing. For production TestFlight releases and store submission, use the eas-app-stores skill.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-dev-client/SKILL.md"
     },
     {
+      "name": "expo-dom",
+      "category": "framework",
+      "description": "Use Expo DOM components to run web code in a webview on native and as-is on web. Migrate web code to native incrementally. For the end-to-end migration of a whole web app, use the expo-web-to-native skill.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-dom/SKILL.md"
+    },
+    {
       "name": "expo-examples",
-      "description": "Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more). Use when integrating a third-party library or service into an existing Expo app and you want the canonical, version-matched pattern to adapt, or when scaffolding a new project from one with `npx create-expo --example`.",
+      "category": "framework",
+      "description": "Expo's official example projects - the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more). Use when integrating a third-party library or service into an existing Expo app and you want the canonical, version-matched pattern to adapt, or when scaffolding a new project from one with `npx create-expo --example`.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-examples/SKILL.md"
     },
     {
       "name": "expo-module",
+      "category": "framework",
       "description": "Guide for creating and writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system. Use when building or modifying native modules for Expo.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-module/SKILL.md"
     },
     {
-      "name": "expo-observe",
-      "description": "Use for anything related to EAS Observe — adding `expo-observe` to an Expo project (AppMetricsRoot/ObserveRoot HOC, markInteractive, the useObserve hook, the Expo Router / React Navigation integrations for per-route metrics, and user-defined events via `Observe.logEvent`), querying via the EAS CLI (`eas observe:metrics-summary`, `observe:metrics`, `observe:routes`, `observe:events`, `observe:versions`), or interpreting the resulting metrics (cold/warm launch, TTR, TTI, navigation cold/warm TTR, update download, and the TTI frameRate params for triaging slow startups).",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-observe/SKILL.md"
+      "name": "expo-native-ui",
+      "category": "framework",
+      "description": "Build beautiful, native-feeling Expo screens. Covers Apple HIG styling, semantic colors, native controls, SF Symbols, media, animations, visual effects, gradients, storage, and responsive layout. For routing and navigation, use the expo-router skill.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-native-ui/SKILL.md"
     },
     {
       "name": "expo-router",
+      "category": "framework",
       "description": "Navigation and routing for Expo Router. Covers file-based routes, groups and dynamic routes, folder organization, Link with previews and context menus, native Stack, page titles, modals and form sheets, NativeTabs, headers and toolbars, and header search bars.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-router/SKILL.md"
     },
     {
       "name": "expo-tailwind-setup",
+      "category": "framework",
       "description": "Set up Tailwind CSS v4 in Expo with react-native-css and NativeWind v5 for universal styling.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-tailwind-setup/SKILL.md"
     },
     {
       "name": "expo-ui",
+      "category": "framework",
       "description": "Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android rendered from React in an Expo or React Native app. Covers universal cross-platform components (Host, Column, Row, Button, Text, List, and more imported from @expo/ui), drop-in replacements for popular React Native community libraries (BottomSheet, DateTimePicker, Slider, Menu, etc.), and platform-specific SwiftUI (@expo/ui/swift-ui, iOS only) and Jetpack Compose (@expo/ui/jetpack-compose, Android only) trees and modifiers. Use when adding or reviewing @expo/ui Host/RNHostView trees, building native-feeling UI where standard React Native components fall short (grouped settings forms with toggles, sections, menus, sheets, pickers, sliders), choosing between universal and platform-specific components, or replacing an RN community UI library with a native @expo/ui equivalent. Not for custom native modules, Expo Router navigation, Reanimated, or data fetching.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-ui/SKILL.md"
     },
     {
-      "name": "native-data-fetching",
-      "description": "Use when implementing or debugging ANY network request, API call, or data fetching. Covers fetch API, React Query, SWR, error handling, caching, offline support, and Expo Router data loaders (`useLoaderData`).",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/native-data-fetching/SKILL.md"
-    },
-    {
-      "name": "upgrading-expo",
+      "name": "expo-upgrade",
+      "category": "framework",
       "description": "Guidelines for upgrading Expo SDK versions and fixing dependency issues.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/upgrading-expo/SKILL.md"
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-upgrade/SKILL.md"
     },
     {
-      "name": "use-dom",
-      "description": "Use Expo DOM components to run web code in a webview on native and as-is on web. Migrate web code to native incrementally.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/use-dom/SKILL.md"
-    },
-    {
-      "name": "web-to-native",
-      "description": "Migrate an existing web React app to a native iOS/Android app with Expo. Use when the user wants to turn a website into a mobile app, port a Next.js/Vite/CRA React codebase to React Native, reuse web code on native incrementally, or asks how web idioms (the DOM, CSS, React Router, localStorage, window) map to native. This is the end-to-end migration guide; use the `use-dom` skill for the DOM-component mechanism itself.",
-      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/web-to-native/SKILL.md"
+      "name": "expo-web-to-native",
+      "category": "framework",
+      "description": "Migrate an existing web React app to a native iOS/Android app with Expo. Use when the user wants to turn a website into a mobile app, port a Next.js/Vite/CRA React codebase to React Native, reuse web code on native incrementally, or asks how web idioms (the DOM, CSS, React Router, localStorage, window) map to native. This is the end-to-end migration guide; use the `expo-dom` skill for the DOM-component mechanism itself.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-web-to-native/SKILL.md"
     }
   ]
 }

--- a/docs/ui/components/ExpoSkillsTable/index.tsx
+++ b/docs/ui/components/ExpoSkillsTable/index.tsx
@@ -6,6 +6,7 @@ import expoSkillsData from './data/expo-skills.json';
 
 type Skill = {
   name: string;
+  category: string;
   description: string;
   githubUrl: string;
 };
@@ -16,19 +17,25 @@ type ExpoSkillsData = {
 
 const data: ExpoSkillsData = expoSkillsData;
 
-export function ExpoSkillsTable() {
+type ExpoSkillsTableProps = {
+  category: 'framework' | 'eas';
+};
+
+export function ExpoSkillsTable({ category }: ExpoSkillsTableProps) {
   return (
     <Table headers={['Skill', 'Description']}>
-      {data.skills.map(skill => (
-        <Row key={skill.name}>
-          <Cell>
-            <A href={skill.githubUrl}>
-              <CODE>{skill.name}</CODE>
-            </A>
-          </Cell>
-          <Cell>{renderDescription(skill.description)}</Cell>
-        </Row>
-      ))}
+      {data.skills
+        .filter(skill => skill.category === category)
+        .map(skill => (
+          <Row key={skill.name}>
+            <Cell>
+              <A href={skill.githubUrl}>
+                <CODE>{skill.name}</CODE>
+              </A>
+            </Cell>
+            <Cell>{renderDescription(skill.description)}</Cell>
+          </Row>
+        ))}
     </Table>
   );
 }

--- a/docs/ui/components/ExpoSkillsTable/sync-expo-skills.js
+++ b/docs/ui/components/ExpoSkillsTable/sync-expo-skills.js
@@ -11,6 +11,11 @@ const GITHUB_API_URL = 'https://api.github.com/repos/expo/skills/contents/plugin
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/expo/skills/main/plugins/expo/skills';
 const GITHUB_BLOB_BASE = 'https://github.com/expo/skills/blob/main/plugins/expo/skills';
 
+const CATEGORY_LABELS = [
+  { pattern: /^Framework \(OSS\)\.\s*/, category: 'framework' },
+  { pattern: /^EAS service \(paid\)\.\s*/, category: 'eas' },
+];
+
 async function fetchJson(url) {
   const response = await fetch(url, {
     headers: { Accept: 'application/vnd.github.v3+json' },
@@ -54,14 +59,25 @@ function parseFrontmatter(content) {
   return frontmatter;
 }
 
+function categorizeSkill(skillName, description) {
+  for (const { pattern, category } of CATEGORY_LABELS) {
+    if (pattern.test(description)) {
+      return { category, description: description.replace(pattern, '') };
+    }
+  }
+  return { category: skillName.startsWith('eas-') ? 'eas' : 'framework', description };
+}
+
 async function fetchSkillMetadata(skillName) {
   const url = `${GITHUB_RAW_BASE}/${skillName}/SKILL.md`;
   const content = await fetchText(url);
   const frontmatter = parseFrontmatter(content);
+  const { category, description } = categorizeSkill(skillName, frontmatter.description ?? '');
 
   return {
     name: skillName,
-    description: ensureTrailingPeriod(frontmatter.description),
+    category,
+    description: ensureTrailingPeriod(description),
     githubUrl: `${GITHUB_BLOB_BASE}/${skillName}/SKILL.md`,
   };
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/skills/pull/98, which renamed every skill with `expo-*`/`eas-*` prefixes and split the catalog into framework and paid EAS service tables, so our synced single table is stale.

# How

- Update `sync-expo-skills.js` to read the `Framework (OSS).` / `EAS service (paid).` label from each skill description, strip it from the display text, and write a `category` field (name-prefix fallback).
- Add a required `category` prop to `ExpoSkillsTable` and render two tables in `skills.mdx` under "Expo SDK and framework" and "Expo Application Services (EAS)" headings.
- Update the example prompts table and the skill mention in `upgrading-expo-sdk-walkthrough.mdx` to the renamed skills.
- Regenerate `expo-skills.json` (19 skills: 13 framework, 6 EAS).

# Test Plan

Open preview and go to Expo Skills page.

<img width="2522" height="2254" alt="CleanShot 2026-07-07 at 22 53 01@2x" src="https://github.com/user-attachments/assets/95a0f4a9-5a45-4390-ae33-fdcac8d7ffef" />

<img width="2438" height="1816" alt="CleanShot 2026-07-07 at 22 53 06@2x" src="https://github.com/user-attachments/assets/cd931aae-3718-458a-9281-6240c1668bc4" />

<img width="2384" height="1308" alt="CleanShot 2026-07-07 at 22 53 09@2x" src="https://github.com/user-attachments/assets/e66ef7f6-2eec-4810-a205-921069ba7b39" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
