### PR TITLE
[tools][ci] Fail docs data generation on error, run tools tests in CI

### DIFF
--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -47,3 +47,6 @@ jobs:
       - name: 🚨 Lint TypeScript sources
         run: pnpm lint --max-warnings 0
         working-directory: tools
+      - name: 🧪 Test sources
+        run: pnpm test
+        working-directory: tools

--- a/tools/src/commands/GenerateDocsAPIData.ts
+++ b/tools/src/commands/GenerateDocsAPIData.ts
@@ -454,6 +454,7 @@ async function action({ packageName, sdk }: ActionOptions) {
     for (const { key, reason } of failures) {
       logger.error(`💥 Failed to generate docs API data for '${key}':`, reason);
     }
+    process.exitCode = 1;
     return;
   }
   logger.log(


### PR DESCRIPTION
<!-- disable:changelog-checks -->

Sets `process.exitCode = 1` when docs API data generation fails and adds a test step to `expotools.yml`, so the next dead mapping entry fails CI instead of shipping silently.

`et generate-docs-api-data` logged failures but always exited 0, so the `docs.yml` step that runs it could never go red on a dead mapping entry ([this green run](https://github.com/expo/expo/actions/runs/29031189096) logs the FilterChip `ENOENT` and passes), which is how `expo-speech.json` stayed unregenerable from April (#44791) to July (#47670). No workflow runs the `tools` test suite either, so the mapping guard from #47670 never runs in CI. Success and unknown-package paths still exit 0, and the per-package error output is unchanged.

# Test Plan

`tools` is green across build, typecheck, test (322 tests, including the mapping guard), and lint:

- A forced failure (`et gdad -p expo-speech -s 999`) names the failing package and exits 1. Success and unknown-package paths still exit 0.
- `actionlint` passes on the modified workflow, and the new step mirrors the existing typecheck and lint steps.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - No package sources changed, repo tooling and CI only.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Repo tooling only, nothing consumed by prebuild or EAS Build.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - No documentation changes.
