### PR TITLE
[expo-modules-jsi] Add clear caches script

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))
 - [iOS] `getExpoNativeState` now probes with the specialized `hasNativeState<jsi::NativeState>` and dynamic-casts the raw pointer once, avoiding a redundant `dynamic_pointer_cast` on the shared object argument unwrap hot path. ([#46712](https://github.com/expo/expo/pull/46712) by [@tsapeta](https://github.com/tsapeta))
+- Added a script to clear local build caches and artifacts.
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -400,7 +400,7 @@ GENERATED_MODULE_MAP="${PACKAGE_DIR}/.generated/module.modulemap"
 SOURCE_FILES+=("$GENERATED_MODULE_MAP")
 
 if [[ "$CLEAN" == true ]]; then
-  rm -rf "$XCFRAMEWORK_PATH" "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH"
+  clean_xcframework_state "$PACKAGE_DIR"
   log "Cleaned existing xcframework, DerivedData, and SwiftPM state"
   # Re-stamp stub slices so the post-clean state matches a fresh `pod install`:
   # CocoaPods reads Info.plist before this script runs, and would fail to

--- a/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
+++ b/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Removes the package's local build caches and artifacts
+# (everything gitignored under apple/).
+
+set -euo pipefail
+
+PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BLUE=""; RESET=""
+if [ -t 1 ]; then
+  BLUE="\033[34m"
+  RESET="\033[0m"
+fi
+echo -e "${BLUE}[Expo]${RESET} Clearing ExpoModulesJSI caches and build artifacts"
+
+# Capital X on purpose: remove ignored files only, keep untracked files.
+git -C "${PACKAGE_DIR}" clean -fdX .

--- a/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
+++ b/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# Removes the package's local build caches and artifacts
-# (everything gitignored under apple/).
+# Removes the package's local build caches and artifacts.
 
 set -euo pipefail
 
 PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+source "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
 
 BLUE=""; RESET=""
 if [ -t 1 ]; then
@@ -14,5 +15,8 @@ if [ -t 1 ]; then
 fi
 echo -e "${BLUE}[Expo]${RESET} Clearing ExpoModulesJSI caches and build artifacts"
 
-# Capital X on purpose: remove ignored files only, keep untracked files.
-git -C "${PACKAGE_DIR}" clean -fdX .
+clean_xcframework_state "$PACKAGE_DIR"
+rm -rf \
+  "${PACKAGE_DIR}/.generated" \
+  "${PACKAGE_DIR}/.xcframework-slices" \
+  "${PACKAGE_DIR}/.test-frameworks"

--- a/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
+++ b/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
@@ -1,8 +1,21 @@
 # Shared helpers for managing ExpoModulesJSI.xcframework.
 #
-# Sourced by create-stub-xcframework.sh and build-xcframework.sh. Defines the
-# canonical slice metadata and the Info.plist writer used by both scripts so
-# the manifest is produced from a single place.
+# Sourced by create-stub-xcframework.sh, build-xcframework.sh and
+# clear-caches.sh. Defines the canonical slice metadata and the Info.plist
+# writer used by those scripts so the manifest is produced from a single place.
+
+# clean_xcframework_state PACKAGE_DIR
+# Removes the built xcframework and the SwiftPM/Xcode build state next to the
+# package. Shared by build-xcframework.sh's --clean path and clear-caches.sh.
+clean_xcframework_state() {
+  local package_dir="$1"
+
+  rm -rf \
+    "${package_dir}/Products/ExpoModulesJSI.xcframework" \
+    "${package_dir}/.DerivedData" \
+    "${package_dir}/.build" \
+    "${package_dir}/.swiftpm"
+}
 
 # resolve_pods_root PACKAGE_DIR
 # Sets PODS_ROOT, preferring an explicit value (e.g. from CocoaPods build phase)

--- a/packages/expo-modules-jsi/package.json
+++ b/packages/expo-modules-jsi/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build:xcframework": "apple/scripts/build-xcframework.sh",
+    "clean": "apple/scripts/clear-caches.sh",
     "swift:format": "../../scripts/swift-format.sh",
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "test:integration": "apple/scripts/test.sh"

--- a/tools/src/commands/PrepareBranchCommand.ts
+++ b/tools/src/commands/PrepareBranchCommand.ts
@@ -84,11 +84,11 @@ function createSteps(): Step[] {
       },
     },
     {
-      title: 'Removing expo-modules-jsi build artifacts',
+      title: 'Clearing expo-modules-jsi caches',
       async runAsync() {
-        for (const name of ['.DerivedData', '.generated', '.swiftpm', 'Products']) {
-          await fs.remove(path.join(jsiAppleDir, name));
-        }
+        await spawnAsync(path.join(jsiAppleDir, 'scripts', 'clear-caches.sh'), [], {
+          stdio: 'inherit',
+        });
       },
     },
     {


### PR DESCRIPTION
# Why
Follow up of #47586. Instead of `et prepare-branch` hardcoding which directories count as expo-modules-jsi build caches, the package should own that with a dedicated script.

# How
- Added `apple/scripts/clear-caches.sh` to `expo-modules-jsi`. It runs `git clean -fdX` scoped to the `apple` directory, so it removes everything gitignored there (`.build`, `.DerivedData`, `.generated`, `.swiftpm`, `.xcframework-slices`, `.test-frameworks`, `Products`) and stays in sync with `.gitignore` automatically. Capital `X` is deliberate, it only touches ignored files so untracked work in progress survives.
- `et prepare-branch` now calls the script in its expo-modules-jsi step instead of removing a hardcoded list of four directories.

# Test Plan
- Ran the script against the real package with all cache directories present plus an untracked decoy file in `Sources`: the ignored directories were removed, the decoy survived, and a second run exited cleanly with nothing to delete.
- `pnpm run clean` from the package directory invokes the script correctly.

