### PR TITLE
[docs][workflows] Add environment variables reference

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -471,6 +471,7 @@ export const eas = [
     makePage('eas/workflows/get-started.mdx'),
     makePage('eas/workflows/pre-packaged-jobs.mdx'),
     makePage('eas/workflows/syntax.mdx'),
+    makePage('eas/workflows/environment.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
     makePage('eas/workflows/rest-api.mdx'),
     makePage('eas/workflows/limitations.mdx'),

--- a/docs/pages/eas/environment-variables/usage.mdx
+++ b/docs/pages/eas/environment-variables/usage.mdx
@@ -142,8 +142,14 @@ For example, it can be useful when uploading source maps to Sentry using a [`SEN
 
 ### Setting EAS environment for workflow jobs
 
+When you omit [`jobs.<job_id>.environment`](/eas/workflows/syntax/#jobsjob_idenvironment), the default depends on the job type:
+
 - **Build jobs**: The environment comes from the build profile in **eas.json** (`build.<profile>.environment`). If that field is missing, the automatic defaults described above apply. [Using environment variables with EAS Build](#using-environment-variables-with-eas-build).
-- **Other jobs** (for example, update, submit, fingerprint, Maestro, and custom jobs): Set [`jobs.<job_id>.environment`](/eas/workflows/syntax/#jobsjob_idenvironment). If you omit it, `production` is used. Setting it explicitly helps keep the job in sync with the build profile you used earlier in the workflow.
+- **Submit jobs**: The environment is inherited from the submitted build.
+- **Maestro jobs** (`maestro` and `maestro-cloud`): The environment defaults to `preview`.
+- **Other jobs** (for example, update, fingerprint, deploy, and custom jobs): The environment defaults to `production`.
+
+Set `environment` explicitly on a job to override its default and keep it in sync with the build profile you used earlier in the workflow. For a full explanation, see [The job environment](/eas/workflows/environment/#the-job-environment).
 
 In the following example, a build job is configured to use the `preview` profile, then an update job is configured to use the same EAS environment.
 

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -81,7 +81,7 @@ Environment variables are not the only thing a job can interpolate. The same `${
 
 Fields from the GitHub event that triggered the workflow. When a run is started with `eas workflow:run`, `event_name` is `workflow_dispatch` and the other fields are empty.
 
-```
+```js
 github {
   triggering_actor,   // User who triggered the run, e.g. jonexpo
   event_name,         // 'pull_request', 'push', 'schedule', or 'workflow_dispatch'
@@ -174,7 +174,7 @@ jobs:
 
 Metadata about the build associated with the job. It is populated for [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs and is an empty object (`{}`) for job types without build metadata, such as custom jobs.
 
-```
+```js
 metadata {
   buildProfile,     // Build profile from eas.json, e.g. production
   appVersion,       // App version, e.g. 1.0.0
@@ -190,7 +190,7 @@ metadata {
 
 Information about the current workflow run.
 
-```
+```js
 workflow {
   id,        // ID of the workflow run
   name,      // Name of the workflow
@@ -213,7 +213,7 @@ jobs:
 
 Information about the App Store Connect entities associated with the run. This context is present only for workflows triggered by an [App Store Connect event](/eas/workflows/syntax/#onapp_store_connect).
 
-```
+```js
 app_store_connect {
   app { id },
   build_upload {

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -253,7 +253,7 @@ For the event domains that populate each field and full examples, see [`app_stor
 
 ## Built-in environment variables
 
-The worker sets the following variables on every job that runs on a VM. These are read at runtime, so reference them from within a `run` step.
+The worker sets the following variables on every job that runs on a virtual machine (VM). These are read at runtime, so reference them from within a `run` step.
 
 | Variable               | Example value                          | Description                                                  |
 | ---------------------- | -------------------------------------- | ------------------------------------------------------------ |

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -33,7 +33,7 @@ The variables available in a job are merged from three sources. When the same na
 | [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**.  |
 | [EAS environment variables](/eas/environment-variables/)                   | Variable names and values stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`). |
 
-On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they aren't shadowed by the built-in ones.
+On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so the built-in ones don't shadow them.
 
 ## The job environment
 

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -273,8 +273,6 @@ The following variables are populated from build metadata and are available in [
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 
-> **warning** The environment also includes internal variables, all prefixed with `__`. These are implementation details that can change or be removed at any time, so don't depend on them.
-
 ## Setting environment variables in a job
 
 To define your own variables, use the [`env` key](/eas/workflows/syntax/#jobsjob_idenv) on a job. Values can reference other context properties.

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -253,7 +253,7 @@ For the event domains that populate each field and full examples, see [`app_stor
 
 ## Built-in environment variables
 
-The worker sets the following variables on every job that runs on a virtual machine (VM). These are read at runtime, so reference them from within a `run` step.
+Workflow jobs run on EAS Build infrastructure, so they receive the same built-in variables as EAS Build. The most useful ones in a workflow are listed below. The worker sets them on every job that runs on a virtual machine (VM), and they are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
 
 | Variable               | Example value                          | Description                                                  |
 | ---------------------- | -------------------------------------- | ------------------------------------------------------------ |
@@ -273,7 +273,7 @@ The following variables are populated from build metadata and are available in [
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 
-> **warning** Variables prefixed with `__` (for example, `__WORKFLOW_JOB_ID`) are internal implementation details. They can change or be removed at any time, so don't depend on them.
+> **warning** If you print the full environment (for example, by running `env` in a step), you will also see variables prefixed with `__`, such as `__WORKFLOW_JOB_ID`. These are internal implementation details, are not surfaced in the dashboard, and can change or be removed at any time, so don't depend on them.
 
 ## Setting environment variables in a job
 

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -23,7 +23,7 @@ jobs:
       - run: echo "Project: $EAS_BUILD_PROJECT_ID"
 ```
 
-## Where environment variables come from
+## Precedence
 
 The variables available in a job are merged from three sources. When the same name is defined in more than one source, the one higher in this list wins:
 
@@ -31,11 +31,11 @@ The variables available in a job are merged from three sources. When the same na
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                          | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                     |
 | [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**. |
-| [EAS environment variables](/eas/environment-variables/)                   | Variables and secrets stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).    |
+| [EAS environment variables](/eas/environment-variables/)                   | Variable names and values stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).    |
 
-> **info** "Secrets" in EAS Workflows are [EAS environment variables](/eas/environment-variables/). Create and manage them from the project's **Environment Variables** page on the EAS dashboard or with the [`eas env`](/eas/environment-variables/) commands, then reference them by name with `${{ env.NAME }}`.
+On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they aren't shadowed by the built-in ones.
 
-On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they don't collide with the built-in ones.
+> **info** **.env** files are not part of this hierarchy. They are meant for local development and are typically listed in **.gitignore**, so they aren't present on the worker. Even if you commit a **.env** file, EAS CLI doesn't load it to populate the job environment, though tools that read **.env** files themselves (such as Expo CLI reading `EXPO_PUBLIC_*` variables while bundling) still do. Use [EAS environment variables](/eas/environment-variables/) instead of committing **.env** files. To pull them into a local **.env** file for development, use [`eas env:pull`](/eas/environment-variables/manage/#pull-variables-for-local-development).
 
 ## The job environment
 
@@ -80,12 +80,9 @@ The worker sets the following variables on every job that runs on a VM. These ar
 | Variable                  | Example value                          | Description                                                         |
 | ------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
 | `CI`                      | `1`                                    | Indicates the job runs in a CI environment.                         |
-| `EAS_BUILD`               | `true`                                 | Indicates the job runs on an EAS worker.                            |
-| `EAS_BUILD_RUNNER`        | `eas-build`                            | The runner executing the job. `eas-build` for EAS cloud workers.    |
-| `EAS_BUILD_ID`            | `019f57e8-f467-723e-a351-7b63c5974f43` | The unique ID of the current job.                                   |
-| `EAS_BUILD_PROJECT_ID`    | `f486dc93-eb27-4a7c-bc94-755965edce8b` | The EAS project ID.                                                 |
+| `EAS_BUILD_ID`            | `019f57e8-f497-723e-a351-7f63c5974f43` | The unique ID of the current job.                                   |
+| `EAS_BUILD_PROJECT_ID`    | `f486dc93-eb27-4b7c-bc94-752965edce8b` | The EAS project ID.                                                 |
 | `EAS_BUILD_WORKINGDIR`    | `/home/expo/workingdir/build`          | The absolute path to your checked-out project on the worker.        |
-| `EAS_BUILD_NPM_CACHE_URL` | `http://npm.caches.eas-build.internal` | The URL of the [npm cache](/build-reference/private-npm-packages/). |
 
 The following variables are populated from build metadata and are available in [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs. They may be empty in other job types:
 
@@ -93,8 +90,8 @@ The following variables are populated from build metadata and are available in [
 | --------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
 | `EAS_BUILD_PLATFORM`        | `android`                                  | The platform being built, either `android` or `ios`.            |
 | `EAS_BUILD_PROFILE`         | `production`                               | The name of the build profile from **eas.json**.                |
-| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5ea39108ade978de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.          |
-| `EAS_BUILD_USERNAME`        | `jonexpo`                                  | The username of the user who initiated the run. Empty for bots. |
+| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5fa39108ade970de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.          |
+| `EAS_BUILD_USERNAME`        | `meowlivia`                                | The username of the user who initiated the run. Empty for robot actors. |
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 
@@ -114,14 +111,40 @@ jobs:
       - run: echo "Building $APP_VARIANT at $COMMIT"
 ```
 
-To set a variable during a job so that later steps can read it, use the `set-env` command, which is available on the worker's `PATH`.
+### Share a value with later steps in the same job
+
+To compute a value in one step and read it in later steps of the same job, use the `set-env` command, which is available on the worker's `PATH`. It's the environment-variable counterpart to [`set-output`](/eas/workflows/syntax/#set-output): `set-output` exposes a named job output, while `set-env` exposes an environment variable to the job's subsequent steps.
 
 ```yaml
 jobs:
   my_job:
     steps:
       - run: set-env GENERATED_TAG "v$(date +%Y%m%d)"
+      # `set-env` only affects later steps, so the value is available here.
       - run: echo "Tag is $GENERATED_TAG"
+```
+
+> **info** `set-env` only affects later steps within the same job. It does not export the variable into the current step's shell, and it is not visible to other jobs. See [Sharing environment variables with other steps](/custom-builds/schema/#sharing-environment-variables-with-other-steps) for details.
+
+### Share a value with another job
+
+Environment variables are scoped to a single job, so a variable set with `env` or `set-env` is not available in other jobs. To pass a value to a later job, expose it as a [job output](/eas/workflows/syntax/#jobsjob_idoutputs) and read it through the [`needs`](/eas/workflows/syntax/#needs) context. The downstream job can then place it in its own `env` if needed.
+
+```yaml
+jobs:
+  setup:
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+    steps:
+      - id: compute
+        run: set-output tag "v$(date +%Y%m%d)"
+
+  build:
+    needs: [setup]
+    env:
+      RELEASE_TAG: ${{ needs.setup.outputs.tag }}
+    steps:
+      - run: echo "Building $RELEASE_TAG"
 ```
 
 <BoxLink

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -35,8 +35,6 @@ The variables available in a job are merged from three sources. When the same na
 
 On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they aren't shadowed by the built-in ones.
 
-> **info** **.env** files are not part of this hierarchy. They are meant for local development and are typically listed in **.gitignore**, so they aren't present on the worker. Even if you commit a **.env** file, EAS CLI doesn't load it to populate the job environment, though tools that read **.env** files themselves (such as Expo CLI reading `EXPO_PUBLIC_*` variables while bundling) still do. Use [EAS environment variables](/eas/environment-variables/) instead of committing **.env** files. To pull them into a local **.env** file for development, use [`eas env:pull`](/eas/environment-variables/manage/#pull-variables-for-local-development).
-
 ## The job environment
 
 Which EAS environment variables a job can read depends on its [environment](/eas/workflows/syntax/#jobsjob_idenvironment): `production` (the default), `preview`, or `development`. Only variables assigned to that environment are exposed to the job.
@@ -72,6 +70,158 @@ Interpolation happens in two places, which changes what `${{ env.NAME }}` can re
 Because of this, read built-in variables like `EAS_BUILD_ID` inside a `run` step rather than in a job's `params`. Inside a `run` step, `${{ env.EAS_BUILD_ID }}` and `$EAS_BUILD_ID` are equivalent.
 
 > **info** Values interpolated from EAS environment variables of type secret or sensitive are redacted in workflow logs.
+
+## Context variables
+
+Environment variables are not the only thing a job can interpolate. The same `${{ ... }}` syntax exposes several context objects that describe the workflow run. The `env` context covered above is one of them. The others are documented below. For the interpolation syntax and the available [context functions](/eas/workflows/syntax/#context-functions) such as `toJSON`, `fromJSON`, and `success()`, see [Syntax](/eas/workflows/syntax/#interpolation).
+
+> **info** To see the full contents of any context at runtime, print it with `toJSON`. For example, `run: echo '${{ toJSON(github) }}'`.
+
+### `github`
+
+Fields from the GitHub event that triggered the workflow. When a run is started with `eas workflow:run`, `event_name` is `workflow_dispatch` and the other fields are empty.
+
+```ts
+type GitHubContext = {
+  triggering_actor?: string;
+  event_name: 'pull_request' | 'push' | 'schedule' | 'workflow_dispatch';
+  sha: string;
+  ref: string; // e.g. refs/heads/main
+  ref_name: string; // e.g. main
+  ref_type: 'branch' | 'tag' | 'other';
+  commit_message?: string; // Only available for push and schedule events
+  label?: string;
+  repository?: string;
+  repository_owner?: string;
+  event?: {
+    action?: string;
+    label?: {
+      name: string;
+    };
+    // Only available for push and schedule events
+    head_commit?: {
+      message: string;
+      id: string;
+    };
+    pull_request?: {
+      number: number;
+      title: string;
+      body: string | null;
+      state: 'open' | 'closed';
+      draft: boolean;
+      merged: boolean | null;
+      // ... Other fields from the GitHub Pull Request webhook payload
+    };
+    number?: number;
+    schedule?: string;
+    inputs?: Record<string, string | number | boolean>;
+  };
+};
+```
+
+The `event` object contains the full [GitHub webhook payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads). For a detailed field reference and examples, see [`github`](/eas/workflows/syntax/#github) in the Syntax guide.
+
+### `inputs`
+
+A record of the inputs provided when the workflow was started manually with [`workflow_dispatch`](/eas/workflows/syntax/#onworkflow_dispatchinputs). Empty when the workflow was triggered another way.
+
+```yaml
+jobs:
+  greet:
+    steps:
+      - run: echo "Hello, ${{ inputs.name }}!"
+```
+
+### `needs`
+
+A record of the upstream jobs listed in the current job's [`needs`](/eas/workflows/syntax/#jobsjob_idneeds). Each entry provides the job's `status` (`success`, `failure`, or `skipped`) and its `outputs`.
+
+```yaml
+jobs:
+  notify:
+    needs: [build]
+    steps:
+      - run: echo "Build status: ${{ needs.build.status }}"
+```
+
+### `after`
+
+A record of the upstream jobs listed in the current job's [`after`](/eas/workflows/syntax/#jobsjob_idafter), whether or not they succeeded. Each entry provides the same `status` and `outputs` shape as [`needs`](#needs).
+
+### `steps`
+
+A record of the steps in the current job, keyed by step `id`. Each entry exposes the `outputs` set with the [`set-output`](/eas/workflows/syntax/#set-output) function. This context is only available within a job's steps.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - id: step_1
+        run: set-output value "hello"
+      - run: echo "${{ steps.step_1.outputs.value }}"
+```
+
+### `metadata`
+
+Metadata about the build associated with the job, such as `buildProfile`, `appVersion`, `appBuildVersion`, `sdkVersion`, `runtimeVersion`, `gitCommitHash`, and `distribution`. It is populated for [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs and is an empty object (`{}`) for job types without build metadata, such as custom jobs.
+
+### `workflow`
+
+Information about the current workflow run.
+
+```ts
+type WorkflowContext = {
+  id: string;
+  name: string;
+  filename: string;
+  url: string;
+};
+```
+
+```yaml
+jobs:
+  notify:
+    type: slack
+    params:
+      message: |
+        Workflow run completed: ${{ workflow.name }}
+        View details: ${{ workflow.url }}
+```
+
+### `app_store_connect`
+
+Information about the App Store Connect entities associated with the run. This context is present only for workflows triggered by an [App Store Connect event](/eas/workflows/syntax/#onapp_store_connect).
+
+```ts
+type AppStoreConnectContext = {
+  app: {
+    id: string;
+  };
+  build_upload?: {
+    id: string;
+    state: 'awaiting_upload' | 'processing' | 'failed' | 'complete';
+    cf_bundle_version?: string;
+    build?: {
+      id: string;
+    };
+  };
+  app_version?: {
+    id: string;
+    state: string;
+  };
+  external_beta?: {
+    id: string;
+    state: string;
+  };
+  beta_feedback?: {
+    id: string;
+    type: 'crash' | 'screenshot';
+    url: string;
+  };
+};
+```
+
+For the event domains that populate each field and full examples, see [`app_store_connect`](/eas/workflows/syntax/#app_store_connect) in the Syntax guide.
 
 ## Built-in environment variables
 
@@ -122,29 +272,6 @@ jobs:
       - run: set-env GENERATED_TAG "v$(date +%Y%m%d)"
       # `set-env` only affects later steps, so the value is available here.
       - run: echo "Tag is $GENERATED_TAG"
-```
-
-> **info** `set-env` only affects later steps within the same job. It does not export the variable into the current step's shell, and it is not visible to other jobs. See [Sharing environment variables with other steps](/custom-builds/schema/#sharing-environment-variables-with-other-steps) for details.
-
-### Share a value with another job
-
-Environment variables are scoped to a single job, so a variable set with `env` or `set-env` is not available in other jobs. To pass a value to a later job, expose it as a [job output](/eas/workflows/syntax/#jobsjob_idoutputs) and read it through the [`needs`](/eas/workflows/syntax/#needs) context. The downstream job can then place it in its own `env` if needed.
-
-```yaml
-jobs:
-  setup:
-    outputs:
-      tag: ${{ steps.compute.outputs.tag }}
-    steps:
-      - id: compute
-        run: set-output tag "v$(date +%Y%m%d)"
-
-  build:
-    needs: [setup]
-    env:
-      RELEASE_TAG: ${{ needs.setup.outputs.tag }}
-    steps:
-      - run: echo "Building $RELEASE_TAG"
 ```
 
 <BoxLink

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -81,60 +81,43 @@ Environment variables are not the only thing a job can interpolate. The same `${
 
 Fields from the GitHub event that triggered the workflow. When a run is started with `eas workflow:run`, `event_name` is `workflow_dispatch` and the other fields are empty.
 
-```ts
-type GitHubContext = {
-  triggering_actor?: string;
-  event_name: 'pull_request' | 'push' | 'schedule' | 'workflow_dispatch';
-  sha: string;
-  ref: string; // e.g. refs/heads/main
-  ref_name: string; // e.g. main
-  ref_type: 'branch' | 'tag' | 'other';
-  commit_message?: string; // Only available for push and schedule events
-  label?: string;
-  repository?: string;
-  repository_owner?: string;
-  event?: {
-    action?: string;
-    label?: {
-      name: string;
-    };
-    // Only available for push and schedule events
-    head_commit?: {
-      message: string;
-      id: string;
-    };
-    pull_request?: {
-      number: number;
-      title: string;
-      body: string | null;
-      state: 'open' | 'closed';
-      draft: boolean;
-      merged: boolean | null;
-      html_url: string;
-      user: {
-        login: string;
-      };
-      labels: {
-        name: string;
-      }[];
-      head: {
-        ref: string; // Source branch
-        sha: string;
-      };
-      base: {
-        ref: string; // Target branch
-        sha: string;
-      };
-      created_at: string;
-      updated_at: string;
-      merged_at: string | null;
+```
+github {
+  triggering_actor,   // User who triggered the run, e.g. jonexpo
+  event_name,         // 'pull_request', 'push', 'schedule', or 'workflow_dispatch'
+  sha,                // Commit SHA
+  ref,                // Full ref, e.g. refs/heads/main
+  ref_name,           // Short ref, e.g. main
+  ref_type,           // 'branch', 'tag', or 'other'
+  commit_message,     // Only for push and schedule events
+  label,              // Label name, for pull_request_labeled events
+  repository,         // e.g. expo/expo
+  repository_owner,   // e.g. expo
+  event {             // Full GitHub webhook payload
+    action,
+    head_commit { message, id },   // Only for push and schedule events
+    pull_request {
+      number,
+      title,
+      body,
+      state,          // 'open' or 'closed'
+      draft,
+      merged,
+      html_url,
+      user { login },
+      labels,         // Array of { name }
+      head { ref, sha },   // Source branch
+      base { ref, sha },   // Target branch
+      created_at,
+      updated_at,
+      merged_at,
       // ... and other fields from the GitHub Pull Request webhook payload
-    };
-    number?: number;
-    schedule?: string;
-    inputs?: Record<string, string | number | boolean>;
-  };
-};
+    },
+    inputs,           // workflow_dispatch inputs
+    schedule,         // Cron expression, for scheduled runs
+    number,
+  }
+}
 ```
 
 The `event` object contains the full [GitHub webhook payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads). For a detailed field reference and examples, see [`github`](/eas/workflows/syntax/#github) in the Syntax guide.
@@ -230,33 +213,23 @@ jobs:
 
 Information about the App Store Connect entities associated with the run. This context is present only for workflows triggered by an [App Store Connect event](/eas/workflows/syntax/#onapp_store_connect).
 
-```ts
-type AppStoreConnectContext = {
-  app: {
-    id: string;
-  };
-  build_upload?: {
-    id: string;
-    state: 'awaiting_upload' | 'processing' | 'failed' | 'complete';
-    cf_bundle_version?: string;
-    build?: {
-      id: string;
-    };
-  };
-  app_version?: {
-    id: string;
-    state: string;
-  };
-  external_beta?: {
-    id: string;
-    state: string;
-  };
-  beta_feedback?: {
-    id: string;
-    type: 'crash' | 'screenshot';
-    url: string;
-  };
-};
+```
+app_store_connect {
+  app { id },
+  build_upload {
+    id,
+    state,             // 'awaiting_upload', 'processing', 'failed', or 'complete'
+    cf_bundle_version,
+    build { id },
+  },
+  app_version { id, state },
+  external_beta { id, state },
+  beta_feedback {
+    id,
+    type,              // 'crash' or 'screenshot'
+    url,
+  },
+}
 ```
 
 ```yaml

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -1,0 +1,137 @@
+---
+title: Environment variables in EAS Workflows
+sidebar_title: Environment variables
+description: Reference for the environment variables available inside EAS Workflows jobs, including the ${{ env }} context and built-in worker variables.
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+Every workflow job runs on a worker that has a set of environment variables available to it. You can read these variables in two ways:
+
+- With the [`${{ env.NAME }}`](/eas/workflows/syntax/#env) interpolation syntax, anywhere a job interpolates values (for example, in `params`, `if`, `env`, and `run`).
+- As standard shell variables (`$NAME`) or through `process.env.NAME` from inside a [`run`](/eas/workflows/syntax/#jobsjob_idstepssteprun) step.
+
+```yaml .eas/workflows/print-env.yml
+name: Print environment
+
+jobs:
+  print:
+    steps:
+      # Interpolated before the command runs.
+      - run: echo "Project: ${{ env.EAS_BUILD_PROJECT_ID }}"
+      # Read from the shell environment at runtime.
+      - run: echo "Project: $EAS_BUILD_PROJECT_ID"
+```
+
+## Where environment variables come from
+
+The variables available in a job are merged from three sources. When the same name is defined in more than one source, the one higher in this list wins:
+
+| Source                                                                            | Description                                                                                                                             |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                                 | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                      |
+| [**eas.json** build profile `env`](/build/eas-json/#environment-variables)         | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**.  |
+| [EAS environment variables](/eas/environment-variables/)                          | Variables and secrets stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).      |
+
+> **info** "Secrets" in EAS Workflows are [EAS environment variables](/eas/environment-variables/). Create and manage them from the project's **Environment Variables** page on the EAS dashboard or with the [`eas env`](/eas/environment-variables/) commands, then reference them by name with `${{ env.NAME }}`.
+
+On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they don't collide with the built-in ones.
+
+## The job environment
+
+Which EAS environment variables a job can read depends on its [environment](/eas/workflows/syntax/#jobsjob_idenvironment): `production` (the default), `preview`, or `development`. Only variables assigned to that environment are exposed to the job.
+
+Each job resolves its environment differently:
+
+- [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs infer it from the build profile's `environment` in **eas.json**.
+- [`submit`](/eas/workflows/pre-packaged-jobs/#submit) jobs inherit it from the submitted build.
+- [`maestro`](/eas/workflows/pre-packaged-jobs/#maestro) and [`maestro-cloud`](/eas/workflows/pre-packaged-jobs/#maestro-cloud) jobs default to `preview`.
+- Other jobs default to `production`.
+
+Set [`jobs.<job_id>.environment`](/eas/workflows/syntax/#jobsjob_idenvironment) explicitly to override the default and keep a job in sync with the build profile it pairs with. For more details on selecting an environment for a job, see [Using environment variables in EAS Workflows](/eas/environment-variables/usage/#using-environment-variables-in-eas-workflows).
+
+## The `${{ env }}` context
+
+The [`${{ env }}` context](/eas/workflows/syntax/#env) is a record of environment variables keyed by name. It is available within a job's context, not at the top level of the workflow. For example, you can use it in a job's `params`, `if`, `env`, `outputs`, and `run`, but not in the top-level `on` triggers.
+
+```yaml
+jobs:
+  notify:
+    type: slack
+    params:
+      # Reads the SLACK_WEBHOOK_URL EAS environment variable.
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: 'Deploy finished'
+```
+
+Interpolation happens in two places, which changes what `${{ env.NAME }}` can resolve:
+
+- **Job configuration** (`params`, `if`, `outputs`, and the value of `env` itself) is interpolated before the job is dispatched to a worker. At this point, `env` contains your [EAS environment variables](/eas/environment-variables/) for the resolved [environment](#the-job-environment). Built-in worker variables and the job's own `env` values are not yet available here.
+- **`run` commands** are interpolated on the worker, where `env` reflects the full runtime environment: EAS environment variables, the job's `env`, and the [built-in variables](#built-in-environment-variables).
+
+Because of this, read built-in variables like `EAS_BUILD_ID` inside a `run` step rather than in a job's `params`. Inside a `run` step, `${{ env.EAS_BUILD_ID }}` and `$EAS_BUILD_ID` are equivalent.
+
+> **info** Values interpolated from EAS environment variables of type secret or sensitive are redacted in workflow logs.
+
+## Built-in environment variables
+
+The worker sets the following variables on every job that runs on a VM. These are read at runtime, so reference them from within a `run` step.
+
+| Variable                | Example value                                     | Description                                                                    |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `CI`                    | `1`                                               | Indicates the job runs in a CI environment.                                    |
+| `EAS_BUILD`             | `true`                                            | Indicates the job runs on an EAS worker.                                       |
+| `EAS_BUILD_RUNNER`      | `eas-build`                                       | The runner executing the job. `eas-build` for EAS cloud workers.               |
+| `EAS_BUILD_ID`          | `019f57e8-f467-723e-a351-7b63c5974f43`            | The unique ID of the current job.                                              |
+| `EAS_BUILD_PROJECT_ID`  | `f486dc93-eb27-4a7c-bc94-755965edce8b`            | The EAS project ID.                                                            |
+| `EAS_BUILD_WORKINGDIR`  | `/home/expo/workingdir/build`                     | The absolute path to your checked-out project on the worker.                   |
+| `EAS_BUILD_NPM_CACHE_URL` | `http://npm.caches.eas-build.internal`          | The URL of the [npm cache](/build-reference/private-npm-packages/).            |
+
+The following variables are populated from build metadata and are available in [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs. They may be empty in other job types:
+
+| Variable                    | Example value                                | Description                                                        |
+| --------------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
+| `EAS_BUILD_PLATFORM`        | `android`                                    | The platform being built, either `android` or `ios`.              |
+| `EAS_BUILD_PROFILE`         | `production`                                 | The name of the build profile from **eas.json**.                  |
+| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5ea39108ade978de2d0d1adeedf0ece76`   | The hash of the Git commit the job is running against.            |
+| `EAS_BUILD_USERNAME`        | `jonexpo`                                     | The username of the user who initiated the run. Empty for bots.   |
+
+Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
+
+> **warning** Variables prefixed with `__` (for example, `__WORKFLOW_JOB_ID`) are internal implementation details. They can change or be removed at any time, so don't depend on them.
+
+## Setting environment variables in a job
+
+To define your own variables, use the [`env` key](/eas/workflows/syntax/#jobsjob_idenv) on a job. Values can reference other context properties.
+
+```yaml
+jobs:
+  my_job:
+    env:
+      APP_VARIANT: staging
+      COMMIT: ${{ github.sha }}
+    steps:
+      - run: echo "Building $APP_VARIANT at $COMMIT"
+```
+
+To set a variable during a job so that later steps can read it, use the `set-env` command, which is available on the worker's `PATH`.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - run: set-env GENERATED_TAG "v$(date +%Y%m%d)"
+      - run: echo "Tag is $GENERATED_TAG"
+```
+
+<BoxLink
+  title="EAS environment variables"
+  description="Create and manage environment variables and secrets for your project's environments."
+  href="/eas/environment-variables/"
+/>
+
+<BoxLink
+  title="Syntax for EAS Workflows"
+  description="Reference for the full set of interpolation contexts and functions available in workflows."
+  href="/eas/workflows/syntax/#interpolation"
+/>

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -124,7 +124,7 @@ The `event` object contains the full [GitHub webhook payload](https://docs.githu
 
 ### `inputs`
 
-A record of the inputs provided when the workflow was started manually with [`workflow_dispatch`](/eas/workflows/syntax/#onworkflow_dispatchinputs). Empty when the workflow was triggered another way.
+A record of the inputs provided when you start the workflow manually with [`workflow_dispatch`](/eas/workflows/syntax/#onworkflow_dispatchinputs). Empty when the workflow is triggered another way.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environment variables in EAS Workflows
 sidebar_title: Environment variables
-description: Reference for the environment variables available inside EAS Workflows jobs, including the env context and built-in worker variables.
+description: Reference for the environment variables available inside EAS Workflows jobs, including the env context and additional worker variables.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -33,7 +33,7 @@ The variables available in a job are merged from three sources. When the same na
 | [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**.  |
 | [EAS environment variables](/eas/environment-variables/)                   | Variable names and values stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`). |
 
-On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so the built-in ones don't shadow them.
+On top of these, the worker sets a number of [additional variables](#additional-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so these don't shadow them.
 
 ## The job environment
 
@@ -64,10 +64,10 @@ jobs:
 
 Interpolation happens in two places, which changes what `${{ env.NAME }}` can resolve:
 
-- **Job configuration** (`params`, `if`, `outputs`, and the value of `env` itself) is interpolated before the job is dispatched to a worker. At this point, `env` contains your [EAS environment variables](/eas/environment-variables/) for the resolved [environment](#the-job-environment). Built-in worker variables and the job's own `env` values are not yet available here.
-- **`run` commands** are interpolated on the worker, where `env` reflects the full runtime environment: EAS environment variables, the job's `env`, and the [built-in variables](#built-in-environment-variables).
+- **Job configuration** (`params`, `if`, `outputs`, and the value of `env` itself) is interpolated before the job is dispatched to a worker. At this point, `env` contains your [EAS environment variables](/eas/environment-variables/) for the resolved [environment](#the-job-environment). The additional worker variables and the job's own `env` values are not yet available here.
+- **`run` commands** are interpolated on the worker, where `env` reflects the full runtime environment: EAS environment variables, the job's `env`, and the [additional variables](#additional-environment-variables).
 
-Because of this, read built-in variables like `EAS_BUILD_ID` inside a `run` step rather than in a job's `params`. Inside a `run` step, `${{ env.EAS_BUILD_ID }}` and `$EAS_BUILD_ID` are equivalent.
+Because of this, read variables like `EAS_BUILD_ID` inside a `run` step rather than in a job's `params`. Inside a `run` step, `${{ env.EAS_BUILD_ID }}` and `$EAS_BUILD_ID` are equivalent.
 
 > **info** Values interpolated from EAS environment variables of type secret or sensitive are redacted in workflow logs.
 
@@ -251,9 +251,9 @@ jobs:
 
 For the event domains that populate each field and full examples, see [`app_store_connect`](/eas/workflows/syntax/#app_store_connect) in the Syntax guide.
 
-## Built-in environment variables
+## Additional environment variables
 
-Workflow jobs run on the same worker infrastructure as EAS Build, so they get the same built-in variables. The most useful ones in a workflow are listed below. The worker sets them on every job that runs on a virtual machine (VM), and they are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
+In addition to the variables you set, the worker provides a number of variables on every job that runs on a virtual machine (VM). The most useful ones in a workflow are listed below. They are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
 
 | Variable               | Example value                          | Description                                                  |
 | ---------------------- | -------------------------------------- | ------------------------------------------------------------ |

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -27,11 +27,11 @@ jobs:
 
 The variables available in a job are merged from three sources. When the same name is defined in more than one source, the one higher in this list wins:
 
-| Source                                                                            | Description                                                                                                                             |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                                 | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                      |
-| [**eas.json** build profile `env`](/build/eas-json/#environment-variables)         | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**.  |
-| [EAS environment variables](/eas/environment-variables/)                          | Variables and secrets stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).      |
+| Source                                                                     | Description                                                                                                                           |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                          | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                     |
+| [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**. |
+| [EAS environment variables](/eas/environment-variables/)                   | Variables and secrets stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).    |
 
 > **info** "Secrets" in EAS Workflows are [EAS environment variables](/eas/environment-variables/). Create and manage them from the project's **Environment Variables** page on the EAS dashboard or with the [`eas env`](/eas/environment-variables/) commands, then reference them by name with `${{ env.NAME }}`.
 
@@ -77,24 +77,24 @@ Because of this, read built-in variables like `EAS_BUILD_ID` inside a `run` step
 
 The worker sets the following variables on every job that runs on a VM. These are read at runtime, so reference them from within a `run` step.
 
-| Variable                | Example value                                     | Description                                                                    |
-| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `CI`                    | `1`                                               | Indicates the job runs in a CI environment.                                    |
-| `EAS_BUILD`             | `true`                                            | Indicates the job runs on an EAS worker.                                       |
-| `EAS_BUILD_RUNNER`      | `eas-build`                                       | The runner executing the job. `eas-build` for EAS cloud workers.               |
-| `EAS_BUILD_ID`          | `019f57e8-f467-723e-a351-7b63c5974f43`            | The unique ID of the current job.                                              |
-| `EAS_BUILD_PROJECT_ID`  | `f486dc93-eb27-4a7c-bc94-755965edce8b`            | The EAS project ID.                                                            |
-| `EAS_BUILD_WORKINGDIR`  | `/home/expo/workingdir/build`                     | The absolute path to your checked-out project on the worker.                   |
-| `EAS_BUILD_NPM_CACHE_URL` | `http://npm.caches.eas-build.internal`          | The URL of the [npm cache](/build-reference/private-npm-packages/).            |
+| Variable                  | Example value                          | Description                                                         |
+| ------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `CI`                      | `1`                                    | Indicates the job runs in a CI environment.                         |
+| `EAS_BUILD`               | `true`                                 | Indicates the job runs on an EAS worker.                            |
+| `EAS_BUILD_RUNNER`        | `eas-build`                            | The runner executing the job. `eas-build` for EAS cloud workers.    |
+| `EAS_BUILD_ID`            | `019f57e8-f467-723e-a351-7b63c5974f43` | The unique ID of the current job.                                   |
+| `EAS_BUILD_PROJECT_ID`    | `f486dc93-eb27-4a7c-bc94-755965edce8b` | The EAS project ID.                                                 |
+| `EAS_BUILD_WORKINGDIR`    | `/home/expo/workingdir/build`          | The absolute path to your checked-out project on the worker.        |
+| `EAS_BUILD_NPM_CACHE_URL` | `http://npm.caches.eas-build.internal` | The URL of the [npm cache](/build-reference/private-npm-packages/). |
 
 The following variables are populated from build metadata and are available in [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs. They may be empty in other job types:
 
-| Variable                    | Example value                                | Description                                                        |
-| --------------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
-| `EAS_BUILD_PLATFORM`        | `android`                                    | The platform being built, either `android` or `ios`.              |
-| `EAS_BUILD_PROFILE`         | `production`                                 | The name of the build profile from **eas.json**.                  |
-| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5ea39108ade978de2d0d1adeedf0ece76`   | The hash of the Git commit the job is running against.            |
-| `EAS_BUILD_USERNAME`        | `jonexpo`                                     | The username of the user who initiated the run. Empty for bots.   |
+| Variable                    | Example value                              | Description                                                     |
+| --------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| `EAS_BUILD_PLATFORM`        | `android`                                  | The platform being built, either `android` or `ios`.            |
+| `EAS_BUILD_PROFILE`         | `production`                               | The name of the build profile from **eas.json**.                |
+| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5ea39108ade978de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.          |
+| `EAS_BUILD_USERNAME`        | `jonexpo`                                  | The username of the user who initiated the run. Empty for bots. |
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -291,7 +291,7 @@ jobs:
 
 ### Share a value with later steps in the same job
 
-To compute a value in one step and read it in later steps of the same job, use the `set-env` command, which is available on the worker's `PATH`. It's the environment-variable counterpart to [`set-output`](/eas/workflows/syntax/#set-output): `set-output` exposes a named job output, while `set-env` exposes an environment variable to the job's subsequent steps.
+Use the [`set-env`](/eas/workflows/syntax/#set-env) command to compute a value in one step and read it in later steps of the same job. The command is available on the worker's `PATH`. It's the environment-variable counterpart to [`set-output`](/eas/workflows/syntax/#set-output): `set-output` exposes a named job output, while `set-env` exposes an environment variable to the job's subsequent steps.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -79,7 +79,7 @@ Environment variables are not the only thing a job can interpolate. The same `${
 
 ### `github`
 
-Fields from the GitHub event that triggered the workflow. When a run is started with `eas workflow:run`, `event_name` is `workflow_dispatch` and the other fields are empty.
+Fields from the GitHub event that triggered the workflow. When you start a run with `eas workflow:run`, `event_name` is `workflow_dispatch` and the other fields are empty.
 
 ```js
 github {

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -110,7 +110,25 @@ type GitHubContext = {
       state: 'open' | 'closed';
       draft: boolean;
       merged: boolean | null;
-      // ... Other fields from the GitHub Pull Request webhook payload
+      html_url: string;
+      user: {
+        login: string;
+      };
+      labels: {
+        name: string;
+      }[];
+      head: {
+        ref: string; // Source branch
+        sha: string;
+      };
+      base: {
+        ref: string; // Target branch
+        sha: string;
+      };
+      created_at: string;
+      updated_at: string;
+      merged_at: string | null;
+      // ... and other fields from the GitHub Pull Request webhook payload
     };
     number?: number;
     schedule?: string;
@@ -148,6 +166,14 @@ jobs:
 
 A record of the upstream jobs listed in the current job's [`after`](/eas/workflows/syntax/#jobsjob_idafter), whether or not they succeeded. Each entry provides the same `status` and `outputs` shape as [`needs`](#needs).
 
+```yaml
+jobs:
+  notify:
+    after: [build]
+    steps:
+      - run: echo "Build status: ${{ after.build.status }}"
+```
+
 ### `steps`
 
 A record of the steps in the current job, keyed by step `id`. Each entry exposes the `outputs` set with the [`set-output`](/eas/workflows/syntax/#set-output) function. This context is only available within a job's steps.
@@ -157,25 +183,37 @@ jobs:
   my_job:
     steps:
       - id: step_1
-        run: set-output value "hello"
-      - run: echo "${{ steps.step_1.outputs.value }}"
+        run: set-output my_greeting "hello"
+      - run: echo "${{ steps.step_1.outputs.my_greeting }}"
 ```
 
 ### `metadata`
 
-Metadata about the build associated with the job, such as `buildProfile`, `appVersion`, `appBuildVersion`, `sdkVersion`, `runtimeVersion`, `gitCommitHash`, and `distribution`. It is populated for [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs and is an empty object (`{}`) for job types without build metadata, such as custom jobs.
+Metadata about the build associated with the job. It is populated for [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs and is an empty object (`{}`) for job types without build metadata, such as custom jobs.
+
+```
+metadata {
+  buildProfile,     // Build profile from eas.json, e.g. production
+  appVersion,       // App version, e.g. 1.0.0
+  appBuildVersion,  // Build number (iOS) or version code (Android)
+  sdkVersion,       // Expo SDK version, e.g. 54.0.0
+  runtimeVersion,   // Runtime version for EAS Update
+  gitCommitHash,    // Git commit the build ran against
+  distribution,     // 'store' or 'internal'
+}
+```
 
 ### `workflow`
 
 Information about the current workflow run.
 
-```ts
-type WorkflowContext = {
-  id: string;
-  name: string;
-  filename: string;
-  url: string;
-};
+```
+workflow {
+  id,        // ID of the workflow run
+  name,      // Name of the workflow
+  filename,  // Name of the workflow file, e.g. deploy.yml
+  url,       // URL of the run on the EAS dashboard
+}
 ```
 
 ```yaml
@@ -219,6 +257,23 @@ type AppStoreConnectContext = {
     url: string;
   };
 };
+```
+
+```yaml
+on:
+  app_store_connect:
+    build_upload:
+      states:
+        - complete
+
+jobs:
+  notify:
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: |
+        Upload complete for app: ${{ app_store_connect.app.id }}
+        Upload state: ${{ app_store_connect.build_upload.state }}
 ```
 
 For the event domains that populate each field and full examples, see [`app_store_connect`](/eas/workflows/syntax/#app_store_connect) in the Syntax guide.

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -27,11 +27,11 @@ jobs:
 
 The variables available in a job are merged from three sources. When the same name is defined in more than one source, the one higher in this list wins:
 
-| Source                                                                     | Description                                                                                                                           |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                          | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                     |
-| [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**. |
-| [EAS environment variables](/eas/environment-variables/)                   | Variable names and values stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`).    |
+| Source                                                                     | Description                                                                                                                            |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [Job `env`](/eas/workflows/syntax/#jobsjob_idenv)                          | Variables you set on the job with the `env` key. These are plain text and defined directly in your workflow file.                      |
+| [**eas.json** build profile `env`](/build/eas-json/#environment-variables) | For [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs, the `env` from the profile selected by `params.profile` in **eas.json**.  |
+| [EAS environment variables](/eas/environment-variables/)                   | Variable names and values stored on EAS for the job's [environment](#the-job-environment) (`production`, `preview`, or `development`). |
 
 On top of these, the worker sets a number of [built-in variables](#built-in-environment-variables) such as `EAS_BUILD_ID` and `CI`. Avoid naming your own variables with the `EAS_` prefix so they aren't shadowed by the built-in ones.
 
@@ -255,20 +255,20 @@ For the event domains that populate each field and full examples, see [`app_stor
 
 The worker sets the following variables on every job that runs on a VM. These are read at runtime, so reference them from within a `run` step.
 
-| Variable                  | Example value                          | Description                                                         |
-| ------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
-| `CI`                      | `1`                                    | Indicates the job runs in a CI environment.                         |
-| `EAS_BUILD_ID`            | `019f57e8-f497-723e-a351-7f63c5974f43` | The unique ID of the current job.                                   |
-| `EAS_BUILD_PROJECT_ID`    | `f486dc93-eb27-4b7c-bc94-752965edce8b` | The EAS project ID.                                                 |
-| `EAS_BUILD_WORKINGDIR`    | `/home/expo/workingdir/build`          | The absolute path to your checked-out project on the worker.        |
+| Variable               | Example value                          | Description                                                  |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------ |
+| `CI`                   | `1`                                    | Indicates the job runs in a CI environment.                  |
+| `EAS_BUILD_ID`         | `019f57e8-f497-723e-a351-7f63c5974f43` | The unique ID of the current job.                            |
+| `EAS_BUILD_PROJECT_ID` | `f486dc93-eb27-4b7c-bc94-752965edce8b` | The EAS project ID.                                          |
+| `EAS_BUILD_WORKINGDIR` | `/home/expo/workingdir/build`          | The absolute path to your checked-out project on the worker. |
 
 The following variables are populated from build metadata and are available in [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs. They may be empty in other job types:
 
-| Variable                    | Example value                              | Description                                                     |
-| --------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
-| `EAS_BUILD_PLATFORM`        | `android`                                  | The platform being built, either `android` or `ios`.            |
-| `EAS_BUILD_PROFILE`         | `production`                               | The name of the build profile from **eas.json**.                |
-| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5fa39108ade970de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.          |
+| Variable                    | Example value                              | Description                                                             |
+| --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
+| `EAS_BUILD_PLATFORM`        | `android`                                  | The platform being built, either `android` or `ios`.                    |
+| `EAS_BUILD_PROFILE`         | `production`                               | The name of the build profile from **eas.json**.                        |
+| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5fa39108ade970de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.                  |
 | `EAS_BUILD_USERNAME`        | `meowlivia`                                | The username of the user who initiated the run. Empty for robot actors. |
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environment variables in EAS Workflows
 sidebar_title: Environment variables
-description: Reference for the environment variables available inside EAS Workflows jobs, including the ${{ env }} context and built-in worker variables.
+description: Reference for the environment variables available inside EAS Workflows jobs, including the env context and built-in worker variables.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -253,23 +253,7 @@ For the event domains that populate each field and full examples, see [`app_stor
 
 ## Additional environment variables
 
-In addition to the variables you set, the worker provides a number of variables on every job that runs on a virtual machine (VM). The most useful ones in a workflow are listed below. They are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
-
-| Variable               | Example value                          | Description                                                  |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------ |
-| `CI`                   | `1`                                    | Indicates the job runs in a CI environment.                  |
-| `EAS_BUILD_ID`         | `019f57e8-f497-723e-a351-7f63c5974f43` | The unique ID of the current job.                            |
-| `EAS_BUILD_PROJECT_ID` | `f486dc93-eb27-4b7c-bc94-752965edce8b` | The EAS project ID.                                          |
-| `EAS_BUILD_WORKINGDIR` | `/home/expo/workingdir/build`          | The absolute path to your checked-out project on the worker. |
-
-The following variables are populated from build metadata and are available in [`build`](/eas/workflows/pre-packaged-jobs/#build) jobs. They may be empty in other job types:
-
-| Variable                    | Example value                              | Description                                                             |
-| --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
-| `EAS_BUILD_PLATFORM`        | `android`                                  | The platform being built, either `android` or `ios`.                    |
-| `EAS_BUILD_PROFILE`         | `production`                               | The name of the build profile from **eas.json**.                        |
-| `EAS_BUILD_GIT_COMMIT_HASH` | `88f28ab5fa39108ade970de2d0d1adeedf0ece76` | The hash of the Git commit the job is running against.                  |
-| `EAS_BUILD_USERNAME`        | `meowlivia`                                | The username of the user who initiated the run. Empty for robot actors. |
+In addition to the variables you set, the worker provides a number of variables on every job that runs on a virtual machine (VM), such as `EAS_BUILD_ID`, `EAS_BUILD_PROJECT_ID`, and `CI`. They are read at runtime, so reference them from within a `run` step. For the full list, see [Built-in environment variables](/eas/environment-variables/usage/#built-in-environment-variables).
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 

--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -253,7 +253,7 @@ For the event domains that populate each field and full examples, see [`app_stor
 
 ## Built-in environment variables
 
-Workflow jobs run on EAS Build infrastructure, so they receive the same built-in variables as EAS Build. The most useful ones in a workflow are listed below. The worker sets them on every job that runs on a virtual machine (VM), and they are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
+Workflow jobs run on the same worker infrastructure as EAS Build, so they get the same built-in variables. The most useful ones in a workflow are listed below. The worker sets them on every job that runs on a virtual machine (VM), and they are read at runtime, so reference them from within a `run` step. For the complete list, see [Using environment variables with EAS Build](/eas/environment-variables/usage/#using-environment-variables-with-eas-build).
 
 | Variable               | Example value                          | Description                                                  |
 | ---------------------- | -------------------------------------- | ------------------------------------------------------------ |
@@ -273,7 +273,7 @@ The following variables are populated from build metadata and are available in [
 
 Workers also expose standard toolchain variables such as `HOME`, `PATH`, `LANG`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME`. Their exact values depend on the worker [image](/eas/workflows/syntax/#jobsjob_idimage) and are subject to change.
 
-> **warning** If you print the full environment (for example, by running `env` in a step), you will also see variables prefixed with `__`, such as `__WORKFLOW_JOB_ID`. These are internal implementation details, are not surfaced in the dashboard, and can change or be removed at any time, so don't depend on them.
+> **warning** The environment also includes internal variables, all prefixed with `__`. These are implementation details that can change or be removed at any time, so don't depend on them.
 
 ## Setting environment variables in a job
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -448,11 +448,11 @@ jobs:
 
 Sets the [EAS environment variable](/eas/environment-variables/) environment for the job. There are three possible values:
 
-- `production` (default)
+- `production`
 - `preview`
 - `development`
 
-The `environment` key is available on all jobs.
+The `environment` key is available on all jobs. When you omit it, the default depends on the job type: `build` jobs infer it from the build profile's `environment` in **eas.json**, `submit` jobs inherit it from the submitted build, `maestro` and `maestro-cloud` jobs default to `preview`, and all other jobs default to `production`. See [The job environment](/eas/workflows/environment/#the-job-environment) for details.
 
 ```yaml
 jobs:


### PR DESCRIPTION
# Why

Closes [ENG-18318](https://linear.app/expo/issue/ENG-18318/write-env-doc-for-workflows).

`${{ env }}` was only mentioned briefly in the Workflows syntax reference, and the built-in variables a job gets from the worker were undocumented. Users need to know where and when `${{ env }}` can be used, what it exposes, and what other environment variables are available when running in a worker.

# How

Adds a dedicated **Environment variables** reference page under EAS Workflows.

# Test Plan

Make sure this reads well and is accurate: https://pr-47727.expo-docs.pages.dev/eas/workflows/environment/