### PR TITLE
[ios][expo] Deliver cold-start deep links under the scene life cycle

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in extensions. ([#46799](https://github.com/expo/expo/pull/46799) by [@jakex7](https://github.com/jakex7))
 - Fix `asyncRoutes` failing on Android and iOS with `Requiring unknown module` ([#46870](https://github.com/expo/expo/pull/46870) by [@hassankhan](https://github.com/hassankhan))
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
+- [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
@@ -44,12 +44,20 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
     // `UIApplication.shared.delegate?.window` keeps working (e.g. expo-system-ui).
     provider.window = window
 
-    // launchOptions is nil under the scene life cycle; cold-start URLs/activities arrive via
-    // `connectionOptions` and are routed below.
+    // Under the scene life cycle UIKit passes cold-start URLs and activities in `connectionOptions`
+    // rather than in the app delegate's launch options. React Native's `Linking.getInitialURL()`
+    // only reads them from launch options, so rebuild them here; otherwise a link that cold-starts
+    // the app is delivered to no one, because the `url` event routed below fires before JS is ready.
+    let browsingWebActivity = connectionOptions.userActivities.first {
+      $0.activityType == NSUserActivityTypeBrowsingWeb
+    }
     factory.startReactNative(
       withModuleName: provider.reactNativeFactoryModuleName,
       in: window,
-      launchOptions: nil
+      launchOptions: Self.launchOptions(
+        url: connectionOptions.urlContexts.first?.url,
+        userActivity: browsingWebActivity
+      )
     )
 
     // Deep links / universal links.
@@ -87,6 +95,38 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
   open func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
     Self.route(userActivity: userActivity)
   }
+}
+
+// MARK: - Launch options & routing helpers
+
+extension ExpoAppSceneDelegate {
+  /// Rebuilds the launch options that `Linking.getInitialURL()` reads from a scene's connection
+  /// options. Returns `nil` when the app wasn't cold-started by a URL or a browsing-web activity,
+  /// so it can be forwarded to `startReactNative` as-is.
+  static func launchOptions(
+    url: URL?,
+    userActivity: NSUserActivity?
+  ) -> [UIApplication.LaunchOptionsKey: Any]? {
+    // Build the keys from their underlying constant strings rather than the `UIApplication`
+    // accessors (`.url`, `.userActivityDictionary`): those accessors are deprecated as of iOS 26
+    // in favor of the scene APIs, but React Native's `getInitialURL` still reads the launch options
+    // by these exact keys, so this is the shape it expects.
+    var launchOptions: [UIApplication.LaunchOptionsKey: Any] = [:]
+    if let url {
+      let urlKey = UIApplication.LaunchOptionsKey(rawValue: "UIApplicationLaunchOptionsURLKey")
+      launchOptions[urlKey] = url
+    }
+    if let userActivity {
+      let userActivityDictionaryKey = UIApplication.LaunchOptionsKey(
+        rawValue: "UIApplicationLaunchOptionsUserActivityDictionaryKey"
+      )
+      launchOptions[userActivityDictionaryKey] = [
+        "UIApplicationLaunchOptionsUserActivityTypeKey": userActivity.activityType,
+        "UIApplicationLaunchOptionsUserActivityKey": userActivity,
+      ]
+    }
+    return launchOptions.isEmpty ? nil : launchOptions
+  }
 
   /// Pass incoming URL contexts to both the subscriber manager and `RCTLinkingManager`.
   public static func route(urlContexts: Set<UIOpenURLContext>) {
@@ -95,20 +135,6 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
       _ = ExpoAppDelegateSubscriberManager.application(UIApplication.shared, open: context.url, options: options)
       RCTLinkingManager.application(UIApplication.shared, open: context.url, options: options)
     }
-  }
-
-  private static func openURLOptions(
-    from sceneOptions: UIScene.OpenURLOptions
-  ) -> [UIApplication.OpenURLOptionsKey: Any] {
-    var options: [UIApplication.OpenURLOptionsKey: Any] = [:]
-    if let sourceApplication = sceneOptions.sourceApplication {
-      options[.sourceApplication] = sourceApplication
-    }
-    if let annotation = sceneOptions.annotation {
-      options[.annotation] = annotation
-    }
-    options[.openInPlace] = sceneOptions.openInPlace
-    return options
   }
 
   /// Passes an incoming `NSUserActivity` to both the subscriber manager and `RCTLinkingManager`.
@@ -123,6 +149,20 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
       continue: userActivity,
       restorationHandler: { _ in }
     )
+  }
+
+  private static func openURLOptions(
+    from sceneOptions: UIScene.OpenURLOptions
+  ) -> [UIApplication.OpenURLOptionsKey: Any] {
+    var options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    if let sourceApplication = sceneOptions.sourceApplication {
+      options[.sourceApplication] = sourceApplication
+    }
+    if let annotation = sceneOptions.annotation {
+      options[.annotation] = annotation
+    }
+    options[.openInPlace] = sceneOptions.openInPlace
+    return options
   }
 }
 

