### PR TITLE
[ios][jsi] Add JavaScriptCodable conformance for Date

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Conform `JavaScriptRuntime` to `Identifiable` with an `id` based on the underlying runtime, equal across multiple wrappers of the same runtime. ([#47068](https://github.com/expo/expo/pull/47068) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRef.withValue`, a non-consuming borrow accessor that reads the referenced value without taking it, so a long-lived reference can be read repeatedly. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add a `JavaScriptCodable` conformance for `Date`: it encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch, or a string parsed by the JS engine's `Date` constructor. ([#47602](https://github.com/expo/expo/pull/47602) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Date.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Date.swift
@@ -1,0 +1,70 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+
+// `Date` encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch,
+// or a string. Strings are parsed by the runtime's own `new Date(str)` (so parsing is identical on every
+// platform, with no native date parser to maintain), which inherits JS's quirks: a zone-less string is
+// read as local time, and an unparseable one becomes an `Invalid Date` (`NaN`), decoded as a thrown error.
+// A `Date` is an absolute instant with no timezone/calendar; resolution is milliseconds.
+
+extension Date: JavaScriptCodable {
+  @JavaScriptActor
+  @inlinable
+  public static func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws -> Date
+  {
+    // The cheap tag checks come before `is("Date")`, which does a global lookup plus an `instanceof`
+    // walk; a number or string can't be a `Date`, so the order is behavior-neutral.
+    if value.isNumber() {
+      return try dateFromMilliseconds(value.getDouble())
+    }
+    if value.isString() {
+      let dateConstructor = try runtime.global().getPropertyAsFunction("Date")
+      let constructed = try dateConstructor.callAsConstructor(value.copy()).asObject()
+      return try dateFromMilliseconds(constructed.callFunction("getTime").asDouble())
+    }
+    if value.is("Date") {
+      return try dateFromMilliseconds(value.asObject().callFunction("getTime").asDouble())
+    }
+    throw InvalidDateException()
+  }
+
+  @JavaScriptActor
+  @inlinable
+  public static func encode(_ value: Date, in runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    let milliseconds = value.timeIntervalSince1970 * 1000.0
+    let dateConstructor = try runtime.global().getPropertyAsFunction("Date")
+    // Typed explicitly so the variadic `callAsConstructor` overload is chosen over the `JavaScriptValuesBuffer?` one.
+    let millisecondsValue: JavaScriptValue = .number(milliseconds)
+    return try dateConstructor.callAsConstructor(millisecondsValue)
+  }
+}
+
+/// The largest magnitude, in milliseconds, a JS `Date` can represent (100,000,000 days from the epoch,
+/// ECMAScript TimeClip); a value beyond it is an `Invalid Date`.
+@usableFromInline
+let maxJavaScriptDateMilliseconds: Double = 8_640_000_000_000_000
+
+/// Builds a `Date` from a milliseconds value, applying the JS `Date` constructor's TimeClip: a non-finite
+/// or out-of-range value throws, an in-range one is truncated toward zero. This keeps the number branch
+/// faithful to `new Date(number)`; the `Date`/string branches pass an already-clipped `getTime()` through.
+@usableFromInline
+func dateFromMilliseconds(_ milliseconds: Double) throws -> Date {
+  guard milliseconds.isFinite, abs(milliseconds) <= maxJavaScriptDateMilliseconds else {
+    throw InvalidDateException()
+  }
+  return Date(timeIntervalSince1970: milliseconds.rounded(.towardZero) / 1000.0)
+}
+
+/// Thrown when a JavaScript value can't be converted to a `Date`. Named after JS's own "Invalid Date".
+public struct InvalidDateException: JavaScriptThrowable {
+  @usableFromInline
+  init() {}
+
+  public var code: String {
+    "ERR_INVALID_DATE"
+  }
+  public var message: String {
+    "Cannot convert the JavaScript value to a Date because it is not a Date, a number of milliseconds since the epoch, or a parseable date string"
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableDateTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableDateTests.swift
@@ -1,0 +1,270 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Foundation
+import Testing
+
+@Suite("JavaScriptCodable+Date")
+@JavaScriptActor
+struct JavaScriptCodableDateTests {
+  let runtime = JavaScriptRuntime()
+
+  // MARK: - Decode
+
+  @Test
+  func `decodes a JS Date to the same instant`() throws {
+    // 2021-01-01T00:00:00.000Z expressed as an absolute UTC millisecond instant. `Date.UTC` returns
+    // that instant directly, so no local timezone enters the JS side.
+    let value = try runtime.eval("new Date(Date.UTC(2021, 0, 1, 0, 0, 0, 0))")
+    let decoded = try Date.decode(value, in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 1_609_459_200.0)
+  }
+
+  @Test
+  func `decodes the Unix epoch`() throws {
+    let decoded = try Date.decode(runtime.eval("new Date(0)"), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 0.0)
+  }
+
+  @Test
+  func `decodes a pre-epoch Date`() throws {
+    // A negative millisecond instant (1960-01-01T00:00:00Z) must decode to a negative interval.
+    let value = try runtime.eval("new Date(Date.UTC(1960, 0, 1))")
+    let decoded = try Date.decode(value, in: runtime)
+    #expect(decoded.timeIntervalSince1970 == -315_619_200.0)
+  }
+
+  @Test
+  func `decode preserves sub-second milliseconds`() throws {
+    // Assert on the whole-millisecond instant (an integer-valued Double, always exact) rather than the
+    // reconstructed fractional seconds, whose last bit can differ by an ULP across the JS boundary.
+    let decoded = try Date.decode(runtime.eval("new Date(1234)"), in: runtime)
+    #expect((decoded.timeIntervalSince1970 * 1000.0).rounded() == 1234.0)
+  }
+
+  @Test
+  func `decodes a JS Date through the borrowed-value overload`() throws {
+    // `Date` does not override the zero-copy overload (it needs a `getTime()` call), so this goes
+    // through the default that copies the borrowed value into an owning one and forwards.
+    let value = try runtime.eval("new Date(5000)")
+    let buffer = JavaScriptValuesBuffer.copying(in: runtime, values: [value])
+    let decoded = try Date.decode(buffer.unownedValue(at: 0), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 5.0)
+  }
+
+  // MARK: - Encode
+
+  @Test
+  func `encodes a Date to a JS Date`() throws {
+    let encoded = try Date.encode(Date(timeIntervalSince1970: 1_609_459_200.0), in: runtime)
+    #expect(encoded.is("Date") == true)
+  }
+
+  @Test
+  func `encoded Date carries the same instant into JS`() throws {
+    // Cross-check the encoded value against JS's own `getTime()`, so the assertion is that JS and
+    // Swift agree on the absolute millisecond instant — not merely that a Date was produced.
+    let date = Date(timeIntervalSince1970: 1_609_459_200.0)
+    let encoded = try Date.encode(date, in: runtime)
+    let millisecondsInJS = try encoded.asObject().callFunction("getTime").asDouble()
+    #expect(millisecondsInJS == 1_609_459_200_000.0)
+  }
+
+  // MARK: - Timezone / calendar independence
+
+  @Test
+  func `instant is independent of the JS Date's local-time getters`() throws {
+    // Build the same absolute instant two ways: from a UTC millisecond value, and from local-time
+    // components. `Date.UTC` and the `new Date(y, m, d, …)` local constructor produce different
+    // instants unless the runtime is at UTC, so we decode the explicitly-UTC one and assert the
+    // instant matches its `getTime()` exactly. The point: decode reads `getTime()` (absolute UTC ms),
+    // never a local-time getter, so no timezone offset is folded in.
+    let value = try runtime.eval("new Date(Date.UTC(2021, 5, 15, 12, 30, 45, 123))")
+    let expectedMilliseconds = try value.asObject().callFunction("getTime").asDouble()
+    let decoded = try Date.decode(value, in: runtime)
+    #expect((decoded.timeIntervalSince1970 * 1000.0).rounded() == expectedMilliseconds)
+  }
+
+  @Test
+  func `round-trip is calendar and timezone agnostic`() throws {
+    // A `Date` is an absolute instant with no stored calendar or timezone; both JS `Date` and Swift
+    // `Date` are epoch-relative. This encodes to JS and decodes back, asserting the instant is
+    // unchanged at millisecond granularity regardless of the ambient calendar/timezone.
+    let original = Date(timeIntervalSince1970: 1_655_296_245.123)
+    let encoded = try Date.encode(original, in: runtime)
+    let roundTripped = try Date.decode(encoded, in: runtime)
+    // Compare at whole-millisecond granularity (JS `Date`'s resolution); the original is already an
+    // exact number of milliseconds, so nothing is lost, but the comparison avoids float-equality ULP noise.
+    #expect(
+      (roundTripped.timeIntervalSince1970 * 1000.0).rounded() == (original.timeIntervalSince1970 * 1000.0).rounded())
+  }
+
+  @Test
+  func `round-trip drops sub-millisecond precision`() throws {
+    // JS `Date` is integer-millisecond resolution, so the microsecond tail of a Swift `Date` is lost
+    // on the way through JS. The round-trip lands on the truncated whole millisecond (JS's `Date`
+    // constructor truncates the fractional millisecond toward zero), and no longer equals the original.
+    let original = Date(timeIntervalSince1970: 1.2345678)
+    let roundTripped = try Date.decode(Date.encode(original, in: runtime), in: runtime)
+    #expect((roundTripped.timeIntervalSince1970 * 1000.0).rounded() == 1234.0)
+    #expect(roundTripped.timeIntervalSince1970 != original.timeIntervalSince1970)
+  }
+
+  @Test
+  func `Date current time round-trips to the millisecond`() throws {
+    let now = Date()
+    let roundTripped = try Date.decode(Date.encode(now, in: runtime), in: runtime)
+    // Truncate the original to whole milliseconds (JS's resolution) and compare on the millisecond
+    // instant, which is an exact integer-valued Double on both sides.
+    let nowMilliseconds = (now.timeIntervalSince1970 * 1000.0).rounded(.towardZero)
+    #expect((roundTripped.timeIntervalSince1970 * 1000.0).rounded() == nowMilliseconds)
+  }
+
+  // MARK: - Decode from a JS number (milliseconds since the epoch)
+
+  @Test
+  func `decodes a number as milliseconds since the epoch`() throws {
+    // A JS number is interpreted the same way `new Date(ms)` interprets it, so `getTime()` round-trips.
+    let decoded = try Date.decode(runtime.eval("1609459200000"), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 1_609_459_200.0)
+  }
+
+  @Test
+  func `decodes zero as the Unix epoch`() throws {
+    let decoded = try Date.decode(runtime.eval("0"), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 0.0)
+  }
+
+  @Test
+  func `decodes a negative number as a pre-epoch instant`() throws {
+    let decoded = try Date.decode(runtime.eval("-315619200000"), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == -315_619_200.0)
+  }
+
+  @Test
+  func `a JS Date's getTime decodes to the same instant as the Date`() throws {
+    // Passing `someDate` and passing `someDate.getTime()` must decode to the same Swift `Date`.
+    let fromDate = try Date.decode(runtime.eval("new Date(Date.UTC(2021, 0, 1))"), in: runtime)
+    let fromMilliseconds = try Date.decode(runtime.eval("new Date(Date.UTC(2021, 0, 1)).getTime()"), in: runtime)
+    #expect(fromDate.timeIntervalSince1970 == fromMilliseconds.timeIntervalSince1970)
+  }
+
+  @Test
+  func `decode truncates a fractional number toward zero like the Date constructor`() throws {
+    // `new Date(1.9).getTime()` is `1` and `new Date(-1.9).getTime()` is `-1`: the constructor applies
+    // TimeClip (truncate toward zero), so the number branch must too rather than keeping 1.9 ms.
+    let positive = try Date.decode(runtime.eval("1.9"), in: runtime)
+    #expect((positive.timeIntervalSince1970 * 1000.0).rounded() == 1.0)
+    let negative = try Date.decode(runtime.eval("-1.9"), in: runtime)
+    #expect((negative.timeIntervalSince1970 * 1000.0).rounded() == -1.0)
+  }
+
+  @Test
+  func `decode accepts the maximum representable JS date`() throws {
+    // ±8.64e15 ms (100,000,000 days from the epoch) is the inclusive bound of a valid JS `Date`.
+    let maximum = try Date.decode(runtime.eval("8640000000000000"), in: runtime)
+    #expect((maximum.timeIntervalSince1970 * 1000.0) == 8_640_000_000_000_000.0)
+    let minimum = try Date.decode(runtime.eval("-8640000000000000"), in: runtime)
+    #expect((minimum.timeIntervalSince1970 * 1000.0) == -8_640_000_000_000_000.0)
+  }
+
+  @Test
+  func `decode rejects a number beyond the JS date range`() throws {
+    // One millisecond past the bound is an `Invalid Date` in JS (`new Date(8640000000000001).getTime()`
+    // is `NaN`), so decode must reject it rather than accept an instant JS `Date` can't hold.
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("8640000000000001"), in: runtime)
+    }
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("-8640000000000001"), in: runtime)
+    }
+  }
+
+  @Test
+  func `decode matches new Date for the same number`() throws {
+    // Cross-check the number branch against the constructor for values that exercise TimeClip.
+    for source in ["1.9", "-1.9", "0.4", "1234.5678", "8640000000000000"] {
+      let expected = try runtime.eval("new Date(\(source)).getTime()").asDouble()
+      let decoded = try Date.decode(runtime.eval(source), in: runtime)
+      #expect((decoded.timeIntervalSince1970 * 1000.0).rounded() == expected)
+    }
+  }
+
+  // MARK: - Decode from a string (parsed by the JS `Date` constructor)
+
+  @Test
+  func `decodes an ISO 8601 string with fractional seconds`() throws {
+    let decoded = try Date.decode(runtime.eval("\"2021-01-01T00:00:00.123Z\""), in: runtime)
+    #expect((decoded.timeIntervalSince1970 * 1000.0).rounded() == 1_609_459_200_123.0)
+  }
+
+  @Test
+  func `decodes an ISO 8601 string without fractional seconds`() throws {
+    let decoded = try Date.decode(runtime.eval("\"2021-01-01T00:00:00Z\""), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 1_609_459_200.0)
+  }
+
+  @Test
+  func `decodes an ISO 8601 string with a timezone offset to the correct UTC instant`() throws {
+    // 01:00 at +01:00 is the same absolute instant as 00:00 UTC; the offset must be applied, not ignored.
+    let decoded = try Date.decode(runtime.eval("\"2021-01-01T01:00:00+01:00\""), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 1_609_459_200.0)
+  }
+
+  @Test
+  func `decodes a date-only string as UTC midnight`() throws {
+    // The JS `Date` constructor reads a date-only ISO string as UTC midnight (unlike a zone-less
+    // date-time, which it reads as local). This form is accepted here because `new Date(str)` accepts it.
+    let decoded = try Date.decode(runtime.eval("\"2021-01-01\""), in: runtime)
+    #expect(decoded.timeIntervalSince1970 == 1_609_459_200.0)
+  }
+
+  @Test
+  func `decodes a string the same way new Date parses it`() throws {
+    // The decode contract for a string is "exactly what `new Date(str)` produces". Cross-check the
+    // decoded instant against the engine's own parse of the same string, so this holds for whatever
+    // date grammar the runtime supports (ISO, RFC-2822-ish, etc.), identically on every platform.
+    let source = "\"2021-06-15T12:30:45.500Z\""
+    let expectedMilliseconds = try runtime.eval("new Date(\(source)).getTime()").asDouble()
+    let decoded = try Date.decode(runtime.eval(source), in: runtime)
+    #expect((decoded.timeIntervalSince1970 * 1000.0).rounded() == expectedMilliseconds)
+  }
+
+  // MARK: - Error paths
+
+  @Test
+  func `Date decode throws on an unparseable string`() throws {
+    // `new Date(...)` yields an `Invalid Date` (NaN time) rather than throwing; decode turns that NaN
+    // into a thrown error.
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("\"not a date\""), in: runtime)
+    }
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("\"\""), in: runtime)
+    }
+  }
+
+  @Test
+  func `Date decode throws on NaN`() throws {
+    // A NaN number produces an `Invalid Date` in JS; decode must reject it rather than yield a bogus instant.
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("NaN"), in: runtime)
+    }
+  }
+
+  @Test
+  func `Date decode throws on an unsupported type`() throws {
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("({})"), in: runtime)
+    }
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("null"), in: runtime)
+    }
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("true"), in: runtime)
+    }
+    #expect(throws: InvalidDateException.self) {
+      _ = try Date.decode(runtime.eval("[1, 2, 3]"), in: runtime)
+    }
+  }
+}


