### PR TITLE
[cli][config][metro-config] Recognize react-native-windows as an out-of-tree platform

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- Add `windows` (react-native-windows) to the experimental out-of-tree platform resolver: registers the Metro platform, autolinking, and a `react-native` -> `react-native-windows` bare-specifier redirect gated on the package being installed ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🎉 New features
 
-- Add `windows` (react-native-windows) to the experimental out-of-tree platform resolver: registers the Metro platform, autolinking, and a `react-native` -> `react-native-windows` bare-specifier redirect gated on the package being installed ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
+- Add `windows` (react-native-windows) to the experimental out-of-tree platform resolver: registers the Metro platform, autolinking, and a `react-native` -> `react-native-windows` bare-specifier redirect gated on the package being installed ([#47704](https://github.com/expo/expo/pull/47704) by [@FaithfulAudio](https://github.com/FaithfulAudio))
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))

--- a/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
@@ -39,7 +39,14 @@ const KNOWN_STICKY_DEPENDENCIES = [
   '@react-navigation/native',
 ];
 
-const AUTOLINKING_PLATFORMS: readonly Platform[] = ['android', 'ios', 'web', 'tvos', 'macos'];
+const AUTOLINKING_PLATFORMS: readonly Platform[] = [
+  'android',
+  'ios',
+  'web',
+  'tvos',
+  'macos',
+  'windows',
+];
 
 export type AutolinkingPlatform = Platform;
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -248,6 +248,8 @@ export function getNodejsExtensions(srcExts: readonly string[]): string[] {
  * - Alias `react-native` to `react-native-web` on web.
  * - Redirect `react-native-web/dist/modules/AssetRegistry/index.js` to `@react-native/assets/registry.js` on web.
  * - Add support for `tsconfig.json`/`jsconfig.json` aliases via `compilerOptions.paths`.
+ * - Alias `react-native` (and its submodules) to `react-native-windows` when targeting
+ *   the Windows out-of-tree platform and `react-native-windows` is installed.
  */
 export function withExtendedResolver(
   config: ConfigT,
@@ -280,6 +282,20 @@ export function withExtendedResolver(
   const isExpoRouterInstalled = hasExpoRouterModule(
     config.projectRoot,
     autolinkingModuleResolverInput
+  );
+
+  // react-native-windows is conventionally installed as an ADDITIONAL dependency
+  // alongside a real, un-aliased `react-native` package (unlike react-native-macos
+  // / react-native-tvos, which projects typically install by aliasing the
+  // `react-native` package name itself, e.g. `"react-native": "npm:react-native-
+  // macos@..."` in package.json -- so for those, resolving `react-native` from the
+  // project already resolves into the OOT package and Metro's default resolution
+  // just works). `react-native-windows` therefore needs an explicit bare-specifier
+  // redirect, gated on the package actually being installed so projects that don't
+  // target Windows see no behavior change. See `requestReactNativeWindowsRedirect`.
+  const hasReactNativeWindows = !!resolveFrom(
+    config.projectRoot,
+    'react-native-windows/package.json'
   );
 
   let _universalAliases: [RegExp, string][] | null;
@@ -493,6 +509,40 @@ export function withExtendedResolver(
         };
       }
       return null;
+    },
+
+    // Redirect bare `react-native` / `react-native/*` imports to `react-native-windows`
+    // when targeting the Windows out-of-tree platform. This is re-implementation (for
+    // Expo's resolver pipeline) of `@react-native/community-cli-plugin`'s
+    // `reactNativePlatformResolver`, which a standalone RNW app gets for free from
+    // `@react-native/community-cli-plugin`'s `loadMetroConfig`:
+    // https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/utils/metroPlatformResolver.js
+    // Without it, `import { Platform } from 'react-native'` resolves into RN core,
+    // whose backwards-compat `Libraries/Utilities/Platform.js` does `import Platform
+    // from './Platform'` -- with no `Platform.windows.js` in RN core that's a
+    // self-referencing circular import -> `undefined` -> `Cannot read property 'OS'
+    // of undefined` at boot. See `hasReactNativeWindows` above for why this platform
+    // needs an explicit redirect where `tvos`/`macos` don't.
+    function requestReactNativeWindowsRedirect(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
+      if (
+        platform !== 'windows' ||
+        !hasReactNativeWindows ||
+        (moduleName !== 'react-native' && !moduleName.startsWith('react-native/'))
+      ) {
+        return null;
+      }
+      const hostPackage = getReactNativeHostPackage(platform)!;
+      const redirected =
+        moduleName === 'react-native'
+          ? hostPackage
+          : `${hostPackage}/${moduleName.slice('react-native/'.length)}`;
+      // Fall back to un-redirected resolution (e.g. a react-native submodule
+      // react-native-windows doesn't override) instead of failing outright.
+      return getOptionalResolver(context, platform)(redirected);
     },
 
     isTsconfigPathsEnabled

--- a/packages/@expo/cli/src/start/server/platformBundlers.ts
+++ b/packages/@expo/cli/src/start/server/platformBundlers.ts
@@ -27,5 +27,6 @@ export function getPlatformBundlers(
     web,
     tvos: 'metro',
     macos: 'metro',
+    windows: 'metro',
   };
 }

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Add experimental `windows` platform (react-native-windows) to the `tvos`/`macos` out-of-tree platform detection gated by `experiments.outOfTreePlatforms` ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
+- Add experimental `windows` platform (react-native-windows) to the `tvos`/`macos` out-of-tree platform detection gated by `experiments.outOfTreePlatforms` ([#47704](https://github.com/expo/expo/pull/47704) by [@FaithfulAudio](https://github.com/FaithfulAudio))
 - Add experimental `tvos` and `macos` platforms gated by `expriments.outOfTreePlatforms` in config ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 - Update for `experiments.outOfTreePlatforms` typing ([#46497](https://github.com/expo/expo/pull/46497) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Add experimental `windows` platform (react-native-windows) to the `tvos`/`macos` out-of-tree platform detection gated by `experiments.outOfTreePlatforms` ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
 - Add experimental `tvos` and `macos` platforms gated by `expriments.outOfTreePlatforms` in config ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 - Update for `experiments.outOfTreePlatforms` typing ([#46497](https://github.com/expo/expo/pull/46497) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/config/src/Config.ts
+++ b/packages/@expo/config/src/Config.ts
@@ -87,6 +87,9 @@ function getSupportedPlatforms(projectRoot: string, exp: Partial<ExpoConfig>): P
     if (resolveFrom(projectRoot, 'react-native-macos/package.json')) {
       platforms.push('macos');
     }
+    if (resolveFrom(projectRoot, 'react-native-windows/package.json')) {
+      platforms.push('windows');
+    }
   }
   return platforms;
 }

--- a/packages/@expo/config/src/Config.types.ts
+++ b/packages/@expo/config/src/Config.types.ts
@@ -139,7 +139,7 @@ export enum ProjectPrivacy {
   UNLISTED = 'unlisted',
 }
 
-export type Platform = 'android' | 'ios' | 'web' | 'tvos' | 'macos';
+export type Platform = 'android' | 'ios' | 'web' | 'tvos' | 'macos' | 'windows';
 export type NativePlatform = Exclude<Platform, 'web'>;
 export type ProjectTarget = 'managed' | 'bare';
 

--- a/packages/@expo/config/src/paths/__tests__/extensions-test.ts
+++ b/packages/@expo/config/src/paths/__tests__/extensions-test.ts
@@ -45,6 +45,17 @@ describe(getPlatformExtensions, () => {
   it(`returns null for platforms without a custom order`, () => {
     expect(getPlatformExtensions('ios', ['js'])).toBeNull();
   });
+
+  it(`expands windows extensions, falling back to native (no ios/apple fallback)`, () => {
+    expect(getPlatformExtensions('windows', ['js', 'ts'])).toStrictEqual([
+      'windows.js',
+      'windows.ts',
+      'native.js',
+      'native.ts',
+      'js',
+      'ts',
+    ]);
+  });
 });
 
 // Enforce that all extensions are returned in the correct order, this is very important!

--- a/packages/@expo/config/src/paths/extensions.ts
+++ b/packages/@expo/config/src/paths/extensions.ts
@@ -68,6 +68,7 @@ export function getBareExtensions(
 const PLATFORM_EXTENSIONS: Record<string, readonly string[]> = {
   tvos: ['tvos', 'ios', 'native'],
   macos: ['macos', 'ios', 'native'],
+  windows: ['windows', 'native'],
 };
 
 /** Expand `extensions` with OOT platform extensions for platform */

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Recognize `windows` (react-native-windows) as an out-of-tree platform in the default Metro config, mirroring existing `tvos`/`macos` support: registers the `.windows.*` extension family and resolves the `react-native-windows` host package for `getPolyfills` ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
+- Recognize `windows` (react-native-windows) as an out-of-tree platform in the default Metro config, mirroring existing `tvos`/`macos` support: registers the `.windows.*` extension family and resolves the `react-native-windows` host package for `getPolyfills` ([#47704](https://github.com/expo/expo/pull/47704) by [@FaithfulAudio](https://github.com/FaithfulAudio))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Recognize `windows` (react-native-windows) as an out-of-tree platform in the default Metro config, mirroring existing `tvos`/`macos` support: registers the `.windows.*` extension family and resolves the `react-native-windows` host package for `getPolyfills` ([#TBD](https://github.com/expo/expo/pull/TBD) by [@FaithfulAudio](https://github.com/FaithfulAudio))
+
 ### 🐛 Bug fixes
 
 - Fix stack frame collapsing for Windows paths. ([#46645](https://github.com/expo/expo/pull/46645) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -65,6 +65,8 @@ function getReactNativeHostPackage(platform?: string | null): string {
       return 'react-native-tvos';
     case 'macos':
       return 'react-native-macos';
+    case 'windows':
+      return 'react-native-windows';
     default:
       return 'react-native';
   }
@@ -305,11 +307,17 @@ export function getDefaultConfig(
         android: ['react-native'],
         tvos: ['react-native'],
         macos: ['react-native'],
+        windows: ['react-native'],
         // This is removed for server platforms.
         web: ['browser'],
       },
       resolverMainFields: ['react-native', 'browser', 'main'],
-      platforms: ['ios', 'android', 'tvos', 'macos'],
+      // NOTE: `windows` (react-native-windows) is an out-of-tree platform, same as
+      // `tvos`/`macos` above -- listing it here only registers the `.windows.*`
+      // extension family with Metro's resolver. It stays inert (nothing to bundle)
+      // unless a project actually targets it; see `getReactNativeHostPackage` above
+      // and the `experiments.outOfTreePlatforms` gate in `@expo/config`.
+      platforms: ['ios', 'android', 'tvos', 'macos', 'windows'],
       assetExts: metroDefaultValues.resolver.assetExts
         .concat(
           // Add default support for `expo-image` file types.


### PR DESCRIPTION
# Why

Proposal/context: #47703 (continues the #30820 discussion). Extends the `tvos`/`macos` out-of-tree (OOT) platform support landed in #46344 to also recognize `windows` (react-native-windows), so an Expo app can target Windows from the same Metro instance and the same tree as iOS/Android/web.

**Production story:** we run a shipping Expo Router app (Facilitron FIT) bundling iOS, Android, web, and Windows from one Metro tree — `expo start`/EAS for iOS/Android, Expo export for web, and a react-native-windows 0.83 new-arch app served by the same Metro dev server for Windows, in production since July 2026. Getting there required reimplementing in userland `metro.config.js` two behaviors a standalone RNW app gets for free from `@react-native/community-cli-plugin`: the `react-native` → `react-native-windows` platform redirect (`metroPlatformResolver.js`) and out-of-tree `InitializeCore`/`setup-env` inclusion (`loadMetroConfig.js`). We packaged that workaround as [`@facilitronworks/expo-metro-windows`](https://github.com/FacilitronWorks/expo-metro-windows) — its README documents all four failure modes in detail and is explicitly framed as an interim shim this PR should obsolete.

While building this we noticed `expo-modules-autolinking/src/platforms/index.ts` already has:
```ts
case 'windows':
  return 'react-native-windows';
```
`windows` was already anticipated in `getSupportPackageForPlatform`, just not threaded through `@expo/config`'s `Platform` type, `@expo/cli`'s `platformBundlers`/`AUTOLINKING_PLATFORMS`, or a bare-specifier redirect. This PR closes that loop.

# How

Mirrors #46344's `tvos`/`macos` pattern file-for-file, plus the one extra piece `windows` structurally needs:

- **`@expo/config`**
  - `Platform` type: add `'windows'`.
  - `getSupportedPlatforms`: detect `windows` via `resolveFrom(projectRoot, 'react-native-windows/package.json')`, gated behind the existing `experiments.outOfTreePlatforms` flag (same as `tvos`/`macos`).
  - `getPlatformExtensions`: add `windows: ['windows', 'native']` (no `ios`/`apple` fallback, unlike `tvos`/`macos`).

- **`@expo/metro-config`**
  - `getReactNativeHostPackage`: add the `windows` → `react-native-windows` case (used by `getPolyfills`, which already receives `platform`).
  - Default `resolver.platforms`: add `'windows'` (inert until a project actually targets it, same as `tvos`/`macos` today).
  - `unstable_conditionsByPlatform.windows = ['react-native']`.

- **`@expo/cli`**
  - `platformBundlers` / `AUTOLINKING_PLATFORMS`: add `windows: 'metro'`.
  - `withMetroMultiPlatform.ts`: add a `react-native` → `react-native-windows` bare-specifier + submodule resolver (`requestReactNativeWindowsRedirect`), gated on `react-native-windows` actually being installed (`hasReactNativeWindows`, computed once via `resolveFrom`).

**Why `windows` needs the redirect but `tvos`/`macos` don't:** `react-native-tvos`/`react-native-macos` are conventionally installed by *aliasing the `react-native` package name itself* (e.g. `"react-native": "npm:react-native-macos@..."` in `package.json`), so `resolveFrom(projectRoot, 'react-native/package.json')` already resolves into the OOT package — Metro's default resolution just works, and the existing `getReactNativeHostPackage`-based path-suffix rewrites in `requestPostRewrites` (InitializeCore/HMRClient/LogBox swaps) already fire correctly against the real (symlink-resolved, pnpm-realpath) package name. `react-native-windows` is conventionally installed as an *additional* dependency alongside a real, un-aliased `react-native` (the standard RNW docs/templates), so nothing redirects the bare specifier without this change — `import { Platform } from 'react-native'` would resolve into RN core, whose backwards-compat `Libraries/Utilities/Platform.js` does `import Platform from './Platform'`, which — with no `Platform.windows.js` in RN core — is a self-referencing circular import, giving `undefined` and `Cannot read property 'OS' of undefined` at boot.

The new resolver is a re-implementation, for Expo's resolver pipeline, of `@react-native/community-cli-plugin`'s [`reactNativePlatformResolver`](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/utils/metroPlatformResolver.js) — falls back to un-redirected resolution (via the existing `getOptionalResolver` helper already used elsewhere in this file) for the rare submodule `react-native-windows` doesn't override, rather than hard-failing.

Once the bare-specifier redirect lands, several already-windows-aware code paths in `withMetroMultiPlatform.ts` that were previously unreachable for `windows` (because nothing ever resolved a `react-native-windows`-rooted path) start working: `getReactNativeHostPathPattern`, and the `hostPackage`-suffix swaps in `requestPostRewrites` (HMRClient, LogBox).

Everything is feature-detected/gated — zero behavior change for any project without `react-native-windows` installed, and `tvos`/`macos`/`ios`/`android`/`web` code paths are untouched (only additive `case`/map entries).

# Test Plan

- Added `getPlatformExtensions('windows', ...)` unit test in `packages/@expo/config/src/paths/__tests__/extensions-test.ts` (mirrors the existing `tvos` test).
- The rest of the diff is additive `case`/array/map entries following the exact shape of existing `tvos`/`macos` entries — no new logic branches beyond `requestReactNativeWindowsRedirect`, which is gated behind `platform === 'windows' && hasReactNativeWindows` and therefore untestable without a `react-native-windows`-having fixture project; happy to add an integration test if maintainers can point me at the right harness (`apps/bare-expo`'s OOT platform tests, if any exist, or a synthetic resolver-level test alongside the existing tests in `withMetroMultiPlatform`'s test suite).
- **Not yet run against our production app or Expo's CI** — this is a fresh reimplementation against current `main` following the #46344 architecture, not a copy-paste of our userland `metro.config.js` workaround (which predates and does not use the OOT-platform machinery this PR extends). Flagging honestly: needs your CI, and ideally a follow-up smoke test swapping `@facilitronworks/expo-metro-windows` for this PR in our app to confirm parity before merge.

# Checklist

- [x] I added a changelog entry to each touched package (`@expo/config`, `@expo/cli`, `@expo/metro-config`) — will fill in the real PR number/link once this PR is open.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — untested for Windows specifically since there's no EAS Build Windows target; no impact expected on existing platforms.
- [x] Conforms with the Documentation Writing Style Guide (n/a — no docs/ changes).
