### PR TITLE
[docs] Mention Workflows works with GitHub Actions in CI/CD tutorial

### DIFF
--- a/docs/pages/tutorial/cicd/introduction.mdx
+++ b/docs/pages/tutorial/cicd/introduction.mdx
@@ -170,7 +170,7 @@ EAS Workflows files live in the **.eas/workflows/** directory at the root of an 
 
 The main difference is pre-packaged jobs: setting `type: build` lets EAS handle the environment and build artifacts, with no `runs-on` or setup step to write. We cover these as we go.
 
-> **info** EAS Workflows can run alongside GitHub Actions and a GitHub Actions job can trigger a workflow with `eas workflow:run`. See [How to integrate EAS Workflows with GitHub Actions](https://expo.dev/blog/how-to-integrate-eas-workflows-with-github-actions) for more information.
+> **Note:** EAS Workflows can run alongside GitHub Actions and a GitHub Actions job can trigger a workflow with `eas workflow:run`. See [How to integrate EAS Workflows with GitHub Actions](https://expo.dev/blog/how-to-integrate-eas-workflows-with-github-actions) for more information.
 
 ## Next step
 

--- a/docs/pages/tutorial/cicd/introduction.mdx
+++ b/docs/pages/tutorial/cicd/introduction.mdx
@@ -170,6 +170,8 @@ EAS Workflows files live in the **.eas/workflows/** directory at the root of an 
 
 The main difference is pre-packaged jobs: setting `type: build` lets EAS handle the environment and build artifacts, with no `runs-on` or setup step to write. We cover these as we go.
 
+> **info** EAS Workflows can run alongside GitHub Actions and a GitHub Actions job can trigger a workflow with `eas workflow:run`. See [How to integrate EAS Workflows with GitHub Actions](https://expo.dev/blog/how-to-integrate-eas-workflows-with-github-actions) for more information.
+
 ## Next step
 
 With our project set up, we can move to the first chapter and write our first workflow.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-23888

# How

Add a callout in "Coming from GitHub Actions?" section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2254" height="548" alt="CleanShot 2026-07-09 at 16 59 33@2x" src="https://github.com/user-attachments/assets/d5610db8-6a59-4fbc-9f98-2f9a35ed7004" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
