### PR TITLE
[docs] Revise TypeScript type definition instructions for dom-to-image in Expo tutorial 

### DIFF
--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -210,11 +210,16 @@ const styles = StyleSheet.create({
 
 <Collapsible summary={<>Fix <CODE>dom-to-image</CODE> TypeScript module error</>}>
 
-We need to add a type definition after importing the `domtoimage` library since we're using TypeScript. We can do this by creating a file **types.d.ts** in the root of our project directory and adding the declaration statement:
+We need to add the type definitions after importing the `domtoimage` library since we're using TypeScript. We can do this by adding `@types/dom-to-image` with:
 
-```tsx types.d.ts
-declare module 'dom-to-image';
-```
+  <Terminal
+    cmd={{
+      npm: ['$ npm install @types/dom-to-image --save-dev'],
+      yarn: ['$ yarn add @types/dom-to-image --dev'],
+      pnpm: ['$ pnpm add @types/dom-to-image --save-dev'],
+      bun: ['$ bun add @types/dom-to-image --dev'],
+    }}
+  />
 
 </Collapsible>
 


### PR DESCRIPTION
Updated instructions for adding TypeScript type definitions for the dom-to-image library, including installation commands for npm, yarn, pnpm, and bun.

# Why

Adding an empty type definition is of little value in TypeScript outside of simply removing the error. As the proper type definitions are (now) available via @types/dom-to-image, it should be used in lieu of an empty type definition.

# How

Simply revised the verbiage and added a Terminal tag with the proper package manager commands.

# Test Plan

Preview the change, as it is documentation only.

# Checklist

- [] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [*] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
