### PR TITLE
fix(cli): Allow non-interactive port selection and refactor port selection code paths

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,9 +34,11 @@
 - Surface the real `xcodebuild` error on `run:ios` failure instead of printing "0 error(s)" when the build formatter parsed none. ([#47748](https://github.com/expo/expo/pull/47748) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
 - Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
+- In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 
+- [Internal] Remove the unreachable port fallbacks and increase consistency in port selection logic ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Add experimental `tvos` and `macos` autolinking gated by `expriments.outOfTreePlatforms` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 - [Internal] Unify favicon injection between SPA, SSG and SSR pipelines ([#46586](https://github.com/expo/expo/pull/46586) by [@hassankhan](https://github.com/hassankhan))
 - Bump to `@expo/ws-tunnel@^2.0.0` ([#46696](https://github.com/expo/expo/pull/46696) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -1,5 +1,5 @@
 import { Log } from '../../log';
-import { resolvePortAsync } from '../../utils/port';
+import { choosePortAsync, resolvePortAsync } from '../../utils/port';
 import { getOptionalDevClientSchemeAsync } from '../../utils/scheme';
 import { canResolveDevClient, hasDirectDevClientDependency } from '../detectDevClient';
 import {
@@ -13,6 +13,7 @@ jest.mock('../../log');
 jest.mock('../../utils/port', () => {
   return {
     resolvePortAsync: jest.fn(),
+    choosePortAsync: jest.fn(),
   };
 });
 jest.mock('../../utils/scheme', () => {
@@ -222,29 +223,45 @@ describe(resolvePortsAsync, () => {
       });
   });
   it(`resolves default port for metro`, async () => {
-    await expect(resolvePortsAsync('/noop', {})).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', {}, ['metro'])).resolves.toStrictEqual({
       metroPort: 8081,
     });
   });
   it(`resolves default port with given port`, async () => {
-    await expect(resolvePortsAsync('/noop', { port: 1234 })).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', { port: 1234 }, ['metro'])).resolves.toStrictEqual({
       metroPort: 1234,
     });
     await expect(
-      resolvePortsAsync('/noop', { port: 1234, devClient: true })
+      resolvePortsAsync('/noop', { port: 1234, devClient: true }, ['metro'])
     ).resolves.toStrictEqual({
       metroPort: 1234,
     });
   });
   it(`resolves default port for metro with dev client`, async () => {
-    await expect(resolvePortsAsync('/noop', { devClient: true })).resolves.toStrictEqual({
+    await expect(
+      resolvePortsAsync('/noop', { devClient: true }, ['metro'])
+    ).resolves.toStrictEqual({
       metroPort: 8081,
     });
   });
   it(`does not abort when port resolves to 0`, async () => {
     jest.mocked(resolvePortAsync).mockResolvedValueOnce(0);
-    await expect(resolvePortsAsync('/noop', { port: 0 })).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', { port: 0 }, ['metro'])).resolves.toStrictEqual({
       metroPort: 0,
     });
+  });
+  it(`resolves the webpack port from its own default, ignoring --port`, async () => {
+    jest.mocked(choosePortAsync).mockResolvedValueOnce(19006);
+    await expect(
+      resolvePortsAsync('/noop', { port: 1234 }, ['metro', 'webpack'])
+    ).resolves.toStrictEqual({
+      metroPort: 1234,
+      webpackPort: 19006,
+    });
+    // Web ignores `--port`, so the webpack port is resolved from its own default (19006).
+    expect(choosePortAsync).toHaveBeenCalledWith(
+      '/noop',
+      expect.objectContaining({ defaultPort: 19006 })
+    );
   });
 });

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -222,59 +222,29 @@ describe(resolvePortsAsync, () => {
       });
   });
   it(`resolves default port for metro`, async () => {
-    await expect(resolvePortsAsync('/noop', {}, { webOnly: false })).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', {})).resolves.toStrictEqual({
       metroPort: 8081,
     });
   });
   it(`resolves default port with given port`, async () => {
-    await expect(
-      resolvePortsAsync('/noop', { port: 1234 }, { webOnly: false })
-    ).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', { port: 1234 })).resolves.toStrictEqual({
       metroPort: 1234,
     });
     await expect(
-      resolvePortsAsync('/noop', { port: 1234, devClient: true }, { webOnly: false })
+      resolvePortsAsync('/noop', { port: 1234, devClient: true })
     ).resolves.toStrictEqual({
       metroPort: 1234,
-    });
-    await expect(
-      resolvePortsAsync('/noop', { port: 1234 }, { webOnly: true })
-    ).resolves.toStrictEqual({
-      webpackPort: 1234,
     });
   });
   it(`resolves default port for metro with dev client`, async () => {
-    await expect(
-      resolvePortsAsync('/noop', { devClient: true }, { webOnly: false })
-    ).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', { devClient: true })).resolves.toStrictEqual({
       metroPort: 8081,
     });
   });
   it(`does not abort when port resolves to 0`, async () => {
     jest.mocked(resolvePortAsync).mockResolvedValueOnce(0);
-    await expect(
-      resolvePortsAsync('/noop', { port: 0 }, { webOnly: false })
-    ).resolves.toStrictEqual({
+    await expect(resolvePortsAsync('/noop', { port: 0 })).resolves.toStrictEqual({
       metroPort: 0,
-    });
-  });
-  it(`does not abort when webpack port resolves to 0`, async () => {
-    jest.mocked(resolvePortAsync).mockResolvedValueOnce(0);
-    await expect(resolvePortsAsync('/noop', { port: 0 }, { webOnly: true })).resolves.toStrictEqual(
-      {
-        webpackPort: 0,
-      }
-    );
-  });
-  it(`resolves default port for webpack`, async () => {
-    await expect(resolvePortsAsync('/noop', {}, { webOnly: true })).resolves.toStrictEqual({
-      webpackPort: 19006,
-    });
-    // dev client changes nothing on Webpack...
-    await expect(
-      resolvePortsAsync('/noop', { devClient: true }, { webOnly: true })
-    ).resolves.toStrictEqual({
-      webpackPort: 19006,
     });
   });
 });

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -2,9 +2,9 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { Log } from '../log';
-import { envIsWebcontainer } from '../utils/env';
+import { env, envIsWebcontainer } from '../utils/env';
 import { AbortCommandError, CommandError } from '../utils/errors';
