### PR TITLE
[core][Android] Support `PlatformColor` as Color

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Added `SharedObject.native(from:)` that recovers the native shared object paired with a JavaScript object, with a generic overload that returns the concrete subclass directly. ([#47054](https://github.com/expo/expo/pull/47054) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `@SharedObject` now binds `@JS` methods, properties and the `@JS init` directly onto the class prototype, so they no longer need `Function(…)` / `Property(…)` / `Constructor { … }` definition entries. ([#47107](https://github.com/expo/expo/pull/47107) by [@tsapeta](https://github.com/tsapeta))
 - Added `ArrayBuffer` as the preferred safe native module argument and return type, and deprecated `NativeArrayBuffer` in favor of it. ([#47106](https://github.com/expo/expo/pull/47106) by [@barthap](https://github.com/barthap))
+- [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -3,17 +3,20 @@ package expo.modules.kotlin.types
 import android.graphics.Color
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.core.graphics.toColorInt
+import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.DynamicCastException
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
-import androidx.core.graphics.toColorInt
-import com.facebook.react.bridge.ReadableArray
 
 /**
  * Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
@@ -360,11 +363,25 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
-      ReadableType.String -> colorFromString(value.asString() ?: throw DynamicCastException(String::class))
+      ReadableType.String -> colorFromString(
+        value.asString() ?: throw DynamicCastException(String::class)
+      )
+
       ReadableType.Array -> {
-        val colorsArray = (value.asArray() ?: throw DynamicCastException(ReadableArray::class)).toArrayList().map { it as Double }.toDoubleArray()
+        val rawArray = value.asArray()
+          ?: throw DynamicCastException(ReadableArray::class)
+        val colorsArray = rawArray
+          .toArrayList()
+          .map { it as Double }
+          .toDoubleArray()
         colorFromDoubleArray(colorsArray)
       }
+
+      ReadableType.Map -> {
+        val colorMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
+        colorFromReadableMap(colorMap, context)
+      }
+
       else -> throw UnexpectedException("Unknown argument type: ${value.type}")
     }
   }
@@ -374,12 +391,19 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
       is Int -> {
         colorFromInt(value)
       }
+
       is String -> {
         colorFromString(value)
       }
+
       is DoubleArray -> {
         colorFromDoubleArray(value)
       }
+
+      is ReadableMap -> {
+        colorFromReadableMap(value, context)
+      }
+
       else -> throw UnexpectedException("Unknown argument type: ${value::class}")
     }
   }
@@ -419,6 +443,12 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
     return Color.valueOf(normalizedValue.toColorInt())
   }
 
+  private fun colorFromReadableMap(value: ReadableMap, context: AppContext?): Color {
+    val reactContext = context?.reactContext ?: throw Exceptions.ReactContextLost()
+    return ColorPropConverter.getColorInstance(value, reactContext)
+      ?: throw UnexpectedException("ColorPropConverter returned null for a non-null color value.")
+  }
+
   override fun getCppRequiredTypes(): ExpectedType =
     ExpectedType(
       SingleType(CppType.INT),
@@ -426,6 +456,9 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
       SingleType(
         CppType.PRIMITIVE_ARRAY,
         arrayOf(ExpectedType(CppType.DOUBLE))
+      ),
+      SingleType(
+        CppType.READABLE_MAP
       )
     )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.ReadableArguments
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.ArrayBuffer
@@ -65,19 +66,19 @@ inline fun <reified T : Any> obtainTypeConverter(): TypeConverter<T> {
   return TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>()) as TypeConverter<T>
 }
 
-inline fun <reified T> convert(value: Dynamic): T {
+inline fun <reified T> convert(value: Dynamic, context: AppContext? = null): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
-  return converter.convert(value) as T
+  return converter.convert(value, context) as T
 }
 
-inline fun <reified T> convert(value: Any?): T {
+inline fun <reified T> convert(value: Any?, context: AppContext? = null): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
-  return converter.convert(value) as T
+  return converter.convert(value, context) as T
 }
 
-fun convert(value: Dynamic, type: KType): Any? {
+fun convert(value: Dynamic, type: KType, context: AppContext? = null): Any? {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(type.toTypeDescriptor())
-  return converter.convert(value)
+  return converter.convert(value, context)
 }
 
 object TypeConverterProviderImpl : TypeConverterProvider {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import android.app.Application
 import android.graphics.Color
+import android.util.TypedValue
 import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
@@ -90,15 +91,25 @@ internal class ColorTypeConverterTest {
   }
 
   @Test
-  fun `converts from Android PlatformColor`() {
-    val platformColor = DynamicFromObject(
-      JavaOnlyMap().apply {
-        putArray("resource_paths", JavaOnlyArray().apply { pushString("@android:color/white") })
-      })
+  fun `converts from Android PlatformColor color`() {
+    val platformColor = DynamicFromObject(platformColor("@android:color/white"))
 
     val color = convert<Color>(platformColor, appContext)
 
     Truth.assertThat(color.toArgb()).isEqualTo(Color.WHITE)
+  }
+
+  @Test
+  fun `converts from Android PlatformColor attr`() {
+    val platformColor = DynamicFromObject(platformColor("?android:attr/textColorPrimary"))
+
+    val color = convert<Color>(platformColor, appContext)
+    val expectedColor = TypedValue().let {
+      appContext.reactContext?.theme?.resolveAttribute(android.R.attr.textColorPrimary, it, true)
+      it.data
+    }
+
+    Truth.assertThat(color.toArgb()).isEqualTo(expectedColor)
   }
 
   @Test
@@ -274,15 +285,28 @@ internal class ColorTypeConverterTest {
 
   @Test
   fun `should throw when color components array has fewer than 3 values`() {
-    val shortArrays = listOf(JavaOnlyArray(), JavaOnlyArray().apply { pushDouble(1.0) }, JavaOnlyArray().apply {
-      pushDouble(1.0)
-      pushDouble(0.5)
-    })
+    val shortArrays = listOf(
+      JavaOnlyArray(),
+      JavaOnlyArray().apply { pushDouble(1.0) },
+      JavaOnlyArray().apply {
+        pushDouble(1.0)
+        pushDouble(0.5)
+      }
+    )
 
     for (array in shortArrays) {
       assertThrows<InvalidColorComponentsException> {
         convert<Color>(DynamicFromObject(array))
       }
     }
+  }
+
+  private fun platformColor(vararg resourcePaths: String) = JavaOnlyMap().apply {
+    putArray(
+      "resource_paths",
+      JavaOnlyArray().apply {
+        resourcePaths.forEach(::pushString)
+      }
+    )
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -1,10 +1,16 @@
 package expo.modules.kotlin.types
 
+import android.app.Application
 import android.graphics.Color
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
 import expo.modules.assertThrows
+import expo.modules.kotlin.AppContext
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -13,6 +19,10 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [30])
 internal class ColorTypeConverterTest {
+  private val appContext = mockk<AppContext> {
+    every { reactContext } returns ApplicationProvider.getApplicationContext<Application>()
+  }
+
   @Test
   fun `converts from CSS named color`() {
     val colorString = DynamicFromObject("papayawhip")
@@ -77,6 +87,18 @@ internal class ColorTypeConverterTest {
     Truth.assertThat(color.red()).isEqualTo(expectedColor[0])
     Truth.assertThat(color.green()).isEqualTo(expectedColor[1])
     Truth.assertThat(color.blue()).isEqualTo(expectedColor[2])
+  }
+
+  @Test
+  fun `converts from Android PlatformColor`() {
+    val platformColor = DynamicFromObject(
+      JavaOnlyMap().apply {
+        putArray("resource_paths", JavaOnlyArray().apply { pushString("@android:color/white") })
+      })
+
+    val color = convert<Color>(platformColor, appContext)
+
+    Truth.assertThat(color.toArgb()).isEqualTo(Color.WHITE)
   }
 
   @Test
@@ -252,14 +274,10 @@ internal class ColorTypeConverterTest {
 
   @Test
   fun `should throw when color components array has fewer than 3 values`() {
-    val shortArrays = listOf(
-      JavaOnlyArray(),
-      JavaOnlyArray().apply { pushDouble(1.0) },
-      JavaOnlyArray().apply {
-        pushDouble(1.0)
-        pushDouble(0.5)
-      }
-    )
+    val shortArrays = listOf(JavaOnlyArray(), JavaOnlyArray().apply { pushDouble(1.0) }, JavaOnlyArray().apply {
+      pushDouble(1.0)
+      pushDouble(0.5)
+    })
 
     for (array in shortArrays) {
       assertThrows<InvalidColorComponentsException> {


### PR DESCRIPTION
# Why

To support converting `PlatformColor`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Call `ColorPropConverter` from `react-native`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- CI should be green
- Tested in Bare Expo
```ts
PlatformColor('@android:color/system_accent1_600')
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)