### PR TITLE
fix(cli): Surface unparsed xcodebuild errors when run:ios fails

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Include external CSS imports in the production server manifest ([#46984](https://github.com/expo/expo/pull/46984) by [@hassankhan](https://github.com/hassankhan))
 - Fall back to AGP's `output-metadata.json` when resolving APK filenames to support projects that override `outputFileName` in `applicationVariants` ([#47083](https://github.com/expo/expo/pull/47083) by [@NikhilVashistha](https://github.com/NikhilVashistha))
+- Surface the real `xcodebuild` error on `run:ios` failure instead of printing "0 error(s)" when the build formatter parsed none. ([#47748](https://github.com/expo/expo/pull/47748) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -452,10 +452,34 @@ export function _assertXcodeBuildResults(
   if (localizedError) {
     throwWithMessage(chalk.bold(localizedError) + '\n\n');
   }
+
+  // `@expo/xcpretty` can leave a real failure uncounted (its compile-error
+  // matching is stateful and anchored, and stderr never passes through it), so
+  // the build summary reads "0 error(s)" and in CI the full log below is
+  // truncated before the real error line.
+  const errorLines = _extractXcodeBuildErrorLines(results + '\n' + error);
+  if (errorLines.length) {
+    throwWithMessage(chalk.red(errorLines.join('\n')) + '\n\n' + results + '\n\n' + error);
+  }
+
   // Show all the log info because often times the error is coming from a shell script,
   // that invoked a node script, that started metro, which threw an error.
 
   throwWithMessage(results + '\n\n' + error);
+}
+
+// Exposed for testing.
+export function _extractXcodeBuildErrorLines(output: string): string[] {
+  const seen = new Set<string>();
+  const errors: string[] = [];
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (/(?:^|\s)error:\s/.test(line) && !seen.has(line)) {
+      seen.add(line);
+      errors.push(line);
+    }
+  }
+  return errors;
 }
 
 function writeBuildLogs(projectRoot: string, buildOutput: string, errorOutput: string) {

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -1,3 +1,4 @@
+import { ExpoRunFormatter } from '@expo/xcpretty';
 import path from 'path';
 
 import {
@@ -5,6 +6,7 @@ import {
   getProcessOptions,
   getXcodeBuildArgsAsync,
   _assertXcodeBuildResults,
+  _extractXcodeBuildErrorLines,
   matchEstimatedBinaryPath,
   getAppBinaryPath,
 } from '../XcodeBuild';
@@ -186,6 +188,109 @@ describe(_assertXcodeBuildResults, () => {
     ).toThrow(
       'This operation can fail if the version of the OS on the device is newer than the version of Xcode that is running.'
     );
+  });
+
+  it(`surfaces the compile error before the raw log dump so it survives truncation`, () => {
+    let message = '';
+    try {
+      _assertXcodeBuildResults(
+        65,
+        fs.readFileSync(path.resolve(__dirname, './fixtures/unhandled-compile-error.log'), 'utf8'),
+        '',
+        { name: 'BareExpo' },
+        './output.log'
+      );
+    } catch (error: any) {
+      message = error.message;
+    }
+    expect(message).toContain(
+      "call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'"
+    );
+    // The extracted error is shown before the raw dependency-graph dump, so it
+    // survives CI log truncation. The full log is still there below for context.
+    expect(message.indexOf('call to undeclared function')).toBeLessThan(
+      message.indexOf('ComputeTargetDependencyGraph')
+    );
+  });
+
+  it(`surfaces an error line that only appeared on stderr`, () => {
+    let message = '';
+    try {
+      _assertXcodeBuildResults(
+        65,
+        'ComputeTargetDependencyGraph\nnote: Building targets in dependency order\n** BUILD FAILED **',
+        '/path/Script-ABC123.sh: error: config generation failed\n',
+        { name: 'BareExpo' },
+        './output.log'
+      );
+    } catch (error: any) {
+      message = error.message;
+    }
+    // stderr never passes through the formatter, so the extractor scans it too.
+    expect(message).toContain('error: config generation failed');
+  });
+
+  it(`extracts an error line the formatter left uncounted`, () => {
+    // The compile-error matching is stateful: a bare `error:` line with no
+    // source and caret following it is never counted, so the summary reads
+    // "0 error(s)". Intentionally coupled to the formatter's current gap: if
+    // an upgrade counts this, revisit the fallback's precondition.
+    const formatter = ExpoRunFormatter.create('/', {
+      xcodeProject: { name: 'BareExpo' },
+      isDebug: false,
+    });
+    const line =
+      "/path/EXDevLauncherController.m:185:3: error: call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'";
+    for (const _ of formatter.pipe(line + '\n')) {
+      // drain
+    }
+    expect(formatter.errors).toHaveLength(0);
+    expect(_extractXcodeBuildErrorLines(line)).toEqual([line]);
+  });
+
+  it(`extracts an error the formatter downgraded to a warning`, () => {
+    // A project-level `ld: warning:` line latches the compile-warning matcher,
+    // so the parser emits the next complete compile error as a warning. The
+    // duplicate `-lc++` warning is routine in CocoaPods projects. Same
+    // intentional coupling as the previous test.
+    const formatter = ExpoRunFormatter.create('/', {
+      xcodeProject: { name: 'BareExpo' },
+      isDebug: false,
+    });
+    const errorLine =
+      "/path/Broken.m:4:3: error: call to undeclared function 'thisFunctionDoesNotExist'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]";
+    const log = [
+      "/path/BareExpo.xcodeproj: BareExpo: ld: warning: ignoring duplicate libraries: '-lc++'",
+      errorLine,
+      '    4 |   thisFunctionDoesNotExist();',
+      '      |   ^',
+      '1 error generated.',
+    ].join('\n');
+    for (const _ of formatter.pipe(log + '\n')) {
+      // drain
+    }
+    // Lost despite the complete error block (source line and caret included).
+    expect(formatter.errors).toHaveLength(0);
+    expect(_extractXcodeBuildErrorLines(log)).toEqual([errorLine]);
+  });
+});
+
+describe(_extractXcodeBuildErrorLines, () => {
+  it(`extracts and dedupes compiler error lines`, () => {
+    const output = [
+      'CompileC Foo.o Foo.m normal arm64',
+      '/path/Foo.m:1:2: error: use of undeclared identifier',
+      '/path/Foo.m:1:2: error: use of undeclared identifier',
+      '› 0 error(s), and 3 warning(s)',
+      "note: expanded from macro 'BAR'",
+    ].join('\n');
+    expect(_extractXcodeBuildErrorLines(output)).toEqual([
+      '/path/Foo.m:1:2: error: use of undeclared identifier',
+    ]);
+  });
+
+  it(`returns nothing when no error lines are present`, () => {
+    expect(_extractXcodeBuildErrorLines('** BUILD SUCCEEDED **\n› 0 error(s)')).toEqual([]);
   });
 });
 

--- a/packages/@expo/cli/src/run/ios/__tests__/fixtures/unhandled-compile-error.log
+++ b/packages/@expo/cli/src/run/ios/__tests__/fixtures/unhandled-compile-error.log
@@ -1,0 +1,18 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -workspace BareExpo.xcworkspace -configuration Release -scheme BareExpo
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+
+CompileC /Users/runner/work/expo/apps/bare-expo/ios/build/Pods.build/Release-iphonesimulator/expo-dev-launcher.build/Objects-normal/arm64/EXDevLauncherController.o /Users/runner/work/expo/packages/expo-dev-launcher/ios/EXDevLauncherController.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0 (in target 'expo-dev-launcher' from project 'Pods')
+    cd /Users/runner/work/expo/apps/bare-expo/ios/Pods
+/Users/runner/work/expo/packages/expo-dev-launcher/ios/EXDevLauncherController.m:185:3: error: call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'; ISO C99 and later do not support implicit function declarations
+  RCTBundleURLProviderAllowPackagerServerAccess(NO);
+  ^
+1 error generated.
+
+** BUILD FAILED **
+
+The following build commands failed:
+	CompileC EXDevLauncherController.o EXDevLauncherController.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0 (in target 'expo-dev-launcher' from project 'Pods')
+(1 failure)


### PR DESCRIPTION
# Why

`expo run:ios` can sometimes end with `0 error(s)` even though Xcode printed an error.

The CLI showed the full build output, but the useful error was near the end and could be cut off in CI.

# How

If `xcpretty` reports no errors, we now check stdout and stderr for `error:` lines and show them before the full log.

# Test Plan

- Added tests for missed errors in stdout and stderr.
- Tested with a broken Xcode script in a new app.
- Ran `et check-packages @expo/cli` and the CLI E2E tests.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)