-import { resolvePortAsync } from '../utils/port';
+import { choosePortAsync, resolvePortAsync } from '../utils/port';
 import { canResolveDevClient, hasDirectDevClientDependency } from './detectDevClient';
 
 export type Options = {
@@ -159,8 +159,9 @@ export function resolveHostType(options: {
 /** Resolve the port options for all supported bundlers. */
 export async function resolvePortsAsync(
   projectRoot: string,
-  options: Partial<Pick<Options, 'port' | 'devClient'>>
-) {
+  options: Partial<Pick<Options, 'port' | 'devClient'>>,
+  bundlers: ('metro' | 'webpack')[]
+): Promise<{ metroPort: number; webpackPort?: number }> {
   const fallbackPort = process.env.RCT_METRO_PORT ? parseInt(process.env.RCT_METRO_PORT, 10) : 8081;
   const metroPort = await resolvePortAsync(projectRoot, {
     defaultPort: options.port,
@@ -168,6 +169,18 @@ export async function resolvePortsAsync(
   });
   if (metroPort == null) {
     throw new AbortCommandError();
+  }
+
+  if (bundlers.includes('webpack')) {
+    // Web runs on its own default port and ignores `--port`.
+    const webpackPort = await choosePortAsync(projectRoot, {
+      defaultPort: 19006,
+      host: env.WEB_HOST,
+    });
+    if (webpackPort == null) {
+      throw new AbortCommandError();
+    }
+    return { metroPort, webpackPort };
   }
 
   return { metroPort };

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -162,18 +162,18 @@ export async function resolvePortsAsync(
   options: Partial<Pick<Options, 'port' | 'devClient'>>,
   bundlers: ('metro' | 'webpack')[]
 ): Promise<{ metroPort: number; webpackPort?: number }> {
-  const fallbackPort = process.env.RCT_METRO_PORT ? parseInt(process.env.RCT_METRO_PORT, 10) : 8081;
   const metroPort = await resolvePortAsync(projectRoot, {
     defaultPort: options.port,
-    fallbackPort,
+    // resolvePortAsync already honors RCT_METRO_PORT, so we only pass the default
+    fallbackPort: 8081,
   });
   if (metroPort == null) {
     throw new AbortCommandError();
   }
 
   if (bundlers.includes('webpack')) {
-    // Web runs on its own default port and ignores `--port`.
     const webpackPort = await choosePortAsync(projectRoot, {
+      // Webpack runs on its own default port and ignores `--port`
       defaultPort: 19006,
       host: env.WEB_HOST,
     });

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -159,34 +159,16 @@ export function resolveHostType(options: {
 /** Resolve the port options for all supported bundlers. */
 export async function resolvePortsAsync(
   projectRoot: string,
-  options: Partial<Pick<Options, 'port' | 'devClient'>>,
-  settings: { webOnly?: boolean }
+  options: Partial<Pick<Options, 'port' | 'devClient'>>
 ) {
-  const multiBundlerSettings: { webpackPort?: number; metroPort?: number } = {};
-
-  if (settings.webOnly) {
-    const webpackPort = await resolvePortAsync(projectRoot, {
-      defaultPort: options.port,
-      // Default web port
-      fallbackPort: 19006,
-    });
-    if (webpackPort == null) {
-      throw new AbortCommandError();
-    }
-    multiBundlerSettings.webpackPort = webpackPort;
-  } else {
-    const fallbackPort = process.env.RCT_METRO_PORT
-      ? parseInt(process.env.RCT_METRO_PORT, 10)
-      : 8081;
-    const metroPort = await resolvePortAsync(projectRoot, {
-      defaultPort: options.port,
-      fallbackPort,
-    });
-    if (metroPort == null) {
-      throw new AbortCommandError();
-    }
-    multiBundlerSettings.metroPort = metroPort;
+  const fallbackPort = process.env.RCT_METRO_PORT ? parseInt(process.env.RCT_METRO_PORT, 10) : 8081;
+  const metroPort = await resolvePortAsync(projectRoot, {
+    defaultPort: options.port,
+    fallbackPort,
+  });
+  if (metroPort == null) {
+    throw new AbortCommandError();
   }
 
-  return multiBundlerSettings;
+  return { metroPort };
 }

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -45,7 +45,6 @@ import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
 import { getEnvFiles, reloadEnvFiles } from '../../../utils/nodeEnv';
-import { getFreePortAsync } from '../../../utils/port';
 import { AndroidAppIdResolver } from '../../platforms/android/AndroidAppIdResolver';
 import { AppleAppIdResolver } from '../../platforms/ios/AppleAppIdResolver';
 import type { BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
@@ -151,12 +150,6 @@ declare namespace globalThis {
   let __expo_rsc_inject_module: (params: { code: string; id: string }) => void | undefined;
 }
 
-/** Default port to use for apps running in Expo Go. */
-const EXPO_GO_METRO_PORT = 8081;
-
-/** Default port to use for apps that run in standard React Native projects or Expo Dev Clients. */
-const DEV_CLIENT_METRO_PORT = 8081;
-
 declare module '2g' {
   interface EventRegistry {
     'devserver:start': {
@@ -187,20 +180,6 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
   get name(): string {
     return 'metro';
-  }
-
-  async resolvePortAsync(options: Partial<BundlerStartOptions> = {}): Promise<number> {
-    const port =
-      // If the manually defined port is busy then an error should be thrown...
-      options.port ??
-      // Otherwise use the default port based on the runtime target.
-      (options.devClient
-        ? // Don't check if the port is busy if we're using the dev client since most clients are hardcoded to 8081.
-          Number(process.env.RCT_METRO_PORT) || DEV_CLIENT_METRO_PORT
-        : // Otherwise (running in Expo Go) use a free port that falls back on the classic 8081 port.
-          await getFreePortAsync(EXPO_GO_METRO_PORT));
-
-    return port;
   }
 
   private async exportServerRouteAsync({
@@ -1270,7 +1249,8 @@ export class MetroBundlerDevServer extends BundlerDevServer {
   protected async startImplementationAsync(
     options: BundlerStartOptions
   ): Promise<DevServerInstance> {
-    options.port = await this.resolvePortAsync(options);
+    assert(options.port, 'Expected a port to be defined before starting the Metro dev server');
+
     await this.initUrlCreator(options);
 
     const config = getConfig(this.projectRoot, { skipSDKVersionRequirement: true });

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -87,12 +87,11 @@ async function getStartedDevServer(options: Partial<BundlerStartOptions> = {}) {
     '/',
     getPlatformBundlers('/', { web: { bundler: 'metro' } })
   );
-  (devServer as unknown as { getAvailablePortAsync: () => Promise<number> }).getAvailablePortAsync =
-    jest.fn(() => Promise.resolve(3000));
   // Tested in the superclass
   devServer['postStartAsync'] = jest.fn(async () => {});
   devServer['startImplementationAsync'] = jest.fn(devServer['startImplementationAsync']);
-  await devServer.startAsync({ location: {}, ...options });
+  // The port is always resolved by the caller before the dev server starts.
+  await devServer.startAsync({ location: {}, port: 3000, ...options });
   return devServer;
 }
 

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { Application } from 'express';
+import assert from 'node:assert';
 import fs from 'node:fs';
 import type http from 'node:http';
 import path from 'node:path';
@@ -11,7 +12,6 @@ import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { setNodeEnv, loadEnvFiles } from '../../../utils/nodeEnv';
-import { choosePortAsync } from '../../../utils/port';
 import { createProgressBar } from '../../../utils/progress';
 import { ensureDotExpoProjectDirectoryInitialized } from '../../project/dotExpo';
 import type { BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
@@ -80,23 +80,6 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     return false;
   }
 
-  private async getAvailablePortAsync(options: { defaultPort?: number }): Promise<number> {
-    try {
-      const defaultPort = options?.defaultPort ?? 19006;
-      const port = await choosePortAsync(this.projectRoot, {
-        defaultPort,
-        host: env.WEB_HOST,
-        explicitPort: options?.defaultPort != null,
-      });
-      if (!port) {
-        throw new CommandError('NO_PORT_FOUND', `Port ${defaultPort} not available.`);
-      }
-      return port;
-    } catch (error: any) {
-      throw new CommandError('NO_PORT_FOUND', error.message);
-    }
-  }
-
   async bundleAsync({ mode, clear }: { mode: 'development' | 'production'; clear: boolean }) {
     // Do this first to fail faster.
     const webpack = importWebpackFromProject(this.projectRoot);
@@ -156,9 +139,8 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
 
     await this.stopAsync();
 
-    options.port = await this.getAvailablePortAsync({
-      defaultPort: options.port,
-    });
+    // The port is resolved by the caller before the dev server is started.
+    assert(options.port, 'Expected a port to be defined before starting the Webpack dev server');
 
     const { resetDevServer, https, port, mode } = options;
 

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -86,6 +86,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       const port = await choosePortAsync(this.projectRoot, {
         defaultPort,
         host: env.WEB_HOST,
+        explicitPort: options?.defaultPort != null,
       });
       if (!port) {
         throw new CommandError('NO_PORT_FOUND', `Port ${defaultPort} not available.`);

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
@@ -27,10 +27,10 @@ async function getStartedDevServer(options: Partial<BundlerStartOptions> = {}) {
     '/',
     getPlatformBundlers('/', { web: { bundler: 'webpack' } })
   );
-  devServer['getAvailablePortAsync'] = jest.fn(() => Promise.resolve(3000));
   // Tested in the superclass
   devServer['postStartAsync'] = jest.fn(async () => {});
-  await devServer.startAsync({ location: {}, ...options });
+  // The port is resolved by the caller before the dev server starts.
+  await devServer.startAsync({ location: {}, port: 3000, ...options });
   return devServer;
 }
 
@@ -57,7 +57,6 @@ describe('startAsync', () => {
   it(`starts webpack`, async () => {
     const devServer = await getStartedDevServer();
 
-    expect(devServer['getAvailablePortAsync']).toHaveBeenCalled();
     expect(devServer['postStartAsync']).toHaveBeenCalled();
 
     expect(devServer.getInstance()).toEqual({

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -29,7 +29,6 @@ import { getPlatformBundlers } from './server/platformBundlers';
 async function getMultiBundlerStartOptions(
   projectRoot: string,
   options: Options,
-  settings: { webOnly?: boolean },
   platformBundlers: PlatformBundlers
 ): Promise<[BundlerStartOptions, MultiBundlerStartOptions]> {
   const commonOptions: BundlerStartOptions = {
@@ -45,7 +44,7 @@ async function getMultiBundlerStartOptions(
       scheme: options.scheme,
     },
   };
-  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options, settings);
+  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options);
 
   const optionalBundlers: Partial<PlatformBundlers> = { ...platformBundlers };
   // In the default case, we don't want to start multiple bundlers since this is
@@ -56,8 +55,8 @@ async function getMultiBundlerStartOptions(
 
   const bundlers = [...new Set(Object.values(optionalBundlers))];
   const multiBundlerStartOptions = bundlers.map((bundler) => {
-    const port =
-      bundler === 'webpack' ? multiBundlerSettings.webpackPort! : multiBundlerSettings.metroPort!;
+    // Webpack resolves its own web port when it starts; Metro uses the resolved port.
+    const port = bundler === 'webpack' ? undefined : multiBundlerSettings.metroPort;
     return {
       type: bundler,
       options: {
@@ -102,7 +101,6 @@ export async function startAsync(
   const [defaultOptions, startOptions] = await getMultiBundlerStartOptions(
     projectRoot,
     options,
-    settings,
     platformBundlers
   );
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -44,8 +44,6 @@ async function getMultiBundlerStartOptions(
       scheme: options.scheme,
     },
   };
-  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options);
-
   const optionalBundlers: Partial<PlatformBundlers> = { ...platformBundlers };
   // In the default case, we don't want to start multiple bundlers since this is
   // a bit slower. Our priority (for legacy) is native platforms.
@@ -54,9 +52,11 @@ async function getMultiBundlerStartOptions(
   }
 
   const bundlers = [...new Set(Object.values(optionalBundlers))];
+  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options, bundlers);
+
   const multiBundlerStartOptions = bundlers.map((bundler) => {
-    // Webpack resolves its own web port when it starts; Metro uses the resolved port.
-    const port = bundler === 'webpack' ? undefined : multiBundlerSettings.metroPort;
+    const port =
+      bundler === 'webpack' ? multiBundlerSettings.webpackPort : multiBundlerSettings.metroPort;
     return {
       type: bundler,
       options: {

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -57,7 +57,7 @@ async function getMultiBundlerStartOptions(
   const bundlers = [...new Set(Object.values(optionalBundlers))];
   const multiBundlerStartOptions = bundlers.map((bundler) => {
     const port =
-      bundler === 'webpack' ? multiBundlerSettings.webpackPort : multiBundlerSettings.metroPort;
+      bundler === 'webpack' ? multiBundlerSettings.webpackPort! : multiBundlerSettings.metroPort!;
     return {
       type: bundler,
       options: {

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -92,7 +92,7 @@ describe(choosePortAsync, () => {
     expect(port).toBe(null);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
-  it(`chooses the next free port without prompting in non-interactive mode`, async () => {
+  it(`chooses the next free port without prompting for a default port in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockResolvedValueOnce({
@@ -102,6 +102,19 @@ describe(choosePortAsync, () => {
     });
     const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
     expect(port).toBe(8082);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`hard-fails for an explicitly requested busy port in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockResolvedValueOnce({
+      pid: 1,
+      directory: '/other/project',
+      command: 'npx expo',
+    });
+    await expect(
+      choosePortAsync('/', { defaultPort: 8081, explicitPort: true, reuseExistingPort: false })
+    ).rejects.toThrow(/Port 8081 is unavailable/);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`still reuses the same-process port in non-interactive mode`, async () => {
@@ -131,6 +144,21 @@ describe(resolvePortAsync, () => {
     const port = await resolvePortAsync('/', { defaultPort: 0, fallbackPort: 8081 });
     expect(port).toBe(8082);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null, 'localhost']);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`rolls over to the next free port when the default port is busy in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    const port = await resolvePortAsync('/', { fallbackPort: 8081 });
+    expect(port).toBe(8082);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`hard-fails when an explicit --port is busy in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    await expect(resolvePortAsync('/', { defaultPort: 8081 })).rejects.toThrow(
+      /Port 8081 is unavailable/
+    );
     expect(confirmAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,5 +1,6 @@
 import { freePortAsync, testPortAsync } from '../freeport';
 import { getRunningProcess } from '../getRunningProcess';
+import { isInteractive } from '../interactive';
 import { choosePortAsync, ensurePortAvailabilityAsync, resolvePortAsync } from '../port';
 import { confirmAsync } from '../prompts';
 
@@ -10,6 +11,9 @@ jest.mock('../freeport', () => ({
 
 jest.mock('../../log');
 jest.mock('../prompts');
+jest.mock('../interactive', () => ({
+  isInteractive: jest.fn(() => true),
+}));
 jest.mock('../getRunningProcess', () => ({
   getRunningProcess: jest.fn(() => null),
 }));
@@ -84,6 +88,30 @@ describe(choosePortAsync, () => {
       command: 'npx expo',
     });
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    const port = await choosePortAsync('/me', { defaultPort: 8081, reuseExistingPort: true });
+    expect(port).toBe(null);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`chooses the next free port without prompting in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockResolvedValueOnce({
+      pid: 1,
+      directory: '/other/project',
+      command: 'npx expo',
+    });
+    const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
+    expect(port).toBe(8082);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`still reuses the same-process port in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockResolvedValueOnce({
+      pid: 1,
+      directory: '/me',
+      command: 'npx expo',
+    });
     const port = await choosePortAsync('/me', { defaultPort: 8081, reuseExistingPort: true });
     expect(port).toBe(null);
     expect(confirmAsync).not.toHaveBeenCalled();

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -132,6 +132,17 @@ describe(choosePortAsync, () => {
 });
 
 describe(resolvePortAsync, () => {
+  const originalRctMetroPort = process.env.RCT_METRO_PORT;
+  beforeEach(() => {
+    delete process.env.RCT_METRO_PORT;
+  });
+  afterEach(() => {
+    if (originalRctMetroPort == null) {
+      delete process.env.RCT_METRO_PORT;
+    } else {
+      process.env.RCT_METRO_PORT = originalRctMetroPort;
+    }
+  });
   it(`finds the first available port from the fallback when port is 0`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8081);
     const port = await resolvePortAsync('/', { defaultPort: 0, fallbackPort: 8081 });
@@ -159,6 +170,13 @@ describe(resolvePortAsync, () => {
     await expect(resolvePortAsync('/', { defaultPort: 8081 })).rejects.toThrow(
       /Port 8081 is unavailable/
     );
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`hard-fails when a configured RCT_METRO_PORT is busy in non-interactive mode`, async () => {
+    process.env.RCT_METRO_PORT = '8081';
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    await expect(resolvePortAsync('/', {})).rejects.toThrow(/Port 8081 is unavailable/);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -7,7 +7,7 @@ import { testPortAsync, freePortAsync } from './freeport';
 import { isInteractive } from './interactive';
 
 /** Get a free port or assert a CLI command error. */
-export async function getFreePortAsync(rangeStart: number): Promise<number> {
+async function getFreePortAsync(rangeStart: number): Promise<number> {
   const port = await freePortAsync(rangeStart, [null, 'localhost']);
   if (!port) {
     throw new CommandError('NO_PORT_FOUND', 'No available port found');

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -180,7 +180,7 @@ export async function resolvePortAsync(
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
     reuseExistingPort,
-    explicitPort: defaultPort != null,
+    explicitPort: defaultPort != null || !!env.RCT_METRO_PORT,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -159,19 +159,22 @@ export async function resolvePortAsync(
     fallbackPort?: number;
   } = {}
 ): Promise<number | null> {
+  // NOTE(@kitten): We treat `--port` and `RCT_METRO_PORT` as the fixed preferred ports
+  const requestedMetroPort = env.RCT_METRO_PORT;
+  const preferredPort = requestedMetroPort || fallbackPort || 8081;
+
   let port: number;
   if (typeof defaultPort === 'string') {
     port = parseInt(defaultPort, 10);
   } else if (typeof defaultPort === 'number') {
     port = defaultPort;
   } else {
-    port = env.RCT_METRO_PORT || fallbackPort || 8081;
+    port = preferredPort;
   }
 
-  // Port 0 means "pick any available port" — scan from the fallback port without prompting.
+  // Port 0 means "pick any available port"
   if (port === 0) {
-    const scanFrom = env.RCT_METRO_PORT || fallbackPort || 8081;
-    const resolvedPort = await getFreePortAsync(scanFrom);
+    const resolvedPort = await getFreePortAsync(preferredPort);
     process.env.RCT_METRO_PORT = String(resolvedPort);
     return resolvedPort;
   }
@@ -180,7 +183,7 @@ export async function resolvePortAsync(
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
     reuseExistingPort,
-    explicitPort: defaultPort != null || !!env.RCT_METRO_PORT,
+    explicitPort: defaultPort != null || !!requestedMetroPort,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -71,10 +71,13 @@ export async function choosePortAsync(
     defaultPort,
     host,
     reuseExistingPort,
+    explicitPort,
   }: {
     defaultPort: number;
     host?: string;
     reuseExistingPort?: boolean;
+    /** Whether the port was explicitly requested (e.g. via `--port`) rather than a default. */
+    explicitPort?: boolean;
   }
 ): Promise<number | null> {
   try {
@@ -111,8 +114,16 @@ export async function choosePortAsync(
     Log.log(`\u203A ${message}`);
 
     if (!isInteractive()) {
-      Log.log(`\u203A Using port ${port} instead`);
-      return port;
+      // An explicitly requested port is a hard requirement
+      if (explicitPort) {
+        throw new CommandError(
+          'PORT_IN_USE',
+          `Port ${defaultPort} is unavailable and 'npx expo' is running in non-interactive mode, so it can't prompt to use another port. Free port ${defaultPort} by stopping the process using it, or re-run with an available '--port'.`
+        );
+      } else {
+        Log.log(`\u203A Using port ${port} instead`);
+        return port;
+      }
     }
 
     const { confirmAsync } = require('./prompts') as typeof import('./prompts');
@@ -169,6 +180,7 @@ export async function resolvePortAsync(
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
     reuseExistingPort,
+    explicitPort: defaultPort != null,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -4,6 +4,7 @@ import * as Log from '../log';
 import { env } from './env';
 import { CommandError } from './errors';
 import { testPortAsync, freePortAsync } from './freeport';
+import { isInteractive } from './interactive';
 
 /** Get a free port or assert a CLI command error. */
 export async function getFreePortAsync(rangeStart: number): Promise<number> {
@@ -108,6 +109,12 @@ export async function choosePortAsync(
     }
 
     Log.log(`\u203A ${message}`);
+
+    if (!isInteractive()) {
+      Log.log(`\u203A Using port ${port} instead`);
+      return port;
+    }
+
     const { confirmAsync } = require('./prompts') as typeof import('./prompts');
     const change = await confirmAsync({
       message: `Use port ${port} instead?`,


### PR DESCRIPTION
# Why

There's two distinct problems with our port selection today:
- The practical problem is that the port selection code in `utils/port.ts` does not have a non-interactive branch that automatically confirms that a next-available port should be selected. This is now the case
- There's several inconsistencies and redundancies around where ports are selected and what the fallbacks are

**Note:** This PR does not address inconsistencies and similar problems in the `UrlCreator` code paths.

# How

- Alter port utilities to select next available port by default on non-interactive sessions
- Fail port selection if the explicitly specified (`--port` or `RCT_METRO_PORT`) port is busy
- Remove dead `resolvePortAsync` method from `MetroBundlerDevServer`
- Remove unused `getFreePortAsync` export (API of `ports.ts` is now clearer)
- Remove unused `webOnly` branch on Webpack start/port-selection code path
- Align Webpack port acquisition to Metro, and delete its `resolvePortAsync` method
- Remove redundant `RCT_METRO_PORT` fallback in `resolveOptions`, since it's embedded in the port utility now

# Test Plan

- Start an `expo start` process interactively then non-interactively with busy port
- Start `expo start` with `RCT_METRO_PORT`
- Validate port selection on `run:*` commands

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
