### PR TITLE
[sdk-56][ci][eas] Pin pnpm to 10.34.5 in EAS CI workflows (#47742 backport)

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
@@ -1,5 +1,9 @@
 name: E2E Test Suite for Expo Brownfield
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch: {}
   push:

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -1,5 +1,9 @@
 name: Smoke Test Precompiled iOS XCFrameworks
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch:
     inputs:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -27,6 +27,7 @@ concurrency:
 defaults:
   tools:
     node: 22.14.0
+    pnpm: '10.34.5'
 
 jobs:
   detect_platform:

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
@@ -1,5 +1,9 @@
 name: Test Suite Brownfield Integrated
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   workflow_dispatch: {}
   pull_request:

--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -1,5 +1,9 @@
 name: TV compile test
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (bricking measures disabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (CLI)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (custom init)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (dev client)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (disabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (enabled)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (error recovery)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (fingerprint)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -1,5 +1,9 @@
 name: Updates E2E (startup)
 
+defaults:
+  tools:
+    pnpm: '10.34.5'
+
 on:
   push:
     branches: [main, 'sdk-*']


### PR DESCRIPTION
# Why

Backport of #47742 (`4b9756342`) to the release branch.

Every EAS workflow run triggered from this branch fails at the "Install node modules" step. The EAS image now defaults to pnpm 11.9.0, while this branch's `pnpm-lock.yaml` was generated with pnpm 10, which reads the root `package.json` `resolutions` field as overrides. pnpm 11 no longer reads overrides from `package.json` (pnpm/pnpm#11536), so `pnpm install --frozen-lockfile` computes an empty overrides set, sees it differs from the lockfile, and fails with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

A single push to this branch currently burns ~11 red EAS workflow runs.

# How

Cherry-pick of #47742: adds `defaults.tools.pnpm: '10.34.5'` (latest pnpm 10) to all 14 workflow files under `apps/expo-workflow-testing/.eas/workflows/`, so EAS installs with the same pnpm major that generated the lockfile. Applied cleanly with no conflicts.

Note: regenerating the lockfile with pnpm 11 would NOT be a safe alternative — pnpm 11 ignores the `resolutions`-declared overrides, so a regenerated lockfile would silently drop all version pins.

# Test Plan

The same change is proven on `main`: since #47742 landed, workflow runs there install with the log line `Installing pnpm@10.34.5` and pass the install step (e.g. TV compile green on `4b9756342`). These workflows trigger on push to `sdk-*`, so the backport takes effect on the next push to this branch — the `Installing pnpm@10.34.5` line in the install step is the verification signal.

# Checklist

- CI/workflow-config only; no package code, so no CHANGELOG entry.
- Not applicable to `npx expo prebuild` / EAS Build app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
