### PR TITLE
patch(require-utils): Engage Node `stripTypeScriptTypes` fallback when `typescript@^7.0.0` is installed

### DIFF
--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Annotate more top-level errors when evaluating modules ([#47441](https://github.com/expo/expo/pull/47441) by [@kitten](https://github.com/kitten))
+- Engage Node.js `stripTypeScriptTypes` fallback when `typescript@^7.0.0` is installed ([#47759](https://github.com/expo/expo/pull/47759) by [@kitten](https://github.com/kitten))
 
 ## 56.1.3 — 2026-05-23
 

--- a/packages/@expo/require-utils/package.json
+++ b/packages/@expo/require-utils/package.json
@@ -55,7 +55,7 @@
     "memfs": "^3.2.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -56,6 +56,7 @@ describe('evalModule', () => {
     );
 
     expect(mod).toEqual({
+      __esModule: true,
       default: {
         mjs: { test: 'test' },
         cjs: { test: 'test' },
@@ -73,6 +74,7 @@ describe('evalModule', () => {
     );
 
     expect(mod).toEqual({
+      __esModule: true,
       default: 'test',
     });
   });

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -55,8 +55,8 @@ describe('evalModule', () => {
       path.join(basepath, 'eval.ts')
     );
 
-    expect(mod).toEqual({
-      __esModule: true,
+    expect(mod.__esModule).toBe(true);
+    expect(mod).toMatchObject({
       default: {
         mjs: { test: 'test' },
         cjs: { test: 'test' },
@@ -73,10 +73,8 @@ describe('evalModule', () => {
       path.join(basepath, 'eval.ts')
     );
 
-    expect(mod).toEqual({
-      __esModule: true,
-      default: 'test',
-    });
+    expect(mod.__esModule).toBe(true);
+    expect(mod).toMatchObject({ default: 'test' });
   });
 
   it('evaluates .js using import.meta as ESM instead of CommonJS', () => {

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -34,6 +34,12 @@ function loadTypescript() {
   if (_ts === undefined) {
     try {
       _ts = require('typescript');
+      // NOTE(@kitten): typescript v7 ships without the necessary compiler/public APIs to use it
+      // for transpilation or other purposes
+      if (typeof _ts?.transpileModule !== 'function') {
+        _ts = null;
+        return null;
+      }
     } catch (error: any) {
       if (error.code !== 'MODULE_NOT_FOUND') {
         throw error;
@@ -329,6 +335,9 @@ function evalModule(
         mode: 'transform',
         sourceMap: true,
       });
+      if (format.mode === 'commonjs-typescript') {
+        inputCode = toCommonJS(filename, inputCode);
+      }
     }
 
     if (inputCode !== code) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2936,7 +2936,7 @@ importers:
         specifier: ^7.24.8
         version: 7.28.6(@babel/core@7.29.0)
       typescript:
-        specifier: ^5.0.0 || ^5.0.0-0 || ^6.0.0
+        specifier: ^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0
         version: 6.0.3
     devDependencies:
       '@types/babel__code-frame':


### PR DESCRIPTION
# Why

Closes #47627

> [!WARNING]
> **This does not imply TypeScript v7 support.** Instead, it's just fault tolerant if you're opting into it with your Expo app. TypeScript `7.0.x` does not yet ship a compiler/public API (and other APIs), and we haven't officially bumped support to v7. Other caveats for other tooling applies too.
>
> Instead, consider installing it as `"@typescript/native": "npm:typescript@^7.0.2"` parallel installation, and don't use it as your main TypeScript package yet, as per: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

Currently, when using `@expo/require-utils` with `typescript@^7.0.0` an error is thrown since that version doesn't ship the public API that is expected. This also corresponds to the peer dependencies **we don't support**

# How

We should check the public API surface for `transpileModule` and engage the `node:module` fallback of `stripTypeScriptTypes` when the former doesn't contain `transpileModule`

We need to also add `toCommonJS` to the fallback to match the current "legacy" behaviour.

This PR also widens the peer dependency range. Mostly, in case users want to test this out and `npm` complains, since, technically, we don't depend on any API that makes use of `typescript@^7.0.0` impossible as of SDK 56. However, that doesn't imply support.

> [!NOTE]
> We should pick this to `sdk-55` for completeness, since all picks otherwise align. However, `sdk-55` won't run since the TypeScript resolver there relies on other APIs in the `typescript` package

# Test Plan

- Install `typescript@^7.0.0` in `@expo/require-utils` and run tests; tests pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
