### PR TITLE
[dev-launcher] Use `https` for `exp://` tunnel URLs (`*.exp.direct`)

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Map `exp://` URLs pointing at tunnel hosts (`*.exp.direct`) to `https` instead of cleartext `http`, matching the scheme Expo CLI uses for tunnel manifest URLs and avoiding iOS App Transport Security blocks. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ciospettw](https://github.com/ciospettw))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherURLHelper.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherURLHelper.kt
@@ -4,6 +4,11 @@ import android.net.Uri
 
 fun replaceEXPScheme(uri: Uri, scheme: String): Uri = if (uri.scheme == "exp") uri.buildUpon().scheme(scheme).build() else uri
 
+// Tunnel hosts (e.g. `*.exp.direct`) are served over TLS, so `exp://` tunnel URLs
+// must map to `https` — matching the scheme the Expo CLI uses for tunnel manifest
+// URLs — while LAN/localhost dev servers keep using `http`.
+fun packagerScheme(uri: Uri): String = if (uri.host?.endsWith(".exp.direct") == true) "https" else "http"
+
 fun isDevLauncherUrl(uri: Uri) = uri.host == "expo-development-client"
 
 fun hasUrlQueryParam(uri: Uri): Boolean {
@@ -21,10 +26,10 @@ class DevLauncherUrl(var url: Uri) {
     if (isDevLauncherUrl(url)) {
       if (queryParams["url"] != null) {
         val queryUrl = Uri.parse(queryParams["url"])
-        url = replaceEXPScheme(queryUrl, "http")
+        url = replaceEXPScheme(queryUrl, packagerScheme(queryUrl))
       }
     } else {
-      url = replaceEXPScheme(url, "http")
+      url = replaceEXPScheme(url, packagerScheme(url))
     }
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -18,9 +18,15 @@ public class EXDevLauncherUrl: NSObject {
     if EXDevLauncherURLHelper.isDevLauncherURL(url),
       let urlParam = queryParams["url"],
       let urlFromParam = URL(string: urlParam) {
-      self.url = EXDevLauncherURLHelper.replaceEXPScheme(urlFromParam, to: "http")
+      self.url = EXDevLauncherURLHelper.replaceEXPScheme(
+        urlFromParam,
+        to: EXDevLauncherURLHelper.packagerScheme(for: urlFromParam)
+      )
     } else {
-      self.url = EXDevLauncherURLHelper.replaceEXPScheme(url, to: "http")
+      self.url = EXDevLauncherURLHelper.replaceEXPScheme(
+        url,
+        to: EXDevLauncherURLHelper.packagerScheme(for: url)
+      )
     }
 
     super.init()
@@ -58,6 +64,19 @@ public class EXDevLauncherURLHelper: NSObject {
     if shouldDisable {
       DevMenuPreferences.isOnboardingFinished = true
     }
+  }
+
+  // Tunnel hosts (e.g. `*.exp.direct`) are served over TLS, and iOS App Transport
+  // Security blocks cleartext HTTP to remote hosts. Map `exp://` tunnel URLs to
+  // `https` — matching the scheme the Expo CLI already uses for tunnel manifest
+  // URLs (`UrlCreator.constructDevClientUrl`) — while LAN/localhost dev servers
+  // keep using `http`.
+  @objc
+  public static func packagerScheme(for url: URL) -> String {
+    if url.host?.hasSuffix(".exp.direct") == true {
+      return "https"
+    }
+    return "http"
   }
 
   @objc


### PR DESCRIPTION
Closes #47815.

Minimal reproducible example: https://github.com/ciospettw/repro-expo-cli-privatekey

# Why

`EXDevLauncherUrl` (iOS) and `DevLauncherUrl` (Android) rewrite `exp://` to `http://` unconditionally:

```swift
self.url = EXDevLauncherURLHelper.replaceEXPScheme(urlFromParam, to: "http")
```

For LAN/localhost this is correct, but tunnel hosts (`*.exp.direct`, from `expo start --tunnel`) are served over TLS. Expo CLI itself generates **https** manifest URLs for tunnels:

```ts
// UrlCreator.constructDevClientUrl
scheme: this.defaults?.hostType === 'tunnel' ? 'https' : 'http',
```

so the two sides disagree on the scheme for the same host.

On iOS this is not just aesthetic — it fails. Expo's default `Info.plist` (both `templates/expo-template-bare-minimum` and the `expo prebuild` output) sets:

```xml
<key>NSAppTransportSecurity</key>
<dict>
  <key>NSAllowsArbitraryLoads</key><false/>
  <key>NSAllowsLocalNetworking</key><true/>
</dict>
```

Cleartext HTTP is allowed to local hosts but blocked to remote hosts. A tunnel host is remote, so the downgraded `http://xxxxx.exp.direct` request is blocked by App Transport Security. This is exactly why LAN `exp://` URLs keep working while tunnel `exp://` URLs fail.

# How

Add a `packagerScheme` helper that returns `https` for `*.exp.direct` hosts and `http` otherwise, and use it where `DevLauncherUrl` currently hardcodes `"http"`, on both platforms. LAN/localhost behavior is unchanged.

# Test Plan

- `npx expo start --dev-client --tunnel`; open `exp://<host>.exp.direct` on device.
  - Before: fails on iOS (cleartext to a TLS-only remote host, blocked by ATS given the default `NSAllowsArbitraryLoads=false` / `NSAllowsLocalNetworking=true`).
  - After: resolves to `https://<host>.exp.direct` and loads.
- LAN: `exp://192.168.1.10:8081` still maps to `http://192.168.1.10:8081` (unchanged; allowed by `NSAllowsLocalNetworking`).

# Checklist

- Changelog entry added under **Unpublished → 🐛 Bug fixes** in `packages/expo-dev-launcher/CHANGELOG.md`.
- Both iOS and Android covered. Follow-up: extend `EXDevLauncherURLHelperTests.swift` / `DevLauncherURLHelperTest.kt` with a tunnel-host case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
