### PR TITLE
[expo][dom] Don't throw when host globals are injected late on Android

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [dom] Wait for the injected host globals instead of throwing, so DOM Components no longer stay permanently blank on Android when `injectedJavaScriptBeforeContentLoaded` is evaluated after the document scripts. ([#47634](https://github.com/expo/expo/pull/47634) by [@yjb94](https://github.com/yjb94))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/src/dom/dom-entry.tsx
+++ b/packages/expo/src/dom/dom-entry.tsx
@@ -56,13 +56,51 @@ function convertError(error: any) {
   return new Error(String(error));
 }
 
+/**
+ * On Android, `RNCWebViewClient.onPageStarted` evaluates
+ * `injectedJavaScriptBeforeContentLoaded` through `WebView.evaluateJavascript`, which races the
+ * HTML parser. The document's own script can therefore run before `$$EXPO_DOM_HOST_OS` and
+ * `$$EXPO_INITIAL_PROPS` are defined. Throwing in that case kills the bundle during module
+ * evaluation, leaving a permanently blank WebView, so wait for the globals instead.
+ */
+const HOST_GLOBALS_TIMEOUT_MS = 10000;
+const HOST_GLOBALS_POLL_MS = 16;
+
+function areHostGlobalsReady() {
+  return (
+    typeof window.$$EXPO_DOM_HOST_OS !== 'undefined' &&
+    typeof window.$$EXPO_INITIAL_PROPS !== 'undefined'
+  );
+}
+
 export function registerDOMComponent(AppModule: any) {
-  if (typeof window.$$EXPO_DOM_HOST_OS === 'undefined') {
-    throw new Error(
-      'Top OS ($$EXPO_DOM_HOST_OS) is not defined. This is a bug in the DOM Component runtime.'
-    );
+  if (areHostGlobalsReady()) {
+    registerDOMComponentWithHostGlobals(AppModule);
+    return;
   }
-  process.env.EXPO_DOM_HOST_OS = window.$$EXPO_DOM_HOST_OS;
+
+  const startedAt = Date.now();
+
+  const poll = () => {
+    if (areHostGlobalsReady()) {
+      registerDOMComponentWithHostGlobals(AppModule);
+      return;
+    }
+
+    if (Date.now() - startedAt >= HOST_GLOBALS_TIMEOUT_MS) {
+      throw new Error(
+        'Top OS ($$EXPO_DOM_HOST_OS) is not defined. This is a bug in the DOM Component runtime.'
+      );
+    }
+
+    setTimeout(poll, HOST_GLOBALS_POLL_MS);
+  };
+
+  setTimeout(poll, HOST_GLOBALS_POLL_MS);
+}
+
+function registerDOMComponentWithHostGlobals(AppModule: any) {
+  process.env.EXPO_DOM_HOST_OS = window.$$EXPO_DOM_HOST_OS as string;
 
   function DOMComponentRoot(props: Record<string, unknown>) {
     // Props listeners


### PR DESCRIPTION
## Why

On Android, a DOM Component can permanently fail to mount — a blank WebView, with no error surfaced anywhere — when `injectedJavaScriptBeforeContentLoaded` is evaluated *after* the document's own `<script>` has already run.

`registerDOMComponent` throws in that case, and the `throw` sits **above** its own `try`/`catch`, so even the "render an empty div" fallback never runs. The bundle dies during module evaluation: React never mounts, callback props (`onReady`, etc.) never fire, and since the renderer process is alive, neither `onRenderProcessGone` nor `onContentProcessDidTerminate` fires. The component stays blank until the app is restarted; remounting it does not help.

`packages/expo/src/dom/webview-wrapper.tsx` seeds the runtime globals through that injection point:

```js
injectedJavaScriptBeforeContentLoaded: [
  `window.$$EXPO_DOM_HOST_OS = ${JSON.stringify(process.env.EXPO_OS)};true;`,
  `window.$$EXPO_INITIAL_PROPS = ${JSON.stringify(smartActions)};true;`,
  // ...
]
```

and `packages/expo/src/dom/dom-entry.tsx` hard-fails if the first one is missing. `DOMComponentRoot` has the same problem for `$$EXPO_INITIAL_PROPS`.

### Why the globals can arrive late

This does not originate in Expo. In `react-native-webview` on Android, `RNCWebViewClient.onPageStarted` calls `callInjectedJavaScriptBeforeContentLoaded()`, which is `WebView.evaluateJavascript(...)` — an asynchronous post to the WebView's JS thread. It races the HTML parser, which can execute the page's `<script>` first. `react-native-webview` does not use `WebViewCompat.addDocumentStartJavaScript`, the platform API that guarantees document-start execution.

`@expo/dom-webview` has the same shape (`DomWebView.kt` → `onPageStarted` → `evaluateJavascript`), so switching the underlying WebView implementation is not a workaround. This PR makes the Expo DOM runtime resilient, since the globals are guaranteed to arrive momentarily.

### Evidence

Instrumenting `injectedJavaScriptBeforeContentLoaded` in an Android release build (expo `55.0.17`, react-native `0.83.6`, react-native-webview `13.16.0`, `expo-updates` enabled, embedded launch). On a failing session, three consecutive mounts of the component each produced:

```
loadStart   {"url":"file:///android_asset/www.bundle/<hash>.html"}
inject:beforeContentLoaded {"readyState":"interactive","hasMetroDefine":true,"scriptCount":1,"rootChildCount":0}
inject:load
loadEnd
inject:probe+1s {"readyState":"complete","hasMetroDefine":true,"scriptCount":1,"rootChildCount":0}
```

Reading it:

- `readyState: "interactive"` at injection time — the document had already been parsed, so the injection landed late.
- `scriptCount: 1` with `hasMetroDefine: true` — the single bundle `<script>` had already executed.
- `rootChildCount: 0`, still `0` after one second — nothing mounted into `#root`, and **not even the `catch` fallback `<div>`**, which confirms the throw happened above the `try`.
- No `onError`, `onHttpError`, or `onRenderProcessGone`.
- A `DOMContentLoaded` listener registered by the injected script never fired, while a `load` listener did — independently confirming the injection landed between `DOMContentLoaded` and `load`.

On a healthy session from the same build, the component mounts and its `onReady` prop fires within ~1 ms of the first animation frame.

## How

`registerDOMComponent` no longer throws immediately. If the host globals are not yet present, it polls every 16 ms (up to 10 s) and registers the root component as soon as both `$$EXPO_DOM_HOST_OS` and `$$EXPO_INITIAL_PROPS` are available. If they never arrive, it throws the original error, so a genuine runtime bug still surfaces.

The timely path is unchanged: when the globals are already there, registration happens synchronously exactly as before. Waiting on `$$EXPO_INITIAL_PROPS` as well means `DOMComponentRoot`'s own `undefined` check can no longer trip either.

A sturdier long-term fix would be to stop depending on document-start injection at all — for example, exposing the globals through `ReactNativeWebView.injectedObjectJson()`, since the JS interface is bound before any page script runs — keeping the current globals as a fast path. Happy to follow up with that instead if you'd prefer it over polling.

## Test Plan

- Applied this change as a `pnpm patch` on `expo@55.0.17` in a production app that renders a Slate-based editor as a DOM Component.
- Android release build on a physical device: the blank-component failure reproduced consistently before the change (three consecutive mounts, all dead) and no longer reproduces after it.
- The healthy path is unaffected: when the globals are injected on time, registration is still synchronous and `onReady` fires on the first animation frame as before.
- iOS release build: no behavior change observed (the race is Android-specific).

## Checklist

- [ ] Documentation is up to date to reflect any changes (no public API change).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (JS-only, no native changes).
- [x] Added an entry to `packages/expo/CHANGELOG.md` under **🐛 Bug fixes**.