### PR TITLE
feat(cli,metro-config,babel-preset): Implement cache-vary capturing in transformer to selectively redirect cache entries

### DIFF
--- a/apps/router-e2e/__e2e__/cache-vary/app/index.js
+++ b/apps/router-e2e/__e2e__/cache-vary/app/index.js
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+
+export default function Page() {
+  return <Text testID="env-value">{`env-value:${process.env.EXPO_PUBLIC_CACHE_VARY_VALUE}`}</Text>;
+}

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix cache pollution in production by inlined environment variable values with a vary-cache approach ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
@@ -38,6 +39,7 @@
 
 ### 💡 Others
 
+- Add `VaryingCacheStore` and embed `expoCacheVary` fingerprints into transform results so a cache output never holds on to stale values inline ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
 - Add sandbox detection to telemetry context ([#47928](https://github.com/expo/expo/pull/47928) by [@davidmokos](https://github.com/davidmokos))
 - [Internal] Remove the unreachable port fallbacks and increase consistency in port selection logic ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Add experimental `tvos` and `macos` autolinking gated by `expriments.outOfTreePlatforms` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
@@ -90,6 +92,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
+- Fix cache pollution in production by inlined environment variable values with a vary-cache approach ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
 - Avoid writing a 500 response when a DevTools plugin server request has already started or aborted. ([#47192](https://github.com/expo/expo/pull/47192) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Pass a fetch API `Request` to DevTools plugin WebSocket handlers instead of `IncomingMessage`. ([#47410](https://github.com/expo/expo/pull/47410) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Use `loadModule` for MCP and DevTools plugin server module loading. ([#47139](https://github.com/expo/expo/pull/47139) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/e2e/__tests__/export/cache-vary.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/cache-vary.test.ts
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+import fs from 'fs';
+import { sync as globSync } from 'glob';
+import path from 'path';
+
+import { runExportSideEffects } from './export-side-effects';
+import { executeExpoAsync } from '../../utils/expo';
+import { getRouterE2ERoot } from '../utils';
+
+runExportSideEffects();
+
+describe('exports sharing one transform cache across different EXPO_PUBLIC_* values', () => {
+  const projectRoot = getRouterE2ERoot();
+
+  async function exportWithEnvValueAsync(outputName: string, value: string): Promise<string> {
+    await executeExpoAsync(
+      projectRoot,
+      ['export', '-p', 'ios', '--output-dir', outputName, '--no-bytecode', '--no-minify'],
+      {
+        env: {
+          NODE_ENV: 'production',
+          E2E_ROUTER_SRC: 'cache-vary',
+          E2E_ROUTER_JS_ENGINE: 'hermes',
+          EXPO_PUBLIC_CACHE_VARY_VALUE: value,
+        },
+      }
+    );
+
+    const bundlePath = globSync('_expo/static/js/ios/*.js', {
+      cwd: path.join(projectRoot, outputName),
+      absolute: true,
+    })[0];
+    expect(bundlePath).toBeDefined();
+    return fs.promises.readFile(bundlePath!, 'utf8');
+  }
+
+  it('re-inlines updated env values instead of serving stale cached transforms', async () => {
+    const first = await exportWithEnvValueAsync('dist-cache-vary-first', 'cache-vary-value-one');
+    expect(first).toContain('env-value:');
+    expect(first).toContain('cache-vary-value-one');
+
+    const second = await exportWithEnvValueAsync('dist-cache-vary-second', 'cache-vary-value-two');
+    expect(second).toContain('cache-vary-value-two');
+    expect(second).not.toContain('cache-vary-value-one');
+
+    const third = await exportWithEnvValueAsync('dist-cache-vary-third', 'cache-vary-value-one');
+    expect(third).toContain('cache-vary-value-one');
+    expect(third).not.toContain('cache-vary-value-two');
+  }, 560_000); // Three full exports run in this test.
+});

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -23,6 +23,10 @@ import { DevServerManager } from '../../start/server/DevServerManager';
 import { MetroBundlerDevServer } from '../../start/server/metro/MetroBundlerDevServer';
 import { replaceMetroFileMap } from '../../start/server/metro/createFileMap-fork';
 import { loadMetroConfigAsync } from '../../start/server/metro/instantiateMetro';
+import {
+  patchGetDeltaForCacheVary,
+  patchTransformFileForCacheVary,
+} from '../../start/server/metro/withMetroCacheVary';
 import { DOM_COMPONENTS_BUNDLE_DIR } from '../../start/server/middleware/DomComponentsMiddleware';
 import { getMetroDirectBundleOptionsForExpoConfig } from '../../start/server/middleware/metroOptions';
 import { stripAnsi } from '../../utils/ansi';
@@ -389,6 +393,10 @@ export async function createMetroServerAndBundleRequestAsync(
   // would otherwise reach Metro's readers in the unwrapped wire shape.
   patchTransformFileForPackedMaps(metro.getBundler().getBundler());
   patchMetroSourceMapStringForPackedMaps();
+
+  // Make ambient-value (cache-vary) staleness visible to the graph and delta layers.
+  patchTransformFileForCacheVary(metro.getBundler().getBundler());
+  patchGetDeltaForCacheVary();
 
   return { server: metro, bundleRequest };
 }

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroCacheVary.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroCacheVary.test.ts
@@ -1,0 +1,364 @@
+import { VaryingCacheStore } from '@expo/metro-config/build/cache-vary/VaryingCacheStore';
+import { patchTransformFileForPackedMaps } from '@expo/metro-config/build/serializer/packedMap';
+import DeltaCalculator from '@expo/metro/metro/DeltaBundler/DeltaCalculator';
+import { EventEmitter } from 'node:events';
+
+import {
+  patchGetDeltaForCacheVary,
+  patchTransformFileForCacheVary,
+  resetAmbientValueTracking,
+  withMetroCacheVary,
+} from '../withMetroCacheVary';
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  resetAmbientValueTracking();
+});
+
+afterAll(() => {
+  process.env = { ...originalEnv };
+});
+
+function makeStore() {
+  return {
+    get: jest.fn(async () => null),
+    set: jest.fn(async () => {}),
+    clear: jest.fn(),
+  };
+}
+
+function makeTransformResult(
+  key: string | null,
+  dims?: { scheme: string; name: string; fp: string }[]
+) {
+  return {
+    unstable_transformResultKey: key,
+    dependencies: [],
+    output: [{ data: { code: 'code', ...(dims ? { expoCacheVary: dims } : {}) } }],
+  };
+}
+
+async function observeResult(result: any) {
+  const bundler = { transformFile: jest.fn(async () => result) } as any;
+  patchTransformFileForCacheVary(bundler);
+  return bundler.transformFile('/file.js', {} as any);
+}
+
+describe(withMetroCacheVary, () => {
+  it('wraps every resolved cache store', () => {
+    const stores = [makeStore(), makeStore()];
+    const config = { cacheStores: stores } as any;
+
+    const result = withMetroCacheVary(config);
+
+    expect(result.cacheStores).toHaveLength(2);
+    for (const store of result.cacheStores) {
+      expect(store).toBeInstanceOf(VaryingCacheStore);
+    }
+  });
+
+  it('does not double-wrap stores that are already varying cache stores', () => {
+    const store = new VaryingCacheStore(makeStore());
+    const config = { cacheStores: [store] } as any;
+
+    const result = withMetroCacheVary(config);
+
+    expect(result.cacheStores).toEqual([store]);
+  });
+
+  it('delegates get/set to the wrapped store', async () => {
+    const inner = makeStore();
+    const config = withMetroCacheVary({ cacheStores: [inner] } as any);
+    const key = Buffer.alloc(20, 1);
+
+    await config.cacheStores[0]!.get(key);
+    expect(inner.get).toHaveBeenCalledWith(key);
+  });
+
+  it('returns the config unchanged when EXPO_NO_CACHE_VARY is set', () => {
+    process.env.EXPO_NO_CACHE_VARY = '1';
+    const config = { cacheStores: [makeStore()] } as any;
+
+    expect(withMetroCacheVary(config)).toBe(config);
+  });
+});
+
+describe(patchTransformFileForCacheVary, () => {
+  const dims = [{ scheme: 'env', name: 'EXPO_PUBLIC_A', fp: 'abc' }];
+
+  it('suffixes the transform result key deterministically from the embedded dims', async () => {
+    const first = await observeResult(makeTransformResult('base-key', dims));
+    const second = await observeResult(makeTransformResult('base-key', dims));
+
+    expect(first.unstable_transformResultKey).toMatch(/^base-key::[0-9a-f]{40}$/);
+    expect(second.unstable_transformResultKey).toBe(first.unstable_transformResultKey);
+  });
+
+  it('produces a different key when the embedded fps change', async () => {
+    const first = await observeResult(makeTransformResult('base-key', dims));
+    const changed = await observeResult(
+      makeTransformResult('base-key', [{ scheme: 'env', name: 'EXPO_PUBLIC_A', fp: 'other' }])
+    );
+
+    expect(changed.unstable_transformResultKey).not.toBe(first.unstable_transformResultKey);
+  });
+
+  it('returns non-varying results untouched, preserving object identity', async () => {
+    const original = makeTransformResult('base-key');
+    await expect(observeResult(original)).resolves.toBe(original);
+  });
+
+  it('preserves the output/data object identity of varying results', async () => {
+    const original = makeTransformResult('base-key', dims);
+    const result = await observeResult(original);
+
+    // Sibling instance patches (packedMap) install fields on `data` — only the top level may
+    // be copied for the key rewrite.
+    expect(result.output).toBe(original.output);
+  });
+
+  it('leaves results without a transform result key untouched', async () => {
+    const original = makeTransformResult(null, dims);
+    await expect(observeResult(original)).resolves.toBe(original);
+  });
+
+  it('is idempotent — patching twice wraps once', async () => {
+    const bundler = {
+      transformFile: jest.fn(async () => makeTransformResult('base-key', dims)),
+    } as any;
+
+    patchTransformFileForCacheVary(bundler);
+    const patchedTransformFile = bundler.transformFile;
+    patchTransformFileForCacheVary(bundler);
+
+    const result = await bundler.transformFile('/file.js', {} as any);
+
+    expect(bundler.transformFile).toBe(patchedTransformFile);
+    expect(result.unstable_transformResultKey).toMatch(/^base-key::[0-9a-f]{40}$/);
+    expect(result.unstable_transformResultKey).not.toMatch(/::[0-9a-f]{40}::[0-9a-f]{40}$/);
+  });
+
+  it('does nothing when EXPO_NO_CACHE_VARY is set', () => {
+    process.env.EXPO_NO_CACHE_VARY = '1';
+    const bundler = {
+      transformFile: jest.fn(async () => makeTransformResult('base-key')),
+    } as any;
+    const before = bundler.transformFile;
+    patchTransformFileForCacheVary(bundler);
+
+    expect(bundler.transformFile).toBe(before);
+  });
+
+  it('composes with the packedMap transformFile patch in production order', async () => {
+    const original = {
+      unstable_transformResultKey: 'base-key',
+      dependencies: [],
+      output: [
+        {
+          data: {
+            code: 'code',
+            lineCount: 1,
+            map: { __version: 1, __count: 0, __packed: [], __names: [] },
+            expoCacheVary: dims,
+          },
+        },
+      ],
+    };
+    const bundler = { transformFile: jest.fn(async () => original) } as any;
+
+    patchTransformFileForPackedMaps(bundler);
+    patchTransformFileForCacheVary(bundler);
+
+    const result = await bundler.transformFile('/file.js', {} as any);
+
+    expect(result.unstable_transformResultKey).toMatch(/^base-key::[0-9a-f]{40}$/);
+    expect(result.output[0].data.expoCacheVary).toEqual(dims);
+    expect(Array.isArray(result.output[0].data.map)).toBe(true);
+  });
+});
+
+describe(patchGetDeltaForCacheVary, () => {
+  function graphModule(dims?: { scheme: string; name: string; fp: string }[]) {
+    return {
+      output: [{ data: { code: 'code', ...(dims ? { expoCacheVary: dims } : {}) } }],
+    };
+  }
+
+  const envDim = (name: string) => ({ scheme: 'env', name, fp: 'fp' });
+
+  function makeDeltaCalculator() {
+    patchGetDeltaForCacheVary();
+
+    const calculator = new (DeltaCalculator as any)(new Set<string>(), new EventEmitter(), {
+      transformOptions: {},
+    });
+    const getChangedDependencies = jest.fn(async () => ({
+      added: new Map(),
+      modified: new Map(),
+      deleted: new Set(),
+    }));
+    calculator._getChangedDependencies = getChangedDependencies;
+    return { calculator, getChangedDependencies };
+  }
+
+  it('marks graphed modules whose observed env values changed', async () => {
+    process.env.EXPO_PUBLIC_OBSERVED = 'one';
+    await observeResult(makeTransformResult('k', [envDim('EXPO_PUBLIC_OBSERVED')]));
+
+    const { calculator, getChangedDependencies } = makeDeltaCalculator();
+    calculator._graph.dependencies.set(
+      '/uses-env.js',
+      graphModule([envDim('EXPO_PUBLIC_OBSERVED')])
+    );
+    calculator._graph.dependencies.set('/plain.js', graphModule());
+
+    await calculator.getDelta({ reset: false, shallow: false });
+    expect(getChangedDependencies).toHaveBeenLastCalledWith(new Set(), new Set(), new Set());
+
+    process.env.EXPO_PUBLIC_OBSERVED = 'two';
+    await calculator.getDelta({ reset: false, shallow: false });
+
+    expect(getChangedDependencies).toHaveBeenLastCalledWith(
+      new Set(['/uses-env.js']),
+      new Set(),
+      new Set()
+    );
+  });
+
+  it('marks only modules whose dim names intersect the changed values', async () => {
+    process.env.EXPO_PUBLIC_CHANGING = 'one';
+    process.env.EXPO_PUBLIC_STABLE = 'same';
+    await observeResult(
+      makeTransformResult('k', [envDim('EXPO_PUBLIC_CHANGING'), envDim('EXPO_PUBLIC_STABLE')])
+    );
+
+    const { calculator, getChangedDependencies } = makeDeltaCalculator();
+    calculator._graph.dependencies.set(
+      '/changing.js',
+      graphModule([envDim('EXPO_PUBLIC_CHANGING')])
+    );
+    calculator._graph.dependencies.set('/stable.js', graphModule([envDim('EXPO_PUBLIC_STABLE')]));
+    await calculator.getDelta({ reset: false, shallow: false });
+
+    process.env.EXPO_PUBLIC_CHANGING = 'two';
+    await calculator.getDelta({ reset: false, shallow: false });
+
+    expect(getChangedDependencies).toHaveBeenLastCalledWith(
+      new Set(['/changing.js']),
+      new Set(),
+      new Set()
+    );
+  });
+
+  it('detects changes that happened between observation and the first scan', async () => {
+    process.env.EXPO_PUBLIC_EARLY = 'one';
+    await observeResult(makeTransformResult('k', [envDim('EXPO_PUBLIC_EARLY')]));
+
+    process.env.EXPO_PUBLIC_EARLY = 'two';
+    const { calculator, getChangedDependencies } = makeDeltaCalculator();
+    calculator._graph.dependencies.set('/early.js', graphModule([envDim('EXPO_PUBLIC_EARLY')]));
+
+    await calculator.getDelta({ reset: false, shallow: false });
+    expect(getChangedDependencies).toHaveBeenLastCalledWith(
+      new Set(['/early.js']),
+      new Set(),
+      new Set()
+    );
+  });
+
+  it('tracks a baseline per calculator so every graph observes the change', async () => {
+    process.env.EXPO_PUBLIC_SHARED = 'one';
+    await observeResult(makeTransformResult('k', [envDim('EXPO_PUBLIC_SHARED')]));
+
+    const first = makeDeltaCalculator();
+    const second = makeDeltaCalculator();
+    for (const { calculator } of [first, second]) {
+      calculator._graph.dependencies.set('/shared.js', graphModule([envDim('EXPO_PUBLIC_SHARED')]));
+      await calculator.getDelta({ reset: false, shallow: false });
+    }
+
+    process.env.EXPO_PUBLIC_SHARED = 'two';
+    await first.calculator.getDelta({ reset: false, shallow: false });
+    await second.calculator.getDelta({ reset: false, shallow: false });
+
+    expect(first.getChangedDependencies).toHaveBeenLastCalledWith(
+      new Set(['/shared.js']),
+      new Set(),
+      new Set()
+    );
+    expect(second.getChangedDependencies).toHaveBeenLastCalledWith(
+      new Set(['/shared.js']),
+      new Set(),
+      new Set()
+    );
+  });
+
+  it('ignores dims of schemes other than env', async () => {
+    await observeResult(makeTransformResult('k', [{ scheme: 'custom', name: 'x', fp: 'f' }]));
+
+    const { calculator, getChangedDependencies } = makeDeltaCalculator();
+    calculator._graph.dependencies.set(
+      '/custom.js',
+      graphModule([{ scheme: 'custom', name: 'x', fp: 'f' }])
+    );
+
+    await calculator.getDelta({ reset: false, shallow: false });
+    expect(getChangedDependencies).toHaveBeenLastCalledWith(new Set(), new Set(), new Set());
+  });
+
+  it('is idempotent — patching twice wraps once', async () => {
+    patchGetDeltaForCacheVary();
+    const patchedGetDelta = (DeltaCalculator.prototype as any).getDelta;
+    patchGetDeltaForCacheVary();
+
+    expect((DeltaCalculator.prototype as any).getDelta).toBe(patchedGetDelta);
+  });
+
+  it('does nothing when EXPO_NO_CACHE_VARY is set', () => {
+    process.env.EXPO_NO_CACHE_VARY = '1';
+    const before = (DeltaCalculator.prototype as any).getDelta;
+    patchGetDeltaForCacheVary();
+
+    expect((DeltaCalculator.prototype as any).getDelta).toBe(before);
+  });
+
+  describe('against the real Metro DeltaCalculator', () => {
+    it('marks changed modules through the real getDelta', async () => {
+      process.env.EXPO_PUBLIC_REAL_DC_TEST = 'one';
+      await observeResult(makeTransformResult('k', [envDim('EXPO_PUBLIC_REAL_DC_TEST')]));
+
+      patchGetDeltaForCacheVary();
+
+      const calculator = new (DeltaCalculator as any)(new Set<string>(), new EventEmitter(), {
+        transformOptions: {},
+      });
+      expect(calculator._graph.dependencies).toBeInstanceOf(Map);
+      expect(calculator._modifiedFiles).toBeInstanceOf(Set);
+
+      calculator._graph.dependencies.set(
+        '/stale.js',
+        graphModule([envDim('EXPO_PUBLIC_REAL_DC_TEST')])
+      );
+      calculator._graph.dependencies.set('/plain.js', graphModule());
+
+      const getChangedDependencies = jest.fn(async () => ({
+        added: new Map(),
+        modified: new Map(),
+        deleted: new Set(),
+      }));
+      calculator._getChangedDependencies = getChangedDependencies;
+
+      await calculator.getDelta({ reset: false, shallow: false });
+      process.env.EXPO_PUBLIC_REAL_DC_TEST = 'two';
+      await calculator.getDelta({ reset: false, shallow: false });
+
+      expect(getChangedDependencies).toHaveBeenLastCalledWith(
+        new Set(['/stale.js']),
+        new Set(),
+        new Set()
+      );
+    });
+  });
+});

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -38,6 +38,11 @@ import { attachAtlasAsync } from './debugging/attachAtlas';
 import { createDebugMiddleware } from './debugging/createDebugMiddleware';
 import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
 import { runServer, type ServerAddressInfo, type SecureServerOptions } from './runServer-fork';
+import {
+  patchGetDeltaForCacheVary,
+  patchTransformFileForCacheVary,
+  withMetroCacheVary,
+} from './withMetroCacheVary';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
 
 declare module '2g' {
@@ -327,6 +332,9 @@ export async function loadMetroConfigAsync(
     getMetroBundler,
   });
 
+  // Post-resolution: `loadUserConfig` has already resolved function-form `cacheStores` to an array.
+  config = withMetroCacheVary(config);
+
   event('config', {
     serverRoot: event.path(serverRoot),
     projectRoot: event.path(projectRoot),
@@ -535,6 +543,10 @@ export async function instantiateMetroAsync(
   // here covers both.
   patchTransformFileForPackedMaps(metro.getBundler().getBundler());
   patchMetroSourceMapStringForPackedMaps();
+
+  // Make ambient-value (cache-vary) staleness visible to the graph and delta layers.
+  patchTransformFileForCacheVary(metro.getBundler().getBundler());
+  patchGetDeltaForCacheVary();
 
   // Warm the transform worker pool during the idle window before the first bundle request
   if (!isExporting) {

--- a/packages/@expo/cli/src/start/server/metro/withMetroCacheVary.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroCacheVary.ts
@@ -1,0 +1,165 @@
+import {
+  VaryingCacheStore,
+  type AmbientVaryScheme,
+} from '@expo/metro-config/build/cache-vary/VaryingCacheStore';
+import type { ConfigT as MetroConfig } from '@expo/metro/metro-config';
+import type Bundler from '@expo/metro/metro/Bundler';
+import DeltaCalculator from '@expo/metro/metro/DeltaBundler/DeltaCalculator';
+import crypto from 'node:crypto';
+
+import { env } from '../../../utils/env';
+
+const debug = require('debug')('expo:metro:cache-vary') as typeof console.log;
+
+interface ObservedAmbientValue {
+  scheme: AmbientVaryScheme;
+  name: string;
+  value: string | undefined;
+}
+
+interface EmbeddedVaryDim {
+  scheme: string;
+  name: string;
+  fp: string;
+}
+
+type CacheVaryPatchedBundler = Bundler & {
+  __expoCacheVaryTransformFilePatched?: boolean;
+};
+
+// Duplicated from `@expo/metro-config/src/cache-vary/ambient.ts`.
+function readAmbientVaryValue(scheme: AmbientVaryScheme, name: string): string | undefined {
+  switch (scheme) {
+    case 'env':
+      return process.env[name];
+  }
+}
+
+const isAmbientVaryScheme = (scheme: string): scheme is AmbientVaryScheme => scheme === 'env';
+
+const dimId = (dim: { scheme: string; name: string }): string => `${dim.scheme}:${dim.name}`;
+
+const embeddedVaryDims = (value: unknown): EmbeddedVaryDim[] | undefined => {
+  const dims = (value as any)?.output?.[0]?.data?.expoCacheVary;
+  return Array.isArray(dims) && dims.length > 0 ? dims : undefined;
+};
+
+const _observedAmbientValues = new Map<string, ObservedAmbientValue>();
+
+export function withMetroCacheVary(config: MetroConfig): MetroConfig {
+  if (env.EXPO_NO_CACHE_VARY) {
+    return config;
+  } else {
+    return {
+      ...config,
+      cacheStores: (config.cacheStores ?? []).map((store) =>
+        store instanceof VaryingCacheStore ? store : new VaryingCacheStore(store)
+      ),
+    };
+  }
+}
+
+export function resetAmbientValueTracking(): void {
+  _observedAmbientValues.clear();
+}
+
+export function patchTransformFileForCacheVary(bundler: Bundler): void {
+  if (env.EXPO_NO_CACHE_VARY) return;
+
+  const patchedBundler = bundler as CacheVaryPatchedBundler;
+  if (patchedBundler.__expoCacheVaryTransformFilePatched) return;
+  patchedBundler.__expoCacheVaryTransformFilePatched = true;
+
+  const originalTransformFile = patchedBundler.transformFile.bind(patchedBundler);
+  patchedBundler.transformFile = async (...args: Parameters<Bundler['transformFile']>) => {
+    let result = await originalTransformFile(...args);
+
+    const dims = embeddedVaryDims(result);
+    if (!dims) {
+      return result;
+    }
+
+    for (const dim of dims) {
+      if (isAmbientVaryScheme(dim.scheme)) {
+        _observedAmbientValues.set(dimId(dim), {
+          scheme: dim.scheme,
+          name: dim.name,
+          value: readAmbientVaryValue(dim.scheme, dim.name),
+        });
+      }
+    }
+
+    if (result.unstable_transformResultKey != null) {
+      const varyHash = crypto
+        .createHash('sha1')
+        .update(
+          dims
+            .map((d) => `${dimId(d)}=${d.fp}`)
+            .sort()
+            .join('\n')
+        )
+        .digest('hex');
+      result = {
+        ...result,
+        unstable_transformResultKey: `${result.unstable_transformResultKey}::${varyHash}`,
+      };
+    }
+
+    return result;
+  };
+}
+
+interface CacheVaryDeltaCalculator extends DeltaCalculator<unknown> {
+  _expoSeenAmbient?: Map<string, string | undefined>;
+}
+
+export function patchGetDeltaForCacheVary(): void {
+  if (env.EXPO_NO_CACHE_VARY) return;
+
+  const proto = DeltaCalculator.prototype as any;
+  if (proto.__expoVaryPatched) {
+    return;
+  } else {
+    proto.__expoVaryPatched = true;
+  }
+
+  const getDelta = proto.getDelta;
+  proto.getDelta = async function _getDelta(
+    this: CacheVaryDeltaCalculator,
+    options: {
+      reset: boolean;
+      shallow: boolean;
+    }
+  ) {
+    const modifiedAmbientDims = new Set<string>();
+
+    try {
+      const seen = (this._expoSeenAmbient ??= new Map());
+      for (const [id, observed] of _observedAmbientValues) {
+        if (!seen.has(id)) {
+          seen.set(id, observed.value);
+        }
+        const current = readAmbientVaryValue(observed.scheme, observed.name);
+        if (seen.get(id) !== current) {
+          modifiedAmbientDims.add(id);
+          seen.set(id, current);
+        }
+      }
+    } catch {
+      // Delta scans must not fail builds.
+    }
+
+    if (modifiedAmbientDims.size && this._graph.dependencies != null) {
+      const dependencies = this._graph.dependencies;
+      for (const [path, module] of dependencies) {
+        const dims = embeddedVaryDims(module);
+        if (dims?.some((dim) => modifiedAmbientDims.has(dimId(dim)))) {
+          debug('Ambient value changed, marking module for re-transform: %s', path);
+          this._modifiedFiles.add(path);
+        }
+      }
+    }
+
+    return getDelta.call(this, options);
+  };
+}

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -80,6 +80,10 @@ class Env {
   get EXPO_NO_CACHE() {
     return boolish('EXPO_NO_CACHE', false);
   }
+  /** Disable validating Metro's transform cache against inlined ambient values (e.g. `EXPO_PUBLIC_*` env vars). */
+  get EXPO_NO_CACHE_VARY() {
+    return boolish('EXPO_NO_CACHE_VARY', false);
+  }
   /** Disable the app select redirect page. */
   get EXPO_NO_REDIRECT_PAGE() {
     return boolish('EXPO_NO_REDIRECT_PAGE', false);

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Add `VaryingCacheStore` and embed `expoCacheVary` fingerprints into transform results so a cache output never holds on to stale values inline ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/metro-config/src/cache-vary/LruCache.ts
+++ b/packages/@expo/metro-config/src/cache-vary/LruCache.ts
@@ -1,0 +1,32 @@
+export class LruCache<K, V> {
+  #map = new Map<K, V>();
+  #capacity: number;
+
+  constructor(capacity: number) {
+    this.#capacity = capacity;
+  }
+
+  get(key: K): V | undefined {
+    if (!this.#map.has(key)) return undefined;
+    const value = this.#map.get(key)!;
+    this.#map.delete(key);
+    this.#map.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    this.#map.delete(key);
+    this.#map.set(key, value);
+    if (this.#map.size > this.#capacity) {
+      this.#map.delete(this.#map.keys().next().value!);
+    }
+  }
+
+  delete(key: K): void {
+    this.#map.delete(key);
+  }
+
+  clear(): void {
+    this.#map.clear();
+  }
+}

--- a/packages/@expo/metro-config/src/cache-vary/VaryingCacheStore.ts
+++ b/packages/@expo/metro-config/src/cache-vary/VaryingCacheStore.ts
@@ -1,0 +1,244 @@
+import type { CacheStore } from '@expo/metro/metro-cache';
+import crypto from 'node:crypto';
+
+import { LruCache } from './LruCache';
+import {
+  canonicalDims,
+  canonicalDimNames,
+  currentFingerprint,
+  dimId,
+  type CacheVaryDim,
+  type EmbeddedVaryDim,
+} from './ambient';
+
+export type { AmbientVaryScheme } from './ambient';
+
+const debug = require('debug')('expo:metro:cache-vary') as typeof console.log;
+
+const VARY_REGISTRY_VERSION = 1;
+const OBSERVATION_LIMIT = 1_000;
+const REGISTRY_TAG = 'expoVaryHead';
+
+type NameSetId = string;
+
+interface NameSetLookup {
+  ids: Set<NameSetId>;
+  dimNameSets: CacheVaryDim[][];
+}
+
+interface VaryRegistry<T> {
+  expoVaryHead: typeof VARY_REGISTRY_VERSION;
+  value: T;
+  nameSets: CacheVaryDim[][];
+}
+
+export class VaryingCacheStore<T> implements CacheStore<T> {
+  #inner: CacheStore<T>;
+  #knownNameSetIdsByKey = new LruCache<string, Set<NameSetId> | null>(OBSERVATION_LIMIT);
+
+  constructor(inner: CacheStore<T>) {
+    this.#inner = inner;
+  }
+
+  async get(key: Buffer): Promise<T | null> {
+    const stored = await this.#inner.get(key);
+    try {
+      const registry = readVaryRegistry<T>(stored);
+      if (registry == null) {
+        this.#knownNameSetIdsByKey.set(key.toString('hex'), null);
+        return null;
+      }
+      const { value, nameSets } = registry;
+      const baseDims = embeddedVaryDims(value);
+      if (!baseDims.length && !nameSets.length) return value;
+
+      let currentBaseDims: EmbeddedVaryDim[] | null = null;
+      if (baseDims.length) {
+        currentBaseDims = await this.#currentDims(baseDims);
+        if (currentBaseDims && sameDims(baseDims, currentBaseDims)) return value;
+      }
+
+      const { ids, dimNameSets } = collectNameSets(baseDims, nameSets);
+      if (currentBaseDims) {
+        const variant = await this.#readVariant(key, currentBaseDims);
+        if (variant != null) return variant;
+      }
+
+      const variant = await this.#findVariant(key, dimNameSets, currentBaseDims ? 1 : 0);
+      if (variant != null) return variant;
+
+      if (nameSets.some((set) => set.length === 0)) {
+        const variant = await this.#readVariant(key, []);
+        if (variant != null) return variant;
+      }
+      if (!baseDims.length) return value;
+
+      this.#knownNameSetIdsByKey.set(key.toString('hex'), ids);
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: Buffer, value: T): Promise<void> {
+    const data = (value as any)?.output?.[0]?.data;
+
+    if (data?.css?.skipCache) {
+      return this.#inner.set(key, value);
+    }
+
+    const hex = key.toString('hex');
+    let knownNameSetIds = this.#knownNameSetIdsByKey.get(hex);
+    if (knownNameSetIds === undefined) {
+      knownNameSetIds = await this.#readBaseNameSetIds(key);
+    } else {
+      this.#knownNameSetIdsByKey.delete(hex);
+    }
+
+    if (knownNameSetIds === null) {
+      return this.#inner.set(key, value);
+    }
+
+    const dims: EmbeddedVaryDim[] = Array.isArray(data?.expoCacheVary) ? data.expoCacheVary : [];
+    const nameSetId = canonicalDimNames(dims);
+    if (knownNameSetIds.has(nameSetId)) {
+      await this.#inner.set(variantKey(key, dims), value);
+    } else {
+      await this.#registerNameSet(key, value, dims);
+    }
+  }
+
+  async #readBaseNameSetIds(key: Buffer): Promise<Set<NameSetId> | null> {
+    const registry = readVaryRegistry<T>(await this.#inner.get(key));
+    if (registry == null) return null;
+    return collectNameSets(embeddedVaryDims(registry.value), registry.nameSets).ids;
+  }
+
+  async #registerNameSet(key: Buffer, value: T, dims: EmbeddedVaryDim[]): Promise<void> {
+    // Blob before registry prevents a dangling registered name set.
+    await this.#inner.set(variantKey(key, dims), value);
+    const current = await this.#inner.get(key);
+    const registry = readVaryRegistry<T>(current);
+    if (registry == null) {
+      await this.#inner.set(key, value);
+      return;
+    }
+    const dimNames: CacheVaryDim[] = dims.map(({ scheme, name }) => ({
+      scheme,
+      name,
+    }));
+    const nameSets = mergeNameSets(embeddedVaryDims(registry.value), registry.nameSets, dimNames);
+    debug(
+      'cache-vary dim names changed under one cache key (producer bug or version skew) — registering name set: [%s]',
+      dimNames.map(dimId).join(',')
+    );
+    const nextRegistry: VaryRegistry<T> = {
+      expoVaryHead: VARY_REGISTRY_VERSION,
+      value: registry.value,
+      nameSets,
+    };
+    await this.#inner.set(key, nextRegistry as T);
+  }
+
+  async #findVariant(
+    key: Buffer,
+    dimNameSets: CacheVaryDim[][],
+    startIndex = 0
+  ): Promise<T | null> {
+    for (let i = startIndex; i < dimNameSets.length; i++) {
+      const names = dimNameSets[i]!;
+      const dims = await this.#currentDims(names);
+      if (!dims) continue;
+      const variant = await this.#readVariant(key, dims);
+      if (variant != null) return variant;
+    }
+    return null;
+  }
+
+  async #readVariant(key: Buffer, dims: EmbeddedVaryDim[]): Promise<T | null> {
+    const variant = await this.#inner.get(variantKey(key, dims));
+    return isRawArtifact(variant) ? (variant as T) : null;
+  }
+
+  async #currentDims(names: CacheVaryDim[]): Promise<EmbeddedVaryDim[] | null> {
+    const ownDims: EmbeddedVaryDim[] = [];
+    for (const { scheme, name } of names) {
+      const fp = await currentFingerprint(scheme, name);
+      if (fp == null) return null;
+      ownDims.push({ scheme, name, fp });
+    }
+    return ownDims;
+  }
+
+  clear(): void | Promise<void> {
+    this.#knownNameSetIdsByKey.clear();
+    return this.#inner.clear();
+  }
+}
+
+function readVaryRegistry<T>(stored: unknown): { value: T; nameSets: CacheVaryDim[][] } | null {
+  if (stored == null) return null;
+  if (!hasRegistryTag(stored)) return { value: stored as T, nameSets: [] };
+  const registry = stored as Partial<VaryRegistry<T>>;
+  if (
+    registry.expoVaryHead !== VARY_REGISTRY_VERSION ||
+    !('value' in registry) ||
+    !Array.isArray(registry.nameSets)
+  ) {
+    return null;
+  }
+  return { value: registry.value as T, nameSets: registry.nameSets };
+}
+
+function hasRegistryTag(stored: unknown): boolean {
+  return typeof stored === 'object' && stored != null && REGISTRY_TAG in stored;
+}
+
+function isRawArtifact<T>(value: T | null): value is T {
+  return value != null && !hasRegistryTag(value);
+}
+
+function embeddedVaryDims(value: unknown): EmbeddedVaryDim[] {
+  const dims = (value as any)?.output?.[0]?.data?.expoCacheVary;
+  return Array.isArray(dims) ? dims : [];
+}
+
+function collectNameSets(baseNames: CacheVaryDim[], nameSets: CacheVaryDim[][]): NameSetLookup {
+  const ids = new Set<NameSetId>();
+  const dimNameSets: CacheVaryDim[][] = [];
+  for (const names of [baseNames, ...nameSets]) {
+    const canonical = canonicalDimNames(names);
+    if (ids.has(canonical)) continue;
+    ids.add(canonical);
+    if (names.length) dimNameSets.push(names);
+  }
+  return { ids, dimNameSets };
+}
+
+function mergeNameSets(
+  baseNames: CacheVaryDim[],
+  nameSets: CacheVaryDim[][],
+  nextNames: CacheVaryDim[]
+): CacheVaryDim[][] {
+  const seen = new Set([canonicalDimNames(baseNames)]);
+  const merged: CacheVaryDim[][] = [];
+  for (const names of [...nameSets, nextNames]) {
+    const canonical = canonicalDimNames(names);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    merged.push(names);
+  }
+  return merged;
+}
+
+function variantKey(key: Buffer, dims: EmbeddedVaryDim[]): Buffer {
+  return crypto
+    .createHash('sha1')
+    .update(key)
+    .update('\0expo-vary\0' + canonicalDims(dims))
+    .digest();
+}
+
+function sameDims(a: EmbeddedVaryDim[], b: EmbeddedVaryDim[]): boolean {
+  return canonicalDims(a) === canonicalDims(b);
+}

--- a/packages/@expo/metro-config/src/cache-vary/__tests__/VaryingCacheStore.test.ts
+++ b/packages/@expo/metro-config/src/cache-vary/__tests__/VaryingCacheStore.test.ts
@@ -1,0 +1,550 @@
+import crypto from 'crypto';
+import { vol } from 'memfs';
+
+import { VaryingCacheStore } from '../VaryingCacheStore';
+import { FileStore } from '../../binary-file-store';
+
+const ROOT = '/cache';
+
+function makeKey(byte = 0xab): Buffer {
+  const key = Buffer.alloc(32);
+  key[0] = byte;
+  for (let i = 1; i < key.length; i++) key[i] = i;
+  return key;
+}
+
+const sha1 = (value: string) => crypto.createHash('sha1').update(value).digest('hex');
+const fingerprintEnv = (name: string) =>
+  sha1(process.env[name] === undefined ? '' : JSON.stringify(process.env[name]));
+
+function makeTransformResult(code: string, dims?: [name: string, fp: string][]) {
+  return {
+    dependencies: [],
+    output: [
+      {
+        data: {
+          code,
+          lineCount: 1,
+          ...(dims?.length
+            ? {
+                expoCacheVary: dims.map(([name, fp]) => ({
+                  scheme: 'env',
+                  name,
+                  fp,
+                })),
+              }
+            : {}),
+        },
+        type: 'js/module',
+      },
+    ],
+  };
+}
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  vol.fromJSON({}, '/');
+});
+
+afterEach(() => {
+  vol.reset();
+  process.env = { ...originalEnv };
+});
+
+function makeStores() {
+  const inner = new FileStore<unknown>({ root: ROOT });
+  const store = new VaryingCacheStore<unknown>(inner);
+  return { inner, store };
+}
+
+function variantCachePaths(key: Buffer): string[] {
+  const basePath = `${ROOT}/${key.subarray(0, 1).toString('hex')}/${key.subarray(1).toString('hex')}.mp`;
+  return Object.keys(vol.toJSON()).filter(
+    (p) => p.startsWith(`${ROOT}/`) && p.endsWith('.mp') && !p.includes('.tmp') && p !== basePath
+  );
+}
+
+describe('non-varying modules', () => {
+  it('passes values through raw, byte-identical to the inner store', async () => {
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    const artifact = makeTransformResult('no-env');
+
+    await store.set(key, artifact);
+    await expect(inner.get(key)).resolves.toEqual(artifact);
+    await expect(store.get(key)).resolves.toEqual(artifact);
+  });
+
+  it('misses with a single inner read', async () => {
+    const { inner, store } = makeStores();
+    const getSpy = jest.spyOn(inner, 'get');
+
+    await expect(store.get(makeKey(0x01))).resolves.toBeNull();
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('varying modules', () => {
+  it('bootstraps the base slot with a raw artifact and hits it with a single read', async () => {
+    process.env.EXPO_PUBLIC_URL = 'https://prod';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    const artifact = makeTransformResult('prod-code', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+
+    await expect(store.get(key)).resolves.toBeNull();
+    await store.set(key, artifact);
+    await expect(inner.get(key)).resolves.toEqual(artifact);
+    const getSpy = jest.spyOn(inner, 'get');
+    await expect(store.get(key)).resolves.toEqual(artifact);
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes non-base variants at their self-derived address, leaving the base untouched', async () => {
+    process.env.EXPO_PUBLIC_URL = 'https://prod';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    const prodArtifact = makeTransformResult('prod-code', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.get(key);
+    await store.set(key, prodArtifact);
+
+    process.env.EXPO_PUBLIC_URL = 'https://staging';
+    await expect(store.get(key)).resolves.toBeNull();
+    const setSpy = jest.spyOn(inner, 'set');
+    const stagingArtifact = makeTransformResult('staging-code', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, stagingArtifact);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    await expect(inner.get(key)).resolves.toEqual(prodArtifact);
+    expect(variantCachePaths(key)).toHaveLength(1);
+    await expect(store.get(key)).resolves.toEqual(stagingArtifact);
+  });
+
+  it('derives the variant address from the base dim names: 2-read hit, 2-IOPS miss', async () => {
+    process.env.EXPO_PUBLIC_URL = 'https://prod';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    await store.set(
+      key,
+      makeTransformResult('prod-code', [['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')]])
+    );
+
+    process.env.EXPO_PUBLIC_URL = 'https://staging';
+    await store.get(key);
+    const stagingArtifact = makeTransformResult('staging-code', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, stagingArtifact);
+    const getSpy = jest.spyOn(inner, 'get');
+    await expect(store.get(key)).resolves.toEqual(stagingArtifact);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    getSpy.mockClear();
+    process.env.EXPO_PUBLIC_URL = 'https://preview';
+    await expect(store.get(key)).resolves.toBeNull();
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    getSpy.mockClear();
+    process.env.EXPO_PUBLIC_URL = 'https://prod';
+    await expect(store.get(key)).resolves.toEqual(
+      makeTransformResult('prod-code', [['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')]])
+    );
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('misses when only one of several dims mismatches (value-dependent values)', async () => {
+    process.env.EXPO_PUBLIC_URL = 'https://prod';
+    process.env.EXPO_PUBLIC_FLAG = 'on';
+    const { store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    await store.set(
+      key,
+      makeTransformResult('two-dims', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+      ])
+    );
+
+    process.env.EXPO_PUBLIC_FLAG = 'off';
+    await expect(store.get(key)).resolves.toBeNull();
+  });
+
+  it('retains every distinct env until TTL — no truncation, all variants resolvable', async () => {
+    const { store } = makeStores();
+    const key = makeKey();
+
+    for (const value of ['a', 'b', 'c', 'd']) {
+      process.env.EXPO_PUBLIC_URL = value;
+      await store.get(key);
+      await store.set(
+        key,
+        makeTransformResult(`code-${value}`, [
+          ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ])
+      );
+    }
+
+    for (const value of ['a', 'b', 'c', 'd']) {
+      process.env.EXPO_PUBLIC_URL = value;
+      await expect(store.get(key)).resolves.toEqual(
+        makeTransformResult(`code-${value}`, [
+          ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ])
+      );
+    }
+  });
+
+  it('re-creates an evicted variant with a single idempotent write, base untouched', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    await store.set(
+      key,
+      makeTransformResult('code-a', [['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')]])
+    );
+
+    process.env.EXPO_PUBLIC_URL = 'b';
+    await store.get(key);
+    await store.set(
+      key,
+      makeTransformResult('code-b', [['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')]])
+    );
+    vol.rmSync(variantCachePaths(key)[0]!);
+    await expect(store.get(key)).resolves.toBeNull();
+
+    const setSpy = jest.spyOn(inner, 'set');
+    const baseBefore = await inner.get(key);
+    const rebuilt = makeTransformResult('code-b2', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, rebuilt);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    await expect(inner.get(key)).resolves.toEqual(baseBefore);
+    await expect(store.get(key)).resolves.toEqual(rebuilt);
+  });
+
+  it('settles two same-cache processes with different envs without shared-cell writes', async () => {
+    const inner = new FileStore<unknown>({ root: ROOT });
+    const storeA = new VaryingCacheStore<unknown>(inner);
+    const storeB = new VaryingCacheStore<unknown>(inner);
+    const key = makeKey();
+
+    process.env.EXPO_PUBLIC_URL = 'a';
+    await storeA.get(key);
+    const artifactA = makeTransformResult('code-a', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await storeA.set(key, artifactA);
+
+    process.env.EXPO_PUBLIC_URL = 'b';
+    await storeB.get(key);
+    const artifactB = makeTransformResult('code-b', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    const setSpy = jest.spyOn(inner, 'set');
+    await storeB.set(key, artifactB);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    await expect(inner.get(key)).resolves.toEqual(artifactA);
+    await expect(storeB.get(key)).resolves.toEqual(artifactB);
+    process.env.EXPO_PUBLIC_URL = 'a';
+    await expect(storeB.get(key)).resolves.toEqual(artifactA);
+    await expect(storeA.get(key)).resolves.toEqual(artifactA);
+  });
+});
+
+describe('foreign data and degradation', () => {
+  it('treats an unknown scheme in the base as a miss with a single read, never a throw', async () => {
+    const { inner, store } = makeStores();
+    const key = makeKey();
+
+    await inner.set(key, {
+      output: [
+        {
+          data: {
+            code: 'x',
+            expoCacheVary: [{ scheme: 'from-the-future', name: 'n', fp: 'f' }],
+          },
+        },
+      ],
+    });
+    const getSpy = jest.spyOn(inner, 'get');
+    await expect(store.get(key)).resolves.toBeNull();
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a foreign wrapper at the base slot as a miss, never as a raw artifact', async () => {
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    await inner.set(key, {
+      expoVaryHead: 1,
+      value: makeTransformResult('older'),
+      others: [],
+    });
+
+    await expect(store.get(key)).resolves.toBeNull();
+    const artifact = makeTransformResult('healed');
+    await store.set(key, artifact);
+    await expect(store.get(key)).resolves.toEqual(artifact);
+  });
+
+  it('claims an empty base slot when no preceding miss was observed (backfill)', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    const getSpy = jest.spyOn(inner, 'get');
+    const artifact = makeTransformResult('backfill', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, artifact);
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    await expect(inner.get(key)).resolves.toEqual(artifact);
+  });
+
+  it('self-addresses when the memo is absent and the base belongs to another population', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    const artifactA = makeTransformResult('code-a', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, artifactA);
+
+    process.env.EXPO_PUBLIC_URL = 'b';
+    const artifactB = makeTransformResult('code-b', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, artifactB);
+
+    await expect(inner.get(key)).resolves.toEqual(artifactA);
+    await expect(store.get(key)).resolves.toEqual(artifactB);
+    process.env.EXPO_PUBLIC_URL = 'a';
+    await expect(store.get(key)).resolves.toEqual(artifactA);
+  });
+
+  it('registers an unknown name-set when the memo is absent', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    const oneDim = makeTransformResult('one-dim', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, oneDim);
+
+    process.env.EXPO_PUBLIC_URL = 'b';
+    process.env.EXPO_PUBLIC_FLAG = 'on';
+    const twoDims = makeTransformResult('two-dims', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+      ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+    ]);
+    await store.set(key, twoDims);
+
+    await expect(store.get(key)).resolves.toEqual(twoDims);
+    process.env.EXPO_PUBLIC_URL = 'a';
+    await expect(store.get(key)).resolves.toEqual(oneDim);
+  });
+
+  it('propagates a failed recomputation read without claiming the base', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    jest.spyOn(inner, 'get').mockRejectedValueOnce(new Error('io'));
+    const artifact = makeTransformResult('code-a', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await expect(store.set(key, artifact)).rejects.toThrow('io');
+
+    await expect(inner.get(key)).resolves.toBeNull();
+  });
+
+  it('never throws on malformed vary metadata: the read barrier degrades to a miss', async () => {
+    const { inner, store } = makeStores();
+    const key = makeKey(0x0a);
+    await inner.set(key, {
+      output: [{ data: { code: 'x', expoCacheVary: [null] } }],
+    });
+
+    await expect(store.get(key)).resolves.toBeNull();
+  });
+
+  it('propagates a failed variant write, leaving the base untouched', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    const artifactA = makeTransformResult('code-a', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.get(key);
+    await store.set(key, artifactA);
+
+    process.env.EXPO_PUBLIC_URL = 'b';
+    await store.get(key);
+    jest.spyOn(inner, 'set').mockRejectedValueOnce(new Error('disk full'));
+    const artifactB = makeTransformResult('code-b', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await expect(store.set(key, artifactB)).rejects.toThrow('disk full');
+    await expect(store.get(key)).resolves.toBeNull();
+    process.env.EXPO_PUBLIC_URL = 'a';
+    await expect(store.get(key)).resolves.toEqual(artifactA);
+  });
+
+  it('passes css.skipCache values through as a full no-op, preserving the pending write target', async () => {
+    process.env.EXPO_PUBLIC_URL = 'a';
+    const { inner, store } = makeStores();
+    const key = makeKey();
+    await store.get(key);
+    const artifact = makeTransformResult('base', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, artifact);
+    process.env.EXPO_PUBLIC_URL = 'b';
+    await store.get(key);
+    await store.set(key, { output: [{ data: { css: { skipCache: true } } }] });
+
+    const artifactB = makeTransformResult('code-b', [
+      ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+    ]);
+    await store.set(key, artifactB);
+    await expect(inner.get(key)).resolves.toEqual(artifact);
+    await expect(store.get(key)).resolves.toEqual(artifactB);
+  });
+
+  describe('dim-name contract violations (name-set registry fallback)', () => {
+    it('keeps BOTH populations resolvable when a producer emits a different dim-name set', async () => {
+      process.env.EXPO_PUBLIC_URL = 'a';
+      process.env.EXPO_PUBLIC_FLAG = 'on';
+      const { store } = makeStores();
+      const key = makeKey();
+      await store.get(key);
+      const oneDim = makeTransformResult('one-dim', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+      ]);
+      await store.set(key, oneDim);
+      process.env.EXPO_PUBLIC_URL = 'b';
+      await store.get(key);
+      const twoDims = makeTransformResult('two-dims', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+      ]);
+      await store.set(key, twoDims);
+      await expect(store.get(key)).resolves.toEqual(twoDims);
+      process.env.EXPO_PUBLIC_URL = 'a';
+      await expect(store.get(key)).resolves.toEqual(oneDim);
+      process.env.EXPO_PUBLIC_URL = 'c';
+      process.env.EXPO_PUBLIC_FLAG = 'off';
+      await store.get(key);
+      const twoDimsC = makeTransformResult('two-dims-c', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+      ]);
+      await store.set(key, twoDimsC);
+      await expect(store.get(key)).resolves.toEqual(twoDimsC);
+    });
+
+    it('registers a name-set once, then self-addresses: no base-slot churn', async () => {
+      process.env.EXPO_PUBLIC_URL = 'a';
+      process.env.EXPO_PUBLIC_FLAG = 'on';
+      const { inner, store } = makeStores();
+      const key = makeKey();
+      await store.get(key);
+      await store.set(
+        key,
+        makeTransformResult('one-dim', [['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')]])
+      );
+      await store.get(key);
+      await store.set(
+        key,
+        makeTransformResult('two-dims', [
+          ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+          ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+        ])
+      );
+      const baseAfterRegistration = await inner.get(key);
+      process.env.EXPO_PUBLIC_FLAG = 'off';
+      await store.get(key);
+      const setSpy = jest.spyOn(inner, 'set');
+      await store.set(
+        key,
+        makeTransformResult('two-dims-2', [
+          ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+          ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+        ])
+      );
+      expect(setSpy).toHaveBeenCalledTimes(1);
+      await expect(inner.get(key)).resolves.toEqual(baseAfterRegistration);
+    });
+
+    it('resolves a non-varying population alongside a varying base (most-specific first)', async () => {
+      process.env.EXPO_PUBLIC_URL = 'a';
+      const { store } = makeStores();
+      const key = makeKey();
+      await store.get(key);
+      const varying = makeTransformResult('varying', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+      ]);
+      await store.set(key, varying);
+      process.env.EXPO_PUBLIC_URL = 'other';
+      await store.get(key);
+      const plain = makeTransformResult('no-deps');
+      await store.set(key, plain);
+      process.env.EXPO_PUBLIC_URL = 'a';
+      await expect(store.get(key)).resolves.toEqual(varying);
+      process.env.EXPO_PUBLIC_URL = 'yet-another';
+      await expect(store.get(key)).resolves.toEqual(plain);
+    });
+
+    it('serves a no-deps BASE artifact to every env by its own claim (under-description is a producer bug)', async () => {
+      process.env.EXPO_PUBLIC_URL = 'a';
+      const { store } = makeStores();
+      const key = makeKey();
+      await store.get(key);
+      const plain = makeTransformResult('no-deps');
+      await store.set(key, plain);
+      process.env.EXPO_PUBLIC_URL = 'b';
+      await expect(store.get(key)).resolves.toEqual(plain);
+    });
+
+    it('converges across two same-cache processes with violating producers', async () => {
+      const inner = new FileStore<unknown>({ root: ROOT });
+      const storeA = new VaryingCacheStore<unknown>(inner);
+      const storeB = new VaryingCacheStore<unknown>(inner);
+      const key = makeKey();
+
+      process.env.EXPO_PUBLIC_URL = 'a';
+      await storeA.get(key);
+      const oneDim = makeTransformResult('one-dim', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+      ]);
+      await storeA.set(key, oneDim);
+
+      process.env.EXPO_PUBLIC_FLAG = 'on';
+      await storeB.get(key);
+      const twoDims = makeTransformResult('two-dims', [
+        ['EXPO_PUBLIC_URL', fingerprintEnv('EXPO_PUBLIC_URL')],
+        ['EXPO_PUBLIC_FLAG', fingerprintEnv('EXPO_PUBLIC_FLAG')],
+      ]);
+      await storeB.set(key, twoDims);
+      await expect(storeA.get(key)).resolves.toEqual(oneDim);
+      await expect(storeB.get(key)).resolves.toEqual(oneDim);
+    });
+  });
+
+  it('clears the inner store', async () => {
+    const { inner, store } = makeStores();
+    const clearSpy = jest.spyOn(inner, 'clear').mockImplementation(() => {});
+
+    await store.clear();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/@expo/metro-config/src/cache-vary/__tests__/VaryingCacheStore.test.ts
+++ b/packages/@expo/metro-config/src/cache-vary/__tests__/VaryingCacheStore.test.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 import { vol } from 'memfs';
 
-import { VaryingCacheStore } from '../VaryingCacheStore';
 import { FileStore } from '../../binary-file-store';
+import { VaryingCacheStore } from '../VaryingCacheStore';
 
 const ROOT = '/cache';
 

--- a/packages/@expo/metro-config/src/cache-vary/__tests__/ambient.test.ts
+++ b/packages/@expo/metro-config/src/cache-vary/__tests__/ambient.test.ts
@@ -1,0 +1,104 @@
+import {
+  canonicalDimNames,
+  canonicalDims,
+  currentFingerprint,
+  dimId,
+  isAmbientVaryScheme,
+  readAmbientVaryValue,
+} from '../ambient';
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterAll(() => {
+  process.env = { ...originalEnv };
+});
+
+describe(readAmbientVaryValue, () => {
+  it('reads current env values and distinguishes unset from empty', () => {
+    process.env.EXPO_PUBLIC_TEST_VAR = 'value';
+    expect(readAmbientVaryValue('env', 'EXPO_PUBLIC_TEST_VAR')).toBe('value');
+
+    process.env.EXPO_PUBLIC_TEST_VAR = '';
+    expect(readAmbientVaryValue('env', 'EXPO_PUBLIC_TEST_VAR')).toBe('');
+
+    delete process.env.EXPO_PUBLIC_TEST_VAR;
+    expect(readAmbientVaryValue('env', 'EXPO_PUBLIC_TEST_VAR')).toBeUndefined();
+  });
+});
+
+describe(isAmbientVaryScheme, () => {
+  it('accepts known schemes and rejects foreign scheme strings', () => {
+    expect(isAmbientVaryScheme('env')).toBe(true);
+    expect(isAmbientVaryScheme('does-not-exist')).toBe(false);
+    expect(isAmbientVaryScheme('constructor')).toBe(false);
+  });
+});
+
+describe(currentFingerprint, () => {
+  it('distinguishes an unset variable from an empty string', async () => {
+    delete process.env.EXPO_PUBLIC_TEST_VAR;
+    const unset = await currentFingerprint('env', 'EXPO_PUBLIC_TEST_VAR');
+
+    process.env.EXPO_PUBLIC_TEST_VAR = '';
+    const empty = await currentFingerprint('env', 'EXPO_PUBLIC_TEST_VAR');
+
+    expect(unset).not.toEqual(empty);
+  });
+
+  it('changes with the value and is stable for equal values', async () => {
+    process.env.EXPO_PUBLIC_TEST_VAR = 'one';
+    const one = await currentFingerprint('env', 'EXPO_PUBLIC_TEST_VAR');
+    const oneAgain = await currentFingerprint('env', 'EXPO_PUBLIC_TEST_VAR');
+
+    process.env.EXPO_PUBLIC_TEST_VAR = 'two';
+    const two = await currentFingerprint('env', 'EXPO_PUBLIC_TEST_VAR');
+
+    expect(one).toEqual(oneAgain);
+    expect(one).not.toEqual(two);
+  });
+
+  it('returns null for an unknown scheme, never a fingerprint of an absent value', async () => {
+    expect(await currentFingerprint('does-not-exist', 'x')).toBeNull();
+  });
+});
+
+describe(canonicalDims, () => {
+  it('serializes dims sorted and newline-joined, independent of input order', () => {
+    const a = canonicalDims([
+      { scheme: 'env', name: 'EXPO_PUBLIC_B', fp: '2' },
+      { scheme: 'env', name: 'EXPO_PUBLIC_A', fp: '1' },
+    ]);
+    const b = canonicalDims([
+      { scheme: 'env', name: 'EXPO_PUBLIC_A', fp: '1' },
+      { scheme: 'env', name: 'EXPO_PUBLIC_B', fp: '2' },
+    ]);
+
+    expect(a).toBe(b);
+    expect(a).toBe('env:EXPO_PUBLIC_A=1\nenv:EXPO_PUBLIC_B=2');
+  });
+
+  it('serializes an empty dim list to an empty string', () => {
+    expect(canonicalDims([])).toBe('');
+  });
+});
+
+describe(canonicalDimNames, () => {
+  it('serializes dim names sorted and newline-joined', () => {
+    expect(
+      canonicalDimNames([
+        { scheme: 'env', name: 'EXPO_PUBLIC_B' },
+        { scheme: 'env', name: 'EXPO_PUBLIC_A' },
+      ])
+    ).toBe('env:EXPO_PUBLIC_A\nenv:EXPO_PUBLIC_B');
+  });
+});
+
+describe(dimId, () => {
+  it('joins a dim scheme and name', () => {
+    expect(dimId({ scheme: 'env', name: 'EXPO_PUBLIC_A' })).toBe('env:EXPO_PUBLIC_A');
+  });
+});

--- a/packages/@expo/metro-config/src/cache-vary/ambient.ts
+++ b/packages/@expo/metro-config/src/cache-vary/ambient.ts
@@ -1,0 +1,48 @@
+import crypto from 'node:crypto';
+
+export type AmbientVaryScheme = 'env';
+
+export function isAmbientVaryScheme(scheme: string): scheme is AmbientVaryScheme {
+  return scheme === 'env';
+}
+
+// Duplicated in `@expo/cli`; keep this function, `dimId`, and `canonicalDimNames` in sync.
+export function readAmbientVaryValue(scheme: AmbientVaryScheme, name: string): string | undefined {
+  switch (scheme) {
+    case 'env':
+      return process.env[name];
+  }
+}
+
+export type CacheVaryDim = { scheme: string; name: string };
+
+export interface EmbeddedVaryDim extends CacheVaryDim {
+  fp: string;
+}
+
+export async function currentFingerprint(scheme: string, name: string): Promise<string | null> {
+  if (!isAmbientVaryScheme(scheme)) return null;
+  return sha1(fingerprintInput(readAmbientVaryValue(scheme, name)));
+}
+
+export const dimId = (dim: CacheVaryDim): string => `${dim.scheme}:${dim.name}`;
+
+export function canonicalDimNames(dims: readonly CacheVaryDim[]): string {
+  return dims.map(dimId).sort().join('\n');
+}
+
+export function canonicalDims(dims: readonly EmbeddedVaryDim[]): string {
+  return dims
+    .map((d) => `${dimId(d)}=${d.fp}`)
+    .sort()
+    .join('\n');
+}
+
+function sha1(value: string): string {
+  return crypto.createHash('sha1').update(value).digest('hex');
+}
+
+function fingerprintInput(value: string | undefined): string {
+  // JSON framing separates unset from empty.
+  return value === undefined ? '' : JSON.stringify(value);
+}

--- a/packages/@expo/metro-config/src/cache-vary/ambient.ts
+++ b/packages/@expo/metro-config/src/cache-vary/ambient.ts
@@ -25,6 +25,18 @@ export async function currentFingerprint(scheme: string, name: string): Promise<
   return sha1(fingerprintInput(readAmbientVaryValue(scheme, name)));
 }
 
+export async function embedCurrentFingerprints(
+  dims: readonly CacheVaryDim[] | undefined
+): Promise<EmbeddedVaryDim[] | undefined> {
+  if (!dims?.length) return undefined;
+  return await Promise.all(
+    dims.map(async (dim) => ({
+      ...dim,
+      fp: (await currentFingerprint(dim.scheme, dim.name))!,
+    }))
+  );
+}
+
 export const dimId = (dim: CacheVaryDim): string => `${dim.scheme}:${dim.name}`;
 
 export function canonicalDimNames(dims: readonly CacheVaryDim[]): string {

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.test.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.test.ts
@@ -62,6 +62,7 @@ it(`can create a micro Metro graph fixture`, async () => {
       var _foo = _$$_REQUIRE(_dependencyMap[0], "./foo");
       console.log(_foo.foo);
     });",
+                  "expoCacheVary": undefined,
                   "expoDomComponentReference": undefined,
                   "functionMap": {
                     "mappings": "AAA",
@@ -207,6 +208,7 @@ it(`can create a micro Metro graph fixture`, async () => {
       });
       const foo = 'foo';
     });",
+                  "expoCacheVary": undefined,
                   "expoDomComponentReference": undefined,
                   "functionMap": {
                     "mappings": "AAA",

--- a/packages/@expo/metro-config/src/serializer/jsOutput.ts
+++ b/packages/@expo/metro-config/src/serializer/jsOutput.ts
@@ -8,6 +8,7 @@ import type { types as t } from '@babel/core';
 import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from '@expo/metro/metro-source-map';
 import type { JsTransformerConfig } from '@expo/metro/metro-transform-worker';
 
+import type { EmbeddedVaryDim } from '../cache-vary/ambient';
 import type { Options as CollectDependenciesOptions } from '../transform-worker/collect-dependencies';
 import type { PackedMap, SerializableSourceMap } from './packedMap';
 
@@ -70,7 +71,7 @@ export type ExpoJsOutput = Omit<JsOutput, 'data'> & {
       duration: number;
     };
     css?: CSSMetadata;
-    expoCacheVary?: { scheme: string; name: string; fp: string }[];
+    expoCacheVary?: EmbeddedVaryDim[];
   };
 };
 

--- a/packages/@expo/metro-config/src/serializer/jsOutput.ts
+++ b/packages/@expo/metro-config/src/serializer/jsOutput.ts
@@ -70,6 +70,7 @@ export type ExpoJsOutput = Omit<JsOutput, 'data'> & {
       duration: number;
     };
     css?: CSSMetadata;
+    expoCacheVary?: { scheme: string; name: string; fp: string }[];
   };
 };
 

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/cache-vary-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/cache-vary-worker.test.ts
@@ -1,0 +1,141 @@
+import type {
+  JsTransformerConfig,
+  JsTransformOptions,
+  MinifierOptions,
+} from '@expo/metro/metro-transform-worker';
+import { Buffer } from 'buffer';
+import crypto from 'crypto';
+import * as fs from 'fs';
+import { vol } from 'memfs';
+import * as path from 'path';
+
+import type { ExpoJsOutput } from '../../serializer/jsOutput';
+
+jest
+  .mock(
+    '@expo/metro/metro-transform-worker/utils/getMinifier',
+    () =>
+      () =>
+      ({ code, map }: MinifierOptions) => ({ code, map })
+  )
+  .mock('@expo/metro/metro-transform-plugins', () => ({
+    ...jest.requireActual('@expo/metro/metro-transform-plugins'),
+    inlinePlugin: () => ({}),
+    constantFoldingPlugin: () => ({}),
+  }))
+  .mock('metro-minify-terser');
+
+const babelTransformerPath = require.resolve('@expo/metro-config/babel-transformer');
+const transformerContents = jest.requireActual('fs').readFileSync(babelTransformerPath);
+
+let Transformer: typeof import('../metro-transform-worker');
+
+const baseConfig: JsTransformerConfig = {
+  allowOptionalDependencies: false,
+  assetPlugins: [],
+  assetRegistryPath: '',
+  asyncRequireModulePath: 'asyncRequire',
+  babelTransformerPath,
+  dynamicDepsInPackages: 'reject',
+  enableBabelRCLookup: false,
+  enableBabelRuntime: true,
+  globalPrefix: '',
+  hermesParser: false,
+  minifierConfig: { output: { comments: false } },
+  minifierPath: 'minifyModulePath',
+  optimizationSizeLimit: 100000,
+  publicPath: '/assets',
+  unstable_dependencyMapReservedName: null,
+  unstable_compactOutput: false,
+  unstable_disableModuleWrapping: false,
+  unstable_disableNormalizePseudoGlobals: false,
+  unstable_allowRequireContext: false,
+};
+
+const baseTransformOptions: JsTransformOptions = {
+  dev: true,
+  inlinePlatform: false,
+  inlineRequires: false,
+  minify: false,
+  platform: 'ios',
+  type: 'module',
+  unstable_transformProfile: 'default',
+  customTransformOptions: {
+    __proto__: null,
+  },
+};
+
+jest.mock('fs');
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+
+  Transformer = require('../metro-transform-worker');
+
+  process.env = { ...originalEnv };
+
+  vol.reset();
+  fs.mkdirSync('/root/local', { recursive: true });
+  fs.mkdirSync(path.dirname(babelTransformerPath), { recursive: true });
+  fs.writeFileSync(babelTransformerPath, transformerContents);
+});
+
+afterAll(() => {
+  process.env = { ...originalEnv };
+});
+
+const sha1 = (value: string) => crypto.createHash('sha1').update(value).digest('hex');
+
+it('embeds current fingerprints for env vars inlined in production', async () => {
+  process.env.EXPO_PUBLIC_TEST = 'test-value';
+
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/file.js',
+    Buffer.from('console.log(process.env.EXPO_PUBLIC_TEST);', 'utf8'),
+    { ...baseTransformOptions, dev: false }
+  );
+
+  const output = result.output[0] as ExpoJsOutput;
+  expect(output.data.expoCacheVary).toEqual([
+    {
+      scheme: 'env',
+      name: 'EXPO_PUBLIC_TEST',
+      fp: sha1(JSON.stringify('test-value')),
+    },
+  ]);
+  expect(typeof output.data.expoCacheVary![0]!.fp).toBe('string');
+});
+
+it('embeds no expoCacheVary in development', async () => {
+  process.env.EXPO_PUBLIC_TEST = 'test-value';
+
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/file.js',
+    Buffer.from('console.log(process.env.EXPO_PUBLIC_TEST);', 'utf8'),
+    baseTransformOptions
+  );
+
+  const output = result.output[0] as ExpoJsOutput;
+  expect(output.data.expoCacheVary).toBeUndefined();
+});
+
+it('embeds no expoCacheVary for files without env usage', async () => {
+  process.env.EXPO_PUBLIC_TEST = 'test-value';
+
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/file.js',
+    Buffer.from('console.log("hello");', 'utf8'),
+    { ...baseTransformOptions, dev: false }
+  );
+
+  const output = result.output[0] as ExpoJsOutput;
+  expect(output.data.expoCacheVary).toBeUndefined();
+});

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/cache-vary-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/cache-vary-worker.test.ts
@@ -110,6 +110,52 @@ it('embeds current fingerprints for env vars inlined in production', async () =>
   expect(typeof output.data.expoCacheVary![0]!.fp).toBe('string');
 });
 
