### PR TITLE
[expo-calendar][ios] Fix MissingPermissionsException typo

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `@platform ios` JSDoc annotations to iOS-exclusive APIs: `ExpoCalendarReminder` class, `listReminders()`, `createReminder()`, `requestRemindersPermissions()`, `getRemindersPermissions()`, `useRemindersPermissions()`, `AddEventWithFormOptions.url`, and `AddEventWithFormOptions.alarms`. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - Throw `UnavailabilityError` when iOS-only Reminders and Sources APIs (`listReminders()`, `createReminder()`, `ExpoCalendarReminder.get/update/delete`, `requestRemindersPermissions()`, `getRemindersPermissions()`, and `getSourcesSync()`) are called on non-iOS platforms. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - Return a denied permission response from `useRemindersPermissions()` on non-iOS platforms instead of throwing. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
-- [ios] Fix typo in the internal permissions exception name (`MissionPermissionsException` -> `MissingPermissionsException`), which corrects the error code surfaced to JS from `ERR_MISSION_PERMISSIONS` to `ERR_MISSING_PERMISSIONS`. ([#PLACEHOLDER](https://github.com/expo/expo/pull/PLACEHOLDER) by [@conanm](https://github.com/conanm))
+- [ios] Fix typo in the internal permissions exception name (`MissionPermissionsException` -> `MissingPermissionsException`), which corrects the error code surfaced to JS from `ERR_MISSION_PERMISSIONS` to `ERR_MISSING_PERMISSIONS`. ([#47804](https://github.com/expo/expo/pull/47804) by [@conanm](https://github.com/conanm))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `@platform ios` JSDoc annotations to iOS-exclusive APIs: `ExpoCalendarReminder` class, `listReminders()`, `createReminder()`, `requestRemindersPermissions()`, `getRemindersPermissions()`, `useRemindersPermissions()`, `AddEventWithFormOptions.url`, and `AddEventWithFormOptions.alarms`. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - Throw `UnavailabilityError` when iOS-only Reminders and Sources APIs (`listReminders()`, `createReminder()`, `ExpoCalendarReminder.get/update/delete`, `requestRemindersPermissions()`, `getRemindersPermissions()`, and `getSourcesSync()`) are called on non-iOS platforms. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - Return a denied permission response from `useRemindersPermissions()` on non-iOS platforms instead of throwing. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
+- [ios] Fix typo in the internal permissions exception name (`MissionPermissionsException` -> `MissingPermissionsException`), which corrects the error code surfaced to JS from `ERR_MISSION_PERMISSIONS` to `ERR_MISSING_PERMISSIONS`. ([#PLACEHOLDER](https://github.com/expo/expo/pull/PLACEHOLDER) by [@conanm](https://github.com/conanm))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/CalendarExceptions.swift
+++ b/packages/expo-calendar/ios/CalendarExceptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-final internal class MissionPermissionsException: GenericException<String> {
+final internal class MissingPermissionsException: GenericException<String> {
   override var reason: String {
     "\(param) permission is required to do this operation"
   }

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -457,7 +457,7 @@ public class CalendarModule: Module {
     }
     if let requester, !permissionsManager.hasGrantedPermission(usingRequesterClass: requester) {
       let message = requester.permissionType().uppercased()
-      throw MissionPermissionsException(message)
+      throw MissingPermissionsException(message)
     }
 
     resetEventStoreIfPermissionWasChanged(entity: entity)

--- a/packages/expo-calendar/ios/Next/CalendarAccessGuard.swift
+++ b/packages/expo-calendar/ios/Next/CalendarAccessGuard.swift
@@ -64,7 +64,7 @@ public class CalendarAccessGuard {
     }
 
     if !permissionsManager.hasGrantedPermission(usingRequesterClass: requester) {
-      throw MissionPermissionsException(permissionName)
+      throw MissingPermissionsException(permissionName)
     }
 
     resetEventStoreIfPermissionWasChanged(entity: entity)


### PR DESCRIPTION
# Why

The internal iOS exception class is misspelled: `MissionPermissionsException` (should be `Missing`). `expo-modules-core` derives the JS error `code` from the exception class name (`errorCodeFromString`), so this typo leaks all the way to app code — the permission error surfaces as **`ERR_MISSION_PERMISSIONS`** instead of `ERR_MISSING_PERMISSIONS`. Apps matching on that code have to hardcode the misspelling.

# How

Rename the class and its two throw sites (`CalendarModule.swift`, `Next/CalendarAccessGuard.swift`). The class is `internal`, so the Swift surface is unaffected — but the rename also corrects the derived JS error code from `ERR_MISSION_PERMISSIONS` → `ERR_MISSING_PERMISSIONS`.

Since that error-code string is observable from JS, I noted the change in the changelog under **🐛 Bug fixes**. Happy to move it to **🛠 Breaking changes** if you consider the derived code part of the public contract.

# Test Plan

Mechanical rename — one class definition + two throw sites, verified there are no remaining `Mission` references in `packages/expo-calendar/ios`. No behavior change beyond the corrected code string.

# Checklist

- [x] Updated the changelog for [any user-facing changes](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelog.md).