--- a/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
+++ b/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
@@ -21,6 +21,39 @@ struct ExpoAppSceneDelegateTests {
     // Conforming to `UIWindowSceneDelegate` is what makes the class usable as the scene delegate.
     #expect(ExpoAppSceneDelegate.self is UIWindowSceneDelegate.Type)
   }
+
+  @Test
+  @MainActor
+  func `builds launch options carrying a cold-start URL`() {
+    // Under the scene life cycle the URL that cold-started the app arrives in the scene connection
+    // options, not in the app delegate's launch options. Synthesizing launch options from it is
+    // what lets `Linking.getInitialURL()` (which reads `UIApplicationLaunchOptionsURLKey`) return
+    // the URL, matching the app-delegate life cycle it replaced.
+    let url = URL(string: "bareexpo://test-suite/run?tests=AppMetrics")!
+    let launchOptions = ExpoAppSceneDelegate.launchOptions(url: url, userActivity: nil)
+    let urlKey = UIApplication.LaunchOptionsKey(rawValue: "UIApplicationLaunchOptionsURLKey")
+    #expect(launchOptions?[urlKey] as? URL == url)
+  }
+
+  @Test
+  @MainActor
+  func `builds launch options carrying a browsing-web user activity`() {
+    let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+    userActivity.webpageURL = URL(string: "https://expo.dev/link")!
+    let launchOptions = ExpoAppSceneDelegate.launchOptions(url: nil, userActivity: userActivity)
+    let userActivityDictionaryKey = UIApplication.LaunchOptionsKey(
+      rawValue: "UIApplicationLaunchOptionsUserActivityDictionaryKey"
+    )
+    let activityDictionary = launchOptions?[userActivityDictionaryKey] as? [AnyHashable: Any]
+    #expect(activityDictionary?["UIApplicationLaunchOptionsUserActivityTypeKey"] as? String == NSUserActivityTypeBrowsingWeb)
+    #expect((activityDictionary?["UIApplicationLaunchOptionsUserActivityKey"] as? NSUserActivity) === userActivity)
+  }
+
+  @Test
+  @MainActor
+  func `returns nil launch options without a URL or user activity`() {
+    #expect(ExpoAppSceneDelegate.launchOptions(url: nil, userActivity: nil) == nil)
+  }
 }
 
 #endif


### PR DESCRIPTION
## Why

Since the app adopted the UIKit scene life cycle in #46733, a deep link (or universal link) that **cold-starts** the app on iOS is dropped: nothing navigates.

`Linking.getInitialURL()` returns `null`, and the `url` event never reaches JS either. This affects every app built with the scene life cycle, not just a test harness. I found it while removing the deep-link confirmation prompt from the bare-expo e2e flows (#47614): once the prompt stopped acting as an accidental warm-up, the first deep link in the flow started failing 100% of the time, and the failure reproduces deterministically with a single `simctl openurl` against a terminated app (the app launches to its default screen and stays there).

## How

`ExpoAppSceneDelegate.scene(_:willConnectTo:options:)` started React Native with `launchOptions: nil`. Two problems flow from that:

- React Native's `RCTLinkingManager.getInitialURL` reads the initial URL only from `bridge.launchOptions[UIApplicationLaunchOptionsURLKey]`. With `nil` launch options that key is never present, so `getInitialURL()` always resolves `null`.
- The URL is separately routed to `RCTLinkingManager.application(_:open:options:)`, which posts the `url` event. At cold start that fires milliseconds into launch, before the JS bundle has registered a listener, so it's lost.

Under the scene life cycle UIKit hands the cold-start URL and user activities to the delegate in `connectionOptions`, not in the app delegate's launch options. The fix rebuilds the launch options from `connectionOptions` (the URL and any browsing-web `NSUserActivity`) and passes them to `startReactNative`, so `getInitialURL()` behaves exactly as it did under the app-delegate life cycle this replaced. Warm-path `url` routing is unchanged.

The keys are built from their underlying constant strings rather than the `UIApplication.LaunchOptionsKey` accessors, because those accessors are deprecated as of iOS 26 in favor of the scene APIs, while React Native still reads the legacy keys.

## Test Plan

- New `ExpoAppSceneDelegateTests` cases cover the launch-options reconstruction (URL, browsing-web activity, and the empty case). `et native-unit-tests -p ios --packages expo` passes.
- Manual: with a bare-expo build that includes this change, a cold-start deep link (`xcrun simctl openurl <udid> "bareexpo://test-suite/run?tests=AppMetrics"` against a terminated app) navigates straight to the test runner instead of stalling on the selection screen. Before the fix the same command leaves the app idle on its default screen.
