### PR TITLE
[router] Render protected routes as redirects

### DIFF
--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -110,9 +110,10 @@ In this case:
 - `/private` is only protected if the user is logged in and is an admin.
 - `/about` is protected to any logged-in user.
 
-## Falling back to a specific screen
+## Redirecting to a specific screen
 
-You can configure the navigator to fall back to a specific screen if access is denied.
+By default, protected screens redirect to the navigator's anchor route or the first available
+screen. You can pass `redirectTo` to send users to a specific route instead.
 
 <FileTree
   files={[
@@ -134,8 +135,7 @@ const isLoggedIn = false;
 export function AppLayout() {
   return (
     <Stack>
-      <Stack.Protected guard={isLoggedIn}>
-        <Stack.Screen name="index" />
+      <Stack.Protected guard={isLoggedIn} redirectTo="/login">
         <Stack.Screen name="private" />
       </Stack.Protected>
 
@@ -145,7 +145,7 @@ export function AppLayout() {
 }
 ```
 
-In the above example, since the **index** screen is protected and the `guard` is **false**, the router redirects to the first available screen — **login**.
+In the above example, when the user is not logged in and attempts to access `/private`, the router redirects to `/login`.
 
 ## Tabs and Drawer
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -110,10 +110,9 @@ In this case:
 - `/private` is only protected if the user is logged in and is an admin.
 - `/about` is protected to any logged-in user.
 
-## Redirecting to a specific screen
+## Falling back to a specific screen
 
-By default, protected screens redirect to the navigator's anchor route or the first available
-screen. You can pass `redirectTo` to send users to a specific route instead.
+You can configure the navigator to fall back to a specific screen if access is denied.
 
 <FileTree
   files={[
@@ -135,7 +134,8 @@ const isLoggedIn = false;
 export function AppLayout() {
   return (
     <Stack>
-      <Stack.Protected guard={isLoggedIn} redirectTo="/login">
+      <Stack.Protected guard={isLoggedIn}>
+        <Stack.Screen name="index" />
         <Stack.Screen name="private" />
       </Stack.Protected>
 
@@ -145,7 +145,7 @@ export function AppLayout() {
 }
 ```
 
-In the above example, when the user is not logged in and attempts to access `/private`, the router redirects to `/login`.
+In the above example, since the **index** screen is protected and the `guard` is **false**, the router redirects to the first available screen — **login**.
 
 ## Tabs and Drawer
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
+
 ### 🎉 New features
 
 - [android] Support `Stack.Toolbar.Badge` in header left/right placements ([#46537](https://github.com/expo/expo/pull/46537) by [@benjaminkomen](https://github.com/benjaminkomen))
@@ -15,7 +17,6 @@
 - [native-tabs] Emit a `tabPress` event with `isPrevented: true` when a `disabled` tab is tapped, without selecting it. ([#46445](https://github.com/expo/expo/pull/46445) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Add `testID` and `accessibilityLabel` props to `NativeTabs.Trigger`. ([#47472](https://github.com/expo/expo/pull/47472) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add `pageHeaders` config plugin option for declaring per-path response headers ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
-- Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [native-tabs] Emit a `tabPress` event with `isPrevented: true` when a `disabled` tab is tapped, without selecting it. ([#46445](https://github.com/expo/expo/pull/46445) by [@Ubax](https://github.com/Ubax))
 - [native-tabs] Add `testID` and `accessibilityLabel` props to `NativeTabs.Trigger`. ([#47472](https://github.com/expo/expo/pull/47472) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add `pageHeaders` config plugin option for declaring per-path response headers ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+- Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -270,6 +270,61 @@ it('uses the innermost failing guard redirectTo for a nested guarded route', () 
   expect(screen).toHavePathname('/inner');
 });
 
+it('applies the parent guard redirectTo to a route nested in a passing child guard', () => {
+  renderRouter(
+    {
+      _layout: function Layout() {
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard={false} redirectTo="/login">
+              <Stack.Protected guard>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack.Protected>
+            <Stack.Screen name="login" />
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      login: () => <Text testID="login">login</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  // The child guard passes, but the parent guard fails, so its redirectTo applies.
+  expect(screen.getByTestId('login')).toBeVisible();
+  expect(screen).toHavePathname('/login');
+});
+
+it('does not apply the parent guard redirectTo to a route nested in a passing child guard when parent guard is true', () => {
+  renderRouter(
+    {
+      _layout: function Layout() {
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard redirectTo="/login">
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack.Protected>
+            <Stack.Screen name="login" />
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      login: () => <Text testID="login">login</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  // The child guard passes, but the parent guard fails, so its redirectTo applies.
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
+});
+
+
 it('should move away from a focused route when its guard flips false', () => {
   let setGuard: Dispatch<SetStateAction<boolean>>;
 

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -292,7 +292,6 @@ it('applies the parent guard redirectTo to a route nested in a passing child gua
     { initialUrl: '/secret' }
   );
 
-  // The child guard passes, but the parent guard fails, so its redirectTo applies.
   expect(screen.getByTestId('login')).toBeVisible();
   expect(screen).toHavePathname('/login');
 });
@@ -319,7 +318,6 @@ it('does not apply the parent guard redirectTo to a route nested in a passing ch
     { initialUrl: '/secret' }
   );
 
-  // The child guard passes, but the parent guard fails, so its redirectTo applies.
   expect(screen.getByTestId('index')).toBeVisible();
   expect(screen).toHavePathname('/');
 });

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -9,7 +9,7 @@ import Stack from '../layouts/Stack';
 import Tabs from '../layouts/Tabs';
 import { renderRouter } from '../testing-library';
 
-it('should protect routes during the initial load', () => {
+it('redirects a guarded route to the anchor default during the initial load', () => {
   let useStateResult: [boolean, Dispatch<SetStateAction<boolean>>];
 
   renderRouter(
@@ -52,7 +52,7 @@ it('should protect routes during the initial load', () => {
   expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'index', 'b', 'c']);
 });
 
-it('should protect nested protected routes', () => {
+it('redirects nested guarded routes to the anchor and unlocks them as guards flip', () => {
   let useStateResultA: [boolean, Dispatch<SetStateAction<boolean>>];
   let useStateResultB: [boolean, Dispatch<SetStateAction<boolean>>];
   let useStateResultC: [boolean, Dispatch<SetStateAction<boolean>>];
@@ -113,14 +113,12 @@ it('should protect nested protected routes', () => {
   expect(screen).toHavePathname('/a');
 
   act(() => router.replace('/b'));
-  expect(screen.getByTestId('a')).toBeVisible();
-  expect(screen).toHavePathname('/a');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
 
   act(() => router.replace('/c'));
-  expect(screen.getByTestId('a')).toBeVisible();
-  expect(screen).toHavePathname('/a');
-
-  expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'index']);
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
 
   // change the guard for route B to true: should make B available and also C
   // should be available now as all its parents guards are true
@@ -143,7 +141,7 @@ it('should protect nested protected routes', () => {
   expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'b', 'c', 'index']);
 });
 
-it('should default to anchor during initial load', () => {
+it('defaults a guarded route to the navigator anchor', () => {
   let useStateResult: [boolean, Dispatch<SetStateAction<boolean>>];
 
   renderRouter(
@@ -190,6 +188,86 @@ it('should default to anchor during initial load', () => {
   expect(screen.getByTestId('a')).toBeVisible();
   expect(screen).toHavePathname('/a');
   expect(store.state!.routes[0]!.state!.routeNames).toStrictEqual(['a', 'b', 'index']);
+});
+
+it('redirects a guarded route to an explicit redirectTo target', () => {
+  renderRouter(
+    {
+      _layout: function Layout() {
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard={false} redirectTo="/login">
+              <Stack.Screen name="secret" />
+            </Stack.Protected>
+            <Stack.Screen name="login" />
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      login: () => <Text testID="login">login</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  expect(screen.getByTestId('login')).toBeVisible();
+  expect(screen).toHavePathname('/login');
+});
+
+it('redirects a guarded route in a nested navigator to that navigator anchor', () => {
+  renderRouter(
+    {
+      _layout: () => <Stack id={undefined} />,
+      index: () => <Text testID="index">index</Text>,
+      'nested/_layout': {
+        unstable_settings: { anchor: 'home' },
+        default: function NestedLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+              <Stack.Screen name="home" />
+            </Stack>
+          );
+        },
+      },
+      'nested/home': () => <Text testID="home">home</Text>,
+      'nested/secret': () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/nested/secret' }
+  );
+
+  expect(screen.getByTestId('home')).toBeVisible();
+  expect(screen).toHavePathname('/nested/home');
+});
+
+it('uses the innermost failing guard redirectTo for a nested guarded route', () => {
+  renderRouter(
+    {
+      _layout: function Layout() {
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard redirectTo="/outer">
+              <Stack.Protected guard={false} redirectTo="/inner">
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack.Protected>
+            <Stack.Screen name="outer" />
+            <Stack.Screen name="inner" />
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      outer: () => <Text testID="outer">outer</Text>,
+      inner: () => <Text testID="inner">inner</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+    },
+    { initialUrl: '/secret' }
+  );
+
+  expect(screen.getByTestId('inner')).toBeVisible();
+  expect(screen).toHavePathname('/inner');
 });
 
 it('should move away from a focused route when its guard flips false', () => {

--- a/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
@@ -1,6 +1,7 @@
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import * as React from 'react';
 
+import { useClearGuardedRoutes } from '../../layouts/useClearGuardedRoutes';
 import {
   INTERNAL_EXPO_ROUTER_GESTURE_ENABLED_OPTION_NAME,
   type InternalNavigationOptions,
@@ -62,6 +63,9 @@ function NativeStackNavigator({
     screenLayout,
     UNSTABLE_router,
   });
+
+  // Let this navigator clear its own guarded routes from history, based on the guard context.
+  useClearGuardedRoutes(state, navigation);
 
   React.useEffect(
     () =>

--- a/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
@@ -64,7 +64,6 @@ function NativeStackNavigator({
     UNSTABLE_router,
   });
 
-  // Let this navigator clear its own guarded routes from history, based on the guard context.
   useClearGuardedRoutes(state, navigation);
 
   React.useEffect(

--- a/packages/expo-router/src/layouts/GuardContext.tsx
+++ b/packages/expo-router/src/layouts/GuardContext.tsx
@@ -21,11 +21,20 @@ function matchesRouteName(route: string, name: string) {
   return route === name || route === `${name}/index` || route.replace(/\/index$/, '') === name;
 }
 
-function routeNodeToHref(route: RouteNode): Href {
+function routeNodeToHref(route: Pick<RouteNode, 'contextKey'>): Href {
   return (stripInvisibleSegmentsFromPath(getContextKey(route.contextKey)) || '/') as Href;
 }
 
-function resolveDefaultHref(node: RouteNode, guardedRedirects: Map<string, Href | undefined>) {
+function serializeGuardedRedirects(guardedRedirects: Map<string, Href | undefined>): string {
+  return Array.from(guardedRedirects.entries())
+    .map(([name, href]) => `${name}=${href ?? ''}`)
+    .join('|');
+}
+
+function resolveDefaultHref(
+  node: Pick<RouteNode, 'children' | 'initialRouteName'>,
+  guardedRedirects: Map<string, Href | undefined>
+) {
   const children = [...node.children].sort(sortRoutesWithInitial(node.initialRouteName));
   const anchor = node.initialRouteName
     ? children.find((child) => matchesRouteName(child.route, node.initialRouteName!))
@@ -57,30 +66,23 @@ export function GuardContextProvider({
   guardedRedirects: Map<string, Href | undefined>;
   children: ReactNode;
 }) {
-  const signature = useMemo(
-    () =>
-      `${node?.contextKey ?? ''}:${node?.initialRouteName ?? ''}:` +
-      Array.from(guardedRedirects.entries())
-        .map(([name, href]) => `${name}=${href ?? ''}`)
-        .join('|'),
-    [guardedRedirects, node?.contextKey, node?.initialRouteName]
-  );
+  const signature = useMemo(() => serializeGuardedRedirects(guardedRedirects), [guardedRedirects]);
 
   const resolved = useMemo(() => {
-    const map = new Map<string, Href>();
-    const defaultHref = node ? resolveDefaultHref(node, guardedRedirects) : '/';
+    const defaultHref = node
+      ? resolveDefaultHref(
+          { children: node.children, initialRouteName: node.initialRouteName },
+          guardedRedirects
+        )
+      : '/';
 
-    guardedRedirects.forEach((redirectTo, name) => {
-      const href = redirectTo ?? defaultHref;
-      if (href != null) {
-        map.set(name, href);
-      }
-    });
-
-    return map;
-    // `signature` captures the guarded map content and navigator identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [signature]);
+    return new Map<string, Href>(
+      Array.from(
+        guardedRedirects,
+        ([name, redirectTo]) => [name, redirectTo ?? defaultHref] as const
+      ).filter((entry): entry is [string, Href] => entry[1] != null)
+    );
+  }, [signature, node?.children, node?.initialRouteName]);
 
   return <GuardContext value={resolved}>{children}</GuardContext>;
 }

--- a/packages/expo-router/src/layouts/GuardContext.tsx
+++ b/packages/expo-router/src/layouts/GuardContext.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { createContext, use, useMemo, type ReactNode } from 'react';
+
+import type { RouteNode } from '../Route';
+import { sortRoutesWithInitial } from '../Route';
+import { getContextKey, stripInvisibleSegmentsFromPath } from '../matchers';
+import type { Href } from '../types';
+
+export const GuardContext = createContext<Map<string, Href> | null>(null);
+
+export function useGuardRedirect(routeName: string): Href | undefined {
+  const guards = use(GuardContext);
+  if (!guards) {
+    return undefined;
+  }
+  return guards.get(routeName) ?? guards.get(routeName.replace(/\/index$/, ''));
+}
+
+function matchesRouteName(route: string, name: string) {
+  return route === name || route === `${name}/index` || route.replace(/\/index$/, '') === name;
+}
+
+function routeNodeToHref(route: RouteNode): Href {
+  return (stripInvisibleSegmentsFromPath(getContextKey(route.contextKey)) || '/') as Href;
+}
+
+function resolveDefaultHref(node: RouteNode, guardedRedirects: Map<string, Href | undefined>) {
+  const children = [...node.children].sort(sortRoutesWithInitial(node.initialRouteName));
+  const anchor = node.initialRouteName
+    ? children.find((child) => matchesRouteName(child.route, node.initialRouteName!))
+    : null;
+
+  if (
+    anchor &&
+    !guardedRedirects.has(anchor.route) &&
+    !guardedRedirects.has(anchor.route.replace(/\/index$/, ''))
+  ) {
+    return routeNodeToHref(anchor);
+  }
+
+  const firstAvailable = children.find(
+    (child) =>
+      !guardedRedirects.has(child.route) &&
+      !guardedRedirects.has(child.route.replace(/\/index$/, ''))
+  );
+
+  return firstAvailable ? routeNodeToHref(firstAvailable) : undefined;
+}
+
+export function GuardContextProvider({
+  node,
+  guardedRedirects,
+  children,
+}: {
+  node: RouteNode | null;
+  guardedRedirects: Map<string, Href | undefined>;
+  children: ReactNode;
+}) {
+  const signature = useMemo(
+    () =>
+      `${node?.contextKey ?? ''}:${node?.initialRouteName ?? ''}:` +
+      Array.from(guardedRedirects.entries())
+        .map(([name, href]) => `${name}=${href ?? ''}`)
+        .join('|'),
+    [guardedRedirects, node?.contextKey, node?.initialRouteName]
+  );
+
+  const resolved = useMemo(() => {
+    const map = new Map<string, Href>();
+    const defaultHref = node ? resolveDefaultHref(node, guardedRedirects) : '/';
+
+    guardedRedirects.forEach((redirectTo, name) => {
+      const href = redirectTo ?? defaultHref;
+      if (href != null) {
+        map.set(name, href);
+      }
+    });
+
+    return map;
+    // `signature` captures the guarded map content and navigator identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature]);
+
+  return <GuardContext value={resolved}>{children}</GuardContext>;
+}

--- a/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
+++ b/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { use, useEffect } from 'react';
+
+import { CommonActions } from '../react-navigation/native';
+import {
+  getRoutesForRouteNames,
+  type ParamListBase,
+  type StackNavigationState,
+} from '../react-navigation/routers';
+import type { Href } from '../types';
+import { GuardContext } from './GuardContext';
+
+function isGuardedRouteName(guards: Map<string, Href>, name: string): boolean {
+  return guards.has(name) || guards.has(name.replace(/\/index$/, ''));
+}
+
+/**
+ * Lets a stack navigator clear its own guarded routes from history, based on the guard context.
+ */
+export function useClearGuardedRoutes(
+  state: StackNavigationState<ParamListBase>,
+  navigation: {
+    dispatch: (
+      action: Readonly<{ type: string; payload?: object; source?: string; target?: string }>
+    ) => void;
+  }
+) {
+  const guards = use(GuardContext);
+
+  useEffect(() => {
+    if (!guards) {
+      return;
+    }
+
+    const focusedName = state.routes[state.index]?.name;
+    // If focused route becomes guarded then we let the redirect fire
+    const hasGuardedRoute = state.routes.some(
+      (route) => route.name !== focusedName && isGuardedRouteName(guards, route.name)
+    );
+    if (!hasGuardedRoute) {
+      return;
+    }
+
+    const allowedNames = state.routeNames.filter(
+      (name) => name === focusedName || !isGuardedRouteName(guards, name)
+    );
+
+    const { routes, index } = getRoutesForRouteNames(state, allowedNames, { routeParamList: {} });
+
+    navigation.dispatch({
+      ...CommonActions.reset({ ...state, routes, index }),
+      target: state.key,
+    });
+  }, [guards, state, navigation]);
+}

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -8,14 +8,15 @@ import type {
 } from 'react';
 import { Children, forwardRef, useMemo } from 'react';
 
-import { useContextKey } from '../Route';
+import { useContextKey, useRouteNode } from '../Route';
 import { isNativeTabTrigger, convertTabPropsToOptions } from '../native-tabs/NativeTabTrigger';
 import type { EventMapBase, NavigationState } from '../react-navigation/native';
-import type { PickPartial } from '../types';
+import type { Href, PickPartial } from '../types';
 import type { ScreenProps } from '../useScreens';
 import { useSortedScreens } from '../useScreens';
 import { isProtectedReactElement, Protected } from '../views/Protected';
 import { isScreen, Screen } from '../views/Screen';
+import { GuardContextProvider } from './GuardContext';
 import { IsWithinLayoutContext } from './IsWithinLayoutContext';
 
 export function useFilterScreenChildren(
@@ -33,42 +34,35 @@ export function useFilterScreenChildren(
     const customChildren: any[] = [];
 
     const screens: (ScreenProps & { name: string })[] = [];
-    const protectedScreens = new Set<string>();
+    const guardedRedirects = new Map<string, Href | undefined>();
 
-    function flattenChild(child: ReactNode, exclude = false) {
+    function flattenChild(child: ReactNode, exclude = false, redirectTo?: Href) {
       if (isScreen(child, contextKey)) {
+        screens.push(child.props);
         if (exclude) {
-          protectedScreens.add(child.props.name);
-        } else {
-          screens.push(child.props);
+          guardedRedirects.set(child.props.name, redirectTo);
         }
         return;
       }
 
       if (isNativeTabTrigger(child, contextKey)) {
+        const options = convertTabPropsToOptions(child.props);
+        screens.push({
+          ...child.props,
+          options: exclude ? { ...options, hidden: true } : options,
+        } as ScreenProps & { name: string });
         if (exclude) {
-          protectedScreens.add(child.props.name);
-        } else {
-          const options = convertTabPropsToOptions(child.props);
-          if (options.hidden === false) {
-            screens.push({
-              ...child.props,
-              options,
-            } as ScreenProps & { name: string });
-          } else {
-            // - hidden = undefined -> then the route was not specified in navigator
-            // - hidden = true -> then the route is hidden
-            // In this cases we should treat the tab as protected
-            protectedScreens.add(child.props.name);
-          }
+          guardedRedirects.set(child.props.name, redirectTo);
         }
         return;
       }
 
       if (isProtectedReactElement(child)) {
-        const excludeChildren = exclude || !child.props.guard;
+        const guardFails = !child.props.guard;
+        const excludeChildren = exclude || guardFails;
+        const childRedirectTo = guardFails ? child.props.redirectTo : redirectTo;
         Children.forEach(child.props.children, (protectedChild) => {
-          flattenChild(protectedChild, excludeChildren);
+          flattenChild(protectedChild, excludeChildren, childRedirectTo);
         });
         return;
       }
@@ -97,8 +91,7 @@ export function useFilterScreenChildren(
         screens?.map(
           (screen) => screen && typeof screen === 'object' && 'name' in screen && screen.name
         ) ?? [];
-      const protectedScreenNames = Array.from(protectedScreens).map(normalizeName);
-      const allNames = [...screenNames.map(normalizeName), ...protectedScreenNames];
+      const allNames = screenNames.map(normalizeName);
       if (new Set(allNames).size !== allNames.length) {
         throw new Error('Screen names must be unique: ' + allNames);
       }
@@ -107,7 +100,7 @@ export function useFilterScreenChildren(
     return {
       screens,
       children: customChildren,
-      protectedScreens,
+      guardedRedirects,
     };
   }, [children]);
 }
@@ -159,14 +152,15 @@ export function withLayoutContext<
   return Object.assign(
     forwardRef(({ children: userDefinedChildren, ...props }: any, ref) => {
       const contextKey = useContextKey();
+      const node = useRouteNode();
 
-      const { screens, protectedScreens } = useFilterScreenChildren(userDefinedChildren, {
+      const { screens, guardedRedirects } = useFilterScreenChildren(userDefinedChildren, {
         contextKey,
       });
 
       const processed = processor ? processor(screens ?? []) : screens;
 
-      const sorted = useSortedScreens(processed ?? [], protectedScreens, useOnlyUserDefinedScreens);
+      const sorted = useSortedScreens(processed ?? [], guardedRedirects, useOnlyUserDefinedScreens);
 
       // Prevent throwing an error when there are no screens.
       if (!sorted.length) {
@@ -175,7 +169,9 @@ export function withLayoutContext<
 
       return (
         <IsWithinLayoutContext value>
-          <Nav {...props} id={contextKey} ref={ref} children={sorted} />
+          <GuardContextProvider node={node} guardedRedirects={guardedRedirects}>
+            <Nav {...props} id={contextKey} ref={ref} children={sorted} />
+          </GuardContextProvider>
         </IsWithinLayoutContext>
       );
     }),

--- a/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
@@ -655,7 +655,7 @@ describe('prefetch', () => {
     });
   });
 
-  it('does not throw an exception when prefetching a protected route with guard false', () => {
+  it.each([false, true])('prefetches a protected route when guard is %s', (guard) => {
     renderRouter({
       index: () => {
         return <Link prefetch href="/test" />;
@@ -663,42 +663,7 @@ describe('prefetch', () => {
       test: () => null,
       _layout: () => (
         <Stack>
-          <Stack.Protected guard={false}>
-            <Stack.Screen name="test" />
-          </Stack.Protected>
-        </Stack>
-      ),
-    });
-
-    // There was no state update, because prefetch of protected route didn't make any state changes, so we received the initial state
-    // This is stale state created by router
-    expect(screen).toHaveRouterState({
-      routes: [
-        {
-          name: '__root',
-          state: {
-            routes: [
-              {
-                name: 'index',
-                params: undefined,
-                path: '/',
-              },
-            ],
-          },
-        },
-      ],
-    });
-  });
-
-  it('does not throw an exception when prefetching a protected route with guard true', () => {
-    renderRouter({
-      index: () => {
-        return <Link prefetch href="/test" />;
-      },
-      test: () => null,
-      _layout: () => (
-        <Stack>
-          <Stack.Protected guard>
+          <Stack.Protected guard={guard}>
             <Stack.Screen name="test" />
           </Stack.Protected>
         </Stack>

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -174,7 +174,8 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
 
 export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
   const triggerChildren = useMemo(
-    () => getAllChildrenOfType(props.children, NativeTabTrigger),
+    () =>
+      getAllChildrenOfType(props.children, NativeTabTrigger).filter((child) => !child.props.hidden),
     [props.children]
   );
   const nonTriggerChildren = useMemo(

--- a/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
@@ -157,11 +157,6 @@ export const StackActions = {
   },
 };
 
-/**
- * Filters a stack's routes down to `routeNames`, recomputing the index and falling back to the
- * initial route when nothing remains. Shared by `getStateForRouteNamesChange` and guard-based
- * pruning so both prune history the same way.
- */
 export function getRoutesForRouteNames(
   state: StackNavigationState<ParamListBase>,
   routeNames: string[],

--- a/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
@@ -158,6 +158,47 @@ export const StackActions = {
 };
 
 /**
+ * Filters a stack's routes down to `routeNames`, recomputing the index and falling back to the
+ * initial route when nothing remains. Shared by `getStateForRouteNamesChange` and guard-based
+ * pruning so both prune history the same way.
+ */
+export function getRoutesForRouteNames(
+  state: StackNavigationState<ParamListBase>,
+  routeNames: string[],
+  {
+    routeParamList,
+    routeKeyChanges = [],
+    initialRouteName,
+  }: {
+    routeParamList: ParamListBase;
+    routeKeyChanges?: string[];
+    initialRouteName?: string;
+  }
+): Pick<StackNavigationState<ParamListBase>, 'routes' | 'index'> {
+  const routes = state.routes.filter(
+    (route) => routeNames.includes(route.name) && !routeKeyChanges.includes(route.name)
+  );
+
+  if (routes.length === 0) {
+    const fallbackName =
+      initialRouteName !== undefined && routeNames.includes(initialRouteName)
+        ? initialRouteName
+        : routeNames[0]!;
+
+    routes.push({
+      key: `${fallbackName}-${nanoid()}`,
+      name: fallbackName,
+      params: routeParamList[fallbackName],
+    });
+  }
+
+  return {
+    routes,
+    index: Math.min(state.index, routes.length - 1),
+  };
+}
+
+/**
  * StackRouter is considered an internal implementation and its behavior may change without a notice between expo-router's version
  */
 export function StackRouter(options: StackRouterOptions) {
@@ -254,28 +295,14 @@ export function StackRouter(options: StackRouterOptions) {
     },
 
     getStateForRouteNamesChange(state, { routeNames, routeParamList, routeKeyChanges }) {
-      const routes = state.routes.filter(
-        (route) => routeNames.includes(route.name) && !routeKeyChanges.includes(route.name)
-      );
-
-      if (routes.length === 0) {
-        const initialRouteName =
-          options.initialRouteName !== undefined && routeNames.includes(options.initialRouteName)
-            ? options.initialRouteName
-            : routeNames[0]!;
-
-        routes.push({
-          key: `${initialRouteName}-${nanoid()}`,
-          name: initialRouteName,
-          params: routeParamList[initialRouteName],
-        });
-      }
-
       return {
         ...state,
         routeNames,
-        routes,
-        index: Math.min(state.index, routes.length - 1),
+        ...getRoutesForRouteNames(state, routeNames, {
+          routeParamList,
+          routeKeyChanges,
+          initialRouteName: options.initialRouteName,
+        }),
       };
     },
 

--- a/packages/expo-router/src/react-navigation/routers/__tests__/getRoutesForRouteNames.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/getRoutesForRouteNames.test.tsx
@@ -1,0 +1,95 @@
+import { expect, jest, test } from '@jest/globals';
+
+import { getRoutesForRouteNames, type StackNavigationState, type ParamListBase } from '..';
+
+jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
+
+function stackState(
+  routes: { name: string; key: string }[],
+  index: number
+): StackNavigationState<ParamListBase> {
+  return {
+    key: 'stack-test',
+    index,
+    routeNames: routes.map((r) => r.name),
+    routes,
+    type: 'stack',
+    stale: false,
+    preloadedRoutes: [],
+  } as StackNavigationState<ParamListBase>;
+}
+
+test('keeps routes whose name is allowed, preserving order', () => {
+  const state = stackState(
+    [
+      { name: 'a', key: 'a-1' },
+      { name: 'secret', key: 'secret-1' },
+      { name: 'b', key: 'b-1' },
+    ],
+    2
+  );
+
+  expect(getRoutesForRouteNames(state, ['a', 'b'], { routeParamList: {} })).toEqual({
+    routes: [
+      { name: 'a', key: 'a-1' },
+      { name: 'b', key: 'b-1' },
+    ],
+    index: 1,
+  });
+});
+
+test('clamps the index to the last remaining route', () => {
+  const state = stackState(
+    [
+      { name: 'a', key: 'a-1' },
+      { name: 'secret', key: 'secret-1' },
+    ],
+    1
+  );
+
+  // Focused route (index 1) is dropped, so index clamps to the last remaining route.
+  expect(getRoutesForRouteNames(state, ['a'], { routeParamList: {} })).toEqual({
+    routes: [{ name: 'a', key: 'a-1' }],
+    index: 0,
+  });
+});
+
+test('excludes routes whose name changed key', () => {
+  const state = stackState(
+    [
+      { name: 'a', key: 'a-1' },
+      { name: 'b', key: 'b-1' },
+    ],
+    1
+  );
+
+  expect(
+    getRoutesForRouteNames(state, ['a', 'b'], { routeParamList: {}, routeKeyChanges: ['b'] })
+  ).toEqual({
+    routes: [{ name: 'a', key: 'a-1' }],
+    index: 0,
+  });
+});
+
+test('falls back to the initial route when nothing remains', () => {
+  const state = stackState([{ name: 'secret', key: 'secret-1' }], 0);
+
+  expect(
+    getRoutesForRouteNames(state, ['a', 'b'], {
+      routeParamList: { a: { from: 'params' } },
+      initialRouteName: 'a',
+    })
+  ).toEqual({
+    routes: [{ name: 'a', key: 'a-test', params: { from: 'params' } }],
+    index: 0,
+  });
+});
+
+test('falls back to the first route name when there is no initial route', () => {
+  const state = stackState([{ name: 'secret', key: 'secret-1' }], 0);
+
+  expect(getRoutesForRouteNames(state, ['b', 'c'], { routeParamList: {} })).toEqual({
+    routes: [{ name: 'b', key: 'b-test', params: undefined }],
+    index: 0,
+  });
+});

--- a/packages/expo-router/src/react-navigation/routers/index.tsx
+++ b/packages/expo-router/src/react-navigation/routers/index.tsx
@@ -17,7 +17,7 @@ export type {
   StackNavigationState,
   StackRouterOptions,
 } from './StackRouter';
-export { StackActions, StackRouter } from './StackRouter';
+export { StackActions, StackRouter, getRoutesForRouteNames } from './StackRouter';
 export type {
   TabActionHelpers,
   TabActionType,

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -222,7 +222,7 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
     ).toEqual(['index', 'second']);
   });
 
-  it('filters out Protected screens whose guard is false', () => {
+  it('keeps Protected screens whose guard is false hidden', () => {
     renderRouter({
       _layout: () => (
         <StandardTabs>
@@ -236,7 +236,11 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
       second: () => <View testID="second" />,
     });
 
-    expect(lastArgs().state.routes.map((r) => r.name)).toEqual(['index']);
+    const args = lastArgs();
+    const second = args.state.routes.find((route) => route.name === 'second')!;
+
+    expect(args.state.routes.map((route) => route.name)).toEqual(['index', 'second']);
+    expect(args.descriptors[second.key]!.options).toMatchObject({ hidden: true });
   });
 
   it('propagates route params into state and href', () => {

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -9,6 +9,8 @@ import { useColorSchemeChangesIfNeeded } from './global-state/utils';
 // Direct import to prevent a require cycle
 import { useCurrentRouteInfo } from './hooks/useCurrentRouteInfo';
 import EXPO_ROUTER_IMPORT_MODE from './import-mode';
+import { useGuardRedirect } from './layouts/GuardContext';
+import { Redirect } from './link/Redirect';
 import { ZoomTransitionEnabler } from './link/zoom/ZoomTransitionEnabler';
 import { ZoomTransitionTargetContextProvider } from './link/zoom/zoom-transition-context-providers';
 import { unstable_navigationEvents } from './navigationEvents';
@@ -20,6 +22,7 @@ import {
 import { Screen } from './primitives';
 import type { BottomTabNavigationEventMap } from './react-navigation/bottom-tabs';
 import {
+  CommonActions,
   useStateForPath,
   type EventConsumer,
   type EventMapBase,
@@ -30,7 +33,7 @@ import {
   type ScreenListeners,
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
-import type { UnknownOutputParams } from './types';
+import type { Href, UnknownOutputParams } from './types';
 import { EmptyRoute } from './views/EmptyRoute';
 import {
   SuspenseFallback as DefaultSuspenseFallback,
@@ -173,7 +176,7 @@ function getSortedChildren(
  */
 export function useSortedScreens(
   order: ScreenProps[],
-  protectedScreens: Set<string>,
+  guardedRedirects: Map<string, Href | undefined> = new Map(),
   useOnlyUserDefinedScreens: boolean = false
 ): React.ReactNode[] {
   const node = useRouteNode();
@@ -190,20 +193,24 @@ export function useSortedScreens(
     : nodeChildren;
 
   const sorted = children.length ? getSortedChildren(children, order, node?.initialRouteName) : [];
-  return React.useMemo(
-    () =>
-      sorted
-        .filter((item) => {
-          const route = item.route.route;
-          return (
-            !protectedScreens.has(route) && !protectedScreens.has(route.replace(/\/index$/, ''))
-          );
-        })
-        .map((value) => {
-          return routeToScreen(value.route, value.props);
-        }),
-    [sorted, protectedScreens]
-  );
+  return React.useMemo(() => {
+    const screensWithGuarded = sorted.map((value) => {
+      const route = value.route.route;
+      const isGuarded =
+        guardedRedirects.has(route) || guardedRedirects.has(route.replace(/\/index$/, ''));
+      return { ...value, isGuarded };
+    });
+    const allScreensGuarded =
+      screensWithGuarded.length > 0 && screensWithGuarded.every((item) => item.isGuarded);
+
+    if (allScreensGuarded) {
+      return [];
+    }
+
+    return screensWithGuarded.map((value) => {
+      return routeToScreen(value.route, value.props, value.isGuarded);
+    });
+  }, [sorted, guardedRedirects]);
 }
 
 function fromImport(
@@ -319,6 +326,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     const isFocused = navigation.isFocused();
     const store = useExpoRouterStore();
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
+    const guardRedirect = useGuardRedirect(value.route);
 
     const ResolvedSuspenseFallback =
       EXPO_ROUTER_IMPORT_MODE === 'lazy'
@@ -329,7 +337,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         ? (LayoutSuspenseFallback ?? InheritedSuspenseFallback)
         : InheritedSuspenseFallback;
 
-    if (isFocused) {
+    if (isFocused && guardRedirect == null) {
       const state = navigation.getState();
       const isLeaf = !(state && 'state' in state.routes[state.index]!);
       if (isLeaf && stateForPath) store.setFocusedState(stateForPath);
@@ -344,9 +352,9 @@ export function getQualifiedRouteComponent(value: RouteNode) {
           // if the component itself didn’t rerender and the route info changed.
           // Otherwise, the update from the `if` above will handle it,
           // and this won’t cause a redundant second update.
-          if (isLeaf && stateForPath) store.setFocusedState(stateForPath);
+          if (isLeaf && stateForPath && guardRedirect == null) store.setFocusedState(stateForPath);
         }),
-      [navigation]
+      [navigation, guardRedirect]
     );
 
     useEffect(() => {
@@ -363,8 +371,50 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       });
     }, [navigation]);
 
+    useEffect(() => {
+      if (guardRedirect == null || isFocused || !route?.key) {
+        return;
+      }
+
+      const state = navigation.getState();
+      if (!state) {
+        return;
+      }
+
+      const routeIndex = state.routes.findIndex((stateRoute) => stateRoute.key === route.key);
+
+      if (routeIndex < 0 || state.routes.length <= 1) {
+        return;
+      }
+
+      const routes = state.routes.filter((stateRoute) => stateRoute.key !== route.key);
+      const preloadedRoutes =
+        'preloadedRoutes' in state && Array.isArray(state.preloadedRoutes)
+          ? state.preloadedRoutes.filter((stateRoute) => stateRoute.key !== route.key)
+          : undefined;
+      const index = routeIndex < state.index ? state.index - 1 : state.index;
+
+      navigation.dispatch({
+        ...CommonActions.reset({
+          ...(state as any),
+          index: Math.min(index, routes.length - 1),
+          routes,
+          ...(preloadedRoutes ? { preloadedRoutes } : null),
+        }),
+        target: state.key,
+      });
+    }, [guardRedirect, isFocused, navigation, route?.key]);
+
     const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;
+
+    if (guardRedirect != null) {
+      return (
+        <Route node={value} params={route?.params}>
+          <Redirect href={guardRedirect} />
+        </Route>
+      );
+    }
 
     return (
       <Route node={value} params={route?.params}>
@@ -495,7 +545,8 @@ function AnalyticsListeners({
 
 export function screenOptionsFactory(
   route: RouteNode,
-  options?: ScreenProps['options']
+  options?: ScreenProps['options'],
+  isGuarded?: boolean
 ): ScreenProps['options'] {
   return (args) => {
     // Only eager load generated components
@@ -508,11 +559,12 @@ export function screenOptionsFactory(
     };
 
     // Prevent generated screens from showing up in the tab bar.
-    if (route.internal) {
+    if (route.internal || isGuarded) {
       output.tabBarItemStyle = { display: 'none' };
       output.tabBarButton = () => null;
       // TODO: React Navigation doesn't provide a way to prevent rendering the drawer item.
       output.drawerItemStyle = { height: 0, display: 'none' };
+      output.hidden = true;
     }
 
     return output;
@@ -521,7 +573,8 @@ export function screenOptionsFactory(
 
 export function routeToScreen(
   route: RouteNode,
-  { options, getId, ...props }: Partial<ScreenProps> = {}
+  { options, getId, ...props }: Partial<ScreenProps> = {},
+  isGuarded?: boolean
 ) {
   return (
     <Screen
@@ -529,7 +582,7 @@ export function routeToScreen(
       name={route.route}
       key={route.route}
       getId={getId}
-      options={screenOptionsFactory(route, options)}
+      options={screenOptionsFactory(route, options, isGuarded)}
       getComponent={() => getQualifiedRouteComponent(route)}
     />
   );

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -22,7 +22,6 @@ import {
 import { Screen } from './primitives';
 import type { BottomTabNavigationEventMap } from './react-navigation/bottom-tabs';
 import {
-  CommonActions,
   useStateForPath,
   type EventConsumer,
   type EventMapBase,
@@ -370,40 +369,6 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         }
       });
     }, [navigation]);
-
-    useEffect(() => {
-      if (!guardRedirect || isFocused || !route?.key) {
-        return;
-      }
-
-      const state = navigation.getState();
-      if (!state) {
-        return;
-      }
-
-      const routeIndex = state.routes.findIndex((stateRoute) => stateRoute.key === route.key);
-
-      if (routeIndex < 0 || state.routes.length <= 1) {
-        return;
-      }
-
-      const routes = state.routes.filter((stateRoute) => stateRoute.key !== route.key);
-      const preloadedRoutes =
-        'preloadedRoutes' in state && Array.isArray(state.preloadedRoutes)
-          ? state.preloadedRoutes.filter((stateRoute) => stateRoute.key !== route.key)
-          : undefined;
-      const index = routeIndex < state.index ? state.index - 1 : state.index;
-
-      navigation.dispatch({
-        ...CommonActions.reset({
-          ...(state as any),
-          index: Math.min(index, routes.length - 1),
-          routes,
-          ...(preloadedRoutes ? { preloadedRoutes } : null),
-        }),
-        target: state.key,
-      });
-    }, [guardRedirect, isFocused, navigation, route?.key]);
 
     const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -337,7 +337,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         ? (LayoutSuspenseFallback ?? InheritedSuspenseFallback)
         : InheritedSuspenseFallback;
 
-    if (isFocused && guardRedirect == null) {
+    if (isFocused && !guardRedirect) {
       const state = navigation.getState();
       const isLeaf = !(state && 'state' in state.routes[state.index]!);
       if (isLeaf && stateForPath) store.setFocusedState(stateForPath);
@@ -352,7 +352,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
           // if the component itself didn’t rerender and the route info changed.
           // Otherwise, the update from the `if` above will handle it,
           // and this won’t cause a redundant second update.
-          if (isLeaf && stateForPath && guardRedirect == null) store.setFocusedState(stateForPath);
+          if (isLeaf && stateForPath && !guardRedirect) store.setFocusedState(stateForPath);
         }),
       [navigation, guardRedirect]
     );
@@ -372,7 +372,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     }, [navigation]);
 
     useEffect(() => {
-      if (guardRedirect == null || isFocused || !route?.key) {
+      if (!guardRedirect || isFocused || !route?.key) {
         return;
       }
 
@@ -408,7 +408,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;
 
-    if (guardRedirect != null) {
+    if (guardRedirect) {
       return (
         <Route node={value} params={route?.params}>
           <Redirect href={guardRedirect} />

--- a/packages/expo-router/src/views/Navigator.tsx
+++ b/packages/expo-router/src/views/Navigator.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { useContextKey } from '../Route';
+import { useContextKey, useRouteNode } from '../Route';
+import { GuardContextProvider } from '../layouts/GuardContext';
 import { StackRouter } from '../layouts/StackClient';
 import { useFilterScreenChildren } from '../layouts/withLayoutContext';
 import type { RouterFactory } from '../react-navigation/native';
@@ -47,18 +48,19 @@ export function Navigator<T extends UseNavigationBuilderRouter = typeof StackRou
   routerOptions,
 }: NavigatorProps<T>) {
   const contextKey = useContextKey();
+  const node = useRouteNode();
 
   // A custom navigator can have a mix of Screen and other components (like a Slot inside a View)
   const {
     screens,
     children: nonScreenChildren,
-    protectedScreens,
+    guardedRedirects,
   } = useFilterScreenChildren(children, {
     isCustomNavigator: true,
     contextKey,
   });
 
-  const sortedScreens = useSortedScreens(screens ?? [], protectedScreens);
+  const sortedScreens = useSortedScreens(screens ?? [], guardedRedirects);
 
   router ||= StackRouter as unknown as T;
 
@@ -84,7 +86,9 @@ export function Navigator<T extends UseNavigationBuilderRouter = typeof StackRou
         contextKey,
         router,
       }}>
-      {nonScreenChildren}
+      <GuardContextProvider node={node} guardedRedirects={guardedRedirects}>
+        {nonScreenChildren}
+      </GuardContextProvider>
     </NavigatorContext.Provider>
   );
 }
@@ -102,20 +106,23 @@ export function useNavigatorContext() {
 
 function SlotNavigator(props: NavigatorProps<any>) {
   const contextKey = useContextKey();
+  const node = useRouteNode();
 
   // Allows adding Screen components as children to configure routes.
-  const { screens, protectedScreens } = useFilterScreenChildren([], {
+  const { screens, guardedRedirects } = useFilterScreenChildren([], {
     contextKey,
   });
 
   const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, {
     ...props,
     id: contextKey,
-    children: useSortedScreens(screens ?? [], protectedScreens),
+    children: useSortedScreens(screens ?? [], guardedRedirects),
   });
 
   return (
-    <NavigationContent>{descriptors[state.routes[state.index]!.key]!.render()}</NavigationContent>
+    <GuardContextProvider node={node} guardedRedirects={guardedRedirects}>
+      <NavigationContent>{descriptors[state.routes[state.index]!.key]!.render()}</NavigationContent>
+    </GuardContextProvider>
   );
 }
 

--- a/packages/expo-router/src/views/Protected.tsx
+++ b/packages/expo-router/src/views/Protected.tsx
@@ -2,8 +2,14 @@ import type { FunctionComponent, ReactElement, ReactNode } from 'react';
 import { isValidElement } from 'react';
 
 import { Group } from '../primitives';
+import type { Href } from '../types';
 
-export type ProtectedProps = { guard: boolean; children?: ReactNode };
+export type ProtectedProps = {
+  guard: boolean;
+  /** Where to redirect when `guard` is false. Defaults to the containing navigator's anchor. */
+  redirectTo?: Href;
+  children?: ReactNode;
+};
 
 export const Protected = Group as FunctionComponent<ProtectedProps>;
 


### PR DESCRIPTION
# Why

Part of router state refactor.

https://linear.app/expo/issue/ENG-22009/refactor-protected-logic-not-to-relay-on-routenames

https://linear.app/expo/issue/ENG-22119/verify-expo-router-bug-still-reproduces-in-sdk-56

Fixes: https://github.com/expo/expo/issues/37816

# How

Instead of relying on `routeNames` to remove protected routes, we provide a way to redirect protected route to any href:
1. Use `Redirect` when route is guarded
2. Add `redirectTo` property
3. Clean state in stack, so that protected routes are removed from history

# Test Plan

1. CI
2. Router e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
