### PR TITLE
[cli] Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG

### DIFF
--- a/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
+++ b/apps/router-e2e/__e2e__/server-headers/app/blog.tsx
@@ -1,7 +1,10 @@
 import { Text, View } from 'react-native';
 
 export async function loader() {
-  return { data: 'blog' };
+  return Response.json(
+    { data: 'blog' },
+    { headers: { 'Cache-Control': 'public, max-age=86400' } }
+  );
 }
 
 export default function Blog() {

--- a/apps/router-e2e/__e2e__/server-loader/app/response.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/response.tsx
@@ -10,7 +10,16 @@ import { Table, TableRow } from '../components/Table';
 export const loader: LoaderFunction = (request) => {
   // In SSG, request is unavailable since there's no HTTP request at build time
   if (!request) {
-    return { foo: null };
+    return Response.json(
+      { foo: null },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=604800',
+          // Not on the SSG header allowlist; never reaches clients
+          'X-Loader-Header': 'loader-value',
+        },
+      }
+    );
   }
 
   const url = new URL(request.url);

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Apply `headers` when serving static exports with `expo serve` ([#47780](https://github.com/expo/expo/pull/47780) by [@hassankhan](https://github.com/hassankhan))
 - Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
+- Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
@@ -34,6 +34,16 @@ const EXPECTED_PAGE_HEADERS = [
     namedRegex: '^/_expo/loaders/blog(?:/)?$',
     headers: { 'Cache-Control': 'public, max-age=604800' },
   },
+  // Added from `/blog`'s loader `Response` at export time and appended after
+  // the config option rules.
+  {
+    namedRegex: '^/blog(?:/)?$',
+    headers: { 'Cache-Control': 'public, max-age=86400' },
+  },
+  {
+    namedRegex: '^/_expo/loaders/blog(?:/)?$',
+    headers: { 'Cache-Control': 'public, max-age=86400' },
+  },
 ];
 
 describe('export static with headers', () => {
@@ -72,25 +82,29 @@ describe('export static with headers', () => {
         cacheControl: 'public, max-age=0',
       },
       {
+        // The loader-declared `Cache-Control` wins over the config option's
+        // `/blog` rule
         path: '/blog',
         status: 200,
         contentType: 'text/html; charset=UTF-8',
         poweredBy: 'expo-server',
         pageRule: 'blog',
         setCookie: 'session=1, session=2',
-        cacheControl: 'public, max-age=3600',
+        cacheControl: 'public, max-age=86400',
       },
       {
-        // Loader data files apply global headers and matching rules
+        // Loader data files apply global headers and matching rules, with the
+        // loader-declared `Cache-Control` winning over the config option's rule
         path: '/_expo/loaders/blog',
         status: 200,
         contentType: 'application/octet-stream',
         poweredBy: 'expo-server',
         pageRule: null,
         setCookie: 'session=1, session=2',
-        cacheControl: 'public, max-age=604800',
+        cacheControl: 'public, max-age=86400',
       },
       {
+        // NOTE(@hassankhan): This currently diverges from SSR/EAS.
         // The static file server serves 404s without header application
         path: '/not-a-route',
         status: 404,

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import {
   prepareServers,
   RUNTIME_EXPO_SERVE,
@@ -5,7 +8,6 @@ import {
   setupServer,
 } from '../../utils/runtime';
 import { findProjectFiles, getHtml, getPageAndLoaderData } from '../utils';
-/* eslint-env jest */
 import { runExportSideEffects } from './export-side-effects';
 
 runExportSideEffects();
@@ -214,12 +216,42 @@ describe.each(
     // NOTE(@hassankhan): expo-server returns `application/octet-stream` for extensionless files,
     // but the content is still valid JSON.
     // expect(response.headers.get('content-type')).toContain('application/json');
-    expect(response.headers.get('cache-control')).not.toBe('public, max-age=3600');
-    expect(response.headers.get('x-custom-header')).not.toBe('test-value');
+
+    expect(response.headers.get('cache-control')).toBe('public, max-age=604800');
+    // Non-allowlisted headers are stripped in dev and static exports
+    expect(response.headers.get('x-loader-header')).toBeNull();
 
     const data = await response.json();
     expect(data).toEqual({ foo: null });
   });
+
+  (server.isExpoStart ? it.skip : it)(
+    'applies loader-declared `Cache-Control` to the pre-rendered page',
+    async () => {
+      const response = await server.fetchAsync('/response');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toBe('public, max-age=604800');
+    }
+  );
+
+  (server.isExpoStart ? it.skip : it)(
+    'writes loader-declared `Cache-Control` rules to the manifest subset',
+    () => {
+      const routesJson = JSON.parse(
+        fs.readFileSync(path.join(server.outputDir, '_expo/.routes.json'), 'utf8')
+      );
+      expect(routesJson.pageHeaders).toEqual([
+        {
+          namedRegex: '^/response(?:/)?$',
+          headers: { 'Cache-Control': 'public, max-age=604800' },
+        },
+        {
+          namedRegex: '^/_expo/loaders/response(?:/)?$',
+          headers: { 'Cache-Control': 'public, max-age=604800' },
+        },
+      ]);
+    }
+  );
 
   it('renders meta tags from loader data in HTML', async () => {
     const response = await server.fetchAsync('/meta');

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -2,6 +2,7 @@ import { getMockConfig as getMockConfigUntyped } from 'expo-router/build/testing
 
 import type { ExpoRouterRuntimeManifest } from '../../start/server/metro/MetroBundlerDevServer';
 import {
+  getExactPathNamedRegex,
   getHtmlFiles,
   getPathVariations,
   getFilesToExportFromServerAsync,
@@ -405,5 +406,57 @@ describe(getFilesToExportFromServerAsync, () => {
     });
 
     expect([...files.keys()]).toEqual(['(a)/index.html', '(b)/index.html']);
+  });
+});
+
+describe(getExactPathNamedRegex, () => {
+  it(`compiles the root pathname`, () => {
+    expect(getExactPathNamedRegex('/')).toBe('^/(?:/)?$');
+  });
+
+  it(`compiles a literal pathname with an optional trailing slash`, () => {
+    const regex = getExactPathNamedRegex('/blog');
+    expect(regex).toBe('^/blog(?:/)?$');
+    expect(new RegExp(regex).test('/blog')).toBe(true);
+    expect(new RegExp(regex).test('/blog/')).toBe(true);
+    expect(new RegExp(regex).test('/blog/post')).toBe(false);
+    expect(new RegExp(regex).test('/blogs')).toBe(false);
+  });
+
+  it(`escapes group segments`, () => {
+    const regex = getExactPathNamedRegex('/(group)/about');
+    expect(new RegExp(regex).test('/(group)/about')).toBe(true);
+    expect(new RegExp(regex).test('/group/about')).toBe(false);
+  });
+
+  it(`escapes dynamic route syntax so fallback pathnames only match literally`, () => {
+    const regex = getExactPathNamedRegex('/posts/[postId]');
+    expect(new RegExp(regex).test('/posts/[postId]')).toBe(true);
+    expect(new RegExp(regex).test('/posts/some-post')).toBe(false);
+  });
+
+  it(`escapes dots so they don't match arbitrary characters`, () => {
+    const regex = getExactPathNamedRegex('/files/report.json');
+    expect(new RegExp(regex).test('/files/report.json')).toBe(true);
+    expect(new RegExp(regex).test('/files/reportXjson')).toBe(false);
+  });
+
+  it(`escapes quantifiers and anchors`, () => {
+    const regex = getExactPathNamedRegex('/v1.0+beta$test');
+    expect(new RegExp(regex).test('/v1.0+beta$test')).toBe(true);
+    expect(new RegExp(regex).test('/v1X0beta$test')).toBe(false);
+  });
+
+  it(`escapes alternation so it matches literally`, () => {
+    const regex = getExactPathNamedRegex('/a|b');
+    expect(new RegExp(regex).test('/a|b')).toBe(true);
+    expect(new RegExp(regex).test('/a')).toBe(false);
+    expect(new RegExp(regex).test('/b')).toBe(false);
+  });
+
+  it(`escapes characters that would otherwise be invalid regex syntax`, () => {
+    const regex = getExactPathNamedRegex('/repeat{2}/star*/question?');
+    expect(new RegExp(regex).test('/repeat{2}/star*/question?')).toBe(true);
+    expect(new RegExp(regex).test('/repeat22/star/question')).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -90,7 +90,6 @@ export async function getFilesToExportFromServerAsync(
   projectRoot: string,
   {
     manifest,
-    serverManifest,
     renderAsync,
     // Servers can handle group routes automatically and therefore
     // don't require the build-time generation of every possible group
@@ -101,9 +100,6 @@ export async function getFilesToExportFromServerAsync(
     files = new Map(),
   }: {
     manifest: ExpoRouterRuntimeManifest;
-    // Optional: the `if (!exportServer && serverManifest)` guard below handles its absence,
-    // and callers exporting only HTML (e.g. tests) don't provide it.
-    serverManifest?: RoutesManifest;
     renderAsync: (requestLocation: HtmlRequestLocation) => Promise<string>;
     exportServer?: boolean;
     /**
@@ -116,20 +112,6 @@ export async function getFilesToExportFromServerAsync(
     files?: ExportAssetMap;
   }
 ): Promise<ExportAssetMap> {
-  if (!exportServer && serverManifest) {
-    // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
-    // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
-    const subsetServerManifest: StaticManifest = {
-      headers: serverManifest.headers,
-      pageHeaders: serverManifest.pageHeaders,
-      redirects: serverManifest.redirects,
-    };
-    files.set('_expo/.routes.json', {
-      contents: JSON.stringify(subsetServerManifest, null, 2),
-      targetDomain: 'client',
-    });
-  }
-
   // Skip HTML pre-rendering in SSR mode since HTML will be rendered at runtime.
   if (skipHtmlPrerendering) {
     return files;
@@ -260,7 +242,6 @@ export async function exportFromServerAsync(
   await getFilesToExportFromServerAsync(projectRoot, {
     files,
     manifest,
-    serverManifest,
     exportServer,
     skipHtmlPrerendering: isExportingWithSSR,
     async renderAsync({ pathname, route }) {
@@ -312,6 +293,20 @@ export async function exportFromServerAsync(
       return html;
     },
   });
+
+  if (!exportServer) {
+    // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
+    // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
+    const subsetServerManifest: StaticManifest = {
+      headers: serverManifest.headers,
+      pageHeaders: serverManifest.pageHeaders,
+      redirects: serverManifest.redirects,
+    };
+    files.set('_expo/.routes.json', {
+      contents: JSON.stringify(subsetServerManifest, null, 2),
+      targetDomain: 'client',
+    });
+  }
 
   getFilesFromSerialAssets(resources.artifacts, {
     platform,
@@ -646,7 +641,6 @@ export async function exportApiRoutesStandaloneAsync(
     // TODO: Export an HTML entry for each file. This is a temporary solution until we have SSR/SSG for RSC.
     await getFilesToExportFromServerAsync(devServer.projectRoot, {
       manifest: htmlManifest,
-      serverManifest,
       exportServer: true,
       files,
       renderAsync: async ({ pathname, filePath }) => {

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -11,7 +11,7 @@ import chalk from 'chalk';
 import type { RouteNode } from 'expo-router/build/Route';
 import { getContextKey, stripGroupSegmentsFromPath } from 'expo-router/build/matchers';
 import { shouldLinkExternally } from 'expo-router/build/utils/url';
-import type { RoutesManifest } from 'expo-server/private';
+import type { PageHeaderInfo, RoutesManifest } from 'expo-server/private';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import { inspect } from 'util';
@@ -22,6 +22,7 @@ import type {
   MetroBundlerDevServer,
 } from '../start/server/metro/MetroBundlerDevServer';
 import { logMetroErrorAsync } from '../start/server/metro/metroErrorInterface';
+import { SSG_LOADER_HEADER_ALLOWLIST } from '../start/server/metro/resolveLoader';
 import { getApiRoutesForDirectory, getMiddlewareForDirectory } from '../start/server/metro/router';
 import {
   assetsRequiresSort,
@@ -239,6 +240,11 @@ export async function exportFromServerAsync(
     withLoaders: loaderReferenceCount,
   });
 
+  // Group variations prerender several pathnames from one loader file, so these maps can differ
+  // in size.
+  const loaderHeadersByPage = new Map<string, Record<string, string>>();
+  const loaderHeadersByFile = new Map<string, Record<string, string>>();
+
   await getFilesToExportFromServerAsync(projectRoot, {
     files,
     manifest,
@@ -265,6 +271,21 @@ export async function exportFromServerAsync(
             targetDomain: 'client',
             loaderId: loaderKey,
           });
+
+          const declaredHeaders: Record<string, string> = {};
+          for (const name of SSG_LOADER_HEADER_ALLOWLIST) {
+            const value = loaderResponse.headers.get(name);
+            if (value) {
+              declaredHeaders[name] = value;
+            }
+          }
+          if (Object.keys(declaredHeaders).length) {
+            loaderHeadersByPage.set(normalizedPathname, declaredHeaders);
+            // NOTE(@hassankhan): Last-write-wins when concurrent group
+            // variations share a loader file; fine for SSG as loaders don't get
+            // a `request` and will produce identical headers.
+            loaderHeadersByFile.set(`/${fileSystemPath}`, declaredHeaders);
+          }
 
           renderOpts.loader = { data, key: loaderKey };
         }
@@ -293,6 +314,16 @@ export async function exportFromServerAsync(
       return html;
     },
   });
+
+  const loaderHeaderRules = [
+    ...toLoaderRules(loaderHeadersByPage),
+    ...toLoaderRules(loaderHeadersByFile),
+  ];
+
+  // Appended after any pre-existing rules so the loader-declared values win.
+  if (loaderHeaderRules.length) {
+    serverManifest.pageHeaders = [...(serverManifest.pageHeaders ?? []), ...loaderHeaderRules];
+  }
 
   if (!exportServer) {
     // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
@@ -338,6 +369,16 @@ export async function exportFromServerAsync(
     // Add the api routes to the files to export.
     for (const [route, contents] of apiRoutes) {
       files.set(route, contents);
+    }
+
+    // Add any loader-declared headers
+    if (loaderHeaderRules.length) {
+      updateExportManifestInFiles({
+        files,
+        callback: (manifest) => {
+          manifest.pageHeaders = [...(manifest.pageHeaders ?? []), ...loaderHeaderRules];
+        },
+      });
     }
 
     // Export SSR render module and add SSR configuration to routes manifest
@@ -795,4 +836,28 @@ function updateExportManifestInFiles({
       contents: JSON.stringify(manifest, null, 2),
     });
   }
+}
+
+/**
+ * Compiles a concrete pathname into an exact-match `namedRegex`. Exported pathnames are literal,
+ * so route syntax like `[param]` or `(group)` is escaped rather than parameterized.
+ *
+ * @see @expo/router-server/src/getNamedParametrizedRoute.ts
+ */
+export function getExactPathNamedRegex(pathname: string): string {
+  const escaped = pathname.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+  return `^${escaped}(?:/)?$`;
+}
+
+/**
+ * Converts headers keyed by pathname into exact-match `pageHeaders` rules, sorted for
+ * deterministic manifest output.
+ */
+function toLoaderRules(rulesByPath: Map<string, Record<string, string>>): PageHeaderInfo<string>[] {
+  return [...rulesByPath.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([pathname, headers]) => ({
+      namedRegex: getExactPathNamedRegex(pathname),
+      headers,
+    }));
 }

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -91,6 +91,7 @@ import { metroWatchTypeScriptFiles } from './metroWatchTypeScriptFiles';
 import {
   fromRuntimeManifestRoute,
   fromServerManifestRoute,
+  SSG_LOADER_HEADER_ALLOWLIST,
   type ResolvedLoaderRoute,
 } from './resolveLoader';
 import {
@@ -1906,19 +1907,27 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         const maybeResponse = await routeModule.loader(request, route.params);
 
         let data: unknown;
+        let headers: Headers | undefined;
         if (maybeResponse instanceof Response) {
           // In SSR, preserve `Response` from the loader
           if (exp.web?.output === 'server' && unstable_useServerRendering) {
             return maybeResponse;
           }
 
-          // In SSG, extract body
+          // In SSG, extract the body and the allowlisted headers
           data = await maybeResponse.json();
+          headers = new Headers();
+          for (const name of SSG_LOADER_HEADER_ALLOWLIST) {
+            const value = maybeResponse.headers.get(name);
+            if (value) {
+              headers.set(name, value);
+            }
+          }
         } else {
           data = maybeResponse;
         }
 
-        return Response.json(data ?? null);
+        return Response.json(data ?? null, { headers });
       }
 
       return undefined;

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -418,6 +418,54 @@ describe('getStaticPageAsync', () => {
   });
 });
 
+describe('executeServerDataLoaderAsync', () => {
+  it('only forwards allowlisted loader `Response` headers in SSG', async () => {
+    jest.mocked(getConfig).mockReturnValue({
+      pkg: {},
+      exp: {
+        name: 'test',
+        slug: 'test',
+        web: {
+          output: 'static',
+        },
+        extra: {
+          router: {
+            unstable_useServerDataLoaders: true,
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof getConfig>);
+
+    const devServer = createDevServerForStaticPageTests();
+    devServer['ssrLoadModule'] = jest.fn(async () => ({
+      loader: async () =>
+        Response.json(
+          { foo: 'bar' },
+          {
+            headers: {
+              'Cache-Control': 'public, max-age=3600',
+              'X-Custom-Header': 'test-value',
+            },
+          }
+        ),
+    })) as unknown as (typeof devServer)['ssrLoadModule'];
+
+    const response = await devServer.executeServerDataLoaderAsync(
+      new URL('http://localhost:8081/posts/123'),
+      {
+        file: 'posts/[postId].tsx',
+        contextKey: '/posts/[postId]',
+        pathname: '/posts/123',
+        params: { postId: '123' },
+      }
+    );
+
+    expect(response?.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    expect(response?.headers.get('X-Custom-Header')).toBeNull();
+    await expect(response!.json()).resolves.toEqual({ foo: 'bar' });
+  });
+});
+
 describe('exportServerRouteAsync', () => {
   it('rewrites only the trailing source map directive', async () => {
     // https://github.com/expo/expo/issues/47960

--- a/packages/@expo/cli/src/start/server/metro/resolveLoader.ts
+++ b/packages/@expo/cli/src/start/server/metro/resolveLoader.ts
@@ -2,6 +2,13 @@ import type { RouteNode } from 'expo-router/build/Route';
 import type { RouteInfo, RoutesManifest } from 'expo-server/private';
 
 /**
+ * An allowlist of loader `Response` headers that are written to the export
+ * manifest as `pageHeaders` rules during `expo export`. In development, they
+ * are forwarded on the loader response, matching static exports.
+ */
+export const SSG_LOADER_HEADER_ALLOWLIST = ['Cache-Control'];
+
+/**
  * Unified route information needed for loader execution
  */
 export interface ResolvedLoaderRoute {


### PR DESCRIPTION
# Why

Loaders can declare `Cache-Control` by returning a `Response`, but these were initially ignored in SSG exports as there was no mechanism to preserve headers from build-time evaluation of a `loader()` export. This PR adds that mechanism, building on the `pageHeaders` rules from #47429.

# How

- During pre-rendering, read allowlisted headers (currently `Cache-Control`) from each loader's `Response` and generate two `pageHeaders` rules; one for the page's path and one for the loader data file's path. Both are appended after config rules, so the loader-declared values take precedence over config-declared ones.
- Write the SSG export manifest _after_ pre-rendering.
- Preserve headers when a loader `Response` is re-wrapped for SSG in `executeServerDataLoaderAsync()` to maintain parity between development and production.

# Test Plan

- CI
- Manual testing locally with the `static-headers` and `static-loader` E2E fixtures in `apps/router-e2e`
- Manual testing on EAS Hosting

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
