### PR TITLE
[docs] Fix typo in `docs/pages/tutorial/screenshot.mdx`

### DIFF
--- a/docs/checks/ja/source-hashes.json
+++ b/docs/checks/ja/source-hashes.json
@@ -10,5 +10,5 @@
   "tutorial/introduction.mdx": "787b2c32b532fa9e",
   "tutorial/overview.mdx": "7556d50fbc3eb9ec",
   "tutorial/platform-differences.mdx": "8bcbde379242448e",
-  "tutorial/screenshot.mdx": "0025e835c121f1bc"
+  "tutorial/screenshot.mdx": "1f7567059ee1b6b0"
 }

--- a/docs/pages/ja/tutorial/screenshot.mdx
+++ b/docs/pages/ja/tutorial/screenshot.mdx
@@ -267,7 +267,4 @@ const styles = StyleSheet.create({
 
 ## まとめ
 
-<ProgressTracker
-  name="GET_STARTED""
-  currentChapterSlug="/tutorial/screenshot"
-/>
+<ProgressTracker name="GET_STARTED"" currentChapterSlug="/tutorial/screenshot" />

--- a/docs/pages/ja/tutorial/screenshot.mdx
+++ b/docs/pages/ja/tutorial/screenshot.mdx
@@ -267,4 +267,4 @@ const styles = StyleSheet.create({
 
 ## まとめ
 
-<ProgressTracker name="GET_STARTED"" currentChapterSlug="/tutorial/screenshot" />
+<ProgressTracker name="GET_STARTED" currentChapterSlug="/tutorial/screenshot" />

--- a/docs/pages/ja/tutorial/screenshot.mdx
+++ b/docs/pages/ja/tutorial/screenshot.mdx
@@ -268,16 +268,6 @@ const styles = StyleSheet.create({
 ## まとめ
 
 <ProgressTracker
+  name="GET_STARTED""
   currentChapterSlug="/tutorial/screenshot"
-  name="GET_STARTED"
-  chapterTitle="第 7 章：スクリーンショットを撮影する"
-  summary={
-    <>
-      <CODE>react-native-view-shot</CODE> と <CODE>expo-media-library</CODE>{' '}
-      を使用して、スクリーンショットを撮影しデバイスのライブラリに保存できました。
-    </>
-  }
-  nextChapterDescription="次の章では、モバイルと web プラットフォームの違いを処理して、web で同じ機能を実装する方法を学びます。"
-  nextChapterTitle="プラットフォームの違いに対応する"
-  nextChapterLink="/ja/tutorial/platform-differences"
 />

--- a/docs/pages/ja/tutorial/screenshot.mdx
+++ b/docs/pages/ja/tutorial/screenshot.mdx
@@ -8,7 +8,6 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { CODE } from '~/ui/components/Text';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 この章では、サードパーティのライブラリを使ってスクリーンショットを撮影し、デバイスのメディアライブラリに保存する方法を学びます。スクリーンショットの撮影には [`react-native-view-shot`](https://github.com/gre/react-native-view-shot) を、デバイスのメディアライブラリへの画像の保存には [`expo-media-library`](/versions/v54.0.0/sdk/media-library/) を使用します。

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -269,7 +269,4 @@ Now, choose a photo and add a sticker in the app. Then tap the "Save" button. We
 <ProgressTracker 
   name="GET_STARTED"
   currentChapterSlug="/tutorial/screenshot"
-  nextChapterDescription="In the next chapter, let's learn how to handle the differences between mobile and web platforms to implement the same functionality on web."
-  nextChapterTitle="Handle platform differences"
-  nextChapterLink="/tutorial/platform-differences"
 />

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -266,8 +266,9 @@ Now, choose a photo and add a sticker in the app. Then tap the "Save" button. We
 
 ## Summary
 
-<ProgressTracker name="GET_STARTED" currentChapterSlug="/tutorial/screenshot" />
-  }
+<ProgressTracker 
+  name="GET_STARTED"
+  currentChapterSlug="/tutorial/screenshot"
   nextChapterDescription="In the next chapter, let's learn how to handle the differences between mobile and web platforms to implement the same functionality on web."
   nextChapterTitle="Handle platform differences"
   nextChapterLink="/tutorial/platform-differences"

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -266,7 +266,4 @@ Now, choose a photo and add a sticker in the app. Then tap the "Save" button. We
 
 ## Summary
 
-<ProgressTracker 
-  name="GET_STARTED"
-  currentChapterSlug="/tutorial/screenshot"
-/>
+<ProgressTracker name="GET_STARTED" currentChapterSlug="/tutorial/screenshot" />


### PR DESCRIPTION
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
