### PR TITLE
[fingerprint] Derive config-plugin modules by diffing a plugins-skipped pass

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added more default `getConfig` exclusion packages. ([#47503](https://github.com/expo/expo/pull/47503) by [@kudo](https://github.com/kudo))
 - Reworked config-plugin module capture with a `Module.prototype._compile` hook. ([#47666](https://github.com/expo/expo/pull/47666) by [@kudo](https://github.com/kudo))
+- Derived config-plugin modules by diffing a plugins-skipped config load, which drops most config-loading framework modules automatically and shrinks the hand-maintained allowlist. ([#47678](https://github.com/expo/expo/pull/47678) by [@kudo](https://github.com/kudo))
 
 ## 0.19.3 — 2026-05-26
 

--- a/packages/@expo/fingerprint/src/ExpoConfig.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfig.ts
@@ -18,7 +18,10 @@ export async function getExpoConfigAsync(
   config: ProjectConfig | null;
   loadedModules: LoadedModuleSource[] | null;
 }> {
-  const result = {
+  const result: {
+    config: ProjectConfig | null;
+    loadedModules: LoadedModuleSource[] | null;
+  } = {
     config: null,
     loadedModules: null,
   };
@@ -30,14 +33,15 @@ export async function getExpoConfigAsync(
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'expo-fingerprint-'));
   const ignoredFile = await createTempIgnoredFileAsync(tmpDir, options);
   try {
-    const { message } = await spawnWithIpcAsync(
-      'node',
-      [getExpoConfigLoaderPath(), path.resolve(projectRoot), ignoredFile],
-      { cwd: projectRoot }
-    );
-    const stdoutJson = JSON.parse(message);
-    result.config = stdoutJson.config;
-    result.loadedModules = stdoutJson.loadedModules;
+    const [
+      { config, loadedModules: modulesWithPlugins },
+      { loadedModules: modulesWithoutPlugins },
+    ] = await Promise.all([
+      spawnConfigLoaderAsync(projectRoot, ignoredFile, /* skipPlugins */ false),
+      spawnConfigLoaderAsync(projectRoot, ignoredFile, /* skipPlugins */ true),
+    ]);
+    result.config = config;
+    result.loadedModules = diffLoadedModules(modulesWithPlugins ?? [], modulesWithoutPlugins ?? []);
   } catch (e: unknown) {
     if (e instanceof Error) {
       console.warn(`Cannot get Expo config from an Expo project - ${e.message}: `, e.stack);
@@ -49,6 +53,48 @@ export async function getExpoConfigAsync(
   }
 
   return result;
+}
+
+async function spawnConfigLoaderAsync(
+  projectRoot: string,
+  ignoredFile: string,
+  skipPlugins: boolean
+): Promise<{ config: ProjectConfig | null; loadedModules: LoadedModuleSource[] | null }> {
+  const args = [getExpoConfigLoaderPath(), path.resolve(projectRoot), ignoredFile];
+  if (skipPlugins) {
+    args.push('--skipPlugins');
+  }
+  const { message } = await spawnWithIpcAsync('node', args, { cwd: projectRoot });
+  return JSON.parse(message);
+}
+
+/**
+ * Keep only the config-plugin modules attributable to applying plugins.
+ *
+ * Anything that also loads when plugins are skipped is the config-loading framework and is dropped.
+ * In-repo files are always kept regardless of the diff, so a local plugin imported at the top of
+ * `app.config` (which loads during config evaluation, not plugin application) is never lost.
+ */
+export function diffLoadedModules(
+  withPlugins: LoadedModuleSource[],
+  withoutPlugins: LoadedModuleSource[]
+): LoadedModuleSource[] {
+  const skippedKeys = new Set(withoutPlugins.map(getLoadedModuleKey));
+  return withPlugins.filter(
+    (source) => isInRepoLoadedModule(source) || !skippedKeys.has(getLoadedModuleKey(source))
+  );
+}
+
+/** Stable identity of a loaded module: its file path, or its id for a virtual module. */
+function getLoadedModuleKey(source: LoadedModuleSource): string {
+  return source.type === 'file' ? source.path : source.id;
+}
+
+/** Whether a loaded module is a project-local file (e.g. a local config plugin) rather than a dependency. */
+function isInRepoLoadedModule(source: LoadedModuleSource): boolean {
+  const key = getLoadedModuleKey(source);
+  // `..` means the path escaped the project root (e.g. a hoisted or linked dependency).
+  return !key.startsWith('..') && !key.includes('node_modules');
 }
 
 /**

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -13,12 +13,14 @@ import { isIgnoredPath, toPosixPath } from './utils/Path';
 
 async function runAsync(programName: string, args: string[] = []) {
   if (args[0] == null) {
-    console.log(`Usage: ${programName} <projectRoot> [ignoredFile]`);
+    console.log(`Usage: ${programName} <projectRoot> [ignoredFile] [--skipPlugins]`);
     return;
   }
 
   const projectRoot = path.resolve(args[0]);
-  const ignoredFile = args[1] ? path.resolve(args[1]) : null;
+  const skipPlugins = args.includes('--skipPlugins');
+  const ignoredFileArg = args[1] && !args[1].startsWith('--') ? args[1] : null;
+  const ignoredFile = ignoredFileArg ? path.resolve(ignoredFileArg) : null;
 
   setNodeEnv('development');
   require('@expo/env').load(projectRoot);
@@ -29,6 +31,7 @@ async function runAsync(programName: string, args: string[] = []) {
     const { getConfig } = require(resolveFrom(path.resolve(projectRoot), 'expo/config'));
     config = await getConfig(projectRoot, {
       skipSDKVersionRequirement: true,
+      skipPlugins,
     });
   } finally {
     uninstall();
@@ -38,7 +41,6 @@ async function runAsync(programName: string, args: string[] = []) {
     ...DEFAULT_CONFIG_LOADING_IGNORE_PATHS,
     ...(await loadIgnoredPathsAsync(ignoredFile)),
   ];
-
   const loadedModules = await resolveLoadedModuleSourcesAsync(
     getCapturedModules(),
     projectRoot,
@@ -46,7 +48,8 @@ async function runAsync(programName: string, args: string[] = []) {
   );
 
   const result = JSON.stringify({
-    config,
+    // The plugins-skipped pass only contributes its module list to the diff; its config is unused.
+    config: skipPlugins ? null : config,
     loadedModules,
   });
 
@@ -208,69 +211,37 @@ function setNodeEnv(mode: 'development' | 'production') {
   globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
 }
 
-// Ignore default javascript files when calling `getConfig()`
+// Ignore known non-native packages loaded while applying config plugins, which the plugins-skipped
+// diff can't drop since they only load during plugin application.
 const DEFAULT_CONFIG_LOADING_IGNORE_PATHS = [
-  // We don't want to include the whole project package.json from the ExpoConfigLoader phase.
-  'package.json',
-
-  '**/node_modules/@babel/**/*',
   '**/node_modules/@expo/**/*',
-  '**/node_modules/@jridgewell/**/*',
-  '**/node_modules/cross-spawn/**/*',
-  '**/node_modules/isexe/**/*',
-  '**/node_modules/shebang-command/**/*',
-  '**/node_modules/shebang-regex/**/*',
-  '**/node_modules/semver/**/*',
-  '**/node_modules/slugify/**/*',
-  '**/node_modules/typescript/**/*',
-  '**/node_modules/expo/config/**/*',
-  '**/node_modules/expo/config.js',
-  '**/node_modules/expo/config-plugins.js',
   `**/node_modules/{${[
-    'ajv',
-    'ajv-formats',
-    'ajv-keywords',
     'ansi-styles',
     'base64-js',
     'big-integer',
     'bplist-creator',
     'chalk',
+    'cross-spawn',
     'debug',
-    'dotenv',
-    'dotenv-expand',
-    'escape-string-regexp',
-    'getenv',
-    'graceful-fs',
-    'fast-deep-equal',
-    'fast-uri',
     'has-flag',
-    'imurmurhash',
+    'isexe',
     'jimp-compact',
-    'js-tokens',
-    'json5',
-    'json-schema-traverse',
     'ms',
     'parse-png',
     'path-key',
-    'picocolors',
     'plist',
     'pngjs',
-    'lines-and-columns',
-    'require-from-string',
-    'resolve-from',
     'sax',
-    'schema-utils',
-    'signal-exit',
+    'semver',
+    'shebang-command',
+    'shebang-regex',
     'simple-plist',
     'stream-buffers',
-    'sucrase',
     'supports-color',
-    'ts-interface-checker',
-    'write-file-atomic',
+    'uuid',
+    'which',
+    'xcode',
     'xml2js',
     'xmlbuilder',
-    'which',
-    'uuid',
-    'xcode',
   ].join(',')}}/**/*`,
 ];

--- a/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
@@ -1,6 +1,7 @@
 import resolveFrom from 'resolve-from';
 
-import { getExpoConfigAsync } from '../ExpoConfig';
+import { getExpoConfigAsync, diffLoadedModules } from '../ExpoConfig';
+import type { LoadedModuleSource } from '../ExpoConfigLoader';
 import { normalizeOptionsAsync } from '../Options';
 
 jest.mock('resolve-from');
@@ -18,5 +19,41 @@ describe(getExpoConfigAsync, () => {
 
     expect(result.config).toBeNull();
     expect(result.loadedModules).toBeNull();
+  });
+});
+
+describe(diffLoadedModules, () => {
+  const file = (p: string): LoadedModuleSource => ({ type: 'file', path: p });
+  const contents = (id: string): LoadedModuleSource => ({ type: 'contents', id, contents: 'x' });
+
+  it('should drop a node_modules module that also loads without plugins', async () => {
+    const full = [file('node_modules/@expo/config-plugins/build/index.js')];
+    const withoutPlugins = [file('node_modules/@expo/config-plugins/build/index.js')];
+    expect(diffLoadedModules(full, withoutPlugins)).toEqual([]);
+  });
+
+  it('should keep a node_modules module that only loads when plugins are applied', async () => {
+    const full = [file('node_modules/expo-router/plugin/build/withRouter.js')];
+    expect(diffLoadedModules(full, [])).toEqual([
+      file('node_modules/expo-router/plugin/build/withRouter.js'),
+    ]);
+  });
+
+  it('should always keep an in-repo file even when it also loads without plugins', async () => {
+    const full = [file('plugins/withLocalPlugin.ts')];
+    const withoutPlugins = [file('plugins/withLocalPlugin.ts')];
+    expect(diffLoadedModules(full, withoutPlugins)).toEqual([file('plugins/withLocalPlugin.ts')]);
+  });
+
+  it('should always keep an in-repo contents (virtual) module', async () => {
+    const full = [contents('plugins/virtual.js')];
+    const withoutPlugins = [contents('plugins/virtual.js')];
+    expect(diffLoadedModules(full, withoutPlugins)).toEqual([contents('plugins/virtual.js')]);
+  });
+
+  it('should treat a linked/hoisted dep (starting with ..) as excludable framework', async () => {
+    const full = [file('../../packages/@expo/config/build/index.js')];
+    const withoutPlugins = [file('../../packages/@expo/config/build/index.js')];
+    expect(diffLoadedModules(full, withoutPlugins)).toEqual([]);
   });
 });

--- a/packages/@expo/fingerprint/src/utils/__mocks__/SpawnIPC.ts
+++ b/packages/@expo/fingerprint/src/utils/__mocks__/SpawnIPC.ts
@@ -12,8 +12,9 @@ export const spawnWithIpcAsync = jest
       // For unit tests, we don't really spawn a process to execute the ExpoConfigLoader because the file system is just a memfs.
       // Rather than that, we just call `getConfig` directly.
       const projectRoot = args[1]!;
-      const config = await getConfig(projectRoot, { skipSDKVersionRequirement: true });
-      const message = JSON.stringify({ config, loadedModules: [] });
+      const skipPlugins = args.includes('--skipPlugins');
+      const config = await getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins });
+      const message = JSON.stringify({ config: skipPlugins ? null : config, loadedModules: [] });
       return {
         message,
       };


### PR DESCRIPTION
# Why

Capturing config-plugin modules relied on a large hand-maintained allowlist (`DEFAULT_CONFIG_LOADING_IGNORE_PATHS`, ~50 packages) to exclude the config-loading framework (Babel, TypeScript, `@expo/config`, …). It drifts every time those dependencies change.

close ENG-18201

# How

Load the config twice in parallel — once fully, once with `skipPlugins` — and keep only the modules that applying plugins added (`B − A`). The framework loads in both passes, so diffing removes it automatically; in-repo files are always kept, so a local plugin imported at the top of `app.config` is never lost. This retires the allowlist. Two separate processes keep each module cache clean, and `Promise.all` makes the second pass ~free in wall-clock time.

# Test Plan

`et check-packages @expo/fingerprint`. Added unit tests for the diff (framework dropped, plugin modules kept, in-repo always kept). Verified end-to-end against `apps/bare-expo`: 138 plugin modules captured, both local plugins kept, framework excluded, ~186 ms for both parallel passes.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Builds, type-checks, lints, and tests via `et check-packages`.
