### PR TITLE
[ui][ios] - Fix BottomSheet opening at an unpredictable detent

### DIFF
--- a/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
@@ -18,6 +18,7 @@ import {
   pickerStyle,
   presentationDetents,
   presentationDragIndicator,
+  presentationBackground,
   presentationBackgroundInteraction,
   interactiveDismissDisabled,
   tag,
@@ -38,6 +39,8 @@ export default function BottomSheetScreen() {
   const [showBasic, setShowBasic] = React.useState(false);
 
   const [showFitsContent, setShowFitsContent] = React.useState(false);
+
+  const [showBackgroundColor, setShowBackgroundColor] = React.useState(false);
 
   const [showConfigured, setShowConfigured] = React.useState(false);
   const [useMedium, setUseMedium] = React.useState(true);
@@ -101,6 +104,17 @@ export default function BottomSheetScreen() {
             Sheet automatically sizes to fit its content
           </Text>
           <Button label="Open Fits Content Sheet" onPress={() => setShowFitsContent(true)} />
+        </Section>
+
+        <Section title="Solid Background Color">
+          <Text modifiers={[foregroundStyle('secondaryLabel')]}>
+            presentationBackground paints a solid sheet color and disables the translucent (Liquid
+            Glass) material
+          </Text>
+          <Button
+            label="Open Solid Background Sheet"
+            onPress={() => setShowBackgroundColor(true)}
+          />
         </Section>
 
         <Section title="Configured Sheet">
@@ -183,6 +197,23 @@ export default function BottomSheetScreen() {
               This sheet sizes to fit its content automatically
             </Text>
             <Button label="Close" onPress={() => setShowFitsContent(false)} />
+          </VStack>
+        </Group>
+      </BottomSheet>
+
+      {/* Solid Background Color Sheet */}
+      <BottomSheet isPresented={showBackgroundColor} onIsPresentedChange={setShowBackgroundColor}>
+        <Group
+          modifiers={[
+            presentationDetents(['medium', 'large']),
+            presentationBackground('#ffffff'),
+          ]}>
+          <VStack modifiers={[padding({ all: 20 })]}>
+            <Text modifiers={[foregroundStyle('#000000')]}>Solid white sheet background</Text>
+            <Text modifiers={[foregroundStyle('#666666')]}>
+              presentationBackground replaces the default translucent material
+            </Text>
+            <Button label="Close" onPress={() => setShowBackgroundColor(false)} />
           </VStack>
         </Group>
       </BottomSheet>

--- a/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
@@ -204,10 +204,7 @@ export default function BottomSheetScreen() {
       {/* Solid Background Color Sheet */}
       <BottomSheet isPresented={showBackgroundColor} onIsPresentedChange={setShowBackgroundColor}>
         <Group
-          modifiers={[
-            presentationDetents(['medium', 'large']),
-            presentationBackground('#ffffff'),
-          ]}>
+          modifiers={[presentationDetents(['medium', 'large']), presentationBackground('#ffffff')]}>
           <VStack modifiers={[padding({ all: 20 })]}>
             <Text modifiers={[foregroundStyle('#000000')]}>Solid white sheet background</Text>
             <Text modifiers={[foregroundStyle('#666666')]}>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -79,6 +79,47 @@ export default function BottomSheetFitsContentExample() {
 }
 ```
 
+### Custom background color
+
+By default, a sheet uses the system's translucent material background (Liquid Glass on iOS 26). Use the [`presentationBackground`](modifiers/#presentationbackgroundcolor) modifier on `Group` to paint the sheet with a solid color instead, which also opts the sheet out of that translucent material.
+
+> **info** Prefer `presentationBackground` over a `background` modifier on the sheet's content. A `background` sits _behind_ the content's own background, so a `Form` or `List` covers it, and the color shows inconsistently as the sheet moves between detents. `presentationBackground` colors the sheet surface itself, so it stays consistent at every detent. When the content is a `Form` or `List`, also add [`scrollContentBackground('hidden')`](modifiers/#scrollcontentbackgroundvisible) so the sheet color shows through the grouped background.
+
+```tsx BottomSheetBackgroundColorExample.tsx
+import { useState } from 'react';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
+import {
+  presentationBackground,
+  presentationDetents,
+  padding,
+  foregroundStyle,
+} from '@expo/ui/swift-ui/modifiers';
+
+export default function BottomSheetBackgroundColorExample() {
+  const [isPresented, setIsPresented] = useState(false);
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <VStack>
+        <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
+        <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
+          <Group
+            modifiers={[
+              presentationDetents(['medium', 'large']),
+              presentationBackground('#ffffff'),
+            ]}>
+            <VStack modifiers={[padding({ all: 20 })]}>
+              <Text modifiers={[foregroundStyle('#000000')]}>Solid white sheet background.</Text>
+              <Button label="Close" onPress={() => setIsPresented(false)} />
+            </VStack>
+          </Group>
+        </BottomSheet>
+      </VStack>
+    </Host>
+  );
+}
+```
+
 ### Bottom sheet with presentation detents
 
 Use the [`presentationDetents`](modifiers/#presentationdetentsdetents-options) modifier on `Group` to control the available heights. You can use:

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
@@ -79,6 +79,47 @@ export default function BottomSheetFitsContentExample() {
 }
 ```
 
+### Custom background color
+
+By default, a sheet uses the system's translucent material background (Liquid Glass on iOS 26). Use the [`presentationBackground`](modifiers/#presentationbackgroundcolor) modifier on `Group` to paint the sheet with a solid color instead, which also opts the sheet out of that translucent material.
+
+> **info** Prefer `presentationBackground` over a `background` modifier on the sheet's content. A `background` sits _behind_ the content's own background, so a `Form` or `List` covers it, and the color shows inconsistently as the sheet moves between detents. `presentationBackground` colors the sheet surface itself, so it stays consistent at every detent. When the content is a `Form` or `List`, also add [`scrollContentBackground('hidden')`](modifiers/#scrollcontentbackgroundvisible) so the sheet color shows through the grouped background.
+
+```tsx BottomSheetBackgroundColorExample.tsx
+import { useState } from 'react';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
+import {
+  presentationBackground,
+  presentationDetents,
+  padding,
+  foregroundStyle,
+} from '@expo/ui/swift-ui/modifiers';
+
+export default function BottomSheetBackgroundColorExample() {
+  const [isPresented, setIsPresented] = useState(false);
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <VStack>
+        <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
+        <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
+          <Group
+            modifiers={[
+              presentationDetents(['medium', 'large']),
+              presentationBackground('#ffffff'),
+            ]}>
+            <VStack modifiers={[padding({ all: 20 })]}>
+              <Text modifiers={[foregroundStyle('#000000')]}>Solid white sheet background.</Text>
+              <Button label="Close" onPress={() => setIsPresented(false)} />
+            </VStack>
+          </Group>
+        </BottomSheet>
+      </VStack>
+    </Host>
+  );
+}
+```
+
 ### Bottom sheet with presentation detents
 
 Use the [`presentationDetents`](modifiers/#presentationdetentsdetents-options) modifier on `Group` to control the available heights. You can use:

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/bottomsheet.mdx
@@ -77,6 +77,47 @@ export default function BottomSheetFitsContentExample() {
 }
 ```
 
+### Custom background color
+
+By default, a sheet uses the system's translucent material background (Liquid Glass on iOS 26). Use the [`presentationBackground`](modifiers/#presentationbackgroundcolor) modifier on `Group` to paint the sheet with a solid color instead, which also opts the sheet out of that translucent material.
+
+> **info** Prefer `presentationBackground` over a `background` modifier on the sheet's content. A `background` sits _behind_ the content's own background, so a `Form` or `List` covers it, and the color shows inconsistently as the sheet moves between detents. `presentationBackground` colors the sheet surface itself, so it stays consistent at every detent. When the content is a `Form` or `List`, also add [`scrollContentBackground('hidden')`](modifiers/#scrollcontentbackgroundvisible) so the sheet color shows through the grouped background.
+
+```tsx BottomSheetBackgroundColorExample.tsx
+import { useState } from 'react';
+import { Host, BottomSheet, Button, Group, Text, VStack } from '@expo/ui/swift-ui';
+import {
+  presentationBackground,
+  presentationDetents,
+  padding,
+  foregroundStyle,
+} from '@expo/ui/swift-ui/modifiers';
+
+export default function BottomSheetBackgroundColorExample() {
+  const [isPresented, setIsPresented] = useState(false);
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <VStack>
+        <Button label="Open Sheet" onPress={() => setIsPresented(true)} />
+        <BottomSheet isPresented={isPresented} onIsPresentedChange={setIsPresented}>
+          <Group
+            modifiers={[
+              presentationDetents(['medium', 'large']),
+              presentationBackground('#ffffff'),
+            ]}>
+            <VStack modifiers={[padding({ all: 20 })]}>
+              <Text modifiers={[foregroundStyle('#000000')]}>Solid white sheet background.</Text>
+              <Button label="Close" onPress={() => setIsPresented(false)} />
+            </VStack>
+          </Group>
+        </BottomSheet>
+      </VStack>
+    </Host>
+  );
+}
+```
+
 ### Bottom sheet with presentation detents
 
 Use the [`presentationDetents`](modifiers/#presentationdetentsdetents-options) modifier on `Group` to control the available heights. You can use:

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `BottomSheet` opening at an unpredictable detent when multiple detents are set without a `selection`. The initial detent now follows the first entry in the array instead of the unordered set. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix `BottomSheet` opening at an unpredictable detent when multiple detents are set without a `selection`. The initial detent now follows the first entry in the array instead of the unordered set. ([#47652](https://github.com/expo/expo/pull/47652) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `BottomSheet` opening at an unpredictable detent when multiple detents are set without a `selection`. The initial detent now follows the first entry in the array instead of the unordered set. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the graphical `DatePicker` style (`community/datetime-picker` `display="inline"`) rendering undersized on mount and jumping to its correct size on the first tap. ([#47062](https://github.com/expo/expo/issues/47062) by [@etiennetalbot](https://github.com/etiennetalbot)) ([#47465](https://github.com/expo/expo/pull/47465) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS][android] Fix `community/masked-view` doubling offsets and transforms by re-applying the user-supplied `style` to the inner mask/content `View` wrappers. ([#47067](https://github.com/expo/expo/issues/47067) by [@tsushanth](https://github.com/tsushanth))
 - [iOS] Fix the SwiftUI `TextField` crashing with "String index is out of bounds" on iOS 18 when JS writes new text into a focused field that holds an active text selection. ([#47447](https://github.com/expo/expo/pull/47447) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/Modifiers/PresentationModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/PresentationModifiers.swift
@@ -67,17 +67,13 @@ internal struct PresentationDetentsModifier: ViewModifier, Record {
 
   func body(content: Content) -> some View {
     if #available(iOS 16.0, tvOS 16.0, *) {
-      if selection != nil || eventDispatcher != nil {
-        PresentationDetentsSelectionView(
-          detents: parseDetents(),
-          rawDetents: detents ?? [],
-          initialSelection: selection.flatMap { parsePresentationDetent($0) },
-          eventDispatcher: eventDispatcher
-        ) {
-          content
-        }
-      } else {
-        content.presentationDetents(parseDetents())
+      PresentationDetentsSelectionView(
+        detents: parseDetents(),
+        rawDetents: detents ?? [],
+        initialSelection: selection.flatMap { parsePresentationDetent($0) },
+        eventDispatcher: eventDispatcher
+      ) {
+        content
       }
     } else {
       content
@@ -128,7 +124,10 @@ private struct PresentationDetentsSelectionView<WrappedContent: View>: View {
     self.initialSelection = initialSelection
     self.eventDispatcher = eventDispatcher
     self.wrappedContent = content()
-    self._selectedDetent = State(initialValue: initialSelection ?? detents.first ?? .large)
+    // Default to the first detent in the ordered array, not `detents.first` (the Set's order is
+    // randomized per process), so the sheet always opens at the same detent.
+    let firstOrderedDetent = rawDetents.compactMap { parsePresentationDetent($0) }.first
+    self._selectedDetent = State(initialValue: initialSelection ?? firstOrderedDetent ?? .large)
   }
 
   var body: some View {


### PR DESCRIPTION
# Why

- `BottomSheet` opened at a random detent (medium vs large when multiple detents were set without a `selection`. 
- Also documents giving a sheet a solid background color. A discord user asked for it.

# How

- `presentationDetents` now always drives the sheet through a `selection` binding always.
- Added a "Solid Background Color" example to the NCL `BottomSheet` screen.

# Test Plan

- Detent fix: relaunch the app several times with detents `['medium', 'large']`; the sheet now opens at the first listed detent every time instead of varying per launch.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
