### PR TITLE
[ios][camera] Fix ZXing barcode fallback emitting raw AVFoundation ty…

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Replace the deprecated `videoOrientation` API with `AVCaptureDevice.RotationCoordinator` for the iOS camera preview. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix dark frames and the preview rotating into place on iOS launch by fully configuring the camera session before it starts running. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
 - Default the iOS camera `pictureSize` to `photo` instead of `high`. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
+- [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,12 +11,12 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Host the iOS camera preview on the view's backing layer so it no longer zooms into place on launch. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 - Replace the deprecated `videoOrientation` API with `AVCaptureDevice.RotationCoordinator` for the iOS camera preview. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix dark frames and the preview rotating into place on iOS launch by fully configuring the camera session before it starts running. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
 - Default the iOS camera `pictureSize` to `photo` instead of `high`. ([#47173](https://github.com/expo/expo/pull/47173) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Host the iOS camera preview on the view's backing layer so it no longer zooms into place on launch. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))
 - Replace the deprecated `videoOrientation` API with `AVCaptureDevice.RotationCoordinator` for the iOS camera preview. ([#47172](https://github.com/expo/expo/pull/47172) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-camera/ios/Current/ExpoBarcodeScannerProvider.swift
+++ b/packages/expo-camera/ios/Current/ExpoBarcodeScannerProvider.swift
@@ -3,7 +3,9 @@ import AVFoundation
 /// Protocol for barcode scanner providers.
 /// Implement this in a separate module and expose via @objc(ExpoCameraZXingProvider) for runtime discovery.
 ///
-/// Returned dictionaries should have `"type"` and `"data"` keys matching the shape expected by the JS event.
+/// Returned dictionaries should have `"type"` and `"data"` keys. `"type"` must be the short
+/// expo `BarcodeType` string the JS event expects (e.g. `"pdf417"`), matching the native
+/// AVFoundation scan path — not the raw `AVMetadataObject.ObjectType` value (e.g. `"org.iso.PDF417"`).
 @objc public protocol ExpoBarcodeScannerProvider {
   /// The AVMetadataObject.ObjectType raw values this provider handles.
   @objc var supportedTypes: [String] { get }

--- a/packages/expo-camera/ios/barcode-scanning/ExpoCameraZXingProvider.swift
+++ b/packages/expo-camera/ios/barcode-scanning/ExpoCameraZXingProvider.swift
@@ -26,7 +26,7 @@ class ExpoCameraZXingProvider: NSObject, ExpoBarcodeScannerProvider {
 
     for (type, reader) in readers {
       if let result = try? reader.decode(bitmap, hints: nil) {
-        return [["type": type, "data": result.text.filter { $0 != "\0" }]]
+        return [["type": expoType(for: type), "data": result.text.filter { $0 != "\0" }]]
       }
     }
 
@@ -34,11 +34,24 @@ class ExpoCameraZXingProvider: NSObject, ExpoBarcodeScannerProvider {
     if bitmap?.rotateSupported == true, let rotated = bitmap?.rotateCounterClockwise() {
       for (type, reader) in readers {
         if let result = try? reader.decode(rotated, hints: nil) {
-          return [["type": type, "data": result.text.filter { $0 != "\0" }]]
+          return [["type": expoType(for: type), "data": result.text.filter { $0 != "\0" }]]
         }
       }
     }
 
     return []
+  }
+
+  /// Converts a decoded reader's raw `AVMetadataObject.ObjectType` key to the short expo
+  /// `BarcodeType` string the JS event expects (e.g. "org.iso.PDF417" -> "pdf417"), matching
+  /// the native AVFoundation scan path. These are exactly the types registered in `readers`;
+  /// anything else is passed through unchanged.
+  private func expoType(for rawType: String) -> String {
+    if rawType == AVMetadataObject.ObjectType.pdf417.rawValue { return "pdf417" }
+    if rawType == AVMetadataObject.ObjectType.code39.rawValue { return "code39" }
+    if #available(iOS 15.4, *), rawType == AVMetadataObject.ObjectType.codabar.rawValue {
+      return "codabar"
+    }
+    return rawType
   }
 }


### PR DESCRIPTION
On iOS, expo-camera has two barcode scan paths, and they disagreed on the type value for three formats:

- The native AVFoundation path (avMetadataCodeObjectToDictionary) emits the short expo BarcodeType strings — pdf417, code39, codabar.
- The ZXing fallback provider (ExpoCameraZXingProvider) emitted the raw AVMetadataObject.ObjectType values — org.iso.PDF417, org.iso.Code39, org.ansi.Codabar.

Because either path can fire for the same barcode, consumers treating event.type as an expo BarcodeType saw flaky, path-dependent values for these formats.

This is a regression. The normalization was originally added in #44726, but was reverted by #44766, which extracted the ZXing logic into the separate ExpoCameraBarcodeScanning companion pod. That pod imports ExpoCamera as an external module and can no longer see the internal BarcodeType / toBarcodeType(type:) mapping, so it fell back to emitting raw values.

How

- Add a small expoType(for:) helper in ExpoCameraZXingProvider that maps the three raw ObjectType keys to their short expo strings, applied on both return paths (the upright decode and the rotated retry).
- Any type the provider doesn't handle is passed through unchanged.
- Document the ExpoBarcodeScannerProvider protocol contract: type must be the short expo BarcodeType string, matching the native path.

This keeps the fix self-contained in the companion pod, touches no shared/public API, and leaves the native path and BarcodeType untouched.

Test Plan

Native iOS build/tests can't run in my environment (Linux; AVFoundation/ZXingObjC are Apple-only). Reviewer verification on macOS:

- pod install in an app that links ExpoCameraBarcodeScanning, then build expo-camera.
- Scan a PDF417, a Code 39, and a Codabar barcode via the ZXing fallback and confirm event.type is pdf417 / code39 / codabar (not org.iso.PDF417 etc.), matching the native AVFoundation path.

Checklist

- [x] Added a CHANGELOG.md entry.
- [x] Change is limited to iOS native source; no config plugin / prebuild impact.
- [x] Conforms to the documentation style guide.

References: restores #44726, reverted by #44766.