### PR TITLE
[core][ui][Android] Change modifiers type and provide appContext

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -327,12 +327,12 @@ class RecordTypeConverter<T : Record>(
  * This function handles numeric type normalization since JS numbers come as Double in Kotlin Maps.
  */
 @PublishedApi
-internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: RecordTypeConverter<T>): T {
-  return converter.conversionStrategy.convertFromMap(map, null, forceConversion = false)
+internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: RecordTypeConverter<T>, appContext: AppContext? = null): T {
+  return converter.conversionStrategy.convertFromMap(map, appContext, forceConversion = false)
 }
 
-inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>): T {
+inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>, appContext: AppContext? = null): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   @Suppress("UNCHECKED_CAST")
-  return recordFromMap(map, converter as RecordTypeConverter<T>)
+  return recordFromMap(map, converter as RecordTypeConverter<T>, appContext = appContext)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -283,7 +283,13 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       // It will always return Unit
       Unit::class.java to UnitTypeConverter(),
 
-      ReadableArguments::class.java to ReadableArgumentsTypeConverter()
+      ReadableArguments::class.java to ReadableArgumentsTypeConverter(),
+
+      // expo-ui modifier prop are converted by ModifierRegistry, so this is just a pass-through.
+      // This converter should not be used in other cases.
+      Dynamic::class.java to createTrivialTypeConverter<Dynamic>(
+        ExpectedType(CppType.NONE)
+      ) { it }
     )
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -74,6 +74,7 @@
 - [universal] Revamp web universal components (`Button`, `Checkbox`, `FieldGroup`, `Picker`, `Slider`,`Switch`,`TextInput`) with shared design tokens, light / dark themes, and keyboard focus styles. ([#46258](https://github.com/expo/expo/pull/46258), [#46541](https://github.com/expo/expo/pull/46541) by [@zoontek](https://github.com/zoontek))
 - [iOS][android] Removed the `react-native-reanimated` dependency from the worklet integration; worklet features rely on `react-native-worklets` directly. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 - Removed `CLAUDE.md` and `CONTRIBUTING.md` from publishing and fixed side effects. ([#47451](https://github.com/expo/expo/pull/47451) by [@kudo](https://github.com/kudo))
+- [Android] Change modifiers type and provide appContext. ([#47616](https://github.com/expo/expo/pull/47616) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.14 — 2026-05-26
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
@@ -1,4 +1,8 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@file:OptIn(
+  ExperimentalMaterial3ExpressiveApi::class,
+  ExperimentalMaterial3Api::class,
+  ExperimentalFoundationApi::class
+)
 
 package expo.modules.ui
 
@@ -17,8 +21,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,15 +31,16 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -68,19 +72,20 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.recordFromMap
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.ui.convertibles.AlignmentType
 import expo.modules.ui.convertibles.CompositingStrategyType
 import expo.modules.ui.convertibles.GraphicsLayerParams
 import expo.modules.ui.convertibles.resolveAnimatable
-import expo.modules.kotlin.types.OptimizedRecord
 
-typealias ModifierType = Map<String, Any?>
+typealias ModifierType = Map<String, Dynamic>
 typealias ModifierList = List<ModifierType>
 typealias ModifierEventDispatcher = (String, Map<String, Any?>) -> Unit
 typealias ModifierFactory = @Composable (ModifierType, ComposableScope?, AppContext?, ModifierEventDispatcher) -> Modifier
@@ -167,10 +172,12 @@ private fun parseColorAnimationSpec(raw: Any?): AnimationSpec<androidx.compose.u
       dampingRatio = (raw["dampingRatio"] as? Number)?.toFloat() ?: Spring.DampingRatioNoBouncy,
       stiffness = (raw["stiffness"] as? Number)?.toFloat() ?: Spring.StiffnessMedium
     )
+
     "tween" -> tween(
       durationMillis = (raw["durationMillis"] as? Number)?.toInt() ?: 300,
       delayMillis = (raw["delayMillis"] as? Number)?.toInt() ?: 0
     )
+
     "snap" -> snap(delayMillis = (raw["delayMillis"] as? Number)?.toInt() ?: 0)
     else -> null
   }
@@ -327,7 +334,8 @@ object ModifierRegistry {
       BuiltinShapeType.RECTANGLE -> RectangleShape
       BuiltinShapeType.CIRCLE -> CircleShape
       BuiltinShapeType.ROUNDED_CORNER -> {
-        val hasPerCorner = shape.topStart != null || shape.topEnd != null || shape.bottomStart != null || shape.bottomEnd != null
+        val hasPerCorner =
+          shape.topStart != null || shape.topEnd != null || shape.bottomStart != null || shape.bottomEnd != null
         if (hasPerCorner) {
           RoundedCornerShape(
             topStart = (shape.topStart ?: 0f).dp,
@@ -339,8 +347,10 @@ object ModifierRegistry {
           RoundedCornerShape((shape.radius ?: 0f).dp)
         }
       }
+
       BuiltinShapeType.CUT_CORNER -> {
-        val hasPerCorner = shape.topStart != null || shape.topEnd != null || shape.bottomStart != null || shape.bottomEnd != null
+        val hasPerCorner =
+          shape.topStart != null || shape.topEnd != null || shape.bottomStart != null || shape.bottomEnd != null
         if (hasPerCorner) {
           CutCornerShape(
             topStart = (shape.topStart ?: 0f).dp,
@@ -352,6 +362,7 @@ object ModifierRegistry {
           CutCornerShape((shape.radius ?: 0f).dp)
         }
       }
+
       BuiltinShapeType.MATERIAL -> {
         shape.name?.toRoundedPolygon()?.toShape()
       }
@@ -393,8 +404,9 @@ object ModifierRegistry {
   ): Modifier {
     if (modifiers.isNullOrEmpty()) return Modifier
     return modifiers.fold(Modifier as Modifier) { acc, config ->
-      val type = config["\$type"] as? String ?: return@fold acc
-      val modifier = modifierFactories[type]?.invoke(config, scope, appContext, eventDispatcher) ?: Modifier
+      val type = config["\$type"]?.asString() ?: return@fold acc
+      val modifier = modifierFactories[type]?.invoke(config, scope, appContext, eventDispatcher)
+        ?: Modifier
       acc.then(modifier)
     }
   }
@@ -415,13 +427,13 @@ object ModifierRegistry {
 
   private fun registerBuiltInModifiers() {
     // Padding modifiers
-    register("paddingAll") { map, _, _, _ ->
-      val params = recordFromMap<PaddingAllParams>(map)
+    register("paddingAll") { map, _, appContext, _ ->
+      val params = recordFromMap<PaddingAllParams>(map, appContext)
       Modifier.padding(params.all.dp)
     }
 
-    register("padding") { map, _, _, _ ->
-      val params = recordFromMap<PaddingParams>(map)
+    register("padding") { map, _, appContext, _ ->
+      val params = recordFromMap<PaddingParams>(map, appContext)
       Modifier.padding(
         params.start.dp,
         params.top.dp,
@@ -431,53 +443,53 @@ object ModifierRegistry {
     }
 
     // Size modifiers
-    register("size") { map, _, _, _ ->
-      val params = recordFromMap<SizeParams>(map)
+    register("size") { map, _, appContext, _ ->
+      val params = recordFromMap<SizeParams>(map, appContext)
       Modifier.size(params.width.dp, params.height.dp)
     }
 
-    register("fillMaxSize") { map, _, _, _ ->
-      val params = recordFromMap<FillMaxSizeParams>(map)
+    register("fillMaxSize") { map, _, appContext, _ ->
+      val params = recordFromMap<FillMaxSizeParams>(map, appContext)
       Modifier.fillMaxSize(fraction = params.fraction)
     }
 
-    register("fillMaxWidth") { map, _, _, _ ->
-      val params = recordFromMap<FillMaxWidthParams>(map)
+    register("fillMaxWidth") { map, _, appContext, _ ->
+      val params = recordFromMap<FillMaxWidthParams>(map, appContext)
       Modifier.fillMaxWidth(fraction = params.fraction)
     }
 
-    register("fillMaxHeight") { map, _, _, _ ->
-      val params = recordFromMap<FillMaxHeightParams>(map)
+    register("fillMaxHeight") { map, _, appContext, _ ->
+      val params = recordFromMap<FillMaxHeightParams>(map, appContext)
       Modifier.fillMaxHeight(fraction = params.fraction)
     }
 
-    register("width") { map, _, _, _ ->
-      val params = recordFromMap<WidthParams>(map)
+    register("width") { map, _, appContext, _ ->
+      val params = recordFromMap<WidthParams>(map, appContext)
       Modifier.width(params.width.dp)
     }
 
-    register("height") { map, _, _, _ ->
-      val params = recordFromMap<HeightParams>(map)
+    register("height") { map, _, appContext, _ ->
+      val params = recordFromMap<HeightParams>(map, appContext)
       Modifier.height(params.height.dp)
     }
 
-    register("defaultMinSize") { map, _, _, _ ->
-      val params = recordFromMap<DefaultMinSizeParams>(map)
+    register("defaultMinSize") { map, _, appContext, _ ->
+      val params = recordFromMap<DefaultMinSizeParams>(map, appContext)
       Modifier.defaultMinSize(
         minWidth = params.minWidth?.dp ?: androidx.compose.ui.unit.Dp.Unspecified,
         minHeight = params.minHeight?.dp ?: androidx.compose.ui.unit.Dp.Unspecified
       )
     }
 
-    register("wrapContentWidth") { map, _, _, _ ->
-      val params = recordFromMap<WrapContentWidthParams>(map)
+    register("wrapContentWidth") { map, _, appContext, _ ->
+      val params = recordFromMap<WrapContentWidthParams>(map, appContext)
       params.alignment?.toHorizontalAlignment()?.let { alignment ->
         Modifier.wrapContentWidth(align = alignment)
       } ?: Modifier.wrapContentWidth()
     }
 
-    register("wrapContentHeight") { map, _, _, _ ->
-      val params = recordFromMap<WrapContentHeightParams>(map)
+    register("wrapContentHeight") { map, _, appContext, _ ->
+      val params = recordFromMap<WrapContentHeightParams>(map, appContext)
       params.alignment?.toVerticalAlignment()?.let { alignment ->
         Modifier.wrapContentHeight(align = alignment)
       } ?: Modifier.wrapContentHeight()
@@ -489,14 +501,14 @@ object ModifierRegistry {
     }
 
     // Position modifiers
-    register("offset") { map, _, _, _ ->
-      val params = recordFromMap<OffsetParams>(map)
+    register("offset") { map, _, appContext, _ ->
+      val params = recordFromMap<OffsetParams>(map, appContext)
       Modifier.offset(params.x.dp, params.y.dp)
     }
 
     // Appearance modifiers
-    register("background") { map, _, _, _ ->
-      val params = recordFromMap<BackgroundParams>(map)
+    register("background") { map, _, appContext, _ ->
+      val params = recordFromMap<BackgroundParams>(map, appContext)
       val color = params.color?.compose ?: return@register Modifier
       val spec = parseColorAnimationSpec(map["animationSpec"])
       if (spec != null) {
@@ -507,20 +519,20 @@ object ModifierRegistry {
       }
     }
 
-    register("border") { map, _, _, _ ->
-      val params = recordFromMap<BorderParams>(map)
+    register("border") { map, _, appContext, _ ->
+      val params = recordFromMap<BorderParams>(map, appContext)
       params.borderColor?.let { borderColor ->
         Modifier.border(BorderStroke(params.borderWidth.dp, borderColor.compose))
       } ?: Modifier
     }
 
-    register("shadow") { map, _, _, _ ->
-      val params = recordFromMap<ShadowParams>(map)
+    register("shadow") { map, _, appContext, _ ->
+      val params = recordFromMap<ShadowParams>(map, appContext)
       Modifier.shadow(params.elevation.dp)
     }
 
-    register("dropShadow") { map, _, _, _ ->
-      val params = recordFromMap<ShadowGeometryParams>(map)
+    register("dropShadow") { map, _, appContext, _ ->
+      val params = recordFromMap<ShadowGeometryParams>(map, appContext)
       val shape = params.shape?.let { resolveShape(it) } ?: RectangleShape
       Modifier.dropShadow(
         shape,
@@ -534,8 +546,8 @@ object ModifierRegistry {
       )
     }
 
-    register("innerShadow") { map, _, _, _ ->
-      val params = recordFromMap<ShadowGeometryParams>(map)
+    register("innerShadow") { map, _, appContext, _ ->
+      val params = recordFromMap<ShadowGeometryParams>(map, appContext)
       val shape = params.shape?.let { resolveShape(it) } ?: RectangleShape
       Modifier.innerShadow(
         shape,
@@ -549,23 +561,23 @@ object ModifierRegistry {
       )
     }
 
-    register("alpha") { map, _, _, _ ->
-      val params = recordFromMap<AlphaParams>(map)
+    register("alpha") { map, _, appContext, _ ->
+      val params = recordFromMap<AlphaParams>(map, appContext)
       Modifier.alpha(params.alpha)
     }
 
-    register("blur") { map, _, _, _ ->
-      val params = recordFromMap<BlurParams>(map)
+    register("blur") { map, _, appContext, _ ->
+      val params = recordFromMap<BlurParams>(map, appContext)
       Modifier.blur(params.radius.dp)
     }
 
     // Transform modifiers
-    register("rotate") { map, _, _, _ ->
-      val params = recordFromMap<RotateParams>(map)
+    register("rotate") { map, _, appContext, _ ->
+      val params = recordFromMap<RotateParams>(map, appContext)
       Modifier.rotate(params.degrees)
     }
 
-    register("graphicsLayer") { map, _, _, _ ->
+    register("graphicsLayer") { map, _, appContext, _ ->
       val rotationX = resolveAnimatable(map, "rotationX", 0f)
       val rotationY = resolveAnimatable(map, "rotationY", 0f)
       val rotationZ = resolveAnimatable(map, "rotationZ", 0f)
@@ -577,7 +589,7 @@ object ModifierRegistry {
       val shadowElevation = resolveAnimatable(map, "shadowElevation", 0f)
 
       // Non-animatable params parsed via Record
-      val params = recordFromMap<GraphicsLayerParams>(map)
+      val params = recordFromMap<GraphicsLayerParams>(map, appContext)
       val composeShape = params.shape?.let { resolveShape(it) } ?: RectangleShape
       val compositingStrategy = when (params.compositingStrategy) {
         CompositingStrategyType.OFFSCREEN -> CompositingStrategy.Offscreen
@@ -607,22 +619,22 @@ object ModifierRegistry {
       }
     }
 
-    register("zIndex") { map, _, _, _ ->
-      val params = recordFromMap<ZIndexParams>(map)
+    register("zIndex") { map, _, appContext, _ ->
+      val params = recordFromMap<ZIndexParams>(map, appContext)
       Modifier.zIndex(params.index)
     }
 
     // Animation modifiers
-    register("animateContentSize") { map, _, _, _ ->
-      val params = recordFromMap<AnimateContentSizeParams>(map)
+    register("animateContentSize") { map, _, appContext, _ ->
+      val params = recordFromMap<AnimateContentSizeParams>(map, appContext)
       Modifier.animateContentSize(
         spring(dampingRatio = params.dampingRatio, stiffness = params.stiffness)
       )
     }
 
     // Scope-dependent modifiers
-    register("weight") { map, scope, _, _ ->
-      val params = recordFromMap<WeightParams>(map)
+    register("weight") { map, scope, appContext, _ ->
+      val params = recordFromMap<WeightParams>(map, appContext)
       scope?.rowScope?.run {
         Modifier.weight(params.weight)
       } ?: scope?.columnScope?.run {
@@ -630,8 +642,8 @@ object ModifierRegistry {
       } ?: Modifier
     }
 
-    register("align") { map, scope, _, _ ->
-      val params = recordFromMap<AlignParams>(map)
+    register("align") { map, scope, appContext, _ ->
+      val params = recordFromMap<AlignParams>(map, appContext)
       scope?.boxScope?.run {
         params.alignment?.toAlignment()?.let { alignment -> Modifier.align(alignment) }
       } ?: scope?.rowScope?.run {
@@ -648,29 +660,29 @@ object ModifierRegistry {
     }
 
     // Utility modifiers
-    register("testID") { map, _, _, _ ->
-      val params = recordFromMap<TestIDParams>(map)
+    register("testID") { map, _, appContext, _ ->
+      val params = recordFromMap<TestIDParams>(map, appContext)
       params.testID?.let { testID ->
         Modifier.applyTestTag(testID)
       } ?: Modifier
     }
 
-    register("semantics") { map, _, _, _ ->
-      val params = recordFromMap<SemanticsParams>(map)
+    register("semantics") { map, _, appContext, _ ->
+      val params = recordFromMap<SemanticsParams>(map, appContext)
       params.contentType.toContentType()?.let { ct ->
         Modifier.semantics { contentType = ct }
       } ?: Modifier
     }
 
-    register("clip") { map, _, _, _ ->
-      val params = recordFromMap<ClipParams>(map)
+    register("clip") { map, _, appContext, _ ->
+      val params = recordFromMap<ClipParams>(map, appContext)
       params.shape?.let { shape ->
         resolveShape(shape)?.let { Modifier.clip(it) }
       } ?: Modifier
     }
 
-    register("onVisibilityChanged") { map, _, _, eventDispatcher ->
-      val params = recordFromMap<OnVisibilityChangedParams>(map)
+    register("onVisibilityChanged") { map, _, appContext, eventDispatcher ->
+      val params = recordFromMap<OnVisibilityChangedParams>(map, appContext)
       Modifier.onVisibilityChanged(
         minDurationMs = params.minDurationMs,
         minFractionVisible = params.minFractionVisible
@@ -712,8 +724,8 @@ object ModifierRegistry {
       }
     }
 
-    register("clickable") { map, _, _, eventDispatcher ->
-      val params = recordFromMap<ClickableParams>(map)
+    register("clickable") { map, _, appContext, eventDispatcher ->
+      val params = recordFromMap<ClickableParams>(map, appContext)
       if (params.indication) {
         Modifier.clickable {
           eventDispatcher("clickable", emptyMap())
@@ -728,8 +740,8 @@ object ModifierRegistry {
       }
     }
 
-    register("combinedClickable") { map, _, _, eventDispatcher ->
-      val params = recordFromMap<ClickableParams>(map)
+    register("combinedClickable") { map, _, appContext, eventDispatcher ->
+      val params = recordFromMap<ClickableParams>(map, appContext)
       val onClick = { eventDispatcher("combinedClickable", mapOf("event" to "click")) }
       val onLongClick = { eventDispatcher("combinedClickable", mapOf("event" to "longClick")) }
       if (params.indication) {
@@ -744,8 +756,8 @@ object ModifierRegistry {
       }
     }
 
-    register("selectable") { map, _, _, eventDispatcher ->
-      val params = recordFromMap<SelectableParams>(map)
+    register("selectable") { map, _, appContext, eventDispatcher ->
+      val params = recordFromMap<SelectableParams>(map, appContext)
       Modifier.selectable(
         selected = params.selected,
         role = when (params.role) {
@@ -763,8 +775,8 @@ object ModifierRegistry {
       Modifier.selectableGroup()
     }
 
-    register("toggleable") { map, _, _, eventDispatcher ->
-      val params = recordFromMap<ToggleableParams>(map)
+    register("toggleable") { map, _, appContext, eventDispatcher ->
+      val params = recordFromMap<ToggleableParams>(map, appContext)
       val role = when (params.role) {
         SemanticRoleType.CHECKBOX -> Role.Checkbox
         SemanticRoleType.RADIO_BUTTON -> Role.RadioButton
@@ -780,10 +792,10 @@ object ModifierRegistry {
     }
 
     // ExposedDropdownMenuBox scope-dependent modifier
-    register("menuAnchor") { map, scope, _, _ ->
+    register("menuAnchor") { map, scope, appContext, _ ->
       val dropdownScope = scope?.exposedDropdownMenuBoxScope
         ?: error("menuAnchor modifier can only be used inside ExposedDropdownMenuBox")
-      val params = recordFromMap<MenuAnchorParams>(map)
+      val params = recordFromMap<MenuAnchorParams>(map, appContext)
       with(dropdownScope) {
         Modifier.menuAnchor(
           type = when (params.type) {


### PR DESCRIPTION
# Why

Modifiers should be converted from dynamic instead of `Any`.

# How

* Added dynamic type converter
* Changed ModifierType from `Map<String, Any?>` to `Map<String, Dynamic>`
* Provided `recordFromMap` with `appContext`

# Test Plan

* CI should be green
* Tested manually in bare-expo
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e5c80672-bf60-4e78-aa36-f685218d64e6" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).