### PR TITLE
[cli] Add dynamic WebSocket upgrades to DevTools plugin request handlers

### DIFF
--- a/apps/router-e2e/modules/devtools-e2e/public/index.html
+++ b/apps/router-e2e/modules/devtools-e2e/public/index.html
@@ -15,6 +15,8 @@
       <pre id="server-result" hidden></pre>
       <button id="open-socket">Open WebSocket</button>
       <pre id="socket-log" hidden></pre>
+      <button id="open-dynamic-socket">Open Dynamic WebSocket</button>
+      <pre id="dynamic-socket-log" hidden></pre>
     </main>
     <script>
       const pluginPathname = location.pathname.replace(/\/$/, '');
@@ -57,6 +59,34 @@
           socket = undefined;
         });
         socket.addEventListener('error', () => append('error'));
+      });
+
+      const dynamicSocketButton = document.getElementById('open-dynamic-socket');
+      const dynamicSocketLog = document.getElementById('dynamic-socket-log');
+      let dynamicSocket;
+      dynamicSocketButton.addEventListener('click', () => {
+        if (dynamicSocket) {
+          dynamicSocket.close();
+          return;
+        }
+        dynamicSocketLog.hidden = false;
+        dynamicSocketLog.textContent = '';
+        const append = (line) => {
+          dynamicSocketLog.textContent += `${line}\n`;
+        };
+        dynamicSocket = new WebSocket(`${pluginPathname}/ws/dynamic/e2e-channel?source=webpage`);
+        dynamicSocket.addEventListener('open', () => {
+          append('open');
+          dynamicSocketButton.textContent = 'Close Dynamic WebSocket';
+          dynamicSocket.send('Hello from the dynamic webpage!');
+        });
+        dynamicSocket.addEventListener('message', (event) => append(`message: ${event.data}`));
+        dynamicSocket.addEventListener('close', () => {
+          append('close');
+          dynamicSocketButton.textContent = 'Open Dynamic WebSocket';
+          dynamicSocket = undefined;
+        });
+        dynamicSocket.addEventListener('error', () => append('error'));
       });
     </script>
     <style>

--- a/apps/router-e2e/modules/devtools-e2e/server.mjs
+++ b/apps/router-e2e/modules/devtools-e2e/server.mjs
@@ -3,7 +3,7 @@
 // require of esm in modern Node works(*)
 await undefined;
 
