### PR TITLE
[config-plugins] fix `getApplicationIdAsync` and `setPackageInBuildGradle` failing with Gradle assignment syntax 

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))
+- Fix `getApplicationIdAsync` failing to read `applicationId` when it is declared with the Gradle assignment syntax (`applicationId = '...'`) used by recent React Native Android templates. This caused `expo run:android` to abort with "Failed to locate the android application identifier" on SDK 57 / React Native 0.86 projects. ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
 
 ### 💡 Others
 

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))
-- Fix `getApplicationIdAsync` failing to read `applicationId` when it is declared with the Gradle assignment syntax (`applicationId = '...'`) used by recent React Native Android templates. This caused `expo run:android` to abort with "Failed to locate the android application identifier" on SDK 57 / React Native 0.86 projects. ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
+- Fix `getApplicationIdAsync` failing to read `applicationId` when it is declared with the Gradle assignment syntax (`applicationId = '...'`) used by recent React Native Android templates. Also fix `setPackageInBuildGradle` to match (and preserve) the assignment syntax when replacing the package. ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
 
 ### 💡 Others
 

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))
-- Fix `getApplicationIdAsync` failing to read `applicationId` when it is declared with the Gradle assignment syntax (`applicationId = '...'`) used by recent React Native Android templates. Also fix `setPackageInBuildGradle` to match (and preserve) the assignment syntax when replacing the package. ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
+- Fix `getApplicationIdAsync` and `setPackageInBuildGradle` failing with the Gradle assignment syntax (`applicationId = '...'`). ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
 
 ### 💡 Others
 

--- a/packages/@expo/config-plugins/src/android/Package.ts
+++ b/packages/@expo/config-plugins/src/android/Package.ts
@@ -248,7 +248,10 @@ export async function getApplicationIdAsync(projectRoot: string): Promise<string
     return null;
   }
   const buildGradle = await fs.promises.readFile(buildGradlePath, 'utf8');
-  const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
+  // Match both the legacy method-call form (`applicationId "com.app"`) and the
+  // Gradle assignment form (`applicationId = "com.app"`) emitted by recent
+  // React Native Android templates.
+  const matchResult = buildGradle.match(/applicationId\s*=?\s*['"](.*)['"]/);
   // TODO add fallback for legacy cases to read from AndroidManifest.xml
   return matchResult?.[1] ?? null;
 }

--- a/packages/@expo/config-plugins/src/android/Package.ts
+++ b/packages/@expo/config-plugins/src/android/Package.ts
@@ -238,8 +238,11 @@ export function setPackageInBuildGradle(config: Pick<ExpoConfig, 'android'>, bui
     return buildGradle;
   }
 
-  const pattern = new RegExp(`(applicationId|namespace) ['"].*['"]`, 'g');
-  return buildGradle.replace(pattern, `$1 '${packageName}'`);
+  // Match either declaration syntax, preserving the original separator so the
+  // method-call form stays `applicationId '...'` and the assignment form stays
+  // `applicationId = '...'`.
+  const pattern = new RegExp(`(applicationId|namespace)(\\s*=\\s*|\\s+)['"].*['"]`, 'g');
+  return buildGradle.replace(pattern, `$1$2'${packageName}'`);
 }
 
 export async function getApplicationIdAsync(projectRoot: string): Promise<string | null> {

--- a/packages/@expo/config-plugins/src/android/Package.ts
+++ b/packages/@expo/config-plugins/src/android/Package.ts
@@ -238,9 +238,6 @@ export function setPackageInBuildGradle(config: Pick<ExpoConfig, 'android'>, bui
     return buildGradle;
   }
 
-  // Match either declaration syntax, preserving the original separator so the
-  // method-call form stays `applicationId '...'` and the assignment form stays
-  // `applicationId = '...'`.
   const pattern = new RegExp(`(applicationId|namespace)(\\s*=\\s*|\\s+)['"].*['"]`, 'g');
   return buildGradle.replace(pattern, `$1$2'${packageName}'`);
 }
@@ -252,8 +249,7 @@ export async function getApplicationIdAsync(projectRoot: string): Promise<string
   }
   const buildGradle = await fs.promises.readFile(buildGradlePath, 'utf8');
   // Match both the legacy method-call form (`applicationId "com.app"`) and the
