### PR TITLE
[ios][updates] Set always_out_of_date on Generate updates resources phase

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Set `always_out_of_date` on the `Generate updates resources for expo-updates` script_phase to silence the Xcode "run script phase will run on every build" dependency-analysis warning. ([#47622](https://github.com/expo/expo/pull/47622) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -124,11 +124,17 @@ Pod::Spec.new do |s|
   if $expo_updates_create_updates_resources != false
     project_root_env_var = ENV['PROJECT_ROOT'] ? "export PROJECT_ROOT=#{ENV['PROJECT_ROOT']}\n" : ""
     force_bundling_flag = ex_updates_native_debug ? "export FORCE_BUNDLING=1\n" : ""
-    s.script_phase = {
+    script_phase = {
       :name => 'Generate updates resources for expo-updates',
       :script => project_root_env_var + force_bundling_flag + 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-updates-resources-ios.sh"',
       :execution_position => :before_compile
     }
+    # :always_out_of_date is only available in CocoaPods 1.13.0 and later
+    if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')
+      # always run the script without warning
+      script_phase[:always_out_of_date] = "1"
+    end
+    s.script_phase = script_phase
 
     # Generate EXUpdates.bundle without existing resources
     # `create-updates-resources-ios.sh` will generate updates resources in EXUpdates.bundle


### PR DESCRIPTION
Sets `:always_out_of_date` on the `Generate updates resources for expo-updates` script phase in `EXUpdates.podspec`, so Xcode stops warning about it on every build of every app using `expo-updates`.

Same as `EXConstants.podspec` (#35181), `ExpoWidgets.podspec` (#43170), and `ExpoLogBox.podspec` (#39958).

# Test Plan

- `et check-packages expo-updates` all green (build, typecheck, lint, format, test). `apps/bare-expo` builds and runs on the iPhone 17 Pro sim.