### PR TITLE
chore(expo): Upgrade to `whatwg-url-minimum@^0.2.0` increasing spec-adherence

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Internal] Return thenable with sync-bailout for async require calls ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - [Internal] Update logbox imports ([#46640](https://github.com/expo/expo/pull/46640) by [@kitten](https://github.com/kitten))
 - Re-export more expo-modules-core APIs ([#45987](https://github.com/expo/expo/pull/45987) by [@Wenszel](https://github.com/Wenszel))
+- Update `URL` and `URLSearchParams` implementation to support IDNA/TR-46 and improve performance. Spec-adherance has increased and few gaps should now be noticeable compared to browsers ([#47813](https://github.com/expo/expo/pull/47813) by [@kitten](https://github.com/kitten))
 
 ## 56.0.5 — 2026-05-26
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -222,7 +222,7 @@
     "expo-modules-core": "workspace:~56.0.13",
     "pretty-format": "^29.7.0",
     "react-refresh": "^0.14.2",
-    "whatwg-url-minimum": "^0.1.2"
+    "whatwg-url-minimum": "^0.2.0"
   },
   "devDependencies": {
     "@expo/dom-webview": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3607,8 +3607,8 @@ importers:
         specifier: ^0.14.2
         version: 0.14.2
       whatwg-url-minimum:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@expo/metro-runtime':
         specifier: workspace:*
@@ -15333,8 +15333,8 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
-  whatwg-url-minimum@0.1.2:
-    resolution: {integrity: sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==}
+  whatwg-url-minimum@0.2.0:
+    resolution: {integrity: sha512-BtjXU1caNcCFfETP2DhqSeVPfRDl2MTUitI107RE34rJXjR/izfUtR5IoTFOK1WqjNLXbbeqaCH/mQAOLjpc8g==}
 
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
@@ -25411,7 +25411,7 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-url-minimum@0.1.2: {}
+  whatwg-url-minimum@0.2.0: {}
 
   whatwg-url@11.0.0:
     dependencies:


### PR DESCRIPTION
# Why

At version `whatwg-url-minimum@^0.1.2`, the `URL` and `URLSearchParams` implementations have a few issues that went unaddressed:
- minor spec-adherance problems due to excluded Web Platform tests
- minor performance issues and short-comings that could be addressed
- full lack of unicode/IDNA/TR-46 support (e.g. punycode)

The new version, `whatwg-url-minimum@^0.2.0`, directly addresses these three issues.

# How

Several PRs were merged in the separate repository to address the above:
- Encoding and search params performance (https://github.com/expo/whatwg-url-minimum/pull/5)
- Refactor URL parser to use recursive-descent (https://github.com/expo/whatwg-url-minimum/pull/6)
- Fast paths for search param appending and lazy decoding (https://github.com/expo/whatwg-url-minimum/pull/7)
- Fix compliance issues with WPTs (https://github.com/expo/whatwg-url-minimum/pull/8)
- Implement `UTS #46` mapping and TR-46 support (https://github.com/expo/whatwg-url-minimum/pull/9)
- Fast paths and optimisations for ASCII common cases (https://github.com/expo/whatwg-url-minimum/pull/13)
- Add approximation for `CheckBidi` requirement/cases (https://github.com/expo/whatwg-url-minimum/pull/15)
- Remove `TextDecoder` reliance and replace with `decodeURIComponent` (https://github.com/expo/whatwg-url-minimum/pull/17)

Effectively, the IDNA/TR-46 support increases the minzipped (minified+gzipped) bundlesize by `+3.81kB`. This is mostly caused by the TR-46 and other data tables, which are required for punycode/unicode support.

However, this new version basically passes all (relevant) WPTs and has high spec-adherence. It effectively becomes almost 100% spec-compliant.

# Test Plan

- Manually test an app build

> [!NOTE]
> I don't think we should backport this yet, since technically this adds a feature that changes which URL input strings are rejected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
