### PR TITLE
[observe] fix proxy on Android

### DIFF
--- a/apps/observe-tester/components/LogEventsSection.tsx
+++ b/apps/observe-tester/components/LogEventsSection.tsx
@@ -1,4 +1,5 @@
 import AppMetrics, { type LogAttributeValue, type LogSeverity } from 'expo-app-metrics';
+import { Observe } from 'expo-observe';
 import { useState } from 'react';
 import { StyleSheet, Text, TextInput } from 'react-native';
 
@@ -133,7 +134,7 @@ export function LogEventsSection() {
             title={title}
             description={description}
             onPress={() =>
-              AppMetrics.logEvent(`debug.${severity}_button_pressed`, {
+              Observe.logEvent(`debug.${severity}_button_pressed`, {
                 severity,
                 body,
                 attributes,

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `logEvent` not being forwarded to the AppMetrics module through the native module proxy. ([@Ubax](https://github.com/Ubax))
 - Fix non-serializable route params issue ([#47497](https://github.com/expo/expo/pull/47497) by [@Ubax](https://github.com/Ubax))
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
 - [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder)) ([#47160](https://github.com/expo/expo/pull/47160) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `logEvent` not being forwarded to the AppMetrics module through the native module proxy. ([@Ubax](https://github.com/Ubax))
+- [Android] Fix `logEvent` not being forwarded to the AppMetrics module through the native module proxy. ([@Ubax](https://github.com/Ubax)) ([#47766](https://github.com/expo/expo/pull/47766) by [@Ubax](https://github.com/Ubax))
 - Fix non-serializable route params issue ([#47497](https://github.com/expo/expo/pull/47497) by [@Ubax](https://github.com/Ubax))
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))
 - [Android] Adjust dispatch code to comply with OTLP retry spec. ([@douglowder](https://github.com/douglowder)) ([#47160](https://github.com/expo/expo/pull/47160) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 export {};
 
-const mockNative = {
+const mockNativeTarget = {
   configure: jest.fn(),
   setBundleDefaults: jest.fn(),
   dispatchEvents: jest.fn(() => Promise.resolve()),
 };
+// The real native module is a JSI host object: it reports every prop as present via `in` and
+// `hasOwnProperty` (a host object has no `has` hook), yet `Object.keys` lists only its real members.
+// Mirror that here so the AppMetrics-fallback tests exercise the actual on-device bug — a fallback
+// gated on `in`/`hasOwnProperty` would wrongly treat every prop as native and never forward.
+const mockNative = new Proxy(mockNativeTarget, {
+  has: () => true,
+  getOwnPropertyDescriptor: (t, prop) =>
+    Object.getOwnPropertyDescriptor(t, prop) ?? { configurable: true, enumerable: false, value: undefined },
+});
 
 const mockAppMetrics = {
   logEvent: jest.fn(),

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -6,14 +6,11 @@ const mockNativeTarget = {
   setBundleDefaults: jest.fn(),
   dispatchEvents: jest.fn(() => Promise.resolve()),
 };
-// The real native module is a JSI host object: it reports every prop as present via `in` and
-// `hasOwnProperty` (a host object has no `has` hook), yet `Object.keys` lists only its real members.
+// The real native module is a JSI host object.
 // Mirror that here so the AppMetrics-fallback tests exercise the actual on-device bug — a fallback
 // gated on `in`/`hasOwnProperty` would wrongly treat every prop as native and never forward.
 const mockNative = new Proxy(mockNativeTarget, {
   has: () => true,
-  getOwnPropertyDescriptor: (t, prop) =>
-    Object.getOwnPropertyDescriptor(t, prop) ?? { configurable: true, enumerable: false, value: undefined },
 });
 
 const mockAppMetrics = {

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -46,7 +46,12 @@ const Observe: ObserveModule = new Proxy(native, {
         return target.configure(config);
       };
     }
-    if (typeof prop === 'string' && !(prop in target)) {
+
+    // The native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report
+    // `true` for names it doesn't implement — a host object has no `has` hook. `Object.keys(target)`
+    // goes through `getPropertyNames`, which lists the module's actual members, so use it to forward
+    // anything not really there (e.g. `logEvent`) to the AppMetrics module.
+    if (typeof prop === 'string' && !Object.keys(target).includes(prop)) {
       return Reflect.get(AppMetrics, prop);
     }
     return Reflect.get(target, prop, receiver);

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -47,7 +47,7 @@ const Observe: ObserveModule = new Proxy(native, {
       };
     }
 
-    // The native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report
+    // On Android, the native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report
     // `true` for names it doesn't implement — a host object has no `has` hook. `Object.keys(target)`
     // goes through `getPropertyNames`, which lists the module's actual members, so use it to forward
     // anything not really there (e.g. `logEvent`) to the AppMetrics module.


### PR DESCRIPTION
# Why

`prop in native` always returns `true` when `native` is a native module. This breaks the check we have in proxy for wether a key exists in `Observe` native module

# How

1. Replace `!(prop in target)` with `!Object.keys(target).includes(prop)`
2. Add tests replicating `in` being always true

# Test Plan

1. CI
2. Observe tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
