### PR TITLE
feat(expo-router): emit per-route loader `Cache-Control` headers in the routes manifest

### DIFF
--- a/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
+++ b/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
@@ -1,7 +1,10 @@
 import { Text, View } from 'react-native';
 
 export async function loader() {
-  return { data: 'blog' };
+  return Response.json(
+    { data: 'blog' },
+    { headers: { 'Cache-Control': 'public, max-age=604800' } }
+  );
 }
 
 export default function Blog() {

--- a/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
@@ -17,6 +17,7 @@ const GLOBAL_HEADERS = {
 const PAGE_HEADERS = [
   { source: '/', headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } },
   { source: '/api', headers: { 'Set-Cookie': ['page=1'] } },
+  { source: '/blog', headers: { 'Cache-Control': 'no-store', 'X-Page-Rule': 'blog' } },
 ];
 
 const EXPECTED_PAGE_HEADERS = [
@@ -27,6 +28,22 @@ const EXPECTED_PAGE_HEADERS = [
   {
     namedRegex: '^/api(?:/)?$',
     headers: { 'Set-Cookie': ['page=1'] },
+  },
+  {
+    namedRegex: '^/blog(?:/)?$',
+    headers: { 'Cache-Control': 'no-store', 'X-Page-Rule': 'blog' },
+  },
+  // Synthesized from the blog loader's `Response`; positioned after the author rules so the
+  // loader-declared `Cache-Control` wins over the `/blog` rule above.
+  {
+    namedRegex: '^/blog(?:/)?$',
+    headers: { 'Cache-Control': 'public, max-age=604800' },
+  },
+  // The same declaration also targets the loader data file, replacing the host's synthetic
+  // asset default.
+  {
+    namedRegex: '^/_expo/loaders/blog(?:/)?$',
+    headers: { 'Cache-Control': 'public, max-age=604800' },
   },
 ];
 
@@ -44,6 +61,7 @@ describe('export static with headers', () => {
         E2E_ROUTER_ASYNC: '',
         E2E_ROUTER_HEADERS: JSON.stringify(GLOBAL_HEADERS),
         E2E_ROUTER_PAGE_HEADERS: JSON.stringify(PAGE_HEADERS),
+        E2E_ROUTER_SERVER_LOADERS: 'true',
       },
     });
   });

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -2,6 +2,7 @@ import { getMockConfig as getMockConfigUntyped } from 'expo-router/build/testing
 
 import type { ExpoRouterRuntimeManifest } from '../../start/server/metro/MetroBundlerDevServer';
 import {
+  getExactPathNamedRegex,
   getHtmlFiles,
   getPathVariations,
   getFilesToExportFromServerAsync,
@@ -405,5 +406,32 @@ describe(getFilesToExportFromServerAsync, () => {
     });
 
     expect([...files.keys()]).toEqual(['(a)/index.html', '(b)/index.html']);
+  });
+});
+
+describe(getExactPathNamedRegex, () => {
+  it(`compiles the root pathname`, () => {
+    expect(getExactPathNamedRegex('/')).toBe('^/(?:/)?$');
+  });
+
+  it(`compiles a literal pathname with an optional trailing slash`, () => {
+    const regex = getExactPathNamedRegex('/blog');
+    expect(regex).toBe('^/blog(?:/)?$');
+    expect(new RegExp(regex).test('/blog')).toBe(true);
+    expect(new RegExp(regex).test('/blog/')).toBe(true);
+    expect(new RegExp(regex).test('/blog/post')).toBe(false);
+    expect(new RegExp(regex).test('/blogs')).toBe(false);
+  });
+
+  it(`escapes group segments`, () => {
+    const regex = getExactPathNamedRegex('/(group)/about');
+    expect(new RegExp(regex).test('/(group)/about')).toBe(true);
+    expect(new RegExp(regex).test('/group/about')).toBe(false);
+  });
+
+  it(`escapes dynamic route syntax so fallback pathnames only match literally`, () => {
+    const regex = getExactPathNamedRegex('/posts/[postId]');
+    expect(new RegExp(regex).test('/posts/[postId]')).toBe(true);
+    expect(new RegExp(regex).test('/posts/some-post')).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -11,7 +11,7 @@ import chalk from 'chalk';
 import type { RouteNode } from 'expo-router/build/Route';
 import { getContextKey, stripGroupSegmentsFromPath } from 'expo-router/build/matchers';
 import { shouldLinkExternally } from 'expo-router/build/utils/url';
-import type { RoutesManifest } from 'expo-server/private';
+import type { PageHeaderInfo, RoutesManifest } from 'expo-server/private';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import { inspect } from 'util';
@@ -86,11 +86,29 @@ function matchGroupName(name: string): string | undefined {
   return name.match(/^\(([^/]+?)\)$/)?.[1];
 }
 
+/**
+ * Loader `Response` headers derived into synthesized `pageHeaders` rules. Intentionally scoped:
+ * a build-time header only carries over when it has a defined meaning for prerendered output
+ * (`Cache-Control`: how long this build's output may be cached), and headers forwarded from
+ * upstream `fetch` responses (e.g. `Set-Cookie`) must not leak into the public manifest.
+ */
+const LOADER_DECLARED_HEADERS = ['Cache-Control'];
+
+/**
+ * Compile a concrete, prerendered pathname into an exact-match `namedRegex` string, matching the
+ * `^…(?:/)?$` shape of the regexes in the routes manifest. Prerendered pathnames are literal, so
+ * any route syntax (`[param]`, `(group)`) is escaped rather than parameterized.
+ */
+export function getExactPathNamedRegex(pathname: string): string {
+  // see also: @expo/router-server/src/getNamedParametrizedRoute.ts
+  const escaped = pathname.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+  return `^${escaped}(?:/)?$`;
+}
+
 export async function getFilesToExportFromServerAsync(
   projectRoot: string,
   {
     manifest,
-    serverManifest,
     renderAsync,
     // Servers can handle group routes automatically and therefore
     // don't require the build-time generation of every possible group
@@ -101,9 +119,6 @@ export async function getFilesToExportFromServerAsync(
     files = new Map(),
   }: {
     manifest: ExpoRouterRuntimeManifest;
-    // Optional: the `if (!exportServer && serverManifest)` guard below handles its absence,
-    // and callers exporting only HTML (e.g. tests) don't provide it.
-    serverManifest?: RoutesManifest;
     renderAsync: (requestLocation: HtmlRequestLocation) => Promise<string>;
     exportServer?: boolean;
     /**
@@ -116,20 +131,6 @@ export async function getFilesToExportFromServerAsync(
     files?: ExportAssetMap;
   }
 ): Promise<ExportAssetMap> {
-  if (!exportServer && serverManifest) {
-    // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
-    // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
-    const subsetServerManifest = {
-      headers: serverManifest.headers,
-      pageHeaders: serverManifest.pageHeaders,
-      redirects: serverManifest.redirects,
-    };
-    files.set('_expo/.routes.json', {
-      contents: JSON.stringify(subsetServerManifest, null, 2),
-      targetDomain: 'client',
-    });
-  }
-
   // Skip HTML pre-rendering in SSR mode since HTML will be rendered at runtime.
   if (skipHtmlPrerendering) {
     return files;
@@ -247,10 +248,14 @@ export async function exportFromServerAsync(
 
   debug('Routes:\n', inspect(manifest, { colors: true, depth: null }));
 
+  // Group variations prerender several pathnames from one loader file, so these maps can differ
+  // in size. Applied to the routes manifest after the prerender loop completes.
+  const loaderHeadersByPage = new Map<string, Record<string, string>>();
+  const loaderHeadersByFile = new Map<string, Record<string, string>>();
+
   await getFilesToExportFromServerAsync(projectRoot, {
     files,
     manifest,
-    serverManifest,
     exportServer,
     skipHtmlPrerendering: isExportingWithSSR,
     async renderAsync({ pathname, route }) {
@@ -274,6 +279,18 @@ export async function exportFromServerAsync(
             targetDomain: 'client',
             loaderId: loaderKey,
           });
+
+          const declaredHeaders: Record<string, string> = {};
+          for (const name of LOADER_DECLARED_HEADERS) {
+            const value = loaderResponse.headers.get(name);
+            if (value) {
+              declaredHeaders[name] = value;
+            }
+          }
+          if (Object.keys(declaredHeaders).length) {
+            loaderHeadersByPage.set(normalizedPathname, declaredHeaders);
+            loaderHeadersByFile.set(`/${fileSystemPath}`, declaredHeaders);
+          }
 
           renderOpts.loader = { data, key: loaderKey };
         }
@@ -302,6 +319,44 @@ export async function exportFromServerAsync(
       return html;
     },
   });
+
+  // Appended after the author's rules so the loader-declared value wins. Loader-file rules never
+  // match page paths; hosts apply them when serving `/_expo/loaders/*` files. Codepoint sort
+  // keeps the manifest byte-stable across build machines.
+  const toLoaderRules = (
+    rulesByPath: Map<string, Record<string, string>>
+  ): PageHeaderInfo<string>[] =>
+    [...rulesByPath.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([pathname, headers]) => ({
+        namedRegex: getExactPathNamedRegex(pathname),
+        headers,
+      }));
+  const loaderHeaderRules = [
+    ...toLoaderRules(loaderHeadersByPage),
+    ...toLoaderRules(loaderHeadersByFile),
+  ];
+
+  if (loaderHeaderRules.length) {
+    serverManifest.pageHeaders = [...(serverManifest.pageHeaders ?? []), ...loaderHeaderRules];
+  }
+
+  if (!exportServer) {
+    // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
+    // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
+    files.set('_expo/.routes.json', {
+      contents: JSON.stringify(
+        {
+          headers: serverManifest.headers,
+          pageHeaders: serverManifest.pageHeaders,
+          redirects: serverManifest.redirects,
+        },
+        null,
+        2
+      ),
+      targetDomain: 'client',
+    });
+  }
 
   getFilesFromSerialAssets(resources.artifacts, {
     platform,
@@ -333,6 +388,17 @@ export async function exportFromServerAsync(
     // Add the api routes to the files to export.
     for (const [route, contents] of apiRoutes) {
       files.set(route, contents);
+    }
+
+    // `_expo/routes.json` is rebuilt from a fresh manifest above, so loader rules are appended
+    // separately.
+    if (loaderHeaderRules.length) {
+      updateExportManifestInFiles({
+        files,
+        callback: (manifest) => {
+          manifest.pageHeaders = [...(manifest.pageHeaders ?? []), ...loaderHeaderRules];
+        },
+      });
     }
 
     // Export SSR render module and add SSR configuration to routes manifest
@@ -636,7 +702,6 @@ export async function exportApiRoutesStandaloneAsync(
     // TODO: Export an HTML entry for each file. This is a temporary solution until we have SSR/SSG for RSC.
     await getFilesToExportFromServerAsync(devServer.projectRoot, {
       manifest: htmlManifest,
-      serverManifest,
       exportServer: true,
       files,
       renderAsync: async ({ pathname, filePath }) => {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1919,6 +1919,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         const maybeResponse = await routeModule.loader(request, route.params);
 
         let data: unknown;
+        let headers: Headers | undefined;
         if (maybeResponse instanceof Response) {
           debug('Loader returned Response for location:', location.pathname);
 
@@ -1927,14 +1928,16 @@ export class MetroBundlerDevServer extends BundlerDevServer {
             return maybeResponse;
           }
 
-          // In SSG, extract body
+          // In SSG, extract the body but keep the declared headers so the export can derive
+          // header rules from them.
           data = await maybeResponse.json();
+          headers = maybeResponse.headers;
         } else {
           data = maybeResponse;
         }
 
         debug('Loader data:', data ?? null, ' for location:', location.pathname);
-        return Response.json(data ?? null);
+        return Response.json(data ?? null, { headers });
       }
 
       debug('No loader found for location:', location.pathname);

--- a/packages/expo-server/src/manifest.ts
+++ b/packages/expo-server/src/manifest.ts
@@ -73,7 +73,8 @@ export interface RouteInfo<TRegex = RegExp | string> {
 }
 
 /**
- * A per-path header rule, applied to matching page responses only.
+ * A per-path header rule, applied to matching page responses. Hosts serving prerendered output
+ * additionally apply matching rules to loader data files (`/_expo/loaders/...`).
  *
  * For scalar headers, the order is headers already on the response (set by
  * `expo-server` or declared by the route itself), then matching rules, then


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
