### PR TITLE
[bare-expo] Run e2e flows in one Maestro invocation and retry only failures

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -395,9 +395,9 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo
-      - name: 🧪 Test image comparison utilities
-        run: bun test
-        working-directory: apps/bare-expo/e2e/image-comparison
+      - name: 🧪 Test e2e utilities
+        run: bun test e2e/image-comparison scripts/lib
+        working-directory: apps/bare-expo
       - name: ⚛️ Display React Native config
         run: pnpm expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo

--- a/apps/bare-expo/e2e/expo-image/test.yaml
+++ b/apps/bare-expo/e2e/expo-image/test.yaml
@@ -2,9 +2,6 @@ appId: dev.expo.Payments
 jsEngine: graaljs
 ---
 - openLink: bareexpo://components/image/comparison
-- tapOn:
-    text: 'Open'
-    optional: true
 
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml

--- a/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
+++ b/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
@@ -91,39 +91,43 @@ export class ScreenInspectorIOS {
     }
   }
 
-  private async writeToNamedPipe(pipePath: string, request: CoordinatesRequest): Promise<void> {
-    return new Promise((resolve, reject) => {
-      // Open the FIFO for writing
-      fs.open(pipePath, 'w', (err: any, fd: number) => {
-        if (err) {
-          reject(new Error(`Failed to open pipe ${pipePath}: ${err.message}`));
-          return;
+  private async writeToNamedPipe(
+    pipePath: string,
+    request: CoordinatesRequest,
+    timeoutMs: number = 10000
+  ): Promise<void> {
+    const buffer = Buffer.from(JSON.stringify(request), 'utf8');
+    console.log(`📤 Sending request: ${buffer.toString()}`);
+
+    // Open the write end non-blocking: it fails with ENXIO while the inspector isn't reading
+    // (e.g. still busy with a previous request or not running), so poll with a deadline. A
+    // blocking open would park a file descriptor forever when the inspector is gone, and
+    // enough of those exhaust the fs thread pool and starve every later lookup.
+    const deadline = Date.now() + timeoutMs;
+    let fd: number | null = null;
+    try {
+      while (fd == null) {
+        try {
+          fd = fs.openSync(pipePath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+        } catch (error: any) {
+          if (error.code !== 'ENXIO' || Date.now() >= deadline) {
+            throw new Error(`Failed to open pipe ${pipePath} for writing: ${error.message}`);
+          }
+          await new Promise((resolve) => setTimeout(resolve, 50));
         }
+      }
 
-        const data = JSON.stringify(request);
-        const buffer = Buffer.from(data, 'utf8');
-
-        console.log(`📤 Sending request: ${data}`);
-
-        fs.write(fd, buffer, 0, buffer.length, null, (err: any, bytesWritten: number) => {
-          fs.close(fd); // Always close the file descriptor
-
-          if (err) {
-            reject(new Error(`Failed to write to pipe ${pipePath}: ${err.message}`));
-            return;
-          }
-
-          if (bytesWritten !== buffer.length) {
-            reject(
-              new Error(`Partial write to pipe ${pipePath}: ${bytesWritten}/${buffer.length} bytes`)
-            );
-            return;
-          }
-
-          resolve();
-        });
-      });
-    });
+      const bytesWritten = fs.writeSync(fd, buffer);
+      if (bytesWritten !== buffer.length) {
+        throw new Error(
+          `Partial write to pipe ${pipePath}: ${bytesWritten}/${buffer.length} bytes`
+        );
+      }
+    } finally {
+      if (fd != null) {
+        fs.closeSync(fd);
+      }
+    }
   }
 
   private async pollResponse(fd: number, timeoutMs: number): Promise<InspectorResponse> {

--- a/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
+++ b/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
@@ -7,7 +7,12 @@ import path from 'node:path';
 interface CoordinatesRequest {
   action: 'getCoordinates';
   accessibilityId: string;
+  // Unique response pipe created by the client for this request, so that a response can never
+  // pair with another request's reader; see resolveResponsePipePath in ScreenInspector.swift.
+  responsePipe: string;
 }
+
+let nextRequestId = 0;
 
 interface InspectorResponse {
   success: boolean;
@@ -38,21 +43,33 @@ export class ScreenInspectorIOS {
   private requestPipePath = '/tmp/ios_screen_inspector_request';
   private responsePipePath = '/tmp/ios_screen_inspector_response';
 
-  async getCoordinates(accessibilityId: string): Promise<{
+  async getCoordinates(
+    accessibilityId: string,
+    timeoutMs: number = 15000
+  ): Promise<{
     x: number;
     y: number;
     width: number;
     height: number;
   }> {
+    const responsePipePath = `${this.responsePipePath}_${process.pid}_${nextRequestId++}`;
     const request: CoordinatesRequest = {
       action: 'getCoordinates',
       accessibilityId,
+      responsePipe: responsePipePath,
     };
 
+    await spawnAsync('mkfifo', [responsePipePath]);
+    let responseFd: number | null = null;
     try {
+      // Open the read end first (non-blocking, so this doesn't wait for a writer): the dylib's
+      // write-open then succeeds immediately, and polling with a deadline below means an
+      // abandoned request leaks nothing.
+      responseFd = fs.openSync(responsePipePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+
       await this.writeToNamedPipe(this.requestPipePath, request);
 
-      const response = await this.readFromNamedPipe(this.responsePipePath);
+      const response = await this.pollResponse(responseFd, timeoutMs);
 
       if (!response.success) {
         throw new Error(`Get coordinates failed: ${response.error}`);
@@ -66,6 +83,11 @@ export class ScreenInspectorIOS {
     } catch (error: any) {
       console.error('❌ iOS get coordinates failed:', error.message);
       throw error;
+    } finally {
+      if (responseFd != null) {
+        fs.closeSync(responseFd);
+      }
+      fs.rmSync(responsePipePath, { force: true });
     }
   }
 
@@ -104,39 +126,35 @@ export class ScreenInspectorIOS {
     });
   }
 
-  private async readFromNamedPipe(pipePath: string): Promise<InspectorResponse> {
-    return new Promise((resolve, reject) => {
-      // Open the FIFO for reading
-      fs.open(pipePath, 'r', (err: any, fd: number) => {
-        if (err) {
-          reject(new Error(`Failed to open pipe ${pipePath}: ${err.message}`));
-          return;
+  private async pollResponse(fd: number, timeoutMs: number): Promise<InspectorResponse> {
+    const buffer = Buffer.alloc(4096);
+    const deadline = Date.now() + timeoutMs;
+
+    console.log('📥 Waiting for response...');
+
+    // The fd is non-blocking: reads return 0 bytes while no writer has connected yet and throw
+    // EAGAIN while a writer is connected but hasn't written, so poll until data or deadline.
+    while (Date.now() < deadline) {
+      let bytesRead = 0;
+      try {
+        bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      } catch (error: any) {
+        if (error.code !== 'EAGAIN') {
+          throw new Error(`Failed to read from response pipe: ${error.message}`);
         }
+      }
 
-        const buffer = Buffer.alloc(4096);
+      if (bytesRead > 0) {
+        const data = buffer.subarray(0, bytesRead).toString('utf8');
+        const json = JSON.parse(data);
+        console.log(`📨 Response received: ${JSON.stringify(json, null, 2)}`);
+        return json;
+      }
 
-        console.log('📥 Waiting for response...');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
 
-        fs.read(fd, buffer, 0, buffer.length, null, (err: any, bytesRead: number) => {
-          fs.close(fd); // Always close the file descriptor
-
-          if (err) {
-            reject(new Error(`Failed to read from pipe ${pipePath}: ${err.message}`));
-            return;
-          }
-
-          if (bytesRead === 0) {
-            reject(new Error(`No data read from pipe ${pipePath}`));
-            return;
-          }
-
-          const data = buffer.subarray(0, bytesRead).toString('utf8');
-          const json = JSON.parse(data);
-          console.log(`📨 Response received: ${JSON.stringify(json, null, 2)}`);
-          resolve(json);
-        });
-      });
-    });
+    throw new Error(`Timed out waiting for the inspector response after ${timeoutMs}ms`);
   }
 
   async startSimulatorAppWithDylib(

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -136,10 +136,23 @@ private func log(_ message: String) {
     private func writeToPipe(_ path: String, data: Data) {
         log("Attempting to open pipe for writing")
 
-        let fd = open(path, O_WRONLY)
-        guard fd != -1 else {
-            log("Failed to open pipe for writing")
-            return
+        // The client may have timed out and abandoned this request, in which case no reader
+        // ever opens the other end and a plain blocking open would wedge the server thread
+        // forever, killing the inspector for the rest of the app's lifetime. Poll with
+        // O_NONBLOCK (which fails with ENXIO while there is no reader) and drop the response
+        // if no reader shows up in time; the server then moves on to the next request.
+        let deadline = Date().addingTimeInterval(5)
+        var fd: Int32 = -1
+        while fd == -1 {
+            fd = open(path, O_WRONLY | O_NONBLOCK)
+            if fd == -1 {
+                let openError = errno
+                if openError != ENXIO || Date() >= deadline {
+                    log("Failed to open pipe for writing, errno: \(openError); dropping response")
+                    return
+                }
+                usleep(50_000)
+            }
         }
 
         log("Pipe opened for writing, sending \(data.count) bytes")

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -107,7 +107,7 @@ private func log(_ message: String) {
             log("Received request: \(String(data: requestData, encoding: .utf8) ?? "invalid UTF8")")
 
             let response = processRequest(requestData)
-            writeToPipe(responsePipePath, data: response)
+            writeToPipe(resolveResponsePipePath(requestData), data: response)
 
             log("Sent response, ready for next request")
         }
@@ -131,6 +131,19 @@ private func log(_ message: String) {
 
         log("Read \(bytesRead) bytes from pipe")
         return Data(buffer.prefix(bytesRead))
+    }
+
+    private func resolveResponsePipePath(_ requestData: Data) -> String {
+        // Clients create a unique response pipe per request and pass its path along, so that a
+        // response can never pair with another request's reader (a shared response pipe gets
+        // permanently desynced once a single client times out and abandons its request).
+        // Requests without the field fall back to the shared legacy pipe.
+        guard let json = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any],
+              let responsePipe = json["responsePipe"] as? String,
+              responsePipe.hasPrefix("/tmp/ios_screen_inspector_response") else {
+            return responsePipePath
+        }
+        return responsePipe
     }
 
     private func writeToPipe(_ path: String, data: Data) {

--- a/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
@@ -119,7 +119,10 @@ function searchJsonNodes(
 async function getCoordinatesViaDylib(
   testID: string,
   displayScaleFactor: number,
-  timeoutMs: number = 3000
+  // The lookup walks the view hierarchy on the app's main thread, which can be busy for a
+  // few seconds on animation-heavy screens; a too-tight timeout abandons requests that would
+  // have succeeded.
+  timeoutMs: number = 10000
 ): Promise<Bounds | null> {
   const screenInspectorIOS = new ScreenInspectorIOS();
 

--- a/apps/bare-expo/scripts/lib/e2e-common.test.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from 'bun:test';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
-import { runMaestroAsync } from './e2e-common';
+import { annotate, runMaestroAsync } from './e2e-common';
 
 // A stand-in `maestro` binary that mimics Maestro's failure modes: it optionally writes the
 // JUnit report passed via --output and then hangs forever, like Maestro 2.4.0 wedging on exit
@@ -131,5 +131,46 @@ describe(runMaestroAsync, () => {
         reinstallDriver: true,
       })
     ).rejects.toThrow();
+  });
+});
+
+describe(annotate, () => {
+  const originalActions = process.env.GITHUB_ACTIONS;
+  const originalWorkspace = process.env.GITHUB_WORKSPACE;
+
+  afterEach(() => {
+    process.env.GITHUB_ACTIONS = originalActions;
+    process.env.GITHUB_WORKSPACE = originalWorkspace;
+    jest.restoreAllMocks();
+  });
+
+  it('emits a workflow command with a repo-relative file path', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_WORKSPACE = '/repo';
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    annotate(
+      'error',
+      'e2e flow failed',
+      'playback-test kept failing',
+      '/repo/apps/bare-expo/e2e/expo-video/playback-test.yaml'
+    );
+    expect(log).toHaveBeenCalledWith(
+      '::error title=e2e flow failed,file=apps/bare-expo/e2e/expo-video/playback-test.yaml::playback-test kept failing'
+    );
+  });
+
+  it('omits the file property without a workspace', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    delete process.env.GITHUB_WORKSPACE;
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    annotate('warning', 'Flaky e2e flow', 'test failed on attempt 1', '/somewhere/test.yaml');
+    expect(log).toHaveBeenCalledWith('::warning title=Flaky e2e flow::test failed on attempt 1');
+  });
+
+  it('does nothing outside of GitHub Actions', () => {
+    delete process.env.GITHUB_ACTIONS;
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    annotate('error', 'title', 'message');
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/apps/bare-expo/scripts/lib/e2e-common.test.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runMaestroAsync } from './e2e-common';
+
+// A stand-in `maestro` binary that mimics Maestro's failure modes: it optionally writes the
+// JUnit report passed via --output and then hangs forever, like Maestro 2.4.0 wedging on exit
+// after its flows have finished.
+const FAKE_MAESTRO = `#!/bin/bash
+report=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--output" ]; then
+    report="$arg"
+  fi
+  previous="$arg"
+done
+if [ -n "$FAKE_MAESTRO_REPORT" ] && [ -n "$report" ]; then
+  printf '%s' "$FAKE_MAESTRO_REPORT" > "$report"
+fi
+if [ "$FAKE_MAESTRO_WEDGE" = "1" ]; then
+  # exec so that the watchdog's signal hits the sleeping process directly instead of
+  # orphaning it behind the killed shell
+  exec sleep 1000
+fi
+exit "\${FAKE_MAESTRO_EXIT_CODE:-1}"
+`;
+
+function makeReport(testcases: string): string {
+  return `<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" tests="2" failures="1" time="2.0">
+${testcases}
+  </testsuite>
+</testsuites>`;
+}
+
+const CLEAN_REPORT = makeReport(`
+    <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
+    <testcase id="playback-test" name="playback-test" classname="playback-test" time="1.0" status="SUCCESS"/>
+`);
+
+const FAILING_REPORT = makeReport(`
+    <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
+    <testcase id="playback-test" name="playback-test" classname="playback-test" time="1.0" status="ERROR">
+      <failure>Element not found</failure>
+    </testcase>
+`);
+
+const FLOWS = ['expo-image/test.yaml', 'expo-video/playback-test.yaml'];
+
+describe(runMaestroAsync, () => {
+  let fixtureDir: string;
+  let originalPath: string | undefined;
+
+  beforeAll(async () => {
+    fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fake-maestro-'));
+    const fakeMaestroPath = path.join(fixtureDir, 'maestro');
+    await fs.writeFile(fakeMaestroPath, FAKE_MAESTRO, { mode: 0o755 });
+    originalPath = process.env.PATH;
+    process.env.PATH = `${fixtureDir}:${originalPath}`;
+  });
+
+  afterAll(async () => {
+    process.env.PATH = originalPath;
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('returns failed flows when maestro exits non-zero with a report', async () => {
+    process.env.FAKE_MAESTRO_REPORT = FAILING_REPORT;
+    process.env.FAKE_MAESTRO_WEDGE = '0';
+    const failedFlows = await runMaestroAsync({
+      deviceArgs: [],
+      flowRelativePaths: FLOWS,
+      e2eDir: fixtureDir,
+      reinstallDriver: true,
+    });
+    expect(failedFlows).toEqual(['expo-video/playback-test.yaml']);
+  });
+
+  it('kills a wedged maestro after a clean report and treats the run as passed', async () => {
+    process.env.FAKE_MAESTRO_REPORT = CLEAN_REPORT;
+    process.env.FAKE_MAESTRO_WEDGE = '1';
+    const failedFlows = await runMaestroAsync({
+      deviceArgs: [],
+      flowRelativePaths: FLOWS,
+      e2eDir: fixtureDir,
+      reinstallDriver: true,
+      reportGracePeriodMs: 300,
+    });
+    expect(failedFlows).toEqual([]);
+  }, 15000);
+
+  it('kills a wedged maestro after a failing report and returns the failed flows', async () => {
+    process.env.FAKE_MAESTRO_REPORT = FAILING_REPORT;
+    process.env.FAKE_MAESTRO_WEDGE = '1';
+    const failedFlows = await runMaestroAsync({
+      deviceArgs: [],
+      flowRelativePaths: FLOWS,
+      e2eDir: fixtureDir,
+      reinstallDriver: true,
+      reportGracePeriodMs: 300,
+    });
+    expect(failedFlows).toEqual(['expo-video/playback-test.yaml']);
+  }, 15000);
+
+  it('throws when maestro hangs without ever writing a report', async () => {
+    delete process.env.FAKE_MAESTRO_REPORT;
+    process.env.FAKE_MAESTRO_WEDGE = '1';
+    await expect(
+      runMaestroAsync({
+        deviceArgs: [],
+        flowRelativePaths: FLOWS,
+        e2eDir: fixtureDir,
+        reinstallDriver: true,
+        invocationTimeoutMs: 1500,
+      })
+    ).rejects.toThrow('was killed');
+  }, 15000);
+
+  it('throws when maestro fails without a report', async () => {
+    delete process.env.FAKE_MAESTRO_REPORT;
+    process.env.FAKE_MAESTRO_WEDGE = '0';
+    await expect(
+      runMaestroAsync({
+        deviceArgs: [],
+        flowRelativePaths: FLOWS,
+        e2eDir: fixtureDir,
+        reinstallDriver: true,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -244,18 +244,30 @@ export interface RunMaestroOptions {
    * invocation in a session needs it; skipping the reinstall saves about a minute per invocation.
    */
   reinstallDriver: boolean;
+  /** How long a wedged maestro may outlive its own JUnit report before it gets killed. */
+  reportGracePeriodMs?: number;
+  /** Hard ceiling on the whole invocation, for runs that never produce a report. */
+  invocationTimeoutMs?: number;
 }
 
 /**
  * Runs the given flows in a single maestro invocation (flows execute in the given order and
  * a failed flow doesn't stop the following ones) and returns the relative paths of failed flows.
  * Throws if maestro fails without producing flow results, e.g. when it can't reach the device.
+ *
+ * Maestro writes the JUnit report only after all flows have finished, so a process that
+ * outlives the report is just wedged on exit (Maestro 2.4.0 can crash its main thread while
+ * finalizing logs and then hang forever on a non-daemon thread). A watchdog kills the process
+ * once the report has been around for the grace period and the results are read as usual;
+ * the invocation timeout backstops runs that never write a report at all.
  */
 export async function runMaestroAsync({
   deviceArgs,
   flowRelativePaths,
   e2eDir,
   reinstallDriver,
+  reportGracePeriodMs = 60_000,
+  invocationTimeoutMs = 20 * 60_000,
 }: RunMaestroOptions): Promise<string[]> {
   const reportPath = path.join(
     await fs.mkdtemp(path.join(os.tmpdir(), 'maestro-report-')),
@@ -271,29 +283,75 @@ export async function runMaestroAsync({
     reportPath,
     ...flowRelativePaths.map((flowRelativePath) => path.join(e2eDir, flowRelativePath)),
   ];
+  const maestroProcess = spawnAsync('maestro', args, {
+    stdio: 'inherit',
+    cwd: e2eDir,
+    env: {
+      ...process.env,
+      ...MAESTRO_ENV_VARS,
+    },
+  });
+
+  let killedReason: 'report-grace-period' | 'invocation-timeout' | null = null;
+  const watchdogTimers: NodeJS.Timeout[] = [];
+  const killMaestro = (reason: NonNullable<typeof killedReason>) => {
+    killedReason = reason;
+    maestroProcess.child?.kill('SIGTERM');
+    watchdogTimers.push(
+      setTimeout(() => {
+        maestroProcess.child?.kill('SIGKILL');
+      }, 10_000)
+    );
+  };
+  const reportPollTimer = setInterval(async () => {
+    if (await fileExistsAsync(reportPath)) {
+      clearInterval(reportPollTimer);
+      watchdogTimers.push(
+        setTimeout(() => {
+          return killMaestro('report-grace-period');
+        }, reportGracePeriodMs)
+      );
+    }
+  }, 1000);
+  watchdogTimers.push(
+    setTimeout(() => {
+      return killMaestro('invocation-timeout');
+    }, invocationTimeoutMs)
+  );
+
   try {
-    await spawnAsync('maestro', args, {
-      stdio: 'inherit',
-      cwd: e2eDir,
-      env: {
-        ...process.env,
-        ...MAESTRO_ENV_VARS,
-      },
-    });
+    await maestroProcess;
     return [];
   } catch (error) {
     const reportContents = await fs.readFile(reportPath, 'utf8').catch(() => null);
     if (reportContents == null) {
+      if (killedReason === 'invocation-timeout') {
+        throw new Error(
+          `maestro exceeded the invocation timeout of ${invocationTimeoutMs}ms and was killed ` +
+            `before producing any flow results.`,
+          { cause: error }
+        );
+      }
       throw error;
     }
     const failedFlows = getFailedFlowsFromJUnitReport(reportContents, flowRelativePaths);
     if (failedFlows.length === 0) {
+      if (killedReason != null) {
+        // maestro finished all flows and wrote a clean report, but wedged on exit; the kill
+        // is ours, not a test failure.
+        console.warn('⚠️ maestro did not exit after writing a clean report and was killed.');
+        return [];
+      }
       // maestro failed even though no flow was reported as failed, so something is wrong with
       // the run itself and retrying the flows wouldn't help.
       throw error;
     }
     return failedFlows;
   } finally {
+    clearInterval(reportPollTimer);
+    for (const timer of watchdogTimers) {
+      clearTimeout(timer);
+    }
     await fs.rm(path.dirname(reportPath), { recursive: true, force: true });
   }
 }

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -1,6 +1,10 @@
 import spawnAsync from '@expo/spawn-async';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
+
+import { getFailedFlowsFromJUnitReport } from './maestro-junit-report';
+
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = String(180_000);
 const MAESTRO_CLI_NO_ANALYTICS = '1';
 
@@ -200,30 +204,103 @@ const getCustomMaestroFlowsAsync = async (
   return yamlFiles;
 };
 
+export type RunMaestroFlowsFunction = (
+  flowRelativePaths: string[],
+  options: { attempt: number }
+) => Promise<string[]>;
+
 export const runCustomMaestroFlowsAsync = async (
   e2eDir: string,
   platform: 'android' | 'ios',
-  fn: (maestroFlowFilePath: string) => Promise<void>
+  runFlowsAsync: RunMaestroFlowsFunction
 ) => {
-  const retriesForCustomTests = 3;
+  const maxAttempts = 3;
 
-  const maestroFlows = await getCustomMaestroFlowsAsync(e2eDir, platform);
-  for (const maestroFlowRelativePath of maestroFlows) {
-    const maestroFlowFilePath = path.join(e2eDir, maestroFlowRelativePath);
-    await retryAsync((retryNumber) => {
-      console.log(
-        `${maestroFlowRelativePath} e2e test attempt ${retryNumber + 1} of ${retriesForCustomTests}`
+  let flows = await getCustomMaestroFlowsAsync(e2eDir, platform);
+  for (let attempt = 1; flows.length > 0; ++attempt) {
+    console.log(`Custom e2e flows attempt ${attempt} of ${maxAttempts}: ${flows.join(', ')}`);
+    const failedFlows = await runFlowsAsync(flows, { attempt });
+    if (failedFlows.length === 0) {
+      return;
+    }
+    if (attempt >= maxAttempts) {
+      throw new Error(
+        `Custom e2e flows kept failing after ${maxAttempts} attempts: ${failedFlows.join(', ')}`
       );
-      return fn(maestroFlowFilePath);
-    }, retriesForCustomTests);
+    }
+    console.warn(`⚠️ Retrying failed flows: ${failedFlows.join(', ')}`);
+    flows = failedFlows;
+    await delayAsync(5000);
   }
 };
 
-export function startGroup(filePath: string) {
+export interface RunMaestroOptions {
+  /** Global maestro CLI arguments selecting the device, e.g. `['--device', deviceId]`. */
+  deviceArgs: string[];
+  flowRelativePaths: string[];
+  e2eDir: string;
+  /**
+   * Whether maestro should reinstall its on-device driver before running. Only the first
+   * invocation in a session needs it; skipping the reinstall saves about a minute per invocation.
+   */
+  reinstallDriver: boolean;
+}
+
+/**
+ * Runs the given flows in a single maestro invocation (flows execute in the given order and
+ * a failed flow doesn't stop the following ones) and returns the relative paths of failed flows.
+ * Throws if maestro fails without producing flow results, e.g. when it can't reach the device.
+ */
+export async function runMaestroAsync({
+  deviceArgs,
+  flowRelativePaths,
+  e2eDir,
+  reinstallDriver,
+}: RunMaestroOptions): Promise<string[]> {
+  const reportPath = path.join(
+    await fs.mkdtemp(path.join(os.tmpdir(), 'maestro-report-')),
+    'report.xml'
+  );
+  const args = [
+    ...deviceArgs,
+    'test',
+    ...(reinstallDriver ? [] : ['--no-reinstall-driver']),
+    '--format',
+    'junit',
+    '--output',
+    reportPath,
+    ...flowRelativePaths.map((flowRelativePath) => path.join(e2eDir, flowRelativePath)),
+  ];
+  try {
+    await spawnAsync('maestro', args, {
+      stdio: 'inherit',
+      cwd: e2eDir,
+      env: {
+        ...process.env,
+        ...MAESTRO_ENV_VARS,
+      },
+    });
+    return [];
+  } catch (error) {
+    const reportContents = await fs.readFile(reportPath, 'utf8').catch(() => null);
+    if (reportContents == null) {
+      throw error;
+    }
+    const failedFlows = getFailedFlowsFromJUnitReport(reportContents, flowRelativePaths);
+    if (failedFlows.length === 0) {
+      // maestro failed even though no flow was reported as failed, so something is wrong with
+      // the run itself and retrying the flows wouldn't help.
+      throw error;
+    }
+    return failedFlows;
+  } finally {
+    await fs.rm(path.dirname(reportPath), { recursive: true, force: true });
+  }
+}
+
+export function startGroup(label: string) {
   if (process.env.CI) {
-    const parts = filePath.split(path.sep).filter(Boolean);
-    const lastTwoComponents = parts.slice(-2).join(path.sep);
-    console.log(`::group::${lastTwoComponents}`);
+    console.log(`::group::${label}`);
   }
 }
 

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -209,6 +209,26 @@ export type RunMaestroFlowsFunction = (
   options: { attempt: number }
 ) => Promise<string[]>;
 
+/**
+ * Emits a GitHub Actions annotation so that flow failures show up on the workflow summary and
+ * the PR checks page. Does nothing outside of GitHub Actions.
+ */
+export function annotate(
+  level: 'warning' | 'error',
+  title: string,
+  message: string,
+  file?: string
+): void {
+  if (!process.env.GITHUB_ACTIONS) {
+    return;
+  }
+  const properties = [`title=${title}`];
+  if (file && process.env.GITHUB_WORKSPACE) {
+    properties.push(`file=${path.relative(process.env.GITHUB_WORKSPACE, file)}`);
+  }
+  console.log(`::${level} ${properties.join(',')}::${message}`);
+}
+
 export const runCustomMaestroFlowsAsync = async (
   e2eDir: string,
   platform: 'android' | 'ios',
@@ -224,8 +244,24 @@ export const runCustomMaestroFlowsAsync = async (
       return;
     }
     if (attempt >= maxAttempts) {
+      for (const failedFlow of failedFlows) {
+        annotate(
+          'error',
+          'e2e flow failed',
+          `${failedFlow} kept failing after ${maxAttempts} attempts`,
+          path.join(e2eDir, failedFlow)
+        );
+      }
       throw new Error(
         `Custom e2e flows kept failing after ${maxAttempts} attempts: ${failedFlows.join(', ')}`
+      );
+    }
+    for (const failedFlow of failedFlows) {
+      annotate(
+        'warning',
+        'Flaky e2e flow',
+        `${failedFlow} failed on attempt ${attempt} of ${maxAttempts}`,
+        path.join(e2eDir, failedFlow)
       );
     }
     console.warn(`⚠️ Retrying failed flows: ${failedFlows.join(', ')}`);
@@ -351,6 +387,13 @@ export async function runMaestroAsync({
     clearInterval(reportPollTimer);
     for (const timer of watchdogTimers) {
       clearTimeout(timer);
+    }
+    if (process.env.CI && (await fileExistsAsync(reportPath))) {
+      // ~/.maestro/tests is uploaded as a workflow artifact, so keep the JUnit report of every
+      // invocation around for debugging.
+      const artifactsDir = path.join(os.homedir(), '.maestro', 'tests');
+      await fs.mkdir(artifactsDir, { recursive: true });
+      await fs.copyFile(reportPath, path.join(artifactsDir, `maestro-report-${Date.now()}.xml`));
     }
     await fs.rm(path.dirname(reportPath), { recursive: true, force: true });
   }

--- a/apps/bare-expo/scripts/lib/maestro-junit-report.test.ts
+++ b/apps/bare-expo/scripts/lib/maestro-junit-report.test.ts
@@ -14,17 +14,17 @@ ${testcases}
 describe(getFailedFlowsFromJUnitReport, () => {
   it('returns an empty array when all flows passed', () => {
     const report = makeReport(`
-    <testcase id="confirm-app-open" name="confirm-app-open" classname="confirm-app-open" time="1.0" status="SUCCESS"/>
+    <testcase id="playback-test" name="playback-test" classname="playback-test" time="1.0" status="SUCCESS"/>
     <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
 `);
-    const flows = ['_nested-flows/confirm-app-open.yaml', 'expo-image/test.yaml'];
+    const flows = ['expo-video/playback-test.yaml', 'expo-image/test.yaml'];
 
     expect(getFailedFlowsFromJUnitReport(report, flows)).toEqual([]);
   });
 
   it('maps failed testcases back to flow paths', () => {
     const report = makeReport(`
-    <testcase id="confirm-app-open" name="confirm-app-open" classname="confirm-app-open" time="1.0" status="SUCCESS"/>
+    <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
     <testcase id="fullscreen-test" name="fullscreen-test" classname="fullscreen-test" time="1.0" status="ERROR">
       <failure>Assertion is false: false is true</failure>
     </testcase>
@@ -33,7 +33,7 @@ describe(getFailedFlowsFromJUnitReport, () => {
     </testcase>
 `);
     const flows = [
-      '_nested-flows/confirm-app-open.yaml',
+      'expo-image/test.yaml',
       'expo-video/fullscreen-test.yaml',
       'expo-video/player-output-test.yaml',
     ];

--- a/apps/bare-expo/scripts/lib/maestro-junit-report.test.ts
+++ b/apps/bare-expo/scripts/lib/maestro-junit-report.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getFailedFlowsFromJUnitReport } from './maestro-junit-report';
+
+function makeReport(testcases: string): string {
+  return `<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" device="iPhone 17 Pro - iOS 26.0 - 0000" tests="3" failures="1" time="2.0">
+${testcases}
+  </testsuite>
+</testsuites>`;
+}
+
+describe(getFailedFlowsFromJUnitReport, () => {
+  it('returns an empty array when all flows passed', () => {
+    const report = makeReport(`
+    <testcase id="confirm-app-open" name="confirm-app-open" classname="confirm-app-open" time="1.0" status="SUCCESS"/>
+    <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
+`);
+    const flows = ['_nested-flows/confirm-app-open.yaml', 'expo-image/test.yaml'];
+
+    expect(getFailedFlowsFromJUnitReport(report, flows)).toEqual([]);
+  });
+
+  it('maps failed testcases back to flow paths', () => {
+    const report = makeReport(`
+    <testcase id="confirm-app-open" name="confirm-app-open" classname="confirm-app-open" time="1.0" status="SUCCESS"/>
+    <testcase id="fullscreen-test" name="fullscreen-test" classname="fullscreen-test" time="1.0" status="ERROR">
+      <failure>Assertion is false: false is true</failure>
+    </testcase>
+    <testcase id="player-output-test" name="player-output-test" classname="player-output-test" time="0.0" status="ERROR">
+      <failure>Element not found</failure>
+    </testcase>
+`);
+    const flows = [
+      '_nested-flows/confirm-app-open.yaml',
+      'expo-video/fullscreen-test.yaml',
+      'expo-video/player-output-test.yaml',
+    ];
+
+    expect(getFailedFlowsFromJUnitReport(report, flows)).toEqual([
+      'expo-video/fullscreen-test.yaml',
+      'expo-video/player-output-test.yaml',
+    ]);
+  });
+
+  it('matches platform-suffixed flow file names', () => {
+    const report = makeReport(`
+    <testcase id="picture-in-picture-test.android" name="picture-in-picture-test.android" classname="picture-in-picture-test.android" time="1.0" status="ERROR">
+      <failure>Element not found</failure>
+    </testcase>
+`);
+    const flows = ['expo-video/picture-in-picture-test.android.yaml'];
+
+    expect(getFailedFlowsFromJUnitReport(report, flows)).toEqual([
+      'expo-video/picture-in-picture-test.android.yaml',
+    ]);
+  });
+
+  it('treats any non-SUCCESS status as a failure', () => {
+    const report = makeReport(`
+    <testcase id="playback-test" name="playback-test" classname="playback-test" time="1.0" status="WARNING"/>
+`);
+    const flows = ['expo-video/playback-test.yaml'];
+
+    expect(getFailedFlowsFromJUnitReport(report, flows)).toEqual(['expo-video/playback-test.yaml']);
+  });
+
+  it('returns an empty array for a report without testcases', () => {
+    const report = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" tests="0" failures="0" time="0.0"/>
+</testsuites>`;
+
+    expect(getFailedFlowsFromJUnitReport(report, ['expo-image/test.yaml'])).toEqual([]);
+  });
+
+  it('throws when a failed testcase does not match any flow', () => {
+    const report = makeReport(`
+    <testcase id="unknown-flow" name="unknown-flow" classname="unknown-flow" time="1.0" status="ERROR">
+      <failure>boom</failure>
+    </testcase>
+`);
+    const flows = ['expo-image/test.yaml'];
+
+    expect(() => getFailedFlowsFromJUnitReport(report, flows)).toThrow('unknown-flow');
+  });
+
+  it('throws when two flows would report under the same name', () => {
+    const report = makeReport(`
+    <testcase id="test" name="test" classname="test" time="1.0" status="SUCCESS"/>
+`);
+    const flows = ['expo-image/test.yaml', 'expo-video/test.yaml'];
+
+    expect(() => getFailedFlowsFromJUnitReport(report, flows)).toThrow('expo-video/test.yaml');
+  });
+});

--- a/apps/bare-expo/scripts/lib/maestro-junit-report.ts
+++ b/apps/bare-expo/scripts/lib/maestro-junit-report.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+
+/**
+ * Maps failed testcases from a Maestro JUnit report back to the flow files that produced them.
+ *
+ * Maestro reports each flow under its file name without the extension (e.g.
+ * `expo-video/playback-test.yaml` shows up as `playback-test`), so the given flow paths must
+ * have unique base names. Returns the failed flow paths in report order.
+ */
+export function getFailedFlowsFromJUnitReport(
+  reportContents: string,
+  flowRelativePaths: string[]
+): string[] {
+  const flowsByName = new Map<string, string>();
+  for (const flowRelativePath of flowRelativePaths) {
+    const flowName = path.basename(flowRelativePath, '.yaml');
+    const existingFlow = flowsByName.get(flowName);
+    if (existingFlow != null) {
+      throw new Error(
+        `Flows '${existingFlow}' and '${flowRelativePath}' would both report as '${flowName}'. ` +
+          `Rename one of them so that Maestro results can be mapped back to flow files.`
+      );
+    }
+    flowsByName.set(flowName, flowRelativePath);
+  }
+
+  const failedFlows: string[] = [];
+  for (const [, testcase] of reportContents.matchAll(/<testcase\b([^>]*)>/g)) {
+    const name = testcase.match(/\bname="([^"]*)"/)?.[1];
+    const status = testcase.match(/\bstatus="([^"]*)"/)?.[1];
+    if (name == null || status === 'SUCCESS') {
+      continue;
+    }
+    const flowRelativePath = flowsByName.get(name);
+    if (flowRelativePath == null) {
+      throw new Error(
+        `The Maestro report contains a failed flow '${name}' that doesn't match any of the ` +
+          `flows passed to this run: ${flowRelativePaths.join(', ')}`
+      );
+    }
+    failedFlows.push(flowRelativePath);
+  }
+  return failedFlows;
+}

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -15,7 +15,7 @@ import {
   printImageComparisonServerLogs,
   setupLogger,
   runCustomMaestroFlowsAsync,
-  MAESTRO_ENV_VARS,
+  runMaestroAsync,
   TEST_DURATION_LABEL,
   startGroup,
   endGroup,
@@ -53,24 +53,41 @@ const __dirname = dirname(__filename);
         );
       }
       const e2eDir = path.join(projectRoot, 'e2e');
-      await runCustomMaestroFlowsAsync(e2eDir, 'android', (maestroFlowFilePath) =>
-        testAsync(maestroFlowFilePath, deviceId, appBinaryPath, adbPath, e2eDir)
+
+      // The app and the maestro driver survive across maestro invocations, so install
+      // everything only once instead of paying for it on every flow and retry.
+      await installAppAsync(adbPath, deviceId, appBinaryPath);
+
+      await runCustomMaestroFlowsAsync(
+        e2eDir,
+        'android',
+        async (flowRelativePaths, { attempt }) => {
+          if (attempt > 1) {
+            // Stop the app to reset any state left over by the failed flows; the next
+            // openLink launches it again.
+            await forceStopAppAsync(adbPath, deviceId);
+          }
+          return await testAsync(flowRelativePaths, deviceId, adbPath, e2eDir);
+        }
       );
 
       const maestroNativeModulesFlowFilePath = await createMaestroFlowAsync({
         appId: APP_ID,
         e2eDir,
       });
+      const nativeModulesFlowRelativePath = path.relative(e2eDir, maestroNativeModulesFlowFilePath);
 
-      await retryAsync((retryNumber) => {
+      await retryAsync(async (retryNumber) => {
         console.log(`Native modules test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
-        return testAsync(
-          maestroNativeModulesFlowFilePath,
+        const failedFlows = await testAsync(
+          [nativeModulesFlowRelativePath],
           deviceId,
-          appBinaryPath,
           adbPath,
           e2eDir
         );
+        if (failedFlows.length > 0) {
+          throw new Error('Native modules test suite failed.');
+        }
       }, NUM_OF_RETRIES);
     }
   } catch (e) {
@@ -91,55 +108,72 @@ async function buildAsync(projectRoot: string): Promise<void> {
   );
 }
 
-async function testAsync(
-  maestroFlowFilePath: string,
-  deviceId: string,
-  appBinaryPath: string,
+async function installAppAsync(
   adbPath: string,
-  maestroWorkspaceRoot: string
+  deviceId: string,
+  appBinaryPath: string
 ): Promise<void> {
-  startGroup(maestroFlowFilePath);
-  const stopLogCollectionController = new AbortController();
-
   console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
   await spawnAsync(adbPath, ['-s', deviceId, 'install', '-r', appBinaryPath]);
+}
+
+async function forceStopAppAsync(adbPath: string, deviceId: string): Promise<void> {
+  await spawnAsync(adbPath, ['-s', deviceId, 'shell', 'am', 'force-stop', APP_ID]);
+}
+
+// The maestro driver only needs to be installed by the first invocation; later invocations
+// reuse it, which saves about a minute each.
+let reinstallMaestroDriver = true;
+
+async function testAsync(
+  flowRelativePaths: string[],
+  deviceId: string,
+  adbPath: string,
+  e2eDir: string
+): Promise<string[]> {
+  startGroup(flowRelativePaths.join(', '));
+  const stopLogCollectionController = new AbortController();
 
   console.log(
-    `\n📷 Starting Maestro tests - deviceId[${deviceId}] maestroFlowFilePath[${maestroFlowFilePath}]`
+    `\n📷 Starting Maestro tests - deviceId[${deviceId}] flows[${flowRelativePaths.join(', ')}]`
   );
   const getLogs = setupLogger(`adb logcat -e ${APP_ID}`, stopLogCollectionController.signal);
   try {
     console.time(TEST_DURATION_LABEL);
-    await spawnAsync('maestro', ['--platform', 'android', 'test', maestroFlowFilePath], {
-      stdio: 'inherit',
-      cwd: maestroWorkspaceRoot,
-      env: {
-        ...process.env,
-        ...MAESTRO_ENV_VARS,
-      },
-    });
-    console.timeEnd(TEST_DURATION_LABEL);
-  } catch (error: unknown) {
-    stopLogCollectionController.abort();
-    console.timeEnd(TEST_DURATION_LABEL);
-    console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
-    const logs = await getLogs();
-    console.log(prettyPrintTestSuiteLogs(logs));
-    await printImageComparisonServerLogs();
-    if (!(await isAppRunning())) {
-      if (logs.length > 0) {
-        console.warn(
-          '\n\n  ❌ The runner app has probably crashed, here are the recent native error logs:\n\n'
-        );
-        console.log(logs.slice(-30).join('\n'));
-      } else {
-        console.warn(
-          '\n\n  ❌ The runner app has probably crashed, but no native logs were captured.\n\n'
-        );
-      }
+    let failedFlows: string[];
+    try {
+      failedFlows = await runMaestroAsync({
+        deviceArgs: ['--platform', 'android'],
+        flowRelativePaths,
+        e2eDir,
+        reinstallDriver: reinstallMaestroDriver,
+      });
+    } finally {
+      console.timeEnd(TEST_DURATION_LABEL);
     }
-    console.log('\n\n');
-    throw new Error('e2e tests have failed.', { cause: error });
+    reinstallMaestroDriver = false;
+
+    if (failedFlows.length > 0) {
+      stopLogCollectionController.abort();
+      console.warn(`\n⚠️ Maestro flows failed: ${failedFlows.join(', ')}\n\n`);
+      const logs = await getLogs();
+      console.log(prettyPrintTestSuiteLogs(logs));
+      await printImageComparisonServerLogs();
+      if (!(await isAppRunning())) {
+        if (logs.length > 0) {
+          console.warn(
+            '\n\n  ❌ The runner app has probably crashed, here are the recent native error logs:\n\n'
+          );
+          console.log(logs.slice(-30).join('\n'));
+        } else {
+          console.warn(
+            '\n\n  ❌ The runner app has probably crashed, but no native logs were captured.\n\n'
+          );
+        }
+      }
+      console.log('\n\n');
+    }
+    return failedFlows;
   } finally {
     endGroup();
     stopLogCollectionController.abort();

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -7,6 +7,7 @@ import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 import {
+  annotate,
   createMaestroFlowAsync,
   fileExistsAsync,
   getStartMode,
@@ -86,6 +87,11 @@ const __dirname = dirname(__filename);
           e2eDir
         );
         if (failedFlows.length > 0) {
+          annotate(
+            retryNumber + 1 >= NUM_OF_RETRIES ? 'error' : 'warning',
+            'Native modules test suite failed',
+            `attempt  of  failed`
+          );
           throw new Error('Native modules test suite failed.');
         }
       }, NUM_OF_RETRIES);

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -90,7 +90,7 @@ const __dirname = dirname(__filename);
           annotate(
             retryNumber + 1 >= NUM_OF_RETRIES ? 'error' : 'warning',
             'Native modules test suite failed',
-            `attempt  of  failed`
+            `attempt ${retryNumber + 1} of ${NUM_OF_RETRIES} failed`
           );
           throw new Error('Native modules test suite failed.');
         }

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -57,22 +57,6 @@ const __dirname = dirname(__filename);
       await startSimulatorAsync(deviceId);
       await preApproveDeepLinkPromptAsync(deviceId);
       await installAppAsync(deviceId, appBinaryPath);
-
-      if (process.env.CI) {
-        // Approve the first-run deep link confirmation prompt before the actual flows (when
-        // running locally, we assume the app can already open without confirmation). This flow
-        // stops and relaunches the app, so it must run before the inspector launch below;
-        // otherwise the relaunched app would lose the injected dylib and every viewshot lookup
-        // would time out.
-        const confirmFlow = '_nested-flows/confirm-app-open.yaml';
-        await retryAsync(async () => {
-          const failedFlows = await testAsync([confirmFlow], deviceId, e2eDir);
-          if (failedFlows.length > 0) {
-            throw new Error('Failed to approve the deep link confirmation prompt.');
-          }
-        }, 2);
-      }
-
       await launchAppWithInspectorAsync(deviceId);
 
       await runCustomMaestroFlowsAsync(e2eDir, 'ios', async (flowRelativePaths, { attempt }) => {

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -16,7 +16,7 @@ import {
   prettyPrintTestSuiteLogs,
   printImageComparisonServerLogs,
   runCustomMaestroFlowsAsync,
-  MAESTRO_ENV_VARS,
+  runMaestroAsync,
   TEST_DURATION_LABEL,
   startGroup,
   endGroup,
@@ -50,18 +50,35 @@ const __dirname = dirname(__filename);
     }
     if (startMode === 'TEST' || startMode === 'BUILD_AND_TEST') {
       const e2eDir = path.join(projectRoot, 'e2e');
-      await runCustomMaestroFlowsAsync(e2eDir, 'ios', (maestroFlowFilePath) =>
-        testAsync(maestroFlowFilePath, deviceId, appBinaryPath, e2eDir)
-      );
+
+      // The simulator, the app and the maestro driver survive across maestro invocations,
+      // so set everything up only once instead of paying for it on every flow and retry.
+      await startSimulatorAsync(deviceId);
+      await preApproveDeepLinkPromptAsync(deviceId);
+      await installAppAsync(deviceId, appBinaryPath);
+      await launchAppWithInspectorAsync(deviceId);
+
+      await runCustomMaestroFlowsAsync(e2eDir, 'ios', async (flowRelativePaths, { attempt }) => {
+        if (attempt > 1) {
+          // Relaunch to reset any app state left over by the failed flows (e.g. a video stuck
+          // in fullscreen) and to restore the inspector dylib in case the app crashed.
+          await launchAppWithInspectorAsync(deviceId);
+        }
+        return await testAsync(flowRelativePaths, deviceId, e2eDir);
+      });
 
       const maestroNativeModulesFlowFilePath = await createMaestroFlowAsync({
         appId: APP_ID,
         e2eDir,
       });
+      const nativeModulesFlowRelativePath = path.relative(e2eDir, maestroNativeModulesFlowFilePath);
 
-      await retryAsync((retryNumber) => {
+      await retryAsync(async (retryNumber) => {
         console.log(`Native modules test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
-        return testAsync(maestroNativeModulesFlowFilePath, deviceId, appBinaryPath, e2eDir);
+        const failedFlows = await testAsync([nativeModulesFlowRelativePath], deviceId, e2eDir);
+        if (failedFlows.length > 0) {
+          throw new Error('Native modules test suite failed.');
+        }
       }, NUM_OF_RETRIES);
     }
   } catch (e) {
@@ -202,37 +219,48 @@ async function preApproveDeepLinkPromptAsync(deviceId: string): Promise<void> {
   ]);
 }
 
+async function installAppAsync(deviceId: string, appBinaryPath: string): Promise<void> {
+  console.log(`\n🔌 Installing App - deviceId[${deviceId}] appBinaryPath[${appBinaryPath}]`);
+  await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
+}
+
+async function launchAppWithInspectorAsync(deviceId: string): Promise<void> {
+  const dylibPath = getDylibPath();
+  console.log(`\n💉 Launching app with dylib injected - dylibPath[${dylibPath}]`);
+
+  try {
+    // The dylib is only injected at launch time, so make sure the app isn't already running.
+    await spawnAsync('xcrun', ['simctl', 'terminate', deviceId, APP_ID], { stdio: 'pipe' });
+  } catch {
+    // The app might not be running, which is fine.
+  }
+
+  try {
+    await spawnAsync('xcrun', ['simctl', 'launch', deviceId, APP_ID], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        SIMCTL_CHILD_DYLD_INSERT_LIBRARIES: dylibPath,
+      },
+    });
+  } catch (error: any) {
+    console.warn('⚠️  App launch with dylib failed:', error.message);
+  }
+}
+
+// The maestro driver only needs to be installed by the first invocation; later invocations
+// reuse it, which saves about a minute each.
+let reinstallMaestroDriver = true;
+
 async function testAsync(
-  maestroFlowFilePath: string,
+  flowRelativePaths: string[],
   deviceId: string,
-  appBinaryPath: string,
-  maestroWorkspaceRoot: string
-): Promise<void> {
-  startGroup(maestroFlowFilePath);
+  e2eDir: string
+): Promise<string[]> {
+  startGroup(flowRelativePaths.join(', '));
   const stopLogCollectionController = new AbortController();
 
   try {
-    await startSimulatorAsync(deviceId);
-    await preApproveDeepLinkPromptAsync(deviceId);
-    console.log(`\n🔌 Installing App - deviceId[${deviceId}] appBinaryPath[${appBinaryPath}]`);
-    await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
-
-    // Launch app with dylib injected
-    const dylibPath = getDylibPath();
-    console.log(`\n💉 Launching app with dylib injected - dylibPath[${dylibPath}]`);
-
-    try {
-      await spawnAsync('xcrun', ['simctl', 'launch', deviceId, APP_ID], {
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          SIMCTL_CHILD_DYLD_INSERT_LIBRARIES: dylibPath,
-        },
-      });
-    } catch (error: any) {
-      console.warn('⚠️  App launch with dylib failed:', error.message);
-    }
-
     const getTestSuiteLogs = setupLogger(
       '(subsystem == "com.facebook.react.log")',
       stopLogCollectionController.signal
@@ -242,23 +270,24 @@ async function testAsync(
       stopLogCollectionController.signal
     );
 
-    console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
+    console.log(`\n📷 Starting Maestro tests - flows[${flowRelativePaths.join(', ')}]`);
+    console.time(TEST_DURATION_LABEL);
+    let failedFlows: string[];
     try {
-      console.time(TEST_DURATION_LABEL);
-
-      await spawnAsync('maestro', ['--device', deviceId, 'test', maestroFlowFilePath], {
-        stdio: 'inherit',
-        cwd: maestroWorkspaceRoot,
-        env: {
-          ...process.env,
-          ...MAESTRO_ENV_VARS,
-        },
+      failedFlows = await runMaestroAsync({
+        deviceArgs: ['--device', deviceId],
+        flowRelativePaths,
+        e2eDir,
+        reinstallDriver: reinstallMaestroDriver,
       });
+    } finally {
       console.timeEnd(TEST_DURATION_LABEL);
-    } catch (error: unknown) {
+    }
+    reinstallMaestroDriver = false;
+
+    if (failedFlows.length > 0) {
       stopLogCollectionController.abort();
-      console.timeEnd(TEST_DURATION_LABEL);
-      console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
+      console.warn(`\n⚠️ Maestro flows failed: ${failedFlows.join(', ')}\n\n`);
 
       console.log(prettyPrintTestSuiteLogs(await getTestSuiteLogs()));
       await printImageComparisonServerLogs();
@@ -278,8 +307,8 @@ async function testAsync(
       }
 
       console.log('\n\n');
-      throw new Error('e2e tests have failed.', { cause: error });
     }
+    return failedFlows;
   } finally {
     endGroup();
     stopLogCollectionController.abort();

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -56,6 +56,22 @@ const __dirname = dirname(__filename);
       await startSimulatorAsync(deviceId);
       await preApproveDeepLinkPromptAsync(deviceId);
       await installAppAsync(deviceId, appBinaryPath);
+
+      if (process.env.CI) {
+        // Approve the first-run deep link confirmation prompt before the actual flows (when
+        // running locally, we assume the app can already open without confirmation). This flow
+        // stops and relaunches the app, so it must run before the inspector launch below;
+        // otherwise the relaunched app would lose the injected dylib and every viewshot lookup
+        // would time out.
+        const confirmFlow = '_nested-flows/confirm-app-open.yaml';
+        await retryAsync(async () => {
+          const failedFlows = await testAsync([confirmFlow], deviceId, e2eDir);
+          if (failedFlows.length > 0) {
+            throw new Error('Failed to approve the deep link confirmation prompt.');
+          }
+        }, 2);
+      }
+
       await launchAppWithInspectorAsync(deviceId);
 
       await runCustomMaestroFlowsAsync(e2eDir, 'ios', async (flowRelativePaths, { attempt }) => {

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -9,6 +9,7 @@ import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 import {
+  annotate,
   createMaestroFlowAsync,
   ensureDirAsync,
   getStartMode,
@@ -93,6 +94,11 @@ const __dirname = dirname(__filename);
         console.log(`Native modules test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
         const failedFlows = await testAsync([nativeModulesFlowRelativePath], deviceId, e2eDir);
         if (failedFlows.length > 0) {
+          annotate(
+            retryNumber + 1 >= NUM_OF_RETRIES ? 'error' : 'warning',
+            'Native modules test suite failed',
+            `attempt ${retryNumber + 1} of ${NUM_OF_RETRIES} failed`
+          );
           throw new Error('Native modules test suite failed.');
         }
       }, NUM_OF_RETRIES);


### PR DESCRIPTION
# Why

The Test Suite e2e jobs are slow and flaky-retry-expensive. Every `maestro test` invocation pays 60-110s of JVM + XCTest driver startup, plus an app reinstall and relaunch, and the runner invoked Maestro once per flow and once per retry attempt. In a typical flaky run (e.g. [this job](https://github.com/expo/expo/actions/runs/28882152638/job/85677328862)) that's 8 invocations, roughly 10 of 23 minutes spent on pure setup. Retries also reran the whole flow set from a cold start.

# How

- All custom flows now run in a single `maestro test` invocation (flows execute in argument order and a failed flow doesn't stop the following ones).
- Simulator boot, app install, and the inspector-dylib launch happen once per job instead of once per flow. On Android the APK is installed once.
- Failed flows are read from the JUnit report (`--format junit`) via a new `maestro-junit-report.ts` parser, so each retry attempt reruns only the flows that actually failed. When Maestro fails without reporting any failed flow (e.g. it can't reach the device), the error propagates instead of burning retries.
- Retry attempts relaunch the app (iOS: `simctl launch` with the inspector dylib re-injected, Android: `am force-stop`) to reset any state left behind by failed flows, and pass `--no-reinstall-driver` to skip the driver reinstall.
- The generated native-modules suite keeps its retry count but no longer reinstalls or relaunches anything between attempts.
- The CI `bun test` step now also covers `scripts/lib`, so the parser tests run in the `android-build` job.

Expected effect on the linked run: ~23.5 min → ~12-13 min with identical failures; a fully green run saves ~6-7 min.

# Test Plan

- `bun test e2e/image-comparison scripts/lib` passes (22 tests, including the new parser tests).
- Verified the orchestration live against a local simulator with probe flows:
  - green path: one invocation, no retries;
  - flaky path: attempt 1 runs all flows, attempts 2-3 rerun only the failed flow, and the runner throws after 3 attempts listing it;
  - infra path (bogus device id): the Maestro error propagates immediately instead of retrying.
- Verified on Maestro 2.3.0 that multiple flow files per invocation, CLI-order execution, continue-on-failure, JUnit output, and `--no-reinstall-driver` all behave as relied upon (CI uses 2.4.0/latest).
- This PR touches `test-suite.yml` and `apps/bare-expo/**`, so the full Test Suite e2e workflow runs on both platforms here.
