### PR TITLE
[notifications][Android] Drain pending notification responses after delivery

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.kt
@@ -36,13 +36,21 @@ object NotificationManager {
     }
     listeners.add(listener)
     if (pendingNotificationResponses.isNotEmpty()) {
+      var handled = false
       for (pendingResponse in pendingNotificationResponses) {
-        listener.onNotificationResponseReceived(pendingResponse)
+        handled = listener.onNotificationResponseReceived(pendingResponse) || handled
+      }
+      if (handled) {
+        pendingNotificationResponses.clear()
       }
     }
     if (pendingNotificationResponsesFromExtras.isNotEmpty()) {
+      var handled = false
       for (extras in pendingNotificationResponsesFromExtras) {
-        listener.onNotificationResponseIntentReceived(extras)
+        handled = listener.onNotificationResponseIntentReceived(extras) || handled
+      }
+      if (handled) {
+        pendingNotificationResponsesFromExtras.clear()
       }
     }
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
@@ -72,11 +72,12 @@ open class NotificationsEmitter : Module(), NotificationListener {
     return true
   }
 
-  override fun onNotificationResponseIntentReceived(extras: Bundle) {
+  override fun onNotificationResponseIntentReceived(extras: Bundle): Boolean {
     val bundle = NotificationSerializer.toResponseBundleFromExtras(extras)
     DebugLogging.logBundle("NotificationsEmitter.onNotificationResponseIntentReceived", bundle)
     lastNotificationResponseBundle = bundle
     sendEvent(NEW_RESPONSE_EVENT_NAME, lastNotificationResponseBundle)
+    return true
   }
 
   /**

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.kt
@@ -18,8 +18,11 @@ interface NotificationListener {
    */
   fun onNotificationResponseReceived(response: NotificationResponse): Boolean = false
 
-  /** Callback called when notification response is received through package lifecycle listeners. */
-  fun onNotificationResponseIntentReceived(extras: Bundle) {}
+  /**
+   * Callback called when notification response is received through package lifecycle listeners.
+   * @return Whether the notification response has been handled
+   */
+  fun onNotificationResponseIntentReceived(extras: Bundle): Boolean = false
 
   /** Callback called when some notifications are dropped. */
   fun onNotificationsDropped() {}


### PR DESCRIPTION
```
Disclaimer: This PR was generated using Fable while investigating issues,
so be extra careful no trusting everything it affirms as being true. 

I still believe this is a good idea to fix this.
❤️ 
```

# Why

On Android, `NotificationManager` (a process-lifetime singleton `object`) parks notification responses that arrive while no listener is registered — the normal case for a tap that cold-starts the app — in `pendingNotificationResponses` / `pendingNotificationResponsesFromExtras`, and replays them to every newly-registered listener in `addListener()`. **The lists are never drained.**

A new `NotificationsEmitter` module instance registers on every JS context creation, so the same tap response is re-delivered after **every reload** (`expo-updates` `reloadAsync()`, dev menu reload) for the lifetime of the OS process — which can be days:

- `useLastNotificationResponse` / `addNotificationResponseReceivedListener` re-fire hours after the original tap, re-triggering app deep-link navigation and inflating "notification opened" analytics on every OTA update rollout.
- `clearLastNotificationResponse()` cannot prevent it: it nulls the emitter instance's `lastNotificationResponseBundle`, but the singleton re-populates the *next* instance.

iOS already behaves correctly: `NotificationCenterManager.addDelegate` drains `pendingResponses` once a delegate handles them ([NotificationCenterManager.swift#L64-L73](https://github.com/expo/expo/blob/main/packages/expo-notifications/ios/ExpoNotifications/Notifications/NotificationCenterManager.swift#L64-L73)). This PR brings Android to parity.

Observed in a production app: after an `expo-updates` blocking update applied at runtime, the fresh JS context received the same notification response again — seconds after the previous context had already handled and cleared it — causing an unwanted re-navigation to the notification's deep link.

# How

Mirror the iOS semantics in `NotificationManager.addListener`:

- Track whether the newly-registered listener handled the replayed responses (`onNotificationResponseReceived` already returns a handled flag) and `clear()` `pendingNotificationResponses` if so.
- `onNotificationResponseIntentReceived` previously returned `Unit`, so there was no handled signal for the extras list. It now returns `Boolean` (default `false`) like its sibling, and `NotificationsEmitter` returns `true`. The extras list is drained only once a consumer actually processed it — draining unconditionally would be wrong because listener registration order (`NotificationsEmitter` vs `NotificationsHandler`) is not guaranteed, and `NotificationsHandler` does not consume responses.

All `NotificationListener` implementations live inside `expo-notifications` (`NotificationsEmitter`, `NotificationsHandler`, `NotificationManager` itself), so the interface change is self-contained.

# Test Plan

- Android: cold-start the app by tapping a notification → response is delivered once to JS (`useLastNotificationResponse`).
- Trigger a JS reload in the same OS process (dev menu reload, or `Updates.reloadAsync()`): before this change the same response is re-delivered to the new JS context; after this change it is not.
- Warm taps (app alive, listeners registered) are unaffected — they never enter the pending lists.
- iOS behavior unchanged (already drains).

# Checklist

- [x] Documentation is up to date to reflect these changes (no public JS API change; internal Android interface only).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: no addition of native code that would require a config plugin change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
