### PR TITLE
[cli] Respect `pageHeaders` in `expo serve`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Support Device Hub as Simulator replacement for Xcode 27+ ([#46757](https://github.com/expo/expo/pull/46757) by [@byCedric](https://github.com/byCedric), [@GersonRocha9](https://github.com/GersonRocha9))
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Apply `headers` when serving static exports with `expo serve` ([#47780](https://github.com/expo/expo/pull/47780) by [@hassankhan](https://github.com/hassankhan))
+- Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-headers.test.ts
@@ -3,20 +3,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { runExportSideEffects } from './export-side-effects';
-import { executeExpoAsync } from '../../utils/expo';
-import { getRouterE2ERoot } from '../utils';
+import { prepareServers, RUNTIME_EXPO_SERVE, setupServer } from '../../utils/runtime';
+import { findProjectFiles } from '../utils';
 
 runExportSideEffects();
 
 const GLOBAL_HEADERS = {
   'X-Powered-By': 'expo-server',
   'X-Global': 'global',
-  'Set-Cookie': ['session=1'],
+  'Set-Cookie': ['session=1', 'session=2'],
+  'Content-Type': 'application/pdf',
 };
 
 const PAGE_HEADERS = [
   { source: '/', headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' } },
-  { source: '/api', headers: { 'Set-Cookie': ['page=1'] } },
+  { source: '/blog', headers: { 'X-Page-Rule': 'blog', 'Cache-Control': 'public, max-age=3600' } },
+  { source: '/_expo/loaders/blog', headers: { 'Cache-Control': 'public, max-age=604800' } },
 ];
 
 const EXPECTED_PAGE_HEADERS = [
@@ -25,34 +27,103 @@ const EXPECTED_PAGE_HEADERS = [
     headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' },
   },
   {
-    namedRegex: '^/api(?:/)?$',
-    headers: { 'Set-Cookie': ['page=1'] },
+    namedRegex: '^/blog(?:/)?$',
+    headers: { 'X-Page-Rule': 'blog', 'Cache-Control': 'public, max-age=3600' },
+  },
+  {
+    namedRegex: '^/_expo/loaders/blog(?:/)?$',
+    headers: { 'Cache-Control': 'public, max-age=604800' },
   },
 ];
 
 describe('export static with headers', () => {
-  const projectRoot = getRouterE2ERoot();
-  const outputName = 'dist-static-headers';
-  const outputDir = path.join(projectRoot, outputName);
-
-  beforeAll(async () => {
-    await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
-      env: {
-        NODE_ENV: 'production',
-        EXPO_USE_STATIC: 'static',
-        E2E_ROUTER_SRC: 'server-headers',
-        E2E_ROUTER_ASYNC: '',
-        E2E_ROUTER_HEADERS: JSON.stringify(GLOBAL_HEADERS),
-        E2E_ROUTER_PAGE_HEADERS: JSON.stringify(PAGE_HEADERS),
+  describe.each(
+    prepareServers([RUNTIME_EXPO_SERVE], {
+      fixtureName: 'server-headers',
+      uniqueOutputKey: 'static',
+      export: {
+        env: {
+          EXPO_USE_STATIC: 'static',
+          E2E_ROUTER_SERVER_LOADERS: 'true',
+          E2E_ROUTER_HEADERS: JSON.stringify(GLOBAL_HEADERS),
+          E2E_ROUTER_PAGE_HEADERS: JSON.stringify(PAGE_HEADERS),
+        },
       },
-    });
-  });
+    })
+  )('$name requests', (config) => {
+    const server = setupServer(config);
 
-  it('writes global headers and pageHeaders into the export manifest', () => {
-    const routesJson = JSON.parse(
-      fs.readFileSync(path.join(outputDir, '_expo/.routes.json'), 'utf8')
+    it('includes `headers` and `pageHeaders` in the export manifest', () => {
+      const routesJson = JSON.parse(
+        fs.readFileSync(path.resolve(server.outputDir, '_expo/.routes.json'), 'utf8')
+      );
+      expect(routesJson.headers).toEqual(GLOBAL_HEADERS);
+      expect(routesJson.pageHeaders).toEqual(EXPECTED_PAGE_HEADERS);
+    });
+
+    it.each([
+      {
+        path: '/',
+        status: 200,
+        contentType: 'text/html; charset=UTF-8',
+        poweredBy: 'page-override',
+        pageRule: 'index',
+        setCookie: 'session=1, session=2',
+        cacheControl: 'public, max-age=0',
+      },
+      {
+        path: '/blog',
+        status: 200,
+        contentType: 'text/html; charset=UTF-8',
+        poweredBy: 'expo-server',
+        pageRule: 'blog',
+        setCookie: 'session=1, session=2',
+        cacheControl: 'public, max-age=3600',
+      },
+      {
+        // Loader data files apply global headers and matching rules
+        path: '/_expo/loaders/blog',
+        status: 200,
+        contentType: 'application/octet-stream',
+        poweredBy: 'expo-server',
+        pageRule: null,
+        setCookie: 'session=1, session=2',
+        cacheControl: 'public, max-age=604800',
+      },
+      {
+        // The static file server serves 404s without header application
+        path: '/not-a-route',
+        status: 404,
+        contentType: null,
+        poweredBy: null,
+        pageRule: null,
+        setCookie: null,
+        cacheControl: null,
+      },
+    ])(
+      'applies `headers` and matching `pageHeaders` to $path',
+      async ({ path, status, contentType, poweredBy, pageRule, setCookie, cacheControl }) => {
+        const response = await server.fetchAsync(path);
+
+        expect(response.status).toBe(status);
+        expect(response.headers.get('Content-Type')).toBe(contentType);
+        expect(response.headers.get('X-Powered-By')).toBe(poweredBy);
+        expect(response.headers.get('X-Page-Rule')).toBe(pageRule);
+        expect(response.headers.get('Set-Cookie')).toBe(setCookie);
+        expect(response.headers.get('Cache-Control')).toBe(cacheControl);
+        expect(response.headers.get('X-Global')).toBe(status === 200 ? 'global' : null);
+      }
     );
-    expect(routesJson.headers).toEqual(GLOBAL_HEADERS);
-    expect(routesJson.pageHeaders).toEqual(EXPECTED_PAGE_HEADERS);
+
+    it('does not apply headers to static assets', async () => {
+      const files = findProjectFiles(server.outputDir);
+      const asset = files.find((file) => file.startsWith('_expo/static/js/web/'));
+      expect(asset).toBeDefined();
+
+      const response = await server.fetchAsync(`/${asset}`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('X-Global')).toBeNull();
+      expect(response.headers.get('Set-Cookie')).toBeNull();
+    });
   });
 });

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -33,6 +33,7 @@ import { generateFaviconAssetAsync } from './favicon';
 import { persistMetroAssetsAsync } from './persistMetroAssets';
 import type { ExportAssetMap } from './saveAssets';
 import { getFilesFromSerialAssets } from './saveAssets';
+import type { StaticManifest } from './static';
 
 const debug = require('debug')('expo:export:generateStaticRoutes') as typeof console.log;
 
@@ -119,7 +120,7 @@ export async function getFilesToExportFromServerAsync(
   if (!exportServer && serverManifest) {
     // When we're not exporting a `server` output, we provide a `_expo/.routes.json` for
     // EAS Hosting to recognize the `headers`, `pageHeaders`, and `redirects` configs
-    const subsetServerManifest = {
+    const subsetServerManifest: StaticManifest = {
       headers: serverManifest.headers,
       pageHeaders: serverManifest.pageHeaders,
       redirects: serverManifest.redirects,

--- a/packages/@expo/cli/src/export/static.ts
+++ b/packages/@expo/cli/src/export/static.ts
@@ -1,9 +1,10 @@
-import type { RouteInfo } from 'expo-server/private';
+import type { PageHeaderInfo, RouteInfo } from 'expo-server/private';
 
 /**
  * The manifest subset that static exports write to `_expo/.routes.json`.
  */
 export type StaticManifest<TRegex = RegExp | string> = {
   headers?: Record<string, string | string[]>;
+  pageHeaders?: PageHeaderInfo<TRegex>[];
   redirects?: RouteInfo<TRegex>[];
 };

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -11,7 +11,7 @@ import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { resolvePortAsync } from '../utils/port';
-import { applyStaticHeaders, loadStaticManifestAsync } from './static';
+import { applyStaticHeaders, loadStaticManifestAsync, resolveStaticHeaders } from './static';
 
 type Options = {
   port?: number;
@@ -72,8 +72,8 @@ async function startStaticServerAsync(dist: string, options: Options) {
       extensions: ['html'],
     })
       .on('headers', (res: http.ServerResponse, resolvedPath: string) => {
-        // If `headers` doesn't exist in the manifest, do nothing
-        if (!staticManifest?.headers) {
+        // If `headers` and `pageHeaders` don't exist in the manifest, do nothing
+        if (!staticManifest?.headers && !staticManifest?.pageHeaders?.length) {
           return;
         }
         // Headers only apply to page responses and loader data files, never to other static assets.
@@ -81,7 +81,7 @@ async function startStaticServerAsync(dist: string, options: Options) {
           return;
         }
 
-        applyStaticHeaders(res, staticManifest.headers);
+        applyStaticHeaders(res, resolveStaticHeaders(staticManifest, filePath));
       })
       .on('error', (err: any) => {
         if (err.status === 404) {

--- a/packages/@expo/cli/src/serve/static.ts
+++ b/packages/@expo/cli/src/serve/static.ts
@@ -1,3 +1,4 @@
+import { mergeHeaderInputs } from 'expo-server/private';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
@@ -16,11 +17,29 @@ export async function loadStaticManifestAsync(
 
   return {
     ...json,
+    pageHeaders: json.pageHeaders?.map((rule) => ({
+      ...rule,
+      namedRegex: new RegExp(rule.namedRegex),
+    })),
     redirects: json.redirects?.map((rule) => ({
       ...rule,
       namedRegex: new RegExp(rule.namedRegex),
     })),
   };
+}
+
+/** Mirrors `resolveRouteHeaders()` in `expo-server/src/vendor/abstract.ts`. */
+export function resolveStaticHeaders(
+  manifest: StaticManifest<RegExp>,
+  pathname: string
+): Record<string, string | string[]> {
+  let mergedHeaders = manifest.headers ?? {};
+  for (const rule of manifest.pageHeaders ?? []) {
+    if (rule.namedRegex.test(pathname)) {
+      mergedHeaders = mergeHeaderInputs(mergedHeaders, rule.headers);
+    }
+  }
+  return mergedHeaders;
 }
 
 /**

--- a/packages/expo-server/src/private.ts
+++ b/packages/expo-server/src/private.ts
@@ -1,4 +1,5 @@
 export { ImmutableRequest } from './ImmutableRequest';
 export { type RenderRscArgs, getRscMiddleware } from './middleware/rsc';
 export { resolveLoaderContextKey } from './utils/matchers';
+export { mergeHeaderInputs } from './utils/headers';
 export type * from './manifest';


### PR DESCRIPTION
# Why

Followup for #47780.

Extends work from #47780 so `expo serve` also applies per-path `pageHeaders` rules to static exports.

# How

Resolve `pageHeaders` from static export manifest and merge them with global headers the same way `expo-server` does for server outputs.

# Test Plan

- CI
- Manual testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
