### PR TITLE
[android][media-library] Fix createAssetAsync failing for files larger than ~2 GB

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix resolving iCloud-offloaded assets ("Optimize iPhone Storage"): allow network access when extracting asset URIs so `Asset.getUri()`, `getInfo()`, `getExif()` and `getOrientation()` can download originals from iCloud, matching the legacy API's `shouldDownloadFromNetwork` default. ([#47790](https://github.com/expo/expo/pull/47790) by [@oeddyo](https://github.com/oeddyo))
+- [Android] Fix saving files larger than ~2 GB (e.g. `createAssetAsync` with large videos) failing with "Unable to copy file into external storage" by looping `FileChannel.transferTo` until the whole file is copied. ([#47811](https://github.com/expo/expo/pull/47811) by [@jiunshinn](https://github.com/jiunshinn))
 - Add `accessPrivileges` to `PermissionResponse` type ([#47177](https://github.com/expo/expo/pull/47177) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix permission guards for limited and write-only photo library access. ([#47216](https://github.com/expo/expo/pull/47216) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/FileChannelExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/FileChannelExtensions.kt
@@ -1,0 +1,19 @@
+package expo.modules.medialibrary
+
+import java.nio.channels.FileChannel
+import java.nio.channels.WritableByteChannel
+
+// A single transferTo copies at most ~2.147 GB (the sendfile(2) 0x7ffff000 cap), so loop until the
+// whole file is copied or the transfer stalls; otherwise larger files silently truncate (expo/expo#47767).
+fun FileChannel.transferAllTo(destination: WritableByteChannel): Long {
+  val size = size()
+  var position = 0L
+  while (position < size) {
+    val transferred = transferTo(position, size - position, destination)
+    if (transferred <= 0L) {
+      break
+    }
+    position += transferred
+  }
+  return position
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -70,7 +70,7 @@ object MediaLibraryUtils {
     }
     FileInputStream(src).channel.use { input ->
       FileOutputStream(newFile).channel.use { output ->
-        val transferred = input.transferTo(0, input.size(), output)
+        val transferred = input.transferAllTo(output)
         if (transferred != input.size()) {
           newFile.delete()
           throw IOException("Could not save file to $destDir Not enough space.")

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
@@ -17,6 +17,7 @@ import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.UnableToLoadPermissionException
 import expo.modules.medialibrary.UnableToSaveException
 import expo.modules.medialibrary.albums.getAlbumFileOrNull
+import expo.modules.medialibrary.transferAllTo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -83,7 +84,7 @@ class CreateAssetWithAlbumFile(
     coroutineContext.ensureActive()
     FileInputStream(localFile).channel.use { input ->
       (contentResolver.openOutputStream(assetUri) as FileOutputStream).channel.use { output ->
-        val transferred = input.transferTo(0, input.size(), output)
+        val transferred = input.transferAllTo(output)
         if (transferred != input.size()) {
           contentResolver.delete(assetUri, null, null)
           throw IOException("Could not save file to $assetUri Not enough space.")

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/FileExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/FileExtensions.kt
@@ -1,6 +1,7 @@
 package expo.modules.medialibrary.next.extensions
 
 import expo.modules.medialibrary.MediaLibraryUtils.getFileNameAndExtension
+import expo.modules.medialibrary.transferAllTo
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -15,7 +16,7 @@ fun File.safeCopy(destinationDirectory: File): File {
   val newFile = createUniqueFileIn(destinationDirectory, name)
   FileInputStream(this).channel.use { input ->
     FileOutputStream(newFile).channel.use { output ->
-      val transferred = input.transferTo(0, input.size(), output)
+      val transferred = input.transferAllTo(output)
       if (transferred != input.size()) {
         newFile.delete()
         throw IOException("Could not save file to $destinationDirectory Not enough space.")

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/FileChannelExtensionsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/FileChannelExtensionsTests.kt
@@ -1,0 +1,97 @@
+package expo.modules.medialibrary
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.WritableByteChannel
+
+internal class FileChannelExtensionsTests {
+  @Test
+  fun `transferAllTo copies a small file in a single call`() {
+    val source = mockk<FileChannel>()
+    val destination = mockk<WritableByteChannel>()
+    every { source.size() } returns 500L
+    every { source.transferTo(0L, 500L, destination) } returns 500L
+
+    val transferred = source.transferAllTo(destination)
+
+    assertEquals(500L, transferred)
+    verify(exactly = 1) { source.transferTo(any(), any(), destination) }
+  }
+
+  @Test
+  fun `transferAllTo loops when transferTo copies at most the sendfile cap per call`() {
+    // expo/expo#47767: a file above the 0x7ffff000 cap needs more than one transferTo call.
+    val source = mockk<FileChannel>()
+    val destination = mockk<WritableByteChannel>()
+    val total = 3_000_000_000L
+    val sendfileCap = 2_147_479_552L // 0x7ffff000
+    every { source.size() } returns total
+    every { source.transferTo(0L, total, destination) } returns sendfileCap
+    every { source.transferTo(sendfileCap, total - sendfileCap, destination) } returns total - sendfileCap
+
+    val transferred = source.transferAllTo(destination)
+
+    assertEquals(total, transferred)
+    verify(exactly = 2) { source.transferTo(any(), any(), destination) }
+  }
+
+  @Test
+  fun `transferAllTo returns a short count when the transfer stalls`() {
+    val source = mockk<FileChannel>()
+    val destination = mockk<WritableByteChannel>()
+    every { source.size() } returns 1000L
+    every { source.transferTo(0L, 1000L, destination) } returns 400L
+    every { source.transferTo(400L, 600L, destination) } returns 0L
+
+    val transferred = source.transferAllTo(destination)
+
+    assertEquals(400L, transferred)
+  }
+
+  @Test
+  fun `transferAllTo copies the whole file through a channel that accepts only partial writes`() {
+    // The capped destination forces the real transferTo to return partial counts (like the sendfile
+    // cap does for >2 GB files), exercising the loop on a tiny file without mocks.
+    val bytes = ByteArray(64 * 1024) { (it % 251).toByte() }
+    val source = File.createTempFile("transferAllTo-src", ".bin").apply { writeBytes(bytes) }
+    val destinationFile = File.createTempFile("transferAllTo-dst", ".bin")
+    try {
+      FileInputStream(source).channel.use { input ->
+        FileOutputStream(destinationFile).channel.use { rawOutput ->
+          val transferred = input.transferAllTo(MaxBytesPerWriteChannel(rawOutput, maxBytesPerWrite = 1000))
+          assertEquals(bytes.size.toLong(), transferred)
+        }
+      }
+      assertArrayEquals(bytes, destinationFile.readBytes())
+    } finally {
+      source.delete()
+      destinationFile.delete()
+    }
+  }
+
+  private class MaxBytesPerWriteChannel(
+    private val delegate: WritableByteChannel,
+    private val maxBytesPerWrite: Int
+  ) : WritableByteChannel {
+    override fun write(src: ByteBuffer): Int {
+      val originalLimit = src.limit()
+      src.limit(src.position() + minOf(maxBytesPerWrite, src.remaining()))
+      val written = delegate.write(src)
+      src.limit(originalLimit)
+      return written
+    }
+
+    override fun isOpen(): Boolean = delegate.isOpen
+
+    override fun close() = delegate.close()
+  }
+}


### PR DESCRIPTION
# Why

Fixes #47767.

On Android, `MediaLibrary.createAssetAsync()` deterministically fails for any file larger than **~2.147 GB** with `java.io.IOException: Unable to copy file into external storage`, even when the device has plenty of free space. This was hit in production with 4 GB videos.

Root cause (confirmed on `main` by @wekor's report and @chrfalch): the file copy performs a single, unlooped `FileChannel.transferTo`. `transferTo` may copy fewer bytes than requested — the underlying `sendfile(2)` syscall caps one transfer at `0x7ffff000` (2,147,479,552) bytes — so for any file above ~2.147 GB the copy is guaranteed to be partial. The code treated the partial transfer as out-of-space, deleted the pending asset, and threw the misleading "Not enough space" `IOException`.

# How

The same unlooped-`transferTo` bug exists in **three** copy helpers in this package, all reachable from `createAssetAsync`/album copies:

- `assets/CreateAsset.kt` → `writeFileContentsToAsset` (content-resolver path, API 30+ — the exact site in the report)
- `MediaLibraryUtils.safeCopyFile` (legacy file copy, API 29 and below + album copies)
- `next/extensions/FileExtensions.kt` → `File.safeCopy` (the object-oriented API's copy path, now the default root API)

Rather than patch one site, I extracted a shared `FileChannel.transferAllTo` extension that loops `transferTo` until every byte is copied, treating a zero-progress iteration (a genuinely stuck transfer, e.g. the volume really is full) as a short return. Each call site keeps its existing `transferred != size` check, cleanup, and error message unchanged — the only change per site is swapping the single call for `transferAllTo`.

(The modern `next` content-resolver path already uses a buffered `InputStream.copyTo` loop and is unaffected.)

If the maintainers prefer to scope this to only the reported `CreateAsset.kt` site, I'm happy to narrow it.

# Test Plan

**Unit tests** (JVM/Robolectric, `:expo-media-library:testDebugUnitTest`): added `FileChannelExtensionsTests` covering
- a small single-call copy,
- the >2 GB case: `transferTo` returning the `0x7ffff000` cap on the first call must loop and copy the whole file (fails against the old single-call code),
- a stalled transfer returning a short count,
- a **non-mocked** case that wraps a real `FileChannel` destination so the real `transferTo` reports partial writes on a tiny file, verifying the loop copies all bytes and the content matches.

```
> Task :expo-media-library:testDebugUnitTest
BUILD SUCCESSFUL — 4 tests passed
> Task :expo-media-library:spotlessCheck
BUILD SUCCESSFUL
```

**Device reproduction** (Galaxy S21 5G, Android 15 / API 35): a local instrumented test copied a real ~3 GB file through the patched `MediaLibraryUtils.safeCopyFile`, exercising the real Android `sendfile` path.

Before the fix (single unlooped `transferTo`) — reproduces the reported failure:

```
SafeCopyLargeFileInstrumentedTest > safeCopyFile_copiesFilesLargerThan2GB[SM-G991N - 15] FAILED
  java.io.IOException: Could not save file to .../large-file-repro/dest Not enough space.
  at expo.modules.medialibrary.MediaLibraryUtils.safeCopyFile(MediaLibraryUtils.kt:76)
> Task :expo-media-library:connectedDebugAndroidTest FAILED
```

After the fix (looped `transferAllTo`) — the whole 3 GB file is copied:

```
Starting 1 tests on SM-G991N - 15
Finished 1 tests on SM-G991N - 15
> Task :expo-media-library:connectedDebugAndroidTest
BUILD SUCCESSFUL in 1m 27s
```

The instrumented test is not included in this PR — a >2 GB copy is too slow for CI; it was used only to gather the before/after evidence above.

# Checklist

- [x] I added a `changelog.md` entry
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A, no config-plugin change.
- [x] Conforms with the Documentation Writing Style Guide
