### PR TITLE
[widgets][Android] Fix modifiers type cast

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - [Android] Fix widget strings file location. ([#46538](https://github.com/expo/expo/pull/46538) by [@jakex7](https://github.com/jakex7))
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))
+- [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetEmittableTree.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetEmittableTree.kt
@@ -282,7 +282,7 @@ private fun ModifierList.toPeekModifier(): PeekModifier {
 }
 
 private fun ModifierType.toPeekModifier(): PeekModifier {
-  return when (this["\$type"] as? String) {
+  return when (this["\$type"]?.asString()) {
     "paddingAll" -> asRecord<PaddingAllParams>()?.let { PeekModifier.padding(it.all.dp) }
     "padding" -> asRecord<PaddingParams>()?.let {
       PeekModifier.padding(


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/47616 changed modifiers type.

# How

Instead of type cast, get the value with `.asString()` from dynamic.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)