### PR TITLE
[babel-preset-expo][widgets] Escape backslashes when serializing widget layouts

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Inline `EXPO_PUBLIC_USE_RN_FETCH` inside `node_modules` so the `expo/fetch` opt-out works in production builds. ([#46986](https://github.com/expo/expo/pull/46986) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - Bump `babel-plugin-syntax-hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
+- Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/src/plugins/widgets-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/widgets-plugin.ts
@@ -110,5 +110,11 @@ function buildTemplateLiteral(t: typeof import('@babel/core').types, code: strin
 }
 
 function escapeTemplateLiteral(value: string) {
-  return value.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+  // Escape backslashes first so escape sequences in the serialized widget
+  // source (e.g. `\n` in a string literal) survive being re-cooked when the app
+  // evaluates this template literal at runtime. Without this, a `\n` inside a
+  // string literal cooks into a real newline, which corrupts the stored layout
+  // and makes the widget runtime's `eval('(' + layout + ')')` throw a
+  // SyntaxError (surfaced on-device as "SyntaxError: Unexpected EOF").
+  return value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 }


### PR DESCRIPTION
# Why

The `expo-widgets` babel plugin serializes each `'widget'` function into a template literal. At runtime the app evaluates that template literal to get the layout **string**, stores it in the app group, and the widget extension renders it via a JS-runtime `eval('(' + layout + ')')`.

`escapeTemplateLiteral` escapes `` ` `` and `${` but **not backslashes**. So any escape sequence inside a *string literal* in the widget source (e.g. `'a\nb'`) gets re-cooked when the outer template literal is evaluated: the `\n` becomes a real newline, turning the serialized function into invalid source. On device this surfaces as a red error box reading **`SyntaxError: Unexpected EOF`**, and the widget never renders.

This affects any widget or Live Activity whose layout contains a string literal with an escape sequence — multi-line text, tabs, `\uXXXX`, `\\`, etc. It's been present since the plugin was introduced in #42941.

# How

Escape backslashes first in `escapeTemplateLiteral`, so escape sequences survive the round-trip through the template literal:

```ts
value
  .replace(/\\/g, '\\\\') // must run first
  .replace(/`/g, '\\`')
  .replace(/\$\{/g, '\\${')
```

# Test Plan

Minimal repro (fails on `main`, passes with this change):

```js
const babel = require('@babel/core')
const { widgetsPlugin } = require('babel-preset-expo/build/plugins/widgets-plugin')

const src = `export function MyWidget(props, environment) {
  'widget'
  const text = 'line one\\nline two'
  return null
}`

const { code } = babel.transformSync(src, {
  filename: 'MyWidget.tsx', babelrc: false, configFile: false,
  presets: ['@babel/preset-typescript'], plugins: [widgetsPlugin],
})

// Extract the emitted template literal and cook it exactly as the runtime does:
const raw = code.slice(code.indexOf('`') + 1, code.lastIndexOf('`'))
const layout = eval('`' + raw + '`')
new Function('return (' + layout + ')') // main: throws SyntaxError; fixed: OK
```

- **Before:** `layout` contains a raw newline inside `'line one<newline>line two'` → `SyntaxError` (JavaScriptCore: `Unexpected EOF`).
- **After:** `layout` contains `'line one\nline two'` with the escape preserved → parses fine, widget renders.