-export default async function handler(request) {
+export default async function handler(request, context) {
   const url = new URL(request.url);
 
   if (url.pathname === '/api/hello') {
@@ -14,6 +14,27 @@ export default async function handler(request) {
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     );
+  }
+
+  // Dynamic WebSocket routes: the channel name is part of the path, so it cannot be
+  // mounted statically through `webSocketHandlers`.
+  const dynamicChannel = url.pathname.match(/^\/ws\/dynamic\/([^/]+)$/)?.[1];
+  if (dynamicChannel) {
+    const response = context.upgrade({
+      onopen(peer) {
+        peer.send({
+          type: 'welcome',
+          message: `Connected to dynamic channel "${dynamicChannel}".`,
+          pathname: url.pathname,
+          search: url.search,
+        });
+      },
+      onmessage(peer, message) {
+        peer.send({ type: 'echo', channel: dynamicChannel, message: message.text() });
+      },
+    });
+    response.headers.set('x-devtools-channel', dynamicChannel);
+    return response;
   }
 
   // Fallback to static plugin page

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+- Support dynamic WebSocket routes in DevTools plugins via `context.upgrade(hooks)`. ([#47745](https://github.com/expo/expo/pull/47745) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/playwright/dev/devtools-e2e.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/devtools-e2e.test.ts
@@ -82,4 +82,19 @@ test.describe('devtools-e2e', () => {
       'message: {"type":"echo","message":"Hello from the webpage!"}'
     );
   });
+
+  test('connects and responds over a dynamic WebSocket route from the request handler', async ({
+    page,
+  }) => {
+    await page.goto(new URL(pluginPath, expoStart.url).href);
+
+    await page.getByRole('button', { name: 'Open Dynamic WebSocket' }).click();
+
+    await expect(page.locator('#dynamic-socket-log')).toContainText(
+      'message: {"type":"welcome","message":"Connected to dynamic channel \\"e2e-channel\\".","pathname":"/ws/dynamic/e2e-channel","search":"?source=webpage"}'
+    );
+    await expect(page.locator('#dynamic-socket-log')).toContainText(
+      'message: {"type":"echo","channel":"e2e-channel","message":"Hello from the dynamic webpage!"}'
+    );
+  });
 });

--- a/packages/@expo/cli/src/start/server/DevToolsPlugin.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPlugin.ts
@@ -8,8 +8,8 @@ import { DevToolsPluginEndpoint } from './DevToolsPluginManager';
 import {
   type DevToolsPluginRequestHandler,
   loadRequestHandlerAsync,
-  loadWebSocketServerAsync,
 } from './DevToolsPluginServerHelpers';
+import { loadWebSocketServerAsync } from './DevToolsPluginSocketHelpers';
 
 export type { DevToolsPluginRequestHandler } from './DevToolsPluginServerHelpers';
 
@@ -106,9 +106,9 @@ export class DevToolsPlugin {
    * Lazily builds the WebSocket servers contributed by the plugin's `serverEntryPoint`. The entry
    * point exports a `webSocketHandlers` map of route (e.g. `/ws`) to a connection handler; each
    * route becomes a `ws` `WebSocketServer` (in `noServer` mode) that the dev server mounts under
-   * `/_expo/plugins/<name>/<route>`. The fetch API based `requestHandler` cannot serve WebSocket
-   * upgrades, so this is how a plugin opts into them. Returns an empty object when the plugin
-   * exports no handlers.
+   * `/_expo/plugins/<name>/<route>` with exact-path matching. For dynamic routes, the fetch API
+   * based `requestHandler` can commit upgrades itself by returning `context.upgrade(hooks)`.
+   * Returns an empty object when the plugin exports no handlers.
    */
   async getWebSocketServersAsync(): Promise<Record<string, WebSocketServer>> {
     if (!this.plugin.serverEntryPoint) {

--- a/packages/@expo/cli/src/start/server/DevToolsPluginServerHelpers.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginServerHelpers.ts
@@ -1,45 +1,45 @@
 import { loadModule } from '@expo/require-utils';
-import type { IncomingMessage } from 'node:http';
-import { type WebSocket, WebSocketServer } from 'ws';
+
+import type { RequestContext } from './DevToolsPluginSocketHelpers';
 
 const debug = require('debug')('expo:start:server:devtools') as typeof console.log;
 
 /**
  * Handler default-exported by a plugin's `serverEntryPoint`. Receives a fetch API `Request`
  * with the plugin endpoint prefix stripped from the URL. Returning `null`/`undefined` falls
- * through to static `webpageRoot` serving.
+ * through to static `webpageRoot` serving. For WebSocket Upgrade requests, return
+ * `context.upgrade(hooks)` to commit the handshake, or any plain `Response` to reject it.
  */
 export type DevToolsPluginRequestHandler = (
-  request: Request
+  request: Request,
+  context: RequestContext
 ) => Response | null | undefined | Promise<Response | null | undefined>;
 
-/**
- * Per-connection WebSocket handler exported by a plugin's `serverEntryPoint`. Receives the
- * connected `ws` socket, the upgrade `request`, and the `WebSocketServer` the connection belongs
- * to (use `server.clients` to broadcast). Mirrors the `ws` `'connection'` event so plugin authors
- * use the familiar `socket.on('message', ...)` / `socket.send(...)` API.
- */
-export type DevToolsPluginWebSocketHandler = (
-  socket: WebSocket,
-  request: Request,
-  server: WebSocketServer
-) => void;
+/** Creates the request context for plain HTTP requests, where no socket can be upgraded. */
+export function createHttpRequestContext(): RequestContext {
+  return {
+    upgrade() {
+      throw new Error(
+        'context.upgrade() was called for a regular HTTP request, so there is no socket to upgrade. ' +
+          'WebSocket hooks can only be attached when the client sends an Upgrade request; ' +
+          "check `request.headers.get('upgrade') === 'websocket'` before calling upgrade(), " +
+          'and return a normal Response for HTTP requests.'
+      );
+    },
+  };
+}
 
-function convertUpgradeRequest(request: IncomingMessage, route: string): Request {
-  const proto = 'encrypted' in request.socket && !!request.socket.encrypted ? 'https' : 'http';
-  const origin = `${proto}://${request.headers.host}`;
-  const url = new URL(request.url ?? '/', origin);
-  url.pathname = route;
-  const headers = new Headers();
-  const { rawHeaders } = request;
-  for (let index = 0; index < rawHeaders.length; index += 2) {
-    const name = rawHeaders[index];
-    const value = rawHeaders[index + 1];
-    if (name != null && value != null) {
-      headers.append(name, value);
-    }
+/**
+ * Extracts the (possibly scoped) plugin package name from a pathname that has the
+ * `/_expo/plugins/` endpoint prefix already stripped.
+ */
+export function parsePluginName(pathname: string): string {
+  const parts = pathname.split('/');
+  if (parts[0]![0] === '@' && parts.length > 1) {
+    // Scoped package name
+    return `${parts[0]}/${parts[1]}`;
   }
-  return new Request(url.href, { method: request.method, headers });
+  return parts[0]!;
 }
 
 export async function loadRequestHandlerAsync({
@@ -63,37 +63,4 @@ export async function loadRequestHandlerAsync({
     );
   }
   return handler;
-}
-
-export async function loadWebSocketServerAsync({
-  packageName,
-  serverEntryPoint,
-}: {
-  packageName: string;
-  serverEntryPoint: string;
-}): Promise<Record<string, WebSocketServer>> {
-  debug('Loading DevTools plugin WebSocket server module: %s', serverEntryPoint);
-  const serverModule = (await loadModule(serverEntryPoint)) as {
-    webSocketHandlers?: Record<string, DevToolsPluginWebSocketHandler>;
-  };
-  const handlers: Record<string, DevToolsPluginWebSocketHandler> =
-    serverModule?.webSocketHandlers ?? {};
-
-  return Object.fromEntries(
-    Object.entries(handlers).map(([route, handler]) => {
-      if (typeof handler !== 'function') {
-        throw new Error(
-          `The webSocketHandlers["${route}"] export of plugin ${packageName} ` +
-            `must be a function (socket, request, server) => void.`
-        );
-      }
-      // Routes are mounted relative to the plugin endpoint, so they must be absolute.
-      const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
-      const server = new WebSocketServer({ noServer: true });
-      server.on('connection', (socket, request) =>
-        handler(socket, convertUpgradeRequest(request, normalizedRoute), server)
-      );
-      return [normalizedRoute, server];
-    })
-  );
 }

--- a/packages/@expo/cli/src/start/server/DevToolsPluginSocketHelpers.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginSocketHelpers.ts
@@ -1,0 +1,200 @@
+import { loadModule } from '@expo/require-utils';
+import type { IncomingMessage } from 'node:http';
+import { type RawData, type WebSocket, WebSocketServer } from 'ws';
+
+const debug = require('debug')('expo:start:server:devtools') as typeof console.log;
+
+/**
+ * Incoming WebSocket message passed to the `message` hook, with lazy conversion helpers
+ * mirroring the fetch API `Body` readers.
+ */
+type WebSocketMessage = {
+  readonly rawData: RawData;
+  readonly isBinary: boolean;
+  text(): string;
+  json<T = unknown>(): T;
+  uint8Array(): Uint8Array;
+  arrayBuffer(): ArrayBuffer;
+};
+
+/**
+ * Connected WebSocket peer passed to the lifecycle hooks. `send` serializes plain objects
+ * as JSON; strings and binary payloads are sent as-is. The raw `ws` socket is exposed as
+ * an escape hatch.
+ */
+type WebSocketPeer = {
+  readonly socket: WebSocket;
+  send(data: string | Buffer | ArrayBufferLike | ArrayBufferView | object): void;
+  close(code?: number, reason?: string): void;
+  terminate(): void;
+};
+
+/** Lifecycle hooks passed to `context.upgrade()`, wired to the socket once the handshake commits. */
+type WebSocketHooks = {
+  onopen?(peer: WebSocketPeer): void;
+  onmessage?(peer: WebSocketPeer, message: WebSocketMessage): void;
+  onclose?(peer: WebSocketPeer, details: { code: number; reason: string }): void;
+  onerror?(peer: WebSocketPeer, error: Error): void;
+};
+
+/**
+ * Per-request context passed to a plugin's request handler as the second argument.
+ * `upgrade()` does not perform the WebSocket handshake — it returns a marker `Response`
+ * that commits the handshake only when the handler returns it. Headers set on that
+ * response (including cookies) are written into the `101 Switching Protocols` handshake.
+ */
+export type RequestContext = {
+  upgrade(hooks: WebSocketHooks): Response;
+};
+
+const upgradeHooksRegistry = new WeakMap<Response, WebSocketHooks>();
+
+/** Creates the request context for WebSocket Upgrade requests. */
+export function createUpgradeRequestContext(): RequestContext {
+  return {
+    upgrade(hooks) {
+      const response = new Response(null, {
+        statusText: 'Switching Protocols',
+      });
+      // The fetch API `Response` constructor does not accept informational status codes
+      Object.defineProperty(response, 'status', { value: 101 });
+      upgradeHooksRegistry.set(response, hooks);
+      return response;
+    },
+  };
+}
+
+/** Returns the hooks attached by `context.upgrade()`, or `undefined` for plain responses. */
+export function getUpgradeHooks(response: Response | null | undefined): WebSocketHooks | undefined {
+  return response ? upgradeHooksRegistry.get(response) : undefined;
+}
+
+function toBuffer(data: RawData): Buffer {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data);
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+  return data;
+}
+
+function createWebSocketMessage(rawData: RawData, isBinary: boolean): WebSocketMessage {
+  return {
+    rawData,
+    isBinary,
+    text: () => toBuffer(rawData).toString('utf8'),
+    json: () => JSON.parse(toBuffer(rawData).toString('utf8')),
+    uint8Array: () => new Uint8Array(toBuffer(rawData)),
+    arrayBuffer: () => {
+      const buffer = toBuffer(rawData);
+      const arrayBuffer = new ArrayBuffer(buffer.byteLength);
+      new Uint8Array(arrayBuffer).set(buffer);
+      return arrayBuffer;
+    },
+  };
+}
+
+/** Wires the hooks from `context.upgrade()` to a connected socket. */
+export function attachWebSocketHooks(socket: WebSocket, hooks: WebSocketHooks): void {
+  const peer: WebSocketPeer = {
+    socket,
+    send(data) {
+      if (
+        typeof data === 'string' ||
+        Buffer.isBuffer(data) ||
+        data instanceof ArrayBuffer ||
+        ArrayBuffer.isView(data)
+      ) {
+        socket.send(data);
+      } else {
+        socket.send(JSON.stringify(data));
+      }
+    },
+    close: (code, reason) => socket.close(code, reason),
+    terminate: () => socket.terminate(),
+  };
+  const invoke = (hook: () => void) => {
+    try {
+      hook();
+    } catch (error: any) {
+      debug('DevTools plugin WebSocket hook failed: %O', error);
+      hooks.onerror?.(peer, error);
+    }
+  };
+  socket.on('message', (data, isBinary) =>
+    invoke(() => hooks.onmessage?.(peer, createWebSocketMessage(data, isBinary)))
+  );
+  socket.on('close', (code, reason) =>
+    // https://www.rfc-editor.org/info/rfc6455/#section-5.5.1 -> defined UTF-8-encoded data
+    invoke(() => hooks.onclose?.(peer, { code, reason: reason.toString() }))
+  );
+  socket.on('error', (error) => hooks.onerror?.(peer, error));
+  invoke(() => hooks.onopen?.(peer));
+}
+
+/**
+ * Per-connection WebSocket handler exported by a plugin's `serverEntryPoint`. Receives the
+ * connected `ws` socket, the upgrade `request`, and the `WebSocketServer` the connection belongs
+ * to (use `server.clients` to broadcast). Mirrors the `ws` `'connection'` event so plugin authors
+ * use the familiar `socket.on('message', ...)` / `socket.send(...)` API.
+ */
+export type DevToolsPluginWebSocketHandler = (
+  socket: WebSocket,
+  request: Request,
+  server: WebSocketServer
+) => void;
+
+/**
+ * Converts a Node.js HTTP Upgrade request to a fetch API `Request`, rewriting the pathname
+ * to `route` (the plugin-relative path) while preserving the query string.
+ */
+export function convertUpgradeRequest(request: IncomingMessage, route: string): Request {
+  const proto = 'encrypted' in request.socket && !!request.socket.encrypted ? 'https' : 'http';
+  const origin = `${proto}://${request.headers.host}`;
+  const url = new URL(request.url ?? '/', origin);
+  url.pathname = route;
+  const headers = new Headers();
+  const { rawHeaders } = request;
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index];
+    const value = rawHeaders[index + 1];
+    if (name != null && value != null) {
+      headers.append(name, value);
+    }
+  }
+  return new Request(url.href, { method: request.method, headers });
+}
+
+export async function loadWebSocketServerAsync({
+  packageName,
+  serverEntryPoint,
+}: {
+  packageName: string;
+  serverEntryPoint: string;
+}): Promise<Record<string, WebSocketServer>> {
+  debug('Loading DevTools plugin WebSocket server module: %s', serverEntryPoint);
+  const serverModule = (await loadModule(serverEntryPoint)) as {
+    webSocketHandlers?: Record<string, DevToolsPluginWebSocketHandler>;
+  };
+  const handlers: Record<string, DevToolsPluginWebSocketHandler> =
+    serverModule?.webSocketHandlers ?? {};
+
+  return Object.fromEntries(
+    Object.entries(handlers).map(([route, handler]) => {
+      if (typeof handler !== 'function') {
+        throw new Error(
+          `The webSocketHandlers["${route}"] export of plugin ${packageName} ` +
+            `must be a function (socket, request, server) => void.`
+        );
+      }
+      // Routes are mounted relative to the plugin endpoint, so they must be absolute.
+      const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+      const server = new WebSocketServer({ noServer: true });
+      server.on('connection', (socket, request) =>
+        handler(socket, convertUpgradeRequest(request, normalizedRoute), server)
+      );
+      return [normalizedRoute, server];
+    })
+  );
+}

--- a/packages/@expo/cli/src/start/server/DevToolsPluginUpgradeHandler.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginUpgradeHandler.ts
@@ -1,0 +1,132 @@
+import { STATUS_CODES, type IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { WebSocketServer } from 'ws';
+
+import type DevToolsPluginManager from './DevToolsPluginManager';
+import { DevToolsPluginEndpoint } from './DevToolsPluginManager';
+import { parsePluginName } from './DevToolsPluginServerHelpers';
+import {
+  attachWebSocketHooks,
+  convertUpgradeRequest,
+  createUpgradeRequestContext,
+  getUpgradeHooks,
+} from './DevToolsPluginSocketHelpers';
+
+const debug = require('debug')('expo:start:server:devtools') as typeof console.log;
+
+type DevToolsPluginUpgradeHandler = (
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+) => Promise<boolean>;
+
+/**
+ * Creates the dynamic WebSocket upgrade dispatcher for DevTools plugins. Upgrade requests under
+ * `/_expo/plugins/<name>/...` that no statically mounted endpoint claimed are routed to the
+ * plugin's fetch request handler with an upgradeable context. The handler commits the handshake
+ * by returning `context.upgrade(hooks)`, rejects it by returning a plain `Response`, or declines
+ * by returning `null`/`undefined` (the returned `upgradeHandler` resolves to `false` and the
+ * caller destroys the socket).
+ *
+ * All connections share one `ws` server in `noServer` mode, returned as `dummyUpgradeEndpoint`
+ * for the caller to merge into the dev server's `websocketEndpoints`, so it is closed (and its
+ * clients terminated) on dev server shutdown.
+ */
+export function createDevToolsPluginUpgradeHandler(pluginManager: DevToolsPluginManager): {
+  upgradeHandler: DevToolsPluginUpgradeHandler;
+  dummyUpgradeEndpoint: Record<string, WebSocketServer>;
+} {
+  const webSocketServer = new WebSocketServer({ noServer: true });
+
+  const upgradeHandler: DevToolsPluginUpgradeHandler = async (request, socket, head) => {
+    const { pathname } = new URL(request.url ?? '/', 'http://localhost');
+    if (!pathname.startsWith(`${DevToolsPluginEndpoint}/`)) {
+      return false;
+    }
+
+    const pluginName = parsePluginName(pathname.substring(DevToolsPluginEndpoint.length + 1));
+    const plugin = await pluginManager.queryPluginAsync(pluginName);
+    if (!plugin || plugin.serverEntryPoint == null) {
+      return false;
+    }
+
+    const pathInPluginRoot =
+      pathname.substring(DevToolsPluginEndpoint.length + pluginName.length + 1) || '/';
+    const upgradeRequest = convertUpgradeRequest(request, pathInPluginRoot);
+
+    let response: Response | null | undefined;
+    try {
+      const handler = await plugin.getRequestHandlerAsync();
+      response = await handler?.(upgradeRequest, createUpgradeRequestContext());
+    } catch (error: any) {
+      debug('DevTools plugin upgrade request failed: %O', error);
+      await writeResponseToSocket(
+        socket,
+        new Response(
+          `The DevTools plugin "${plugin.packageName}" failed to handle the WebSocket upgrade to "${pathInPluginRoot}": ` +
+            `${error?.message ?? error}. This is likely a bug in the plugin's server entry point ` +
+            `(${plugin.serverEntryPoint}); report it to the plugin author.`,
+          { status: 500, headers: { 'Content-Type': 'text/plain' } }
+        )
+      );
+      return true;
+    }
+
+    if (response == null) {
+      return false;
+    }
+
+    const hooks = getUpgradeHooks(response);
+    if (!hooks) {
+      // A plain response rejects the upgrade and is written back over the raw socket.
+      await writeResponseToSocket(socket, response);
+      return true;
+    }
+
+    const onHeaders = (headers: string[], headersRequest: IncomingMessage) => {
+      if (headersRequest !== request) {
+        return;
+      }
+      for (const [name, value] of response.headers) {
+        headers.push(`${name}: ${value}`);
+      }
+    };
+    webSocketServer.on('headers', onHeaders);
+    try {
+      webSocketServer.handleUpgrade(request, socket, head, (ws) => {
+        attachWebSocketHooks(ws, hooks);
+      });
+    } finally {
+      webSocketServer.off('headers', onHeaders);
+    }
+    return true;
+  };
+
+  return {
+    upgradeHandler,
+    dummyUpgradeEndpoint: {
+      // The key with no leading slash will never match, ensuring no conflicts with exact-path endpoints.
+      // https://github.com/expo/expo/blob/8bf7d23a090d2d9f7affbefb7d7c983d53cd2735/packages/%40expo/cli/src/start/server/metro/runServer-fork.ts#L183
+      // We add the server to ensure automatic close handling.
+      '__/expo-dev-plugins/upgrade': webSocketServer,
+    },
+  };
+}
+
+/** Serializes a fetch API `Response` as a raw HTTP/1.1 response onto an upgrade socket. */
+async function writeResponseToSocket(socket: Duplex, response: Response): Promise<void> {
+  const body = Buffer.from(await response.arrayBuffer());
+  const statusText = response.statusText || STATUS_CODES[response.status] || '';
+  const headers = new Headers(response.headers);
+  if (!headers.has('content-length')) {
+    headers.set('content-length', String(body.byteLength));
+  }
+  headers.set('connection', 'close');
+
+  let head = `HTTP/1.1 ${response.status} ${statusText}\r\n`;
+  for (const [name, value] of headers) {
+    head += `${name}: ${value}\r\n`;
+  }
+  socket.write(head + '\r\n');
+  socket.end(body);
+}

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPlugin-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPlugin-test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { DevToolsPlugin } from '../DevToolsPlugin';
+import { createHttpRequestContext } from '../DevToolsPluginServerHelpers';
 
 describe('DevToolsPlugin', () => {
   it('should create an instance from a plugin with only the webpageRoot configuration set', () => {
@@ -192,12 +193,13 @@ describe('DevToolsPlugin', () => {
       const handler = await plugin.getRequestHandlerAsync();
       expect(typeof handler).toBe('function');
 
-      const response = await handler!(new Request('http://localhost:8081/api/hello'));
+      const context = createHttpRequestContext();
+      const response = await handler!(new Request('http://localhost:8081/api/hello'), context);
       expect(response).not.toBeNull();
       expect(response!.status).toBe(200);
       expect(await response!.json()).toEqual({ message: 'hello' });
 
-      const passthrough = await handler!(new Request('http://localhost:8081/unknown'));
+      const passthrough = await handler!(new Request('http://localhost:8081/unknown'), context);
       expect(passthrough).toBeNull();
     });
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginUpgradeHandler-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginUpgradeHandler-test.ts
@@ -1,0 +1,222 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
+
+import type DevToolsPluginManager from '../DevToolsPluginManager';
+import { createDevToolsPluginUpgradeHandler } from '../DevToolsPluginUpgradeHandler';
+import type { DevToolsPluginRequestHandler } from '../DevToolsPluginServerHelpers';
+
+describe(createDevToolsPluginUpgradeHandler, () => {
+  it('commits a dynamic upgrade and wires the hooks to the socket', async () => {
+    const { origin, handledResults, close } = await startServer(async (request, context) => {
+      const url = new URL(request.url);
+      if (!url.pathname.startsWith('/ws/')) {
+        return null;
+      }
+      return context.upgrade({
+        onopen(peer) {
+          peer.send({
+            type: 'welcome',
+            pathname: url.pathname,
+            search: url.search,
+          });
+        },
+        onmessage(peer, message) {
+          peer.send({ type: 'echo', message: message.text() });
+        },
+      });
+    });
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws/session-1?token=abc`);
+      const welcome = nextMessage(socket);
+      await new Promise((resolve) => socket.once('open', resolve));
+      // The plugin prefix is stripped, so handlers see package-relative URLs.
+      expect(JSON.parse(await welcome)).toEqual({
+        type: 'welcome',
+        pathname: '/ws/session-1',
+        search: '?token=abc',
+      });
+
+      const echo = nextMessage(socket);
+      socket.send('ping');
+      expect(JSON.parse(await echo)).toEqual({ type: 'echo', message: 'ping' });
+
+      socket.close();
+      expect(handledResults).toEqual([true]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('applies headers set on the returned response to the 101 handshake', async () => {
+    const { origin, close } = await startServer(async (request, context) => {
+      const response = context.upgrade({});
+      response.headers.set('x-connection-id', 'test-123');
+      response.headers.append('Set-Cookie', 'plugin-session=abc; Path=/');
+      response.headers.append('Set-Cookie', 'plugin-flag=1; Path=/');
+      return response;
+    });
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws`);
+      const handshake = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        socket.once('upgrade', resolve);
+        socket.once('error', reject);
+      });
+
+      expect(handshake.statusCode).toBe(101);
+      expect(handshake.headers['x-connection-id']).toBe('test-123');
+      expect(handshake.headers['set-cookie']).toEqual([
+        'plugin-session=abc; Path=/',
+        'plugin-flag=1; Path=/',
+      ]);
+
+      socket.close();
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects the upgrade when the handler returns a plain response', async () => {
+    const { origin, handledResults, close } = await startServer(
+      async () => new Response('Unauthorized', { status: 401 })
+    );
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws`);
+      const rejection = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        socket.once('unexpected-response', (_request, response) => resolve(response));
+        socket.once('open', () => reject(new Error('Expected the upgrade to be rejected')));
+      });
+
+      expect(rejection.statusCode).toBe(401);
+      const body = await new Promise<string>((resolve) => {
+        const chunks: Buffer[] = [];
+        rejection.on('data', (chunk) => chunks.push(chunk));
+        rejection.on('end', () => resolve(Buffer.concat(chunks).toString()));
+      });
+      expect(body).toBe('Unauthorized');
+      expect(handledResults).toEqual([true]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('does not handle the upgrade when the handler returns null', async () => {
+    const { origin, handledResults, close } = await startServer(async () => null);
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws`);
+      await new Promise((resolve) => socket.once('error', resolve));
+      expect(handledResults).toEqual([false]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('does not handle upgrades for unknown plugins or non-plugin paths', async () => {
+    const { origin, handledResults, close } = await startServer(async () => null);
+
+    try {
+      const unknownPlugin = new WebSocket(`${origin}/_expo/plugins/unknown-plugin/ws`);
+      await new Promise((resolve) => unknownPlugin.once('error', resolve));
+
+      const nonPluginPath = new WebSocket(`${origin}/hot`);
+      await new Promise((resolve) => nonPluginPath.once('error', resolve));
+
+      expect(handledResults).toEqual([false, false]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('does not handle upgrades for plugins without a serverEntryPoint', async () => {
+    const { origin, handledResults, close } = await startServer(undefined);
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws`);
+      await new Promise((resolve) => socket.once('error', resolve));
+      expect(handledResults).toEqual([false]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects the upgrade with a 500 when the handler throws', async () => {
+    const { origin, handledResults, close } = await startServer(async () => {
+      throw new Error('boom');
+    });
+
+    try {
+      const socket = new WebSocket(`${origin}/_expo/plugins/hello-plugin/ws`);
+      const rejection = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        socket.once('unexpected-response', (_request, response) => resolve(response));
+        socket.once('open', () => reject(new Error('Expected the upgrade to be rejected')));
+      });
+
+      expect(rejection.statusCode).toBe(500);
+      expect(handledResults).toEqual([true]);
+    } finally {
+      await close();
+    }
+  });
+});
+
+function createPluginManager(requestHandler: DevToolsPluginRequestHandler | undefined) {
+  const plugin = {
+    packageName: 'hello-plugin',
+    packageRoot: '/root/packages/hello-plugin',
+    serverEntryPoint: requestHandler ? '/root/packages/hello-plugin/dist/server.js' : undefined,
+    getRequestHandlerAsync: async () => requestHandler,
+  };
+  return {
+    queryPluginAsync: jest.fn(async (pluginName: string) =>
+      pluginName === 'hello-plugin' ? plugin : null
+    ),
+  } as unknown as DevToolsPluginManager;
+}
+
+async function startServer(requestHandler: DevToolsPluginRequestHandler | undefined) {
+  const { upgradeHandler, dummyUpgradeEndpoint } = createDevToolsPluginUpgradeHandler(
+    createPluginManager(requestHandler)
+  );
+  // Mirrors how `instantiateMetro` registers the endpoint: values are closed on server shutdown,
+  // while the non-pathname key keeps it out of the exact-path upgrade dispatch.
+  const webSocketServer = Object.values(dummyUpgradeEndpoint)[0]!;
+  const server = http.createServer((req, res) => {
+    res.statusCode = 404;
+    res.end();
+  });
+  const handledResults: boolean[] = [];
+  server.on('upgrade', async (request, socket, head) => {
+    const handled = await upgradeHandler(request, socket, head);
+    handledResults.push(handled);
+    if (!handled) {
+      socket.destroy();
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    server,
+    webSocketServer,
+    handledResults,
+    origin: `ws://127.0.0.1:${port}`,
+    close: async () => {
+      webSocketServer.close();
+      webSocketServer.clients.forEach((client) => client.terminate());
+      await new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function nextMessage(socket: WebSocket): Promise<string> {
+  return new Promise((resolve, reject) => {
+    socket.once('message', (data) => resolve(data.toString()));
+    socket.once('error', reject);
+  });
+}

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -24,6 +24,7 @@ import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import type DevToolsPluginManager from '../DevToolsPluginManager';
 import { DevToolsPluginEndpoint } from '../DevToolsPluginManager';
+import { createDevToolsPluginUpgradeHandler } from '../DevToolsPluginUpgradeHandler';
 import { createCorsMiddleware } from '../middleware/CorsMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
@@ -35,7 +36,12 @@ import { replaceMetroFileMap } from './createFileMap-fork';
 import { attachAtlasAsync } from './debugging/attachAtlas';
 import { createDebugMiddleware } from './debugging/createDebugMiddleware';
 import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
-import { runServer, type ServerAddressInfo, type SecureServerOptions } from './runServer-fork';
+import {
+  runServer,
+  type ServerAddressInfo,
+  type SecureServerOptions,
+  type WebsocketUpgradeHandler,
+} from './runServer-fork';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
 
 // prettier-ignore
@@ -388,6 +394,8 @@ export async function instantiateMetroAsync(
     { getMetroBundler, serverBaseUrl }
   );
 
+  let websocketUpgradeHandler: WebsocketUpgradeHandler | undefined;
+
   if (!isExporting) {
     // Enable correct CORS headers for Expo Router features
     prependMiddleware(middleware, createCorsMiddleware(exp));
@@ -417,6 +425,10 @@ export async function instantiateMetroAsync(
 
     const devtoolsWebsocketEndpoints = createDevToolsPluginWebsocketEndpoint();
     Object.assign(websocketEndpoints, devtoolsWebsocketEndpoints);
+
+    const pluginUpgradeHandler = createDevToolsPluginUpgradeHandler(devToolsPluginManager);
+    websocketUpgradeHandler = pluginUpgradeHandler.upgradeHandler;
+    Object.assign(websocketEndpoints, pluginUpgradeHandler.dummyUpgradeEndpoint);
 
     // Register WebSocket endpoints contributed by DevTools plugins. A plugin's `serverEntryPoint`
     // exports a `webSocketHandlers` map (route -> connection handler); each becomes a `ws` server
@@ -471,6 +483,7 @@ export async function instantiateMetroAsync(
       {
         host: options.host,
         websocketEndpoints,
+        websocketUpgradeHandler,
         watch,
         secureServerOptions,
       },

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -12,6 +12,7 @@ import createWebsocketServer from '@expo/metro/metro/lib/createWebsocketServer';
 import assert from 'assert';
 import http from 'http';
 import https from 'https';
+import type { Duplex } from 'stream';
 import type { WebSocketServer } from 'ws';
 
 import { Log } from '../../../log';
@@ -32,6 +33,17 @@ export interface ServerAddressInfo {
   port: number;
 }
 
+/**
+ * Called for Upgrade requests that no exact-path `websocketEndpoints` entry claimed.
+ * Resolve to `true` when the upgrade was handled (committed or rejected); resolving to
+ * `false` (or throwing) destroys the socket.
+ */
+export type WebsocketUpgradeHandler = (
+  request: http.IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+) => Promise<boolean> | boolean;
+
 interface RunServerOptionsFork {
   hasReducedPerformance?: boolean;
   host?: string;
@@ -39,6 +51,7 @@ interface RunServerOptionsFork {
   onReady?(server: http.Server | https.Server): void;
   onClose?(): void;
   websocketEndpoints?: RunServerOptions['websocketEndpoints'];
+  websocketUpgradeHandler?: WebsocketUpgradeHandler;
   secureServerOptions?: SecureServerOptions;
   waitForBundler?: boolean;
   watch?: boolean;
@@ -54,6 +67,7 @@ export const runServer = async (
     onReady,
     secureServerOptions,
     websocketEndpoints = {},
+    websocketUpgradeHandler,
     watch,
     waitForBundler = !!watch,
   }: RunServerOptionsFork,
@@ -178,15 +192,24 @@ export const runServer = async (
         }),
       });
 
-      httpServer.on('upgrade', (request, socket, head) => {
+      httpServer.on('upgrade', async (request, socket, head) => {
         const { pathname } = new URL(request.url!, 'http://localhost');
         if (pathname != null && websocketEndpoints[pathname]) {
           websocketEndpoints[pathname].handleUpgrade(request, socket, head, (ws) => {
             websocketEndpoints[pathname]?.emit('connection', ws, request);
           });
-        } else {
-          socket.destroy();
+          return;
         }
+        if (websocketUpgradeHandler) {
+          try {
+            if (await websocketUpgradeHandler(request, socket, head)) {
+              return;
+            }
+          } catch (error) {
+            Log.exception(error as Error);
+          }
+        }
+        socket.destroy();
       });
 
       const address = httpServer.address();

--- a/packages/@expo/cli/src/start/server/middleware/DevToolsPluginMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DevToolsPluginMiddleware.ts
@@ -6,6 +6,7 @@ import send from 'send';
 import type { DevToolsPlugin } from '../DevToolsPlugin';
 import type DevToolsPluginManager from '../DevToolsPluginManager';
 import { DevToolsPluginEndpoint } from '../DevToolsPluginManager';
+import { createHttpRequestContext, parsePluginName } from '../DevToolsPluginServerHelpers';
 import { ExpoMiddleware } from './ExpoMiddleware';
 import type { ServerRequest, ServerResponse } from './server.types';
 
@@ -31,9 +32,7 @@ export class DevToolsPluginMiddleware extends ExpoMiddleware {
   async handleRequestAsync(req: ServerRequest, res: ServerResponse): Promise<void> {
     assert(req.headers.host, 'Request headers must include host');
     const { pathname, search } = new URL(req.url ?? '/', `http://${req.headers.host}`);
-    const pluginName = this.queryPossiblePluginName(
-      pathname.substring(DevToolsPluginEndpoint.length + 1)
-    );
+    const pluginName = parsePluginName(pathname.substring(DevToolsPluginEndpoint.length + 1));
     const plugin = await this.pluginManager.queryPluginAsync(pluginName);
     if (!plugin) {
       res.statusCode = 404;
@@ -82,7 +81,7 @@ export class DevToolsPluginMiddleware extends ExpoMiddleware {
       req.url = urlInPluginRoot;
       request = convertRequest(req as http.IncomingMessage, res as http.ServerResponse);
       const handler = await plugin.getRequestHandlerAsync();
-      const response = await handler?.(request);
+      const response = await handler?.(request, createHttpRequestContext());
       if (response == null) {
         return false;
       }
@@ -104,14 +103,5 @@ export class DevToolsPluginMiddleware extends ExpoMiddleware {
     } finally {
       req.url = originalUrl;
     }
-  }
-
-  private queryPossiblePluginName(pathname: string): string {
-    const parts = pathname.split('/');
-    if (parts[0]![0] === '@' && parts.length > 1) {
-      // Scoped package name
-      return `${parts[0]}/${parts[1]}`;
-    }
-    return parts[0]!;
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
@@ -246,6 +246,30 @@ describe(DevToolsPluginMiddleware, () => {
       expect(requestHandler).toHaveBeenCalledTimes(1);
     });
 
+    it('should pass a context whose upgrade() throws for plain HTTP requests', async () => {
+      const requestHandler = jest.fn(async (request: Request, context: any) => {
+        expect(() => context.upgrade({})).toThrow(/regular HTTP request/);
+        return new Response('ok', { status: 200 });
+      });
+      const middleware = createMiddleware(
+        createPluginManager({
+          packageName: 'hello-plugin',
+          packageRoot: '/root/packages/hello-plugin',
+          serverEntryPoint: '/root/packages/hello-plugin/dist/server.js',
+          getRequestHandlerAsync: async () => requestHandler,
+        })
+      );
+
+      const response = createStreamingResponse();
+      await middleware.handleRequestAsync(
+        createServerRequest('http://localhost:8081/_expo/plugins/hello-plugin/api/hello'),
+        response
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(requestHandler).toHaveBeenCalledTimes(1);
+    });
+
     it('should fall back to static serving when the handler returns null', async () => {
       const requestHandler = jest.fn(async () => null);
       const middleware = createMiddleware(


### PR DESCRIPTION
## Why

DevTools plugin servers could only open WebSockets at **static, exact-path routes** declared up front through the `webSocketHandlers` export — each route is mounted into Metro's `websocketEndpoints` map before the server starts and matched by literal pathname equality. Dynamic routes (e.g. `/ws/sessions/:id`) were impossible, and the fetch-based request handler had no way to participate in upgrades at all.

This PR lets the plugin's request handler handle WebSocket upgrades on any route, inspired by the [Next.js WebSocket RFC](https://github.com/vercel/next.js/discussions/95514) (crossws-based, "similar API as Bun").

## How

- `runServer-fork.ts` gains a `websocketUpgradeHandler` fallback, called for Upgrade requests that no exact-path endpoint claimed (previously: unconditional `socket.destroy()`).
- The new dispatcher (`DevToolsPluginUpgradeHandler.ts`) resolves the plugin lazily at upgrade time, converts the raw upgrade to a fetch `Request`, and invokes the plugin's request handler with a `context` as second argument:

```js
export default function handler(request, context) {
  const url = new URL(request.url);
  const channel = url.pathname.match(/^\/ws\/(.+)$/)?.[1];
  if (channel) {
    const response = context.upgrade({
      onopen(peer) { peer.send({ hello: channel }); },
      onmessage(peer, message) { peer.send(message.text()); },
    });
    response.headers.set('x-channel', channel); // written into the 101 handshake
    return response;
  }
  return null; // falls through to static webpageRoot serving
}
```

- **Return value is the contract**: `context.upgrade(hooks)` returns a marker `Response` (status 101) that *commits the handshake only when returned*. Returning a plain `Response` (e.g. a 401) rejects the upgrade with that response written raw onto the socket; `null`/`undefined` declines and the socket is destroyed. Headers/cookies set on the upgrade response land on the `101 Switching Protocols` reply.
- The static `webSocketHandlers` path is unchanged; plain HTTP requests get a context whose `upgrade()` throws with guidance.

## Approaches considered

**1. Bun / Vercel (crossws) hooks style — implemented.** `context.upgrade({ onopen, onmessage, onclose, onerror })` where hooks receive a `peer` (send with object→JSON convenience, `close`, `terminate`, raw `ws` socket as escape hatch) and a lazy `message` wrapper (`text()`, `json()`, `uint8Array()`, `arrayBuffer()`, mirroring fetch `Body`). Chosen because:
- the handshake hasn't happened while the handler runs, and hooks make pre-open socket access *unrepresentable* — there is no socket object to misuse before `onopen`;
- commit-on-return keeps one exhaustive contract (`Response | null`) for HTTP and WS alike, and rejection is just a normal `Response`;
- it matches the Next.js RFC and Bun, so the shape is familiar and portable.

**2. Deno style (`const { socket, response } = context.upgrade()`).** Returns a standard-flavored socket synchronously in `CONNECTING` state; the handshake commits when `response` is returned and the facade binds to the real socket. Browser-symmetric (`onopen`/`onmessage` like client code), but it forces a facade with pre-open semantics (`send()` must throw before open, buffered `close()`, `readyState` bookkeeping), and the facade type is either a thin subset (consumers lose `ping`/`pong` liveness, `terminate`, multi-listener registration, backpressure signals) or a full `ws`-compatible implementation — prototyped at ~290 lines, ~3× the hooks implementation, with half the code servicing the dual browser-compat event API.

Not addressed in either variant: `Sec-WebSocket-Protocol` negotiation (a client requesting a subprotocol fails the handshake — would need a `handleProtocols` option at upgrade time).

## Test Plan

- unit, e2e tests

https://claude.ai/code/session_013qcxr3fWQXxDEft4PUpkwM