### PR TITLE
[ios][dev-launcher] Fix compile error in Release builds

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix auto-launching into the most recently opened project on startup. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Forward the launching intent's extras when cold-launching the most recently opened bundle, so launch arguments (e.g. from Maestro/Detox or `adb am start -e`) reach the app and `react-native-launch-arguments` can read them. ([#47352](https://github.com/expo/expo/pull/47352) by [@kanzelm3](https://github.com/kanzelm3))
+- [iOS] Fix Release build failure from an unguarded call to `RCTBundleURLProviderAllowPackagerServerAccess`.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -24,7 +24,7 @@
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix auto-launching into the most recently opened project on startup. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Forward the launching intent's extras when cold-launching the most recently opened bundle, so launch arguments (e.g. from Maestro/Detox or `adb am start -e`) reach the app and `react-native-launch-arguments` can read them. ([#47352](https://github.com/expo/expo/pull/47352) by [@kanzelm3](https://github.com/kanzelm3))
-- [iOS] Fix Release build failure from an unguarded call to `RCTBundleURLProviderAllowPackagerServerAccess`.
+- [iOS] Fix Release build failure from an unguarded call to `RCTBundleURLProviderAllowPackagerServerAccess`. ([#47688](https://github.com/expo/expo/pull/47688) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -182,7 +182,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
 - (void)start:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions
 {
+#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
+  // Matches the guard on the declaration in React/Base/RCTBundleURLProvider.h.
+  // The function isn't declared in builds without packager support.
   RCTBundleURLProviderAllowPackagerServerAccess(NO);
+#endif
 
   _delegate = delegate;
   _launchOptions = launchOptions;
@@ -389,9 +393,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
       onSuccess:(void (^ _Nullable)(void))onSuccess
         onError:(void (^ _Nullable)(NSError *error))onError
 {
+#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
   // A dev server has been chosen — re-allow packager access (denied at launcher boot in
   // `start:launchOptions:`). Replaces the RCTBundleURLProvider.guessPackagerHost swizzle.
   RCTBundleURLProviderAllowPackagerServerAccess(YES);
+#endif
 
   EXDevLauncherUrl *devLauncherUrl = [[EXDevLauncherUrl alloc] init:url];
   NSURL *expoUrl = devLauncherUrl.url;


### PR DESCRIPTION
Guards the two `RCTBundleURLProviderAllowPackagerServerAccess` calls added in #47638 with the same `#if` React Native uses to declare that function, so `expo-dev-launcher` compiles in Release again.

The function is only declared under `RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY`, both off in Release, so the unguarded calls failed with `call to undeclared function` and broke the `ios-build` CI job on every PR that triggers it. The nearby `RCTDevLoadingViewSetEnabled` calls need no guard, they are declared unconditionally.

# Test Plan

`packages/expo-dev-launcher`, green via `et check-packages expo-dev-launcher` (build, typecheck, lint, format, test):

- `apps/bare-expo` builds and runs in Release on the iPhone 17 Pro simulator (Xcode 26.6), the exact `ios-build` scenario that regressed. `et native-unit-tests -p ios --packages expo-dev-launcher` passes, and a Debug build still discovers and loads dev servers.
- Reproduced the break and the fix standalone against the bare-expo pods headers: the call fails without `DEBUG` and compiles with `-DDEBUG=1`, matching Release and Debug.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: no module plugin touched.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - No documentation changes needed.
