### PR TITLE
[docs] Increase SDK 57 support range due to off-cycle release cadence

### DIFF
--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -26,7 +26,7 @@
       "react-native-web": "0.21.0",
       "react-native-tvos": "0.85-stable",
       "react": "19.2.3",
-      "node": "22.13.x"
+      "node": "20.19.x"
     },
     {
       "sdk": "55.0.0",

--- a/docs/ui/components/SDKTables/utils.ts
+++ b/docs/ui/components/SDKTables/utils.ts
@@ -12,7 +12,11 @@ export const getThreeVersions = (currentVersion: string) => {
     return [];
   }
 
-  const endIndex = Math.min(sdkData.sdkVersions.length, currentIndex + 3);
+  // NOTE(@kitten): This is a temporary exception for SDK 57, which keeps SDK 54 in range
+  // as it was an "off-cycle" release
+  const inRange = normalizedVersion === '57.0.0' ? 4 : 3;
+
+  const endIndex = Math.min(sdkData.sdkVersions.length, currentIndex + inRange);
   return sdkData.sdkVersions.slice(currentIndex, endIndex);
 };
 


### PR DESCRIPTION
# Why

This was a release that was off-cadence, so SDK 54 should technically still be in range.

Also added a small drive-by fix since we technically didn't bump out of Node 20.19.x for SDK 56. The React Native and Metro teams didn't either. That's because the branch cut date of this SDK and React Native release was 2026-03-02, before LTS ended.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
