### PR TITLE
[router] Add information about route source

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🎉 New features
 
+- Expose route provenance to custom navigators through descriptor `routeSource`. ([#47827](https://github.com/expo/expo/pull/47827) by [@Ubax](https://github.com/Ubax))
 - [android] Support `Stack.Toolbar.Badge` in header left/right placements ([#46537](https://github.com/expo/expo/pull/46537) by [@benjaminkomen](https://github.com/benjaminkomen))
 - [android] Support `Stack.Toolbar.Badge` on `Stack.Toolbar.Menu` icons in header left/right placements ([#47276](https://github.com/expo/expo/pull/47276) by [@Ubax](https://github.com/Ubax))
 - Add `standard-navigation` integration ([#46456](https://github.com/expo/expo/pull/46456) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/screen-provenance.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/screen-provenance.test.ios.tsx
@@ -1,0 +1,160 @@
+import type { NavigatorArgs } from 'standard-navigation';
+import { Text } from 'react-native';
+
+import { NativeTabs } from '../native-tabs/NativeTabs';
+import {
+  TabRouter,
+  type ParamListBase,
+  type TabNavigationState,
+  type TabRouterOptions,
+} from '../react-navigation/native';
+import {
+  unstable_createStandardRouterNavigator,
+  type StandardNavigatorDescriptor,
+} from '../standard-navigation';
+import { renderRouter, screen } from '../testing-library';
+import { TabList, TabTrigger, useTabsWithChildren } from '../ui';
+
+const probeContent = jest.fn((args: NavigatorArgs<object, Record<string, never>>) =>
+  args.descriptors[args.state.routes[args.state.index]!.key]!.render()
+);
+
+const Probe = unstable_createStandardRouterNavigator<
+  object,
+  TabNavigationState<ParamListBase>,
+  Record<string, never>,
+  object,
+  TabRouterOptions
+>(probeContent, TabRouter);
+
+function descriptorByRouteName(
+  name: string
+): StandardNavigatorDescriptor<object> | undefined {
+  const { state, descriptors } = probeContent.mock.calls.at(-1)![0];
+  const route = state.routes.find((route) => route.name === name);
+  return route ? (descriptors[route.key] as StandardNavigatorDescriptor<object>) : undefined;
+}
+
+beforeEach(() => {
+  probeContent.mockClear();
+});
+
+it('marks layout-declared screens as layout and filesystem-only screens as filesystem', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Probe>
+          <Probe.Screen name="a" />
+        </Probe>
+      ),
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text testID="b">B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  expect(descriptorByRouteName('a')?.routeSource).toBe('layout');
+  expect(descriptorByRouteName('b')?.routeSource).toBe('filesystem');
+});
+
+it('marks screens declared by name matching an index file as layout', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Probe>
+          <Probe.Screen name="c" />
+        </Probe>
+      ),
+      'c/index': () => <Text testID="c">C</Text>,
+      d: () => <Text testID="d">D</Text>,
+    },
+    { initialUrl: '/c' }
+  );
+
+  expect(descriptorByRouteName('c/index')?.routeSource).toBe('layout');
+  expect(descriptorByRouteName('d')?.routeSource).toBe('filesystem');
+});
+
+it('marks all screens as filesystem when the layout declares none', () => {
+  renderRouter(
+    {
+      _layout: () => <Probe />,
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text testID="b">B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  expect(descriptorByRouteName('a')?.routeSource).toBe('filesystem');
+  expect(descriptorByRouteName('b')?.routeSource).toBe('filesystem');
+});
+
+it('keeps layout provenance when redirecting from a screen behind a failing guard', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Probe>
+          <Probe.Protected guard={false} redirectTo="/b">
+            <Probe.Screen name="a" />
+          </Probe.Protected>
+        </Probe>
+      ),
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text testID="b">B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  expect(screen.getByTestId('b')).toBeVisible();
+  expect(screen).toHavePathname('/b');
+  expect(descriptorByRouteName('a')?.routeSource).toBe('layout');
+  expect(descriptorByRouteName('b')?.routeSource).toBe('filesystem');
+});
+
+it('marks screens declared with NativeTabs.Trigger as layout', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Probe>
+          <NativeTabs.Trigger name="a" />
+        </Probe>
+      ),
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text testID="b">B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  expect(descriptorByRouteName('a')?.routeSource).toBe('layout');
+  expect(descriptorByRouteName('b')?.routeSource).toBe('filesystem');
+});
+
+it('marks screens declared with headless TabTrigger as layout', () => {
+  const headlessTabsSpy = jest.fn(
+    (_args: Pick<ReturnType<typeof useTabsWithChildren>, 'state' | 'descriptors'>) => undefined
+  );
+
+  function Layout() {
+    const children = (
+      <TabList>
+        <TabTrigger name="a" href="/a" />
+      </TabList>
+    );
+    const { state, descriptors, NavigationContent } = useTabsWithChildren({ children });
+    headlessTabsSpy({ state, descriptors });
+    return <NavigationContent>{children}</NavigationContent>;
+  }
+
+  renderRouter(
+    {
+      _layout: Layout,
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text testID="b">B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  const { state, descriptors } = headlessTabsSpy.mock.calls.at(-1)![0];
+  const route = state.routes.find((route) => route.name === 'a')!;
+  expect(descriptors[route.key]!.routeSource).toBe('layout');
+});

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -74,9 +74,12 @@ export {
 export type {
   IntegrateWithRouterOptions,
   NavigatorContentProps,
+  StandardNavigatorDescriptor,
   StandardNavigatorEventMapBase,
   StandardUseNavigationBuilderOptions,
 } from './standard-navigation';
+
+export type { RouteSource } from './react-navigation/native';
 
 // Router factories for use with `unstable_createStandardRouterNavigator` / `unstable_integrateWithRouter`.
 export { StackRouter, TabRouter } from './react-navigation/routers';

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -562,6 +562,12 @@ export type ScreenLayoutArgs<
   children: React.ReactElement;
 };
 
+/**
+ * Whether a screen was declared in the layout (`<Screen>`/`<NativeTabs.Trigger>`)
+ * or inferred from the filesystem.
+ */
+export type RouteSource = 'layout' | 'filesystem';
+
 export type Descriptor<
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   ScreenOptions extends {},
@@ -587,6 +593,13 @@ export type Descriptor<
    * Navigation object for the screen
    */
   navigation: Navigation;
+
+  /**
+   * Whether this screen was declared in the layout (`<Screen>`/`<NativeTabs.Trigger>`)
+   * or inferred from the filesystem. Set by Expo Router; `undefined` for screens
+   * created outside Expo Router's screen pipeline.
+   */
+  routeSource?: RouteSource;
 };
 
 export type ScreenListeners<
@@ -702,6 +715,12 @@ export type RouteConfigProps<
    * Initial params object for the route.
    */
   initialParams?: Partial<ParamList[RouteName]>;
+
+  /**
+   * Whether this screen was declared in the layout (`<Screen>`/`<NativeTabs.Trigger>`)
+   * or inferred from the filesystem.
+   */
+  routeSource?: RouteSource;
 };
 
 export type RouteConfig<

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -282,6 +282,7 @@ export function useDescriptors<
         return element;
       },
       options: customOptions as ScreenOptions,
