### PR TITLE
[ios][apple-authentication] Run requests on main queue

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Run Sign in with Apple requests on the main queue to prevent a dispatch assertion. ([#47733](https://github.com/expo/expo/pull/47733) by [@eliotgevers](https://github.com/eliotgevers))
 - [iOS] Resolve the presentation window scene-aware and fail gracefully instead of crashing when no window is available for the Sign in with Apple sheet. ([#46955](https://github.com/expo/expo/pull/46955) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
@@ -21,7 +21,7 @@ public final class AppleAuthenticationModule: Module {
           promise.resolve(response)
         }
       }
-    }
+    }.runOnQueue(.main)
 
     AsyncFunction("getCredentialStateAsync") { (userId: String, promise: Promise) in
       let appleIdProvider = ASAuthorizationAppleIDProvider()


### PR DESCRIPTION
# Why

`AppleAuthenticationRequest.performRequest` now resolves the presentation window with `Utilities.keyWindow()`. That API is main-actor isolated, while Expo async functions run on `expo.modules.AsyncFunctionQueue` by default.

Calling `AppleAuthentication.signInAsync()` therefore hits `_dispatch_assert_queue_fail` and terminates the app before the authorization UI can be presented.

# How

Run the `requestAsync` body on the main queue. This keeps the window lookup and `AuthenticationServices` request setup on the queue required by UIKit.

# Test Plan

Tested on macOS 26.5.1 with Xcode 26.6 and an iOS 26.5 iPhone 17 Pro Max simulator.

The canary below is used only because it contains the current `main` branch change that introduced this regression. Stable Expo 57.0.4 with `expo-apple-authentication` 57.0.0 was tested separately as an unaffected control and did not crash.

1. Created a clean app with `bun create expo expo-apple-auth-repro --yes`.
2. Installed the full `57.0.0-canary-20260629-3010085` Expo dependency set and `expo-apple-authentication`.
3. Enabled the `expo-apple-authentication` plugin and `ios.usesAppleSignIn`.
4. Called `AppleAuthentication.signInAsync()` from the initial screen.
5. Built and ran the native app with `bunx expo run:ios`.

Before this change, LLDB stops with:

```text
thread #8, queue = 'expo.modules.AsyncFunctionQueue'
stop reason = EXC_BREAKPOINT
libdispatch.dylib`_dispatch_assert_queue_fail
ExpoModulesCore`static Utilities.keyWindow()
AppleAuthenticationRequest.performRequest(callback:)
```

After this change, the same clean project stays alive, presents the Apple account authorization UI, and delivers the simulator's expected recoverable error to JavaScript when no Apple account is configured.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
