### PR TITLE
[docs] Sync SDK version tabs in EAS Observe pages

### DIFF
--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -6,9 +6,11 @@ searchRank: 9
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+<TabsGroup>
 
 EAS Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
 
@@ -103,7 +105,7 @@ Call `markInteractive()` when your app is fully ready for user interaction. This
 
 <Tabs>
 
-<Tab label="SDK 56">
+<Tab label="SDK 56 and later">
 
 ```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
@@ -236,3 +238,5 @@ You can also query metrics from the terminal using the EAS CLI:
 Run any of these commands with `--help` to see the available flags and arguments.
 
 </Step>
+
+</TabsGroup>

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -4,7 +4,9 @@ sidebar_title: Metrics
 description: A reference of each performance metric tracked by EAS Observe, including concepts and data handling.
 ---
 
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
+
+<TabsGroup>
 
 Reference for the performance metrics EAS Observe collects, the core concepts used to organize events (sessions and users), and how collected data is retained.
 
@@ -285,3 +287,5 @@ Metrics collected from debug builds are dropped before dispatching unless `dispa
 ### Disabling dispatching
 
 You can disable all dispatching globally using `configure({ dispatchingEnabled: false })`. While disabled, any pending metrics are dropped without being dispatched and no further metrics are dispatched until it is set back to `true`.
+
+</TabsGroup>

--- a/docs/pages/eas/observe/reference/troubleshooting.mdx
+++ b/docs/pages/eas/observe/reference/troubleshooting.mdx
@@ -7,7 +7,9 @@ description: Solutions for common EAS Observe issues.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
+
+<TabsGroup>
 
 ## Common issues
 
@@ -59,7 +61,7 @@ This metric requires manual instrumentation. Verify that:
 
 <Tabs>
 
-<Tab label="SDK 56">
+<Tab label="SDK 56 and later">
 
 1. You are calling `markInteractive()` (from `useObserve()`) after your splash screen is hidden.
 2. The call is actually being executed (add a `console.log` to verify).
@@ -170,3 +172,5 @@ After completing the migration, create a new build of your app:
 </Step>
 
 </Collapsible>
+
+</TabsGroup>


### PR DESCRIPTION
# Why

The SDK 56/55 tab blocks on the EAS Observe pages do not sync, so switching the version in one block leaves the others on the old selection.

# How

- Wrap the page body of `get-started.mdx`, `reference/metrics.mdx`, and `reference/troubleshooting.mdx` in `TabsGroup` so all SDK version tab blocks on a page share one selection.
- Normalize the two bare `SDK 56` tab labels to `SDK 56 and later` to match the rest of the section.

# Test Plan

Open `/eas/observe/get-started/`, switch the tab in step 2, and confirm the step 3 tabs follow. Repeat on the metrics and troubleshooting references, including the tabs inside the "Migrating from expo-eas-observe" collapsible.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).