+      routeSource: screens[route.name]?.props.routeSource,
     };
 
     return acc;
@@ -314,6 +315,7 @@ export function useDescriptors<
         return element;
       },
       options: customOptions as ScreenOptions,
+      routeSource: screens[route.name]?.props.routeSource,
     };
   };
 

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../react-navigation/routers';
 import { act, fireEvent, renderRouter, screen } from '../../testing-library';
 import { unstable_createStandardRouterNavigator, unstable_integrateWithRouter } from '../index';
-import type { NavigatorContentProps } from '../types';
+import type { NavigatorContentProps, StandardNavigatorDescriptor } from '../types';
 
 type TestOptions = { title?: string };
 type TestEventMap = Record<string, { data: object | undefined; canPreventDefault: boolean }>;
@@ -220,6 +220,27 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
         .state.routes.map((r) => r.name)
         .sort()
     ).toEqual(['index', 'second']);
+  });
+
+  it('distinguishes declared and inferred routes via descriptor routeSource', () => {
+    renderRouter({
+      _layout: () => (
+        <StandardTabsAll>
+          <StandardTabsAll.Screen name="index" />
+        </StandardTabsAll>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
+
+    const { state, descriptors } = lastArgs();
+    const routeSourceByName = Object.fromEntries(
+      state.routes.map((route) => [
+        route.name,
+        (descriptors[route.key]! as StandardNavigatorDescriptor<TestOptions>).routeSource,
+      ])
+    );
+    expect(routeSourceByName).toEqual({ index: 'layout', second: 'filesystem' });
   });
 
   it('keeps Protected screens whose guard is false hidden', () => {

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type ComponentProps } from 'react';
-import { createStandardNavigator, type NavigatorArgs } from 'standard-navigation';
+import {
+  createStandardNavigator,
+  type NavigatorArgs,
+  type NavigatorDescriptor,
+} from 'standard-navigation';
 
 import type { CommonNavigationAction, ParamListBase } from '../../react-navigation/core';
 import {
@@ -14,6 +18,7 @@ import type {
   IntegrateWithRouterOptions,
   NavigatorContentProps,
   StandardNavigationAction,
+  StandardNavigatorDescriptor,
 } from '../types';
 
 // Type-equality helpers
@@ -23,6 +28,10 @@ type Equal<A, B> =
 
 type Opts = { title?: string };
 type EventMap = { tabPress: { data: undefined; canPreventDefault: true } };
+
+export type _DescriptorExtendsStandardDescriptor = Expect<
+  StandardNavigatorDescriptor<Opts> extends NavigatorDescriptor<Opts> ? true : false
+>;
 
 function Content(_args: NavigatorArgs<Opts, EventMap>) {
   return null;

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -28,6 +28,7 @@ import { useStandardState } from './useStandardState';
 export type {
   IntegrateWithRouterOptions,
   NavigatorContentProps,
+  StandardNavigatorDescriptor,
   StandardNavigatorEventMapBase,
   StandardUseNavigationBuilderOptions,
 } from './types';

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -1,4 +1,8 @@
-import type { createStandardNavigator, NavigatorArgs } from 'standard-navigation';
+import type {
+  createStandardNavigator,
+  NavigatorArgs,
+  NavigatorDescriptor,
+} from 'standard-navigation';
 
 import type {
   DefaultNavigatorOptions,
@@ -7,6 +11,7 @@ import type {
   NavigationHelpers,
   NavigationState,
   ParamListBase,
+  RouteSource,
 } from '../react-navigation/native';
 import type { GoBackAction, NavigateAction } from '../react-navigation/routers/CommonActions';
 
@@ -85,6 +90,19 @@ export type IntegrateWithRouterOptions<
    */
   useOnlyUserDefinedScreens?: boolean;
 } & CreatePropsOption<State, CreateProps>;
+
+/**
+ * A standard-navigation descriptor extended with Expo Router route information.
+ */
+export interface StandardNavigatorDescriptor<
+  NavigatorOptions extends object,
+> extends NavigatorDescriptor<NavigatorOptions> {
+  /**
+   * Indicates whether Expo Router received the route from a layout declaration or inferred it
+   * from the filesystem.
+   */
+  routeSource?: RouteSource;
+}
 
 export type StandardNavigatorContentProps<
   NavigatorOptions extends object,

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -179,7 +179,8 @@ export function triggersToScreens(
     triggerMap[config.name] = { ...config, index };
 
     if (config.type === 'internal') {
-      children.push(routeToScreen(config.routeNode));
+      // Trigger-declared screens are layout-declared, same as `<Screen>` children.
+      children.push(routeToScreen(config.routeNode, undefined, undefined, 'layout'));
     }
   }
   return {

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -29,6 +29,7 @@ import {
   type NavigationState,
   type ParamListBase,
   type RouteProp,
+  type RouteSource,
   type ScreenListeners,
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
@@ -83,11 +84,11 @@ function getSortedChildren(
   children: RouteNode[],
   order: ScreenProps[] = [],
   initialRouteName?: string
-): { route: RouteNode; props: Partial<ScreenProps> }[] {
+): { route: RouteNode; props: Partial<ScreenProps>; routeSource: RouteSource }[] {
   if (!order?.length) {
     return children
       .sort(sortRoutesWithInitial(initialRouteName))
-      .map((route) => ({ route, props: {} }));
+      .map((route) => ({ route, props: {}, routeSource: 'filesystem' as const }));
   }
   const entries = [...children];
 
@@ -153,6 +154,7 @@ function getSortedChildren(
           return {
             route: match,
             props: { initialParams, listeners, options, getId },
+            routeSource: 'layout' as const,
           };
         }
       }
@@ -160,11 +162,14 @@ function getSortedChildren(
     .filter(Boolean) as {
     route: RouteNode;
     props: Partial<ScreenProps>;
+    routeSource: RouteSource;
   }[];
 
   // Add any remaining children
   ordered.push(
-    ...entries.sort(sortRoutesWithInitial(initialRouteName)).map((route) => ({ route, props: {} }))
+    ...entries
+      .sort(sortRoutesWithInitial(initialRouteName))
+      .map((route) => ({ route, props: {}, routeSource: 'filesystem' as const }))
   );
 
   return ordered;
@@ -207,7 +212,7 @@ export function useSortedScreens(
     }
 
     return screensWithGuarded.map((value) => {
-      return routeToScreen(value.route, value.props, value.isGuarded);
+      return routeToScreen(value.route, value.props, value.isGuarded, value.routeSource);
     });
   }, [sorted, guardedRedirects]);
 }
@@ -536,10 +541,12 @@ export function screenOptionsFactory(
   };
 }
 
+// TODO: Refactor to take a single named-args object instead of positional params.
 export function routeToScreen(
   route: RouteNode,
   { options, getId, ...props }: Partial<ScreenProps> = {},
-  isGuarded?: boolean
+  isGuarded?: boolean,
+  routeSource?: RouteSource
 ) {
   return (
     <Screen
@@ -547,6 +554,7 @@ export function routeToScreen(
       name={route.route}
       key={route.route}
       getId={getId}
+      routeSource={routeSource}
       options={screenOptionsFactory(route, options, isGuarded)}
       getComponent={() => getQualifiedRouteComponent(route)}
     />


### PR DESCRIPTION
# Why

First commit in stack to remove render time `setState` from `useNavigationBuilder`
- **This PR: add `routeSource` information - wether route is defined in layout or only as a file**
- Remove `useUserDefinedOnly` option from `withLayoutContext` - replaced with `routeSource` in 2nd PR
- Fixes `.Protected` routes when all are protected in a single navigator - redirects to parent navigator 3rd PR
- Remove `UNSTABLE_routeNamesChangeBehavior` - no longer needed, as in the new router model the `routeNames` will be static - coming from filesystem - PR 4
- Remove the render time `setState` for route names change from `useNavigationBuilder` - PR 5

# How

1. In `packages/expo-router/src/useScreens.tsx` when route is defined in `_layout.tsx` (passed as `order` to `getSortedChildren`, then set the routeSource to `'layout'`. Otherwise set to `'filesystem'`
2. For headless tabs every `Trigger` should be `layout` defined (not all of them may come from filesystem - href defined)

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
