### PR TITLE
[android][camera] Catch launch errors

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Remove a redundant full-resolution JPEG re-encode when saving captured photos on iOS. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras.
+- [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Remove a redundant full-resolution JPEG re-encode when saving captured photos on iOS. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -78,8 +78,10 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.File
@@ -134,7 +136,11 @@ class ExpoCameraView(
   private var previewView = PreviewView(context).apply {
     elevation = 0f
   }
-  private val scope = CoroutineScope(Dispatchers.Main)
+  private val scope = CoroutineScope(
+    Dispatchers.Main + SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
+      Log.e(CameraViewModule.TAG, "Unhandled exception in camera coroutine", throwable)
+    }
+  )
   private var shouldCreateCamera = false
   private var previewPaused = false
 
@@ -430,12 +436,25 @@ class ExpoCameraView(
     }
   }
 
-  @SuppressLint("UnsafeOptInUsageError")
   private suspend fun createCamera() {
     if (!shouldCreateCamera || previewPaused) {
       return
     }
     shouldCreateCamera = false
+    try {
+      configureAndBindCamera()
+    } catch (e: Exception) {
+      shouldCreateCamera = true
+      onMountError(
+        CameraMountErrorEvent(
+          "Camera could not be started, it may be unavailable or in use by another app: ${e.message ?: e.javaClass.simpleName}"
+        )
+      )
+    }
+  }
+
+  @SuppressLint("UnsafeOptInUsageError")
+  private suspend fun configureAndBindCamera() {
     val cameraProvider = ProcessCameraProvider.awaitInstance(context)
 
     ratio?.let {
@@ -514,20 +533,14 @@ class ExpoCameraView(
       }
     }.build()
 
-    try {
-      cameraProvider.unbindAll()
-      camera = cameraProvider.bindToLifecycle(currentActivity, cameraSelector, useCases)
-      camera?.let {
-        observeCameraState(it.cameraInfo)
-      }
-      // Set the previous zoom level after recreating the camera
-      setCameraZoom(zoom)
-      this.cameraProvider = cameraProvider
-    } catch (_: Exception) {
-      onMountError(
-        CameraMountErrorEvent("Camera component could not be rendered - is there any other instance running?")
-      )
+    cameraProvider.unbindAll()
+    camera = cameraProvider.bindToLifecycle(currentActivity, cameraSelector, useCases)
+    camera?.let {
+      observeCameraState(it.cameraInfo)
     }
+    // Set the previous zoom level after recreating the camera
+    setCameraZoom(zoom)
+    this.cameraProvider = cameraProvider
   }
 
   private fun createImageAnalyzer(): ImageAnalysis =


### PR DESCRIPTION
# Why
Closes #47696. On Android, if the camera can't be started the app crashes with an uncaught `CameraUnavailableException` ("Available cameras: 0") instead of firing `onMountError`. 

The camera view runs its setup inside `scope.launch { createCamera() }`, where the scope was a plain `CoroutineScope(Dispatchers.Main)` with no supervision or exception handler. `createCamera()` only guarded the final `bindToLifecycle` call, so an exception thrown earlier escaped the coroutine, which kills the process.

# How
- Give the scope a `SupervisorJob` and a `CoroutineExceptionHandler`, so a failed coroutine no longer cancels the others and any uncaught exception is logged instead of crashing the app. 
- Guard the entire camera-creation path. `createCamera()` now runs the setup in a  try/catch that converts any failure into an `onMountError` event and resets the retry flag so a later mount attempt can recover. This replaces the previous guard that only wrapped `bindToLifecycle`.

# Test Plan
Bare expo

