### PR TITLE
[expo-widgets] Fix typecheck

### DIFF
--- a/packages/expo-widgets/plugin/src/__tests__/withPushNotifications-test.ts
+++ b/packages/expo-widgets/plugin/src/__tests__/withPushNotifications-test.ts
@@ -1,4 +1,4 @@
-import { withEntitlementsPlist, withInfoPlist } from 'expo/config-plugins';
+import { type InfoPlist, withEntitlementsPlist, withInfoPlist } from 'expo/config-plugins';
 
 import { mockModWithResults } from './mockMods';
 import withPushNotifications from '../ios/withPushNotifications';
@@ -20,8 +20,8 @@ describe(withPushNotifications, () => {
   });
 
   it('adds the aps-environment entitlement when push notifications are enabled', () => {
-    const entitlements: Record<string, unknown> = {};
-    const infoPlist: Record<string, unknown> = {};
+    const entitlements: InfoPlist = {};
+    const infoPlist: InfoPlist = {};
     mockModWithResults(withEntitlementsPlist, entitlements);
     mockModWithResults(withInfoPlist, infoPlist);
 
@@ -32,7 +32,7 @@ describe(withPushNotifications, () => {
   });
 
   it('keeps a pre-existing aps-environment value when push notifications are enabled', () => {
-    const entitlements: Record<string, unknown> = { 'aps-environment': 'production' };
+    const entitlements: InfoPlist = { 'aps-environment': 'production' };
     mockModWithResults(withEntitlementsPlist, entitlements);
     mockModWithResults(withInfoPlist, {});
 
@@ -42,7 +42,7 @@ describe(withPushNotifications, () => {
   });
 
   it('does not add the aps-environment entitlement when push notifications are disabled', () => {
-    const infoPlist: Record<string, unknown> = {};
+    const infoPlist: InfoPlist = {};
     mockModWithResults(withInfoPlist, infoPlist);
 
     withPushNotifications(config as any, { enablePushNotifications: false });


### PR DESCRIPTION
# Why

Fix typecheck issue in a test introduced in https://github.com/expo/expo/commit/44c4e97fec8151b48956c1cad226f9612657b473

I'm slightly mystified why this didn't show up on the PR or in main after merging it, but I can repro it locally so this should stort it.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Type the mock objects with `InfoPlist` instead of `Record<string, unknown>`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<img width="915" height="126" alt="Screenshot 2026-07-14 at 10 04 24" src="https://github.com/user-attachments/assets/e154f7fc-c656-4d90-b72f-24c748179f25" />


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