### PR DESCRIPTION
# Why

The Expo Modules v2 direct-JSI binding path decodes and encodes every argument, return value, record field, and event payload through `JavaScriptCodable`. `Date` had no such conformance, so a `@JS`/`@Record` member typed `Date` would fail the compile-time conformance assertion. Only the legacy DSL `Date: Convertible` existed, which the macro path deliberately doesn't use.

# How

Adds `JavaScriptCodable+Date` in `expo-modules-jsi`:

- **Encode** always constructs `new Date(ms)` from the Swift `Date`'s millisecond instant, so a return value / event payload arrives in JS as a real `Date`.
- **Decode** accepts three shapes, checked in this order:
  - a number is milliseconds since the epoch (mapped straight across, no JS round-trip),
  - a string is parsed by handing it to the runtime's own `new Date(str)` and reading `getTime()` back,
  - a JS `Date` reads its `getTime()` instant.

The cheap tag checks (`isNumber`/`isString`) come before `is("Date")`, which is far more expensive (a global `Date` lookup plus an `instanceof` walk on every call). A number or string can't be a `Date` object, so the ordering is behavior-neutral and keeps the common inputs (a timestamp or a date string) off the expensive path.

Canonical decode contract: *a `Date` decodes to exactly what JavaScript's `new Date(value)` produces for that value.* Delegating string parsing to the JS engine means iOS and Android parse strings identically (the same engine parses them) with no native date grammar to keep in sync. A value that yields an `Invalid Date` (`NaN` time) is a decode error.

Both sides are absolute epoch-relative instants with no timezone or calendar; resolution is milliseconds (sub-millisecond precision is dropped by JS). As inherited from `new Date()`, a zone-less date-time string is read as local time, so an explicit `Z`/offset or a date-only string is unambiguous.

# Test Plan

`pnpm test:integration` in `packages/expo-modules-jsi` (via `apple/scripts/test.sh`): the new `JavaScriptCodable+Date` suite covers decode from a JS `Date`, ms-number, and string (ISO with/without fractional seconds, timezone offset, date-only), the "decodes exactly like `new Date(str)`" cross-check, encode producing a real JS `Date`, timezone/calendar independence, millisecond-precision round-tripping, and error paths (unparseable string, empty string, `NaN`, unsupported types). All 579 tests pass.
