### PR TITLE
[gha][docs] Fix upstream sync generator failures and report per-generator status

### DIFF
--- a/.github/workflows/docs-upstream-sync.yml
+++ b/.github/workflows/docs-upstream-sync.yml
@@ -29,8 +29,10 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
-      - name: 📦 Install workspace deps
-        run: pnpm install --ignore-scripts --frozen-lockfile
+          cache-dependency-path: docs/pnpm-lock.yaml
+      - name: 📦 Install docs deps
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
       - name: 🔄 Run upstream sync
         id: sync
         working-directory: docs
@@ -54,6 +56,11 @@ jobs:
           committer: Expo Bot <expo-bot@users.noreply.github.com>
           author: Expo Bot <expo-bot@users.noreply.github.com>
           reviewers: amandeepmittal
+      - name: 🚨 Surface generator failures
+        if: ${{ fromJSON(steps.sync.outputs.result).failedCount != 0 }}
+        run: |
+          echo "::error::Some generators failed. Check the 'Run upstream sync' step log for details."
+          exit 1
       - name: 🔔 Notify on Slack
         if: failure()
         uses: ./.github/actions/slack-notify

--- a/docs/scripts/upstream-sync.ts
+++ b/docs/scripts/upstream-sync.ts
@@ -6,8 +6,8 @@ import { relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SYNCS = [
-  { label: '@expo/ui component tables', script: 'generate-ui-component-tables', match: 'ExpoUI' },
-  { label: 'App config schema', script: 'schema-sync', match: 'schemas/' },
+  { label: '@expo/ui component tables', script: 'generate-ui-component-tables', match: 'sdk/ui' },
+  { label: 'App config schema', script: 'schema-sync unversioned', match: 'schemas/' },
   { label: 'Expo Skills', script: 'expo-skills-sync', match: 'ExpoSkillsTable' },
   { label: 'EAS CLI reference', script: 'eas-cli-sync', match: 'EASCLIReference' },
   { label: 'Android permissions', script: 'permissions-sync-android', match: 'permissions' },
@@ -37,13 +37,20 @@ if (status().length) {
   process.exit(1);
 }
 
-const failed: string[] = [];
+const failures = new Map<string, string>();
 for (const { label, script } of SYNCS) {
   console.error(`Running ${script}`);
   try {
     execSync(`pnpm ${script}`, { cwd: docsDir, stdio: 'pipe' });
-  } catch {
-    failed.push(label);
+  } catch (error) {
+    const { stdout, stderr } = error as { stdout?: Buffer; stderr?: Buffer };
+    const output =
+      [stdout, stderr]
+        .map(stream => (stream ? String(stream).trim() : ''))
+        .filter(Boolean)
+        .join('\n') || String(error);
+    console.error(`${label} failed:\n${output}`);
+    failures.set(label, output);
   }
 }
 
@@ -68,13 +75,45 @@ const sources = [
 const title = sources.length
   ? `[docs] Sync upstream reference content (${sources.join(', ')})`
   : '[docs] Sync upstream reference content';
+
+const statusOf = (label: string) =>
+  failures.has(label) ? '❌ Failed' : sources.includes(label) ? '✅ Synced' : '➖ No changes';
+
+// Keep only the tail of a failure log so the PR body stays within GitHub's size limits.
+const excerpt = (text: string) => text.split('\n').slice(-30).join('\n').slice(-2000);
+
 const body = [
   'Automated upstream sync of generated reference content.',
-  ...(sources.length ? ['', '## Synced', ...sources.map(s => `- ${s}`)] : []),
+  '',
+  '| Generator | Status |',
+  '| --- | --- |',
+  ...SYNCS.map(({ label }) => `| ${label} | ${statusOf(label)} |`),
   ...(changed.length ? ['', '## Files', ...changed.map(f => `- \`${f}\``)] : []),
-  ...(failed.length ? ['', '## Generators that failed', ...failed.map(f => `- ${f}`)] : []),
+  ...(failures.size
+    ? [
+        '',
+        '## Failures',
+        ...[...failures].flatMap(([label, output]) => [
+          '',
+          '<details>',
+          `<summary>${label}</summary>`,
+          '',
+          '```',
+          excerpt(output),
+          '```',
+          '',
+          '</details>',
+        ]),
+      ]
+    : []),
 ].join('\n');
 
 process.stdout.write(
-  JSON.stringify({ hasChanged: changed.length > 0, title, commitMessage: title, body })
+  JSON.stringify({
+    hasChanged: changed.length > 0,
+    failedCount: failures.size,
+    title,
+    commitMessage: title,
+    body,
+  })
 );


### PR DESCRIPTION
# Why

Follow-up https://github.com/expo/expo/pull/47676

Every daily upstream sync PR since the workflow landed reports the same two failed generators with no error output, because the workflow never installs docs dependencies and the sync script discards generator stderr.

# How

- Install docs deps in `docs-upstream-sync.yml` instead of root workspace deps (docs is not a root workspace member, so `front-matter` and `@apidevtools/json-schema-ref-parser` never resolved) and key the pnpm cache on `docs/pnpm-lock.yaml`.
- Run `schema-sync` with the `unversioned` argument in `upstream-sync.ts`; without it the script prints usage and exits 0 without syncing anything.
- Fix the `@expo/ui` component tables match to `sdk/ui` so its changes are attributed correctly instead of falling into `other`.
- Replace the Synced/failed lists in the bot PR body with a per-generator status table (✅ Synced, ➖ No changes, ❌ Failed) and collapsible failure log excerpts.
- Add a workflow step that fails the run when any generator failed so the existing Slack notify fires.

# Test Plan

Ran a scratch copy of the script with a deliberately broken generator to verify the failure capture, status table, and `failedCount` output; `pnpm schema-sync unversioned` and `pnpm generate-ui-component-tables` run clean locally and `pnpm lint` passes. 

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
