### PR TITLE
fix(metro-config): Recover from negative original pos in source-map segments emitted by Hermes

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bump `hermes-parser` to `^0.36.0` to parse newer Flow syntax (e.g. `readonly` property modifiers) shipped in recent React Native versions ([#46636](https://github.com/expo/expo/pull/46636) by [@zoontek](https://github.com/zoontek))
 - Treat dynamic imports with rejection handlers as optional dependencies, ported from [react/metro#1697](https://github.com/react/metro/pull/1697) ([#47334](https://github.com/expo/expo/pull/47334) by [@kitten](https://github.com/kitten))
 - Fix `resolver.useWatchman: true` not re-enabling watchman as intended ([#47662](https://github.com/expo/expo/issues/47662) by [@isaka1022](https://github.com/isaka1022))
+- Fix `composeSourceMaps` crashing on Hermes source-map segments with a negative original position ([#47752](https://github.com/expo/expo/pull/47752) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/sourceMap.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/sourceMap.test.ts
@@ -1,4 +1,5 @@
 import { GenMapping, addMapping, toEncodedMap } from '@jridgewell/gen-mapping';
+import { encode } from '@jridgewell/sourcemap-codec';
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
 
 import { installPackedMap } from '../packedMap';
@@ -101,6 +102,100 @@ describe('composeSourceMaps', () => {
       line: 5,
       column: 0,
       name: 'greet',
+    });
+  });
+
+  it('tolerates a segment with a negative original position (Hermes no-location sentinel)', () => {
+    const bundler = buildMap({
+      file: 'bundle.js',
+      segments: [
+        { generated: { line: 1, column: 0 }, source: 'a.js', original: { line: 1, column: 0 } },
+        { generated: { line: 1, column: 10 }, source: 'a.js', original: { line: 2, column: 0 } },
+      ],
+    });
+
+    // Raw (0-based) segments for the single generated line:
+    //   genCol 0 -> bundle.js 1:0
+    //   genCol 3 -> no original location  (the sentinel that crashes)
+    //   genCol 6 -> bundle.js 1:10
+    const hermes: ComposableSourceMap = {
+      version: 3,
+      file: 'bundle.hbc',
+      sources: ['bundle.js'],
+      names: [],
+      mappings: encode([
+        [
+          [0, 0, 0, 0],
+          [3, 0, -1, -1],
+          [6, 0, 0, 10],
+        ],
+      ]),
+    };
+
+    let composed!: ComposableSourceMap;
+    expect(() => {
+      composed = composeSourceMaps([bundler, hermes]);
+    }).not.toThrow();
+
+    const tracer = new TraceMap(composed as any);
+    // Real-location segments still trace all the way back to the source.
+    expect(originalPositionFor(tracer, { line: 1, column: 0 })).toMatchObject({
+      source: 'a.js',
+      line: 1,
+      column: 0,
+    });
+    expect(originalPositionFor(tracer, { line: 1, column: 6 })).toMatchObject({
+      source: 'a.js',
+      line: 2,
+      column: 0,
+    });
+    // The sentinel resolves to "no original location" rather than crashing.
+    expect(originalPositionFor(tracer, { line: 1, column: 3 })).toMatchObject({
+      source: null,
+    });
+  });
+
+  it('tolerates a segment with a negative source index', () => {
+    const bundler = buildMap({
+      file: 'bundle.js',
+      segments: [
+        { generated: { line: 1, column: 0 }, source: 'a.js', original: { line: 1, column: 0 } },
+        { generated: { line: 1, column: 10 }, source: 'a.js', original: { line: 2, column: 0 } },
+      ],
+    });
+
+    // Raw (0-based) segments for the single generated line:
+    //   genCol 0 -> bundle.js 1:0
+    //   genCol 3 -> source index -1  (crashes trace-mapping via `sources[-1]`)
+    //   genCol 6 -> bundle.js 1:10
+    const hermes: ComposableSourceMap = {
+      version: 3,
+      file: 'bundle.hbc',
+      sources: ['bundle.js'],
+      names: [],
+      mappings: encode([
+        [
+          [0, 0, 0, 0],
+          [3, -1, 0, 0],
+          [6, 0, 0, 10],
+        ],
+      ]),
+    };
+
+    let composed!: ComposableSourceMap;
+    expect(() => {
+      composed = composeSourceMaps([bundler, hermes]);
+    }).not.toThrow();
+
+    const tracer = new TraceMap(composed as any);
+    expect(originalPositionFor(tracer, { line: 1, column: 0 })).toMatchObject({
+      source: 'a.js',
+      line: 1,
+      column: 0,
+    });
+    // The negative source index resolves to "no original location".
+    expect(originalPositionFor(tracer, { line: 1, column: 3 })).toMatchObject({
+      source: null,
     });
   });
 

--- a/packages/@expo/metro-config/src/serializer/sourceMap.ts
+++ b/packages/@expo/metro-config/src/serializer/sourceMap.ts
@@ -75,6 +75,14 @@ function loadRemapping(): Remapping {
   return _remapping!;
 }
 
+let _sourcemapCodec: typeof import('@jridgewell/sourcemap-codec') | undefined;
+function loadSourcemapCodec(): typeof import('@jridgewell/sourcemap-codec') {
+  if (!_sourcemapCodec) {
+    _sourcemapCodec = require('@jridgewell/sourcemap-codec');
+  }
+  return _sourcemapCodec!;
+}
+
 // NOTE(@kitten): @jridgewell/gen-mapping has no streaming encoder — its
 // `addSegment` buffers every segment into `_mappings` until
 // `toEncodedMap` runs VLQ encoding at the end (~100 MB transient on a
@@ -330,6 +338,24 @@ export function patchMetroSourceMapStringForPackedMaps(): void {
   stock.sourceMapStringNonBlocking = sourceMapStringNonBlocking;
 }
 
+function repairInvalidNegativeIndices(map: ComposableSourceMap): ComposableSourceMap {
+  const { decode, encode } = loadSourcemapCodec();
+  const decoded = decode(map.mappings);
+
+  let changed = false;
+  for (const line of decoded) {
+    for (let i = 0; i < line.length; i++) {
+      const segment = line[i];
+      // If we have a `[genCol, srcIdx, srcLine, ...]` segment, check if `srcLine` is negative
+      if (segment != null && segment.length > 1 && segment[2]! < 0) {
+        line[i] = [segment[0]!];
+        changed = true;
+      }
+    }
+  }
+  return changed ? { ...map, mappings: encode(decoded) } : map;
+}
+
 // `maps[0]` is the original-most transform; `maps[maps.length - 1]` is
 // the most recent. Built on `@jridgewell/remapping` instead of mozilla's
 // `SourceMapConsumer`-based composer.
@@ -359,9 +385,36 @@ export function composeSourceMaps(maps: readonly ComposableSourceMap[]): Composa
   });
 
   // Metro convention is original-first; remapping is most-recent first.
-  const reversed = normalized.slice().reverse();
+  let input = normalized.slice().reverse();
+  const remap = loadRemapping();
 
-  const composed = loadRemapping()(reversed, () => null);
+  let composed: RemappingResult;
+
+  try {
+    composed = remap(input, () => null);
+  } catch (error) {
+    // `@jridgewell/trace-mapping` (through `@jridgewell/remapping`) crashes
+    // on any mapping where original line/column is negative. Hermes may emit
+    // such segments and we should gracefully recover from this on a crash.
+    // See:
+    // - https://github.com/jridgewell/sourcemaps/issues/54
+    // - https://github.com/expo/expo/issues/46843
+    let didRepair = false;
+    try {
+      input = input.map((map) => {
+        const fixed = repairInvalidNegativeIndices(map);
+        didRepair ||= fixed !== map;
+        return fixed;
+      });
+    } catch {
+      throw error;
+    }
+    if (!didRepair) {
+      throw error;
+    } else {
+      composed = remap(input, () => null);
+    }
+  }
 
   // Re-emit as a plain object — remapping returns a `SourceMap` class
   // instance, which doesn't round-trip JSON cleanly.

--- a/packages/@expo/metro-config/src/serializer/sourceMap.ts
+++ b/packages/@expo/metro-config/src/serializer/sourceMap.ts
@@ -346,8 +346,10 @@ function repairInvalidNegativeIndices(map: ComposableSourceMap): ComposableSourc
   for (const line of decoded) {
     for (let i = 0; i < line.length; i++) {
       const segment = line[i];
-      // If we have a `[genCol, srcIdx, srcLine, ...]` segment, check if `srcLine` is negative
-      if (segment != null && segment.length > 1 && segment[2]! < 0) {
+      // A `[genCol, srcIdx, srcLine, ...]` segment crashes `trace-mapping`
+      // when either the source index or the source line is negative
+      // (Hermes' no-location sentinel)
+      if (segment != null && segment.length > 1 && (segment[1]! < 0 || segment[2]! < 0)) {
         line[i] = [segment[0]!];
         changed = true;
       }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/46843
Related to https://github.com/jridgewell/sourcemaps/issues/54

`composeSourceMaps` may crash when receiving invalid source-map segments with negative original source positions. Hermes is incorrect here since [the original positions must be strictly non-negative](https://tc39.es/ecma426/#sec-original-position-record-type) but it may still emit these sentinels, and they have to be handled.

# How

We can semi-gracefully recover from this issue by entering a recovery re-formatting function in a `catch` when the remapping throws. This allows us to detect and remap the `-1` original positions, and subsequently retry the remap call.

# Test Plan

- Unit test added

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
