### PR TITLE
[ui][Android] Change `Text` color props to `ColorValue`

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -78,6 +78,7 @@
 - [iOS][android] Removed the `react-native-reanimated` dependency from the worklet integration; worklet features rely on `react-native-worklets` directly. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 - Removed `CLAUDE.md` and `CONTRIBUTING.md` from publishing and fixed side effects. ([#47451](https://github.com/expo/expo/pull/47451) by [@kudo](https://github.com/kudo))
 - [Android] Change modifiers type and provide appContext. ([#47616](https://github.com/expo/expo/pull/47616) by [@jakex7](https://github.com/jakex7))
+- [Android] Change `Text` color props to `ColorValue`. ([#47739](https://github.com/expo/expo/pull/47739) by [@jakex7](https://github.com/jakex7))
 
 ## 56.0.14 — 2026-05-26
 

--- a/packages/expo-ui/src/jetpack-compose/Text/index.tsx
+++ b/packages/expo-ui/src/jetpack-compose/Text/index.tsx
@@ -1,5 +1,6 @@
 import { requireNativeView } from 'expo';
 import * as React from 'react';
+import type { ColorValue } from 'react-native';
 
 import { type ModifierConfig } from '../../types';
 import { getTextFromChildren } from '../../utils';
@@ -73,7 +74,7 @@ export type TextShadow = {
   /**
    * The color of the shadow.
    */
-  color?: string;
+  color?: ColorValue;
   /**
    * The horizontal offset of the shadow in dp.
    */
@@ -147,7 +148,7 @@ export type TextSpanStyleBase = {
   /**
    * The background color behind the text.
    */
-  background?: string;
+  background?: ColorValue;
 
   /**
    * The shadow applied to the text.
@@ -190,7 +191,7 @@ export type TextStyle = TextSpanStyleBase & {
  */
 type TextSpanRecord = TextSpanStyleBase & {
   text?: string;
-  color?: string;
+  color?: ColorValue;
   children?: TextSpanRecord[];
 };
 
@@ -204,7 +205,7 @@ export interface TextProps {
   /**
    * The color of the text.
    */
-  color?: string;
+  color?: ColorValue;
 
   /**
    * How visual overflow should be handled.


### PR DESCRIPTION
# Why

`Text` color props does not allow `PlatformColor`

# How

Widen `Text` color props types from `string` to `ColorValue`, allowing `PlatformColor` and other opaque colors.

# Test Plan

Tested in Bare Expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)