### PR TITLE
[bare-expo][image] Speed up the expo-image e2e flow with in-process view capture

### DIFF
--- a/apps/bare-expo/e2e/_nested-flows/compare-images-http.js
+++ b/apps/bare-expo/e2e/_nested-flows/compare-images-http.js
@@ -18,6 +18,7 @@ function getParams() {
     platform,
     mode,
     resizingFactor,
+    captureMode,
   };
   /* eslint-enable no-undef */
 }

--- a/apps/bare-expo/e2e/_nested-flows/screenshot-comparison.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/screenshot-comparison.yaml
@@ -24,6 +24,9 @@ appId: dev.expo.Payments
       # Explicitly unset testID and mode to prevent them from persisting from previous flows
       testID: ''
       mode: ''
+      # Same for captureMode, except it must hold a valid value ('' fails the schema) and
+      # full-screen comparisons always capture the screen anyway
+      captureMode: 'screen'
 
 - assertTrue:
     condition: ${output.comparisonResult.success}

--- a/apps/bare-expo/e2e/_nested-flows/viewshot-comparison.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/viewshot-comparison.yaml
@@ -11,6 +11,10 @@
 #            With 'normalize', only one original view shot is kept, and the view shots taken at test time are normalized (if needed) and then compared with the base shot.
 #   - similarityThreshold: The percentage of similarity required to pass the comparison. Defaults to 5 and 15% for the platformDependent and crossPlatform modes, respectively
 #   - resizingFactor: this factor resizes the taken images to occupy less space
+#   - captureMode: 'screen' (default) takes a full-screen screenshot and crops it to the view bounds.
+#                  'in-process' renders the view inside the app via the inspector dylib (iOS only, much
+#                  faster; other platforms fall back to 'screen'). Don't use it for views with video
+#                  playback: video layers render blank in-process.
 
 appId: dev.expo.Payments
 ---
@@ -31,6 +35,7 @@ appId: dev.expo.Payments
       similarityThreshold: ${similarityThreshold}
       mode: ${mode}
       resizingFactor: ${resizingFactor}
+      captureMode: ${captureMode}
 
 - assertTrue:
     condition: ${output.comparisonResult.success}

--- a/apps/bare-expo/e2e/expo-image/test.yaml
+++ b/apps/bare-expo/e2e/expo-image/test.yaml
@@ -9,12 +9,14 @@ jsEngine: graaljs
       screenshotOutputPath: expo-image
       testID: 'header-Appearance'
       mode: 'normalize'
+      captureMode: 'in-process'
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
       screenshotOutputPath: expo-image
       testID: 'image-comparison-list'
       mode: 'keep-originals'
+      captureMode: 'in-process'
 
 - runFlow:
     file: ../_nested-flows/screenshot-comparison.yaml

--- a/apps/bare-expo/e2e/expo-image/test.yaml
+++ b/apps/bare-expo/e2e/expo-image/test.yaml
@@ -1,7 +1,7 @@
 appId: dev.expo.Payments
 jsEngine: graaljs
 ---
-- openLink: bareexpo://components/image/comparison
+- openLink: bareexpo://components/image/comparison-e2e
 
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml

--- a/apps/bare-expo/e2e/image-comparison/inspector/.gitignore
+++ b/apps/bare-expo/e2e/image-comparison/inspector/.gitignore
@@ -1,0 +1,2 @@
+# SwiftPM build and SourceKit index output
+.build/

--- a/apps/bare-expo/e2e/image-comparison/inspector/README.md
+++ b/apps/bare-expo/e2e/image-comparison/inspector/README.md
@@ -1,10 +1,15 @@
 # Screen Inspector for iOS Simulator
 
-A dynamic library (dylib) that enables fast UI element coordinate lookup (compared to `maestro hierarchy`) for iOS Simulator testing.
+A dynamic library (dylib) that enables fast UI element coordinate lookup (compared to `maestro hierarchy`) and in-process view capture for iOS Simulator testing.
 
 ## What it does
 
-This tool injects itself into an iOS Simulator app (with `xcrun simctl launch`) and provides **UI element coordinate lookup** by accessibility ID. Usage of this tool is recommended but optional — the output should be equivalent to processing the output of `maestro hierarchy` but a lot faster (see `findElementByTestID` in `image-comparison/src/viewCropper.ts`). It is also used in CI.
+This tool injects itself into an iOS Simulator app (with `xcrun simctl launch`) and provides two actions, both addressed by accessibility ID:
+
+- **`getCoordinates`** — UI element coordinate lookup. Usage of this tool is recommended but optional — the output should be equivalent to processing the output of `maestro hierarchy` but a lot faster (see `findElementByTestID` in `image-comparison/src/viewCropper.ts`).
+- **`captureView`** — renders the element's window cropped to the element's frame and writes a PNG to the requested path, replacing the full-screen screenshot + crop pipeline for viewshots (see `captureViewShotInProcess` in `image-comparison/src/viewCropper.ts`). Note that video layers render blank this way, so video flows keep the screenshot pipeline.
+
+It is also used in CI.
 
 Injection only works at app launch time. If the app is already running, then you can't make use of this tool. You can run `./ScreenInspectorIOS.ts` to launch the app with the Screen Inspector injected and it'll stay there until terminated. In CI, the Inspector is injected each time the app starts.
 
@@ -45,7 +50,7 @@ Look for `[ScreenInspector]` prefix in logs.
 
 - `Package.swift` - Swift package manifest
 - `src/ScreenInspector.swift` - Main server implementation
-- `src/UICapture.swift` - UI element finding logic
+- `src/UICapture.swift` - UI element finding and view capture logic
 - `src/constructor.c` - C constructor for dylib initialization
 - `scripts/build.sh` - Build script for creating the framework
 - `ScreenInspectorIOS.ts` - TypeScript client for communicating with the dylib

--- a/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
+++ b/apps/bare-expo/e2e/image-comparison/inspector/ScreenInspectorIOS.ts
@@ -4,13 +4,23 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'node:fs';
 import path from 'node:path';
 
