### PR TITLE
[cli] Respect `headers` in `expo serve`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+- Apply `headers` when serving static exports with `expo serve` ([#47780](https://github.com/expo/expo/pull/47780) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/static.ts
+++ b/packages/@expo/cli/src/export/static.ts
@@ -1,0 +1,9 @@
+import type { RouteInfo } from 'expo-server/private';
+
+/**
+ * The manifest subset that static exports write to `_expo/.routes.json`.
+ */
+export type StaticManifest<TRegex = RegExp | string> = {
+  headers?: Record<string, string | string[]>;
+  redirects?: RouteInfo<TRegex>[];
+};

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import connect from 'connect';
 import { createRequestHandler } from 'expo-server/adapter/http';
-import http from 'http';
-import path from 'path';
+import http from 'node:http';
+import path from 'node:path';
 import send from 'send';
 
 import * as Log from '../log';
@@ -11,6 +11,7 @@ import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { resolvePortAsync } from '../utils/port';
+import { applyStaticHeaders, loadStaticManifestAsync } from './static';
 
 type Options = {
   port?: number;
@@ -59,6 +60,8 @@ export async function serveAsync(inputDir: string, options: Options) {
 }
 
 async function startStaticServerAsync(dist: string, options: Options) {
+  const staticManifest = await loadStaticManifestAsync(dist);
+
   const server = http.createServer((req, res) => {
     // Remove query strings and decode URI
     const filePath = decodeURI(req.url?.split('?')[0] ?? '');
@@ -68,6 +71,18 @@ async function startStaticServerAsync(dist: string, options: Options) {
       index: 'index.html',
       extensions: ['html'],
     })
+      .on('headers', (res: http.ServerResponse, resolvedPath: string) => {
+        // If `headers` doesn't exist in the manifest, do nothing
+        if (!staticManifest?.headers) {
+          return;
+        }
+        // Headers only apply to page responses and loader data files, never to other static assets.
+        if (!resolvedPath.endsWith('.html') && !filePath.startsWith('/_expo/loaders/')) {
+          return;
+        }
+
+        applyStaticHeaders(res, staticManifest.headers);
+      })
       .on('error', (err: any) => {
         if (err.status === 404) {
           res.statusCode = 404;

--- a/packages/@expo/cli/src/serve/static.ts
+++ b/packages/@expo/cli/src/serve/static.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+
+import type { StaticManifest } from '../export/static';
+
+export async function loadStaticManifestAsync(
+  dist: string
+): Promise<StaticManifest<RegExp> | null> {
+  let json: StaticManifest<string>;
+  try {
+    json = JSON.parse(await fs.readFile(path.join(dist, '_expo/.routes.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+
+  return {
+    ...json,
+    redirects: json.redirects?.map((rule) => ({
+      ...rule,
+      namedRegex: new RegExp(rule.namedRegex),
+    })),
+  };
+}
+
+/**
+ * Applies headers from a static export manifest to a response, except
+ * `Content-Type` which must come from the served file.
+ */
+export function applyStaticHeaders(
+  res: http.ServerResponse,
+  headers: Record<string, string | string[]>
+): void {
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === 'content-type') {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const headerValue of value) {
+        res.appendHeader(name, headerValue);
+      }
+    } else if (!res.hasHeader(name)) {
+      res.setHeader(name, value);
+    }
+  }
+}


### PR DESCRIPTION
# Why

When using `expo serve`, `headers` declared in `expo-router`'s config plugin options were only applied when using server output (`web.output: 'server'`) but not in static output.

# How

Load the static export manifest on server startup and apply the headers, if they are declared. `Content-Type` is always derived from the file, as per existing behavior.

# Test Plan

- CI
- Manual testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
