### PR TITLE
[iOS][expo-contacts] Fix bulk THUMBNAIL crash by splitting ImageMapper into separate ThumbnailMapper

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `ContactField.THUMBNAIL` crash in bulk `getAllDetails` by reading `thumbnailImageData` instead of `imageData`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 - Fix `getDetails` throwing NPE on malformed label ([#46405](https://github.com/expo/expo/pull/46405) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `ContactField.THUMBNAIL` crash in bulk `getAllDetails` by reading `thumbnailImageData` instead of `imageData`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- [iOS] Fix `ContactField.THUMBNAIL` crash in bulk `getAllDetails` by reading `thumbnailImageData` instead of `imageData`. ([#47779](https://github.com/expo/expo/pull/47779) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 - Fix `getDetails` throwing NPE on malformed label ([#46405](https://github.com/expo/expo/pull/46405) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others

--- a/packages/expo-contacts/ios/next/Contact.swift
+++ b/packages/expo-contacts/ios/next/Contact.swift
@@ -6,7 +6,7 @@ class ContactNext: SharedObject {
   private let contactRepository: ContactRepository
   private let imageService: ImageService
   private let imageMapper: ImageMapper
-  private let thumbnailMapper: ImageMapper
+  private let thumbnailMapper: ThumbnailMapper
 
   init(
     id: String,
@@ -21,7 +21,7 @@ class ContactNext: SharedObject {
       filename: "\(id)-\(CNContactImageDataKey).png"
     )
 
-    self.thumbnailMapper = ImageMapper(
+    self.thumbnailMapper = ThumbnailMapper(
       service: imageService,
       filename: "\(id)-\(CNContactThumbnailImageDataKey).png"
     )

--- a/packages/expo-contacts/ios/next/mappers/contact/GetContactDetailsMapper.swift
+++ b/packages/expo-contacts/ios/next/mappers/contact/GetContactDetailsMapper.swift
@@ -11,7 +11,7 @@ class GetContactDetailsMapper {
 
   func map(contact: CNContact) throws -> GetContactDetailsRecord {
     let imageMapper = ImageMapper(service: imageService, filename: "\(contact.identifier)-image.png")
-    let thumbnailMapper = ImageMapper(service: imageService, filename: "\(contact.identifier)-thumb.png")
+    let thumbnailMapper = ThumbnailMapper(service: imageService, filename: "\(contact.identifier)-thumb.png")
 
     return GetContactDetailsRecord(
       id: contact.identifier,

--- a/packages/expo-contacts/ios/next/mappers/property/ThumbnailMapper.swift
+++ b/packages/expo-contacts/ios/next/mappers/property/ThumbnailMapper.swift
@@ -1,0 +1,24 @@
+import Contacts
+
+struct ThumbnailMapper: PropertyMapper {
+  typealias TDto = String?
+  internal var descriptor: CNKeyDescriptor { CNContactThumbnailImageDataKey as CNKeyDescriptor }
+  private let service: ImageService
+  private let filename: String
+
+  init(service: ImageService, filename: String) {
+    self.service = service
+    self.filename = filename
+  }
+
+  func extract(from contact: CNContact) throws -> String? {
+    guard let data = contact.thumbnailImageData else {
+      return nil
+    }
+    return try service.url(from: data, filename: filename)
+  }
+
+  func apply(_ value: String?, to contact: CNMutableContact) throws {
+    throw FailedToSetReadOnlyProperty()
+  }
+}


### PR DESCRIPTION
# Why

`ContactField.THUMBNAIL` crashes on iOS when used in bulk `getAllDetails()` calls. The `ImageMapper` was reading `contact.imageData` (full-resolution) even when used as a thumbnail mapper. Since only `CNContactThumbnailImageDataKey` was fetched, accessing `contact.imageData` throws `CNContactPropertyNotFetchedExceptionName`.

# How

Split `ImageMapper` into two separate structs following the existing codebase pattern (`BirthdayMapper` / `NonGregorianBirthdayMapper`):

- `ImageMapper` — reads `contact.imageData`, supports read and write (unchanged from original)
- `ThumbnailMapper` — reads `contact.thumbnailImageData`, throws `FailedToSetReadOnlyProperty` on write attempts since thumbnails are system-derived on iOS

Updated `GetContactDetailsMapper` and `Contact` to use `ThumbnailMapper` for the thumbnail field. `ContactPatcher` is unchanged — it only writes full images.

# Test Plan

- Built and ran a local test app on iOS simulator with 10k contacts
- Called `Contact.getAllDetails([FULL_NAME, THUMBNAIL])` in bulk — previously crashed with `CNContactPropertyNotFetchedExceptionName`, now completes successfully
- Verified `Contact.getAllDetails([FULL_NAME, IMAGE])` still works as before
- Verified single contact `getDetails()` with THUMBNAIL field returns the correct thumbnail URI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
