### PR TITLE
[bare-expo] Verify the Maestro install and fail honestly when it is missing

### DIFF
--- a/.github/actions/setup-maestro/action.yml
+++ b/.github/actions/setup-maestro/action.yml
@@ -1,0 +1,27 @@
+name: Setup Maestro
+description: Install a pinned Maestro CLI version, verifying the install and retrying on transient download failures.
+inputs:
+  version:
+    description: The Maestro CLI version to install
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: 🍺 Install Maestro
+      shell: bash
+      run: |
+        # The installer doesn't propagate download failures (a CDN 504 once left this step
+        # green with no binary installed), so verify the install and retry on failure.
+        for attempt in 1 2 3; do
+          if curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION="${{ inputs.version }}" bash && "$HOME/.maestro/bin/maestro" --version; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "Maestro install failed after 3 attempts"
+            exit 1
+          fi
+          echo "Maestro install failed (attempt $attempt of 3); retrying..."
+          rm -rf "$HOME/.maestro"
+          sleep 10
+        done
+        echo "${HOME}/.maestro/bin" >> $GITHUB_PATH

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -8,10 +8,12 @@ on:
     branches: [main]
     paths:
       - .github/workflows/test-suite-nightly.yml
+      - .github/actions/setup-maestro/action.yml
       - tools/src/commands/SetupReactNativeNightly.ts
   pull_request:
     paths:
       - .github/workflows/test-suite-nightly.yml
+      - .github/actions/setup-maestro/action.yml
       - tools/src/commands/SetupReactNativeNightly.ts
 
 concurrency:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -246,7 +246,7 @@ jobs:
         with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
+          # the Android emulator in CI; verified still broken in 2.6.1.
           version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -244,10 +244,10 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Trying 2.6.1: 2.5.0 replaced TCP port forwarding with a direct ADB socket
-          # gRPC connection that failed (UNAVAILABLE / tcp:7001 closed) against the
-          # Android emulator in CI; checking whether 2.6.x still has the problem.
-          version: 2.6.1
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -116,9 +116,10 @@ jobs:
           xcrun simctl shutdown all
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-maestro
+        with:
+          # Pinned so that a new Maestro release can't break CI without a change in this repo.
+          version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -241,12 +242,12 @@ jobs:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
       - name: 🍺 Install Maestro
-        run: |
+        uses: ./.github/actions/setup-maestro
+        with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
           # the Android emulator in CI.
-          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
-          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+          version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -244,10 +244,10 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
-          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
-          version: 2.4.0
+          # Trying 2.6.1: 2.5.0 replaced TCP port forwarding with a direct ADB socket
+          # gRPC connection that failed (UNAVAILABLE / tcp:7001 closed) against the
+          # Android emulator in CI; checking whether 2.6.x still has the problem.
+          version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -120,7 +120,6 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Pinned so that a new Maestro release can't break CI without a change in this repo.
           version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -248,7 +247,7 @@ jobs:
         with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI; verified still broken in 2.6.1.
+          # the Android emulator in CI.
           version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,6 +8,7 @@ on:
       - .github/actions/detect-platform-change/action.yml
       - .github/workflows/test-suite.yml
       - .github/actions/use-android-emulator/action.yml
