### PR TITLE
[media-library][iOS] Allow network access when resolving iCloud-offloaded assets in the modern API

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix resolving iCloud-offloaded assets ("Optimize iPhone Storage"): allow network access when extracting asset URIs so `Asset.getUri()`, `getInfo()`, `getExif()` and `getOrientation()` can download originals from iCloud, matching the legacy API's `shouldDownloadFromNetwork` default. ([#47790](https://github.com/expo/expo/pull/47790) by [@oeddyo](https://github.com/oeddyo))
 - Add `accessPrivileges` to `PermissionResponse` type ([#47177](https://github.com/expo/expo/pull/47177) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix permission guards for limited and write-only photo library access. ([#47216](https://github.com/expo/expo/pull/47216) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/ios/next/objects/asset/Asset.swift
+++ b/packages/expo-media-library/ios/next/objects/asset/Asset.swift
@@ -110,9 +110,11 @@ class Asset: SharedObject {
 
   func getOrientation() async throws -> Int? {
     let phAsset = try await requirePHAsset()
+    let options = PHContentEditingInputRequestOptions()
+    options.isNetworkAccessAllowed = true
     guard
       phAsset.mediaType == .image,
-      let contentEditingInput = try await phAsset.requestContentEditingInput().input
+      let contentEditingInput = try await phAsset.requestContentEditingInput(options: options).input
     else {
       return nil
     }

--- a/packages/expo-media-library/ios/next/objects/asset/UriExtractor.swift
+++ b/packages/expo-media-library/ios/next/objects/asset/UriExtractor.swift
@@ -14,7 +14,9 @@ class UriExtractor {
   }
 
   private static func extract(fromImage phAsset: PHAsset) async throws -> URL {
-    let result = try await phAsset.requestContentEditingInput()
+    let options = PHContentEditingInputRequestOptions()
+    options.isNetworkAccessAllowed = true
+    let result = try await phAsset.requestContentEditingInput(options: options)
     guard let contentEditingInput = result.input else {
       throw FailedToExtractUri("Missing content editing input for image")
     }
@@ -27,6 +29,7 @@ class UriExtractor {
   private static func extract(fromVideo phAsset: PHAsset) async throws -> URL {
     let options = PHVideoRequestOptions()
     options.version = .original
+    options.isNetworkAccessAllowed = true
     let result = try await PHImageManager.default()
       .requestAVAsset(forVideo: phAsset, options: options)
     guard let avAsset = result.asset else {


### PR DESCRIPTION
# Why

Fixes #47789.

On iOS, the modern class-based `expo-media-library` API cannot resolve any asset whose original has been offloaded to iCloud (Settings → Photos → **Optimize iPhone Storage**): `Asset.getUri()`, `getInfo()`, and `getExif()` throw (`Missing content editing input for image` / `Missing fullSizeImageURL for image` / `Missing AVAsset for video`), and `getOrientation()` silently returns `null`.

The legacy API handles the same assets transparently because `getAssetInfoAsync` applies `shouldDownloadFromNetwork` (default `true`) to its PhotoKit request options. The modern API never sets `isNetworkAccessAllowed`, and the platform default is `false` for both `PHContentEditingInputRequestOptions` and `PHVideoRequestOptions` — so apps migrating from `getAssetInfoAsync().localUri` to `asset.getUri()` start hard-failing for every "Optimize iPhone Storage" user.

# How

Set `isNetworkAccessAllowed = true` at the three PhotoKit request sites in the modern API:

- `UriExtractor.extract(fromImage:)` — used by `getUri()`, `getInfo()`, and `getExif()`
- `UriExtractor.extract(fromVideo:)` — used by `getUri()` and `getInfo()`
- `Asset.getOrientation()`

This restores the legacy default and makes the module internally consistent — `LivePhotoVideoUriExtractor` already sets `isNetworkAccessAllowed = true` for paired Live Photo videos. `Asset.getIsInCloud()` intentionally keeps the flag `false` (it is the cheap "is this offloaded?" probe and must not trigger a download); this PR does not touch it.

**On API parity with legacy's `shouldDownloadFromNetwork`:** the only use case for passing `false` in the legacy API was detecting an iCloud-offloaded asset without downloading it (checking `isNetworkAsset` in the result). The modern API already covers that with the dedicated `getIsInCloud()` method, so this PR restores just the default rather than adding a per-call boolean. If per-call download control is wanted in the modern API, an explicit `asset.download({ onProgress })` (PhotoKit's `progressHandler` is available on these request options) would compose better with `getIsInCloud()` than a throwing opt-out on `getUri()` — happy to follow up on that separately if there's interest.

# Test Plan

- Repro app from #47789: https://github.com/oeddyo/rn-icloud-download — on a physical iPhone with iCloud Photos + Optimize iPhone Storage, it finds an offloaded asset via `getIsInCloud()`, then demonstrates `getUri()`/`getInfo()` throwing while legacy `getAssetInfoAsync()` succeeds on the same asset.
- The failure mechanism and this fix were verified against the PhotoKit request-option defaults (`isNetworkAccessAllowed == false` for `PHContentEditingInputRequestOptions`, `PHVideoRequestOptions`, and `PHImageRequestOptions`, checked empirically against the Photos framework) and against the legacy implementation's use of `shouldDownloadFromNetwork` (`MediaLibraryModule.swift` image and video paths).
- Behavior is not reproducible on simulators (no iCloud Photos), so CI cannot exercise it; I can provide before/after logs from a physical device run of the repro app with this patch applied if helpful.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (iOS-only change; no TypeScript sources affected, so no rebuild output)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no config plugin changes)
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (no docs changes)
