### PR TITLE
[expo] Update `react-native-gesture-handler` to `3.0.2`

### DIFF
--- a/apps/bare-expo/android/app/src/main/jni/CMakeLists.txt
+++ b/apps/bare-expo/android/app/src/main/jni/CMakeLists.txt
@@ -45,6 +45,11 @@ function(add_pch_if_eligible target)
     "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>"
   )
 
+  # clang rejects a PCH built with a different C++ dialect, so pin consumers
+  # to the owner's -std=c++20 (libraries that set CMAKE_CXX_STANDARD themselves
+  # would otherwise get -std=gnu++20).
+  set_target_properties(${target} PROPERTIES CXX_STANDARD 20 CXX_EXTENSIONS OFF)
+
   target_precompile_headers(${target} REUSE_FROM appmodules_pch)
 endfunction()
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2985,7 +2985,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNGestureHandler (2.32.0):
+  - RNGestureHandler (3.0.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3525,7 +3525,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.0_@react-native_df9b5bdf4983a534926d94e4f6b171c1/node_modules/@react-native-picker/picker`)"
   - "RNDateTimePicker (from `../../../node_modules/.pnpm/@react-native-community+datetimepicker@8.6.0_expo@packages+expo_react-native@0.86.0_@ba_3ff387633cd73d92abf33032fa835aa1/node_modules/@react-native-community/datetimepicker`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated`)"
   - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.26.0-nightly-20260625-9b9b39fa5_react-native@0.86.0_@babel+core@_9065dac1b4c05235ca8dad70cb3f3647/node_modules/react-native-screens`)"
   - "RNSVG (from `../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-pres_7db2513d16ccc60642452ad7fe65813d/node_modules/react-native-svg`)"
@@ -3992,7 +3992,7 @@ EXTERNAL SOURCES:
   RNDateTimePicker:
     :path: "../../../node_modules/.pnpm/@react-native-community+datetimepicker@8.6.0_expo@packages+expo_react-native@0.86.0_@ba_3ff387633cd73d92abf33032fa835aa1/node_modules/@react-native-community/datetimepicker"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated"
   RNScreens:
@@ -4102,7 +4102,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
+  hermes-engine: dd9a9191125ffe9f57c224173db85afb0210cd23
   JestMockSchema: 96b4cfec246644f6323d1c30693b6a02044be1e6
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -4198,7 +4198,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNCPicker: d74667bdfc08ed389a2a277d95b8faf2349290a9
   RNDateTimePicker: b9e20c2a3af26f4ab10646359777205bbad1fdac
-  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
+  RNGestureHandler: 953af68599a35f425ea962dda2ee15ee4e3ca719
   RNReanimated: acf36f3396b05d25e998c917bcf834524ea6fc71
   RNScreens: ccbb8554b95292b74535617f1cdb6ddb6350d40c
   RNSVG: 3fe8590403ac9f107b4d14591bc6e54da4894e5c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "react": "^19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-keyboard-controller": "^1.21.9",
     "react-native-pager-view": "8.0.2",
     "react-native-reanimated": "4.5.1",

--- a/apps/brownfield-tester/expo-app/package.json
+++ b/apps/brownfield-tester/expo-app/package.json
@@ -31,7 +31,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-worklets": "0.10.1",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/apps/brownfield-tester/integrated/ios/Podfile.lock
+++ b/apps/brownfield-tester/integrated/ios/Podfile.lock
@@ -1599,7 +1599,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context (5.6.2):
+  - react-native-safe-area-context (5.7.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1611,8 +1611,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.2)
-    - react-native-safe-area-context/fabric (= 5.6.2)
+    - react-native-safe-area-context/common (= 5.7.0)
+    - react-native-safe-area-context/fabric (= 5.7.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1623,7 +1623,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/common (5.6.2):
+  - react-native-safe-area-context/common (5.7.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1645,7 +1645,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.2):
+  - react-native-safe-area-context/fabric (5.7.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2087,7 +2087,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNGestureHandler (2.32.0):
+  - RNGestureHandler (3.0.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2109,34 +2109,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.4.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - RNReanimated/apple (= 4.4.1)
-    - RNReanimated/common (= 4.4.1)
-    - RNWorklets
-    - Yoga
-  - RNReanimated/apple (4.4.1):
+  - RNReanimated (4.5.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2159,9 +2132,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
+    - RNReanimated/apple (= 4.5.1)
+    - RNReanimated/common (= 4.5.1)
+    - RNReanimated/view (= 4.5.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/common (4.4.1):
+  - RNReanimated/apple (4.5.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2186,7 +2162,57 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.25.2):
+  - RNReanimated/common (4.5.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNReanimated/view (4.5.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNScreens (4.26.0-nightly-20260625-9b9b39fa5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2208,9 +2234,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.25.2)
+    - RNScreens/common (= 4.26.0-nightly-20260625-9b9b39fa5)
     - Yoga
-  - RNScreens/common (4.25.2):
+  - RNScreens/common (4.26.0-nightly-20260625-9b9b39fa5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2233,7 +2259,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.9.2):
+  - RNWorklets (0.10.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2256,10 +2282,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.9.2)
-    - RNWorklets/common (= 0.9.2)
+    - RNWorklets/apple (= 0.10.1)
+    - RNWorklets/common (= 0.10.1)
     - Yoga
-  - RNWorklets/apple (0.9.2):
+  - RNWorklets/apple (0.10.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2283,7 +2309,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.9.2):
+  - RNWorklets/common (0.10.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2387,7 +2413,7 @@ DEPENDENCIES:
   - "React-Mapbuffer (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon`)"
   - "React-microtasksnativemodule (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)"
   - "React-mutationobservernativemodule (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver`)"
-  - "react-native-safe-area-context (from `../../../../node_modules/.pnpm/react-native-safe-area-context@5.6.2_react-native@0.86.0_@babel+core@7.29.0_@react-nati_574aa10db7c8f8409a0c365378ba5a67/node_modules/react-native-safe-area-context`)"
+  - "react-native-safe-area-context (from `../../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.0_@react-nati_5fbb277e95644896606144d0e4eeaf29/node_modules/react-native-safe-area-context`)"
   - "React-NativeModulesApple (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)"
   - "React-networking (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/networking`)"
   - "React-oscompat (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/oscompat`)"
@@ -2424,10 +2450,10 @@ DEPENDENCIES:
   - "ReactCommon/turbomodule/core (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon`)"
   - "ReactNativeDependencies (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)"
   - "RNCMaskedView (from `../../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view`)"
-  - "RNGestureHandler (from `../../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../../node_modules/.pnpm/react-native-reanimated@4.4.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_a74cc18fafa65e7651a9d50fd7a881ac/node_modules/react-native-reanimated`)"
-  - "RNScreens (from `../../../../node_modules/.pnpm/react-native-screens@4.25.2_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-p_bc74c8251353228e298a45eaf397fd0f/node_modules/react-native-screens`)"
-  - "RNWorklets (from `../../../../node_modules/.pnpm/react-native-worklets@0.9.2_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa75012_a381df5e861150bf105798ed8aeeeb09/node_modules/react-native-worklets`)"
+  - "RNGestureHandler (from `../../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler`)"
+  - "RNReanimated (from `../../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated`)"
+  - "RNScreens (from `../../../../node_modules/.pnpm/react-native-screens@4.26.0-nightly-20260625-9b9b39fa5_react-native@0.86.0_@babel+core@_9065dac1b4c05235ca8dad70cb3f3647/node_modules/react-native-screens`)"
+  - "RNWorklets (from `../../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_e98144a6c5d6242836167e9069761b53/node_modules/react-native-worklets`)"
   - "Yoga (from `../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/yoga`)"
 
 SPEC REPOS:
@@ -2573,7 +2599,7 @@ EXTERNAL SOURCES:
   React-mutationobservernativemodule:
     :path: "../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver"
   react-native-safe-area-context:
-    :path: "../../../../node_modules/.pnpm/react-native-safe-area-context@5.6.2_react-native@0.86.0_@babel+core@7.29.0_@react-nati_574aa10db7c8f8409a0c365378ba5a67/node_modules/react-native-safe-area-context"
+    :path: "../../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.0_@react-nati_5fbb277e95644896606144d0e4eeaf29/node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
     :path: "../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-networking:
@@ -2647,18 +2673,18 @@ EXTERNAL SOURCES:
   RNCMaskedView:
     :path: "../../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
-    :path: "../../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler"
+    :path: "../../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../../node_modules/.pnpm/react-native-reanimated@4.4.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_a74cc18fafa65e7651a9d50fd7a881ac/node_modules/react-native-reanimated"
+    :path: "../../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated"
   RNScreens:
-    :path: "../../../../node_modules/.pnpm/react-native-screens@4.25.2_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-p_bc74c8251353228e298a45eaf397fd0f/node_modules/react-native-screens"
+    :path: "../../../../node_modules/.pnpm/react-native-screens@4.26.0-nightly-20260625-9b9b39fa5_react-native@0.86.0_@babel+core@_9065dac1b4c05235ca8dad70cb3f3647/node_modules/react-native-screens"
   RNWorklets:
-    :path: "../../../../node_modules/.pnpm/react-native-worklets@0.9.2_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa75012_a381df5e861150bf105798ed8aeeeb09/node_modules/react-native-worklets"
+    :path: "../../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_e98144a6c5d6242836167e9069761b53/node_modules/react-native-worklets"
   Yoga:
     :path: "../../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXConstants: 682bc4d71c01c779fc3b02fddb75dee39a044100
+  EXConstants: 5dfc240550dd6517bbda62ab97ad8c6ef280d309
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
   EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
   Expo: 848f62d607a8a550d4b8064f8f3f69feaf0555c6
@@ -2675,17 +2701,17 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinking: 82458b046854a5802092a37a5228a8a228f928a4
   ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
-  ExpoModulesCore: 7ee5c9715b287b20ec9caa7f2577007597adf25a
+  ExpoModulesCore: ede87d8176627de2d322b38e4485d9e31ba99459
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
-  ExpoModulesWorkletsAdapter: bb5bea0b1e6de7f6552e94746e9b2d0f2f325c2d
+  ExpoModulesWorkletsAdapter: dd35b501e286451317740a80a87bc5fe26e5c56d
   ExpoRouter: 06524ed53f9833aabf49053a119bcc92c1442098
   ExpoSymbols: b3c964ddc1f1c8d8ddb0eeb830e3a8e42b77ed2d
   ExpoSystemUI: 8f4fb641c6a6ebe2a01dda0fbd3fdd952ab5823a
   ExpoUI: 649b8cbcccd23277afa83bf0d065bc40906b7e3a
   ExpoWebBrowser: 6e3d90e3fe1952d21a8494872b1e1a485cd50e2f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: e355eb94d3f8b7f4c08531a4d42af958d36c13de
+  hermes-engine: dd9a9191125ffe9f57c224173db85afb0210cd23
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -2726,7 +2752,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
   React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
   React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
-  react-native-safe-area-context: 91a90d98c310adcc90a511e5aeb6046d7c19d885
+  react-native-safe-area-context: 6b4966397ada0f7dd481e4486a2ef936834861a1
   React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
   React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
