### PR TITLE
[docs] Document PostHog EAS Workflow functions

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -376,7 +376,11 @@ export const general = [
       makePage('guides/using-bugsnag.mdx'),
       makePage('guides/using-logrocket.mdx'),
       makePage('guides/using-vexo.mdx'),
-      makePage('guides/using-posthog.mdx'),
+      makeGroup(
+        'Using PostHog',
+        [makePage('guides/using-posthog/index.mdx'), makePage('guides/using-posthog/recipes.mdx')],
+        { expanded: false }
+      ),
     ]),
     makeGroup('Authentication', [
       makePage('guides/using-authentication.mdx'),

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1963,6 +1963,209 @@ build:
   href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
 />
 
+#### `eas/posthog_capture_event`
+
+Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline. Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key; the other PostHog functions use a personal API key with the scope noted for each one. When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
+
+```yaml posthog-capture-event.yml
+build:
+  name: Build and mark the release in PostHog
+  steps:
+    - eas/build
+    - eas/posthog_capture_event:
+        name: Capture a PostHog event
+        inputs:
+          event: store_build_finished
+          properties:
+            platform: ios
+            profile: production
+```
+
+| Input          | Type      | Description                                                                                                                                                                                  |
+| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event`        | `string`  | Required. The name of the event to send.                                                                                                                                                     |
+| `distinct_id`  | `string`  | The person to attribute the event to. When omitted, the event is sent anonymously and does not create a person profile.                                                                      |
+| `properties`   | `json`    | Properties to attach to the event.                                                                                                                                                           |
+| `api_key`      | `string`  | PostHog project API key. Defaults to the `EXPO_PUBLIC_POSTHOG_API_KEY` environment variable set by `eas integrations:posthog:connect`, falling back to `POSTHOG_API_KEY` if that is not set. |
+| `host`         | `string`  | PostHog host. Defaults to the `EXPO_PUBLIC_POSTHOG_HOST` environment variable, or `https://us.posthog.com`.                                                                                  |
+| `ignore_error` | `boolean` | When `true`, a failure to send the event is logged but does not fail the step. Defaults to `false`.                                                                                          |
+
+<BoxLink
+  title="eas/posthog_capture_event source code"
+  description="View the source code for the eas/posthog_capture_event function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/capturePosthogEvent.ts"
+/>
+
+#### `eas/posthog_flag_rollout`
+
+Enables, disables, or rolls out a [PostHog feature flag](https://posthog.com/docs/feature-flags). The function looks up the flag by key and then updates it. Provide at least one of `active`, `rollout_percentage`, or `payload`.
+
+```yaml posthog-flag-rollout.yml
+build:
+  name: Roll out a PostHog feature flag
+  steps:
+    - eas/posthog_flag_rollout:
+        name: Roll out the flag to 25 percent
+        inputs:
+          flag: new-checkout
+          rollout_percentage: 25
+```
+
+| Input                | Type      | Description                                                                                                                                                                                                                                         |
+| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flag`               | `string`  | Required. The key of the feature flag to update.                                                                                                                                                                                                    |
+| `active`             | `boolean` | Whether the flag is enabled.                                                                                                                                                                                                                        |
+| `rollout_percentage` | `number`  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. It is applied to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, it is applied to the first condition. |
+| `payload`            | `json`    | Payload to attach to the flag.                                                                                                                                                                                                                      |
+| `variant`            | `string`  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                             |
+| `api_key`            | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                             |
+| `project_id`         | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                  |
+| `ignore_error`       | `boolean` | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.       |
+
+<BoxLink
+  title="eas/posthog_flag_rollout source code"
+  description="View the source code for the eas/posthog_flag_rollout function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/rolloutPosthogFlag.ts"
+/>
+
+#### `eas/posthog_wait_for_metric`
+
+Pauses the build until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate on a metric, such as holding until the error count over the last few minutes stays low. The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses.
+
+> **info** This step has no `ignore_error` input. A gate you ignore is not a gate, so a timeout or an unreadable query always fails the step.
+
+```yaml posthog-wait-for-metric.yml
+build:
+  name: Gate on the error count
+  steps:
+    - eas/posthog_wait_for_metric:
+        name: Wait for the error count to stay low
+        inputs:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+```
+
+| Input              | Type     | Description                                                                                                                       |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `query`            | `string` | Required. A HogQL query. The first column of the first row must be a single number.                                               |
+| `operator`         | `string` | Required. Comparison operator. One of `lt`, `lte`, `gt`, `gte`, or `eq`. The step clears when `value <operator> threshold` holds. |
+| `threshold`        | `number` | Required. The value to compare the query result against.                                                                          |
+| `timeout_seconds`  | `number` | Maximum time to wait, in seconds. Defaults to `600`.                                                                              |
+| `interval_seconds` | `number` | Time between checks, in seconds. Defaults to `30`.                                                                                |
+| `api_key`          | `string` | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope.            |
+| `project_id`       | `string` | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                |
+
+This function sets the following output:
+
+| Output  | Type     | Description                                     |
+| ------- | -------- | ----------------------------------------------- |
+| `value` | `string` | The metric value that satisfied the comparison. |
+
+<BoxLink
+  title="eas/posthog_wait_for_metric source code"
+  description="View the source code for the eas/posthog_wait_for_metric function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogMetric.ts"
+/>
+
+#### `eas/posthog_wait_for_query`
+
+Pauses the build until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead. The step clears when the first column of the first row is `true` or a nonzero number.
+
+> **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
+
+```yaml posthog-wait-for-query.yml
+build:
+  name: Wait for a smoke test event
+  steps:
+    - eas/posthog_wait_for_query:
+        name: Wait for the smoke test to pass
+        inputs:
+          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
+```
+
+| Input              | Type     | Description                                                                                                            |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `query`            | `string` | Required. A HogQL query. The step clears when the first column of the first row is `true` or a nonzero number.         |
+| `timeout_seconds`  | `number` | Maximum time to wait, in seconds. Defaults to `600`.                                                                   |
+| `interval_seconds` | `number` | Time between checks, in seconds. Defaults to `30`.                                                                     |
+| `api_key`          | `string` | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope. |
+| `project_id`       | `string` | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                     |
+
+<BoxLink
+  title="eas/posthog_wait_for_query source code"
+  description="View the source code for the eas/posthog_wait_for_query function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogQuery.ts"
+/>
+
+#### `eas/posthog_annotation`
+
+Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds and releases next to the metrics they affect.
+
+```yaml posthog-annotation.yml
+build:
+  name: Annotate the release in PostHog
+  steps:
+    - eas/posthog_annotation:
+        name: Create a PostHog annotation
+        inputs:
+          content: Published a production build
+```
+
+| Input          | Type      | Description                                                                                                                                                  |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `content`      | `string`  | Required. The annotation text.                                                                                                                               |
+| `date_marker`  | `string`  | The ISO 8601 timestamp the annotation is pinned to. Defaults to the current time.                                                                            |
+| `api_key`      | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `annotation:write` scope.                                 |
+| `project_id`   | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                           |
+| `ignore_error` | `boolean` | When `true`, a network error or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error always fails the step. |
+
+<BoxLink
+  title="eas/posthog_annotation source code"
+  description="View the source code for the eas/posthog_annotation function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/createPosthogAnnotation.ts"
+/>
+
+#### `eas/posthog_upload_sourcemaps`
+
+Uploads JavaScript source maps to PostHog so that stack traces in [error tracking](/guides/using-posthog/#error-tracking) are symbolicated. Run it after the step that produces your bundle, in the same job, so the bundle and source maps are on disk. Configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+
+> **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
+
+```yaml posthog-upload-sourcemaps.yml
+build:
+  name: Export and upload source maps
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - run:
+        name: Export the bundle and source maps
+        command: npx expo export --source-maps --platform ios
+    - eas/posthog_upload_sourcemaps:
+        name: Upload source maps to PostHog
+        inputs:
+          directory: dist
+```
+
+| Input          | Type      | Description                                                                                                              |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `directory`    | `string`  | The directory that contains the bundle and source maps, relative to the working directory. Defaults to `dist`.           |
+| `api_key`      | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires source map upload access. |
+| `project_id`   | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                       |
+| `ignore_error` | `boolean` | When `true`, a failed upload is logged but does not fail the step. Defaults to `false`.                                  |
+
+<BoxLink
+  title="eas/posthog_upload_sourcemaps source code"
+  description="View the source code for the eas/posthog_upload_sourcemaps function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadPosthogSourcemaps.ts"
+/>
+
 ### Using built-in EAS functions to build an app
 
 Using the built-in EAS functions you can recreate the default EAS Build process for different build types.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1965,7 +1965,7 @@ build:
 
 #### `eas/posthog_capture_event`
 
-Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline. Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key; the other PostHog functions use a personal API key with the scope noted for each one. When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
+Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline. Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key. The other PostHog functions use a personal API key with the scope noted for each one. When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
 
 ```yaml posthog-capture-event.yml
 build:
@@ -2012,16 +2012,16 @@ build:
           rollout_percentage: 25
 ```
 
-| Input                | Type      | Description                                                                                                                                                                                                                                         |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flag`               | `string`  | Required. The key of the feature flag to update.                                                                                                                                                                                                    |
-| `active`             | `boolean` | Whether the flag is enabled.                                                                                                                                                                                                                        |
-| `rollout_percentage` | `number`  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. It is applied to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, it is applied to the first condition. |
-| `payload`            | `json`    | Payload to attach to the flag.                                                                                                                                                                                                                      |
-| `variant`            | `string`  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                             |
-| `api_key`            | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                             |
-| `project_id`         | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                  |
-| `ignore_error`       | `boolean` | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.       |
+| Input                | Type      | Description                                                                                                                                                                                                                                                             |
+| -------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flag`               | `string`  | Required. The key of the feature flag to update.                                                                                                                                                                                                                        |
+| `active`             | `boolean` | Whether the flag is enabled.                                                                                                                                                                                                                                            |
+| `rollout_percentage` | `number`  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. The function applies it to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, the function applies it to the first condition. |
+| `payload`            | `json`    | Payload to attach to the flag.                                                                                                                                                                                                                                          |
+| `variant`            | `string`  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                                                 |
+| `api_key`            | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                                                 |
+| `project_id`         | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                                      |
+| `ignore_error`       | `boolean` | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.                           |
 
 <BoxLink
   title="eas/posthog_flag_rollout source code"
@@ -2034,7 +2034,7 @@ build:
 
 Pauses the build until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate on a metric, such as holding until the error count over the last few minutes stays low. The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses.
 
-> **info** This step has no `ignore_error` input. A gate you ignore is not a gate, so a timeout or an unreadable query always fails the step.
+> **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
 
 ```yaml posthog-wait-for-metric.yml
 build:
@@ -2133,7 +2133,7 @@ build:
 
 #### `eas/posthog_upload_sourcemaps`
 
-Uploads JavaScript source maps to PostHog so that stack traces in [error tracking](/guides/using-posthog/#error-tracking) are symbolicated. Run it after the step that produces your bundle, in the same job, so the bundle and source maps are on disk. Configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are on disk. Configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
 
 > **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
 

--- a/docs/pages/eas/workflows/examples/introduction.mdx
+++ b/docs/pages/eas/workflows/examples/introduction.mdx
@@ -47,3 +47,10 @@ The following workflows are examples of how you can use EAS Workflows to automat
   href="/eas/workflows/examples/e2e-tests"
   Icon={Dataflow03Icon}
 />
+
+<BoxLink
+  title="Use PostHog"
+  description="Learn how to send events, roll out feature flags, and gate rollouts on metrics with PostHog."
+  href="/guides/using-posthog/recipes"
+  Icon={Dataflow03Icon}
+/>

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -2187,16 +2187,16 @@ jobs:
 
 ##### Properties
 
-| Property             | Type    | Required    | Description                                                                                                                                                                                                                                         |
-| -------------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flag`               | string  | <YesIcon /> | The key of the feature flag to update.                                                                                                                                                                                                              |
-| `active`             | boolean | <NoIcon />  | Whether the flag is enabled.                                                                                                                                                                                                                        |
-| `rollout_percentage` | number  | <NoIcon />  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. It is applied to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, it is applied to the first condition. |
-| `payload`            | json    | <NoIcon />  | Payload to attach to the flag.                                                                                                                                                                                                                      |
-| `variant`            | string  | <NoIcon />  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                             |
-| `api_key`            | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                             |
-| `project_id`         | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                  |
-| `ignore_error`       | boolean | <NoIcon />  | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.       |
+| Property             | Type    | Required    | Description                                                                                                                                                                                                                                                             |
+| -------------------- | ------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flag`               | string  | <YesIcon /> | The key of the feature flag to update.                                                                                                                                                                                                                                  |
+| `active`             | boolean | <NoIcon />  | Whether the flag is enabled.                                                                                                                                                                                                                                            |
+| `rollout_percentage` | number  | <NoIcon />  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. The function applies it to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, the function applies it to the first condition. |
+| `payload`            | json    | <NoIcon />  | Payload to attach to the flag.                                                                                                                                                                                                                                          |
+| `variant`            | string  | <NoIcon />  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                                                 |
+| `api_key`            | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                                                 |
+| `project_id`         | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                                      |
+| `ignore_error`       | boolean | <NoIcon />  | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.                           |
 
 <BoxLink
   title="eas/posthog_flag_rollout source code"
@@ -2211,7 +2211,7 @@ Pauses the workflow until a [HogQL](https://posthog.com/docs/hogql) query return
 
 The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses. A query that cannot be read, such as invalid HogQL, fails the step immediately, while transient errors are retried until the timeout.
 
-> **info** This step has no `ignore_error` input. A gate you ignore is not a gate, so a timeout or an unreadable query always fails the step.
+> **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
 
 ```yaml
 jobs:
@@ -2321,7 +2321,7 @@ jobs:
 
 #### `eas/posthog_upload_sourcemaps`
 
-Uploads JavaScript source maps to PostHog so that stack traces in [error tracking](/guides/using-posthog/#error-tracking) are symbolicated. Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
 
 > **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -2130,6 +2130,231 @@ jobs:
   href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadArtifact.ts"
 />
 
+The following functions connect your workflow to [PostHog](/guides/using-posthog/). Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key, while the other functions use a PostHog personal API key with the scopes noted for each one. For setup, see [Using PostHog](/guides/using-posthog/), and for complete workflows, see [PostHog recipes for EAS Workflows](/guides/using-posthog/recipes).
+
+#### `eas/posthog_capture_event`
+
+Sends an analytics event to PostHog. Use it to mark deploys, updates, and other workflow milestones on your PostHog timeline.
+
+When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons), which keeps workflow events out of your list of people.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_capture_event
+        # @end #
+        with:
+          event: ota_update_published
+          properties:
+            branch: main
+```
+
+##### Properties
+
+| Property       | Type    | Required    | Description                                                                                                                                                                                  |
+| -------------- | ------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event`        | string  | <YesIcon /> | The name of the event to send.                                                                                                                                                               |
+| `distinct_id`  | string  | <NoIcon />  | The person to attribute the event to. When omitted, the event is sent anonymously and does not create a person profile.                                                                      |
+| `properties`   | json    | <NoIcon />  | Properties to attach to the event.                                                                                                                                                           |
+| `api_key`      | string  | <NoIcon />  | PostHog project API key. Defaults to the `EXPO_PUBLIC_POSTHOG_API_KEY` environment variable set by `eas integrations:posthog:connect`, falling back to `POSTHOG_API_KEY` if that is not set. |
+| `host`         | string  | <NoIcon />  | PostHog host. Defaults to the `EXPO_PUBLIC_POSTHOG_HOST` environment variable, or `https://us.posthog.com`.                                                                                  |
+| `ignore_error` | boolean | <NoIcon />  | When `true`, a failure to send the event is logged but does not fail the step. Defaults to `false`.                                                                                          |
+
+<BoxLink
+  title="eas/posthog_capture_event source code"
+  description="View the source code for the eas/posthog_capture_event function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/capturePosthogEvent.ts"
+/>
+
+#### `eas/posthog_flag_rollout`
+
+Enables, disables, or rolls out a [PostHog feature flag](https://posthog.com/docs/feature-flags). The function looks up the flag by key and then updates it. Provide at least one of `active`, `rollout_percentage`, or `payload`.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_flag_rollout
+        # @end #
+        with:
+          flag: new-checkout
+          rollout_percentage: 25
+```
+
+##### Properties
+
+| Property             | Type    | Required    | Description                                                                                                                                                                                                                                         |
+| -------------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flag`               | string  | <YesIcon /> | The key of the feature flag to update.                                                                                                                                                                                                              |
+| `active`             | boolean | <NoIcon />  | Whether the flag is enabled.                                                                                                                                                                                                                        |
+| `rollout_percentage` | number  | <NoIcon />  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. It is applied to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, it is applied to the first condition. |
+| `payload`            | json    | <NoIcon />  | Payload to attach to the flag.                                                                                                                                                                                                                      |
+| `variant`            | string  | <NoIcon />  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                             |
+| `api_key`            | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                             |
+| `project_id`         | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                  |
+| `ignore_error`       | boolean | <NoIcon />  | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.       |
+
+<BoxLink
+  title="eas/posthog_flag_rollout source code"
+  description="View the source code for the eas/posthog_flag_rollout function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/rolloutPosthogFlag.ts"
+/>
+
+#### `eas/posthog_wait_for_metric`
+
+Pauses the workflow until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate a rollout on a metric, such as holding until the error count over the last few minutes stays low.
+
+The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses. A query that cannot be read, such as invalid HogQL, fails the step immediately, while transient errors are retried until the timeout.
+
+> **info** This step has no `ignore_error` input. A gate you ignore is not a gate, so a timeout or an unreadable query always fails the step.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_wait_for_metric
+        # @end #
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+```
+
+##### Properties
+
+| Property           | Type   | Required    | Description                                                                                                             |
+| ------------------ | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `query`            | string | <YesIcon /> | A HogQL query. The first column of the first row must be a single number.                                               |
+| `operator`         | string | <YesIcon /> | Comparison operator. One of `lt`, `lte`, `gt`, `gte`, or `eq`. The step clears when `value <operator> threshold` holds. |
+| `threshold`        | number | <YesIcon /> | The value to compare the query result against.                                                                          |
+| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                    |
+| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                      |
+| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope.  |
+| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                      |
+
+##### Outputs
+
+| Property | Type   | Description                                     |
+| -------- | ------ | ----------------------------------------------- |
+| `value`  | string | The metric value that satisfied the comparison. |
+
+<BoxLink
+  title="eas/posthog_wait_for_metric source code"
+  description="View the source code for the eas/posthog_wait_for_metric function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogMetric.ts"
+/>
+
+#### `eas/posthog_wait_for_query`
+
+Pauses the workflow until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead.
+
+The step clears when the first column of the first row is `true` or a nonzero number, so write the query to select a single boolean, such as `SELECT count() > 100 FROM events`.
+
+> **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_wait_for_query
+        # @end #
+        with:
+          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
+```
+
+##### Properties
+
+| Property           | Type   | Required    | Description                                                                                                            |
+| ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `query`            | string | <YesIcon /> | A HogQL query. The step clears when the first column of the first row is `true` or a nonzero number.                   |
+| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                   |
+| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                     |
+| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope. |
+| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                     |
+
+<BoxLink
+  title="eas/posthog_wait_for_query source code"
+  description="View the source code for the eas/posthog_wait_for_query function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogQuery.ts"
+/>
+
+#### `eas/posthog_annotation`
+
+Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking deploys and releases next to the metrics they affect.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_annotation
+        # @end #
+        with:
+          content: Published update to production
+```
+
+##### Properties
+
+| Property       | Type    | Required    | Description                                                                                                                                                  |
+| -------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `content`      | string  | <YesIcon /> | The annotation text.                                                                                                                                         |
+| `date_marker`  | string  | <NoIcon />  | The ISO 8601 timestamp the annotation is pinned to. Defaults to the current time.                                                                            |
+| `api_key`      | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `annotation:write` scope.                                 |
+| `project_id`   | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                           |
+| `ignore_error` | boolean | <NoIcon />  | When `true`, a network error or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error always fails the step. |
+
+<BoxLink
+  title="eas/posthog_annotation source code"
+  description="View the source code for the eas/posthog_annotation function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/createPosthogAnnotation.ts"
+/>
+
+#### `eas/posthog_upload_sourcemaps`
+
+Uploads JavaScript source maps to PostHog so that stack traces in [error tracking](/guides/using-posthog/#error-tracking) are symbolicated. Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+
+> **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
+
+```yaml
+jobs:
+  publish_update:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - run: npx expo export --source-maps
+      # @info #
+      - uses: eas/posthog_upload_sourcemaps
+        # @end #
+        with:
+          directory: dist
+```
+
+##### Properties
+
+| Property       | Type    | Required   | Description                                                                                                              |
+| -------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `directory`    | string  | <NoIcon /> | The directory that contains the bundle and source maps, relative to the working directory. Defaults to `dist`.           |
+| `api_key`      | string  | <NoIcon /> | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires source map upload access. |
+| `project_id`   | string  | <NoIcon /> | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                       |
+| `ignore_error` | boolean | <NoIcon /> | When `true`, a failed upload is logged but does not fail the step. Defaults to `false`.                                  |
+
+<BoxLink
+  title="eas/posthog_upload_sourcemaps source code"
+  description="View the source code for the eas/posthog_upload_sourcemaps function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadPosthogSourcemaps.ts"
+/>
+
 ## Built-in shell functions
 
 EAS Workflows provides the following shell function that you can use in your workflow steps to set variable outputs.

--- a/docs/pages/guides/using-posthog/index.mdx
+++ b/docs/pages/guides/using-posthog/index.mdx
@@ -153,11 +153,11 @@ PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that 
 
 **On EAS Build**, the `posthog-react-native/expo` config plugin uploads source maps automatically during the Android (Gradle) and iOS (Xcode) build phases, so there's no extra command to run.
 
-**On EAS Update**, over-the-air updates ship only JavaScript, so upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then:
+**On EAS Update**, over-the-air updates ship only JavaScript, so upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then export one platform at a time and upload its maps:
 
-<Terminal cmd={['$ eas update', '', '$ posthog-cli hermes upload --directory dist']} />
+<Terminal cmd={['$ eas update --platform ios', '', '$ posthog-cli hermes upload --directory dist']} />
 
-**dist** is the default EAS Update output directory.
+**dist** is the default EAS Update output directory. Export one platform per upload: PostHog uploads native (Hermes) source maps, so a web bundle in **dist** would not process.
 
 <Collapsible summary="Automate uploads with EAS Workflows">
 

--- a/docs/pages/guides/using-posthog/index.mdx
+++ b/docs/pages/guides/using-posthog/index.mdx
@@ -155,7 +155,9 @@ PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that 
 
 **On EAS Update**, over-the-air updates ship only JavaScript, so upload just their source maps after each update (native symbols are fixed at build time). [Install PostHog's CLI](https://posthog.com/docs/error-tracking/upload-source-maps/cli), then export one platform at a time and upload its maps:
 
-<Terminal cmd={['$ eas update --platform ios', '', '$ posthog-cli hermes upload --directory dist']} />
+<Terminal
+  cmd={['$ eas update --platform ios', '', '$ posthog-cli hermes upload --directory dist']}
+/>
 
 **dist** is the default EAS Update output directory. Export one platform per upload: PostHog uploads native (Hermes) source maps, so a web bundle in **dist** would not process.
 

--- a/docs/pages/guides/using-posthog/index.mdx
+++ b/docs/pages/guides/using-posthog/index.mdx
@@ -1,9 +1,13 @@
 ---
 title: Using PostHog
+sidebar_title: Overview
 description: A guide on installing and configuring PostHog for product analytics, session replay, and error tracking.
 platforms: ['android', 'ios']
 ---
 
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
@@ -153,37 +157,18 @@ PostHog's CLI authenticates with the `POSTHOG_CLI_*` environment variables that 
 
 <Terminal cmd={['$ eas update', '', '$ posthog-cli hermes upload --directory dist']} />
 
-`dist` is the default EAS Update output directory.
+**dist** is the default EAS Update output directory.
 
 <Collapsible summary="Automate uploads with EAS Workflows">
 
-EAS Build uploads source maps as part of the native build, so a build workflow needs nothing extra. For updates, add a job that re-exports and uploads after publishing:
+EAS Build uploads source maps as part of the native build, so a build workflow needs nothing extra. For updates, publish with `eas update`, then run the [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) function on the **dist** directory the update exported.
 
-```yaml .eas/workflows/publish-update.yml
-name: Publish update
-on:
-  push:
-    branches: ['main']
-jobs:
-  publish_update:
-    name: Publish update
-    type: update
-    params:
-      channel: production
-  upload_update_sourcemaps:
-    name: Upload OTA source maps to PostHog
-    needs: [publish_update]
-    environment: production
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - name: Export JS bundle and source maps
-        run: npx expo export --dump-sourcemap --output-dir dist
-      - name: Upload source maps to PostHog
-        run: npx --yes @posthog/cli@latest hermes upload --directory dist
-```
-
-`environment: production` gives the job the `POSTHOG_CLI_*` variables that `connect` stored. The chunk IDs injected by `getPostHogExpoConfig` let the re-exported source maps match the bundle the update published. For external CI, set the `POSTHOG_CLI_*` variables yourself.
+<BoxLink
+  title="Upload source maps for error tracking"
+  description="A complete workflow that publishes an update and uploads the source maps from the same export."
+  href="/guides/using-posthog/recipes#upload-source-maps-for-error-tracking"
+  Icon={Dataflow03Icon}
+/>
 
 </Collapsible>
 
@@ -230,6 +215,17 @@ Render `<ReleaseTagger />` inside `<PostHogProvider>`. Every subsequent `capture
 ## Feature flags
 
 Once the provider is set up, feature flags work with no extra configuration. See [PostHog's feature flags for React Native](https://posthog.com/docs/feature-flags/installation/react-native) and [bootstrapping](https://posthog.com/docs/feature-flags/bootstrapping) to avoid a network round-trip on app start.
+
+## Usage with EAS Workflows
+
+[EAS Workflows](/eas/workflows/get-started/) can talk to PostHog from your CI pipeline. You can send events, create annotations, roll out feature flags, gate a rollout on a live metric, and upload source maps as workflow steps. These steps automatically read the `EXPO_PUBLIC_POSTHOG_*` and `POSTHOG_CLI_*` environment variables that `connect` sets. For the full input reference of each step, see [PostHog functions in the EAS Workflows syntax reference](/eas/workflows/syntax/#easposthog_capture_event).
+
+<BoxLink
+  title="Progressive delivery with PostHog"
+  description="Go from marking a deploy to gated rollouts, automatic kill switches, and approval-gated releases, with a recipe reference for quick lookup."
+  href="/guides/using-posthog/recipes"
+  Icon={Dataflow03Icon}
+/>
 
 ## Manage the integration
 

--- a/docs/pages/guides/using-posthog/recipes.mdx
+++ b/docs/pages/guides/using-posthog/recipes.mdx
@@ -112,7 +112,7 @@ jobs:
       profile: production
 ```
 
-An update ships JavaScript only, so you upload its source maps after publishing. The [`update`](/eas/workflows/pre-packaged-jobs#update) job can't run an extra step, and the source maps have to be on disk in the job that uploads them. So publish with `eas update` in a custom job and add the upload step there:
+An update ships JavaScript only, so you upload its source maps after publishing. The [`update`](/eas/workflows/pre-packaged-jobs#update) job can't run an extra step, and the source maps have to be on disk in the job that uploads them. So publish with `eas update` for one platform in a custom job and add the upload step there:
 
 ```yaml .eas/workflows/update-with-sourcemaps.yml
 name: Publish update with source maps
@@ -126,7 +126,7 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/install_node_modules
-      - run: npx eas-cli@latest update --branch main --auto --non-interactive
+      - run: npx eas-cli@latest update --branch main --platform ios --auto --non-interactive
       - uses: eas/posthog_upload_sourcemaps
         with:
           directory: dist
@@ -134,7 +134,7 @@ jobs:
 
 ### How it works
 
-1. `eas update` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory.
+1. `eas update --platform ios` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory. Scope it to one platform: source maps are per platform, and PostHog only uploads native (Hermes) source maps, so exporting every platform at once would put a web bundle in **dist** that the upload can't process. Add a second job with `--platform android` to cover Android.
 2. [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) uploads those maps to PostHog error tracking, so stack traces from the update symbolicate back to your original code. It uses the [PostHog Metro config](/guides/using-posthog/#source-maps), which gives each bundle the chunk IDs that match it to its source maps. See [error tracking](/guides/using-posthog/#error-tracking) for how symbolication works.
 
 ## Release a feature behind a flag

--- a/docs/pages/guides/using-posthog/recipes.mdx
+++ b/docs/pages/guides/using-posthog/recipes.mdx
@@ -89,7 +89,7 @@ jobs:
 ### How it works
 
 1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes the update.
-2. [`eas/posthog_annotation`](/eas/workflows/syntax/#easposthog_annotation) pins an annotation to the current time, which appears on every PostHog chart for the project. The runtime version in the content tells you which release each marker is. The update job's [outputs](/eas/workflows/pre-packaged-jobs#update) also expose the update group ID and, through [`fromJSON`](/eas/workflows/syntax/#fromjsonvalue) on `updates_json`, the message and git commit hash.
+2. [`eas/posthog_annotation`](/eas/workflows/syntax/#easposthog_annotation) pins the annotation to the current time, and the runtime version in the content identifies the release.
 
 ## Upload source maps for error tracking
 
@@ -134,7 +134,7 @@ jobs:
 
 ### How it works
 
-1. `eas update --platform ios` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory. Scope it to one platform. Source maps are per platform, and PostHog uploads only native (Hermes) source maps. Exporting every platform at once would put a web bundle in **dist** that the upload can't process. Add a second job with `--platform android` to cover Android.
+1. `eas update --platform ios` publishes the update and leaves the export, source maps included, in the **dist** directory. Export one native platform per job: a full export also includes a web bundle, which PostHog's Hermes upload rejects.
 2. [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) uploads those maps to PostHog error tracking, so stack traces from the update symbolicate back to your original code. It uses the [PostHog Metro config](/guides/using-posthog/#source-maps), which gives each bundle the chunk IDs that match it to its source maps. See [error tracking](/guides/using-posthog/#error-tracking) for how symbolication works.
 
 ## Release a feature behind a flag
@@ -252,7 +252,7 @@ jobs:
 
 ## Roll out an EAS Update channel, or revert on failure
 
-The rollout above controls exposure with a PostHog feature flag. If you roll out with [EAS Update channel percentages](/eas-update/rollouts/) instead, the same gate drives `eas channel:rollout`: publish an update, send a fraction of users to it, watch the error rate, then widen the rollout to everyone or revert it. This is the most hands-off recipe here, and it touches the most of EAS: the update job, channel rollouts, the metric gate, and an event to record the outcome.
+The rollout above controls exposure with a PostHog feature flag. If you roll out with [EAS Update channel percentages](/eas-update/rollouts/) instead, the same gate drives `eas channel:rollout`: publish an update, send a fraction of users to it, watch the error rate, then widen the rollout to everyone or revert it. It touches more of EAS than any other recipe here: the update job, channel rollouts, the metric gate, and an outcome event.
 
 ```yaml .eas/workflows/channel-rollout.yml
 name: Channel rollout that widens or reverts
@@ -306,7 +306,7 @@ jobs:
 1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes to the `rollout` branch, then `eas channel:rollout` starts a rollout on the `production` channel that sends 10% of users to the new update. The `--runtime-version` value must match the published update's runtime version.
 2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) holds until the exception count over the last 15 minutes stays under 10, then records the count that cleared the gate through the step's `value` output.
 3. When the gate clears, `widen` ends the rollout with `--outcome republish-and-revert`, which publishes the new update to everyone.
-4. When the gate fails, `revert` ends the rollout with `--outcome revert`, which sends users back to the previous update. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif), the same pattern as the flag rollback above, because a `needs` dependency would skip it before its `if` is evaluated.
+4. When the gate fails, `revert` ends the rollout with `--outcome revert`, which sends users back to the previous update. It uses the same [`after`](/eas/workflows/syntax/#jobsjob_idafter) plus [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) pattern as the [flag rollback](#roll-out-or-roll-back-on-your-error-rate).
 
 ## Take a flag to full rollout with human approval
 
@@ -372,15 +372,15 @@ jobs:
 
 ### How it works
 
-1. Start it during an incident with:
+1. Run it with:
 
    <Terminal cmd={['$ eas workflow:run kill-switch.yml']} />
 
-2. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off for everyone, and the follow-up event records when the kill switch was pulled and for which flag.
+2. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off, and the follow-up event records that it happened.
 
 ## Turn a feature off automatically on an error spike
 
-Turn a feature off automatically when the error rate spikes after a deploy. This is the kill switch from the previous recipe wired to an error gate, so it fires without anyone watching a dashboard.
+This is the kill switch from the previous recipe wired to an error gate, so it turns the feature off on its own when the error rate spikes after a deploy.
 
 ```yaml .eas/workflows/auto-kill-switch.yml
 name: Turn off new-checkout automatically on an error spike
@@ -424,8 +424,8 @@ jobs:
 ### How it works
 
 1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes the update, and [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) waits until the exception count over the last 10 minutes is under 20. If a bad update keeps the count elevated, the gate times out and fails.
-2. The `auto_kill_switch` job uses the same `after` plus `if: ${{ failure() }}` pattern as the rollback in [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate): `after` instead of `needs`, because a failed `needs` dependency skips the job before its `if` condition is evaluated.
-3. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off, the same action as the manual kill switch, and the follow-up event records that it happened automatically.
+2. The `auto_kill_switch` job uses the same [`after`](/eas/workflows/syntax/#jobsjob_idafter) plus [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) pattern as the [flag rollback](#roll-out-or-roll-back-on-your-error-rate).
+3. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off, the same action as the manual kill switch, and records that it fired automatically.
 
 ## Announce a release once users adopt it
 
@@ -472,7 +472,7 @@ jobs:
 
 ## More recipes
 
-These recipes cover narrower needs. Each is a complete workflow you can copy as-is.
+Shorter recipes for narrower needs.
 
 ### Wait for a specific event
 

--- a/docs/pages/guides/using-posthog/recipes.mdx
+++ b/docs/pages/guides/using-posthog/recipes.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 - **Product analytics**: [Mark a deploy](#mark-a-deploy-on-your-posthog-timeline), [Annotate a release](#annotate-a-release), and [Announce a release once users adopt it](#announce-a-release-once-users-adopt-it)
 - **Feature flags**: [Release a feature behind a flag](#release-a-feature-behind-a-flag), [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate), [Take a flag to full rollout with human approval](#take-a-flag-to-full-rollout-with-human-approval), and turn a feature off [manually](#turn-a-feature-off-with-a-kill-switch) or [automatically on an error spike](#turn-a-feature-off-automatically-on-an-error-spike)
-- **Error tracking**: [Upload source maps](#upload-source-maps-for-error-tracking) for readable stack traces, and [gate or roll back an EAS Update channel rollout on errors](#more-recipes)
+- **Error tracking**: [Upload source maps](#upload-source-maps-for-error-tracking) for readable stack traces, and [roll out an EAS Update channel or revert on failure](#roll-out-an-eas-update-channel-or-revert-on-failure)
 
 A compact [list of more recipes](#more-recipes) covers narrower needs. For every input each function accepts, see the [EAS Workflows syntax reference](/eas/workflows/syntax/#easposthog_capture_event).
 
@@ -93,7 +93,7 @@ jobs:
 
 ## Upload source maps for error tracking
 
-Upload your source maps so error tracking can symbolicate crashes back to your original code. How they get uploaded depends on the flagship job that produced the bundle. Both paths need the PostHog setup from the [Using PostHog](/guides/using-posthog/#error-tracking) guide.
+Upload your source maps so error tracking can symbolicate crashes back to your original code. How they get uploaded depends on the pre-packaged job that produced the bundle. Both paths need the PostHog setup from the [Using PostHog](/guides/using-posthog/#error-tracking) guide.
 
 A [`build`](/eas/workflows/pre-packaged-jobs#build) uploads source maps on its own. The `posthog-react-native/expo` config plugin uploads them during the native build, so the job needs nothing extra:
 
@@ -134,7 +134,7 @@ jobs:
 
 ### How it works
 
-1. `eas update --platform ios` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory. Scope it to one platform: source maps are per platform, and PostHog only uploads native (Hermes) source maps, so exporting every platform at once would put a web bundle in **dist** that the upload can't process. Add a second job with `--platform android` to cover Android.
+1. `eas update --platform ios` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory. Scope it to one platform. Source maps are per platform, and PostHog uploads only native (Hermes) source maps. Exporting every platform at once would put a web bundle in **dist** that the upload can't process. Add a second job with `--platform android` to cover Android.
 2. [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) uploads those maps to PostHog error tracking, so stack traces from the update symbolicate back to your original code. It uses the [PostHog Metro config](/guides/using-posthog/#source-maps), which gives each bundle the chunk IDs that match it to its source maps. See [error tracking](/guides/using-posthog/#error-tracking) for how symbolication works.
 
 ## Release a feature behind a flag
@@ -185,13 +185,13 @@ jobs:
 
 ### How it works
 
-1. The [`paths`](/eas/workflows/syntax/#onpush) filter runs this workflow only when **.eas/feature-rollout.json** changes, which makes the file the single source of truth for the rollout state.
+1. The [`paths`](/eas/workflows/syntax/#onpush) filter runs this workflow only when **.eas/feature-rollout.json** changes, so the file is where you define the rollout state.
 2. `read_rollout` reads the file with [`set-output`](/eas/workflows/syntax/#jobsjob_idoutputs) and exposes the values through the job's `outputs`.
 3. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) applies the flag state after both dependencies finish, so the flag flips only once the code that reads it is live.
 
 ## Roll out or roll back on your error rate
 
-Release to a small slice of users, watch the error rate, and let the workflow decide. When errors stay low, it widens the flag to everyone. When they don't, it turns the flag off. Either way, nobody has to watch a dashboard in between.
+Release to a small percentage of users, watch the error rate, and let the workflow decide. When errors stay low, it widens the flag to everyone. When they don't, it turns the flag off. Either way, nobody has to watch a dashboard in between.
 
 ```yaml .eas/workflows/canary-rollout.yml
 name: Canary rollout that rolls forward or back
@@ -249,6 +249,64 @@ jobs:
 1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job ships the code, then [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) exposes it to 25% of users.
 2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) runs a [HogQL](https://posthog.com/docs/hogql) query and waits until the exception count over the last 30 minutes is 5 or fewer. Once the gate clears, `full_rollout` widens the flag to 100%. If a bad rollout keeps the count elevated, the gate times out and fails, and `full_rollout` never runs.
 3. On failure, `roll_back` turns the flag off. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) because a `needs` dependency would not work here: a job is skipped when a `needs` dependency fails, before its `if` condition is evaluated. `failure()` reflects the whole workflow run, so keep this workflow focused on the rollout and its gate.
+
+## Roll out an EAS Update channel, or revert on failure
+
+The rollout above controls exposure with a PostHog feature flag. If you roll out with [EAS Update channel percentages](/eas-update/rollouts/) instead, the same gate drives `eas channel:rollout`: publish an update, send a fraction of users to it, watch the error rate, then widen the rollout to everyone or revert it. This is the most hands-off recipe here, and it touches the most of EAS: the update job, channel rollouts, the metric gate, and an event to record the outcome.
+
+```yaml .eas/workflows/channel-rollout.yml
+name: Channel rollout that widens or reverts
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: rollout
+
+  start_rollout:
+    needs: [publish]
+    steps:
+      - run: npx eas-cli@latest channel:rollout production --action create --branch rollout --percent 10 --runtime-version 1.0.0 --non-interactive
+
+  error_gate:
+    needs: [start_rollout]
+    steps:
+      - id: gate
+        uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+          interval_seconds: 60
+          timeout_seconds: 900
+      - uses: eas/posthog_capture_event
+        with:
+          event: channel_rollout_cleared
+          properties:
+            error_count: ${{ steps.gate.outputs.value }}
+
+  widen:
+    needs: [error_gate]
+    steps:
+      - run: npx eas-cli@latest channel:rollout production --action end --outcome republish-and-revert --non-interactive
+
+  revert:
+    after: [error_gate]
+    if: ${{ failure() }}
+    steps:
+      - run: npx eas-cli@latest channel:rollout production --action end --outcome revert --non-interactive
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes to the `rollout` branch, then `eas channel:rollout` starts a rollout on the `production` channel that sends 10% of users to the new update. The `--runtime-version` value must match the published update's runtime version.
+2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) holds until the exception count over the last 15 minutes stays under 10, then records the count that cleared the gate through the step's `value` output.
+3. When the gate clears, `widen` ends the rollout with `--outcome republish-and-revert`, which publishes the new update to everyone.
+4. When the gate fails, `revert` ends the rollout with `--outcome revert`, which sends users back to the previous update. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif), the same pattern as the flag rollback above, because a `needs` dependency would skip it before its `if` is evaluated.
 
 ## Take a flag to full rollout with human approval
 
@@ -435,95 +493,6 @@ jobs:
 
 [`eas/posthog_wait_for_query`](/eas/workflows/syntax/#easposthog_wait_for_query) clears once the query returns true. The 30-minute window keeps an old smoke-test event from clearing the gate immediately.
 
-### Gate an EAS Update channel rollout
-
-If you roll out with EAS Update channel percentages instead of a feature flag, the same gate pattern from [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate) applies to `eas channel:rollout`.
-
-```yaml .eas/workflows/staged-rollout.yml
-name: Staged rollout gated on errors
-
-on:
-  push:
-    branches: ['main']
-
-jobs:
-  publish:
-    type: update
-    params:
-      branch: rollout
-
-  start_at_10:
-    needs: [publish]
-    steps:
-      - run: npx eas-cli@latest channel:rollout production --action create --branch rollout --percent 10 --runtime-version 1.0.0 --non-interactive
-
-  error_gate:
-    needs: [start_at_10]
-    steps:
-      - id: gate
-        uses: eas/posthog_wait_for_metric
-        with:
-          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
-          operator: lt
-          threshold: 10
-          interval_seconds: 60
-          timeout_seconds: 900
-      - uses: eas/posthog_capture_event
-        with:
-          event: rollout_gate_cleared
-          properties:
-            error_count: ${{ steps.gate.outputs.value }}
-
-  widen_to_100:
-    needs: [error_gate]
-    steps:
-      - run: npx eas-cli@latest channel:rollout production --action end --outcome republish-and-revert --non-interactive
-```
-
-The `--runtime-version` value must match the runtime version of the published update. The follow-up event records the count that cleared the gate through the step's `value` output.
-
-### Roll back an EAS Update channel automatically
-
-The channel equivalent of the [automatic kill switch](#turn-a-feature-off-automatically-on-an-error-spike) above: if the error rate stays elevated, roll users back to the embedded update instead of turning off a flag.
-
-```yaml .eas/workflows/auto-rollback.yml
-name: Publish update with auto-rollback
-
-on:
-  push:
-    branches: ['main']
-
-jobs:
-  publish:
-    type: update
-    params:
-      branch: main
-
-  error_gate:
-    needs: [publish]
-    steps:
-      - uses: eas/posthog_wait_for_metric
-        with:
-          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 10 MINUTE
-          operator: lt
-          threshold: 20
-          interval_seconds: 60
-          timeout_seconds: 600
-
-  rollback:
-    after: [error_gate]
-    if: ${{ failure() }}
-    steps:
-      - run: npx eas-cli@latest update:roll-back-to-embedded --branch main --runtime-version 1.0.0 --message "Auto-rollback after error spike" --non-interactive
-      - uses: eas/posthog_capture_event
-        with:
-          event: auto_rollback_triggered
-          properties:
-            branch: main
-```
-
-As with the automatic kill switch, `after` plus `if: ${{ failure() }}` is required here because a `needs` dependency would skip `rollback` before `if` is ever evaluated. The `--runtime-version` value must match the runtime version of the update to roll back.
-
 ### Check your nightly error budget
 
 Run a gate on a schedule instead of after a deploy, as a standalone health check.
@@ -584,6 +553,6 @@ jobs:
 ## Important notes
 
 - **Credentials come from the connect command.** Every function defaults to the environment variables that `eas integrations:posthog:connect` sets, and each accepts an `api_key` input when you need to override them. To set them yourself, add these as [EAS environment variables](/eas/environment-variables/manage/): `EXPO_PUBLIC_POSTHOG_API_KEY` for `eas/posthog_capture_event`, and `POSTHOG_CLI_API_KEY` plus `POSTHOG_CLI_PROJECT_ID` for every other function. The [syntax reference](/eas/workflows/syntax/#easposthog_capture_event) lists the scope each function requires.
-- **Gates fail closed.** `eas/posthog_wait_for_metric` and `eas/posthog_wait_for_query` have no `ignore_error` input. When a gate times out, the step fails, which is what lets it stop a rollout.
+- **A gate that times out fails the step.** `eas/posthog_wait_for_metric` and `eas/posthog_wait_for_query` have no `ignore_error` input, so a gate that never passes stops the rollout instead of letting it continue.
 - **Gates pass as soon as the condition holds.** A gate checking for a low error count can pass on its first check, including right after a deploy, before users are on the new update. Pair it with an adoption gate, like the one in [Announce a release once users adopt it](#announce-a-release-once-users-adopt-it), when you need errors to have had a chance to surface first.
 - **Scope queries to the current run.** Event and metric queries return historical data. Add a `timestamp > now() - INTERVAL ...` filter, or a property unique to this run, so an old event does not clear a gate immediately. Setting up [release tagging](/guides/using-posthog/#release-tagging) attaches `expo_update_id`, `expo_channel`, and `expo_runtime_version` to every client event, so you can filter a gate on `properties.expo_update_id` to scope it to the exact release.

--- a/docs/pages/guides/using-posthog/recipes.mdx
+++ b/docs/pages/guides/using-posthog/recipes.mdx
@@ -248,7 +248,7 @@ jobs:
 
 1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job ships the code, then [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) exposes it to 25% of users.
 2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) runs a [HogQL](https://posthog.com/docs/hogql) query and waits until the exception count over the last 30 minutes is 5 or fewer. Once the gate clears, `full_rollout` widens the flag to 100%. If a bad rollout keeps the count elevated, the gate times out and fails, and `full_rollout` never runs.
-3. On failure, `roll_back` turns the flag off. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) because a `needs` dependency would not work here: a job is skipped when a `needs` dependency fails, before its `if` condition is evaluated. `failure()` reflects the whole workflow run, so keep this workflow focused on the rollout and its gate.
+3. On failure, `roll_back` turns the flag off. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) because a `needs` dependency would not work here. When a `needs` dependency fails, the job is skipped before its `if` condition is evaluated. `failure()` reflects the whole workflow run, so keep this workflow focused on the rollout and its gate.
 
 ## Roll out an EAS Update channel, or revert on failure
 

--- a/docs/pages/guides/using-posthog/recipes.mdx
+++ b/docs/pages/guides/using-posthog/recipes.mdx
@@ -1,0 +1,589 @@
+---
+title: PostHog recipes for EAS Workflows
+sidebar_title: EAS Workflows recipes
+description: A guided path from marking your first deploy in PostHog to gated rollouts, automatic kill switches, and approval-gated releases with EAS Workflows.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+[EAS Workflows](/eas/workflows/get-started/) can run PostHog actions as steps in your CI pipeline. Each recipe below is a complete workflow you can copy as-is, and together they build up to a full progressive delivery pipeline:
+
+- **Product analytics**: [Mark a deploy](#mark-a-deploy-on-your-posthog-timeline), [Annotate a release](#annotate-a-release), and [Announce a release once users adopt it](#announce-a-release-once-users-adopt-it)
+- **Feature flags**: [Release a feature behind a flag](#release-a-feature-behind-a-flag), [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate), [Take a flag to full rollout with human approval](#take-a-flag-to-full-rollout-with-human-approval), and turn a feature off [manually](#turn-a-feature-off-with-a-kill-switch) or [automatically on an error spike](#turn-a-feature-off-automatically-on-an-error-spike)
+- **Error tracking**: [Upload source maps](#upload-source-maps-for-error-tracking) for readable stack traces, and [gate or roll back an EAS Update channel rollout on errors](#more-recipes)
+
+A compact [list of more recipes](#more-recipes) covers narrower needs. For every input each function accepts, see the [EAS Workflows syntax reference](/eas/workflows/syntax/#easposthog_capture_event).
+
+## Get started
+
+One command sets up everything these recipes need. Run it from your project directory:
+
+<Terminal cmd={['$ eas integrations:posthog:connect']} />
+
+It links a PostHog project to your Expo project and saves the credentials these functions read as EAS environment variables. The [Using PostHog](/guides/using-posthog/) guide walks through the full setup.
+
+When the command asks for a personal API key, create it with the "Source map upload" preset plus the `feature_flag:read`, `feature_flag:write`, `query:read`, and `annotation:write` scopes. That one key covers every recipe on this page. If you connected earlier with a narrower key, create a new one and set it as the `POSTHOG_CLI_API_KEY` [environment variable](/eas/environment-variables/manage/) with the **Sensitive** visibility.
+
+> **info** Workflows that run on GitHub events, such as a push to `main`, need your EAS project linked to a GitHub repository. See [Get started with EAS Workflows](/eas/workflows/get-started/#automate-workflows-with-github-events).
+
+## Mark a deploy on your PostHog timeline
+
+Send a PostHog event every time you publish an update. Each deploy then shows up in your PostHog data, so you can check whether a change in a metric lines up with a release.
+
+```yaml .eas/workflows/mark-deploy.yml
+name: Publish update and mark it in PostHog
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  mark_deploy:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_capture_event
+        with:
+          event: ota_update_published
+          properties:
+            branch: main
+            runtime_version: ${{ fromJSON(needs.publish.outputs.updates_json || '[]')[0].runtimeVersion }}
+            update_group_id: ${{ needs.publish.outputs.first_update_group_id }}
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes an EAS Update to the `main` branch.
+2. [`eas/posthog_capture_event`](/eas/workflows/syntax/#easposthog_capture_event) runs after it and records the deploy. Both properties come from the update job's [outputs](/eas/workflows/pre-packaged-jobs#update): the runtime version says which builds can run the update, and the update group ID points at the exact update. With the [`fingerprint` runtime version policy](/eas-update/runtime-versions/), the runtime version changes whenever your native runtime does, based on your project's [fingerprint](/versions/latest/sdk/fingerprint/).
+3. Because no `distinct_id` is set, the event is anonymous and does not create a person profile.
+
+## Annotate a release
+
+Create a PostHog annotation when you publish an update. Annotations appear as markers on every chart in the project, so you can see each release directly on the graphs it affects.
+
+```yaml .eas/workflows/annotate-release.yml
+name: Annotate release in PostHog
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  annotate:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_annotation
+        with:
+          content: Published update for runtime ${{ fromJSON(needs.publish.outputs.updates_json || '[]')[0].runtimeVersion }} to main
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes the update.
+2. [`eas/posthog_annotation`](/eas/workflows/syntax/#easposthog_annotation) pins an annotation to the current time, which appears on every PostHog chart for the project. The runtime version in the content tells you which release each marker is. The update job's [outputs](/eas/workflows/pre-packaged-jobs#update) also expose the update group ID and, through [`fromJSON`](/eas/workflows/syntax/#fromjsonvalue) on `updates_json`, the message and git commit hash.
+
+## Upload source maps for error tracking
+
+Upload your source maps so error tracking can symbolicate crashes back to your original code. How they get uploaded depends on the flagship job that produced the bundle. Both paths need the PostHog setup from the [Using PostHog](/guides/using-posthog/#error-tracking) guide.
+
+A [`build`](/eas/workflows/pre-packaged-jobs#build) uploads source maps on its own. The `posthog-react-native/expo` config plugin uploads them during the native build, so the job needs nothing extra:
+
+```yaml .eas/workflows/build-production.yml
+name: Build for production
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+      profile: production
+```
+
+An update ships JavaScript only, so you upload its source maps after publishing. The [`update`](/eas/workflows/pre-packaged-jobs#update) job can't run an extra step, and the source maps have to be on disk in the job that uploads them. So publish with `eas update` in a custom job and add the upload step there:
+
+```yaml .eas/workflows/update-with-sourcemaps.yml
+name: Publish update with source maps
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish_update:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - run: npx eas-cli@latest update --branch main --auto --non-interactive
+      - uses: eas/posthog_upload_sourcemaps
+        with:
+          directory: dist
+```
+
+### How it works
+
+1. `eas update` bundles the app, publishes it, and leaves the export, source maps included, in the **dist** directory.
+2. [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) uploads those maps to PostHog error tracking, so stack traces from the update symbolicate back to your original code. It uses the [PostHog Metro config](/guides/using-posthog/#source-maps), which gives each bundle the chunk IDs that match it to its source maps. See [error tracking](/guides/using-posthog/#error-tracking) for how symbolication works.
+
+## Release a feature behind a flag
+
+Keep a feature's rollout state in a file in your repo and let the workflow apply it to PostHog. Shipping a feature or widening its rollout becomes a pull request that edits one file.
+
+```json .eas/feature-rollout.json
+{
+  "flag": "new-checkout",
+  "rollout_percentage": 10
+}
+```
+
+```yaml .eas/workflows/feature-release.yml
+name: Apply the feature rollout from the repo
+
+on:
+  push:
+    branches: ['main']
+    paths: ['.eas/feature-rollout.json']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  read_rollout:
+    outputs:
+      flag: ${{ steps.rollout.outputs.flag }}
+      percent: ${{ steps.rollout.outputs.percent }}
+    steps:
+      - uses: eas/checkout
+      - id: rollout
+        run: |
+          set-output flag "$(node -p "require('./.eas/feature-rollout.json').flag")"
+          set-output percent "$(node -p "require('./.eas/feature-rollout.json').rollout_percentage")"
+
+  apply_rollout:
+    needs: [publish, read_rollout]
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: ${{ needs.read_rollout.outputs.flag }}
+          active: true
+          rollout_percentage: ${{ needs.read_rollout.outputs.percent }}
+```
+
+### How it works
+
+1. The [`paths`](/eas/workflows/syntax/#onpush) filter runs this workflow only when **.eas/feature-rollout.json** changes, which makes the file the single source of truth for the rollout state.
+2. `read_rollout` reads the file with [`set-output`](/eas/workflows/syntax/#jobsjob_idoutputs) and exposes the values through the job's `outputs`.
+3. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) applies the flag state after both dependencies finish, so the flag flips only once the code that reads it is live.
+
+## Roll out or roll back on your error rate
+
+Release to a small slice of users, watch the error rate, and let the workflow decide. When errors stay low, it widens the flag to everyone. When they don't, it turns the flag off. Either way, nobody has to watch a dashboard in between.
+
+```yaml .eas/workflows/canary-rollout.yml
+name: Canary rollout that rolls forward or back
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  canary:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          active: true
+          rollout_percentage: 25
+
+  error_gate:
+    needs: [canary]
+    steps:
+      - uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 30 MINUTE
+          operator: lte
+          threshold: 5
+          interval_seconds: 60
+          timeout_seconds: 1800
+
+  full_rollout:
+    needs: [error_gate]
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          rollout_percentage: 100
+
+  roll_back:
+    after: [error_gate]
+    if: ${{ failure() }}
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          active: false
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job ships the code, then [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) exposes it to 25% of users.
+2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) runs a [HogQL](https://posthog.com/docs/hogql) query and waits until the exception count over the last 30 minutes is 5 or fewer. Once the gate clears, `full_rollout` widens the flag to 100%. If a bad rollout keeps the count elevated, the gate times out and fails, and `full_rollout` never runs.
+3. On failure, `roll_back` turns the flag off. It uses [`after`](/eas/workflows/syntax/#jobsjob_idafter) with [`if: ${{ failure() }}`](/eas/workflows/syntax/#jobsjob_idif) because a `needs` dependency would not work here: a job is skipped when a `needs` dependency fails, before its `if` condition is evaluated. `failure()` reflects the whole workflow run, so keep this workflow focused on the rollout and its gate.
+
+## Take a flag to full rollout with human approval
+
+Pause the workflow for an explicit approval in the EAS dashboard before a flag goes to 100%. Use this for rollouts you don't want to automate end to end.
+
+```yaml .eas/workflows/approved-ga.yml
+name: Take a feature to GA with human approval
+
+jobs:
+  approve:
+    name: Approve new-checkout GA?
+    type: require-approval
+
+  go_full:
+    needs: [approve]
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          active: true
+          rollout_percentage: 100
+
+  bookkeeping:
+    needs: [go_full]
+    steps:
+      - uses: eas/posthog_capture_event
+        with:
+          event: feature_went_ga
+          properties:
+            flag: new-checkout
+```
+
+### How it works
+
+1. The [`require-approval`](/eas/workflows/pre-packaged-jobs#require-approval) job pauses the workflow until a person approves or rejects it in the EAS dashboard.
+2. If approved, [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) rolls the flag out to 100%. If rejected, the job fails and `go_full` is skipped.
+3. The follow-up event records when the flag reached full rollout.
+
+## Turn a feature off with a kill switch
+
+Turn a feature off for everyone with a single command. This workflow has no `on` trigger, so it runs only when you start it, such as during an incident.
+
+```yaml .eas/workflows/kill-switch.yml
+name: Disable new-checkout now
+
+jobs:
+  disable_flag:
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          active: false
+
+  audit_trail:
+    needs: [disable_flag]
+    steps:
+      - uses: eas/posthog_capture_event
+        with:
+          event: kill_switch_pulled
+          properties:
+            flag: new-checkout
+```
+
+### How it works
+
+1. Start it during an incident with:
+
+   <Terminal cmd={['$ eas workflow:run kill-switch.yml']} />
+
+2. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off for everyone, and the follow-up event records when the kill switch was pulled and for which flag.
+
+## Turn a feature off automatically on an error spike
+
+Turn a feature off automatically when the error rate spikes after a deploy. This is the kill switch from the previous recipe wired to an error gate, so it fires without anyone watching a dashboard.
+
+```yaml .eas/workflows/auto-kill-switch.yml
+name: Turn off new-checkout automatically on an error spike
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  error_gate:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 10 MINUTE
+          operator: lt
+          threshold: 20
+          interval_seconds: 60
+          timeout_seconds: 600
+
+  auto_kill_switch:
+    after: [error_gate]
+    if: ${{ failure() }}
+    steps:
+      - uses: eas/posthog_flag_rollout
+        with:
+          flag: new-checkout
+          active: false
+      - uses: eas/posthog_capture_event
+        with:
+          event: auto_kill_switch_pulled
+          properties:
+            flag: new-checkout
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes the update, and [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) waits until the exception count over the last 10 minutes is under 20. If a bad update keeps the count elevated, the gate times out and fails.
+2. The `auto_kill_switch` job uses the same `after` plus `if: ${{ failure() }}` pattern as the rollback in [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate): `after` instead of `needs`, because a failed `needs` dependency skips the job before its `if` condition is evaluated.
+3. [`eas/posthog_flag_rollout`](/eas/workflows/syntax/#easposthog_flag_rollout) turns the flag off, the same action as the manual kill switch, and the follow-up event records that it happened automatically.
+
+## Announce a release once users adopt it
+
+Post a Slack message once enough users are on the new update. The workflow waits for real adoption instead of announcing as soon as the deploy finishes.
+
+```yaml .eas/workflows/announce-on-adoption.yml
+name: Announce release once adopted
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  adoption_gate:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count(DISTINCT distinct_id) FROM events WHERE timestamp > now() - INTERVAL 1 HOUR
+          operator: gte
+          threshold: 50
+          interval_seconds: 120
+          timeout_seconds: 3600
+
+  announce:
+    needs: [adoption_gate]
+    type: slack
+    environment: production
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: The latest update is live and 50 or more users are on it.
+```
+
+### How it works
+
+1. The [`update`](/eas/workflows/pre-packaged-jobs#update) job publishes the update.
+2. [`eas/posthog_wait_for_metric`](/eas/workflows/syntax/#easposthog_wait_for_metric) waits until at least 50 distinct users have sent events in the last hour.
+3. The [`slack`](/eas/workflows/pre-packaged-jobs#slack) job announces the release once the gate clears. Set `SLACK_WEBHOOK_URL` as an [environment variable](/eas/environment-variables/manage/) on EAS.
+
+## More recipes
+
+These recipes cover narrower needs. Each is a complete workflow you can copy as-is.
+
+### Wait for a specific event
+
+Hold the workflow until a specific event arrives, such as a post-deploy smoke test reporting success, instead of gating on an aggregate metric.
+
+```yaml .eas/workflows/wait-for-smoke-test.yml
+name: Wait for smoke test to pass
+
+jobs:
+  wait_for_smoke_test:
+    steps:
+      - uses: eas/posthog_wait_for_query
+        with:
+          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
+          interval_seconds: 15
+          timeout_seconds: 600
+```
+
+[`eas/posthog_wait_for_query`](/eas/workflows/syntax/#easposthog_wait_for_query) clears once the query returns true. The 30-minute window keeps an old smoke-test event from clearing the gate immediately.
+
+### Gate an EAS Update channel rollout
+
+If you roll out with EAS Update channel percentages instead of a feature flag, the same gate pattern from [Roll out or roll back on your error rate](#roll-out-or-roll-back-on-your-error-rate) applies to `eas channel:rollout`.
+
+```yaml .eas/workflows/staged-rollout.yml
+name: Staged rollout gated on errors
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: rollout
+
+  start_at_10:
+    needs: [publish]
+    steps:
+      - run: npx eas-cli@latest channel:rollout production --action create --branch rollout --percent 10 --runtime-version 1.0.0 --non-interactive
+
+  error_gate:
+    needs: [start_at_10]
+    steps:
+      - id: gate
+        uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+          interval_seconds: 60
+          timeout_seconds: 900
+      - uses: eas/posthog_capture_event
+        with:
+          event: rollout_gate_cleared
+          properties:
+            error_count: ${{ steps.gate.outputs.value }}
+
+  widen_to_100:
+    needs: [error_gate]
+    steps:
+      - run: npx eas-cli@latest channel:rollout production --action end --outcome republish-and-revert --non-interactive
+```
+
+The `--runtime-version` value must match the runtime version of the published update. The follow-up event records the count that cleared the gate through the step's `value` output.
+
+### Roll back an EAS Update channel automatically
+
+The channel equivalent of the [automatic kill switch](#turn-a-feature-off-automatically-on-an-error-spike) above: if the error rate stays elevated, roll users back to the embedded update instead of turning off a flag.
+
+```yaml .eas/workflows/auto-rollback.yml
+name: Publish update with auto-rollback
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    type: update
+    params:
+      branch: main
+
+  error_gate:
+    needs: [publish]
+    steps:
+      - uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 10 MINUTE
+          operator: lt
+          threshold: 20
+          interval_seconds: 60
+          timeout_seconds: 600
+
+  rollback:
+    after: [error_gate]
+    if: ${{ failure() }}
+    steps:
+      - run: npx eas-cli@latest update:roll-back-to-embedded --branch main --runtime-version 1.0.0 --message "Auto-rollback after error spike" --non-interactive
+      - uses: eas/posthog_capture_event
+        with:
+          event: auto_rollback_triggered
+          properties:
+            branch: main
+```
+
+As with the automatic kill switch, `after` plus `if: ${{ failure() }}` is required here because a `needs` dependency would skip `rollback` before `if` is ever evaluated. The `--runtime-version` value must match the runtime version of the update to roll back.
+
+### Check your nightly error budget
+
+Run a gate on a schedule instead of after a deploy, as a standalone health check.
+
+```yaml .eas/workflows/error-budget.yml
+name: Nightly error-budget check
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  assert_error_budget:
+    steps:
+      - uses: eas/posthog_wait_for_metric
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 24 HOUR
+          operator: lt
+          threshold: 100
+          interval_seconds: 30
+          timeout_seconds: 60
+```
+
+The [`on.schedule.cron`](/eas/workflows/syntax/#onschedulecron) trigger runs this independently of any deploy, so it works as a standing health check rather than a gate on a specific rollout.
+
+### Mark a store submission
+
+`eas/posthog_capture_event` works the same way for native releases as it does for updates.
+
+```yaml .eas/workflows/store-release.yml
+name: Build, submit to the store, mark it in PostHog
+
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  submit:
+    needs: [build]
+    type: submit
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+      profile: production
+
+  mark_release:
+    needs: [submit]
+    steps:
+      - uses: eas/posthog_capture_event
+        with:
+          event: store_build_submitted
+          properties:
+            platform: ios
+            profile: production
+```
+
+## Important notes
+
+- **Credentials come from the connect command.** Every function defaults to the environment variables that `eas integrations:posthog:connect` sets, and each accepts an `api_key` input when you need to override them. To set them yourself, add these as [EAS environment variables](/eas/environment-variables/manage/): `EXPO_PUBLIC_POSTHOG_API_KEY` for `eas/posthog_capture_event`, and `POSTHOG_CLI_API_KEY` plus `POSTHOG_CLI_PROJECT_ID` for every other function. The [syntax reference](/eas/workflows/syntax/#easposthog_capture_event) lists the scope each function requires.
+- **Gates fail closed.** `eas/posthog_wait_for_metric` and `eas/posthog_wait_for_query` have no `ignore_error` input. When a gate times out, the step fails, which is what lets it stop a rollout.
+- **Gates pass as soon as the condition holds.** A gate checking for a low error count can pass on its first check, including right after a deploy, before users are on the new update. Pair it with an adoption gate, like the one in [Announce a release once users adopt it](#announce-a-release-once-users-adopt-it), when you need errors to have had a chance to surface first.
+- **Scope queries to the current run.** Event and metric queries return historical data. Add a `timestamp > now() - INTERVAL ...` filter, or a property unique to this run, so an old event does not clear a gate immediately. Setting up [release tagging](/guides/using-posthog/#release-tagging) attaches `expo_update_id`, `expo_channel`, and `expo_runtime_version` to every client event, so you can filter a gate on `properties.expo_update_id` to scope it to the exact release.


### PR DESCRIPTION
# Why

Give developers a task-oriented guide for using the PostHog EAS Workflow functions, not just the syntax reference.

# How

Stacked on #47734 (which adds the function syntax reference).

Moves the PostHog examples out of the generic Workflows examples section and into a recipes page under the PostHog guide, rewritten as a guided path (mark a deploy, annotate, upload source maps, flag rollouts, gated rollout with rollback, kill switches, approval-gated GA, adoption announce) grouped by PostHog product. Every recipe is a complete, copy-paste workflow, verified against the eas-cli function contracts and the workflow engine. The parent guide gains an "Overview" sidebar title and a link to the recipes.

Depends on the eas-cli PostHog function PRs shipping first.

# Test Plan

CI passes.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
