### PR TITLE
[docs] Add server-side redirects for Algolia crawler 404s

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -379,6 +379,16 @@
 # After archiving Configure JS engines guide
 /guides/configuring-js-engines/ /archive/configuring-js-engines/ 301
 
+# After Algolia 404 report on 2026-07-13
+/router/reference/middleware/ /router/web/middleware 301
+/guides/configuring-statusbar/ /develop/user-interface/system-bars 301
+/get-started/introduction/ /get-started/create-a-project 301
+/eas/workflows/examples/ /eas/workflows/examples/introduction 301
+/eas/using-environment-variables/ /eas/environment-variables 301
+/eas/hosting/environment-variables/ /eas/environment-variables/usage/#using-environment-variables-with-eas-hosting 301
+/versions/v50.0.0/* /versions/latest/:splat 301
+/versions/v52.0.0/* /versions/latest/:splat 301
+
 # Serve markdown at the sibling /<slug>.md path that AI agents typically request,
 # rewriting to the canonical /<slug>/index.md the build script writes.
 # The first two rules are pass-throughs that preserve canonical URLs (root /index.md


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-24585

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add trailing-slash variants of six existing 301 rules to `public/_redirects` (for example `/get-started/introduction/`). The rules match exact paths only, so the slashed URLs fell through to the 404 page and were only rescued client-side, which the Algolia crawler reported as HTTP 404.
- Add `/versions/v50.0.0/*` and `/versions/v52.0.0/*` splat rules redirecting retired SDK version docs to `/versions/latest/:splat`, mirroring the existing client-side behavior server-side.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
After merging this PR, re-run Algolia's crawler and verify no 404 links are reported under monitoring.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
