### PR TITLE
[iOS][media-library] Add support for smart albums and album.getType()

### DIFF
--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -6,6 +6,7 @@ import {
   Query,
   MediaType,
   AssetField,
+  AlbumType,
   addListener,
   removeAllListeners,
 } from 'expo-media-library';
@@ -269,6 +270,37 @@ export async function test(t: any) {
       t.expect(albums.find((a) => a.id === album.id)).toBeUndefined();
     });
   });
+
+  if (Platform.OS === 'ios') {
+    t.describe('Album getType', () => {
+      t.it('returns ALBUM for a user album', async () => {
+        // given
+        const albumName = createAlbumName('getType album');
+        const album = await Album.create(albumName, [jpgFileLocalUri], true);
+        albumsContainer.push(album);
+
+        // then
+        t.expect(await album.getType()).toBe(AlbumType.ALBUM);
+      });
+    });
+
+    t.describe('Album getSmartAlbums', () => {
+      t.it('returns system smart albums', async () => {
+        // given
+        const asset = await Asset.create(pngFileLocalUri);
+        assetsContainer.push(asset);
+
+        // when
+        const smartAlbums = await Album.getSmartAlbums();
+
+        // then
+        t.expect(smartAlbums.length).toBeGreaterThan(0);
+        for (const album of smartAlbums) {
+          t.expect(await album.getType()).toBe(AlbumType.SMART_ALBUM);
+        }
+      });
+    });
+  }
 
   t.describe('Album deletion', () => {
     t.it('deletes an album', async () => {

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 - Add filtering by `isFavorite` to `Query` ([#45769](https://github.com/expo/expo/pull/45769) by [@Wenszel](https://github.com/Wenszel))
 - Add `Query.exeForMetadata()` for cheap bulk fetch ([#46485](https://github.com/expo/expo/pull/46485) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] Add `Album.getSmartAlbums()` and `Album.getType()`. ([#47822](https://github.com/expo/expo/pull/47822) by [@Wenszel](https://github.com/Wenszel))
 
 ### 🐛 Bug fixes
 
@@ -16,6 +17,7 @@
 - [Android] Fix saving files larger than ~2 GB (e.g. `createAssetAsync` with large videos) failing with "Unable to copy file into external storage" by looping `FileChannel.transferTo` until the whole file is copied. ([#47811](https://github.com/expo/expo/pull/47811) by [@jiunshinn](https://github.com/jiunshinn))
 - Add `accessPrivileges` to `PermissionResponse` type ([#47177](https://github.com/expo/expo/pull/47177) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix permission guards for limited and write-only photo library access. ([#47216](https://github.com/expo/expo/pull/47216) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] Fix `Album.getAll()` not returning albums nested inside folders. ([#47822](https://github.com/expo/expo/pull/47822) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
@@ -217,6 +217,10 @@ public final class MediaLibraryNextModule: Module {
         try await album.getAssets()
       }
 
+      AsyncFunction("getType") { (album: Album) async throws in
+        try await album.getType()
+      }
+
       AsyncFunction("add") { (album: Album, assets: [Asset]) async throws in
         try await album.add(assets)
       }
@@ -232,6 +236,11 @@ public final class MediaLibraryNextModule: Module {
       StaticAsyncFunction("getAll") {
         try await permissionDelegate.checkIfFullAccessGranted()
         return try await Album.getAll(assetMapper: assetMapper)
+      }
+
+      StaticAsyncFunction("getSmartAlbums") {
+        try await permissionDelegate.checkIfFullAccessGranted()
+        return try await Album.getSmartAlbums(assetMapper: assetMapper)
       }
 
       StaticAsyncFunction("get") { (title: String) -> Album? in

--- a/packages/expo-media-library/ios/next/exceptions/Exceptions.swift
+++ b/packages/expo-media-library/ios/next/exceptions/Exceptions.swift
@@ -89,3 +89,9 @@ internal final class FailedToExtractUri: GenericException<String> {
     "Failed to extract an uri: \(param)"
   }
 }
+
+internal final class UnsupportedAlbumTypeException: GenericException<String> {
+  override var reason: String {
+    "Unsupported album collection type: \(param)"
+  }
+}

--- a/packages/expo-media-library/ios/next/objects/album/Album.swift
+++ b/packages/expo-media-library/ios/next/objects/album/Album.swift
@@ -31,6 +31,11 @@ class Album: SharedObject {
     return title
   }
 
+  func getType() async throws -> AlbumType {
+    let collection = try await requirePHAssetCollection()
+    return try AlbumType.from(collection.assetCollectionType)
+  }
+
   func add(_ assets: [Asset]) async throws {
     let collection = try await requirePHAssetCollection()
     let phAssets = try resolvePHAssets(from: assets)
@@ -92,7 +97,12 @@ class Album: SharedObject {
   }
 
   static func getAll(assetMapper: AssetMapper) async throws -> [Album] {
-    AssetCollectionRepository.shared.getAll()
+    AssetCollectionRepository.shared.getUserAlbums()
+      .map { Album(id: $0.localIdentifier, assetMapper: assetMapper) }
+  }
+
+  static func getSmartAlbums(assetMapper: AssetMapper) async throws -> [Album] {
+    AssetCollectionRepository.shared.get(type: .smartAlbum)
       .map { Album(id: $0.localIdentifier, assetMapper: assetMapper) }
   }
 }

--- a/packages/expo-media-library/ios/next/objects/album/AlbumType.swift
+++ b/packages/expo-media-library/ios/next/objects/album/AlbumType.swift
@@ -1,0 +1,15 @@
+import Photos
+import ExpoModulesCore
+
+enum AlbumType: String, Enumerable {
+  case ALBUM = "album"
+  case SMART_ALBUM = "smartAlbum"
+
+  static func from(_ type: PHAssetCollectionType) throws -> AlbumType {
+    switch type {
+    case .album: return .ALBUM
+    case .smartAlbum: return .SMART_ALBUM
+    default: throw UnsupportedAlbumTypeException("\(type.rawValue)")
+    }
+  }
+}

--- a/packages/expo-media-library/ios/next/repository/AssetCollectionRepository.swift
+++ b/packages/expo-media-library/ios/next/repository/AssetCollectionRepository.swift
@@ -4,16 +4,29 @@ final class AssetCollectionRepository {
   static let shared = AssetCollectionRepository()
   private init() {}
 
-  func getAll() -> [PHAssetCollection] {
+  func get(type: PHAssetCollectionType) -> [PHAssetCollection] {
     var collections: [PHAssetCollection] = []
-    let pHFetchResult = PHCollectionList.fetchTopLevelUserCollections(with: nil)
-
-    pHFetchResult.enumerateObjects { collection, _, _ in
-      if let assetCollection = collection as? PHAssetCollection {
-        collections.append(assetCollection)
-      }
+    let fetchResult = PHAssetCollection.fetchAssetCollections(with: type, subtype: .any, options: nil)
+    fetchResult.enumerateObjects { collection, _, _ in
+      collections.append(collection)
     }
     return collections
+  }
+
+  func getUserAlbums() -> [PHAssetCollection] {
+    flatten(PHCollectionList.fetchTopLevelUserCollections(with: nil))
+  }
+
+  private func flatten(_ collections: PHFetchResult<PHCollection>) -> [PHAssetCollection] {
+    var result: [PHAssetCollection] = []
+    collections.enumerateObjects { collection, _, _ in
+      if let album = collection as? PHAssetCollection {
+        result.append(album)
+      } else if let folder = collection as? PHCollectionList {
+        result.append(contentsOf: self.flatten(PHCollectionList.fetchCollections(in: folder, options: nil)))
+      }
+    }
+    return result
   }
 
   func get(by ids: [String]) -> [PHAssetCollection] {

--- a/packages/expo-media-library/src/next/index.ts
+++ b/packages/expo-media-library/src/next/index.ts
@@ -11,6 +11,7 @@ export {
 } from './js';
 
 export {
+  AlbumType,
   AssetField,
   MediaSubtype,
   MediaType,

--- a/packages/expo-media-library/src/next/js/AssetAlbum.ts
+++ b/packages/expo-media-library/src/next/js/AssetAlbum.ts
@@ -2,7 +2,7 @@ import { UnavailabilityError } from 'expo';
 import { Platform } from 'react-native';
 
 import { NativeAsset, NativeAlbum } from '../native';
-import type { AssetInfo, Location, MediaSubtype, MediaType, Shape } from '../types';
+import type { AlbumType, AssetInfo, Location, MediaSubtype, MediaType, Shape } from '../types';
 
 // Asset and Album construct each other, so their implementations live together to avoid Metro require-cycle warnings
 
@@ -301,6 +301,23 @@ export class Album {
   }
 
   /**
+   * Gets the album's type — whether it is a regular or a smart album.
+   * @returns A promise resolving to an [`AlbumType`](#albumtype).
+   * @platform ios
+   *
+   * @example
+   * ```ts
+   * const type = await album.getType(); // AlbumType.ALBUM
+   * ```
+   */
+  getType(): Promise<AlbumType> {
+    if (Platform.OS !== 'ios') {
+      throw new UnavailabilityError('MediaLibrary', 'getType is only available on iOS');
+    }
+    return this.nativeAlbum.getType();
+  }
+
+  /**
    * Permanently deletes the album from the device.
    * On Android, it deletes the album and all its assets.
    * On iOS, it deletes the album but keeps the assets in the main library.
@@ -426,7 +443,7 @@ export class Album {
   }
 
   /**
-   * A static function. Retrieves all albums on the device.
+   * A static function. Retrieves albums from the device library.
    * @returns A promise resolving to an array of [`Album`](#album) objects.
    *
    * @example
@@ -436,6 +453,24 @@ export class Album {
    */
   static async getAll(): Promise<Album[]> {
     const natives = await NativeAlbum.getAll();
+    return natives.map((a) => new Album(a.id));
+  }
+
+  /**
+   * A static function. Retrieves system smart albums (for example Favorites, Videos, or Screenshots).
+   * @returns A promise resolving to an array of [`Album`](#album) objects.
+   *
+   * @example
+   * ```ts
+   * const smartAlbums = await Album.getSmartAlbums();
+   * ```
+   * @platform ios
+   */
+  static async getSmartAlbums(): Promise<Album[]> {
+    if (Platform.OS !== 'ios') {
+      throw new UnavailabilityError('MediaLibrary', 'getSmartAlbums');
+    }
+    const natives = await NativeAlbum.getSmartAlbums();
     return natives.map((a) => new Album(a.id));
   }
 }

--- a/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
+++ b/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
@@ -6,6 +6,7 @@ import {
 } from 'expo';
 
 import type {
+  AlbumType,
   AssetField,
   AssetFieldValueMap,
   AssetMetadata,
@@ -120,6 +121,9 @@ class NativeAlbumWeb implements NativeAlbumClass {
   getTitle() {
     return unavailable('Album.getTitle');
   }
+  getType(): Promise<AlbumType> {
+    return unavailable('Album.getType');
+  }
   delete() {
     return unavailable('Album.delete');
   }
@@ -148,6 +152,10 @@ class NativeAlbumWeb implements NativeAlbumClass {
 
   static getAll(): Promise<NativeAlbumClass[]> {
     return unavailable('Album.getAll');
+  }
+
+  static getSmartAlbums(): Promise<NativeAlbumClass[]> {
+    return unavailable('Album.getSmartAlbums');
   }
 }
 

--- a/packages/expo-media-library/src/next/native/types/NativeAlbumClass.types.ts
+++ b/packages/expo-media-library/src/next/native/types/NativeAlbumClass.types.ts
@@ -1,3 +1,4 @@
+import type { AlbumType } from '../../types';
 import type { NativeAssetClass } from './NativeAssetClass.types';
 
 export declare class NativeAlbumClass {
@@ -5,6 +6,7 @@ export declare class NativeAlbumClass {
   id: string;
   getAssets(): Promise<NativeAssetClass[]>;
   getTitle(): Promise<string>;
+  getType(): Promise<AlbumType>;
   delete(): Promise<void>;
   add(assets: NativeAssetClass | NativeAssetClass[]): Promise<void>;
   removeAssets(assets: NativeAssetClass[]): Promise<void>;
@@ -16,4 +18,5 @@ export declare class NativeAlbumClass {
   static delete(albums: NativeAlbumClass[], deleteAssets?: boolean): Promise<void>;
   static get(title: string): Promise<NativeAlbumClass | null>;
   static getAll(): Promise<NativeAlbumClass[]>;
+  static getSmartAlbums(): Promise<NativeAlbumClass[]>;
 }

--- a/packages/expo-media-library/src/next/types/Album.types.ts
+++ b/packages/expo-media-library/src/next/types/Album.types.ts
@@ -1,0 +1,8 @@
+/**
+ * The type of an album. Maps to [`PHAssetCollectionType`](https://developer.apple.com/documentation/photokit/phassetcollectiontype).
+ * @platform ios
+ */
+export enum AlbumType {
+  ALBUM = 'album',
+  SMART_ALBUM = 'smartAlbum',
+}

--- a/packages/expo-media-library/src/next/types/index.ts
+++ b/packages/expo-media-library/src/next/types/index.ts
@@ -1,3 +1,4 @@
+export * from './Album.types';
 export * from './Asset.types';
 export * from './Query.types';
 export * from './Permissions.types';


### PR DESCRIPTION
# Why

Implements the smart-albums part of this feature request: https://expo.canny.io/feature-requests/p/expo-media-library-new-api-album-listing-lacks-smart-albums-asset-counts-and-bul

The PR adds `Album.getSmartAlbums()` and `Album.getType()`, and fixes `Album.getAll()` skipping albums nested inside folders

# How

- Fixes a regression in `Album.getAll()` compared to `expo-media-library/legacy`. `Album.getAll()` fetched `fetchTopLevelUserCollections` but kept only the top-level albums, while dropping the ones inside folders
- Added `Album.getType()`, which returns whether an album is `regular` or `smart`
- Added `Album.getSmartAlbums()`
   - An alternative would be to fold smart albums into `Album.getAll()` (e.g. an `includeSmartAlbums` flag), but this way allows users to fetch smart albums only

# Test Plan
Tested on BareExpo Playground on a physical device ✅
Added tests to test-suite ✅