### PR TITLE
[macos][dev-menu] Fix build with react-native-macos's older RCTDevMenu

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#47047](https://github.com/expo/expo/pull/47047) by [@lindboe](https://github.com/lindboe))
 - [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section. ([#47136](https://github.com/expo/expo/pull/47136) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
+- [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Android] Restore the "Open React Native dev menu" entry in the dev menu's Tools section (regressed in [#38759](https://github.com/expo/expo/pull/38759)). ([#47047](https://github.com/expo/expo/pull/47047) by [@lindboe](https://github.com/lindboe))
 - [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section. ([#47136](https://github.com/expo/expo/pull/47136) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
-- [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have.
+- [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have. ([#47693](https://github.com/expo/expo/pull/47693) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -50,7 +50,7 @@ class DevMenuPackagerConnectionHandler {
   }
 
   private func disableRnDevMenu(_ manager: DevMenuManager) {
-    // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
+// TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
 #if !os(macOS)
     let rctDevMenu: RCTDevMenu? = manager.currentAppContext?.nativeModule(named: "RCTDevMenu")
     rctDevMenu?.devMenuEnabled = false

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -50,9 +50,12 @@ class DevMenuPackagerConnectionHandler {
   }
 
   private func disableRnDevMenu(_ manager: DevMenuManager) {
+    // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
+#if !os(macOS)
     let rctDevMenu: RCTDevMenu? = manager.currentAppContext?.nativeModule(named: "RCTDevMenu")
     rctDevMenu?.devMenuEnabled = false
     rctDevMenu?.keyboardShortcutsEnabled = false
+#endif
     DevMenuKeyCommandsInterceptor.reinstall()
   }
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -127,6 +127,8 @@ class DevMenuViewModel: ObservableObject {
   }
 
   func openRNDevMenu() {
+    // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
+#if !os(macOS)
     guard let rctDevMenu: RCTDevMenu = devMenuManager.currentAppContext?.nativeModule(named: "RCTDevMenu") else {
       return
     }
@@ -136,6 +138,7 @@ class DevMenuViewModel: ObservableObject {
       rctDevMenu.show()
       rctDevMenu.devMenuEnabled = false
     }
+#endif
   }
 
   func copyToClipboard(_ content: String) {

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -132,13 +132,13 @@ class DevMenuViewModel: ObservableObject {
     }
 
     devMenuManager.closeMenu {
-      // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
+// TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
 #if !os(macOS)
       rctDevMenu.devMenuEnabled = true
       rctDevMenu.show()
       rctDevMenu.devMenuEnabled = false
 #else
-      // react-native-macos leaves the RN dev menu enabled, so show it directly.
+      // react-native-macos's RCTDevMenu has no devMenuEnabled property, so show it directly.
       rctDevMenu.show()
 #endif
     }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -127,18 +127,21 @@ class DevMenuViewModel: ObservableObject {
   }
 
   func openRNDevMenu() {
-    // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
-#if !os(macOS)
     guard let rctDevMenu: RCTDevMenu = devMenuManager.currentAppContext?.nativeModule(named: "RCTDevMenu") else {
       return
     }
 
     devMenuManager.closeMenu {
+      // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
+#if !os(macOS)
       rctDevMenu.devMenuEnabled = true
       rctDevMenu.show()
       rctDevMenu.devMenuEnabled = false
-    }
+#else
+      // react-native-macos leaves the RN dev menu enabled, so show it directly.
+      rctDevMenu.show()
 #endif
+    }
   }
 
   func copyToClipboard(_ content: String) {


### PR DESCRIPTION
Guards the `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` writes added in #47638 with `#if !os(macOS)`, so `expo-dev-menu` compiles on macOS again.

react-native-macos trails RN core, and its `RCTDevMenu` has neither member (they land in core 0.83), so the writes failed with `value of type 'RCTDevMenu' has no member 'devMenuEnabled'` and broke the `test-suite-macos` CI job. `openRNDevMenu` guards only the toggle: macOS `RCTDevMenu` still has `show()` with no enabled gate, so the "Open RN dev menu" button keeps working by calling `show()` directly. iOS and tvOS use RN core and keep the writes. The guard mirrors the `// TODO(gabrieldonadel)` block already in the same file.

# Test Plan

`packages/expo-dev-menu`, green via `et check-packages expo-dev-menu` (build, typecheck, lint, format, test):

- `apps/bare-expo` builds the `ExpoMacOS-macOS` scheme against `react-native-macos@0.81.8`: fails without the guard (`has no member 'devMenuEnabled'`), succeeds with it. The exact `test-suite-macos` scenario that regressed.
- iOS unaffected: `et native-unit-tests -p ios --packages expo-dev-menu` passes. The guard excludes only macOS, and iOS and tvOS use RN core, which has the members.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: native-only guard, no module plugin touched.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - No documentation changes needed.
