### PR TITLE
[docs][map-view] Add .easignore troubleshooting tip for API key injection

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -125,6 +125,8 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
+> **info** If EAS Build does not pick up the API key, make sure your project contains a [.easignore](/build-reference/easignore/) file. This file should mirror your **.gitignore** but must not exclude **.env**, so that EAS Build can access your environment variables.
+
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/introduction/#how-would-you-like-to-build-your-development-build).
 

--- a/docs/pages/versions/v57.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/map-view.mdx
@@ -125,6 +125,8 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
+> **info** If EAS Build does not pick up the API key, make sure your project contains a [.easignore](/build-reference/easignore/) file. This file should mirror your **.gitignore** but must not exclude **.env**, so that EAS Build can access your environment variables.
+
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/introduction/#how-would-you-like-to-build-your-development-build).
 


### PR DESCRIPTION
# Why

When using a **.env** file to supply the Google Maps API key via the config plugin, the key silently fails to load in EAS Build if the project's **.gitignore** excludes **.env** and no **.easignore** file is present. 
* Common pitfall for inexperienced devs, and there is currently no mention of it in the docs.

# How

Added an `> **info**` callout in both the Android (step 4) and iOS (step 3) "Add the API key to your project" sections, explaining that a **.easignore** file (mirroring **.gitignore** but not excluding **.env**) may be needed for the API key to be available at build time.

Changes applied to both `unversioned` and `v57.0.0` copies of the file.

# Test plan

Documentation-only change. Verified that:
- The MDX syntax is consistent with existing callouts in the file (for example, `> **important**` on line 15).
- File names use **bold** formatting per the [Expo Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- Copy uses present tense, active voice, and second person per style guide conventions.
- Both `unversioned` and `v57.0.0` copies are kept in sync.

<!-- disable:changelog-checks -->

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — *N/A, docs-only change*
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin) — *N/A, docs-only change*
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
