### PR TITLE
[ios][dev-menu] Fix macOS build broken by RCTDevMenu 0.86 properties

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 💡 Others
 
 - [iOS] Replace dev-menu swizzling and reflection into React Native internals with public APIs. ([#47638](https://github.com/expo/expo/pull/47638) by [@alanjhughes](https://github.com/alanjhughes))
+- [macOS] Fix the macOS build breaking on the `RCTDevMenu.devMenuEnabled` and `keyboardShortcutsEnabled` properties, which react-native-macos doesn't yet expose. ([#47715](https://github.com/expo/expo/pull/47715) by [@tsapeta](https://github.com/tsapeta))
 
 ## 56.0.15 — 2026-05-26
 

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -51,8 +51,11 @@ class DevMenuPackagerConnectionHandler {
 
   private func disableRnDevMenu(_ manager: DevMenuManager) {
     let rctDevMenu: RCTDevMenu? = manager.currentAppContext?.nativeModule(named: "RCTDevMenu")
+// TODO: Remove this once we bump react-native-macos to 0.86, which exposes these properties.
+#if !os(macOS)
     rctDevMenu?.devMenuEnabled = false
     rctDevMenu?.keyboardShortcutsEnabled = false
+#endif
     DevMenuKeyCommandsInterceptor.reinstall()
   }
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -132,9 +132,14 @@ class DevMenuViewModel: ObservableObject {
     }
 
     devMenuManager.closeMenu {
+// TODO: Remove the `devMenuEnabled` toggling once we bump react-native-macos to 0.86, which exposes this property.
+#if os(macOS)
+      rctDevMenu.show()
+#else
       rctDevMenu.devMenuEnabled = true
       rctDevMenu.show()
       rctDevMenu.devMenuEnabled = false
+#endif
     }
   }
 


### PR DESCRIPTION
# Why

The macOS build is currently broken on `main`. It fails to compile `expo-dev-menu` with:

```
value of type 'RCTDevMenu' has no member 'devMenuEnabled'
value of type 'RCTDevMenu' has no member 'keyboardShortcutsEnabled'
```

[#47638](https://github.com/expo/expo/pull/47638) replaced the RN dev-menu suppression swizzle with the public `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` properties, which were introduced in react-native 0.86. react-native-macos is still pinned to 0.81.8 (see `apps/bare-expo/macos/Podfile.lock`: `React-Core (= 0.81.8)`), so those properties don't exist there and the macOS target no longer compiles. iOS is unaffected.

# How

Guard the two new property accesses behind `#if !os(macOS)`, matching the existing `TODO` version-skew carve-out already present in `DevMenuPackagerConnectionHandler.setup()`. On macOS:

- `DevMenuPackagerConnectionHandler.disableRnDevMenu` skips the two assignments; `DevMenuKeyCommandsInterceptor.reinstall()` still runs, so Cmd+D continues to route to our menu.
- `DevMenuViewModel.openRNDevMenu` calls `rctDevMenu.show()` without toggling `devMenuEnabled`.

RN's own dev menu is no longer *explicitly* suppressed on macOS. This matches the interim state [#47638](https://github.com/expo/expo/pull/47638) left the platform in (the old suppression swizzle it removed is gone for all platforms), and the guards can be dropped once react-native-macos reaches 0.86. In practice our key-command interceptor re-registers Cmd+D so our menu still wins (verified below), so the lost explicit suppression has no visible effect on macOS.

# Test Plan

Built `apps/bare-expo/macos` locally against react-native-macos 0.81.8 (the version CI failed on), following the CI recipe (`setup-macos-project.sh` -> `pod install` -> `xcodebuild ... -scheme ExpoMacOS-macOS`):

- `** BUILD SUCCEEDED **`, zero compile errors; the `RCTDevMenu has no member` errors are gone.
- Launched the app with Metro running, loaded the bundle, pressed Cmd+D: our Expo dev menu opens and RN's default dev menu does not appear.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Verified the macOS build compiles and the dev menu works at runtime (local macOS build + Cmd+D check). iOS is unaffected (compile-time platform guard only).
- [ ] Ran `npx expo prebuild` & EAS Build (not relevant, dev-menu native source change).
