### PR TITLE
[dev-launcher] Surface dev server error responses instead of a generic connectivity message

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Surface the development server's error response (e.g. an expo-updates code signing misconfiguration) when loading an app fails with a non-2xx manifest response, instead of a generic connectivity message. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ciospettw](https://github.com/ciospettw))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -27,10 +27,45 @@ class DevLauncherManifestParser(
   private suspend fun downloadManifest(): Reader {
     val response = fetch(url, "GET", getHeaders()).await(httpClient)
     if (!response.isSuccessful) {
-      throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.")
+      // Surface the server-provided error instead of blaming connectivity: the dev
+      // server reached us and answered, so this is not a networking failure. Expo CLI
+      // responds with a JSON body ({"error": "..."}) explaining exactly what went
+      // wrong (e.g. a code signing misconfiguration), which used to be discarded here.
+      @Suppress("DEPRECATION_ERROR")
+      val serverMessage = serverErrorMessageFromResponseBody(response.body()?.string())
+      val message = if (serverMessage != null) {
+        "The development server responded with status code ${response.code()}:\n\n$serverMessage"
+      } else {
+        "The development server responded with status code ${response.code()}.\n\nIf you are trying to load the app from a development server, check the server logs for errors.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps."
+      }
+      throw Exception(message)
     }
     @Suppress("DEPRECATION_ERROR")
     return response.body()!!.charStream()
+  }
+
+  /**
+   * Extract a human-readable error message from a dev server error response body.
+   * Expo CLI returns JSON like {"error": "..."}; fall back to a short plain-text body.
+   */
+  private fun serverErrorMessageFromResponseBody(body: String?): String? {
+    if (body.isNullOrBlank()) {
+      return null
+    }
+    try {
+      val json = JSONObject(body)
+      val error = json.optString("error").ifEmpty { json.optString("message") }
+      if (error.isNotEmpty()) {
+        return error
+      }
+    } catch (_: Exception) {
+      // not JSON — fall through to plain text handling
+    }
+    // Only use plain-text bodies that are short enough to be a message rather than an HTML page.
+    if (body.length <= 1024 && !body.contains("<html")) {
+      return body.trim()
+    }
+    return null
   }
 
   suspend fun parseManifest(): Manifest {

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -75,7 +75,17 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
       NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
       if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
-        NSString *message = @"Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.";
+        // Surface the server-provided error instead of blaming connectivity: the dev
+        // server reached us and answered, so this is not a networking failure. Expo CLI
+        // responds with a JSON body ({"error": "..."}) explaining exactly what went
+        // wrong (e.g. a code signing misconfiguration), which used to be discarded here.
+        NSString *serverMessage = [EXDevLauncherManifestParser serverErrorMessageFromResponseBody:data];
+        NSString *message;
+        if (serverMessage) {
+          message = [NSString stringWithFormat:@"The development server responded with status code %ld:\n\n%@", (long)httpResponse.statusCode, serverMessage];
+        } else {
+          message = [NSString stringWithFormat:@"The development server responded with status code %ld.\n\nIf you are trying to load the app from a development server, check the server logs for errors.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.", (long)httpResponse.statusCode];
+        }
         onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: message}]);
         return;
       }
@@ -96,6 +106,33 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   }];
 }
 
+
+/**
+ * Extract a human-readable error message from a dev server error response body.
+ * Expo CLI returns JSON like {"error": "..."}; fall back to a short plain-text body.
+ */
++ (nullable NSString *)serverErrorMessageFromResponseBody:(nullable NSData *)data
+{
+  if (data.length == 0) {
+    return nil;
+  }
+
+  NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+  if ([jsonObject isKindOfClass:[NSDictionary class]]) {
+    id errorValue = jsonObject[@"error"] ?: jsonObject[@"message"];
+    if ([errorValue isKindOfClass:[NSString class]] && [(NSString *)errorValue length] > 0) {
+      return errorValue;
+    }
+  }
+
+  // Only use plain-text bodies that are short enough to be a message rather than an HTML page.
+  NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  if (text.length > 0 && text.length <= 1024 && ![text containsString:@"<html"]) {
+    return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  }
+
+  return nil;
+}
 
 - (void)_fetch:(NSString *)method onError:(OnManifestError)onError completionHandler:(CompletionHandler)completionHandler
 {


### PR DESCRIPTION
Closes #47814.

Minimal reproducible example: https://github.com/ciospettw/repro-expo-cli-privatekey

# Why

When a manifest request returns a non-2xx status, the dev launcher discards the response body and reports a fixed *"check your network connectivity"* message. But a server that answered with a status code is reachable, and Expo CLI fills that body with a precise explanation (`{"error": "CommandError: …"}`). The real cause is hidden behind a networking message.

### The smoking gun: two entry points, two different error handlers

The same `loadApp` call, with the same error, is reported completely differently depending on how the app was opened — which is why the same URL "fails to connect" from the server list / manual URL entry but shows a real error from a dev-client deep link:

- Manual URL entry / server list → `DevLauncherViewModel.openApp` (SDK 55):
  ```swift
  onError: { [weak self] _ in
    let message = "Failed to connect to \(url)"   // the NSError is discarded (`_`)
  ```
- Dev-client deep link → `EXDevLauncherController.onDeepLink`:
  ```objc
  onError:^(NSError *error) {
    NSString *errorMessage = [NSString stringWithFormat:@"Failed to load app from %@ with error: %@",
                              appUrl.absoluteString, error.localizedDescription];  // shows the real error
  ```

On `main`, `openApp` was improved (#46866) to route through `DevLauncherLoadErrorMessage`, but the underlying manifest parser still throws a fixed message and never reads the body on either platform, so the server's own message is still lost:

- iOS: `EXDevLauncherManifestParser.m` `tryToParseManifest` — fixed message on non-2xx, `data` discarded.
- Android: `DevLauncherManifestParser.kt` `downloadManifest` — same.

Real-world impact: a code-signing misconfiguration (server responded 500 with `Must specify --private-key-path…`) presented as "Failed to connect to http://172.20.10.4:8081", sending debugging toward the network for hours.

# How

In both platforms' manifest parsers, on a non-2xx response read the body and extract a human-readable message (JSON `error`/`message` field, falling back to a short non-HTML plain-text body), then include the status code and that message in the thrown error. Fall back to a status-code message that no longer blames the network when the body has nothing usable.

# Test Plan

- Code-signing-enabled dev client + `expo start --dev-client` missing the signing private key (server returns 500 with `{"error": "Must specify --private-key-path…"}`):
  - Before: "Failed to open app / check your network connectivity" (SDK 55: "Failed to connect to <url>").
  - After: *"The development server responded with status code 500: Must specify --private-key-path argument to sign development manifest for requested code signing key"*.
- A genuine connectivity failure (server not running) still produces a transport error (`NSURLErrorDomain` / `IOException`) and is unaffected.
- 2xx responses unchanged.

# Checklist

- Changelog entry added under **Unpublished → 🐛 Bug fixes** in `packages/expo-dev-launcher/CHANGELOG.md`.
- Both iOS and Android covered. Follow-up: unit tests for the body-parsing helper (JSON `error`, plain text, HTML page, empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