-  // Gradle assignment form (`applicationId = "com.app"`) emitted by recent
-  // React Native Android templates.
+  // Gradle assignment form (`applicationId = "com.app"`)
   const matchResult = buildGradle.match(/applicationId\s*=?\s*['"](.*)['"]/);
   // TODO add fallback for legacy cases to read from AndroidManifest.xml
   return matchResult?.[1] ?? null;

--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -47,6 +47,27 @@ describe('package', () => {
     expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
   });
 
+  it(`returns the applicationId when defined with Gradle assignment syntax (applicationId = '...')`, () => {
+    const projectRoot = '/';
+    // Recent React Native Android templates define the applicationId using the
+    // Gradle assignment form rather than the legacy method-call form.
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': [
+          'android {',
+          '    namespace = "com.helloworld"',
+          '    defaultConfig {',
+          '        applicationId = "com.helloworld"',
+          '    }',
+          '}',
+        ].join('\n'),
+      },
+      projectRoot
+    );
+
+    expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
+  });
+
   it(`sets the applicationId in build.gradle if package is given`, () => {
     expect(
       setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)

--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -28,9 +28,7 @@ const EXAMPLE_BUILD_GRADLE = `
   }
   `;
 
-// Recent React Native Android templates define the applicationId and namespace
-// using the Gradle assignment form rather than the legacy method-call form.
-const EXAMPLE_BUILD_GRADLE_ASSIGNMENT = `
+const EXAMPLE_BUILD_GRADLE_ASSIGNMENT_FORM = `
   android {
       compileSdkVersion rootProject.ext.compileSdkVersion
       buildToolsVersion rootProject.ext.buildToolsVersion
@@ -58,44 +56,29 @@ describe('package', () => {
     expect(getPackage({ android: { package: 'com.example.xyz' } })).toBe('com.example.xyz');
   });
 
-  it(`returns the applicationId defined in build.gradle`, () => {
-    const projectRoot = '/';
-    vol.fromJSON(rnFixture, projectRoot);
-
-    expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
-  });
-
   describe.each([
-    ['method-call', EXAMPLE_BUILD_GRADLE, "applicationId 'my.new.app'", "namespace 'my.new.app'"],
-    [
-      'assignment',
-      EXAMPLE_BUILD_GRADLE_ASSIGNMENT,
-      "applicationId = 'my.new.app'",
-      "namespace = 'my.new.app'",
-    ],
-  ])(
-    `with Gradle %s syntax`,
-    (_syntax, buildGradle, expectedApplicationId, expectedNamespace) => {
-      it(`returns the applicationId defined in build.gradle`, async () => {
-        const projectRoot = '/';
-        vol.fromJSON({ 'android/app/build.gradle': buildGradle }, projectRoot);
+    ['method-call', EXAMPLE_BUILD_GRADLE, ' '],
+    ['assignment', EXAMPLE_BUILD_GRADLE_ASSIGNMENT_FORM, ' = '],
+  ])(`with Gradle %s syntax`, (_syntax, buildGradle, separator) => {
+    it(`returns the applicationId defined in build.gradle`, async () => {
+      const projectRoot = '/';
+      vol.fromJSON({ 'android/app/build.gradle': buildGradle }, projectRoot);
 
-        await expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
-      });
+      await expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
+    });
 
-      it(`sets the applicationId in build.gradle if package is given`, () => {
-        expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
-          expectedApplicationId
-        );
-      });
+    it(`sets the applicationId in build.gradle if package is given`, () => {
+      expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
+        `applicationId${separator}'my.new.app'`
+      );
+    });
 
-      it(`sets the namespace in build.gradle if package is given`, () => {
-        expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
-          expectedNamespace
-        );
-      });
-    }
-  );
+    it(`sets the namespace in build.gradle if package is given`, () => {
+      expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
+        `namespace${separator}'my.new.app'`
+      );
+    });
+  });
 });
 
 describe(renamePackageOnDiskForType, () => {

--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -28,6 +28,24 @@ const EXAMPLE_BUILD_GRADLE = `
   }
   `;
 
+// Recent React Native Android templates define the applicationId and namespace
+// using the Gradle assignment form rather than the legacy method-call form.
+const EXAMPLE_BUILD_GRADLE_ASSIGNMENT = `
+  android {
+      compileSdkVersion rootProject.ext.compileSdkVersion
+      buildToolsVersion rootProject.ext.buildToolsVersion
+
+      namespace = "com.helloworld"
+      defaultConfig {
+          applicationId = "com.helloworld"
+          minSdkVersion rootProject.ext.minSdkVersion
+          targetSdkVersion rootProject.ext.targetSdkVersion
+          versionCode 1
+          versionName "1.0"
+      }
+  }
+  `;
+
 describe('package', () => {
   afterAll(async () => {
     vol.reset();
@@ -47,38 +65,37 @@ describe('package', () => {
     expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
   });
 
-  it(`returns the applicationId when defined with Gradle assignment syntax (applicationId = '...')`, () => {
-    const projectRoot = '/';
-    // Recent React Native Android templates define the applicationId using the
-    // Gradle assignment form rather than the legacy method-call form.
-    vol.fromJSON(
-      {
-        'android/app/build.gradle': [
-          'android {',
-          '    namespace = "com.helloworld"',
-          '    defaultConfig {',
-          '        applicationId = "com.helloworld"',
-          '    }',
-          '}',
-        ].join('\n'),
-      },
-      projectRoot
-    );
+  describe.each([
+    ['method-call', EXAMPLE_BUILD_GRADLE, "applicationId 'my.new.app'", "namespace 'my.new.app'"],
+    [
+      'assignment',
+      EXAMPLE_BUILD_GRADLE_ASSIGNMENT,
+      "applicationId = 'my.new.app'",
+      "namespace = 'my.new.app'",
+    ],
+  ])(
+    `with Gradle %s syntax`,
+    (_syntax, buildGradle, expectedApplicationId, expectedNamespace) => {
+      it(`returns the applicationId defined in build.gradle`, async () => {
+        const projectRoot = '/';
+        vol.fromJSON({ 'android/app/build.gradle': buildGradle }, projectRoot);
 
-    expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
-  });
+        await expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
+      });
 
-  it(`sets the applicationId in build.gradle if package is given`, () => {
-    expect(
-      setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
-    ).toMatch("applicationId 'my.new.app'");
-  });
+      it(`sets the applicationId in build.gradle if package is given`, () => {
+        expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
+          expectedApplicationId
+        );
+      });
 
-  it(`sets the namespace in build.gradle if package is given`, () => {
-    expect(
-      setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
-    ).toMatch("namespace 'my.new.app'");
-  });
+      it(`sets the namespace in build.gradle if package is given`, () => {
+        expect(setPackageInBuildGradle({ android: { package: 'my.new.app' } }, buildGradle)).toMatch(
+          expectedNamespace
+        );
+      });
+    }
+  );
 });
 
 describe(renamePackageOnDiskForType, () => {


### PR DESCRIPTION
# Why

`AndroidConfig.Package.getApplicationIdAsync()` returns `null` when `android/app/build.gradle` declares the application id with the Gradle **assignment** syntax:

```gradle
defaultConfig {
    applicationId = "com.example.app"   // note the `=`
}
```

The current regex only matches the method-call form (`applicationId "com.example.app"`), so it fails to read the id from projects whose `build.gradle` uses the assignment form — e.g. files modernized to the new AGP DSL style (Android Studio's AGP Upgrade Assistant emits `applicationId = '…'` / `namespace = '…'` in Groovy), or any `build.gradle.kts` project, where assignment is the only valid syntax (`getAppBuildGradleFilePath` resolves `.gradle.kts` too).

This breaks `expo run:android`. `AndroidAppIdResolver.resolveAppIdFromNativeAsync()` calls `getApplicationIdAsync()` (→ `null`), then falls back to `androidManifest.manifest.$.package` — which no longer exists under AGP 8 (the package moved to `namespace` in `build.gradle`). Both resolve to `null`, so the run aborts before Gradle with:

> CommandError: Failed to locate the android application identifier in the "android/" folder. This is required to open the app.

Hit in a production **Expo SDK 57 / React Native 0.86** app (CNG — `android/` gitignored and periodically prebuilt): its `android/app/build.gradle` had been modernized to the AGP DSL style (`applicationId = '…'`, `namespace = '…'`) during an AGP 8 upgrade pass, and non-`--clean` prebuilds preserve the file. The file itself shows the silent write-path failure: `setVersionCode`'s form-agnostic regex kept rewriting its line back to method form on every prebuild, while `setPackageInBuildGradle`'s method-form-only regex silently no-oped on the assignment lines.

# How

Widen the regex in `getApplicationIdAsync` to allow an optional `=` between `applicationId` and the quoted value:

```diff
- const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
+ const matchResult = buildGradle.match(/applicationId\s*=?\s*['"](.*)['"]/);
```

It still matches the legacy `applicationId "…"` form, so the change is backward compatible.

Per review, `setPackageInBuildGradle` is fixed as well: its pattern now matches either syntax and the replacement preserves the original separator, so method-call files stay `applicationId '…'` and assignment files stay `applicationId = '…'`. Tests cover both syntaxes for both functions via `describe.each`.

# Test Plan

- Added a regression test in `Package-test.ts` covering the assignment syntax (`applicationId = "com.helloworld"`), next to the existing method-call test.
- Both pass locally.
- Verified against a real SDK 57 project: with the fix, `getApplicationIdAsync` returns the correct id (previously `null`), and `expo run:android` resolves the launch activity instead of throwing.

# Checklist

- [x] I have added tests to cover my changes.
- [x] I have added a changelog entry (`packages/@expo/config-plugins/CHANGELOG.md`).
- [x] This is a backward-compatible bug fix.

