### PR TITLE
[router] Improve standard-navigation types for createProps

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [native-tabs] Add `testID` and `accessibilityLabel` props to `NativeTabs.Trigger`. ([#47472](https://github.com/expo/expo/pull/47472) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add `pageHeaders` config plugin option for declaring per-path response headers ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Upgrade react-native-screens to 4.26.0 ([#47770](https://github.com/expo/expo/pull/47770) by [@Ubax](https://github.com/Ubax))
+- Improve standard-navigation types for `createProps`. ([#47825](https://github.com/expo/expo/pull/47825) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/standard-navigation/__tests__/docs-examples.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/docs-examples.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Pressable, Text, View } from 'react-native';
+import { createStandardNavigator } from 'standard-navigation';
+
+import { TabRouter } from '../../react-navigation/routers';
+import { unstable_createStandardRouterNavigator } from '../index';
+import type { NavigatorContentProps } from '../types';
+
+function typecheck(_value: unknown) {}
+
+// These examples mirror docs/pages/router/advanced/custom-navigators.mdx and must stay in sync so
+// the snippets users copy keep compiling.
+
+// "Create a navigator in your app" — `EventMap` is inferred without explicit type arguments.
+{
+  type TabsContentProps = NavigatorContentProps<{ title?: string }>;
+
+  const TabsContent = ({ state, descriptors, actions }: TabsContentProps) => {
+    const focusedRoute = state.routes[state.index]!;
+
+    return (
+      <View style={{ flex: 1 }}>
+        <View style={{ flex: 1 }}>{descriptors[focusedRoute.key]!.render()}</View>
+        <View style={{ flexDirection: 'row' }}>
+          {state.routes.map((route) => (
+            <Pressable
+              key={route.key}
+              style={{ flex: 1, padding: 16 }}
+              onPress={() => actions.navigate(route.name)}>
+              <Text>{descriptors[route.key]!.options.title ?? route.name}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    );
+  };
+
+  // eslint-disable-next-line no-unused-expressions
+  unstable_createStandardRouterNavigator(TabsContent, TabRouter);
+}
+
+// "Typed events" — the event map is inferred from the component and `emitter.emit` is typed
+// against it (unknown event names and mismatched payloads are rejected).
+{
+  type TabsContentProps = NavigatorContentProps<
+    { title?: string },
+    { tabPress: { data: undefined; canPreventDefault: true } }
+  >;
+
+  const TabsContent = ({ emitter }: TabsContentProps) => {
+    emitter.emit({ type: 'tabPress', canPreventDefault: true });
+    // @ts-expect-error `nope` is not a declared event.
+    emitter.emit({ type: 'nope' });
+    return null;
+  };
+
+  // eslint-disable-next-line no-unused-expressions
+  unstable_createStandardRouterNavigator(TabsContent, TabRouter);
+}
+
+// "Options" — the optional third argument type-checks, and `createProps` may dispatch a `PRELOAD`
+// action against the raw router `dispatch` (the guide's `createProps` example). `POP_TO_TOP` would
+// be a no-op on a TabRouter, so the guide uses `PRELOAD`.
+{
+  type TabsCreateProps = { activeRouteKey: string; preload: (name: string) => void };
+  type TabsContentProps = NavigatorContentProps<
+    { title?: string },
+    Record<string, never>,
+    object,
+    TabsCreateProps
+  >;
+
+  const TabsContent = ({ state, descriptors, activeRouteKey, preload }: TabsContentProps) => {
+    const focusedRoute = state.routes[state.index]!;
+    return (
+      <Pressable onPress={() => preload(activeRouteKey)} style={{ flex: 1 }}>
+        {descriptors[focusedRoute.key]!.render()}
+      </Pressable>
+    );
+  };
+
+  const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
+    useOnlyUserDefinedScreens: true,
+    createProps: ({ state, dispatch }) => ({
+      activeRouteKey: state.routes[state.index]!.key,
+      preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),
+    }),
+  });
+
+  typecheck(<Tabs />);
+  // @ts-expect-error `activeRouteKey` is injected by `createProps`.
+  typecheck(<Tabs activeRouteKey="route" />);
+  // @ts-expect-error `preload` is injected by `createProps`.
+  typecheck(<Tabs preload={() => {}} />);
+}
+
+// "Library entry points" — a framework-agnostic navigator created directly with
+// `createStandardNavigator`, declaring a real event map (the guide's library-author example).
+{
+  type TabsContentProps = NavigatorContentProps<
+    { title?: string },
+    { tabPress: { data: undefined; canPreventDefault: true } }
+  >;
+
+  const TabsContent = ({ emitter }: TabsContentProps) => {
+    emitter.emit({ type: 'tabPress', canPreventDefault: true });
+    return null;
+  };
+
+  // eslint-disable-next-line no-unused-expressions
+  createStandardNavigator<
+    { title?: string },
+    { tabPress: { data: undefined; canPreventDefault: true } }
+  >(TabsContent);
+}
+
+describe('custom navigator documentation examples', () => {
+  it('is type-checked by tsc via pnpm typecheck or et check-packages', () => {
+    expect(typeof unstable_createStandardRouterNavigator).toBe('function');
+  });
+});

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -599,6 +599,7 @@ describe('custom-navigators guide example', () => {
   type ContentProps = NavigatorContentProps<
     { title?: string },
     Record<string, never>,
+    object,
     CreatePropsProps
   >;
 

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -305,8 +305,9 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
       TestOptions,
       TabNavigationState<ParamListBase>,
       TestEventMap,
-      { focusedName?: string },
-      TabRouterOptions
+      object,
+      TabRouterOptions,
+      { focusedName: string }
     >(NavigatorContent, TabRouter, {
       useOnlyUserDefinedScreens: true,
       createProps: ({ state }) => ({ focusedName: state.routes[state.index]!.name }),
@@ -337,8 +338,9 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
       TestOptions,
       TabNavigationState<ParamListBase>,
       TestEventMap,
-      { goToSecond?: () => void },
-      TabRouterOptions
+      object,
+      TabRouterOptions,
+      { goToSecond: () => void }
     >(NavigatorContent, TabRouter, {
       useOnlyUserDefinedScreens: true,
       createProps: ({ dispatch }) => ({
@@ -589,12 +591,10 @@ describe('custom-navigators guide example', () => {
   // `preloadedNames` is derived from the raw `state` — exactly the "router-specific information that
   // is not part of the standard state" that `createProps` exists to expose (TabRouter keeps preloaded
   // routes in `preloadedRouteKeys`, which the standard contract does not project).
-  // Props supplied by `createProps` are declared optional so they are not required on the `<Tabs>`
-  // element (it is rendered without them); the content still receives them at runtime.
   type CreatePropsProps = {
-    activeRouteKey?: string;
-    preload?: (name: string) => void;
-    preloadedNames?: string[];
+    activeRouteKey: string;
+    preload: (name: string) => void;
+    preloadedNames: string[];
   };
   type ContentProps = NavigatorContentProps<
     { title?: string },
@@ -615,8 +615,9 @@ describe('custom-navigators guide example', () => {
     { title?: string },
     TabNavigationState<ParamListBase>,
     Record<string, never>,
-    CreatePropsProps,
-    TabRouterOptions
+    object,
+    TabRouterOptions,
+    CreatePropsProps
   >(TabsContent, TabRouter, {
     useOnlyUserDefinedScreens: true,
     createProps: ({ state, dispatch }) => ({
@@ -653,7 +654,7 @@ describe('custom-navigators guide example', () => {
     renderExample();
     expect(lastProps().preloadedNames).toEqual([]);
 
-    act(() => lastProps().preload!('settings'));
+    act(() => lastProps().preload('settings'));
 
     // The action reached the TabRouter: `settings` is now preloaded, and focus stayed on `index`.
     expect(lastProps().preloadedNames).toEqual(['settings']);

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -11,12 +11,17 @@ import {
 } from '../../react-navigation/routers';
 import type { GoBackAction, NavigateAction } from '../../react-navigation/routers/CommonActions';
 import { unstable_createStandardRouterNavigator, unstable_integrateWithRouter } from '../index';
-import type { NavigatorContentProps, StandardNavigationAction } from '../types';
+import type {
+  IntegrateWithRouterOptions,
+  NavigatorContentProps,
+  StandardNavigationAction,
+} from '../types';
 
 // Type-equality helpers
 type Expect<T extends true> = T;
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+function typecheck(_value: unknown) {}
 
 type Opts = { title?: string };
 type EventMap = { tabPress: { data: undefined; canPreventDefault: true } };
@@ -92,7 +97,7 @@ export const _options: OptionsFn = ({ route, theme }) => {
 
 type NavProps = { tintColor?: string };
 type CreateProps = { routeNames: string[]; preload: (name: string) => void };
-type SplitContentProps = NavigatorContentProps<Opts, EventMap, NavProps & CreateProps>;
+type SplitContentProps = NavigatorContentProps<Opts, EventMap, NavProps, CreateProps>;
 type RequiredNavProps = { label: string };
 
 function SplitContent(_props: SplitContentProps) {
@@ -140,6 +145,83 @@ export type _InferredElementRequiresPublicProp = Expect<
   Equal<InferredPublicElementProps['label'], string>
 >;
 
+const InferredSplitNav = unstable_createStandardRouterNavigator(SplitContent, TabRouter, {
+  createProps: () => ({ routeNames: [], preload: () => {} }),
+});
+type InferredSplitElementProps = ComponentProps<typeof InferredSplitNav>;
+export type _InferredElementAcceptsNavigatorProps = Expect<
+  Equal<InferredSplitElementProps['tintColor'], string | undefined>
+>;
+export type _InferredElementLacksRouteNames = Expect<
+  Equal<'routeNames' extends keyof InferredSplitElementProps ? true : false, false>
+>;
+export type _InferredElementLacksPreload = Expect<
+  Equal<'preload' extends keyof InferredSplitElementProps ? true : false, false>
+>;
+
+unstable_createStandardRouterNavigator(RequiredPublicContent, TabRouter, {
+  // @ts-expect-error This content does not declare any injected props.
+  createProps: () => ({ label: 1 }),
+});
+
+type CarrierCreateProps = { x: string };
+function CarrierContent(
+  _props: NavigatorContentProps<Opts, EventMap, object, CarrierCreateProps>
+) {
+  return null;
+}
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  object,
+  TabRouterOptions,
+  { x: number }
+  // @ts-expect-error Explicit CreateProps must match the content's declared CreateProps.
+>(CarrierContent, TabRouter, { createProps: () => ({ x: 1 }) });
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  RequiredNavProps,
+  TabRouterOptions
+  // @ts-expect-error Five explicit generics declare no injected props, so `createProps` is forbidden.
+>(RequiredPublicContent, TabRouter, { createProps: () => ({ label: 1 }) });
+
+const broadlyAnnotatedFactoryOptions: IntegrateWithRouterOptions = {
+  // @ts-expect-error Bare options do not declare injected props, so `createProps` is forbidden.
+  createProps: () => ({ label: 1 }),
+};
+unstable_createStandardRouterNavigator(
+  RequiredPublicContent,
+  TabRouter,
+  broadlyAnnotatedFactoryOptions
+);
+
+// @ts-expect-error Inferred non-empty CreateProps require the options argument.
+unstable_createStandardRouterNavigator(SplitContent, TabRouter);
+
+// `NoInfer` keeps a zero-argument factory from declaring injected props for content that has none.
+unstable_createStandardRouterNavigator(PublicContent, TabRouter, {
+  // @ts-expect-error `PublicContent` does not declare any injected props.
+  createProps: () => ({ injected: true }),
+});
+
+type OptionalCreateProps = { a?: string };
+function OptionalCreateContent(
+  _props: NavigatorContentProps<Opts, EventMap, object, OptionalCreateProps>
+) {
+  return null;
+}
+
+// @ts-expect-error CreateProps with optional keys still require options.
+unstable_createStandardRouterNavigator(OptionalCreateContent, TabRouter);
+unstable_createStandardRouterNavigator(OptionalCreateContent, TabRouter, {
+  createProps: () => ({}),
+});
+
 // @ts-expect-error The options argument is required when `CreateProps` is non-empty.
 unstable_createStandardRouterNavigator<
   Opts,
@@ -157,12 +239,8 @@ unstable_createStandardRouterNavigator<
   NavProps,
   TabRouterOptions,
   CreateProps
->(
-  SplitContent,
-  TabRouter,
   // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
-  { useOnlyUserDefinedScreens: true }
-);
+>(SplitContent, TabRouter, { useOnlyUserDefinedScreens: true });
 
 unstable_createStandardRouterNavigator<
   Opts,
@@ -174,6 +252,22 @@ unstable_createStandardRouterNavigator<
 >(SplitContent, TabRouter, {
   // @ts-expect-error `createProps` must return the complete `CreateProps` shape.
   createProps: () => ({ routeNames: [] }),
+});
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(SplitContent, TabRouter, {
+  createProps: (): CreateProps => ({
+    routeNames: [],
+    preload: () => {},
+    // @ts-expect-error `createProps` must not return undeclared properties.
+    extra: true,
+  }),
 });
 
 unstable_createStandardRouterNavigator<
@@ -331,21 +425,36 @@ unstable_integrateWithRouter<
 // action against the raw router `dispatch` (the guide's `createProps` example). `POP_TO_TOP` would
 // be a no-op on a TabRouter, so the guide uses `PRELOAD`.
 {
-  type TabsContentProps = NavigatorContentProps<{ title?: string }>;
+  type TabsCreateProps = { activeRouteKey: string; preload: (name: string) => void };
+  type TabsContentProps = NavigatorContentProps<
+    { title?: string },
+    Record<string, never>,
+    object,
+    TabsCreateProps
+  >;
 
-  const TabsContent = ({ state, descriptors }: TabsContentProps) => {
+  const TabsContent = ({ state, descriptors, activeRouteKey, preload }: TabsContentProps) => {
     const focusedRoute = state.routes[state.index]!;
-    return <View style={{ flex: 1 }}>{descriptors[focusedRoute.key]!.render()}</View>;
+    return (
+      <Pressable onPress={() => preload(activeRouteKey)} style={{ flex: 1 }}>
+        {descriptors[focusedRoute.key]!.render()}
+      </Pressable>
+    );
   };
 
-  // eslint-disable-next-line no-unused-expressions
-  unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
+  const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
     useOnlyUserDefinedScreens: true,
     createProps: ({ state, dispatch }) => ({
       activeRouteKey: state.routes[state.index]!.key,
       preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),
     }),
   });
+
+  typecheck(<Tabs />);
+  // @ts-expect-error `activeRouteKey` is injected by `createProps`.
+  typecheck(<Tabs activeRouteKey="route" />);
+  // @ts-expect-error `preload` is injected by `createProps`.
+  typecheck(<Tabs preload={() => {}} />);
 }
 
 // "Library entry points" — a framework-agnostic navigator created directly with

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -87,7 +87,7 @@ export const _options: OptionsFn = ({ route, theme }) => {
 };
 
 // ---------------------------------------------------------------------------
-// CreateProps: content-only props injected by createProps
+// CreateProps - unstable_createStandardRouterNavigator: content-only props injected by createProps
 // ---------------------------------------------------------------------------
 
 type NavProps = { tintColor?: string };
@@ -176,6 +176,27 @@ unstable_createStandardRouterNavigator<
   createProps: () => ({ routeNames: [] }),
 });
 
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions
+>(PublicContent, TabRouter);
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  object
+>(PublicContent, TabRouter);
+
+// ---------------------------------------------------------------------------
+// CreateProps - unstable_integrateWithRouter: content-only props injected by createProps
+// ---------------------------------------------------------------------------
+
 const splitStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps & CreateProps>(
   SplitContent
 );
@@ -252,23 +273,6 @@ unstable_integrateWithRouter<
   TabRouterOptions,
   object
 >(publicStandardNavigator, TabRouter);
-
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions
->(PublicContent, TabRouter);
-
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  object
->(PublicContent, TabRouter);
 
 // ---------------------------------------------------------------------------
 // The exact example from the "Custom navigators" guide

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -10,7 +10,7 @@ import {
   type TabRouterOptions,
 } from '../../react-navigation/routers';
 import type { GoBackAction, NavigateAction } from '../../react-navigation/routers/CommonActions';
-import { unstable_createStandardRouterNavigator } from '../index';
+import { unstable_createStandardRouterNavigator, unstable_integrateWithRouter } from '../index';
 import type { NavigatorContentProps, StandardNavigationAction } from '../types';
 
 // Type-equality helpers
@@ -85,6 +85,190 @@ export const _options: OptionsFn = ({ route, theme }) => {
   route.href;
   return { title: `${route.name}-${theme.dark}` };
 };
+
+// ---------------------------------------------------------------------------
+// CreateProps: content-only props injected by createProps
+// ---------------------------------------------------------------------------
+
+type NavProps = { tintColor?: string };
+type CreateProps = { routeNames: string[]; preload: (name: string) => void };
+type SplitContentProps = NavigatorContentProps<Opts, EventMap, NavProps & CreateProps>;
+type RequiredNavProps = { label: string };
+
+function SplitContent(_props: SplitContentProps) {
+  return null;
+}
+
+function PublicContent(_props: NavigatorContentProps<Opts, EventMap, NavProps>) {
+  return null;
+}
+
+function RequiredPublicContent(_props: NavigatorContentProps<Opts, EventMap, RequiredNavProps>) {
+  return null;
+}
+
+const SplitNav = unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(SplitContent, TabRouter, {
+  createProps: () => ({ routeNames: [], preload: () => {} }),
+});
+
+type SplitElementProps = ComponentProps<typeof SplitNav>;
+
+export type _ElementAcceptsNavigatorProps = Expect<
+  Equal<SplitElementProps['tintColor'], string | undefined>
+>;
+export type _ContentRequiresRouteNames = Expect<Equal<SplitContentProps['routeNames'], string[]>>;
+export type _ContentRequiresPreload = Expect<
+  Equal<SplitContentProps['preload'], (name: string) => void>
+>;
+export type _ElementLacksRouteNames = Expect<
+  Equal<'routeNames' extends keyof SplitElementProps ? true : false, false>
+>;
+export type _ElementLacksPreload = Expect<
+  Equal<'preload' extends keyof SplitElementProps ? true : false, false>
+>;
+
+const InferredPublicNav = unstable_createStandardRouterNavigator(RequiredPublicContent, TabRouter);
+type InferredPublicElementProps = ComponentProps<typeof InferredPublicNav>;
+export type _InferredElementRequiresPublicProp = Expect<
+  Equal<InferredPublicElementProps['label'], string>
+>;
+
+// @ts-expect-error The options argument is required when `CreateProps` is non-empty.
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(SplitContent, TabRouter);
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(
+  SplitContent,
+  TabRouter,
+  // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
+  { useOnlyUserDefinedScreens: true }
+);
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(SplitContent, TabRouter, {
+  // @ts-expect-error `createProps` must return the complete `CreateProps` shape.
+  createProps: () => ({ routeNames: [] }),
+});
+
+const splitStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps & CreateProps>(
+  SplitContent
+);
+
+const IntegratedSplitNav = unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(splitStandardNavigator, TabRouter, {
+  createProps: () => ({ routeNames: [], preload: () => {} }),
+});
+
+type IntegratedSplitElementProps = ComponentProps<typeof IntegratedSplitNav>;
+export type _IntegratedElementAcceptsNavigatorProps = Expect<
+  Equal<IntegratedSplitElementProps['tintColor'], string | undefined>
+>;
+export type _IntegratedElementLacksCreateProps = Expect<
+  Equal<'routeNames' extends keyof IntegratedSplitElementProps ? true : false, false>
+>;
+
+// @ts-expect-error The options argument is required when `CreateProps` is non-empty.
+unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(splitStandardNavigator, TabRouter);
+
+unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(splitStandardNavigator, TabRouter, {
+  // @ts-expect-error `createProps` must return the complete `CreateProps` shape.
+  createProps: () => ({ routeNames: [] }),
+});
+
+unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>(
+  splitStandardNavigator,
+  TabRouter,
+  // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
+  { useOnlyUserDefinedScreens: true }
+);
+
+const publicStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps>(PublicContent);
+unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions
+>(publicStandardNavigator, TabRouter);
+
+unstable_integrateWithRouter<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  object
+>(publicStandardNavigator, TabRouter);
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions
+>(PublicContent, TabRouter);
+
+unstable_createStandardRouterNavigator<
+  Opts,
+  TabNavigationState<ParamListBase>,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  object
+>(PublicContent, TabRouter);
 
 // ---------------------------------------------------------------------------
 // The exact example from the "Custom navigators" guide

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type ComponentProps } from 'react';
-import { Pressable, Text, View } from 'react-native';
 import { createStandardNavigator, type NavigatorArgs } from 'standard-navigation';
 
 import type { CommonNavigationAction, ParamListBase } from '../../react-navigation/core';
@@ -21,7 +20,6 @@ import type {
 type Expect<T extends true> = T;
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
-function typecheck(_value: unknown) {}
 
 type Opts = { title?: string };
 type EventMap = { tabPress: { data: undefined; canPreventDefault: true } };
@@ -91,14 +89,11 @@ export const _options: OptionsFn = ({ route, theme }) => {
   return { title: `${route.name}-${theme.dark}` };
 };
 
-// ---------------------------------------------------------------------------
-// CreateProps - unstable_createStandardRouterNavigator: content-only props injected by createProps
-// ---------------------------------------------------------------------------
-
 type NavProps = { tintColor?: string };
 type CreateProps = { routeNames: string[]; preload: (name: string) => void };
 type SplitContentProps = NavigatorContentProps<Opts, EventMap, NavProps, CreateProps>;
 type RequiredNavProps = { label: string };
+type TabState = TabNavigationState<ParamListBase>;
 
 function SplitContent(_props: SplitContentProps) {
   return null;
@@ -112,31 +107,67 @@ function RequiredPublicContent(_props: NavigatorContentProps<Opts, EventMap, Req
   return null;
 }
 
-const SplitNav = unstable_createStandardRouterNavigator<
+const splitStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps & CreateProps>(
+  SplitContent
+);
+const publicStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps>(PublicContent);
+
+// These instantiated signatures are for explicit-instantiation tests only. Inference tests below
+// call the original functions directly so they continue to exercise the carrier and `NoInfer`.
+const createSplitNav = unstable_createStandardRouterNavigator<
   Opts,
-  TabNavigationState<ParamListBase>,
+  TabState,
   EventMap,
   NavProps,
   TabRouterOptions,
   CreateProps
->(SplitContent, TabRouter, {
+>;
+const createPublicNav = unstable_createStandardRouterNavigator<
+  Opts,
+  TabState,
+  EventMap,
+  NavProps,
+  TabRouterOptions
+>;
+const integrateSplitNav = unstable_integrateWithRouter<
+  Opts,
+  TabState,
+  EventMap,
+  NavProps,
+  TabRouterOptions,
+  CreateProps
+>;
+const integratePublicNav = unstable_integrateWithRouter<
+  Opts,
+  TabState,
+  EventMap,
+  NavProps,
+  TabRouterOptions
+>;
+
+// ---------------------------------------------------------------------------
+// Injected CreateProps keys reach content but never leak into element props
+// ---------------------------------------------------------------------------
+
+const SplitNav = createSplitNav(SplitContent, TabRouter, {
   createProps: () => ({ routeNames: [], preload: () => {} }),
 });
-
 type SplitElementProps = ComponentProps<typeof SplitNav>;
 
+const InferredSplitNav = unstable_createStandardRouterNavigator(SplitContent, TabRouter, {
+  createProps: () => ({ routeNames: [], preload: () => {} }),
+});
+type InferredSplitElementProps = ComponentProps<typeof InferredSplitNav>;
+
+export type _ExplicitAndInferredElementPropsMatch = Expect<
+  Equal<SplitElementProps, InferredSplitElementProps>
+>;
 export type _ElementAcceptsNavigatorProps = Expect<
-  Equal<SplitElementProps['tintColor'], string | undefined>
+  Equal<InferredSplitElementProps['tintColor'], string | undefined>
 >;
 export type _ContentRequiresRouteNames = Expect<Equal<SplitContentProps['routeNames'], string[]>>;
-export type _ContentRequiresPreload = Expect<
-  Equal<SplitContentProps['preload'], (name: string) => void>
->;
 export type _ElementLacksRouteNames = Expect<
-  Equal<'routeNames' extends keyof SplitElementProps ? true : false, false>
->;
-export type _ElementLacksPreload = Expect<
-  Equal<'preload' extends keyof SplitElementProps ? true : false, false>
+  Equal<'routeNames' extends keyof InferredSplitElementProps ? true : false, false>
 >;
 
 const InferredPublicNav = unstable_createStandardRouterNavigator(RequiredPublicContent, TabRouter);
@@ -145,69 +176,12 @@ export type _InferredElementRequiresPublicProp = Expect<
   Equal<InferredPublicElementProps['label'], string>
 >;
 
-const InferredSplitNav = unstable_createStandardRouterNavigator(SplitContent, TabRouter, {
-  createProps: () => ({ routeNames: [], preload: () => {} }),
-});
-type InferredSplitElementProps = ComponentProps<typeof InferredSplitNav>;
-export type _InferredElementAcceptsNavigatorProps = Expect<
-  Equal<InferredSplitElementProps['tintColor'], string | undefined>
->;
-export type _InferredElementLacksRouteNames = Expect<
-  Equal<'routeNames' extends keyof InferredSplitElementProps ? true : false, false>
->;
-export type _InferredElementLacksPreload = Expect<
-  Equal<'preload' extends keyof InferredSplitElementProps ? true : false, false>
->;
-
-unstable_createStandardRouterNavigator(RequiredPublicContent, TabRouter, {
-  // @ts-expect-error This content does not declare any injected props.
-  createProps: () => ({ label: 1 }),
-});
-
-type CarrierCreateProps = { x: string };
-function CarrierContent(
-  _props: NavigatorContentProps<Opts, EventMap, object, CarrierCreateProps>
-) {
-  return null;
-}
-
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  object,
-  TabRouterOptions,
-  { x: number }
-  // @ts-expect-error Explicit CreateProps must match the content's declared CreateProps.
->(CarrierContent, TabRouter, { createProps: () => ({ x: 1 }) });
-
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  RequiredNavProps,
-  TabRouterOptions
-  // @ts-expect-error Five explicit generics declare no injected props, so `createProps` is forbidden.
->(RequiredPublicContent, TabRouter, { createProps: () => ({ label: 1 }) });
-
-const broadlyAnnotatedFactoryOptions: IntegrateWithRouterOptions = {
-  // @ts-expect-error Bare options do not declare injected props, so `createProps` is forbidden.
-  createProps: () => ({ label: 1 }),
-};
-unstable_createStandardRouterNavigator(
-  RequiredPublicContent,
-  TabRouter,
-  broadlyAnnotatedFactoryOptions
-);
+// ---------------------------------------------------------------------------
+// createProps and the options argument are required iff content declares injected props
+// ---------------------------------------------------------------------------
 
 // @ts-expect-error Inferred non-empty CreateProps require the options argument.
 unstable_createStandardRouterNavigator(SplitContent, TabRouter);
-
-// `NoInfer` keeps a zero-argument factory from declaring injected props for content that has none.
-unstable_createStandardRouterNavigator(PublicContent, TabRouter, {
-  // @ts-expect-error `PublicContent` does not declare any injected props.
-  createProps: () => ({ injected: true }),
-});
 
 type OptionalCreateProps = { a?: string };
 function OptionalCreateContent(
@@ -223,45 +197,59 @@ unstable_createStandardRouterNavigator(OptionalCreateContent, TabRouter, {
 });
 
 // @ts-expect-error The options argument is required when `CreateProps` is non-empty.
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(SplitContent, TabRouter);
+createSplitNav(SplitContent, TabRouter);
+
+// @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
+createSplitNav(SplitContent, TabRouter, { useOnlyUserDefinedScreens: true });
+
+createPublicNav(PublicContent, TabRouter);
+
+// ---------------------------------------------------------------------------
+// createProps cannot declare props the content does not declare
+// ---------------------------------------------------------------------------
+
+// `NoInfer` keeps a zero-argument factory from declaring injected props for content that has none.
+unstable_createStandardRouterNavigator(PublicContent, TabRouter, {
+  // @ts-expect-error `PublicContent` does not declare any injected props.
+  createProps: () => ({ injected: true }),
+});
+
+// @ts-expect-error Five explicit generics declare no injected props, so `createProps` is forbidden.
+createPublicNav(PublicContent, TabRouter, { createProps: () => ({ injected: true }) });
+
+const broadlyAnnotatedFactoryOptions: IntegrateWithRouterOptions = {
+  // @ts-expect-error Bare options do not declare injected props, so `createProps` is forbidden.
+  createProps: () => ({ injected: true }),
+};
+unstable_createStandardRouterNavigator(PublicContent, TabRouter, broadlyAnnotatedFactoryOptions);
+
+type CarrierCreateProps = { x: string };
+function CarrierContent(
+  _props: NavigatorContentProps<Opts, EventMap, object, CarrierCreateProps>
+) {
+  return null;
+}
 
 unstable_createStandardRouterNavigator<
   Opts,
-  TabNavigationState<ParamListBase>,
+  TabState,
   EventMap,
-  NavProps,
+  object,
   TabRouterOptions,
-  CreateProps
-  // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
->(SplitContent, TabRouter, { useOnlyUserDefinedScreens: true });
+  { x: number }
+  // @ts-expect-error Explicit CreateProps must match the content's declared CreateProps.
+>(CarrierContent, TabRouter, { createProps: () => ({ x: 1 }) });
 
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(SplitContent, TabRouter, {
+// ---------------------------------------------------------------------------
+// createProps return shape is exact
+// ---------------------------------------------------------------------------
+
+createSplitNav(SplitContent, TabRouter, {
   // @ts-expect-error `createProps` must return the complete `CreateProps` shape.
   createProps: () => ({ routeNames: [] }),
 });
 
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(SplitContent, TabRouter, {
+createSplitNav(SplitContent, TabRouter, {
   createProps: (): CreateProps => ({
     routeNames: [],
     preload: () => {},
@@ -270,215 +258,27 @@ unstable_createStandardRouterNavigator<
   }),
 });
 
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions
->(PublicContent, TabRouter);
-
-unstable_createStandardRouterNavigator<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  object
->(PublicContent, TabRouter);
-
 // ---------------------------------------------------------------------------
-// CreateProps - unstable_integrateWithRouter: content-only props injected by createProps
+// unstable_integrateWithRouter enforces the same contract on its own signature
 // ---------------------------------------------------------------------------
 
-const splitStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps & CreateProps>(
-  SplitContent
-);
-
-const IntegratedSplitNav = unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(splitStandardNavigator, TabRouter, {
+// Shared option types are exhaustively tested above. This smoke set guards the independently
+// declared rest tuple and verifies the resulting element props.
+const IntegratedSplitNav = integrateSplitNav(splitStandardNavigator, TabRouter, {
   createProps: () => ({ routeNames: [], preload: () => {} }),
 });
-
 type IntegratedSplitElementProps = ComponentProps<typeof IntegratedSplitNav>;
-export type _IntegratedElementAcceptsNavigatorProps = Expect<
-  Equal<IntegratedSplitElementProps['tintColor'], string | undefined>
->;
-export type _IntegratedElementLacksCreateProps = Expect<
-  Equal<'routeNames' extends keyof IntegratedSplitElementProps ? true : false, false>
+export type _IntegratedAndCreatedElementPropsMatch = Expect<
+  Equal<IntegratedSplitElementProps, SplitElementProps>
 >;
 
 // @ts-expect-error The options argument is required when `CreateProps` is non-empty.
-unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(splitStandardNavigator, TabRouter);
+integrateSplitNav(splitStandardNavigator, TabRouter);
 
-unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(splitStandardNavigator, TabRouter, {
-  // @ts-expect-error `createProps` must return the complete `CreateProps` shape.
-  createProps: () => ({ routeNames: [] }),
-});
-
-unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  CreateProps
->(
-  splitStandardNavigator,
-  TabRouter,
-  // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
-  { useOnlyUserDefinedScreens: true }
-);
-
-const publicStandardNavigator = createStandardNavigator<Opts, EventMap, NavProps>(PublicContent);
-unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions
->(publicStandardNavigator, TabRouter);
-
-unstable_integrateWithRouter<
-  Opts,
-  TabNavigationState<ParamListBase>,
-  EventMap,
-  NavProps,
-  TabRouterOptions,
-  object
->(publicStandardNavigator, TabRouter);
-
-// ---------------------------------------------------------------------------
-// The exact example from the "Custom navigators" guide
-// (docs/pages/router/advanced/custom-navigators.mdx) must type-check, so the
-// snippet users copy keeps compiling.
-// ---------------------------------------------------------------------------
-
-// "Create a navigator in your app" — `EventMap` is inferred without explicit type arguments.
-{
-  type TabsContentProps = NavigatorContentProps<{ title?: string }>;
-
-  const TabsContent = ({ state, descriptors, actions }: TabsContentProps) => {
-    const focusedRoute = state.routes[state.index]!;
-
-    return (
-      <View style={{ flex: 1 }}>
-        <View style={{ flex: 1 }}>{descriptors[focusedRoute.key]!.render()}</View>
-        <View style={{ flexDirection: 'row' }}>
-          {state.routes.map((route) => (
-            <Pressable
-              key={route.key}
-              style={{ flex: 1, padding: 16 }}
-              onPress={() => actions.navigate(route.name)}>
-              <Text>{descriptors[route.key]!.options.title ?? route.name}</Text>
-            </Pressable>
-          ))}
-        </View>
-      </View>
-    );
-  };
-
-  // eslint-disable-next-line no-unused-expressions
-  unstable_createStandardRouterNavigator(TabsContent, TabRouter);
-}
-
-// "Typed events" — the event map is inferred from the component and `emitter.emit` is typed
-// against it (unknown event names and mismatched payloads are rejected).
-{
-  type TabsContentProps = NavigatorContentProps<
-    { title?: string },
-    { tabPress: { data: undefined; canPreventDefault: true } }
-  >;
-
-  const TabsContent = ({ emitter }: TabsContentProps) => {
-    emitter.emit({ type: 'tabPress', canPreventDefault: true });
-    // @ts-expect-error `nope` is not a declared event.
-    emitter.emit({ type: 'nope' });
-    return null;
-  };
-
-  // eslint-disable-next-line no-unused-expressions
-  unstable_createStandardRouterNavigator(TabsContent, TabRouter);
-}
-
-// "Options" — the optional third argument type-checks, and `createProps` may dispatch a `PRELOAD`
-// action against the raw router `dispatch` (the guide's `createProps` example). `POP_TO_TOP` would
-// be a no-op on a TabRouter, so the guide uses `PRELOAD`.
-{
-  type TabsCreateProps = { activeRouteKey: string; preload: (name: string) => void };
-  type TabsContentProps = NavigatorContentProps<
-    { title?: string },
-    Record<string, never>,
-    object,
-    TabsCreateProps
-  >;
-
-  const TabsContent = ({ state, descriptors, activeRouteKey, preload }: TabsContentProps) => {
-    const focusedRoute = state.routes[state.index]!;
-    return (
-      <Pressable onPress={() => preload(activeRouteKey)} style={{ flex: 1 }}>
-        {descriptors[focusedRoute.key]!.render()}
-      </Pressable>
-    );
-  };
-
-  const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
-    useOnlyUserDefinedScreens: true,
-    createProps: ({ state, dispatch }) => ({
-      activeRouteKey: state.routes[state.index]!.key,
-      preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),
-    }),
-  });
-
-  typecheck(<Tabs />);
-  // @ts-expect-error `activeRouteKey` is injected by `createProps`.
-  typecheck(<Tabs activeRouteKey="route" />);
-  // @ts-expect-error `preload` is injected by `createProps`.
-  typecheck(<Tabs preload={() => {}} />);
-}
-
-// "Library entry points" — a framework-agnostic navigator created directly with
-// `createStandardNavigator`, declaring a real event map (the guide's library-author example).
-{
-  type TabsContentProps = NavigatorContentProps<
-    { title?: string },
-    { tabPress: { data: undefined; canPreventDefault: true } }
-  >;
-
-  const TabsContent = ({ emitter }: TabsContentProps) => {
-    emitter.emit({ type: 'tabPress', canPreventDefault: true });
-    return null;
-  };
-
-  // eslint-disable-next-line no-unused-expressions
-  createStandardNavigator<
-    { title?: string },
-    { tabPress: { data: undefined; canPreventDefault: true } }
-  >(TabsContent);
-}
+integratePublicNav(publicStandardNavigator, TabRouter);
 
 describe('standard-navigation types', () => {
-  it('type-checks via pnpm test:types', () => {
+  it('is type-checked by tsc via pnpm typecheck or et check-packages', () => {
     expect(typeof unstable_createStandardRouterNavigator).toBe('function');
   });
 });

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -43,7 +43,7 @@ type NavigatorPropsWithCreateProps<NavigatorProps extends object, CreateProps ex
   : NavigatorProps & CreateProps;
 
 // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
-// required otherwise; a normal optional parameter would allow it in both cases.
+// required otherwise; a normal optional parameter would accept `undefined` in both cases.
 type IntegrateWithRouterOptionsTuple<State extends NavigationState, CreateProps extends object> = [
   keyof CreateProps,
 ] extends [never]
@@ -86,7 +86,7 @@ export function unstable_createStandardRouterNavigator<
   >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
   // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
-  // required otherwise; a normal optional parameter would allow it in both cases.
+  // required otherwise; a normal optional parameter would accept `undefined` in both cases.
   ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
 ) {
   const navigator = createStandardNavigator<
@@ -94,8 +94,6 @@ export function unstable_createStandardRouterNavigator<
     EventMap,
     NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
   >(NavigatorContent);
-  // `options` can only be undefined when `CreateProps` is empty, where it is optional in the
-  // forwarded call. TypeScript cannot narrow that unresolved conditional here.
   return unstable_integrateWithRouter<
     NavigatorOptions,
     State,
@@ -103,7 +101,7 @@ export function unstable_createStandardRouterNavigator<
     NavigatorProps,
     RouterOptions,
     CreateProps
-  >(navigator, router, options!);
+  >(navigator, router, ...([options ?? {}] as IntegrateWithRouterOptionsTuple<State, CreateProps>));
 }
 
 /**
@@ -141,7 +139,7 @@ export function unstable_integrateWithRouter<
   >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
   // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
-  // required otherwise; a normal optional parameter would allow it in both cases.
+  // required otherwise; a normal optional parameter would accept `undefined` in both cases.
   ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
 ) {
   assertStandardNavigator(navigator);
@@ -199,6 +197,8 @@ export function unstable_integrateWithRouter<
           // its type, so the TS contract keeps users from reading router options off `NavigatorContent`
           // in the common case, even though they are physically present on the object.
           {...(extraProps as unknown as NavigatorProps)}
+          // `derivedProps` is partial only when `CreateProps` is empty; otherwise `createProps` is
+          // required and returns the complete shape.
           {...(derivedProps as CreateProps)}
           {...standardArgs}
         />

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -36,12 +36,6 @@ export type {
 const SUPPORTED_VERSION = 1;
 const STANDARD_NAVIGATOR_TYPE = 'standard';
 
-type NavigatorPropsWithCreateProps<NavigatorProps extends object, CreateProps extends object> = [
-  keyof CreateProps,
-] extends [never]
-  ? NavigatorProps
-  : NavigatorProps & CreateProps;
-
 // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
 // required otherwise; a normal optional parameter would accept `undefined` in both cases.
 type IntegrateWithRouterOptionsTuple<State extends NavigationState, CreateProps extends object> = [
@@ -50,12 +44,31 @@ type IntegrateWithRouterOptionsTuple<State extends NavigationState, CreateProps 
   ? [options?: IntegrateWithRouterOptions<State, CreateProps>]
   : [options: IntegrateWithRouterOptions<State, CreateProps>];
 
+type StandardRouterNavigatorComponent<
+  NavigatorOptions extends object,
+  State extends NavigationState,
+  EventMap extends StandardNavigatorEventMapBase,
+  NavigatorProps extends object,
+  RouterOptions extends DefaultRouterOptions,
+> = ReturnType<
+  typeof withLayoutContext<
+    NavigatorOptions,
+    ComponentType<
+      StandardRouterNavigatorProps<State, NavigatorOptions, EventMap, NavigatorProps, RouterOptions>
+    >,
+    State,
+    EventMap & EventMapBase
+  >
+>;
+
 /**
  * > **warning** This API is unstable and may change between minor releases.
  *
  * Creates a [`standard-navigation`](https://www.npmjs.com/package/standard-navigation) navigator and
  * wires it into Expo Router in one step. Use `unstable_integrateWithRouter` instead if you already
  * have a navigator from `createStandardNavigator`.
+ * Props declared in both `NavigatorProps` and `CreateProps` are intersected, so incompatible types
+ * produce `never` rather than a type error at this call.
  *
  * @param NavigatorContent Renders the navigator UI; receives the standard-navigation `state`,
  * `descriptors`, `actions`, and `emitter`.
@@ -78,21 +91,21 @@ export function unstable_createStandardRouterNavigator<
   CreateProps extends object = object,
 >(
   NavigatorContent: ComponentType<
-    NavigatorContentProps<
-      NavigatorOptions,
-      EventMap,
-      NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
-    >
+    NavigatorContentProps<NavigatorOptions, EventMap, NavigatorProps, CreateProps>
   >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
-  // required otherwise; a normal optional parameter would accept `undefined` in both cases.
-  ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
-) {
+  ...options: IntegrateWithRouterOptionsTuple<State, NoInfer<CreateProps>>
+): StandardRouterNavigatorComponent<
+  NavigatorOptions,
+  State,
+  EventMap,
+  NavigatorProps,
+  RouterOptions
+> {
   const navigator = createStandardNavigator<
     NavigatorOptions,
     EventMap,
-    NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
+    NavigatorProps & CreateProps
   >(NavigatorContent);
   return unstable_integrateWithRouter<
     NavigatorOptions,
@@ -101,7 +114,7 @@ export function unstable_createStandardRouterNavigator<
     NavigatorProps,
     RouterOptions,
     CreateProps
-  >(navigator, router, ...([options ?? {}] as IntegrateWithRouterOptionsTuple<State, CreateProps>));
+  >(navigator, router, ...options);
 }
 
 /**
@@ -132,22 +145,12 @@ export function unstable_integrateWithRouter<
   RouterOptions extends DefaultRouterOptions,
   CreateProps extends object = object,
 >(
-  navigator: StandardNavigator<
-    NavigatorOptions,
-    EventMap,
-    NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
-  >,
+  navigator: StandardNavigator<NavigatorOptions, EventMap, NavigatorProps & CreateProps>,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
-  // required otherwise; a normal optional parameter would accept `undefined` in both cases.
-  ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
+  ...[options]: IntegrateWithRouterOptionsTuple<State, NoInfer<CreateProps>>
 ) {
   assertStandardNavigator(navigator);
-  const { NavigatorContent } = navigator as StandardNavigator<
-    NavigatorOptions,
-    EventMap,
-    NavigatorProps & CreateProps
-  >;
+  const { NavigatorContent } = navigator;
 
   type NavPropsType = StandardRouterNavigatorProps<
     State,

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -36,6 +36,20 @@ export type {
 const SUPPORTED_VERSION = 1;
 const STANDARD_NAVIGATOR_TYPE = 'standard';
 
+type NavigatorPropsWithCreateProps<NavigatorProps extends object, CreateProps extends object> = [
+  keyof CreateProps,
+] extends [never]
+  ? NavigatorProps
+  : NavigatorProps & CreateProps;
+
+// A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
+// required otherwise; a normal optional parameter would allow it in both cases.
+type IntegrateWithRouterOptionsTuple<State extends NavigationState, CreateProps extends object> = [
+  keyof CreateProps,
+] extends [never]
+  ? [options?: IntegrateWithRouterOptions<State, CreateProps>]
+  : [options: IntegrateWithRouterOptions<State, CreateProps>];
+
 /**
  * > **warning** This API is unstable and may change between minor releases.
  *
@@ -61,23 +75,35 @@ export function unstable_createStandardRouterNavigator<
   EventMap extends StandardNavigatorEventMapBase,
   NavigatorProps extends object,
   RouterOptions extends DefaultRouterOptions,
+  CreateProps extends object = object,
 >(
   NavigatorContent: ComponentType<
-    NavigatorContentProps<NavigatorOptions, EventMap, NavigatorProps>
+    NavigatorContentProps<
+      NavigatorOptions,
+      EventMap,
+      NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
+    >
   >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  options?: IntegrateWithRouterOptions<State, NavigatorProps>
+  // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
+  // required otherwise; a normal optional parameter would allow it in both cases.
+  ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
 ) {
-  const navigator = createStandardNavigator<NavigatorOptions, EventMap, NavigatorProps>(
-    NavigatorContent
-  );
+  const navigator = createStandardNavigator<
+    NavigatorOptions,
+    EventMap,
+    NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
+  >(NavigatorContent);
+  // `options` can only be undefined when `CreateProps` is empty, where it is optional in the
+  // forwarded call. TypeScript cannot narrow that unresolved conditional here.
   return unstable_integrateWithRouter<
     NavigatorOptions,
     State,
     EventMap,
     NavigatorProps,
-    RouterOptions
-  >(navigator, router, options);
+    RouterOptions,
+    CreateProps
+  >(navigator, router, options!);
 }
 
 /**
@@ -106,13 +132,24 @@ export function unstable_integrateWithRouter<
   EventMap extends StandardNavigatorEventMapBase,
   NavigatorProps extends object,
   RouterOptions extends DefaultRouterOptions,
+  CreateProps extends object = object,
 >(
-  navigator: StandardNavigator<NavigatorOptions, EventMap, NavigatorProps>,
+  navigator: StandardNavigator<
+    NavigatorOptions,
+    EventMap,
+    NavigatorPropsWithCreateProps<NavigatorProps, CreateProps>
+  >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  options?: IntegrateWithRouterOptions<State, NavigatorProps>
+  // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
+  // required otherwise; a normal optional parameter would allow it in both cases.
+  ...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>
 ) {
   assertStandardNavigator(navigator);
-  const { NavigatorContent } = navigator;
+  const { NavigatorContent } = navigator as StandardNavigator<
+    NavigatorOptions,
+    EventMap,
+    NavigatorProps & CreateProps
+  >;
 
   type NavPropsType = StandardRouterNavigatorProps<
     State,
@@ -140,7 +177,7 @@ export function unstable_integrateWithRouter<
 
     const { dispatch } = navigation;
 
-    const derivedProps = useMemo<Partial<NavigatorProps>>(
+    const derivedProps = useMemo<Partial<CreateProps>>(
       () => options?.createProps?.({ state, dispatch, navigation }) ?? {},
       [state, dispatch, navigation, options]
     );
@@ -162,7 +199,7 @@ export function unstable_integrateWithRouter<
           // its type, so the TS contract keeps users from reading router options off `NavigatorContent`
           // in the common case, even though they are physically present on the object.
           {...(extraProps as unknown as NavigatorProps)}
-          {...derivedProps}
+          {...(derivedProps as CreateProps)}
           {...standardArgs}
         />
       </NavigationContent>

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -66,7 +66,13 @@ type CreatePropsFn<State extends NavigationState, CreateProps extends object> = 
 type CreatePropsOption<State extends NavigationState, CreateProps extends object> = [
   keyof CreateProps,
 ] extends [never]
-  ? { createProps?: CreatePropsFn<State, CreateProps> }
+  ? {
+      /**
+       * Declare injected props with the fourth type argument of `NavigatorContentProps` before
+       * providing this factory.
+       */
+      createProps?: never;
+    }
   : { createProps: CreatePropsFn<State, CreateProps> };
 
 export type IntegrateWithRouterOptions<
@@ -88,12 +94,13 @@ export type StandardNavigatorContentProps<
   Omit<NavigatorProps, keyof NavigatorArgs<NavigatorOptions, EventMap>>;
 
 /**
- * Lets TypeScript infer `EventMap` and `NavigatorProps` from a `NavigatorContent` component.
+ * Lets TypeScript infer `EventMap`, `NavigatorProps`, and `CreateProps` from a `NavigatorContent`
+ * component.
  *
  * On their own these can't be inferred: `EventMap` only appears as an argument to `emitter.emit`,
- * and `NavigatorProps` only inside `Omit<NavigatorProps, …>` — neither is a position TypeScript can
- * read a type back out of. Without these two properties it gives up and falls back to the base
- * shapes, rejecting components that declare specific events or extra props.
+ * while `NavigatorProps` and `CreateProps` are combined inside an intersection and `Omit` — none
+ * are positions TypeScript can read a type back out of. Without these properties it gives up and
+ * falls back to the base shapes, rejecting components that declare specific events or extra props.
  *
  * The properties are phantom: they never exist at runtime and are never read. They exist only to
  * put each type somewhere TypeScript will infer it from.
@@ -101,11 +108,14 @@ export type StandardNavigatorContentProps<
 type NavigatorContentInferenceCarrier<
   EventMap extends StandardNavigatorEventMapBase,
   NavigatorProps extends object,
+  CreateProps extends object,
 > = {
   /** @internal */
   readonly __eventMap__?: EventMap;
   /** @internal */
   readonly __navigatorProps__?: NavigatorProps;
+  /** @internal */
+  readonly __createProps__?: CreateProps;
 };
 
 /**
@@ -121,7 +131,9 @@ type NavigatorContentInferenceCarrier<
  * // Typed events:
  * type TabsContentProps = NavigatorContentProps<
  *   { title?: string },
- *   { tabPress: { data: undefined; canPreventDefault: true } }
+ *   { tabPress: { data: undefined; canPreventDefault: true } },
+ *   { tintColor?: string },
+ *   { activeRouteKey: string }
  * >;
  * ```
  */
@@ -129,8 +141,9 @@ export type NavigatorContentProps<
   NavigatorOptions extends object,
   EventMap extends StandardNavigatorEventMapBase = Record<string, never>,
   NavigatorProps extends object = object,
-> = StandardNavigatorContentProps<NavigatorOptions, EventMap, NavigatorProps> &
-  NavigatorContentInferenceCarrier<EventMap, NavigatorProps>;
+  CreateProps extends object = object,
+> = StandardNavigatorContentProps<NavigatorOptions, EventMap, NavigatorProps & CreateProps> &
+  NavigatorContentInferenceCarrier<EventMap, NavigatorProps, CreateProps>;
 
 export type StandardRouterNavigatorProps<
   State extends NavigationState,

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -43,34 +43,42 @@ export interface StandardNavigatorCreatePropsFactoryDeps<State extends Navigatio
   navigation: NavigationHelpers<ParamListBase>;
 }
 
-export interface IntegrateWithRouterOptions<
+/**
+ * Allows router-specific information to be exposed via navigator props alongside the standard
+ * `state` and `actions`.
+ *
+ * Receives the raw Expo Router `state` and `dispatch`. Both are internal and may have small
+ * breaking changes between releases, so prefer the `state` and `actions` passed to
+ * `NavigatorContent` when they suffice.
+ *
+ * @example
+ * ```tsx
+ * createProps: ({ state, dispatch }) => ({
+ *   activeRouteKey: state.routes[state.index].key,
+ *   preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),
+ * })
+ * ```
+ */
+type CreatePropsFn<State extends NavigationState, CreateProps extends object> = (
+  deps: StandardNavigatorCreatePropsFactoryDeps<State>
+) => CreateProps;
+
+type CreatePropsOption<State extends NavigationState, CreateProps extends object> = [
+  keyof CreateProps,
+] extends [never]
+  ? { createProps?: CreatePropsFn<State, CreateProps> }
+  : { createProps: CreatePropsFn<State, CreateProps> };
+
+export type IntegrateWithRouterOptions<
   State extends NavigationState = NavigationState,
-  NavigatorProps extends object = object,
-> {
+  CreateProps extends object = object,
+> = {
   /**
    * When `true`, only screens explicitly declared as `<Navigator.Screen>` children are rendered;
    * routes discovered from the filesystem that were not declared are ignored.
    */
   useOnlyUserDefinedScreens?: boolean;
-
-  /**
-   * Allows router-specific information to be exposed via navigator props alongside the standard
-   * `state` and `actions`.
-   *
-   * Receives the raw Expo Router `state` and `dispatch`. Both are internal and may have small
-   * breaking changes between releases, so prefer the `state` and `actions` passed to
-   * `NavigatorContent` when they suffice.
-   *
-   * @example
-   * ```tsx
-   * createProps: ({ state, dispatch }) => ({
-   *   activeRouteKey: state.routes[state.index].key,
-   *   preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),
-   * })
-   * ```
-   */
-  createProps?: (deps: StandardNavigatorCreatePropsFactoryDeps<State>) => Partial<NavigatorProps>;
-}
+} & CreatePropsOption<State, CreateProps>;
 
 export type StandardNavigatorContentProps<
   NavigatorOptions extends object,


### PR DESCRIPTION
# Why

Standard navigation integration distinguishes two types of props:
- `NavigatorProps` - these are the props which user needs to pass to the navigator, for example `<Stack prop1={v}>`
- `CreateProps` - these are the props created with `createProps` function. The main reason to use these, is to use expo-router internals to pass framework specific values. For example if someone wants to call a custom action not available in the standard-navigation contract then they need to add this as custom prop, e.g `preload: () => void`, and in both react-navigaton and expo-router add their own implementation, e.g. `createProps: ({navigation}) => ({ preload: navigation.preload })`. 

Since developer may not need the custom props, they don't need to specify any and they don't need to pass `createProps` function. However the typescript layer is too loose at the moment. Since `createProps` is optional, then all the `CreateProps` are marked as `Partial`. 

This PR fixes it - when `CreateProps` are specified then TS will require the developer to pass `createProps`

# How

1. Improve typescript for standard navigators - mark `createProps` required when custom props need to be passed and optional when they don't (`[keyof CreateProps] extends [never]`)
2. Fix TS errors in the tests and integrations

> I know that using `...[options]: IntegrateWithRouterOptionsTuple<State, CreateProps>` is not the cleanest syntax, but I was not able to find a better way to make this optional without adding 40 lines of function declaration overload.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
