### PR TITLE
[web][expo] Fix getBundleUrl returning null after script execution

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fix `asyncRoutes` failing on Android and iOS with `Requiring unknown module` ([#46870](https://github.com/expo/expo/pull/46870) by [@hassankhan](https://github.com/hassankhan))
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
-- Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports).
+- Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fix `asyncRoutes` failing on Android and iOS with `Requiring unknown module` ([#46870](https://github.com/expo/expo/pull/46870) by [@hassankhan](https://github.com/hassankhan))
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
-- Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47754](https://github.com/expo/expo/issues/47754) by [@zoontek](https://github.com/zoontek))
+- Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports).
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix `asyncRoutes` failing on Android and iOS with `Requiring unknown module` ([#46870](https://github.com/expo/expo/pull/46870) by [@hassankhan](https://github.com/hassankhan))
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
+- Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47754](https://github.com/expo/expo/issues/47754) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo/src/utils/__tests__/getBundleUrl.test.web.ts
+++ b/packages/expo/src/utils/__tests__/getBundleUrl.test.web.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+function setCurrentScript(src: string | null) {
+  Object.defineProperty(document, 'currentScript', {
+    configurable: true,
+    value: src == null ? null : Object.assign(document.createElement('script'), { src }),
+  });
+}
+
+// The web test project runs this file in jsdom, the node project on the server.
+// `getBundleUrl` reads `document.currentScript`, so only assert in the browser.
+if (typeof window === 'undefined') {
+  it('noop', () => {});
+} else {
+  afterEach(() => {
+    setCurrentScript(null);
+    jest.resetModules();
+  });
+
+  it('returns the bundle URL while the script is executing synchronously', () => {
+    setCurrentScript('https://localhost:8081/index.bundle?platform=web');
+    const { getBundleUrl } = require('../getBundleUrl');
+    expect(getBundleUrl()).toBe('https://localhost:8081/index.bundle');
+  });
+
+  it('still returns the bundle URL after the script finished executing', () => {
+    setCurrentScript('https://localhost:8081/index.bundle?platform=web');
+    const { getBundleUrl } = require('../getBundleUrl');
+    setCurrentScript(null);
+    expect(getBundleUrl()).toBe('https://localhost:8081/index.bundle');
+  });
+}

--- a/packages/expo/src/utils/getBundleUrl.web.ts
+++ b/packages/expo/src/utils/getBundleUrl.web.ts
@@ -1,21 +1,22 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// `document.currentScript` is only set during synchronous script execution, so we capture its URL
+// at module load; reading it later (effect, async, dynamic import) would see `null`.
+const initialScriptURL: string | null =
+  typeof window !== 'undefined' ? (document.currentScript as HTMLScriptElement)?.src : null;
+
 export function getBundleUrl(): string | null {
-  let scriptURL: string | null | undefined = null;
+  let scriptURL: string | null = initialScriptURL;
 
   if (typeof window === 'undefined') {
     // For server runtime, we use the filename of the current script
-    // @ts-ignore The react-native tsconfig doesn't support CJS
     scriptURL = 'file://' + __filename;
-  } else {
-    // TODO: Try to support `import.meta.url` when the ecosystem supports ESM,
-    // and jest doesn't throw SyntaxError when accessing `import.meta`.
-    scriptURL = (document.currentScript as HTMLScriptElement)?.src;
   }
 
   if (scriptURL == null) {
     return null;
   }
+
   const url = new URL(scriptURL);
   return `${url.protocol}//${url.host}${url.pathname}`;
 }


### PR DESCRIPTION
# Why

On web, `import.meta.url` was `null` when read after the bundle's synchronous execution (effects, async code, dynamic imports). It comes from `getBundleUrl()`, which read `document.currentScript` on every call, but that's only set while the script runs synchronously, so later reads returned `null`.

Fixes [#47754](https://github.com/expo/expo/issues/47754).

# How

Read `document.currentScript?.src` once at module load and cache it; reuse it on every `getBundleUrl()` call. The server branch is unchanged.

# Test Plan

Added `getBundleUrl.test.web.ts`. The key case clears `document.currentScript` before calling `getBundleUrl()` - it fails against the old per-call read, passes now.

```
$ jest src/utils/__tests__/getBundleUrl.test.web.ts
Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