+it('embeds current fingerprints with the noxcturnal transform worker', async () => {
+  process.env.EXPO_PUBLIC_TEST = 'native-test-value';
+
+  const result = await Transformer.transform(
+    { ...baseConfig, unstable_noxcturnalTransformWorker: true } as JsTransformerConfig & {
+      unstable_noxcturnalTransformWorker: boolean;
+    },
+    '/root',
+    'local/file.js',
+    Buffer.from('console.log(process.env.EXPO_PUBLIC_TEST);', 'utf8'),
+    { ...baseTransformOptions, dev: false }
+  );
+
+  const output = result.output[0] as ExpoJsOutput;
+  expect(output.data.expoCacheVary).toEqual([
+    {
+      scheme: 'env',
+      name: 'EXPO_PUBLIC_TEST',
+      fp: sha1(JSON.stringify('native-test-value')),
+    },
+  ]);
+});
+
+it('embeds current fingerprints for noxcturnal defines in node_modules', async () => {
+  process.env.EXPO_PUBLIC_USE_RN_FETCH = '1';
+
+  const result = await Transformer.transform(
+    { ...baseConfig, unstable_noxcturnalTransformWorker: true } as JsTransformerConfig & {
+      unstable_noxcturnalTransformWorker: boolean;
+    },
+    '/root',
+    'node_modules/example/index.js',
+    Buffer.from('console.log(process.env.EXPO_PUBLIC_USE_RN_FETCH);', 'utf8'),
+    { ...baseTransformOptions, dev: false }
+  );
+
+  const output = result.output[0] as ExpoJsOutput;
+  expect(output.data.expoCacheVary).toEqual([
+    {
+      scheme: 'env',
+      name: 'EXPO_PUBLIC_USE_RN_FETCH',
+      fp: sha1(JSON.stringify('1')),
+    },
+  ]);
+});
+
 it('embeds no expoCacheVary in development', async () => {
   process.env.EXPO_PUBLIC_TEST = 'test-value';
 

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -30,7 +30,7 @@ import {
 } from '@expo/metro/metro/ModuleGraph/worker/importLocationsPlugin';
 import assert from 'node:assert';
 
-import { currentFingerprint, type CacheVaryDim } from '../cache-vary/ambient';
+import { embedCurrentFingerprints, type CacheVaryDim } from '../cache-vary/ambient';
 import type { ExpoJsOutput, ReconcileTransformSettings } from '../serializer/jsOutput';
 import {
   countLinesAndTerminateSourceMap,
@@ -660,14 +660,7 @@ async function transformJS(
         reactClientReference: file.reactClientReference,
         expoDomComponentReference: file.expoDomComponentReference,
         loaderReference: file.loaderReference,
-        expoCacheVary: file.cacheVary?.length
-          ? await Promise.all(
-              file.cacheVary.map(async (d) => ({
-                ...d,
-                fp: (await currentFingerprint(d.scheme, d.name))!,
-              }))
-            )
-          : undefined,
+        expoCacheVary: await embedCurrentFingerprints(file.cacheVary),
         ...(possibleReconcile
           ? {
               ast: wrappedAst,

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -795,6 +795,7 @@ async function completeFullNoxcturnalTransform(
   context: TransformationContext,
   fullNoxcturnal: Extract<NoxcturnalMetroTransformAttempt, { status: 'complete' }>
 ): Promise<TransformResponse> {
+  const cacheVary = fullNoxcturnal.result.metadata.cacheVary as readonly CacheVaryDim[] | undefined;
   if (String(context.options.customTransformOptions?.optimize) === 'true') {
     return transformJS(
       {
@@ -826,6 +827,7 @@ async function completeFullNoxcturnalTransform(
             ? fullNoxcturnal.result.metadata.loaderReference
             : file.loaderReference,
         functionMap: fullNoxcturnal.result.functionMap ?? file.functionMap,
+        cacheVary,
       },
       context
     );
@@ -892,6 +894,7 @@ async function completeFullNoxcturnalTransform(
             typeof fullNoxcturnal.result.metadata.loaderReference === 'string'
               ? fullNoxcturnal.result.metadata.loaderReference
               : file.loaderReference,
+          expoCacheVary: await embedCurrentFingerprints(cacheVary),
         },
       },
     ],

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -30,6 +30,7 @@ import {
 } from '@expo/metro/metro/ModuleGraph/worker/importLocationsPlugin';
 import assert from 'node:assert';
 
+import { currentFingerprint, type CacheVaryDim } from '../cache-vary/ambient';
 import type { ExpoJsOutput, ReconcileTransformSettings } from '../serializer/jsOutput';
 import {
   countLinesAndTerminateSourceMap,
@@ -97,6 +98,7 @@ interface JSFile extends BaseFile {
     readonly names: string[];
     readonly originalCode: string;
   };
+  readonly cacheVary?: readonly CacheVaryDim[];
 }
 
 interface JSONFile extends BaseFile {
@@ -658,6 +660,14 @@ async function transformJS(
         reactClientReference: file.reactClientReference,
         expoDomComponentReference: file.expoDomComponentReference,
         loaderReference: file.loaderReference,
+        expoCacheVary: file.cacheVary?.length
+          ? await Promise.all(
+              file.cacheVary.map(async (d) => ({
+                ...d,
+                fp: (await currentFingerprint(d.scheme, d.name))!,
+              }))
+            )
+          : undefined,
         ...(possibleReconcile
           ? {
               ast: wrappedAst,
@@ -926,6 +936,7 @@ async function transformJSWithBabelFallback(
     expoDomComponentReference: transformResult.metadata?.expoDomComponentReference,
     loaderReference: transformResult.metadata?.loaderReference,
     performConstantFolding: transformResult.metadata?.performConstantFolding,
+    cacheVary: transformResult.metadata?.cacheVary,
   };
 
   return await transformJS(jsFile, context);
@@ -1063,6 +1074,7 @@ export async function transform(
 
 // NOTE: Increment if cache becomes incompatible (original value would be '')
 // 1. Added new packed source map format
+// 2. `expoCacheVary` is embedded in cached transform results
 const CACHE_VERSION = '2';
 
 export function getCacheKey(

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
@@ -12,6 +12,7 @@ import type {
   TransformResult,
 } from 'noxcturnal';
 
+import type { CacheVaryDim } from '../../cache-vary/ambient';
 import type { Dependency } from '../collect-dependencies';
 import { mayContainReactNativeCodegen } from './codegen';
 import { getHermesV0PreflightConfig } from './configs/hermes-v0';
@@ -19,6 +20,7 @@ import { getHermesV1PreflightConfig } from './configs/hermes-v1';
 import type { ProfilePreflightFacts } from './configs/types';
 import { getWebPreflightConfig } from './configs/web';
 import { getWebViewPreflightConfig } from './configs/webview';
+import { createCacheVaryMetadataPlugin } from './plugins/cache-vary';
 import { createCjsDetectionPlugin } from './plugins/cjs-detection';
 import { createClientServerDirectiveBoundaryPlugin } from './plugins/client-server-directive-boundary';
 import { createClientServerReferenceProxyPlugin } from './plugins/client-server-reference-proxy';
@@ -77,6 +79,7 @@ export interface ExpoTransformPluginData {
   input: NoxcturnalTransformInput;
   sourceFacts: NoxcturnalSourceFacts;
   serverBoundary: ServerBoundaryShared;
+  cacheVary: CacheVaryDim[];
 }
 
 export function sortedUniqueCaptureNames(captures: readonly NodeView[]): string[] {
@@ -109,6 +112,7 @@ function createExpoTransformPluginData(
   return {
     input,
     sourceFacts,
+    cacheVary: [],
     serverBoundary: {
       clientProxy: false,
       moduleServerActions: false,
@@ -871,6 +875,9 @@ function createPipeline(
   }
   if (sourceFacts.hasProcess) {
     addPlugin('process-env', () => createProcessEnvPlugin(nox));
+  }
+  if (sourceFacts.hasDefineCandidate || sourceFacts.hasProcess) {
+    addPlugin('cache-vary-metadata', () => createCacheVaryMetadataPlugin(nox));
   }
   if (!options.dev && sourceFacts.hasPlatform && sourceFacts.hasSelect) {
     addPlugin(`platform-select:${options.platform ?? ''}`, () =>

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/cache-vary.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/cache-vary.ts
@@ -1,0 +1,28 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { CacheVaryDim } from '../../../cache-vary/ambient';
+import { expoPluginData, type Noxcturnal } from '../noxcturnal-transformer';
+
+export function addCacheVary(context: { pluginData: unknown }, dim: CacheVaryDim): void {
+  const dims = expoPluginData(context).cacheVary;
+  if (!dims.some((item) => item.scheme === dim.scheme && item.name === dim.name)) {
+    dims.push(dim);
+  }
+}
+
+export function createCacheVaryMetadataPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<Record<string, never>> {
+  return nox.defineNativePlugin({
+    name: 'expo-cache-vary-metadata',
+    contract: {
+      metadata: { writes: ['cacheVary'] },
+    },
+    post(context) {
+      const dims = expoPluginData(context).cacheVary;
+      if (dims.length > 0) {
+        context.metadata.set('cacheVary', dims);
+      }
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/define.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/define.ts
@@ -2,6 +2,7 @@ import type { DefinedNativePlugin } from 'noxcturnal';
 
 import { expoPluginInput, isNodeModule, mappedLiteral } from '../noxcturnal-transformer';
 import type { Noxcturnal } from '../noxcturnal-transformer';
+import { addCacheVary } from './cache-vary';
 
 interface DefineState {
   identifiers: Map<string, unknown>;
@@ -87,6 +88,12 @@ export function createDefinePlugin(nox: Noxcturnal): DefinedNativePlugin<DefineS
           if (!members.has(pattern)) return;
           const root = pattern.slice(0, pattern.indexOf('.'));
           if (path.scope.hasBinding(root)) return;
+          if (pattern.startsWith('process.env.EXPO_PUBLIC_')) {
+            addCacheVary(path.context, {
+              scheme: 'env',
+              name: pattern.slice('process.env.'.length),
+            });
+          }
           path.replaceWith(mappedLiteral(path.context, members.get(pattern)));
         }
       ),

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/process-env.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/process-env.ts
@@ -8,6 +8,7 @@ import {
   type Noxcturnal,
   type NoxcturnalTransformInput,
 } from '../noxcturnal-transformer';
+import { addCacheVary } from './cache-vary';
 
 const NO_PROCESS_ENV_REPLACEMENT = Symbol('NO_PROCESS_ENV_REPLACEMENT');
 
@@ -73,6 +74,9 @@ export function createProcessEnvPlugin(nox: Noxcturnal): DefinedNativePlugin<Pro
           if (member.scope.hasBinding('process')) return;
           const replacement = processEnvReplacement(name, state);
           if (replacement === NO_PROCESS_ENV_REPLACEMENT) return;
+          if (!state.input.options.dev && name.startsWith('EXPO_PUBLIC_')) {
+            addCacheVary(member.context, { scheme: 'env', name });
+          }
           member.replaceWith(mappedLiteral(member.context, replacement));
         }
       ),

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Record inlined `EXPO_PUBLIC_*` env vars in `cacheVary` metadata so the value is invalidating when it changes ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
+- Inline `EXPO_PUBLIC_USE_RN_FETCH` as `undefined` inside `node_modules` when the flag is unset to allow cache invaliation as intended ([#47750](https://github.com/expo/expo/pull/47750) by [@kitten](https://github.com/kitten))
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 

--- a/packages/babel-preset-expo/src/cache-vary.ts
+++ b/packages/babel-preset-expo/src/cache-vary.ts
@@ -1,0 +1,25 @@
+import type { PluginPass } from '@babel/core';
+
+export type CacheVaryDim = { scheme: string; name: string };
+
+/**
+ * Record that the current file's transform output depends on an ambient value.
+ *
+ * Babel caches plugin instances across files within a worker, so closure state would leak dims.
+ */
+export function addCacheVary(pass: PluginPass, dim: CacheVaryDim): void {
+  const metadata = pass.file.metadata;
+  assertExpoMetadata(metadata);
+  const dims = (metadata.cacheVary ??= []);
+  if (!dims.some((d) => d.scheme === dim.scheme && d.name === dim.name)) {
+    dims.push(dim);
+  }
+}
+
+function assertExpoMetadata(metadata: any): asserts metadata is {
+  cacheVary?: CacheVaryDim[];
+} {
+  if (!metadata || typeof metadata !== 'object') {
+    throw new Error('Expected Babel state.file.metadata to be an object');
+  }
+}

--- a/packages/babel-preset-expo/src/configs/expo.ts
+++ b/packages/babel-preset-expo/src/configs/expo.ts
@@ -319,7 +319,7 @@ function getInlinesFromOptions(
   // `EXPO_PUBLIC_USE_RN_FETCH` isn't inlined in `node_modules`
   // https://github.com/expo/expo/issues/46982
   // TODO(@kitten): Handle it in `getInlineEnvVarsEnabled` during the env var refactor.
-  if (options.isNodeModule && process.env.EXPO_PUBLIC_USE_RN_FETCH != null) {
+  if (options.isNodeModule) {
     inlines['process.env.EXPO_PUBLIC_USE_RN_FETCH'] = process.env.EXPO_PUBLIC_USE_RN_FETCH;
   }
 

--- a/packages/babel-preset-expo/src/plugins/__tests__/cache-vary.test.ts
+++ b/packages/babel-preset-expo/src/plugins/__tests__/cache-vary.test.ts
@@ -1,0 +1,172 @@
+import * as babel from '@babel/core';
+
+import preset from '../..';
+import type { CacheVaryDim } from '../../cache-vary';
+
+const ENABLED_CALLER = {
+  name: 'metro',
+  isDev: false,
+  isServer: false,
+  isHMREnabled: true,
+};
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+const DEF_OPTIONS = {
+  // Ensure this is absolute to prevent the filename from being converted to absolute and breaking CI tests.
+  filename: '/unknown',
+  babelrc: false,
+  presets: [preset],
+  sourceMaps: true,
+  configFile: false,
+  compact: false,
+  comments: true,
+  retainLines: true,
+  caller: getCaller({ ...ENABLED_CALLER, platform: 'ios' }),
+};
+
+type Metadata = {
+  cacheVary?: CacheVaryDim[];
+  publicEnvVars?: string[];
+};
+
+function transformGetMetadata(
+  sourceCode: string,
+  customOptions: { filename?: string; caller?: any; presets?: any[] } = {}
+): Metadata {
+  const results = babel.transform(sourceCode, { ...DEF_OPTIONS, ...customOptions });
+  if (!results) throw new Error('Failed to transform code');
+  return results.metadata as unknown as Metadata;
+}
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterAll(() => {
+  process.env = { ...originalEnv };
+});
+
+it(`records a cacheVary dim for each environment variable inlined in production`, () => {
+  process.env.EXPO_PUBLIC_A = 'a';
+  process.env.EXPO_PUBLIC_B = 'b';
+
+  const metadata = transformGetMetadata(`
+console.log(process.env.EXPO_PUBLIC_A);
+console.log(process.env.EXPO_PUBLIC_B);
+console.log(process.env.NODE_ENV);
+console.log(process.env.JEST_WORKER_ID);
+`);
+
+  expect(metadata.cacheVary).toEqual([
+    { scheme: 'env', name: 'EXPO_PUBLIC_A' },
+    { scheme: 'env', name: 'EXPO_PUBLIC_B' },
+  ]);
+});
+
+it(`records a cacheVary dim for inlined env vars that are unset`, () => {
+  delete process.env.EXPO_PUBLIC_UNSET;
+
+  const metadata = transformGetMetadata(`console.log(process.env.EXPO_PUBLIC_UNSET);`);
+
+  expect(metadata.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_UNSET' }]);
+});
+
+it(`dedupes cacheVary dims for repeated usage in one file`, () => {
+  process.env.EXPO_PUBLIC_A = 'a';
+
+  const metadata = transformGetMetadata(`
+console.log(process.env.EXPO_PUBLIC_A);
+console.log(process.env.EXPO_PUBLIC_A);
+process.env['EXPO_PUBLIC_A'];
+`);
+
+  expect(metadata.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_A' }]);
+});
+
+it(`records no cacheVary dims in development`, () => {
+  process.env.EXPO_PUBLIC_A = 'a';
+
+  const metadata = transformGetMetadata(`console.log(process.env.EXPO_PUBLIC_A);`, {
+    caller: getCaller({ ...ENABLED_CALLER, platform: 'ios', isDev: true }),
+  });
+
+  expect(metadata.cacheVary).toBeUndefined();
+});
+
+it(`records no cacheVary dims for files that inline no env vars`, () => {
+  process.env.EXPO_PUBLIC_A = 'a';
+
+  const metadata = transformGetMetadata(`console.log(process.env.NODE_ENV);`);
+
+  expect(metadata.cacheVary).toBeUndefined();
+});
+
+it(`keeps cacheVary dims per-file when the plugin instance is shared across files`, () => {
+  process.env.EXPO_PUBLIC_A = 'a';
+  process.env.EXPO_PUBLIC_B = 'b';
+
+  // Share one preset config item so babel reuses cached plugin instances across transforms,
+  // matching how Metro workers transform many files through the same babel config.
+  const presetItem = babel.createConfigItem(preset, { type: 'preset' });
+  const options = { presets: [presetItem] };
+
+  const first = transformGetMetadata(`console.log(process.env.EXPO_PUBLIC_A);`, {
+    ...options,
+    filename: '/a.js',
+  });
+  const second = transformGetMetadata(`console.log(process.env.EXPO_PUBLIC_B);`, {
+    ...options,
+    filename: '/b.js',
+  });
+
+  // Harness sanity check: `publicEnvVars` is a known per-instance closure accumulator — if it
+  // does NOT leak across the two files, the plugin instance was not shared and this test would
+  // pass trivially against a closure-based cacheVary implementation.
+  expect(second.publicEnvVars).toEqual(expect.arrayContaining(['EXPO_PUBLIC_A', 'EXPO_PUBLIC_B']));
+
+  expect(first.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_A' }]);
+  expect(second.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_B' }]);
+});
+
+describe('define-plugin inlines (EXPO_PUBLIC_USE_RN_FETCH in node_modules)', () => {
+  const NODE_MODULE_CALLER = getCaller({
+    name: 'metro',
+    engine: 'hermes',
+    platform: 'ios',
+    isDev: false,
+    isNodeModule: true,
+  });
+
+  it(`records a cacheVary dim only for files where the var was actually replaced`, () => {
+    process.env.EXPO_PUBLIC_USE_RN_FETCH = '1';
+
+    const using = transformGetMetadata(
+      `const useRnFetch = process.env.EXPO_PUBLIC_USE_RN_FETCH === '1';`,
+      { caller: NODE_MODULE_CALLER }
+    );
+    const notUsing = transformGetMetadata(`console.log(process.env.NODE_ENV);`, {
+      caller: NODE_MODULE_CALLER,
+    });
+
+    expect(using.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_USE_RN_FETCH' }]);
+    expect(notUsing.cacheVary).toBeUndefined();
+  });
+
+  it(`records the cacheVary dim when the flag is unset (dims are a pure function of the source)`, () => {
+    delete process.env.EXPO_PUBLIC_USE_RN_FETCH;
+
+    const metadata = transformGetMetadata(
+      `const useRnFetch = process.env.EXPO_PUBLIC_USE_RN_FETCH === '1';`,
+      // Use a different platform than the set-flag test above: babel caches the preset
+      // evaluation per caller, and the preset reads the env var at preset-init.
+      { caller: getCaller({ ...(NODE_MODULE_CALLER as any), platform: 'android' }) }
+    );
+
+    expect(metadata.cacheVary).toEqual([{ scheme: 'env', name: 'EXPO_PUBLIC_USE_RN_FETCH' }]);
+  });
+});

--- a/packages/babel-preset-expo/src/plugins/__tests__/inline-env-vars.test.ts
+++ b/packages/babel-preset-expo/src/plugins/__tests__/inline-env-vars.test.ts
@@ -197,7 +197,7 @@ const useRnFetch =
   expect(normalized).toContain('var useRnFetch = true || false;');
 });
 
-it(`leaves EXPO_PUBLIC_USE_RN_FETCH untouched inside node modules when the flag is unset`, () => {
+it(`inlines EXPO_PUBLIC_USE_RN_FETCH as undefined inside node modules when the flag is unset`, () => {
   delete process.env.EXPO_PUBLIC_USE_RN_FETCH;
 
   const options = {
@@ -216,9 +216,10 @@ const useRnFetch =
   process.env.EXPO_PUBLIC_USE_RN_FETCH === '1' || process.env.EXPO_PUBLIC_USE_RN_FETCH === 'true';
 `;
 
-  const contents = babel.transform(sourceCode, options)!.code;
+  const normalized = babel.transform(sourceCode, options)!.code!.replace(/\s+/g, ' ');
 
-  expect(contents).toMatch('process.env.EXPO_PUBLIC_USE_RN_FETCH');
+  expect(normalized).not.toMatch('process.env.EXPO_PUBLIC_USE_RN_FETCH');
+  expect(normalized).toContain('var useRnFetch = false || false;');
 });
 
 function transformTest(

--- a/packages/babel-preset-expo/src/plugins/define-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/define-plugin.ts
@@ -8,7 +8,10 @@
 
 import type { ConfigAPI, PluginObj, PluginPass, NodePath, types as t } from '@babel/core';
 
+import { addCacheVary } from '../cache-vary';
+
 const TYPEOF_PREFIX = 'typeof ';
+const PROCESS_ENV_PREFIX = 'process.env.';
 
 interface ProcessedReplacements {
   /** Identifier name -> replacement value (e.g., "__DEV__" -> false) */
@@ -111,6 +114,12 @@ function definePlugin({
         // Check against patterns
         for (const [pattern, replacement] of memberPatterns) {
           if (nodePath.matchesPattern(pattern)) {
+            if (pattern.startsWith(PROCESS_ENV_PREFIX + 'EXPO_PUBLIC_')) {
+              addCacheVary(state, {
+                scheme: 'env',
+                name: pattern.slice(PROCESS_ENV_PREFIX.length),
+              });
+            }
             replaceAndEvaluateNode(nodePath, replacement);
             return;
           }

--- a/packages/babel-preset-expo/src/plugins/inline-env-vars.ts
+++ b/packages/babel-preset-expo/src/plugins/inline-env-vars.ts
@@ -1,5 +1,6 @@
 import type { ConfigAPI, NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
 
+import { addCacheVary } from '../cache-vary';
 import { createAddNamedImportOnce, getIsProd } from '../common';
 
 const debug = require('debug')('expo:babel:env-vars');
@@ -60,6 +61,7 @@ export function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core'))
 
       publicEnvVars.add(key);
       if (isProduction) {
+        addCacheVary(state, { scheme: 'env', name: key });
         path.replaceWith(t.valueToNode(process.env[key]));
       } else {
         path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(key)));

--- a/packages/expo-module-scripts/types/expo-metro-augmentations.d.ts
+++ b/packages/expo-module-scripts/types/expo-metro-augmentations.d.ts
@@ -46,6 +46,8 @@ declare module '@expo/metro/metro-babel-transformer' {
     performConstantFolding?: boolean;
     /** @privateRemarks Augmentation used in babel-preset-expo/src/server-data-loaders-plugin.ts */
     loaderReference?: string;
+    /** @privateRemarks Augmentation used in babel-preset-expo/src/cache-vary.ts */
+    cacheVary?: { scheme: string; name: string }[];
   }
 
   // NOTE(@kitten): Compare to `customTransformOptions` in `src/start/server/middleware/metroOptions.ts`


### PR DESCRIPTION
# Why

We currently have really narrow and few strategies to deal with impure changes on the transformer. The cache considers the input coupled to the output purely. The input considers a cache key (mostly made up of a predetermined set of file inputs, and config shape) as an additional hash discriminator.

This means that we always have a choice of:
- discriminating the cache/transform purity by adding a Metro config entry
- pushing impure modifications to the uncached serializer

However, even if we cleanly did both of these refactors above, sometimes this isn't ideal or possible. The best (and currently most important) example are arbitrary envirionment variables.

Per module, we cannot predict which values are important per-module, however the `babel-preset-expo`'s inliner means that module outputs become impure.

This PR implements a **cache-vary feature** on top of Metro to address this.

# How

The cache-vary strategy is split into three parts:
1. CLI patches for Metro in `@expo/cli`
2. The transform-worker outputs and the `VaryingCacheStore` in `@expo/metro-config`
3. The cache vary entry additions in `babel-preset-expo`

This feature can be disabled using `EXPO_NO_CACHE_VARY=1`

The CLI makes three distinct changes:
- the cache store(s) are wrapped in the `VaryingCacheStore`
- the `transformFile` method modifies the `unstable_transformResultKey` returned entry to add cache-vary hashes (and track cache-vary dims)
- the `getDelta` method is modified to mark modules as invalidated when their dependent ambient values have changed

This cascades upwards in reverse; on a delta update (HMR), `getDelta` is consulted and checks the dims that have been tracked by the previous build's `transformFile` calls. It then notices changes to the ambient values and marks modules as invalidated. It re-checks `transformFile`, and since the `unstable_transformResultKey` changes, the cache is re-consulted. The cache store forks by ambient cache-vary values using the `VaryingCacheStore`.

The `VaryingCacheStore` itself has a simple 3 option output that minimises overhead. It assumes that the **cache-vary dimensionss per module are stable** (purity of module to vary dims).
- If there are no cache-vary dims in a module, an entry is still the raw cache entry, as it was before (zero overhead).
- If the cache entry is replaced by a "head value", the target variant is computed with the cache-vary entries against the ambient values
- If the cache entry is a "head value" with varying cache-dims (which breaks the assumption) it checks multiple in order of specificity, basically

The two most common cases keep overhead low, and the performance impact should be minimal.

The changes in `babel-preset-expo` only currently address the `env` scheme for cache-vary dimensions:
- For production env inlining of `EXPO_PUBLIC_*` variables, in the `inline-env-vars-plugin`, a cache-vary marker is added
- For inlining of `EXPO_PUBLIC_*` variables in the `define-plugin`, a cache-vary marker is added too (this only affects `EXPO_PUBLIC_USE_RN_FETCH` currently)

The cache-vary markers are returned via the Babel metadata in a `cacheVary` property. This is computed into a `expoCacheVary` output on our Metro transform worker. That's the vary output that's used by all the other logic above.

> [!WARNING]
> The implementation in `babel-preset-expo` (and of cache-vary schemes) isn't complete, but has reached a nice stopping point. Currently, we do not synchronise environment variables from the main thread to the transform worker threads. This will be done separately. Meaning, in development, when `.env` changes, these changes aren't synchronised to the transform-workers.

**Note:** We should apply this change to other Babel plugins where appropriate in subsequent PRs. This might also allow us to remove `ExpoMetroConfig` entries that were only added for cache invalidation (e.g. `expo-router` base URL or root app-dir path).

# Test Plan

- Unit tests added
- E2E test added
- Manually verified against `expo export`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
