### PR TITLE
[app-metrics][insights][iOS] Anchor bundle end time to app startup end marker

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 💡 Others
 
+- [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Remove the unstable, development-only `triggerCrash` and `simulateCrashReport` APIs. ([#46924](https://github.com/expo/expo/pull/46924) by [@Ubax](https://github.com/Ubax))
 - Add private `getForegroundSession` ([#46657](https://github.com/expo/expo/pull/46657) by [@Ubax](https://github.com/Ubax))
 - Add session shared object API ([#46652](https://github.com/expo/expo/pull/46652) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-app-metrics/ios/AppStartup/AppStartupMarkers.swift
+++ b/packages/expo-app-metrics/ios/AppStartup/AppStartupMarkers.swift
@@ -58,9 +58,17 @@ final class AppStartupMarkers: Sendable {
     return nil
   }
 
+  /// Duration of JS bundle evaluation, which also covers synchronous setup of the native modules
+  /// eagerly required during that evaluation. React Native logs `APP_STARTUP_STOP` right after
+  /// evaluation finishes, so it stands in for the bundle end time.
   func getBundleLoadTime() -> TimeInterval? {
     let bundleStartTime = ReactMarker.getRunJSBundleStartTime()
-    let bundleEndTime = ReactMarker.getRunJSBundleEndTime()
+    let bundleEndTime = ReactMarker.getAppStartupEndTime()
+    // The markers are `NaN` until React Native logs them (e.g. no logger attached), and any
+    // arithmetic on `NaN` stays `NaN`. Skip the metric rather than report a bogus value.
+    guard bundleStartTime.isFinite, bundleEndTime.isFinite else {
+      return nil
+    }
     return (bundleEndTime - bundleStartTime) / 1000
   }
 }

--- a/packages/expo-app-metrics/ios/EXReactMarker.h
+++ b/packages/expo-app-metrics/ios/EXReactMarker.h
@@ -6,11 +6,7 @@ using namespace facebook::react::ReactMarker;
 NS_SWIFT_NAME(ReactMarker)
 @interface EXAppMetricsReactMarker : NSObject
 
-+ (double)getAppStartupStartTime;
 + (double)getAppStartupEndTime;
 + (double)getRunJSBundleStartTime;
-+ (double)getRunJSBundleEndTime;
-+ (double)getInitReactRuntimeStartTime;
-+ (double)getInitReactRuntimeEndTime;
 
 @end

--- a/packages/expo-app-metrics/ios/EXReactMarker.mm
+++ b/packages/expo-app-metrics/ios/EXReactMarker.mm
@@ -2,11 +2,6 @@
 
 @implementation EXAppMetricsReactMarker
 
-+ (double)getAppStartupStartTime
-{
-  return StartupLogger::getInstance().getAppStartupStartTime();
-}
-
 + (double)getAppStartupEndTime
 {
   return StartupLogger::getInstance().getAppStartupEndTime();
@@ -15,21 +10,6 @@
 + (double)getRunJSBundleStartTime
 {
   return StartupLogger::getInstance().getRunJSBundleStartTime();
-}
-
-+ (double)getRunJSBundleEndTime
-{
-  return StartupLogger::getInstance().getRunJSBundleEndTime();
-}
-
-+ (double)getInitReactRuntimeStartTime
-{
-  return StartupLogger::getInstance().getInitReactRuntimeStartTime();
-}
-
-+ (double)getInitReactRuntimeEndTime
-{
-  return StartupLogger::getInstance().getInitReactRuntimeEndTime();
 }
 
 @end

--- a/packages/expo-insights/ios/EXReactMarker.mm
+++ b/packages/expo-insights/ios/EXReactMarker.mm
@@ -14,7 +14,9 @@
 
 + (NSDate *)getRunJSBundleEndTime
 {
-  return [self getDateFromMediaTime:StartupLogger::getInstance().getRunJSBundleEndTime()];
+  // React Native logs `APP_STARTUP_STOP` right after bundle evaluation, so it stands in for the
+  // bundle end time.
+  return [self getDateFromMediaTime:StartupLogger::getInstance().getAppStartupEndTime()];
 }
 
 + (NSDate *)getDateFromMediaTime:(double)mediaTime


### PR DESCRIPTION
# Why

React Native removed the `getRunJSBundleEndTime` getter from its public `StartupLogger` API in facebook/react-native#57142. Two packages read that getter on iOS and would fail to compile once the repo bumps to the RN that drops it (`0.86` still ships it, so nothing is broken today):

- `expo-app-metrics`: `getBundleLoadTime` feeds the `bundleLoadTime` metric.
- `expo-insights`: the `RUN_JS_BUNDLE_END` event.

This unblocks the RN 0.87 bump for both. Fixes ENG-24158.

# How

Both packages now read `getAppStartupEndTime` (`APP_STARTUP_STOP`) as the bundle end anchor instead of `getRunJSBundleEndTime`. On iOS, `APP_STARTUP_STOP` is logged immediately after bundle evaluation finishes, in both the bridge and bridgeless paths, so it stands in for the bundle end time. It also survives on RN `main`, since `NativePerformance` still consumes it.

**expo-app-metrics:** `getBundleLoadTime` reads the surviving marker, guards against unset markers (`nil` when either is `NaN`), and the four unused wrappers on the `ReactMarker` shim were dropped so it no longer references any removed getter.

**expo-insights:** the `getRunJSBundleEndTime` wrapper now sources its timestamp from `getAppStartupEndTime`. The `RUN_JS_BUNDLE_END` event name and its `NSDate` shape are unchanged.

# Test Plan

Verified on a real cold launch. `et native-unit-tests -p ios --packages expo-app-metrics` passes. expo-insights ships no native tests and isn't in an installed Pods target; its change is a one-line swap of the C++ getter inside an existing method, matching the app-metrics fix.
