### PR TITLE
[ci][eas] Pin `pnpm` to `10.34.5` (latest 10) in EAS CI workflows

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
@@ -1,5 +1,9 @@
 name: E2E Test Suite for Expo Brownfield
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch: {}
   push:

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -1,5 +1,9 @@
 name: Smoke Test Precompiled iOS XCFrameworks
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch:
     inputs:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -35,6 +35,7 @@ concurrency:
 defaults:
   tools:
     node: 22.14.0
+    pnpm: '10.34.5'
 
 jobs:
   detect_platform:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
@@ -1,5 +1,9 @@
 name: Test Suite Brownfield Integrated
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch: {}
   pull_request:

--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -1,5 +1,9 @@
 name: TV compile test
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (bricking measures disabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (CLI)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (custom init)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (dev client)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (disabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (enabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (error recovery)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (fingerprint)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (startup)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']


### PR DESCRIPTION
# Why

EAS workflows are failing with below error. Failure [example](https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019f5230-b5c6-7b2a-ac23-292aade8b736#job-019f5230-ba80-7d45-a4de-c88e29700a32)

```
We detected that 'apps/expo-workflow-testing' is a pnpm workspace
Running "pnpm install --frozen-lockfile" in /home/expo/workingdir/build directory
[ERR_PNPM_UNSUPPORTED_ENGINE] Unsupported environment (bad pnpm and/or Node.js version)
Your pnpm version is incompatible with "/home/expo/workingdir/build".
Expected version: ^10.33.0
Got: 11.9.0
This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.
To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
pnpm install --frozen-lockfile exited with non-zero code: 1
```


# How

Adds `pnpm` version in workflow config files. The version is set to `"pnpm": "10.34.5"` (latest 10 version)

# Test Plan

Verify workflows pass
