### PR TITLE
[router] Improve tests for protected route fallback behavior

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -31,7 +31,6 @@
 
 ### 💡 Others
 
-- Improve tests for protected route fallback behavior ([#47743](https://github.com/expo/expo/pull/47743) by [@Ubax](https://github.com/Ubax))
 - Rewrite native tabs using standard-navigation ([#46457](https://github.com/expo/expo/pull/46457) by [@Ubax](https://github.com/Ubax))
 - [Internal] Split `useLoaderData()` into a document cache and a per-mount Suspense store ([#47365](https://github.com/expo/expo/pull/47365) by [@hassankhan](https://github.com/hassankhan))
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 💡 Others
 
+- Improve tests for protected route fallback behavior ([#47743](https://github.com/expo/expo/pull/47743) by [@Ubax](https://github.com/Ubax))
 - Rewrite native tabs using standard-navigation ([#46457](https://github.com/expo/expo/pull/46457) by [@Ubax](https://github.com/Ubax))
 - [Internal] Split `useLoaderData()` into a document cache and a per-mount Suspense store ([#47365](https://github.com/expo/expo/pull/47365) by [@hassankhan](https://github.com/hassankhan))
 

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -287,6 +287,118 @@ it('should default to anchor during initial load', () => {
   });
 });
 
+it('should move away from a focused route when its guard flips false', () => {
+  let setGuard: Dispatch<SetStateAction<boolean>>;
+
+  renderRouter(
+    {
+      _layout: function Layout() {
+        const [guard, setState] = useState(true);
+        setGuard = setState;
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard={guard}>
+              <Stack.Screen name="secret" />
+            </Stack.Protected>
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  expect(screen.getByTestId('secret')).toBeVisible();
+  expect(screen).toHavePathname('/secret');
+
+  act(() => {
+    setGuard(false);
+  });
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
+});
+
+it('should remove guarded routes from history when a guard flips false', () => {
+  let setGuard: Dispatch<SetStateAction<boolean>>;
+
+  renderRouter({
+    _layout: function Layout() {
+      const [guard, setState] = useState(true);
+      setGuard = setState;
+      return (
+        <Stack id={undefined}>
+          <Stack.Protected guard={guard}>
+            <Stack.Screen name="secret" />
+          </Stack.Protected>
+          <Stack.Screen name="other" />
+        </Stack>
+      );
+    },
+    index: () => <Text testID="index">index</Text>,
+    secret: () => <Text testID="secret">secret</Text>,
+    other: () => <Text testID="other">other</Text>,
+  });
+
+  act(() => router.push('/secret'));
+  expect(screen.getByTestId('secret')).toBeVisible();
+  expect(screen).toHavePathname('/secret');
+
+  act(() => router.push('/other'));
+  expect(screen.getByTestId('other')).toBeVisible();
+  expect(screen).toHavePathname('/other');
+
+  act(() => {
+    setGuard(false);
+  });
+
+  act(() => router.back());
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
+});
+
+it('should use the anchor when a focused route guard flips false', () => {
+  let setGuard: Dispatch<SetStateAction<boolean>>;
+
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: {
+          anchor: 'home',
+        },
+        default: function Layout() {
+          const [guard, setState] = useState(true);
+          setGuard = setState;
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={guard}>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+              <Stack.Screen name="home" />
+            </Stack>
+          );
+        },
+      },
+      index: () => <Text testID="index">index</Text>,
+      home: () => <Text testID="home">home</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  expect(screen.getByTestId('secret')).toBeVisible();
+  expect(screen).toHavePathname('/secret');
+
+  act(() => {
+    setGuard(false);
+  });
+
+  expect(screen.getByTestId('home')).toBeVisible();
+  expect(screen).toHavePathname('/home');
+});
+
 it('will wait for React state updates before pushing', async () => {
   const SetterContext = createContext<Dispatch<SetStateAction<boolean>>>(() => {});
 

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -357,6 +357,54 @@ it('should remove guarded routes from history when a guard flips false', () => {
 
   expect(screen.getByTestId('index')).toBeVisible();
   expect(screen).toHavePathname('/');
+  expect(router.canGoBack()).toBe(false);
+});
+
+it('should not restore pruned guarded history when a guard flips true->false->true', () => {
+  let setGuard: Dispatch<SetStateAction<boolean>>;
+
+  renderRouter({
+    _layout: function Layout() {
+      const [guard, setState] = useState(true);
+      setGuard = setState;
+      return (
+        <Stack id={undefined}>
+          <Stack.Protected guard={guard}>
+            <Stack.Screen name="secret" />
+          </Stack.Protected>
+          <Stack.Screen name="other" />
+        </Stack>
+      );
+    },
+    index: () => <Text testID="index">index</Text>,
+    secret: () => <Text testID="secret">secret</Text>,
+    other: () => <Text testID="other">other</Text>,
+  });
+
+  act(() => router.push('/secret'));
+  expect(screen.getByTestId('secret')).toBeVisible();
+  expect(screen).toHavePathname('/secret');
+
+  act(() => router.push('/other'));
+  expect(screen.getByTestId('other')).toBeVisible();
+  expect(screen).toHavePathname('/other');
+
+  // Revoke access: the guarded /secret history entry is pruned.
+  act(() => {
+    setGuard(false);
+  });
+
+  // Re-grant access while still on /other.
+  act(() => {
+    setGuard(true);
+  });
+
+  // Flipping the guard back to true must not resurrect the pruned /secret entry.
+  act(() => router.back());
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
+  expect(router.canGoBack()).toBe(false);
 });
 
 it('should use the anchor when a focused route guard flips false', () => {

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -34,23 +34,7 @@ it('should protect routes during the initial load', () => {
     { initialUrl: '/a' }
   );
 
-  // This should be a stale state for the /a route, but index should be visible
-  expect(store.state).toStrictEqual({
-    routes: [
-      {
-        name: '__root',
-        state: {
-          routes: [
-            {
-              name: 'a',
-              path: '/a',
-            },
-          ],
-        },
-      },
-    ],
-  });
-
+  // Guarded /a is unreachable during initial load: index is shown at /.
   expect(screen.getByTestId('index')).toBeVisible();
   expect(screen).toHavePathname('/');
 
@@ -64,36 +48,8 @@ it('should protect routes during the initial load', () => {
   act(() => router.replace('/a'));
 
   expect(screen.getByTestId('a')).toBeVisible();
-  expect(store.state).toStrictEqual({
-    index: 0,
-    key: expect.any(String),
-    preloadedRoutes: [],
-    routeNames: ['__root', '+not-found', '_sitemap'],
-    routes: [
-      {
-        key: expect.any(String),
-        name: '__root',
-        params: undefined,
-        state: {
-          index: 0,
-          key: expect.any(String),
-          preloadedRoutes: [],
-          routeNames: ['a', 'index', 'b', 'c'],
-          routes: [
-            {
-              key: expect.any(String),
-              name: 'a',
-              params: {},
-            },
-          ],
-          stale: false,
-          type: 'stack',
-        },
-      },
-    ],
-    stale: false,
-    type: 'stack',
-  });
+  expect(screen).toHavePathname('/a');
+  expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'index', 'b', 'c']);
 });
 
 it('should protect nested protected routes', () => {
@@ -164,8 +120,6 @@ it('should protect nested protected routes', () => {
   expect(screen.getByTestId('a')).toBeVisible();
   expect(screen).toHavePathname('/a');
 
-  expect(store.state!.index).toBe(0);
-  expect(store.state!.routes[0]!.name).toBe('__root');
   expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'index']);
 
   // change the guard for route B to true: should make B available and also C
@@ -186,8 +140,6 @@ it('should protect nested protected routes', () => {
   expect(screen.getByTestId('c')).toBeVisible();
   expect(screen).toHavePathname('/c');
 
-  expect(store.state!.index).toBe(0);
-  expect(store.state!.routes[0]!.name).toBe('__root');
   expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'b', 'c', 'index']);
 });
 
@@ -222,28 +174,9 @@ it('should default to anchor during initial load', () => {
     { initialUrl: '/a' }
   );
 
-  expect(store.state).toStrictEqual({
-    routes: [
-      {
-        name: '__root',
-        state: {
-          index: 1,
-          routes: [
-            {
-              name: 'b',
-              params: undefined,
-            },
-            {
-              name: 'a',
-              path: '/a',
-            },
-          ],
-        },
-      },
-    ],
-  });
-
+  // Guarded /a is unreachable; the anchor route b is shown instead.
   expect(screen.getByTestId('b')).toBeVisible();
+  expect(screen).toHavePathname('/b');
 
   // Enable the /a route
   act(() => {
@@ -255,36 +188,8 @@ it('should default to anchor during initial load', () => {
   act(() => router.replace('/a'));
 
   expect(screen.getByTestId('a')).toBeVisible();
-  expect(store.state).toStrictEqual({
-    index: 0,
-    key: expect.any(String),
-    preloadedRoutes: [],
-    routeNames: ['__root', '+not-found', '_sitemap'],
-    routes: [
-      {
-        key: expect.any(String),
-        name: '__root',
-        params: undefined,
-        state: {
-          index: 0,
-          key: expect.any(String),
-          preloadedRoutes: [],
-          routeNames: ['a', 'b', 'index'],
-          routes: [
-            {
-              key: expect.any(String),
-              name: 'a',
-              params: {},
-            },
-          ],
-          stale: false,
-          type: 'stack',
-        },
-      },
-    ],
-    stale: false,
-    type: 'stack',
-  });
+  expect(screen).toHavePathname('/a');
+  expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'b', 'index']);
 });
 
 it('should move away from a focused route when its guard flips false', () => {


### PR DESCRIPTION
# Why

Before refactoring protected logic (in follow-up PR), I want to first ensure that we have proper test coverage

# How

1. Replace all `toStrictEquals` on state, with targeted expects
2. Add more tests for Protected route fallback

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
