### PR TITLE
[ios][camera] Report correct capture dimensions after orientation normalization

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -51,6 +51,13 @@ export const CameraScreens = [
       return optionalRequire(() => require('./CameraScreenDocumentScanner'));
     },
   },
+  {
+    name: 'Capture Dimensions',
+    route: 'camera/expo-camera-capture-dimensions',
+    getComponent() {
+      return optionalRequire(() => require('./CameraScreenCaptureDimensions'));
+    },
+  },
 ];
 
 export default function CameraScreen() {

--- a/apps/native-component-list/src/screens/Camera/CameraScreenCaptureDimensions.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenCaptureDimensions.tsx
@@ -1,0 +1,138 @@
+import { CameraView, type CameraCapturedPicture } from 'expo-camera';
+import { Image as ExpoImage } from 'expo-image';
+import React, { useRef, useState } from 'react';
+import { View, StyleSheet, Button, Text, Image, ScrollView } from 'react-native';
+
+type Check = { label: string; ok: boolean; detail: string };
+
+function getDecodedSize(uri: string) {
+  return new Promise<{ width: number; height: number }>((resolve, reject) => {
+    Image.getSize(uri, (width, height) => resolve({ width, height }), reject);
+  });
+}
+
+export default function CameraScreenCaptureDimensions() {
+  const ref = useRef<CameraView>(null);
+  const [photo, setPhoto] = useState<CameraCapturedPicture | null>(null);
+  const [checks, setChecks] = useState<Check[]>([]);
+  const [error, setError] = useState<string | undefined>();
+
+  const takePicture = async () => {
+    if (!ref.current) {
+      return;
+    }
+    setError(undefined);
+    try {
+      const result = await ref.current.takePictureAsync({ exif: true, quality: 1 });
+      if (!result?.uri) {
+        setError('No image returned');
+        return;
+      }
+      setPhoto(result);
+
+      const decoded = await getDecodedSize(result.uri);
+      const exif = result.exif ?? {};
+      const pixelX = exif.PixelXDimension;
+      const pixelY = exif.PixelYDimension;
+      const orientation = exif.Orientation;
+
+      setChecks([
+        {
+          label: 'Returned size matches the encoded file',
+          ok: result.width === decoded.width && result.height === decoded.height,
+          detail: `returned ${result.width}×${result.height}, file ${decoded.width}×${decoded.height}`,
+        },
+        {
+          label: 'EXIF pixel dimensions match the returned size',
+          ok: pixelX === result.width && pixelY === result.height,
+          detail: `exif ${pixelX}×${pixelY}, returned ${result.width}×${result.height}`,
+        },
+        {
+          label: 'EXIF orientation is normalized to 1',
+          ok: orientation === 1,
+          detail: `orientation ${orientation}`,
+        },
+      ]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.screen}>
+      <View style={styles.row}>
+        <CameraView style={styles.camera} ref={ref} />
+        {photo && <ExpoImage source={{ uri: photo.uri }} style={styles.picture} />}
+      </View>
+      <Button onPress={takePicture} title="Take Picture" />
+      {error && <Text style={styles.error}>{error}</Text>}
+      {checks.length > 0 && (
+        <View style={styles.infoBox}>
+          {checks.map((check) => (
+            <View key={check.label} style={styles.checkRow}>
+              <Text style={styles.checkMark}>{check.ok ? '✅' : '❌'}</Text>
+              <View style={styles.checkText}>
+                <Text style={styles.checkLabel}>{check.label}</Text>
+                <Text style={styles.checkDetail}>{check.detail}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    padding: 10,
+  },
+  row: {
+    height: 300,
+    flexDirection: 'row',
+  },
+  camera: {
+    flex: 1,
+    margin: 10,
+    borderRadius: 10,
+    borderColor: 'black',
+    borderWidth: 2,
+  },
+  picture: {
+    flex: 1,
+    margin: 10,
+    borderColor: 'black',
+    borderWidth: 2,
+    borderRadius: 10,
+  },
+  error: {
+    margin: 10,
+    color: 'red',
+  },
+  infoBox: {
+    padding: 10,
+    margin: 10,
+    backgroundColor: '#f0f2f0',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'black',
+  },
+  checkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 4,
+  },
+  checkMark: {
+    fontSize: 20,
+    marginRight: 8,
+  },
+  checkText: {
+    flex: 1,
+  },
+  checkLabel: {
+    fontWeight: 'bold',
+  },
+  checkDetail: {
+    color: '#555',
+  },
+});

--- a/apps/native-component-list/src/screens/Camera/CameraScreenCaptureDimensions.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenCaptureDimensions.tsx
@@ -36,20 +36,26 @@ export default function CameraScreenCaptureDimensions() {
       const pixelY = exif.PixelYDimension;
       const orientation = exif.Orientation;
 
+      const sameSet = (a: [number, number], b: [number, number]) =>
+        (a[0] === b[0] && a[1] === b[1]) || (a[0] === b[1] && a[1] === b[0]);
+      const quarterTurn = typeof orientation === 'number' && orientation >= 5 && orientation <= 8;
+
       setChecks([
         {
           label: 'Returned size matches the encoded file',
-          ok: result.width === decoded.width && result.height === decoded.height,
+          ok: sameSet([result.width, result.height], [decoded.width, decoded.height]),
           detail: `returned ${result.width}×${result.height}, file ${decoded.width}×${decoded.height}`,
         },
         {
-          label: 'EXIF pixel dimensions match the returned size',
-          ok: pixelX === result.width && pixelY === result.height,
-          detail: `exif ${pixelX}×${pixelY}, returned ${result.width}×${result.height}`,
+          label: 'EXIF pixel dimensions are consistent with the orientation tag',
+          ok: quarterTurn
+            ? pixelX === result.height && pixelY === result.width
+            : pixelX === result.width && pixelY === result.height,
+          detail: `orientation ${orientation}, exif ${pixelX}×${pixelY}, returned ${result.width}×${result.height}`,
         },
         {
-          label: 'EXIF orientation is normalized to 1',
-          ok: orientation === 1,
+          label: 'EXIF orientation tag is present and valid',
+          ok: typeof orientation === 'number' && orientation >= 1 && orientation <= 8,
           detail: `orientation ${orientation}`,
         },
       ]);

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
-- Report the encoded pixel dimensions from `takePictureAsync`.
+- Report the encoded pixel dimensions from `takePictureAsync`. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
-- Report the encoded pixel dimensions from `takePictureAsync`. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Preserve the capture orientation as EXIF metadata instead of rotating captured pixels, so `takePictureAsync` and `savePictureAsync` return the real orientation tag and dimensions. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
+- Report the encoded pixel dimensions from `takePictureAsync`.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -167,20 +167,6 @@ struct ExpoCameraUtils {
     return UIImage(cgImage: croppedCgImage, scale: image.scale, orientation: image.imageOrientation)
   }
 
-  static func normalizeOrientation(of image: UIImage) -> UIImage {
-    guard image.imageOrientation != .up else {
-      return image
-    }
-    // Render at the image's own scale — the default format uses the screen scale (2x/3x),
-    // which would upscale the photo to 4-9x its native pixel count
-    let format = UIGraphicsImageRendererFormat()
-    format.scale = image.scale
-    let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-    return renderer.image { _ in
-      image.draw(in: CGRect(origin: .zero, size: image.size))
-    }
-  }
-
   static func write(data: Data, to path: String) -> String? {
     let url = URL(fileURLWithPath: path)
     do {
@@ -234,8 +220,6 @@ struct ExpoCameraUtils {
       throw CameraSavingImageException("Failed to locate `cacheDirectory`")
     }
 
-    let normalizedImage = normalizeOrientation(of: image)
-
     var result = [String: Any]()
     let directory = URL(fileURLWithPath: cachesDirectory.path).appendingPathComponent("Camera")
     let filename = UUID().uuidString.appending(".jpg")
@@ -243,13 +227,17 @@ struct ExpoCameraUtils {
 
     FileSystemUtilities.ensureDirExists(at: directory)
 
-    guard let data = data(from: normalizedImage, with: options.metadata ?? [:], quality: Float(options.quality)) else {
+    // Record the capture orientation as an EXIF tag instead of rotating the pixels so viewers display it upright.
+    var metadata = options.metadata ?? [:]
+    metadata[kCGImagePropertyOrientation as String] = toExifOrientation(orientation: image.imageOrientation)
+
+    guard let data = data(from: image, with: metadata, quality: Float(options.quality)) else {
       throw CameraSavingImageException("Image data could not be processed")
     }
 
     result["url"] = fileUrl.absoluteString
-    result["width"] = normalizedImage.size.width
-    result["height"] = normalizedImage.size.height
+    result["width"] = image.size.width
+    result["height"] = image.size.height
     result["base64"] = options.base64 ? data.base64EncodedString() : nil
 
     do {

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -188,10 +188,9 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
     let croppedSize = AVMakeRect(aspectRatio: previewSize, insideRect: cropRect)
 
     takenImage = ExpoCameraUtils.crop(image: takenImage, to: croppedSize)
-    takenImage = ExpoCameraUtils.normalizeOrientation(of: takenImage)
 
-    let width = takenImage.cgImage.map { CGFloat($0.width) } ?? takenImage.size.width
-    let height = takenImage.cgImage.map { CGFloat($0.height) } ?? takenImage.size.height
+    let width = takenImage.size.width
+    let height = takenImage.size.height
     var processedImageData: Data?
 
     var response = [String: Any]()
@@ -206,12 +205,15 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
         with: ["Orientation": ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)]
       )
 
-      updatedExif[kCGImagePropertyExifPixelXDimension as String] = width
-      updatedExif[kCGImagePropertyExifPixelYDimension as String] = height
+      if let cgImage = takenImage.cgImage {
+        updatedExif[kCGImagePropertyExifPixelXDimension as String] = cgImage.width
+        updatedExif[kCGImagePropertyExifPixelYDimension as String] = cgImage.height
+      }
       response["exif"] = updatedExif
 
       var updatedMetadata = metadata
-      updatedMetadata[kCGImagePropertyOrientation as String] = 1
+      updatedMetadata[kCGImagePropertyOrientation as String] =
+        ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)
 
       if let additionalExif = options.additionalExif {
         for (key, value) in additionalExif {

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -190,8 +190,8 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
     takenImage = ExpoCameraUtils.crop(image: takenImage, to: croppedSize)
     takenImage = ExpoCameraUtils.normalizeOrientation(of: takenImage)
 
-    let width = takenImage.size.width
-    let height = takenImage.size.height
+    let width = takenImage.cgImage.map { CGFloat($0.width) } ?? takenImage.size.width
+    let height = takenImage.cgImage.map { CGFloat($0.height) } ?? takenImage.size.height
     var processedImageData: Data?
 
     var response = [String: Any]()
@@ -206,8 +206,8 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
         with: ["Orientation": ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)]
       )
 
-      updatedExif[kCGImagePropertyExifPixelYDimension as String] = width
-      updatedExif[kCGImagePropertyExifPixelXDimension as String] = height
+      updatedExif[kCGImagePropertyExifPixelXDimension as String] = width
+      updatedExif[kCGImagePropertyExifPixelYDimension as String] = height
       response["exif"] = updatedExif
 
       var updatedMetadata = metadata


### PR DESCRIPTION
# Why
Closes #47823
On iOS, `takePictureAsync` returned a broken orientation contract. It always reported an EXIF Orientation of 1 and transposed the EXIF pixel dimensions.

The regression was introduced by #44171, which added orientation normalization as a workaround for React Native #54184. That RN change stopped `<Image>` applying EXIF orientation, so camera photos displayed rotated, and #44171 worked around it by baking the rotation into the pixels and forcing Orientation to 1.

React Native fixed #54184 upstream in #55379. The fix is present in the RN source from 0.85.0-rc.0 onward and absent in 0.83.2 and 0.84.0. The original report (#44143) was on 0.83.2 where the fix was genuinely missing, but by the time #44171 merged the tree was already on 0.85.0-rc.7 which had it. The workaround was redundant on 0.85 and later, and it got into sdk-57 through sdk-56 where it now only causes this regression. Since React Native honors EXIF orientation again, we can drop the workaround and restore the original behavior.

# How
Reverted the normalization and returned to keeping the capture orientation on the pixels with an EXIF tag, in both capture paths.

- Removed the normalizeOrientation call so the pixels keep their capture orientation.
- width/height come from UIImage.size again, which is the display oriented size.
- EXIF PixelXDimension/PixelYDimension are read from the encoded buffer (cgImage.width/height), which is what these tags mean and what AVFoundation writes. This also corrects a latent wrong value for landscape captures.
- The top level orientation tag is set from the real capture orientation instead of a hardcoded 1.
- saveImage no longer rotates the pixels. It injects the capture orientation as an EXIF tag so the raw buffer still displays upright, which also fixes a latent case where a save with empty metadata wrote an untagged, sideways buffer.

Removing the normalization also fixes the oversized files from #47823, since there is no longer a full resolution redraw at the screen scale.

I also updated the "Capture Dimensions" example screen in native-component-list. It captures with exif: true, decodes the saved file independently, and runs PASS/FAIL checks that the returned size matches the file, the EXIF pixel dimensions are consistent with the orientation tag, and the orientation tag is present and valid.

# Test Plan
Bare expo. Ran the "Capture Dimensions" screen and rotated through all four orientations. The photo displays upright in every case and the orientation tag matches the iPhone back camera: portrait 6, landscape 1 and 3, upside down 8. All checks pass. Before this change orientation was always 1 and the EXIF pixel dimensions were transposed.