+      - .github/actions/setup-maestro/action.yml
       - apps/bare-expo/**
       - apps/test-suite/**
       - packages/**
@@ -24,6 +25,7 @@ on:
       - .github/actions/detect-platform-change/action.yml
       - .github/workflows/test-suite.yml
       - .github/actions/use-android-emulator/action.yml
+      - .github/actions/setup-maestro/action.yml
       - apps/bare-expo/**
       - apps/test-suite/**
       - packages/**
@@ -67,6 +69,7 @@ jobs:
           common-paths: >-
             .github/workflows/test-suite.yml,
             .github/actions/use-android-emulator/action.yml,
+            .github/actions/setup-maestro/action.yml,
             "apps/bare-expo/**",
             "apps/test-suite/**",
             "packages/**",
@@ -117,6 +120,7 @@ jobs:
           common-paths: >-
             .github/workflows/test-suite.yml,
             .github/actions/use-android-emulator/action.yml,
+            .github/actions/setup-maestro/action.yml,
             "apps/bare-expo/**",
             "apps/test-suite/**",
             "packages/expo-modules-core/**",

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -470,7 +470,7 @@ jobs:
         with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
+          # the Android emulator in CI; verified still broken in 2.6.1.
           version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -268,9 +268,10 @@ jobs:
           xcrun simctl shutdown all
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-maestro
+        with:
+          # Pinned so that a new Maestro release can't break CI without a change in this repo.
+          version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -465,12 +466,12 @@ jobs:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk/release
       - name: 🍺 Install Maestro
-        run: |
+        uses: ./.github/actions/setup-maestro
+        with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
           # the Android emulator in CI.
-          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
-          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+          version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -468,10 +468,10 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
-          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
-          version: 2.4.0
+          # Trying 2.6.1: 2.5.0 replaced TCP port forwarding with a direct ADB socket
+          # gRPC connection that failed (UNAVAILABLE / tcp:7001 closed) against the
+          # Android emulator in CI; checking whether 2.6.x still has the problem.
+          version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -274,7 +274,6 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Pinned so that a new Maestro release can't break CI without a change in this repo.
           version: 2.6.1
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -474,7 +473,7 @@ jobs:
         with:
           # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
           # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI; verified still broken in 2.6.1.
+          # the Android emulator in CI.
           version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -468,10 +468,10 @@ jobs:
       - name: 🍺 Install Maestro
         uses: ./.github/actions/setup-maestro
         with:
-          # Trying 2.6.1: 2.5.0 replaced TCP port forwarding with a direct ADB socket
-          # gRPC connection that failed (UNAVAILABLE / tcp:7001 closed) against the
-          # Android emulator in CI; checking whether 2.6.x still has the problem.
-          version: 2.6.1
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          version: 2.4.0
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -359,6 +359,14 @@ export async function runMaestroAsync({
     await maestroProcess;
     return [];
   } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      throw new Error(
+        `The maestro binary was not found on PATH, so the flows never ran. The "Install ` +
+          `Maestro" workflow step probably failed to download it; check that step's logs ` +
+          `and re-run the job.`,
+        { cause: error }
+      );
+    }
     const reportContents = await fs.readFile(reportPath, 'utf8').catch(() => null);
     if (reportContents == null) {
       if (killedReason === 'invocation-timeout') {


### PR DESCRIPTION
# Why

This [Test Suite e2e run on main](https://github.com/expo/expo/actions/runs/29032108430/job/86170497034) failed in a misleading way. The chain of events:

1. The Maestro download from `get.maestro.mobile.dev` hit a CDN 504. The installer printed "Downloaded zip archive is corrupt" but exited 0, so the install step went green with no `maestro` binary installed.
2. Every Maestro invocation then failed instantly with `ENOENT` (the per-attempt `test duration` logs read 3.02ms, 1.52ms, 0.84ms).
3. The runner's crash heuristic found no app process (it was never launched) and printed "The runner app has probably crashed" with empty logs, pointing anyone reading the log at a crash that never happened.
4. All retries burned in minutes and the job failed.

Separately, the iOS job installed whatever the latest Maestro release was at run time, so a new release could break iOS CI overnight with no change in this repo (this already forced pinning on Android, where 2.5.0+ breaks the emulator ADB connection).

# How

- The install moves into a `setup-maestro` composite action that verifies `maestro --version` runs after the installer finishes (the only reliable check, since the installer swallows download failures) and retries the download up to 3 times before failing the step. All four e2e jobs use it, including the two in `test-suite-nightly.yml` that were still unpinned and unhardened.
- iOS is pinned to Maestro 2.6.1, the version yesterday's passing runs resolved to; Android stays on 2.4.0 for the known gRPC/ADB reason.
- `runMaestroAsync` recognizes an `ENOENT` spawn failure and throws "The maestro binary was not found on PATH..." instead of falling through to flow-failure handling, so the job fails fast on the first invocation with the real cause instead of retrying and misreporting an app crash.

# Test Plan

- `bun test scripts/lib/` in `apps/bare-expo` passes (15 tests).
- Workflow YAML parses.
- The Test Suite e2e runs on this PR exercise both modified install steps end to end.

