### PR TITLE
[docs] Clarify that MenuView trigger doesn't need a `Pressable`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/menu.mdx
@@ -13,7 +13,7 @@ A `MenuView` component with an API compatible with [`@react-native-menu/menu`](h
 
 Under the hood this component wraps the platform-specific `@expo/ui` primitives:
 
-- **Android**: [Jetpack Compose DropdownMenu](../jetpack-compose/dropdownmenu) anchored to a `Pressable` trigger.
+- **Android**: [Jetpack Compose DropdownMenu](../jetpack-compose/dropdownmenu) anchored to an internal `Pressable` trigger.
 - **iOS**: [SwiftUI Menu](../swift-ui/menu) for tap triggers and [SwiftUI ContextMenu](../swift-ui/contextmenu) for long-press triggers.
 
 If you need lower-level control, use those primitives directly.
@@ -33,10 +33,12 @@ If you need lower-level control, use those primitives directly.
 
 ## Basic usage
 
+Pass any view as the trigger. `MenuView` attaches its own tap or long-press handling.
+
 ```tsx MenuExample.tsx
 import { Icon } from '@expo/ui';
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 const editIcon = Icon.select({
   ios: 'pencil',
@@ -56,9 +58,9 @@ export default function MenuExample() {
         { id: 'delete', title: 'Delete', image: deleteIcon, attributes: { destructive: true } },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Open menu</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -66,12 +68,12 @@ export default function MenuExample() {
 
 ## Long-press (context menu)
 
-Set `shouldOpenOnLongPress` to render as a context menu. On Android, the same controlled `DropdownMenu` opens from the `Pressable`'s `onLongPress` instead of `onPress`. On iOS, this uses SwiftUI's `ContextMenu` and shows the trigger as a blurred preview.
+Set `shouldOpenOnLongPress` to render as a context menu. On Android, the same controlled `DropdownMenu` opens from a long press on the trigger instead of a tap. On iOS, this uses SwiftUI's `ContextMenu` and shows the trigger as a blurred preview.
 
 ```tsx LongPressMenuExample.tsx
 import { Icon } from '@expo/ui';
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 const copyIcon = Icon.select({
   ios: 'doc.on.doc',
@@ -92,9 +94,9 @@ export default function LongPressMenuExample() {
         { id: 'share', title: 'Share', image: shareIcon },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Long-press me</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -106,7 +108,7 @@ export default function LongPressMenuExample() {
 
 ```tsx SubmenuExample.tsx
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 export default function SubmenuExample() {
   return (
@@ -133,9 +135,9 @@ export default function SubmenuExample() {
         },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Open menu</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -148,7 +150,7 @@ Set `state` to `'on'` or `'off'` to render an action as a togglable item with a 
 ```tsx ToggleMenuExample.tsx
 import { MenuView } from '@expo/ui/community/menu';
 import { useState } from 'react';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 export default function ToggleMenuExample() {
   const [pinned, setPinned] = useState(false);
@@ -158,9 +160,9 @@ export default function ToggleMenuExample() {
       onPressAction={e => {
         if (e.nativeEvent.event === 'pin') setPinned(p => !p);
       }}>
-      <Pressable>
+      <View>
         <Text>{pinned ? 'Pinned' : 'Not pinned'}</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }

--- a/docs/pages/versions/v57.0.0/sdk/ui/drop-in-replacements/menu.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/drop-in-replacements/menu.mdx
@@ -13,7 +13,7 @@ A `MenuView` component with an API compatible with [`@react-native-menu/menu`](h
 
 Under the hood this component wraps the platform-specific `@expo/ui` primitives:
 
-- **Android**: [Jetpack Compose DropdownMenu](../jetpack-compose/dropdownmenu) anchored to a `Pressable` trigger.
+- **Android**: [Jetpack Compose DropdownMenu](../jetpack-compose/dropdownmenu) anchored to an internal `Pressable` trigger.
 - **iOS**: [SwiftUI Menu](../swift-ui/menu) for tap triggers and [SwiftUI ContextMenu](../swift-ui/contextmenu) for long-press triggers.
 
 If you need lower-level control, use those primitives directly.
@@ -33,10 +33,12 @@ If you need lower-level control, use those primitives directly.
 
 ## Basic usage
 
+Pass any view as the trigger. `MenuView` attaches its own tap or long-press handling.
+
 ```tsx MenuExample.tsx
 import { Icon } from '@expo/ui';
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 const editIcon = Icon.select({
   ios: 'pencil',
@@ -56,9 +58,9 @@ export default function MenuExample() {
         { id: 'delete', title: 'Delete', image: deleteIcon, attributes: { destructive: true } },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Open menu</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -66,12 +68,12 @@ export default function MenuExample() {
 
 ## Long-press (context menu)
 
-Set `shouldOpenOnLongPress` to render as a context menu. On Android, the same controlled `DropdownMenu` opens from the `Pressable`'s `onLongPress` instead of `onPress`. On iOS, this uses SwiftUI's `ContextMenu` and shows the trigger as a blurred preview.
+Set `shouldOpenOnLongPress` to render as a context menu. On Android, the same controlled `DropdownMenu` opens from a long press on the trigger instead of a tap. On iOS, this uses SwiftUI's `ContextMenu` and shows the trigger as a blurred preview.
 
 ```tsx LongPressMenuExample.tsx
 import { Icon } from '@expo/ui';
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 const copyIcon = Icon.select({
   ios: 'doc.on.doc',
@@ -92,9 +94,9 @@ export default function LongPressMenuExample() {
         { id: 'share', title: 'Share', image: shareIcon },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Long-press me</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -106,7 +108,7 @@ export default function LongPressMenuExample() {
 
 ```tsx SubmenuExample.tsx
 import { MenuView } from '@expo/ui/community/menu';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 export default function SubmenuExample() {
   return (
@@ -133,9 +135,9 @@ export default function SubmenuExample() {
         },
       ]}
       onPressAction={e => console.log(e.nativeEvent.event)}>
-      <Pressable>
+      <View>
         <Text>Open menu</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }
@@ -148,7 +150,7 @@ Set `state` to `'on'` or `'off'` to render an action as a togglable item with a 
 ```tsx ToggleMenuExample.tsx
 import { MenuView } from '@expo/ui/community/menu';
 import { useState } from 'react';
-import { Pressable, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 export default function ToggleMenuExample() {
   const [pinned, setPinned] = useState(false);
@@ -158,9 +160,9 @@ export default function ToggleMenuExample() {
       onPressAction={e => {
         if (e.nativeEvent.event === 'pin') setPinned(p => !p);
       }}>
-      <Pressable>
+      <View>
         <Text>{pinned ? 'Pinned' : 'Not pinned'}</Text>
-      </Pressable>
+      </View>
     </MenuView>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-23676 and https://github.com/expo/expo/issues/47609

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Swap `Pressable` for `View` in all four `MenuView` examples and their imports, matching upstream `@react-native-menu/menu` examples.
- State the trigger contract at the top of Basic usage: pass any view, `MenuView` attaches its own tap or long-press handling.
- Update related wording: "internal `Pressable` trigger" in the under-the-hood bullet, and the long-press section now says "a long press on the trigger" instead of pointing at the removed `Pressable`.
- Apply the same changes to the `unversioned` and `v57.0.0` copies of the page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
