### PR TITLE
[fingerprint] Fix config-plugin module capture with a compile hook

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Added more default `getConfig` exclusion packages. ([#47503](https://github.com/expo/expo/pull/47503) by [@kudo](https://github.com/kudo))
+- Reworked config-plugin module capture with a `Module.prototype._compile` hook. ([#47666](https://github.com/expo/expo/pull/47666) by [@kudo](https://github.com/kudo))
 
 ## 0.19.3 — 2026-05-26
 

--- a/packages/@expo/fingerprint/src/ExpoConfig.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfig.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
-import { getExpoConfigLoaderPath } from './ExpoConfigLoader';
+import { getExpoConfigLoaderPath, type LoadedModuleSource } from './ExpoConfigLoader';
 import type { NormalizedOptions } from './Fingerprint.types';
 import { spawnWithIpcAsync } from './utils/SpawnIPC';
 
@@ -16,7 +16,7 @@ export async function getExpoConfigAsync(
   options: NormalizedOptions
 ): Promise<{
   config: ProjectConfig | null;
-  loadedModules: string[] | null;
+  loadedModules: LoadedModuleSource[] | null;
 }> {
   const result = {
     config: null,

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { DEFAULT_IGNORE_PATHS } from './Options';
-import { isIgnoredPath } from './utils/Path';
+import { isIgnoredPath, toPosixPath } from './utils/Path';
 
 async function runAsync(programName: string, args: string[] = []) {
   if (args[0] == null) {
@@ -23,39 +23,15 @@ async function runAsync(programName: string, args: string[] = []) {
   setNodeEnv('development');
   require('@expo/env').load(projectRoot);
 
-  const loadedModulesBefore = new Set(Object.keys(module._cache));
-
-  const { getConfig } = require(resolveFrom(path.resolve(projectRoot), 'expo/config'));
-  const config = await getConfig(projectRoot, {
-    skipSDKVersionRequirement: true,
-  });
-
-  const virtualModuleNames = new Set<string>();
-  const loadedModules: string[] = [];
-
-  // TODO(@kitten): Don't rely on `module._cache` for this over Node loader hooks
-  // The module cache isn't reflective of real files necessarily
-  for (const id of Object.keys(module._cache)) {
-    if (loadedModulesBefore.has(id)) {
-      continue;
-    }
-
-    let filename = id;
-
-    const mod = module._cache[id] as any;
-    if (mod != null && mod.filename != null) {
-      filename = mod.filename || id;
-    }
-
-    // NOTE(@kitten): Virtual modules may be placed on `module._cache` and we can't rely on the ID to be accurate
-    // The IDs are also not necessarily paths. We prefer `filename`, and trust they exist, but if the ID mismatches
-    // with the module name, we use the ID, and ignore the filename entirely
-    if (filename !== id) {
-      virtualModuleNames.add(filename);
-      loadedModules.push(id);
-    } else {
-      loadedModules.push(filename);
-    }
+  const { getCapturedModules, uninstall } = installModuleCaptureHook();
+  let config;
+  try {
+    const { getConfig } = require(resolveFrom(path.resolve(projectRoot), 'expo/config'));
+    config = await getConfig(projectRoot, {
+      skipSDKVersionRequirement: true,
+    });
+  } finally {
+    uninstall();
   }
 
   const ignoredPaths = [
@@ -63,39 +39,15 @@ async function runAsync(programName: string, args: string[] = []) {
     ...(await loadIgnoredPathsAsync(ignoredFile)),
   ];
 
-  const filteredLoadedModules = loadedModules.filter(
-    (modulePath) => !virtualModuleNames.has(modulePath)
+  const loadedModules = await resolveLoadedModuleSourcesAsync(
+    getCapturedModules(),
+    projectRoot,
+    ignoredPaths
   );
-
-  const existingLoadedModules = (
-    await Promise.all(
-      filteredLoadedModules.map(async (modulePath) => {
-        const relativePath = path.relative(projectRoot, modulePath);
-        if (isIgnoredPath(relativePath, ignoredPaths)) {
-          return null;
-        }
-
-        try {
-          const stat = await fs.stat(modulePath);
-          if (!stat.isFile()) {
-            return null;
-          }
-
-          return relativePath;
-        } catch (error: any) {
-          // Filter out virtual paths / non-existent files
-          if (error.code === 'ENOENT') {
-            return null;
-          }
-          throw error;
-        }
-      })
-    )
-  ).filter((modulePath) => modulePath != null);
 
   const result = JSON.stringify({
     config,
-    loadedModules: existingLoadedModules,
+    loadedModules,
   });
 
   if (process.send) {
@@ -140,6 +92,101 @@ async function loadIgnoredPathsAsync(ignoredFile: string | null) {
   } catch {}
 
   return ignorePaths;
+}
+
+/**
+ * A CommonJS module observed while `installModuleCaptureHook()` was active.
+ */
+export interface CapturedModule {
+  /** The module id (cache key). May diverge from `filename` for virtual modules. */
+  id: string;
+  /** The filename Node compiled the module under. Authoritative even for transpiled sources. */
+  filename: string;
+  /** The source content Node executed for the module. */
+  content: string;
+}
+
+/**
+ * A config-plugin source produced from a captured module.
+ * A module backed by a real file becomes a `file` source.
+ * For virtual modules without a physical file in the file system, it becomes a `contents` source
+ * carrying the captured body.
+ */
+export type LoadedModuleSource =
+  | { type: 'file'; path: string }
+  | { type: 'contents'; id: string; contents: string };
+
+/**
+ * Observe every CommonJS module compiled while the hook is installed.
+ * We hook `Module.prototype._compile` to keep each module's authoritative filename and source
+ * content.
+ */
+export function installModuleCaptureHook(): {
+  getCapturedModules: () => CapturedModule[];
+  uninstall: () => void;
+} {
+  const moduleProto = (module as unknown as { prototype: ModuleCompilePrototype }).prototype;
+  const capturedModules: CapturedModule[] = [];
+  const originalCompile = moduleProto._compile;
+  moduleProto._compile = function (this: { id?: string }, content: string, filename: string) {
+    capturedModules.push({ id: this.id ?? filename, filename, content });
+    return originalCompile.call(this, content, filename);
+  };
+  return {
+    getCapturedModules: () => capturedModules,
+    uninstall: () => {
+      moduleProto._compile = originalCompile;
+    },
+  };
+}
+
+interface ModuleCompilePrototype {
+  _compile: (this: { id?: string }, content: string, filename: string) => unknown;
+}
+
+/**
+ * Turn captured modules into config-plugin sources, dropping ignored paths.
+ * A real file becomes a `file` source; a module with no file on disk (virtual / compiled from a
+ * string) becomes a `contents` source keyed by its project-relative path so it stays stable across
+ * runs. A path that exists but is not a file (e.g. a directory) is skipped.
+ */
+export async function resolveLoadedModuleSourcesAsync(
+  capturedModules: CapturedModule[],
+  projectRoot: string,
+  ignoredPaths: string[]
+): Promise<LoadedModuleSource[]> {
+  const seen = new Set<string>();
+  const candidates = capturedModules
+    .map(({ filename, content }) => ({
+      relativePath: toPosixPath(path.relative(projectRoot, filename)),
+      filename,
+      content,
+    }))
+    .filter(({ relativePath }) => {
+      if (seen.has(relativePath) || isIgnoredPath(relativePath, ignoredPaths)) {
+        return false;
+      }
+      seen.add(relativePath);
+      return true;
+    });
+
+  const sources = await Promise.all(
+    candidates.map(
+      async ({ relativePath, filename, content }): Promise<LoadedModuleSource | null> => {
+        try {
+          const stat = await fs.stat(filename);
+          return stat.isFile() ? { type: 'file', path: relativePath } : null;
+        } catch (error: any) {
+          if (error.code === 'ENOENT') {
+            return { type: 'contents', id: relativePath, contents: content };
+          }
+          throw error;
+        }
+      }
+    )
+  );
+
+  return sources.filter((source): source is LoadedModuleSource => source !== null);
 }
 
 /**

--- a/packages/@expo/fingerprint/src/__tests__/ExpoConfigLoader-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ExpoConfigLoader-test.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import requireString from 'require-from-string';
+
+import {
+  installModuleCaptureHook,
+  resolveLoadedModuleSourcesAsync,
+  type CapturedModule,
+} from '../ExpoConfigLoader';
+
+describe('installModuleCaptureHook', () => {
+  let tmpDir: string;
+  let hook: ReturnType<typeof installModuleCaptureHook> | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-fingerprint-hook-'));
+  });
+
+  afterEach(() => {
+    hook?.uninstall();
+    hook = null;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should capture a compiled module with its authoritative filename and content', () => {
+    hook = installModuleCaptureHook();
+    const filename = path.join(tmpDir, 'plugin.js');
+    const content = 'module.exports = 42;';
+    requireString(content, filename);
+
+    expect(hook.getCapturedModules()).toContainEqual(
+      expect.objectContaining({ filename, content })
+    );
+  });
+
+  it('should capture the real source filename that a transpiler passes to _compile', () => {
+    // A transpiler (sucrase/tsx) reads a `.ts` source and compiles it under the real source
+    // filename, so the hook must record `.ts` — not a guessed `.js`.
+    hook = installModuleCaptureHook();
+    const tsFilename = path.join(tmpDir, 'with-local-plugin.ts');
+    const transpiled = 'module.exports = () => {};';
+    requireString(transpiled, tsFilename);
+
+    const captured = hook.getCapturedModules();
+    expect(captured.some((m) => m.filename === tsFilename)).toBe(true);
+    expect(captured.every((m) => !m.filename.endsWith('with-local-plugin.js'))).toBe(true);
+  });
+
+  it('should stop capturing after uninstall', () => {
+    hook = installModuleCaptureHook();
+    hook.uninstall();
+    requireString('module.exports = 1;', path.join(tmpDir, 'after-uninstall.js'));
+    expect(hook.getCapturedModules()).toEqual([]);
+  });
+});
+
+describe('resolveLoadedModuleSourcesAsync', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-fingerprint-resolve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should classify an existing file as a file source with a project-relative posix path', async () => {
+    const pluginDir = path.join(tmpDir, 'plugins');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const filePath = path.join(pluginDir, 'with-plugin.ts');
+    fs.writeFileSync(filePath, 'export default {};');
+
+    const captured: CapturedModule[] = [{ id: filePath, filename: filePath, content: 'ignored' }];
+    const sources = await resolveLoadedModuleSourcesAsync(captured, tmpDir, []);
+
+    expect(sources).toEqual([{ type: 'file', path: 'plugins/with-plugin.ts' }]);
+  });
+
+  it('should classify a module with no file on disk as a contents source with its captured content', async () => {
+    const virtualPath = path.join(tmpDir, 'plugins', 'virtual.js');
+    const content = 'module.exports = () => {};';
+    const captured: CapturedModule[] = [{ id: virtualPath, filename: virtualPath, content }];
+
+    const sources = await resolveLoadedModuleSourcesAsync(captured, tmpDir, []);
+
+    expect(sources).toEqual([{ type: 'contents', id: 'plugins/virtual.js', contents: content }]);
+  });
+
+  it('should skip ignored paths', async () => {
+    const nodeModDir = path.join(tmpDir, 'node_modules', 'chalk');
+    fs.mkdirSync(nodeModDir, { recursive: true });
+    const ignoredFile = path.join(nodeModDir, 'index.js');
+    fs.writeFileSync(ignoredFile, 'x');
+
+    const captured: CapturedModule[] = [
+      { id: ignoredFile, filename: ignoredFile, content: 'x' },
+    ];
+    const sources = await resolveLoadedModuleSourcesAsync(captured, tmpDir, [
+      '**/node_modules/chalk/**/*',
+    ]);
+
+    expect(sources).toEqual([]);
+  });
+
+  it('should dedupe modules captured more than once', async () => {
+    const filePath = path.join(tmpDir, 'plugin.ts');
+    fs.writeFileSync(filePath, 'export default {};');
+    const captured: CapturedModule[] = [
+      { id: filePath, filename: filePath, content: 'a' },
+      { id: filePath, filename: filePath, content: 'a' },
+    ];
+
+    const sources = await resolveLoadedModuleSourcesAsync(captured, tmpDir, []);
+
+    expect(sources).toEqual([{ type: 'file', path: 'plugin.ts' }]);
+  });
+});

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -6,6 +6,7 @@ import type { Props as SplashProps } from 'expo-splash-screen/plugin';
 import path from 'path';
 import semver from 'semver';
 
+import type { LoadedModuleSource } from '../ExpoConfigLoader';
 import { resolveExpoAutolinkingCliPath } from '../ExpoResolver';
 import type { HashSource, NormalizedOptions } from '../Fingerprint.types';
 import { toPosixPath } from '../utils/Path';
@@ -22,7 +23,7 @@ const debug = require('debug')('expo:fingerprint:sourcer:Expo');
 export async function getExpoConfigSourcesAsync(
   projectRoot: string,
   config: ProjectConfig | null,
-  loadedModules: string[] | null,
+  loadedModules: LoadedModuleSource[] | null,
   options: NormalizedOptions
 ): Promise<HashSource[]> {
   if (options.sourceSkips & SourceSkips.ExpoConfigAll) {
@@ -111,11 +112,20 @@ export async function getExpoConfigSourcesAsync(
   });
 
   // config plugins
-  const configPluginModules: HashSource[] = (loadedModules ?? []).map((modulePath) => ({
-    type: 'file',
-    filePath: toPosixPath(modulePath),
-    reasons: ['expoConfigPlugins'],
-  }));
+  const configPluginModules: HashSource[] = (loadedModules ?? []).map((loadedModule) =>
+    loadedModule.type === 'file'
+      ? {
+          type: 'file',
+          filePath: loadedModule.path,
+          reasons: ['expoConfigPlugins'],
+        }
+      : {
+          type: 'contents',
+          id: loadedModule.id,
+          contents: loadedModule.contents,
+          reasons: ['expoConfigPlugins'],
+        }
+  );
   results.push(...configPluginModules);
 
   return results;

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
@@ -494,8 +494,11 @@ describe(getExpoConfigSourcesAsync, () => {
     const configResult = JSON.stringify({
       config,
       loadedModules: [
-        'node_modules/third-party/index.js',
-        'node_modules/third-party/node_modules/transitive-third-party/index.js',
+        { type: 'file', path: 'node_modules/third-party/index.js' },
+        {
+          type: 'file',
+          path: 'node_modules/third-party/node_modules/transitive-third-party/index.js',
+        },
       ],
     });
     mockSpawnWithIpcAsync.mockResolvedValueOnce({
@@ -519,6 +522,39 @@ describe(getExpoConfigSourcesAsync, () => {
       expect.objectContaining({
         type: 'file',
         filePath: 'node_modules/third-party/node_modules/transitive-third-party/index.js',
+      })
+    );
+  });
+
+  it('should map a virtual config-plugin module to a contents source', async () => {
+    vol.fromJSON(require('./fixtures/ExpoManaged47Project.json'));
+    const config = await getConfig('/app', { skipSDKVersionRequirement: true });
+    const mockSpawnWithIpcAsync = spawnWithIpcAsync as jest.MockedFunction<
+      typeof spawnWithIpcAsync
+    >;
+    const configResult = JSON.stringify({
+      config,
+      loadedModules: [
+        { type: 'contents', id: 'plugins/virtual-plugin.js', contents: 'module.exports = () => {};' },
+      ],
+    });
+    mockSpawnWithIpcAsync.mockResolvedValueOnce({
+      output: [],
+      stdout: configResult,
+      message: configResult,
+      stderr: '',
+      signal: null,
+      status: 0,
+    });
+    const options = await normalizeOptionsAsync('/app');
+    const { config: expoConfig, loadedModules } = await getExpoConfigAsync('/app', options);
+    const sources = await getExpoConfigSourcesAsync('/app', expoConfig, loadedModules, options);
+    expect(sources).toContainEqual(
+      expect.objectContaining({
+        type: 'contents',
+        id: 'plugins/virtual-plugin.js',
+        contents: 'module.exports = () => {};',
+        reasons: ['expoConfigPlugins'],
       })
     );
   });


### PR DESCRIPTION
# Why

Fingerprinting crashed on projects with a local TypeScript config plugin — the loader recorded a `.js` path for a `.ts` source and then couldn't open it. It also silently dropped virtual (compiled-in-memory) modules. Rework upon #46092

close ENG-18201

# How

Replaced the post-hoc `module._cache` diff with a `Module.prototype._compile` hook, so we keep each module's real filename and source content. Real files are hashed from disk (so the hash stays transpiler-independent); modules with no file on disk are hashed from their captured contents. This finishes the long-standing loader-hook TODO in `ExpoConfigLoader`.

# Test Plan

`et check-packages @expo/fingerprint`. Added unit tests for the capture hook and source classification, and ran the built loader against `apps/bare-expo` to confirm the crash is gone.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Builds, type-checks, lints, and tests via `et check-packages`.
