### PR TITLE
[build-properties][Android] Fix PCH dialect mismatch for libraries that set CMAKE_CXX_STANDARD

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Make the precompiled header reusable by passing `-Xclang -fno-pch-timestamp`, so ccache can reuse it across builds. ([#46915](https://github.com/expo/expo/pull/46915) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Pin the C++ dialect of PCH consumer targets to `-std=c++20`.
 
 ### 💡 Others
 

--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Make the precompiled header reusable by passing `-Xclang -fno-pch-timestamp`, so ccache can reuse it across builds. ([#46915](https://github.com/expo/expo/pull/46915) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Pin the C++ dialect of PCH consumer targets to `-std=c++20`.
+- [Android] Pin the C++ dialect of PCH consumer targets to `-std=c++20`. ([#47788](https://github.com/expo/expo/pull/47788) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-build-properties/src/androidPCHTemplates.ts
+++ b/packages/expo-build-properties/src/androidPCHTemplates.ts
@@ -46,6 +46,11 @@ function(add_pch_if_eligible target)
     "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>"
   )
 
+  # clang rejects a PCH built with a different C++ dialect, so pin consumers
+  # to the owner's -std=c++20 (libraries that set CMAKE_CXX_STANDARD themselves
+  # would otherwise get -std=gnu++20).
+  set_target_properties(\${target} PROPERTIES CXX_STANDARD 20 CXX_EXTENSIONS OFF)
+
   target_precompile_headers(\${target} REUSE_FROM appmodules_pch)
 endfunction()
 


### PR DESCRIPTION
# Why

First noticed this while bumping react-native-gesture-handler in https://github.com/expo/expo/pull/47783

Gesture Handler 3.x ships its own `android/CMakeLists.txt` for its codegen target and calls `set(CMAKE_CXX_STANDARD 20)` without `CXX_EXTENSIONS OFF`. Since CMake defaults extensions to ON, that target compiles with `-std=gnu++20`, while the shared PCH owner (`appmodules_pch`) is built with React Native's `-std=c++20`. Clang refuses to reuse a precompiled header across C++ dialects, so the build fails. Any project using `usePrecompiledHeaders` together with a library that sets `CMAKE_CXX_STANDARD` in its own CMakeLists hits the same error.

# How

In `add_pch_if_eligible`, pin every PCH consumer target to the owner's dialect before attaching the header. This is safe for targets that do not set a standard themselves given they already compile with -std=c++20 via target_compile_reactnative_options.


# Test Plan

Run BareExpo locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