@@ -2763,10 +2789,10 @@ SPEC CHECKSUMS:
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
-  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
-  RNReanimated: d3ebae9248488f632af6894572113bd2eaced510
-  RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNWorklets: 30ca1f710a80daa9cb28f9823eada955d6c2218f
+  RNGestureHandler: 953af68599a35f425ea962dda2ee15ee4e3ca719
+  RNReanimated: ae471cd78ed9c8c2865ff57b12370eaaf9d153dc
+  RNScreens: ccbb8554b95292b74535617f1cdb6ddb6350d40c
+  RNWorklets: 11ce5589058480653fe45c9a44524eb0847835fb
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3623,7 +3623,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNGestureHandler (2.32.0):
+  - RNGestureHandler (3.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -4327,7 +4327,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.0_@react-native_df9b5bdf4983a534926d94e4f6b171c1/node_modules/@react-native-picker/picker`)"
   - "RNDateTimePicker (from `../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_3410ef6ce3d9f843a98f5e317302287f/node_modules/@react-native-community/datetimepicker`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated`)"
   - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.26.0-nightly-20260625-9b9b39fa5_react-native@0.86.0_@babel+core@_9065dac1b4c05235ca8dad70cb3f3647/node_modules/react-native-screens`)"
   - "RNSVG (from `../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-pres_7db2513d16ccc60642452ad7fe65813d/node_modules/react-native-svg`)"
@@ -4709,7 +4709,7 @@ EXTERNAL SOURCES:
   RNDateTimePicker:
     :path: "../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_3410ef6ce3d9f843a98f5e317302287f/node_modules/@react-native-community/datetimepicker"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated"
   RNScreens:
@@ -4814,7 +4814,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: e0efaf5c05d0bb8b3e03760d040e9480def9bff8
+  hermes-engine: 9c084a6e3fdd40f70d498576a8540d94aee5a76e
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4912,7 +4912,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
   RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
-  RNGestureHandler: 83e66307c200b98c746bd03113c4403da5c9b486
+  RNGestureHandler: 644af257ee6f781129ae37acb1d24c8c4e9e722a
   RNReanimated: f06a7e844a5ca4178837f6663e151620eac9f513
   RNScreens: ae4213790924e85a9dd3f25da82e047249d5291d
   RNSVG: c6acd5c597d26625214295105756c5e488f5ae4c

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -83,7 +83,7 @@
     "lottie-react-native": "^7.3.8",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-keyboard-controller": "^1.21.9",
     "react-native-maps": "1.27.2",
     "react-native-pager-view": "8.0.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -132,7 +132,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
     "react-native-dropdown-picker": "^5.3.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-keyboard-controller": "^1.21.9",
     "react-native-maps": "1.27.2",
     "react-native-pager-view": "8.0.2",

--- a/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
@@ -15,9 +15,14 @@ import {
   VideoStabilization,
 } from 'expo-camera';
 import * as FileSystem from 'expo-file-system/legacy';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import {
+  GestureDetector,
+  useCompetingGestures,
+  useLongPressGesture,
+  useTapGesture,
+} from 'react-native-gesture-handler';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 
 import GalleryScreen from './GalleryScreen';
@@ -78,36 +83,28 @@ interface State {
 }
 
 function Gestures({ children }: { children: React.ReactNode }) {
-  const doubleTapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .numberOfTaps(2)
-        .maxDuration(250)
-        .onStart(() => {
-          console.log('doubleTapGesture > onStart');
-        }),
-    []
-  );
+  const doubleTapGesture = useTapGesture({
+    numberOfTaps: 2,
+    maxDuration: 250,
+    onActivate: () => {
+      console.log('doubleTapGesture > onActivate');
+    },
+  });
 
-  const longPressGesture = useMemo(
-    () =>
-      Gesture.LongPress()
-        .minDuration(750)
-        .onStart(() => {
-          console.log('longPressGesture > onStart');
-        }),
-    []
-  );
+  const longPressGesture = useLongPressGesture({
+    minDuration: 750,
+    onActivate: () => {
+      console.log('longPressGesture > onActivate');
+    },
+  });
+
+  const gesture = useCompetingGestures(doubleTapGesture, longPressGesture);
 
   if (Platform.OS === 'web') {
     return children;
   }
 
-  return (
-    <GestureDetector gesture={Gesture.Race(doubleTapGesture, longPressGesture)}>
-      {children}
-    </GestureDetector>
-  );
+  return <GestureDetector gesture={gesture}>{children}</GestureDetector>;
 }
 
 export default function CameraScreen() {

--- a/apps/native-component-list/src/screens/GL/GLReanimatedExample.tsx
+++ b/apps/native-component-list/src/screens/GL/GLReanimatedExample.tsx
@@ -2,7 +2,7 @@ import { Asset, useAssets } from 'expo-asset';
 import { ExpoWebGLRenderingContext, GLView, getWorkletContext } from 'expo-gl';
 import React, { useState, useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, { runOnUI, useSharedValue, withSpring } from 'react-native-reanimated';
 
 interface RenderContext {
@@ -150,15 +150,16 @@ export default function GLReanimated() {
     }
   }, [assets]);
 
-  const panGestureHandler = Gesture.Pan()
-    .onUpdate((event) => {
+  const panGestureHandler = usePanGesture({
+    onUpdate: (event) => {
       x.value = event.translationX;
       y.value = event.translationY;
-    })
-    .onEnd(() => {
+    },
+    onDeactivate: () => {
       x.value = withSpring(0);
       y.value = withSpring(0);
-    });
+    },
+  });
 
   const onContextCreate = useWorkletAwareGlContext<RenderContext>(
     {

--- a/apps/native-component-list/src/screens/GestureHandler/AppleStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/AppleStyleSwipeableRow.tsx
@@ -1,75 +1,96 @@
-// @ts-nocheck
-import React, { Component } from 'react';
-import { Animated, StyleSheet, Text, View } from 'react-native';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
-import Swipeable from 'react-native-gesture-handler/Swipeable';
+import Swipeable, { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Animated, { interpolate, SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 
-export default class AppleStyleSwipeableRow extends Component {
-  _swipeableRow?: Swipeable;
+function LeftAction({ dragX, onPress }: { dragX: SharedValue<number>; onPress: () => void }) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: interpolate(dragX.value, [0, 50, 100, 101], [-20, 0, 0, 1]) }],
+  }));
+  return (
+    <RectButton style={styles.leftAction} onPress={onPress}>
+      <Animated.Text style={[styles.actionText, animatedStyle]}>Archive</Animated.Text>
+    </RectButton>
+  );
+}
 
-  renderLeftActions = (progress: Animated.Value, dragX: Animated.Value) => {
-    const trans = dragX.interpolate({
-      inputRange: [0, 50, 100, 101],
-      outputRange: [-20, 0, 0, 1],
-    });
-    return (
-      <RectButton style={styles.leftAction} onPress={this.close}>
-        <Animated.Text
-          style={[
-            styles.actionText,
-            {
-              transform: [{ translateX: trans }],
-            },
-          ]}>
-          Archive
-        </Animated.Text>
+function RightAction({
+  text,
+  color,
+  x,
+  progress,
+  onPress,
+}: {
+  text: string;
+  color: string;
+  x: number;
+  progress: SharedValue<number>;
+  onPress: () => void;
+}) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: interpolate(progress.value, [0, 1], [x, 0]) }],
+  }));
+  return (
+    <Animated.View style={[{ flex: 1 }, animatedStyle]}>
+      <RectButton style={[styles.rightAction, { backgroundColor: color }]} onPress={onPress}>
+        <Text style={styles.actionText}>{text}</Text>
       </RectButton>
-    );
+    </Animated.View>
+  );
+}
+
+export default function AppleStyleSwipeableRow({ children }: { children?: React.ReactNode }) {
+  const swipeableRow = useRef<SwipeableMethods>(null);
+
+  const close = () => {
+    swipeableRow.current?.close();
   };
-  renderRightAction = (text: string, color: string, x: number, progress: Animated.Value) => {
-    const trans = progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [x, 0],
-    });
-    const pressHandler = () => {
-      this.close();
-      alert(text);
-    };
-    return (
-      <Animated.View style={{ flex: 1, transform: [{ translateX: trans }] }}>
-        <RectButton style={[styles.rightAction, { backgroundColor: color }]} onPress={pressHandler}>
-          <Text style={styles.actionText}>{text}</Text>
-        </RectButton>
-      </Animated.View>
-    );
+  const pressHandler = (text: string) => {
+    close();
+    alert(text);
   };
-  renderRightActions = (progress: Animated.Value) => (
+
+  const renderLeftActions = (_progress: SharedValue<number>, dragX: SharedValue<number>) => (
+    <LeftAction dragX={dragX} onPress={close} />
+  );
+  const renderRightActions = (progress: SharedValue<number>) => (
     <View style={{ width: 192, flexDirection: 'row' }}>
-      {this.renderRightAction('More', '#C8C7CD', 192, progress)}
-      {this.renderRightAction('Flag', '#ffab00', 128, progress)}
-      {this.renderRightAction('More', '#dd2c00', 64, progress)}
+      <RightAction
+        text="More"
+        color="#C8C7CD"
+        x={192}
+        progress={progress}
+        onPress={() => pressHandler('More')}
+      />
+      <RightAction
+        text="Flag"
+        color="#ffab00"
+        x={128}
+        progress={progress}
+        onPress={() => pressHandler('Flag')}
+      />
+      <RightAction
+        text="More"
+        color="#dd2c00"
+        x={64}
+        progress={progress}
+        onPress={() => pressHandler('More')}
+      />
     </View>
   );
-  updateRef = (ref: Swipeable) => {
-    this._swipeableRow = ref;
-  };
-  close = () => {
-    this._swipeableRow!.close();
-  };
-  render() {
-    const { children } = this.props;
-    return (
-      <Swipeable
-        ref={this.updateRef}
-        friction={2}
-        leftThreshold={30}
-        rightThreshold={40}
-        renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}>
-        {children}
-      </Swipeable>
-    );
-  }
+
+  return (
+    <Swipeable
+      ref={swipeableRow}
+      friction={2}
+      leftThreshold={30}
+      rightThreshold={40}
+      renderLeftActions={renderLeftActions}
+      renderRightActions={renderRightActions}>
+      {children}
+    </Swipeable>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-component-list/src/screens/GestureHandler/BouncyBox.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/BouncyBox.tsx
@@ -1,114 +1,85 @@
-import React, { Component } from 'react';
-import { Animated, StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
-import {
-  PanGestureHandler,
-  RotationGestureHandler,
-  State,
-  PanGestureHandlerStateChangeEvent,
-  RotationGestureHandlerStateChangeEvent,
-} from 'react-native-gesture-handler';
+import React from 'react';
+import { StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
+import { GestureDetector, usePanGesture, useRotationGesture } from 'react-native-gesture-handler';
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
 
-const USE_NATIVE_DRIVER = true;
+function Snappable({ children }: { children?: React.ReactNode }) {
+  const dragX = useSharedValue(0);
 
-class Snappable extends Component<{ children?: React.ReactNode }> {
-  _dragX = new Animated.Value(0);
-  _transX = this._dragX.interpolate({
-    inputRange: [-100, -50, 0, 50, 100],
-    outputRange: [-30, -10, 0, 10, 30],
+  const pan = usePanGesture({
+    maxPointers: 1,
+    onUpdate: (event) => {
+      dragX.value = event.translationX;
+    },
+    onDeactivate: (event) => {
+      dragX.value = withSpring(0, { velocity: event.velocityX });
+    },
   });
-  _onGestureEvent = Animated.event([{ nativeEvent: { translationX: this._dragX } }], {
-    useNativeDriver: USE_NATIVE_DRIVER,
-  });
-  _onHandlerStateChange = (event: PanGestureHandlerStateChangeEvent) => {
-    if (event.nativeEvent.oldState === State.ACTIVE) {
-      Animated.spring(this._dragX, {
-        velocity: event.nativeEvent.velocityX,
-        tension: 10,
-        friction: 2,
-        toValue: 0,
-        useNativeDriver: USE_NATIVE_DRIVER,
-      }).start();
-    }
-  };
-  render() {
-    const { children } = this.props;
-    return (
-      <PanGestureHandler
-        {...this.props}
-        maxPointers={1}
-        onGestureEvent={this._onGestureEvent}
-        onHandlerStateChange={this._onHandlerStateChange}>
-        <Animated.View style={{ transform: [{ translateX: this._transX }] }}>
-          {children}
-        </Animated.View>
-      </PanGestureHandler>
-    );
-  }
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: interpolate(dragX.value, [-100, -50, 0, 50, 100], [-30, -10, 0, 10, 30]) },
+    ],
+  }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={animatedStyle}>{children}</Animated.View>
+    </GestureDetector>
+  );
 }
 
-class Twistable extends Component<{ children?: React.ReactNode }> {
-  _gesture = new Animated.Value(0);
+function Twistable({ children }: { children?: React.ReactNode }) {
+  const rotation = useSharedValue(0);
 
-  _rot = this._gesture
-    .interpolate({
-      inputRange: [-1.2, -1, -0.5, 0, 0.5, 1, 1.2],
-      outputRange: [-0.52, -0.5, -0.3, 0, 0.3, 0.5, 0.52],
-    })
-    .interpolate({
-      inputRange: [-100, 100],
-      outputRange: ['-100rad', '100rad'],
-    });
-
-  _onGestureEvent = Animated.event([{ nativeEvent: { rotation: this._gesture } }], {
-    useNativeDriver: USE_NATIVE_DRIVER,
+  const rotate = useRotationGesture({
+    onUpdate: (event) => {
+      rotation.value = event.rotation;
+    },
+    onDeactivate: (event) => {
+      rotation.value = withSpring(0, { velocity: event.velocity });
+    },
   });
 
-  _onHandlerStateChange = (event: RotationGestureHandlerStateChangeEvent) => {
-    if (event.nativeEvent.oldState === State.ACTIVE) {
-      Animated.spring(this._gesture, {
-        velocity: event.nativeEvent.velocity,
-        tension: 10,
-        friction: 0.2,
-        toValue: 0,
-        useNativeDriver: USE_NATIVE_DRIVER,
-      }).start();
-    }
-  };
-  render() {
-    const { children } = this.props;
-    return (
-      <RotationGestureHandler
-        {...this.props}
-        onGestureEvent={this._onGestureEvent}
-        onHandlerStateChange={this._onHandlerStateChange}>
-        <Animated.View style={{ transform: [{ rotate: this._rot }] }}>{children}</Animated.View>
-      </RotationGestureHandler>
-    );
-  }
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        rotate: `${interpolate(
+          rotation.value,
+          [-1.2, -1, -0.5, 0, 0.5, 1, 1.2],
+          [-0.52, -0.5, -0.3, 0, 0.3, 0.5, 0.52]
+        )}rad`,
+      },
+    ],
+  }));
+
+  return (
+    <GestureDetector gesture={rotate}>
+      <Animated.View style={animatedStyle}>{children}</Animated.View>
+    </GestureDetector>
+  );
 }
 
-export default class Example extends Component<{ style?: StyleProp<ViewStyle> }> {
-  render() {
-    return (
-      <View style={this.props.style}>
-        <Snappable>
-          <Twistable>
-            <View style={styles.box} />
-          </Twistable>
-        </Snappable>
-      </View>
-    );
-  }
+export default function BouncyBox({ style }: { style?: StyleProp<ViewStyle> }) {
+  return (
+    <View style={style}>
+      <Snappable>
+        <Twistable>
+          <View style={styles.box} />
+        </Twistable>
+      </Snappable>
+    </View>
+  );
 }
 
 const BOX_SIZE = 200;
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   box: {
     width: BOX_SIZE,
     height: BOX_SIZE,

--- a/apps/native-component-list/src/screens/GestureHandler/FancyButton.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/FancyButton.tsx
@@ -1,89 +1,59 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
 import {
-  LongPressGestureHandler,
-  State,
-  TapGestureHandler,
-  LongPressGestureHandlerStateChangeEvent,
-  TapGestureHandlerStateChangeEvent,
+  GestureDetector,
+  useExclusiveGestures,
+  useLongPressGesture,
+  useTapGesture,
 } from 'react-native-gesture-handler';
 
-interface FBState {
-  singleTap?: State;
-  longPress?: State;
-}
+export default function FancyButton({
+  style,
+  onLongPress,
+  onSingleTap,
+  onDoubleTap,
+  children,
+}: {
+  style?: StyleProp<ViewStyle>;
+  onLongPress?: () => void;
+  onSingleTap?: () => void;
+  onDoubleTap?: () => void;
+  children?: React.ReactNode;
+}) {
+  // Intentionally leave out double tap
+  const [longPressed, setLongPressed] = useState(false);
+  const [singleTapped, setSingleTapped] = useState(false);
 
-export default class FancyButton extends Component<
-  {
-    style?: StyleProp<ViewStyle>;
-    onLongPress?: () => void;
-    onSingleTap?: () => void;
-    onDoubleTap?: () => void;
-    children?: React.ReactNode;
-  },
-  FBState
-> {
-  doubleTapRef = React.createRef<TapGestureHandler>();
+  const longPress = useLongPressGesture({
+    runOnJS: true,
+    minDuration: 800,
+    onBegin: () => setLongPressed(true),
+    onActivate: () => onLongPress?.(),
+    onFinalize: () => setLongPressed(false),
+  });
 
-  readonly state: FBState = {};
+  const doubleTap = useTapGesture({
+    runOnJS: true,
+    numberOfTaps: 2,
+    onActivate: () => onDoubleTap?.(),
+  });
 
-  render() {
-    return (
-      <LongPressGestureHandler minDurationMs={800} onHandlerStateChange={this._onLongPressEvent}>
-        <TapGestureHandler
-          numberOfTaps={1}
-          waitFor={this.doubleTapRef}
-          onHandlerStateChange={this._onSingleTapEvent}>
-          <TapGestureHandler
-            numberOfTaps={2}
-            ref={this.doubleTapRef}
-            onHandlerStateChange={this._onDoubleTapEvent}>
-            <View
-              style={[styles.button, this.props.style, { opacity: this._isPressed() ? 0.5 : 1 }]}>
-              {this.props.children}
-            </View>
-          </TapGestureHandler>
-        </TapGestureHandler>
-      </LongPressGestureHandler>
-    );
-  }
+  const singleTap = useTapGesture({
+    runOnJS: true,
+    onBegin: () => setSingleTapped(true),
+    onActivate: () => onSingleTap?.(),
+    onFinalize: () => setSingleTapped(false),
+  });
 
-  _isPressed = () => {
-    const { longPress, singleTap } = this.state;
+  const gesture = useExclusiveGestures(longPress, doubleTap, singleTap);
 
-    // Intentionally leave out double tap
-    if (longPress === State.BEGAN || singleTap === State.BEGAN) {
-      return true;
-    } else {
-      return false;
-    }
-  };
-
-  _onLongPressEvent = (event: LongPressGestureHandlerStateChangeEvent) => {
-    const { state } = event.nativeEvent;
-    this.setState({ longPress: state });
-
-    if (state === State.ACTIVE) {
-      this.props.onLongPress && this.props.onLongPress();
-    }
-  };
-
-  _onSingleTapEvent = (event: TapGestureHandlerStateChangeEvent) => {
-    const { state } = event.nativeEvent;
-    this.setState({ singleTap: state });
-
-    if (state === State.ACTIVE) {
-      this.props.onSingleTap && this.props.onSingleTap();
-    }
-  };
-
-  _onDoubleTapEvent = (event: TapGestureHandlerStateChangeEvent) => {
-    const { state } = event.nativeEvent;
-
-    if (state === State.ACTIVE) {
-      this.props.onDoubleTap && this.props.onDoubleTap();
-    }
-  };
+  return (
+    <GestureDetector gesture={gesture}>
+      <View style={[styles.button, style, { opacity: longPressed || singleTapped ? 0.5 : 1 }]}>
+        {children}
+      </View>
+    </GestureDetector>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
@@ -1,69 +1,81 @@
-// @ts-nocheck
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import React, { Component } from 'react';
-import { Animated, StyleSheet } from 'react-native';
+import React, { useRef } from 'react';
+import { StyleSheet } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
-import Swipeable from 'react-native-gesture-handler/Swipeable';
+import Swipeable, { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  SharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
 const AnimatedIcon = Animated.createAnimatedComponent(MaterialIcons);
 
-export default class AppleStyleSwipeableRow extends Component {
-  _swipeableRow?: Swipeable;
+function ActionIcon({
+  name,
+  style,
+  dragX,
+  inputRange,
+  outputRange,
+  onPress,
+}: {
+  name: 'archive' | 'delete-forever';
+  style: typeof styles.leftAction;
+  dragX: SharedValue<number>;
+  inputRange: number[];
+  outputRange: number[];
+  onPress: () => void;
+}) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: interpolate(dragX.value, inputRange, outputRange, Extrapolation.CLAMP) }],
+  }));
+  return (
+    <RectButton style={style} onPress={onPress}>
+      <AnimatedIcon name={name} size={30} color="#fff" style={[styles.actionIcon, animatedStyle]} />
+    </RectButton>
+  );
+}
 
-  renderLeftActions = (progress: Animated.Value, dragX: Animated.Value) => {
-    const scale = dragX.interpolate({
-      inputRange: [0, 80],
-      outputRange: [0, 1],
-      extrapolate: 'clamp',
-    });
-    return (
-      <RectButton style={styles.leftAction} onPress={this.close}>
-        <AnimatedIcon
-          name="archive"
-          size={30}
-          color="#fff"
-          style={[styles.actionIcon, { transform: [{ scale }] }]}
-        />
-      </RectButton>
-    );
+export default function GmailStyleSwipeableRow({ children }: { children?: React.ReactNode }) {
+  const swipeableRow = useRef<SwipeableMethods>(null);
+
+  const close = () => {
+    swipeableRow.current?.close();
   };
-  renderRightActions = (progress: Animated.Value, dragX: Animated.Value) => {
-    const scale = dragX.interpolate({
-      inputRange: [-80, 0],
-      outputRange: [1, 0],
-      extrapolate: 'clamp',
-    });
-    return (
-      <RectButton style={styles.rightAction} onPress={this.close}>
-        <AnimatedIcon
-          name="delete-forever"
-          size={30}
-          color="#fff"
-          style={[styles.actionIcon, { transform: [{ scale }] }]}
-        />
-      </RectButton>
-    );
-  };
-  updateRef = (ref: Swipeable) => {
-    this._swipeableRow = ref;
-  };
-  close = () => {
-    this._swipeableRow!.close();
-  };
-  render() {
-    const { children } = this.props;
-    return (
-      <Swipeable
-        ref={this.updateRef}
-        friction={2}
-        leftThreshold={80}
-        rightThreshold={40}
-        renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}>
-        {children}
-      </Swipeable>
-    );
-  }
+
+  const renderLeftActions = (_progress: SharedValue<number>, dragX: SharedValue<number>) => (
+    <ActionIcon
+      name="archive"
+      style={styles.leftAction}
+      dragX={dragX}
+      inputRange={[0, 80]}
+      outputRange={[0, 1]}
+      onPress={close}
+    />
+  );
+  const renderRightActions = (_progress: SharedValue<number>, dragX: SharedValue<number>) => (
+    <ActionIcon
+      name="delete-forever"
+      style={styles.rightAction}
+      dragX={dragX}
+      inputRange={[-80, 0]}
+      outputRange={[1, 0]}
+      onPress={close}
+    />
+  );
+
+  return (
+    <Swipeable
+      ref={swipeableRow}
+      friction={2}
+      leftThreshold={80}
+      rightThreshold={40}
+      renderLeftActions={renderLeftActions}
+      renderRightActions={renderRightActions}>
+      {children}
+    </Swipeable>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-component-list/src/screens/GestureHandlerListScreen.tsx
+++ b/apps/native-component-list/src/screens/GestureHandlerListScreen.tsx
@@ -8,7 +8,7 @@ import FancyButton from './GestureHandler/FancyButton';
 export default function GestureHandlerListScreen() {
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
-      <BodyText style={styles.title}>LongPressGestureHandler, TapGestureHandler</BodyText>
+      <BodyText style={styles.title}>useLongPressGesture, useTapGesture</BodyText>
       <BodyText color="secondary" style={styles.paragraph}>
         You can single tap, double tap, or long press these buttons!
       </BodyText>
@@ -30,7 +30,7 @@ export default function GestureHandlerListScreen() {
 
       <View style={{ marginTop: 10 }} />
 
-      <BodyText style={styles.title}>PanGestureHandler, RotationGestureHandler</BodyText>
+      <BodyText style={styles.title}>usePanGesture, useRotationGesture</BodyText>
       <BodyText color="secondary" style={styles.paragraph}>
         You can drag it left and right, and also use two fingers to rotate it, and it'll bounce
         back!

--- a/apps/native-component-list/src/screens/GestureHandlerPinchScreen.tsx
+++ b/apps/native-component-list/src/screens/GestureHandlerPinchScreen.tsx
@@ -1,139 +1,80 @@
-import React from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import {
-  PanGestureHandler,
-  PanGestureHandlerStateChangeEvent,
-  PinchGestureHandler,
-  PinchGestureHandlerStateChangeEvent,
-  RotationGestureHandler,
-  RotationGestureHandlerStateChangeEvent,
-  State,
+  GestureDetector,
+  useCompetingGestures,
+  usePanGesture,
+  usePinchGesture,
+  useRotationGesture,
+  useSimultaneousGestures,
 } from 'react-native-gesture-handler';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
 
-const USE_NATIVE_DRIVER = true;
+function PinchableBox() {
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const rotation = useSharedValue(0);
+  const savedRotation = useSharedValue(0);
+  const tilt = useSharedValue(0);
+  const savedTilt = useSharedValue(0);
 
-class PinchableBox extends React.Component {
-  panRef = React.createRef<PanGestureHandler>();
-  rotationRef = React.createRef<RotationGestureHandler>();
-  pinchRef = React.createRef<PinchGestureHandler>();
+  const pinch = usePinchGesture({
+    onUpdate: (event) => {
+      scale.value = savedScale.value * event.scale;
+    },
+    onDeactivate: () => {
+      savedScale.value = scale.value;
+    },
+  });
 
-  _baseScale: Animated.Value;
-  _pinchScale: Animated.Value;
-  _scale: Animated.AnimatedMultiplication<number>;
-  _lastScale: number;
-  _onPinchGestureEvent: (...args: any[]) => void;
+  const rotate = useRotationGesture({
+    onUpdate: (event) => {
+      rotation.value = savedRotation.value + event.rotation;
+    },
+    onDeactivate: () => {
+      savedRotation.value = rotation.value;
+    },
+  });
 
-  _rotate: Animated.Value;
-  _rotateStr: Animated.AnimatedInterpolation<number>;
-  _lastRotate: number;
-  _onRotateGestureEvent?: (...args: any[]) => void;
+  const tiltPan = usePanGesture({
+    minDistance: 10,
+    minPointers: 2,
+    maxPointers: 2,
+    averageTouches: true,
+    onUpdate: (event) => {
+      tilt.value = savedTilt.value + event.translationY;
+    },
+    onDeactivate: () => {
+      savedTilt.value = tilt.value;
+    },
+  });
 
-  _tilt: Animated.Value;
-  _tiltStr: Animated.AnimatedInterpolation<number>;
-  _lastTilt: number;
-  _onTiltGestureEvent: (...args: any[]) => void;
+  const pinchAndRotate = useSimultaneousGestures(pinch, rotate);
+  const gesture = useCompetingGestures(tiltPan, pinchAndRotate);
 
-  constructor(props: any) {
-    super(props);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { perspective: 200 },
+      { scale: scale.value },
+      { rotate: `${rotation.value}rad` },
+      { rotateX: `${interpolate(tilt.value, [-500, 0], [1, 0], Extrapolation.CLAMP)}rad` },
+    ],
+  }));
 
-    /* Pinching */
-    this._baseScale = new Animated.Value(1);
-    this._pinchScale = new Animated.Value(1);
-    this._scale = Animated.multiply(this._baseScale, this._pinchScale);
-    this._lastScale = 1;
-    this._onPinchGestureEvent = Animated.event([{ nativeEvent: { scale: this._pinchScale } }], {
-      useNativeDriver: USE_NATIVE_DRIVER,
-    });
-
-    /* Rotation */
-    this._rotate = new Animated.Value(0);
-    this._rotateStr = this._rotate.interpolate({
-      inputRange: [-100, 100],
-      outputRange: ['-100rad', '100rad'],
-    });
-    this._lastRotate = 0;
-    this._onRotateGestureEvent = Animated.event([{ nativeEvent: { rotation: this._rotate } }], {
-      useNativeDriver: USE_NATIVE_DRIVER,
-    });
-
-    /* Tilt */
-    this._tilt = new Animated.Value(0);
-    this._tiltStr = this._tilt.interpolate({
-      inputRange: [-501, -500, 0, 1],
-      outputRange: ['1rad', '1rad', '0rad', '0rad'],
-    });
-    this._lastTilt = 0;
-    this._onTiltGestureEvent = Animated.event([{ nativeEvent: { translationY: this._tilt } }], {
-      useNativeDriver: USE_NATIVE_DRIVER,
-    });
-  }
-
-  _onRotateHandlerStateChange = (event: RotationGestureHandlerStateChangeEvent) => {
-    if (event.nativeEvent.oldState === State.ACTIVE) {
-      this._lastRotate += event.nativeEvent.rotation;
-      this._rotate.setOffset(this._lastRotate);
-      this._rotate.setValue(0);
-    }
-  };
-  _onPinchHandlerStateChange = (event: PinchGestureHandlerStateChangeEvent) => {
-    if (event.nativeEvent.oldState === State.ACTIVE) {
-      this._lastScale *= event.nativeEvent.scale;
-      this._baseScale.setValue(this._lastScale);
-      this._pinchScale.setValue(1);
-    }
-  };
-  _onTiltGestureStateChange = (event: PanGestureHandlerStateChangeEvent) => {
-    if (event.nativeEvent.oldState === State.ACTIVE) {
-      this._lastTilt += event.nativeEvent.translationY;
-      this._tilt.setOffset(this._lastTilt);
-      this._tilt.setValue(0);
-    }
-  };
-  render() {
-    return (
-      <PanGestureHandler
-        ref={this.panRef}
-        onGestureEvent={this._onTiltGestureEvent}
-        onHandlerStateChange={this._onTiltGestureStateChange}
-        minDist={10}
-        minPointers={2}
-        maxPointers={2}
-        avgTouches>
-        <Animated.View style={styles.wrapper}>
-          <RotationGestureHandler
-            ref={this.rotationRef}
-            simultaneousHandlers={this.pinchRef}
-            onGestureEvent={this._onRotateGestureEvent}
-            onHandlerStateChange={this._onRotateHandlerStateChange}>
-            <Animated.View style={styles.wrapper}>
-              <PinchGestureHandler
-                ref={this.pinchRef}
-                simultaneousHandlers={this.rotationRef}
-                onGestureEvent={this._onPinchGestureEvent}
-                onHandlerStateChange={this._onPinchHandlerStateChange}>
-                <Animated.View style={styles.container} collapsable={false}>
-                  <Animated.Image
-                    style={[
-                      styles.pinchableImage,
-                      {
-                        transform: [
-                          { perspective: 200 },
-                          { scale: this._scale },
-                          { rotate: this._rotateStr },
-                          { rotateX: this._tiltStr },
-                        ],
-                      },
-                    ]}
-                    source={require('../../assets/images/swmansion.png')}
-                  />
-                </Animated.View>
-              </PinchGestureHandler>
-            </Animated.View>
-          </RotationGestureHandler>
-        </Animated.View>
-      </PanGestureHandler>
-    );
-  }
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View style={styles.container} collapsable={false}>
+        <Animated.Image
+          style={[styles.pinchableImage, animatedStyle]}
+          source={require('../../assets/images/swmansion.png')}
+        />
+      </Animated.View>
+    </GestureDetector>
+  );
 }
 
 const GestureHandlerPinchScreen = () => (
@@ -161,8 +102,5 @@ const styles = StyleSheet.create({
   pinchableImage: {
     width: 250,
     height: 250,
-  },
-  wrapper: {
-    flex: 1,
   },
 });

--- a/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
@@ -11,7 +11,7 @@ import {
 } from 'expo-glass-effect';
 import React from 'react';
 import { StyleSheet, ScrollView, Text, View, Image, TouchableOpacity } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 
 import { BodyText } from '../../components/BodyText';
@@ -52,14 +52,15 @@ export default function GlassViewScreen() {
   const translateY = useSharedValue(100);
   const startPosition = useSharedValue({ x: 0, y: 0 });
 
-  const panGesture = Gesture.Pan()
-    .onStart(() => {
+  const panGesture = usePanGesture({
+    onActivate: () => {
       startPosition.value = { x: translateX.value, y: translateY.value };
-    })
-    .onUpdate((event) => {
+    },
+    onUpdate: (event) => {
       translateX.value = startPosition.value.x + event.translationX;
       translateY.value = startPosition.value.y + event.translationY;
-    });
+    },
+  });
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/apps/native-component-list/src/screens/Image/ImageResizableScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageResizableScreen.tsx
@@ -9,7 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedProps,
   useAnimatedStyle,
@@ -37,12 +37,12 @@ const ResizableView: React.FC<CustomViewProps> = ({ children }) => {
   const startingPointX = useSharedValue(0);
   const startingPointY = useSharedValue(0);
 
-  const panGestureHandler = Gesture.Pan()
-    .onStart(() => {
+  const panGestureHandler = usePanGesture({
+    onActivate: () => {
       startingPointX.value = width.value;
       startingPointY.value = height.value;
-    })
-    .onUpdate((event) => {
+    },
+    onUpdate: (event) => {
       width.value = Math.max(
         HANDLE_SIZE,
         Math.min(event.translationX + startingPointX.value, MAX_WIDTH)
@@ -51,7 +51,8 @@ const ResizableView: React.FC<CustomViewProps> = ({ children }) => {
         HANDLE_SIZE,
         Math.min(event.translationY + startingPointY.value, MAX_HEIGHT)
       );
-    });
+    },
+  });
 
   const canvasStyle = useAnimatedStyle(() => {
     return {

--- a/apps/native-component-list/src/screens/MeshGradientScreen.tsx
+++ b/apps/native-component-list/src/screens/MeshGradientScreen.tsx
@@ -2,7 +2,7 @@ import { Platform } from 'expo';
 import { MeshGradientView } from 'expo-mesh-gradient';
 import { useCallback, useState } from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedProps,
   useAnimatedStyle,
@@ -24,17 +24,18 @@ export default function MeshGradientScreen() {
   const [mask, setMask] = useState(false);
   const point = useSharedValue({ x: 0.5, y: 0.5 });
 
-  const panGesture = Gesture.Pan()
-    .minDistance(1)
-    .onUpdate((event) => {
+  const panGesture = usePanGesture({
+    minDistance: 1,
+    onUpdate: (event) => {
       point.value = {
         x: event.absoluteX / SCREEN_SIZE.width,
         y: event.absoluteY / SCREEN_SIZE.height,
       };
-    })
-    .onEnd(() => {
+    },
+    onDeactivate: () => {
       point.value = withSpring({ x: 0.5, y: 0.5 });
-    });
+    },
+  });
 
   const animatedProps = useAnimatedProps(() => {
     return {

--- a/apps/native-component-list/src/screens/Reanimated/ReanimatedSlider.tsx
+++ b/apps/native-component-list/src/screens/Reanimated/ReanimatedSlider.tsx
@@ -4,7 +4,7 @@ import {
   TextInput,
   GestureHandlerRootView,
   GestureDetector,
-  Gesture,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
@@ -22,18 +22,20 @@ export function SliderExample() {
   const boxWidth = useSharedValue(INITIAL_BOX_SIZE);
   const MAX_VALUE = SLIDER_WIDTH - INITIAL_BOX_SIZE;
 
-  const pan = Gesture.Pan().onChange((event) => {
-    offset.value =
-      Math.abs(offset.value) <= MAX_VALUE
-        ? offset.value + event.changeX <= 0
-          ? 0
-          : offset.value + event.changeX >= MAX_VALUE
-            ? MAX_VALUE
-            : offset.value + event.changeX
-        : offset.value;
+  const pan = usePanGesture({
+    onUpdate: (event) => {
+      offset.value =
+        Math.abs(offset.value) <= MAX_VALUE
+          ? offset.value + event.changeX <= 0
+            ? 0
+            : offset.value + event.changeX >= MAX_VALUE
+              ? MAX_VALUE
+              : offset.value + event.changeX
+          : offset.value;
 
-    const newWidth = INITIAL_BOX_SIZE + offset.value;
-    boxWidth.value = newWidth;
+      const newWidth = INITIAL_BOX_SIZE + offset.value;
+      boxWidth.value = newWidth;
+    },
   });
 
   const boxStyle = useAnimatedStyle(() => {

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -39,38 +39,6 @@ PODS:
     - Yoga
   - expo-dev-launcher (56.0.16):
     - EXManifests
-    - expo-dev-launcher/Main (= 56.0.16)
-    - expo-dev-menu
-    - expo-dev-menu-interface
-    - ExpoModulesCore
-    - EXUpdatesInterface
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactAppDependencyProvider
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - expo-dev-launcher/Main (56.0.16):
-    - EXManifests
-    - expo-dev-launcher/Unsafe
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -115,36 +83,6 @@ PODS:
     - React-Core
     - React-Core-prebuilt
     - React-CoreModules
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactAppDependencyProvider
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - expo-dev-launcher/Unsafe (56.0.16):
-    - EXManifests
-    - expo-dev-menu
-    - expo-dev-menu-interface
-    - ExpoModulesCore
-    - EXUpdatesInterface
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2520,7 +2458,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNGestureHandler (2.32.0):
+  - RNGestureHandler (3.0.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2904,7 +2842,7 @@ DEPENDENCIES:
   - "ReactCommon/turbomodule/core (from `../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/ReactCommon`)"
   - "ReactNativeDependencies (from `../../../node_modules/.pnpm/react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-preset@0.86.0_@babel+core@7.2_ef63ad2607bf1660bcad07b5e75613ee/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)"
   - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated`)"
   - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.26.0-nightly-20260625-9b9b39fa5_react-native@0.86.0_@babel+core@_9065dac1b4c05235ca8dad70cb3f3647/node_modules/react-native-screens`)"
   - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_e98144a6c5d6242836167e9069761b53/node_modules/react-native-worklets`)"
@@ -3147,7 +3085,7 @@ EXTERNAL SOURCES:
   RNCMaskedView:
     :path: "../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_@babel+core@7.29.0_@react-nativ_8313629b77c6557c08d7b3ab032d2fe3/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native_c4bb1b48904f6bfa6f37f9a78934de4d/node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated"
   RNScreens:
@@ -3165,7 +3103,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
   EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
   Expo: 848f62d607a8a550d4b8064f8f3f69feaf0555c6
-  expo-dev-launcher: f761f01b43a9d7cc32f4bbac53269b0ffe17b349
+  expo-dev-launcher: ca577f99be535273f7278a27e94cda779432ba89
   expo-dev-menu: d9ea09994a5a9bec05005bd7ccbdfcca8f970772
   expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
   ExpoAppMetrics: 5cdb64cf96504ddef0aa2b87e0be3c337416c75d
@@ -3185,7 +3123,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 0195e08bbc1ef6f012db66639dac3d0abe1c92a3
+  hermes-engine: dd9a9191125ffe9f57c224173db85afb0210cd23
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3267,7 +3205,7 @@ SPEC CHECKSUMS:
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
-  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
+  RNGestureHandler: 953af68599a35f425ea962dda2ee15ee4e3ca719
   RNReanimated: acf36f3396b05d25e998c917bcf834524ea6fc71
   RNScreens: ccbb8554b95292b74535617f1cdb6ddb6350d40c
   RNWorklets: 2e32d9b0895989f340df9804902643ce46a6b6d4

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -38,7 +38,7 @@
     "native-component-list": "workspace:*",
     "test-suite": "workspace:*",
     "expo-task-manager": "workspace:*",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react": "19.2.3",
     "react-native": "0.86.0",
     "react-native-reanimated": "4.5.1",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -82,7 +82,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-pager-view": "^8.0.2",
     "react-native-safe-area-context": "5.7.0",
     "react-native-screens": "4.26.0-nightly-20260625-9b9b39fa5",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -78,7 +78,7 @@
     "path": "^0.12.7",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-safe-area-context": "^5.7.0",
     "semver": "^7.7.4"
   },

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -327,7 +327,7 @@
     "@types/react-test-renderer": "^19.1.0",
     "expect-type": "^1.3.0",
     "immer": "^10.1.1",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.26.0-nightly-20260625-9b9b39fa5",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -102,7 +102,7 @@
   "react-dom": "19.2.3",
   "react-native": "0.86.0",
   "react-native-web": "~0.21.0",
-  "react-native-gesture-handler": "~2.32.0",
+  "react-native-gesture-handler": "~3.0.2",
   "react-native-get-random-values": "~1.11.0",
   "react-native-keyboard-controller": "1.21.9",
   "react-native-maps": "1.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,8 +229,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: ^1.21.9
         version: 1.21.9(react-native-reanimated@4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -396,8 +396,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.1
         version: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -662,8 +662,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: ^1.21.9
         version: 1.21.9(react-native-reanimated@4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -813,7 +813,7 @@ importers:
         version: 7.15.5(2523bf3a15448b07dfdcac35af75e150)
       '@react-navigation/drawer':
         specifier: ^7.9.4
-        version: 7.9.4(42c728d28eea59c4946289531db98362)
+        version: 7.9.4(81982a55358bd928990122534aa498fd)
       '@react-navigation/elements':
         specifier: ^2.9.10
         version: 2.9.10(@react-native-masked-view/masked-view@0.3.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(@react-navigation/native@7.1.33(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-safe-area-context@5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -825,7 +825,7 @@ importers:
         version: 7.14.5(2523bf3a15448b07dfdcac35af75e150)
       '@react-navigation/stack':
         specifier: ^7.8.5
-        version: 7.8.5(59a3eb5cdf3e251d9f4a1024f8a5af54)
+        version: 7.8.5(9643eafe3394a2a68282337f7d1c1a66)
       '@shopify/flash-list':
         specifier: 2.0.2
         version: 2.0.2(@babel/runtime@7.29.2)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -1103,8 +1103,8 @@ importers:
         specifier: ^5.3.0
         version: 5.4.6(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: ^1.21.9
         version: 1.21.9(react-native-reanimated@4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -1303,8 +1303,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.1
         version: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -1491,8 +1491,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-pager-view:
         specifier: ^8.0.2
         version: 8.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -1602,7 +1602,7 @@ importers:
         version: 7.14.5(2523bf3a15448b07dfdcac35af75e150)
       '@react-navigation/stack':
         specifier: ^7.8.5
-        version: 7.8.5(59a3eb5cdf3e251d9f4a1024f8a5af54)
+        version: 7.8.5(9643eafe3394a2a68282337f7d1c1a66)
       async-retry:
         specifier: ^1.1.4
         version: 1.3.3
@@ -1781,8 +1781,8 @@ importers:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context:
         specifier: ^5.7.0
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -5351,7 +5351,7 @@ importers:
         version: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-drawer-layout:
         specifier: ^4.2.2
-        version: 4.2.2(37c19a79695f56a7e5a51ee0acaf3649)
+        version: 4.2.2(e9c7d8928716eb425182017e4d1ff601)
       react-native-screens:
         specifier: 4.26.0-nightly-20260625-9b9b39fa5
         version: 4.26.0-nightly-20260625-9b9b39fa5(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -5414,8 +5414,8 @@ importers:
         specifier: ^10.1.1
         version: 10.2.0
       react-native-gesture-handler:
-        specifier: ~2.32.0
-        version: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~3.0.2
+        version: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.1
         version: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -7318,10 +7318,6 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-
-  '@egjs/hammerjs@2.0.17':
-    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
-    engines: {node: '>=0.8.0'}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -9489,9 +9485,6 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
-
-  '@types/hammerjs@2.0.46':
-    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -13841,8 +13834,8 @@ packages:
       react: '*'
       react-native: 0.86.0
 
-  react-native-gesture-handler@2.32.0:
-    resolution: {integrity: sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==}
+  react-native-gesture-handler@3.0.2:
+    resolution: {integrity: sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg==}
     peerDependencies:
       react: '*'
       react-native: 0.86.0
@@ -16529,10 +16522,6 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@egjs/hammerjs@2.0.17':
-    dependencies:
-      '@types/hammerjs': 2.0.46
-
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -18104,7 +18093,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -18144,15 +18135,15 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
-  '@react-navigation/drawer@7.9.4(42c728d28eea59c4946289531db98362)':
+  '@react-navigation/drawer@7.9.4(81982a55358bd928990122534aa498fd)':
     dependencies:
       '@react-navigation/elements': 2.9.10(@react-native-masked-view/masked-view@0.3.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(@react-navigation/native@7.1.33(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-safe-area-context@5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@react-navigation/native': 7.1.33(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       color: 4.2.3
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-drawer-layout: 4.2.2(37c19a79695f56a7e5a51ee0acaf3649)
-      react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-drawer-layout: 4.2.2(e9c7d8928716eb425182017e4d1ff601)
+      react-native-gesture-handler: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context: 5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-screens: 4.26.0-nightly-20260625-9b9b39fa5(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -18200,14 +18191,14 @@ snapshots:
     dependencies:
       nanoid: 3.3.11
 
-  '@react-navigation/stack@7.8.5(59a3eb5cdf3e251d9f4a1024f8a5af54)':
+  '@react-navigation/stack@7.8.5(9643eafe3394a2a68282337f7d1c1a66)':
     dependencies:
       '@react-navigation/elements': 2.9.10(@react-native-masked-view/masked-view@0.3.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(@react-navigation/native@7.1.33(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-safe-area-context@5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@react-navigation/native': 7.1.33(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       color: 4.2.3
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-gesture-handler: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context: 5.7.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-screens: 4.26.0-nightly-20260625-9b9b39fa5(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
@@ -18595,8 +18586,6 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.19.15
-
-  '@types/hammerjs@2.0.46': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -23646,12 +23635,12 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-drawer-layout@4.2.2(37c19a79695f56a7e5a51ee0acaf3649):
+  react-native-drawer-layout@4.2.2(e9c7d8928716eb425182017e4d1ff601):
     dependencies:
       color: 4.2.3
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-gesture-handler: 3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
@@ -23660,11 +23649,9 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
 
-  react-native-gesture-handler@2.32.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  react-native-gesture-handler@3.0.2(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
-      hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -29,7 +29,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-gesture-handler": "~2.32.0",
+    "react-native-gesture-handler": "~3.0.2",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",


### PR DESCRIPTION
# Why

Upgrade `react-native-gesture-handler` to `3.0.2` to unblock https://github.com/expo/expo/pull/47729

# How

Bump  `react-native-gesture-handler` to latest

# Test Plan

Run BareExpo locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
