### PR TITLE
[workflows] Pin pnpm 10 on EAS builders

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Build and publish Android brownfield artifacts
         working_directory: ../brownfield-tester/expo-app
@@ -83,6 +85,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - uses: eas/restore_build_cache
         with:

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -37,6 +37,9 @@ jobs:
       - if: ${{ steps.detect.outputs.packages != 'none' }}
         uses: eas/use_npm_token
       - if: ${{ steps.detect.outputs.packages != 'none' }}
+        name: Pin pnpm 10
+        run: npm install -g pnpm@10
+      - if: ${{ steps.detect.outputs.packages != 'none' }}
         uses: eas/install_node_modules
       - if: ${{ steps.detect.outputs.packages != 'none' }}
         name: Prebuild XCFrameworks

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -69,6 +69,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Remove EAS Gradle init script
         run: rm -f /home/expo/.gradle/init.gradle
@@ -136,6 +138,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - uses: eas/restore_build_cache
         with:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Install CocoaPods
         working_directory: ../brownfield-tester/integrated
@@ -75,6 +77,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Build Android (Debug)
         working_directory: ../brownfield-tester/integrated/android

--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -93,6 +93,8 @@ jobs:
           xcrun simctl list
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up TV compile test project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E bricking measures disabled project
         id: setup
@@ -69,6 +71,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E bricking measures disabled project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Run CLI tests
         id: cli

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E custom init project
         id: setup
@@ -81,6 +83,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
@@ -85,6 +87,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
@@ -87,6 +89,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -57,6 +57,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup
@@ -103,6 +105,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E error recovery project
         id: setup
@@ -69,6 +71,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E error recovery project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E fingerprint project
         id: setup
@@ -69,6 +71,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E fingerprint project
         id: setup

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E startup project
         id: setup
@@ -79,6 +81,8 @@ jobs:
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
+      - name: Pin pnpm 10
+        run: npm install -g pnpm@10
       - uses: eas/install_node_modules
       - name: Set up Updates E2E startup project
         id: setup


### PR DESCRIPTION
# Why

All EAS workflows in `apps/expo-workflow-testing` are currently failing on `main` during the `eas/install_node_modules` step:

```
[ERR_PNPM_UNSUPPORTED_ENGINE] Unsupported environment (bad pnpm and/or Node.js version)
Expected version: ^10.33.0
Got: 11.9.0
```

The `image: latest` EAS builder now ships pnpm 11, while the repo root `package.json` requires `engines.pnpm: ^10.33.0`. The `engines` field only validates the running pnpm; nothing on the builder selects the right version, so the install hard-fails.

GitHub Actions workflows already pin pnpm explicitly (`pnpm/action-setup` with `version: 10`); the EAS workflows never did because the image happened to ship pnpm 10 until now. Adding `packageManager` to the root `package.json` would also fix this, but that approach was explicitly declined in #47253.

# How

Add a `npm install -g pnpm@10` step before every `eas/install_node_modules` step in the `.eas/workflows` files (25 occurrences across 14 files). In `ios-prebuild-xcframeworks-smoke.yml` the step carries the same `if:` condition as its neighbors.

# Test Plan

Each workflow file lists itself in its `paths` trigger, so the EAS workflows run on this PR and exercise the fix directly.