-interface CoordinatesRequest {
-  action: 'getCoordinates';
-  accessibilityId: string;
+type InspectorRequestBody =
+  | {
+      action: 'getCoordinates';
+      accessibilityId: string;
+    }
+  | {
+      action: 'captureView';
+      accessibilityId: string;
+      // Path where the inspector writes the captured PNG.
+      outputPath: string;
+    };
+
+type InspectorRequest = InspectorRequestBody & {
   // Unique response pipe created by the client for this request, so that a response can never
   // pair with another request's reader; see resolveResponsePipePath in ScreenInspector.swift.
   responsePipe: string;
-}
+};
 
 let nextRequestId = 0;
 
@@ -22,6 +32,9 @@ interface InspectorResponse {
     width: number;
     height: number;
   };
+  path?: string;
+  width?: number;
+  height?: number;
   error: string;
 }
 
@@ -52,12 +65,55 @@ export class ScreenInspectorIOS {
     width: number;
     height: number;
   }> {
+    const response = await this.sendRequest(
+      {
+        action: 'getCoordinates',
+        accessibilityId,
+      },
+      timeoutMs
+    );
+
+    if (!response.success) {
+      throw new Error(`Get coordinates failed: ${response.error}`);
+    }
+
+    if (!response.bounds) {
+      throw new Error('No bounds returned in response');
+    }
+
+    return response.bounds;
+  }
+
+  async captureView(
+    accessibilityId: string,
+    outputPath: string,
+    timeoutMs: number = 15000
+  ): Promise<string> {
+    const response = await this.sendRequest(
+      {
+        action: 'captureView',
+        accessibilityId,
+        outputPath,
+      },
+      timeoutMs
+    );
+
+    if (!response.success) {
+      throw new Error(`Capture view failed: ${response.error}`);
+    }
+
+    if (!response.path) {
+      throw new Error('No output path returned in response');
+    }
+
+    return response.path;
+  }
+
+  private async sendRequest(
+    request: InspectorRequestBody,
+    timeoutMs: number
+  ): Promise<InspectorResponse> {
     const responsePipePath = `${this.responsePipePath}_${process.pid}_${nextRequestId++}`;
-    const request: CoordinatesRequest = {
-      action: 'getCoordinates',
-      accessibilityId,
-      responsePipe: responsePipePath,
-    };
 
     await spawnAsync('mkfifo', [responsePipePath]);
     let responseFd: number | null = null;
@@ -67,21 +123,14 @@ export class ScreenInspectorIOS {
       // abandoned request leaks nothing.
       responseFd = fs.openSync(responsePipePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
 
-      await this.writeToNamedPipe(this.requestPipePath, request);
+      await this.writeToNamedPipe(this.requestPipePath, {
+        ...request,
+        responsePipe: responsePipePath,
+      });
 
-      const response = await this.pollResponse(responseFd, timeoutMs);
-
-      if (!response.success) {
-        throw new Error(`Get coordinates failed: ${response.error}`);
-      }
-
-      if (!response.bounds) {
-        throw new Error('No bounds returned in response');
-      }
-
-      return response.bounds;
+      return await this.pollResponse(responseFd, timeoutMs);
     } catch (error: any) {
-      console.error('❌ iOS get coordinates failed:', error.message);
+      console.error(`❌ iOS ${request.action} request failed:`, error.message);
       throw error;
     } finally {
       if (responseFd != null) {
@@ -93,7 +142,7 @@ export class ScreenInspectorIOS {
 
   private async writeToNamedPipe(
     pipePath: string,
-    request: CoordinatesRequest,
+    request: InspectorRequest,
     timeoutMs: number = 10000
   ): Promise<void> {
     const buffer = Buffer.from(JSON.stringify(request), 'utf8');

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -191,28 +191,25 @@ private func log(_ message: String) {
 
     switch action {
     case "getCoordinates":
-      return getElementCoordinates(accessibilityId: accessibilityId)
+      return runOnMainActor {
+        return self.getElementCoordinates(accessibilityId: accessibilityId)
+      }
 
     case "captureView":
       guard let outputPath = json["outputPath"] as? String else {
         return createErrorResponse("Missing 'outputPath' for captureView")
       }
-      return captureView(accessibilityId: accessibilityId, outputPath: outputPath)
+      return runOnMainActor {
+        return self.captureView(accessibilityId: accessibilityId, outputPath: outputPath)
+      }
 
     default:
       return createErrorResponse("Unknown action: \(action)")
     }
   }
 
+  @MainActor
   private func getElementCoordinates(accessibilityId: String) -> Data {
-    guard Thread.isMainThread else {
-      var result: Data!
-      DispatchQueue.main.sync {
-        result = getElementCoordinates(accessibilityId: accessibilityId)
-      }
-      return result
-    }
-
     guard let element = self.findElementByAccessibilityId(accessibilityId) else {
       return createErrorResponse("Element with accessibilityId '\(accessibilityId)' not found")
     }

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -7,242 +7,244 @@ private let LOG_TAG = "ScreenInspector"
 
 // Helper to log with proper string conversion
 private func log(_ message: String) {
-    logger.log("[\(LOG_TAG)] \(message)")
+  logger.log("[\(LOG_TAG)] \(message)")
 }
 
 @objc public class ScreenInspector: NSObject {
-    private var isRunning = false
-    private var serverQueue: DispatchQueue
-    private let requestPipePath = "/tmp/ios_screen_inspector_request"
-    private let responsePipePath = "/tmp/ios_screen_inspector_response"
+  private var isRunning = false
+  private var serverQueue: DispatchQueue
+  private let requestPipePath = "/tmp/ios_screen_inspector_request"
+  private let responsePipePath = "/tmp/ios_screen_inspector_response"
 
-    public override init() {
-        self.serverQueue = DispatchQueue(label: "screenInspector.server", qos: .userInitiated)
-        super.init()
+  public override init() {
+    self.serverQueue = DispatchQueue(label: "screenInspector.server", qos: .userInitiated)
+    super.init()
+  }
+
+  @objc public func start() {
+    guard !isRunning else {
+      log("Server already running")
+      return
+    }
+    isRunning = true
+
+    log("Starting screenInspector server...")
+
+    createPipes()
+
+    // Start server in background thread using lower-level threading
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      self?.runServer()
     }
 
-    @objc public func start() {
-        guard !isRunning else {
-            log("Server already running")
-            return
-        }
-        isRunning = true
+    log("server started successfully")
+  }
 
-        log("Starting screenInspector server...")
+  @objc public func stop() {
+    isRunning = false
+    // Clean up pipes
+    unlink(requestPipePath)
+    unlink(responsePipePath)
+  }
 
-        createPipes()
+  private func createPipes() {
+    log("Creating named pipes...")
 
-        // Start server in background thread using lower-level threading
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            self?.runServer()
-        }
+    // Remove existing pipes
+    unlink(requestPipePath)
+    unlink(responsePipePath)
 
-        log("server started successfully")
+    // Create new pipes with more permissive permissions
+    let requestResult = mkfifo(requestPipePath, 0o777)
+    let responseResult = mkfifo(responsePipePath, 0o777)
+
+    if requestResult != 0 {
+      let error = errno
+      log("Failed to create request pipe, errno: \(error)")
+    } else {
+      log("Created request pipe successfully")
     }
 
-    @objc public func stop() {
-        isRunning = false
-        // Clean up pipes
-        unlink(requestPipePath)
-        unlink(responsePipePath)
+    if responseResult != 0 {
+      let error = errno
+      log("Failed to create response pipe, errno: \(error)")
+    } else {
+      log("Created response pipe successfully")
     }
 
-    private func createPipes() {
-        log("Creating named pipes...")
+    // Verify pipes exist on filesystem
+    let requestExists = access(requestPipePath, F_OK) == 0
+    let responseExists = access(responsePipePath, F_OK) == 0
+    log("Request pipe exists on filesystem: \(requestExists)")
+    log("Response pipe exists on filesystem: \(responseExists)")
+  }
 
-        // Remove existing pipes
-        unlink(requestPipePath)
-        unlink(responsePipePath)
+  private func runServer() {
+    log("Server loop started, waiting for requests...")
 
-        // Create new pipes with more permissive permissions
-        let requestResult = mkfifo(requestPipePath, 0o777)
-        let responseResult = mkfifo(responsePipePath, 0o777)
+    while isRunning {
+      // Open request pipe - blocks until a writer connects
+      log("Opening request pipe...")
+      let requestFd = open(requestPipePath, O_RDONLY)
+      guard requestFd != -1 else {
+        let error = errno
+        log("Failed to open request pipe, errno: \(error)")
+        usleep(100000)  // Wait before retrying
+        continue
+      }
 
-        if requestResult != 0 {
-            let error = errno
-            log("Failed to create request pipe, errno: \(error)")
-        } else {
-            log("Created request pipe successfully")
-        }
+      log("Request pipe opened, reading request...")
 
-        if responseResult != 0 {
-            let error = errno
-            log("Failed to create response pipe, errno: \(error)")
-        } else {
-            log("Created response pipe successfully")
-        }
+      // Read request - blocks until data arrives
+      guard let requestData = readFromPipe(fd: requestFd) else {
+        log("Read failed or EOF, closing pipe")
+        close(requestFd)
+        continue
+      }
 
-        // Verify pipes exist on filesystem
-        let requestExists = access(requestPipePath, F_OK) == 0
-        let responseExists = access(responsePipePath, F_OK) == 0
-        log("Request pipe exists on filesystem: \(requestExists)")
-        log("Response pipe exists on filesystem: \(responseExists)")
+      close(requestFd)
+
+      log("Received request: \(String(data: requestData, encoding: .utf8) ?? "invalid UTF8")")
+
+      let response = processRequest(requestData)
+      writeToPipe(resolveResponsePipePath(requestData), data: response)
+
+      log("Sent response, ready for next request")
     }
 
-    private func runServer() {
-        log("Server loop started, waiting for requests...")
+    log("Server loop ended")
+  }
 
-        while isRunning {
-            // Open request pipe - blocks until a writer connects
-            log("Opening request pipe...")
-            let requestFd = open(requestPipePath, O_RDONLY)
-            guard requestFd != -1 else {
-                let error = errno
-                log("Failed to open request pipe, errno: \(error)")
-                usleep(100000) // Wait before retrying
-                continue
-            }
+  private func readFromPipe(fd: Int32) -> Data? {
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    let bytesRead = read(fd, &buffer, buffer.count)
 
-            log("Request pipe opened, reading request...")
-
-            // Read request - blocks until data arrives
-            guard let requestData = readFromPipe(fd: requestFd) else {
-                log("Read failed or EOF, closing pipe")
-                close(requestFd)
-                continue
-            }
-
-            close(requestFd)
-
-            log("Received request: \(String(data: requestData, encoding: .utf8) ?? "invalid UTF8")")
-
-            let response = processRequest(requestData)
-            writeToPipe(resolveResponsePipePath(requestData), data: response)
-
-            log("Sent response, ready for next request")
-        }
-
-        log("Server loop ended")
+    guard bytesRead > 0 else {
+      if bytesRead == 0 {
+        log("EOF on pipe")
+      } else {
+        let error = errno
+        log("Read error, errno: \(error)")
+      }
+      return nil
     }
 
-    private func readFromPipe(fd: Int32) -> Data? {
-        var buffer = [UInt8](repeating: 0, count: 4096)
-        let bytesRead = read(fd, &buffer, buffer.count)
+    log("Read \(bytesRead) bytes from pipe")
+    return Data(buffer.prefix(bytesRead))
+  }
 
-        guard bytesRead > 0 else {
-            if bytesRead == 0 {
-                log("EOF on pipe")
-            } else {
-                let error = errno
-                log("Read error, errno: \(error)")
-            }
-            return nil
+  private func resolveResponsePipePath(_ requestData: Data) -> String {
+    // Clients create a unique response pipe per request and pass its path along, so that a
+    // response can never pair with another request's reader (a shared response pipe gets
+    // permanently desynced once a single client times out and abandons its request).
+    // Requests without the field fall back to the shared legacy pipe.
+    guard let json = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any],
+      let responsePipe = json["responsePipe"] as? String,
+      responsePipe.hasPrefix("/tmp/ios_screen_inspector_response")
+    else {
+      return responsePipePath
+    }
+    return responsePipe
+  }
+
+  private func writeToPipe(_ path: String, data: Data) {
+    log("Attempting to open pipe for writing")
+
+    // The client may have timed out and abandoned this request, in which case no reader
+    // ever opens the other end and a plain blocking open would wedge the server thread
+    // forever, killing the inspector for the rest of the app's lifetime. Poll with
+    // O_NONBLOCK (which fails with ENXIO while there is no reader) and drop the response
+    // if no reader shows up in time; the server then moves on to the next request.
+    let deadline = Date().addingTimeInterval(5)
+    var fd: Int32 = -1
+    while fd == -1 {
+      fd = open(path, O_WRONLY | O_NONBLOCK)
+      if fd == -1 {
+        let openError = errno
+        if openError != ENXIO || Date() >= deadline {
+          log("Failed to open pipe for writing, errno: \(openError); dropping response")
+          return
         }
-
-        log("Read \(bytesRead) bytes from pipe")
-        return Data(buffer.prefix(bytesRead))
+        usleep(50_000)
+      }
     }
 
-    private func resolveResponsePipePath(_ requestData: Data) -> String {
-        // Clients create a unique response pipe per request and pass its path along, so that a
-        // response can never pair with another request's reader (a shared response pipe gets
-        // permanently desynced once a single client times out and abandons its request).
-        // Requests without the field fall back to the shared legacy pipe.
-        guard let json = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any],
-              let responsePipe = json["responsePipe"] as? String,
-              responsePipe.hasPrefix("/tmp/ios_screen_inspector_response") else {
-            return responsePipePath
-        }
-        return responsePipe
+    log("Pipe opened for writing, sending \(data.count) bytes")
+    defer {
+      close(fd)
+      log("Write pipe closed")
     }
 
-    private func writeToPipe(_ path: String, data: Data) {
-        log("Attempting to open pipe for writing")
+    data.withUnsafeBytes { bytes in
+      let written = write(fd, bytes.bindMemory(to: UInt8.self).baseAddress, data.count)
+      log("Wrote \(written) bytes to pipe")
+    }
+  }
 
-        // The client may have timed out and abandoned this request, in which case no reader
-        // ever opens the other end and a plain blocking open would wedge the server thread
-        // forever, killing the inspector for the rest of the app's lifetime. Poll with
-        // O_NONBLOCK (which fails with ENXIO while there is no reader) and drop the response
-        // if no reader shows up in time; the server then moves on to the next request.
-        let deadline = Date().addingTimeInterval(5)
-        var fd: Int32 = -1
-        while fd == -1 {
-            fd = open(path, O_WRONLY | O_NONBLOCK)
-            if fd == -1 {
-                let openError = errno
-                if openError != ENXIO || Date() >= deadline {
-                    log("Failed to open pipe for writing, errno: \(openError); dropping response")
-                    return
-                }
-                usleep(50_000)
-            }
-        }
-
-        log("Pipe opened for writing, sending \(data.count) bytes")
-        defer {
-            close(fd)
-            log("Write pipe closed")
-        }
-
-        data.withUnsafeBytes { bytes in
-            let written = write(fd, bytes.bindMemory(to: UInt8.self).baseAddress, data.count)
-            log("Wrote \(written) bytes to pipe")
-        }
+  private func processRequest(_ requestData: Data) -> Data {
+    guard let json = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any],
+      let action = json["action"] as? String,
+      let accessibilityId = json["accessibilityId"] as? String
+    else {
+      return createErrorResponse("Invalid request format")
     }
 
-    private func processRequest(_ requestData: Data) -> Data {
-        guard let json = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any],
-              let action = json["action"] as? String,
-              let accessibilityId = json["accessibilityId"] as? String else {
-            return createErrorResponse("Invalid request format")
-        }
+    switch action {
+    case "getCoordinates":
+      return getElementCoordinates(accessibilityId: accessibilityId)
 
-        switch action {
-        case "getCoordinates":
-            return getElementCoordinates(accessibilityId: accessibilityId)
+    default:
+      return createErrorResponse("Unknown action: \(action)")
+    }
+  }
 
-        default:
-            return createErrorResponse("Unknown action: \(action)")
-        }
+  private func getElementCoordinates(accessibilityId: String) -> Data {
+    guard Thread.isMainThread else {
+      var result: Data!
+      DispatchQueue.main.sync {
+        result = getElementCoordinates(accessibilityId: accessibilityId)
+      }
+      return result
     }
 
-    private func getElementCoordinates(accessibilityId: String) -> Data {
-        guard Thread.isMainThread else {
-            var result: Data!
-            DispatchQueue.main.sync {
-                result = getElementCoordinates(accessibilityId: accessibilityId)
-            }
-            return result
-        }
-
-        guard let element = self.findElementByAccessibilityId(accessibilityId) else {
-            return createErrorResponse("Element with accessibilityId '\(accessibilityId)' not found")
-        }
-
-        // Convert element bounds to window coordinates (**visible portion only!**)
-        let frameInWindow = element.convert(element.bounds, to: nil)
-
-        let response: [String: Any] = [
-            "success": true,
-            "description": element.description,
-            "bounds": [
-                "x": Int(frameInWindow.origin.x),
-                "y": Int(frameInWindow.origin.y),
-                "width": Int(frameInWindow.size.width),
-                "height": Int(frameInWindow.size.height),
-            ],
-            "error": ""
-        ]
-
-        do {
-            return try JSONSerialization.data(withJSONObject: response, options: [])
-        } catch {
-            return createErrorResponse("Failed to serialize coordinates: \(error.localizedDescription)")
-        }
+    guard let element = self.findElementByAccessibilityId(accessibilityId) else {
+      return createErrorResponse("Element with accessibilityId '\(accessibilityId)' not found")
     }
 
-    private func createErrorResponse(_ message: String) -> Data {
-        let response: [String: Any] = [
-            "success": false,
-            "error": message
-        ]
+    // Convert element bounds to window coordinates (**visible portion only!**)
+    let frameInWindow = element.convert(element.bounds, to: nil)
 
-        do {
-            return try JSONSerialization.data(withJSONObject: response, options: [])
-        } catch {
-            return Data("{\"success\": false, \"error\": \"JSON serialization failed\"}".utf8)
-        }
+    let response: [String: Any] = [
+      "success": true,
+      "description": element.description,
+      "bounds": [
+        "x": Int(frameInWindow.origin.x),
+        "y": Int(frameInWindow.origin.y),
+        "width": Int(frameInWindow.size.width),
+        "height": Int(frameInWindow.size.height),
+      ],
+      "error": "",
+    ]
+
+    do {
+      return try JSONSerialization.data(withJSONObject: response, options: [])
+    } catch {
+      return createErrorResponse("Failed to serialize coordinates: \(error.localizedDescription)")
     }
+  }
+
+  private func createErrorResponse(_ message: String) -> Data {
+    let response: [String: Any] = [
+      "success": false,
+      "error": message,
+    ]
+
+    do {
+      return try JSONSerialization.data(withJSONObject: response, options: [])
+    } catch {
+      return Data("{\"success\": false, \"error\": \"JSON serialization failed\"}".utf8)
+    }
+  }
 }
 
 private let screenInspector = ScreenInspector()
@@ -250,5 +252,5 @@ private let screenInspector = ScreenInspector()
 // Declare C function
 @_cdecl("screen_inspector_dylib_init")
 public func screen_inspector_dylib_init() {
-    screenInspector.start()
+  screenInspector.start()
 }

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -193,6 +193,12 @@ private func log(_ message: String) {
     case "getCoordinates":
       return getElementCoordinates(accessibilityId: accessibilityId)
 
+    case "captureView":
+      guard let outputPath = json["outputPath"] as? String else {
+        return createErrorResponse("Missing 'outputPath' for captureView")
+      }
+      return captureView(accessibilityId: accessibilityId, outputPath: outputPath)
+
     default:
       return createErrorResponse("Unknown action: \(action)")
     }
@@ -233,7 +239,7 @@ private func log(_ message: String) {
     }
   }
 
-  private func createErrorResponse(_ message: String) -> Data {
+  func createErrorResponse(_ message: String) -> Data {
     let response: [String: Any] = [
       "success": false,
       "error": message,

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -2,27 +2,27 @@ import UIKit
 
 extension ScreenInspector {
 
-    func findElementByAccessibilityId(_ accessibilityId: String) -> UIView? {
-        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else {
-            return nil
-        }
-
-        return findElementRecursively(in: window, accessibilityId: accessibilityId)
+  func findElementByAccessibilityId(_ accessibilityId: String) -> UIView? {
+    guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else {
+      return nil
     }
 
-    private func findElementRecursively(in view: UIView, accessibilityId: String) -> UIView? {
-        // Check current view
-        if view.accessibilityIdentifier == accessibilityId {
-            return view
-        }
+    return findElementRecursively(in: window, accessibilityId: accessibilityId)
+  }
 
-        // Search subviews
-        for subview in view.subviews {
-            if let found = findElementRecursively(in: subview, accessibilityId: accessibilityId) {
-                return found
-            }
-        }
-
-        return nil
+  private func findElementRecursively(in view: UIView, accessibilityId: String) -> UIView? {
+    // Check current view
+    if view.accessibilityIdentifier == accessibilityId {
+      return view
     }
+
+    // Search subviews
+    for subview in view.subviews {
+      if let found = findElementRecursively(in: subview, accessibilityId: accessibilityId) {
+        return found
+      }
+    }
+
+    return nil
+  }
 }

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -42,8 +42,15 @@ extension ScreenInspector {
         "Element with accessibilityId '\(accessibilityId)' has a zero-sized frame; is it laid out and visible?")
     }
     let renderer = UIGraphicsImageRenderer(bounds: frameInWindow)
+    var didDraw = false
     let image = renderer.image { _ in
-      window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+      didDraw = window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+    }
+
+    guard didDraw else {
+      // Failing here beats returning the blank or stale image the renderer produced,
+      // which would only surface much later as an opaque image-diff mismatch.
+      return createErrorResponse("drawHierarchy failed for accessibilityId '\(accessibilityId)'")
     }
 
     guard let pngData = image.pngData() else {

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -39,6 +39,10 @@ extension ScreenInspector {
     // screenshot cropped to the view bounds shows. UIGraphicsImageRenderer defaults to the
     // screen scale, so the PNG comes out at the same pixel density as that crop too.
     let frameInWindow = element.convert(element.bounds, to: window)
+    guard !frameInWindow.isEmpty else {
+      return createErrorResponse(
+        "Element with accessibilityId '\(accessibilityId)' has a zero-sized frame; is it laid out and visible?")
+    }
     let renderer = UIGraphicsImageRenderer(bounds: frameInWindow)
     let image = renderer.image { _ in
       window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -1,7 +1,21 @@
 import UIKit
 
+/// Runs the body isolated to the main actor and blocks the calling thread until it returns.
+/// The pipe server runs on a plain blocking thread, so it cannot `await` a main-actor hop;
+/// a synchronous dispatch to the main queue is the bridge (the main queue is the main
+/// actor's executor, so `assumeIsolated` is sound in both branches).
+func runOnMainActor<T>(_ body: @MainActor () -> T) -> T {
+  if Thread.isMainThread {
+    return MainActor.assumeIsolated(body)
+  }
+  return DispatchQueue.main.sync {
+    return MainActor.assumeIsolated(body)
+  }
+}
+
 extension ScreenInspector {
 
+  @MainActor
   func findElementByAccessibilityId(_ accessibilityId: String) -> UIView? {
     guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else {
       return nil
@@ -10,15 +24,8 @@ extension ScreenInspector {
     return findElementRecursively(in: window, accessibilityId: accessibilityId)
   }
 
+  @MainActor
   func captureView(accessibilityId: String, outputPath: String) -> Data {
-    guard Thread.isMainThread else {
-      var result: Data!
-      DispatchQueue.main.sync {
-        result = captureView(accessibilityId: accessibilityId, outputPath: outputPath)
-      }
-      return result
-    }
-
     guard let element = findElementByAccessibilityId(accessibilityId) else {
       return createErrorResponse("Element with accessibilityId '\(accessibilityId)' not found")
     }
@@ -62,6 +69,7 @@ extension ScreenInspector {
     }
   }
 
+  @MainActor
   private func findElementRecursively(in view: UIView, accessibilityId: String) -> UIView? {
     // Check current view
     if view.accessibilityIdentifier == accessibilityId {

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -10,6 +10,58 @@ extension ScreenInspector {
     return findElementRecursively(in: window, accessibilityId: accessibilityId)
   }
 
+  func captureView(accessibilityId: String, outputPath: String) -> Data {
+    guard Thread.isMainThread else {
+      var result: Data!
+      DispatchQueue.main.sync {
+        result = captureView(accessibilityId: accessibilityId, outputPath: outputPath)
+      }
+      return result
+    }
+
+    guard let element = findElementByAccessibilityId(accessibilityId) else {
+      return createErrorResponse("Element with accessibilityId '\(accessibilityId)' not found")
+    }
+    guard let window = element.window else {
+      return createErrorResponse("Element with accessibilityId '\(accessibilityId)' is not attached to a window")
+    }
+
+    // Render the whole window and let the renderer bounds crop to the element's frame:
+    // rendering the element alone would lose whatever the screen composites behind or over
+    // it (transparent backgrounds turn blank), while this matches what a full-screen
+    // screenshot cropped to the view bounds shows. UIGraphicsImageRenderer defaults to the
+    // screen scale, so the PNG comes out at the same pixel density as that crop too.
+    let frameInWindow = element.convert(element.bounds, to: window)
+    let renderer = UIGraphicsImageRenderer(bounds: frameInWindow)
+    let image = renderer.image { _ in
+      window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+    }
+
+    guard let pngData = image.pngData() else {
+      return createErrorResponse("Failed to encode the captured view as PNG")
+    }
+
+    do {
+      try pngData.write(to: URL(fileURLWithPath: outputPath))
+    } catch {
+      return createErrorResponse("Failed to write the captured PNG to '\(outputPath)': \(error.localizedDescription)")
+    }
+
+    let response: [String: Any] = [
+      "success": true,
+      "path": outputPath,
+      "width": Int(image.size.width * image.scale),
+      "height": Int(image.size.height * image.scale),
+      "error": "",
+    ]
+
+    do {
+      return try JSONSerialization.data(withJSONObject: response, options: [])
+    } catch {
+      return createErrorResponse("Failed to serialize capture response: \(error.localizedDescription)")
+    }
+  }
+
   private func findElementRecursively(in view: UIView, accessibilityId: String) -> UIView? {
     // Check current view
     if view.accessibilityIdentifier == accessibilityId {

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/UICapture.swift
@@ -33,11 +33,9 @@ extension ScreenInspector {
       return createErrorResponse("Element with accessibilityId '\(accessibilityId)' is not attached to a window")
     }
 
-    // Render the whole window and let the renderer bounds crop to the element's frame:
-    // rendering the element alone would lose whatever the screen composites behind or over
-    // it (transparent backgrounds turn blank), while this matches what a full-screen
-    // screenshot cropped to the view bounds shows. UIGraphicsImageRenderer defaults to the
-    // screen scale, so the PNG comes out at the same pixel density as that crop too.
+    // Render the whole window cropped to the element's frame: an element-only render loses
+    // whatever the screen composites behind or over it (transparent backgrounds turn blank).
+    // The renderer defaults to the screen scale, so this matches a cropped screenshot.
     let frameInWindow = element.convert(element.bounds, to: window)
     guard !frameInWindow.isEmpty else {
       return createErrorResponse(

--- a/apps/bare-expo/e2e/image-comparison/src/resizeImage.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/resizeImage.ts
@@ -10,5 +10,5 @@ export async function resizeImage(imagePath: string, resizingFactor: number): Pr
   const newHeight = Math.round(image.bitmap.height * resizingFactor);
 
   const resizedImage = image.resize(newWidth, newHeight);
-  await resizedImage.write(imagePath);
+  await resizedImage.writeAsync(imagePath);
 }

--- a/apps/bare-expo/e2e/image-comparison/src/schema.test.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/schema.test.ts
@@ -16,7 +16,7 @@ describe('Zod schema validation', () => {
   it('should validate data with testID and mode', () => {
     const parsedBody = schema.parse(testData);
 
-    expect(parsedBody).toEqual({ ...testData, resizingFactor: 0.5 });
+    expect(parsedBody).toEqual({ ...testData, resizingFactor: 0.5, captureMode: 'screen' });
 
     expect(
       schema.parse({
@@ -39,6 +39,7 @@ describe('Zod schema validation', () => {
       resizingFactor: 0.5,
       similarityThreshold: 0.05,
       testID: undefined,
+      captureMode: 'screen',
     });
   });
 
@@ -77,6 +78,62 @@ describe('Zod schema validation', () => {
     });
 
     expect(result.similarityThreshold).toBe(0.15);
+  });
+
+  it('should default captureMode to screen', () => {
+    const result = schema.parse({
+      baseImage: 'expo-image/test.base.png',
+      currentScreenshot: 'expo-image/test.png',
+      diffOutputPath: '~/.maestro/tests/expo-image/test.diff.png',
+      platform: 'ios' as const,
+      mode: 'keep-originals' as const,
+      testID: 'test-id',
+    });
+
+    expect('captureMode' in result && result.captureMode).toBe('screen');
+  });
+
+  it('should treat the undefined string as the default captureMode', () => {
+    const result = schema.parse({
+      baseImage: 'expo-image/test.base.png',
+      currentScreenshot: 'expo-image/test.png',
+      diffOutputPath: '~/.maestro/tests/expo-image/test.diff.png',
+      platform: 'ios' as const,
+      mode: 'keep-originals' as const,
+      testID: 'test-id',
+      // maestro passes undefined env values as the 'undefined' string
+      captureMode: 'undefined',
+    });
+
+    expect('captureMode' in result && result.captureMode).toBe('screen');
+  });
+
+  it('should accept the in-process captureMode', () => {
+    const result = schema.parse({
+      baseImage: 'expo-image/test.base.png',
+      currentScreenshot: 'expo-image/test.png',
+      diffOutputPath: '~/.maestro/tests/expo-image/test.diff.png',
+      platform: 'ios' as const,
+      mode: 'keep-originals' as const,
+      testID: 'test-id',
+      captureMode: 'in-process',
+    });
+
+    expect('captureMode' in result && result.captureMode).toBe('in-process');
+  });
+
+  it('should reject an unknown captureMode', () => {
+    expect(() =>
+      schema.parse({
+        baseImage: 'expo-image/test.base.png',
+        currentScreenshot: 'expo-image/test.png',
+        diffOutputPath: '~/.maestro/tests/expo-image/test.diff.png',
+        platform: 'ios' as const,
+        mode: 'keep-originals' as const,
+        testID: 'test-id',
+        captureMode: 'out-of-process',
+      })
+    ).toThrow();
   });
 
   it('should allow explicit similarityThreshold to override default', () => {

--- a/apps/bare-expo/e2e/image-comparison/src/schema.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/schema.ts
@@ -10,6 +10,12 @@ const undefinableString = z
   .transform((val) => (val === 'undefined' ? undefined : val))
   .pipe(z.string().nonempty().optional());
 
+// 'in-process' renders the view inside the app via the inspector dylib (iOS only; other
+// platforms fall back to 'screen'), 'screen' takes a full-screen screenshot and crops it.
+const undefinableCaptureMode = z
+  .transform((val) => (val === 'undefined' ? undefined : val))
+  .pipe(z.enum(['in-process', 'screen']).default('screen'));
+
 const screenshotSchema = z.object({
   baseImage: z.string().nonempty(),
   currentScreenshot: z.string().nonempty(),
@@ -17,6 +23,7 @@ const screenshotSchema = z.object({
   similarityThreshold: undefinablePercentage(0).default(-1), // default to make TS happy, overridden later
   platform: z.enum(['ios', 'android']),
   resizingFactor: undefinablePercentage(0.1).default(0.5),
+  captureMode: undefinableCaptureMode,
 });
 
 const viewShotSchema = screenshotSchema.and(

--- a/apps/bare-expo/e2e/image-comparison/src/server.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/server.ts
@@ -7,7 +7,7 @@ import { transformPaths } from './pathUtils';
 import { resizeImage } from './resizeImage';
 import { schema } from './schema';
 import { takeScreenshot } from './takeScreenshot';
-import { cropViewByTestID } from './viewCropper';
+import { captureViewShotInProcess, cropViewByTestID } from './viewCropper';
 
 const PORT = process.env.PORT || 7123;
 const e2eDir = path.resolve(path.join(__dirname, '..', '..'));
@@ -24,7 +24,7 @@ Bun.serve({
         const parsedBody = schema.parse(bodyJson);
         const isNormalizationMode = 'mode' in parsedBody && parsedBody.mode === 'normalize';
 
-        const { similarityThreshold, platform, resizingFactor } = parsedBody;
+        const { similarityThreshold, platform, resizingFactor, captureMode } = parsedBody;
 
         const testID = 'testID' in parsedBody ? parsedBody.testID : undefined;
 
@@ -37,32 +37,51 @@ Bun.serve({
           currentScreenshotArtifactPath,
         } = transformPaths(e2eDir, parsedBody);
 
-        await takeScreenshot({
-          platform,
-          outputFilePath: currentScreenshotPath,
-        });
         await fs.promises.mkdir(path.dirname(currentScreenshotArtifactPath), { recursive: true });
 
         if (testID && viewShotOutputPath) {
-          // TODO get scale factor from simctl
-          const displayScaleFactor = platform === 'android' ? 1 : 3;
-          await cropViewByTestID({
-            testID,
-            currentScreenshotPath,
-            viewShotPath: viewShotOutputPath,
-            platform,
-            displayScaleFactor,
-            resizingFactor,
-          });
-          // we don't care about the full screenshot when taking view shots
-          console.log(
-            `deleting full screenshot: ${currentScreenshotPath} because we have a view shot`
-          );
-          await fs.promises.rm(currentScreenshotPath, { force: true });
+          if (captureMode === 'in-process' && platform === 'ios') {
+            // The inspector dylib renders the view at its exact bounds inside the app, so
+            // there is no full-screen screenshot to take and nothing to crop.
+            await captureViewShotInProcess({
+              testID,
+              viewShotPath: viewShotOutputPath,
+              resizingFactor,
+            });
+          } else {
+            if (captureMode === 'in-process') {
+              console.log(
+                `in-process capture is only available on iOS; falling back to screen capture on ${platform}`
+              );
+            }
+            await takeScreenshot({
+              platform,
+              outputFilePath: currentScreenshotPath,
+            });
+            // TODO get scale factor from simctl
+            const displayScaleFactor = platform === 'android' ? 1 : 3;
+            await cropViewByTestID({
+              testID,
+              currentScreenshotPath,
+              viewShotPath: viewShotOutputPath,
+              platform,
+              displayScaleFactor,
+              resizingFactor,
+            });
+            // we don't care about the full screenshot when taking view shots
+            console.log(
+              `deleting full screenshot: ${currentScreenshotPath} because we have a view shot`
+            );
+            await fs.promises.rm(currentScreenshotPath, { force: true });
+          }
 
           await fs.promises.copyFile(viewShotOutputPath, currentScreenshotArtifactPath);
           console.log(`View shot copied to artifact: ${currentScreenshotArtifactPath}`);
         } else {
+          await takeScreenshot({
+            platform,
+            outputFilePath: currentScreenshotPath,
+          });
           await resizeImage(currentScreenshotPath, resizingFactor);
 
           await fs.promises.copyFile(currentScreenshotPath, currentScreenshotArtifactPath);

--- a/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
@@ -212,6 +212,46 @@ async function cropImageAsync({
   console.log('wrote cropped image to', outputPath);
 }
 
+export async function captureViewShotInProcess({
+  testID,
+  viewShotPath,
+  resizingFactor,
+  // The capture renders the view on the app's main thread, which can be busy for a few
+  // seconds on animation-heavy screens; a too-tight timeout abandons requests that would
+  // have succeeded.
+  timeoutMs = 10000,
+}: {
+  testID: string;
+  viewShotPath: string;
+  resizingFactor: number;
+  timeoutMs?: number;
+}): Promise<{ viewShotPath: string }> {
+  const screenInspectorIOS = new ScreenInspectorIOS();
+
+  const label = `Duration of capturing "${testID}" testID in-process via dylib`;
+  console.time(label);
+
+  await Promise.race([
+    screenInspectorIOS.captureView(testID, viewShotPath),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Dylib timeout')), timeoutMs)
+    ),
+  ]);
+  console.timeEnd(label);
+
+  // The dylib writes the view at its exact bounds, so only resizing is left to do here.
+  if (resizingFactor !== 1) {
+    const image = await Jimp.read(viewShotPath);
+    const newWidth = Math.round(image.bitmap.width * resizingFactor);
+    const newHeight = Math.round(image.bitmap.height * resizingFactor);
+    await image.resize(newWidth, newHeight).writeAsync(viewShotPath);
+  }
+
+  return {
+    viewShotPath,
+  };
+}
+
 export async function cropViewByTestID({
   testID,
   currentScreenshotPath,

--- a/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
@@ -3,6 +3,7 @@ import Jimp from 'jimp-compact';
 
 import { MAESTRO_ENV_VARS } from '../../../scripts/lib/e2e-common';
 import { ScreenInspectorIOS } from '../inspector/ScreenInspectorIOS';
+import { resizeImage } from './resizeImage';
 
 interface Bounds {
   x: number;
@@ -230,22 +231,11 @@ export async function captureViewShotInProcess({
 
   const label = `Duration of capturing "${testID}" testID in-process via dylib`;
   console.time(label);
-
-  await Promise.race([
-    screenInspectorIOS.captureView(testID, viewShotPath),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Dylib timeout')), timeoutMs)
-    ),
-  ]);
+  await screenInspectorIOS.captureView(testID, viewShotPath, timeoutMs);
   console.timeEnd(label);
 
   // The dylib writes the view at its exact bounds, so only resizing is left to do here.
-  if (resizingFactor !== 1) {
-    const image = await Jimp.read(viewShotPath);
-    const newWidth = Math.round(image.bitmap.width * resizingFactor);
-    const newHeight = Math.round(image.bitmap.height * resizingFactor);
-    await image.resize(newWidth, newHeight).writeAsync(viewShotPath);
-  }
+  await resizeImage(viewShotPath, resizingFactor);
 
   return {
     viewShotPath,

--- a/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
@@ -1,6 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
 import Jimp from 'jimp-compact';
-import fs from 'node:fs';
 
 import { MAESTRO_ENV_VARS } from '../../../scripts/lib/e2e-common';
 import { ScreenInspectorIOS } from '../inspector/ScreenInspectorIOS';
@@ -207,11 +206,9 @@ async function cropImageAsync({
     croppedImage = croppedImage.resize(newWidth, newHeight);
   }
 
-  await croppedImage.write(outputPath);
-
-  // Ensure file is fully written to disk before returning
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  await fs.promises.access(outputPath, fs.constants.F_OK);
+  // write() resolves before the file hits the disk (it awaits the image, not the write);
+  // writeAsync() is the promise-returning variant.
+  await croppedImage.writeAsync(outputPath);
   console.log('wrote cropped image to', outputPath);
 }
 

--- a/apps/native-component-list/src/screens/Image/ImageComparisonE2EScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageComparisonE2EScreen.tsx
@@ -11,6 +11,8 @@ import AppearanceTests from './tests/appearance';
  */
 export default function ImageComparisonE2EScreen() {
   return (
-    <ImageComparisonBody sections={[{ title: AppearanceTests.name, data: AppearanceTests.tests }]} />
+    <ImageComparisonBody
+      sections={[{ title: AppearanceTests.name, data: AppearanceTests.tests }]}
+    />
   );
 }

--- a/apps/native-component-list/src/screens/Image/ImageComparisonE2EScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageComparisonE2EScreen.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { ImageComparisonBody } from './ImageComparisonScreen';
+import AppearanceTests from './tests/appearance';
+
+/**
+ * Dedicated screen for the expo-image e2e viewshot flow. It renders only the section
+ * the flow screenshots, so the screen mounts fast and the view hierarchy settles
+ * immediately, while the full comparison screen mounts a large list that keeps
+ * mutating for a long time and stalls Maestro's settle wait after opening the link.
+ */
+export default function ImageComparisonE2EScreen() {
+  return (
+    <ImageComparisonBody sections={[{ title: AppearanceTests.name, data: AppearanceTests.tests }]} />
+  );
+}

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -13,6 +13,14 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Comparison with original image (e2e)',
+    route: 'image/comparison-e2e',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./ImageComparisonE2EScreen'));
+    },
+  },
+  {
     name: 'Animated styles',
     route: 'image/animated-styles',
     options: {},


### PR DESCRIPTION
# Why

The expo-image e2e flow was the slowest one left after the expo-video de-flaking: 67s on a healthy runner, 2m20s+ on loaded VMs. Almost all of that was overhead:

- ~64s of `openLink` settle wait: the comparison screen mounts a large `SectionList` that keeps mutating the view hierarchy long after the link opens.
- Full-screen `simctl` screenshots (0.3-7s each, up to 30s on loaded VMs), plus a bounds round-trip and a Jimp crop.
- A hardcoded 1-second sleep after every crop.

# How

- **In-process view capture.** The screen-inspector dylib gets a `captureView` action: it renders the element's window with `UIGraphicsImageRenderer` + `drawHierarchy(in:afterScreenUpdates:)`, cropped to the element's frame, and writes the PNG. Sub-second, and it replaces the full-screen screenshot, the bounds round-trip, and the crop. Rendering the window rather than the element alone keeps everything the screen composites behind or over the view, so the result matches a screenshot crop.
- **Opt-in `captureMode` flow parameter.** `screen` (default) keeps the screenshot+crop pipeline; `in-process` uses the new path. Only the expo-image viewshots opt in: video flows must stay on `screen` because `AVPlayerLayer` renders blank through `drawHierarchy` on the simulator. Non-iOS platforms fall back to `screen`.
- **Dedicated e2e screen.** The flow now opens `ImageComparisonE2EScreen`, which reuses `ImageComparisonBody` with only the Appearance section (local assets only). The visible viewport is unchanged, but the screen mounts fast and settles immediately.
- **Fixed a masked write race.** Jimp's `write()` resolves before the file hits the disk; the 1-second sleep was hiding that. All call sites now use the promise-returning `writeAsync()`.
- **Main-actor isolation in the inspector.** The dylib's UIKit-touching functions are `@MainActor`; a single `runOnMainActor` bridge dispatches synchronously from the blocking pipe-server thread.

# Test Plan

- The Test Suite e2e workflow is green on both platforms with **no baseline regeneration**: the in-process captures pass the comparisons against the existing baselines.
- On the CI runner, the iOS expo-image flow passed on the first attempt in 29-52s across runs (previously 67s on a healthy runner, 2m20s+ on loaded VMs). Captures took 0.3-0.7s where the old path spent several seconds per viewshot.
- `bun test` in `apps/bare-expo/e2e/image-comparison` (19 tests, including schema coverage for `captureMode`).
- Fidelity, verified locally against the running app: the in-process capture is bit-for-bit deterministic across consecutive runs and differs from the old screenshot+crop result by 0.56% on identical screen content.
