### PR TITLE
[android] Set CMAKE_OBJECT_PATH_MAX=1024 default for CMake modules

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
 - [Android] Apply the `android.cmakeVersion` build property to the app and all library subprojects. ([#47377](https://github.com/expo/expo/pull/47377) by [@zoontek](https://github.com/zoontek))
 - Add option to specify targets to use with inline modules ([#46698](https://github.com/expo/expo/pull/46698) by [@HubertBer](https://github.com/HubertBer))
 - Added support for compile-only inline module files, which are compiled into the target without being registered as Expo modules. ([#46969](https://github.com/expo/expo/pull/46969) by [@behenate](https://github.com/behenate))

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/README.md
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/README.md
@@ -21,6 +21,28 @@ Responsibilities:
 - Add previously linked modules to the dependency graph.
 - Create a task that will generate the package list file.
 
+### `expo-root-project`
+
+This plugin should be applied to the root `build.gradle` file of the application (the project templates already do this). It configures defaults that apply to the app and all of its modules.
+
+Responsibilities:
+- Define default versions shared across all projects (`compileSdkVersion`, `minSdkVersion`, `targetSdkVersion`, `buildToolsVersion`, `ndkVersion`, `kotlinVersion`, `kspVersion`), sourced from React Native's version catalog when available.
+- Skip lint-vital analysis for autolinked native modules unless linting is enabled with the `expo.android.enableLint` Gradle property or the `EXPO_ANDROID_ENABLE_LINT` environment variable.
+- Override the CMake version for every module when the `android.cmakeVersion` Gradle property is set.
+- Set `CMAKE_OBJECT_PATH_MAX=1024` for every module that builds native code with CMake. CMake limits the length of object file paths (250 characters on Windows, 1000 elsewhere) and fails the build when paths exceed the limit, which commonly happens on Windows with deeply nested project structures such as pnpm monorepos.
+
+The `expo.android.cmakeObjectPathMax` Gradle property controls the `CMAKE_OBJECT_PATH_MAX` value:
+
+| Value | Behavior |
+| --- | --- |
+| Unset or empty | Uses the default of `1024` |
+| Integer greater than or equal to `128` (CMake's minimum) | Uses the given value |
+| `0` | Opts out; keeps CMake's platform defaults |
+
+Set the property in the app's `gradle.properties` file, for example `expo.android.cmakeObjectPathMax=2048`, or pass it on the command line with `-Pexpo.android.cmakeObjectPathMax=2048`. A module that passes its own `-DCMAKE_OBJECT_PATH_MAX` argument in `externalNativeBuild.cmake.arguments` overrides the value for that module, since its argument comes later on the CMake command line.
+
+The limit is CMake's generate-time prediction of the longest object file path the tools it generates build files for (Ninja, the compiler, the archiver) can handle. CMake can't know their real limits, so it uses a hardcoded conservative guess and fails preemptively, even when those tools support longer paths. Raising `CMAKE_OBJECT_PATH_MAX` removes only that guess; when the tools genuinely can't handle long paths on Windows (the Android Gradle plugin's default CMake 3.22.1 bundles a version of Ninja without long-path support), set the `android.cmakeVersion` Gradle property to select a newer CMake whose Ninja handles long paths.
+
 ### `shared`
 
 This project contains common code for both plugins.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
@@ -20,6 +20,7 @@ class ExpoRootProjectPlugin : Plugin<Project> {
     with(rootProject) {
       defineDefaultProperties(libs)
       maybeOverrideCmakeVersion()
+      setDefaultCmakeObjectPathMax()
       disableLinkedModulesLintWhenRequested()
     }
   }
@@ -47,6 +48,74 @@ private fun Project.maybeOverrideCmakeVersion() {
     subproject.plugins.withId("com.android.library") { applyCmakeVersion(subproject) }
   }
 }
+
+/**
+ * Raises the maximum object file path length CMake allows before it warns and eventually fails
+ * the build. CMake's default is 250 characters on Windows and 1000 elsewhere, and deeply nested
+ * project structures (a home folder plus `node_modules`, or a pnpm virtual store) commonly
+ * exceed the Windows limit. 1024 is the safe maximum on macOS; Windows needs long paths support,
+ * which is commonly enabled, and Linux typically allows 4096.
+ *
+ * The limit is CMake's generate-time prediction of the longest object file path the tools it
+ * generates build files for (Ninja, the compiler, the archiver) can handle. CMake can't know
+ * their real limits, so it uses a hardcoded conservative guess and fails preemptively, even
+ * when those tools support longer paths. Raising it removes only that guess; when the tools
+ * genuinely can't handle long paths on Windows (AGP's default CMake 3.22.1 bundles a version
+ * of Ninja without long-path support), the `android.cmakeVersion` property read by
+ * [maybeOverrideCmakeVersion] selects a newer CMake whose Ninja handles long paths.
+ *
+ * Setting the value here, on the root project, applies it to every module that builds native
+ * code with CMake, so individual libraries don't need to set it themselves. A library that
+ * passes its own `-DCMAKE_OBJECT_PATH_MAX` still wins: its argument comes later on the CMake
+ * command line.
+ *
+ * The `expo.android.cmakeObjectPathMax` Gradle property controls the value: when the property
+ * is unset or empty, the default of 1024 applies; `0` opts out and keeps CMake's platform
+ * defaults; any other value must be an integer greater than or equal to 128, CMake's minimum.
+ */
+internal fun Project.setDefaultCmakeObjectPathMax() {
+  val objectPathMax = cmakeObjectPathMax() ?: return
+
+  allprojects { project ->
+    // "com.android.base" is applied by both the Android application and library plugins
+    project.pluginManager.withPlugin("com.android.base") {
+      project.extensions.findByType(CommonExtension::class.java)
+        ?.defaultConfig
+        ?.externalNativeBuild
+        ?.cmake
+        ?.arguments
+        ?.add("-DCMAKE_OBJECT_PATH_MAX=$objectPathMax")
+    }
+  }
+}
+
+/**
+ * Reads and validates the `expo.android.cmakeObjectPathMax` Gradle property. Returns null when
+ * the property is set to `0`, which opts out of setting `CMAKE_OBJECT_PATH_MAX` entirely.
+ */
+internal fun Project.cmakeObjectPathMax(): Int? {
+  val rawValue = (findProperty(CMAKE_OBJECT_PATH_MAX_PROPERTY) as? String)?.trim()
+  if (rawValue.isNullOrEmpty()) {
+    return DEFAULT_CMAKE_OBJECT_PATH_MAX
+  }
+
+  val value = rawValue.toIntOrNull()
+  if (value == 0) {
+    return null
+  }
+  if (value == null || value < 128) {
+    logger.warn(
+      "The \"$CMAKE_OBJECT_PATH_MAX_PROPERTY\" Gradle property is set to \"$rawValue\", which is not a valid value for CMAKE_OBJECT_PATH_MAX " +
+        "because CMake requires an integer greater than or equal to 128. Using a recommended value of $DEFAULT_CMAKE_OBJECT_PATH_MAX instead. " +
+        "Set the property to an integer greater than or equal to 128, remove it to use $DEFAULT_CMAKE_OBJECT_PATH_MAX (recommended), or set it to 0 to keep CMake's defaults."
+    )
+    return DEFAULT_CMAKE_OBJECT_PATH_MAX
+  }
+  return value
+}
+
+private const val CMAKE_OBJECT_PATH_MAX_PROPERTY = "expo.android.cmakeObjectPathMax"
+private const val DEFAULT_CMAKE_OBJECT_PATH_MAX = 1024
 
 /**
  * Determines whether autolinked native modules should be linted when building the release version


### PR DESCRIPTION
Why
===
CMake limits object file paths to 250 characters on Windows and 1000 elsewhere; builds that exceed the limit get a warning and eventually fail. The limit is CMake's guess at the longest path the downstream tools (Ninja, the compiler, the archiver) can handle; CMake can't know their real limits, so it guesses conservatively and fails preemptively, even when the tools support longer paths.

Deeply nested paths like a pnpm virtual store commonly exceed the Windows limit and `react-native-reanimated` and `react-native-worklets` had this problem, too.

Each Android module that builds native code runs its own CMake configure, so fixing this per library (as #39662 proposed for `expo-modules-core`) would require the same change from every affected library author. Every SDK 53+ project applies `expo-root-project` in its root `build.gradle`, so modern projects will pick this up with a package upgrade and library authors don't need to do anything.

There are two parts to this Windows long-path problem (#36274): the toolchain programs (like Ninja) need to support longer file paths, and CMake needs to stop blocking longer file paths:
- PR #47377 addressed the toolchain part. AGP's default CMake 3.22.1 bundles a Ninja without long-path support, and the opt-in `android.cmakeVersion` build property selects a newer CMake.
- This PR addresses CMake's check.

How
===
A new `expo.android.cmakeObjectPathMax` Gradle property controls CMake's `CMAKE_OBJECT_PATH_MAX`:

| `expo.android.cmakeObjectPathMax` | Behavior                                                  |
| --------------------------------- | --------------------------------------------------------- |
| Unset or empty                    | Uses the default of `1024`                                |
| `0`                               | Opts out; keeps CMake's platform defaults                 |
| Integer ≥ `128` (CMake's minimum) | Uses that value                                           |
| Anything else                     | Logs a warning and falls back to the default of `1024`    |

`ExpoRootProjectPlugin` adds `-DCMAKE_OBJECT_PATH_MAX=1024` to `defaultConfig.externalNativeBuild.cmake.arguments` for every subproject that applies an Android plugin. PR #47377 overrides the CMake version the same way.

The injection runs when a module applies the Android plugin, before the module's own `android` block. This means a library that passes its own `-DCMAKE_OBJECT_PATH_MAX` argument can override our default since the library's argument comes later on the CMake command line.

A note on 1024: macOS limits paths to 1024 bytes (`PATH_MAX`), so we can't go higher there. CMake already allowed 1000 on Mac and Linux, so this barely changes anything for them; the real point is to raise the 250-character limit on Windows.

Test Plan
===
Ran `configureCMakeDebug[arm64-v8a]` in bare-expo and confirmed `-DCMAKE_OBJECT_PATH_MAX=1024` appears in the generated `.cxx/**/metadata_generation_command.txt` for `expo-modules-core`, `react-native-worklets`, and the app module, none of which set the value themselves.

Verified `-Pexpo.android.cmakeObjectPathMax=2048` changes the injected value, `-Pexpo.android.cmakeObjectPathMax=0` omits the argument entirely, and `-Pexpo.android.cmakeObjectPathMax=abc` logs a warning and falls back to the default of 1024.

Ran `et check-packages expo-modules-autolinking`, which passed.

