### PR TITLE
[video][ios] Fix player not releasing in SDK 57

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle.
+- [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle. ([#47828](https://github.com/expo/expo/pull/47828) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback. ([#46753](https://github.com/expo/expo/pull/46753) by [@zoontek](https://github.com/zoontek))
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle.
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback. ([#46753](https://github.com/expo/expo/pull/46753) by [@zoontek](https://github.com/zoontek))
 - Deduplicate `availableVideoTracks` for HLS sources with multiple audio renditions. ([#46691](https://github.com/expo/expo/pull/46691) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-video/ios/Utils/RunOnMainThread.swift
+++ b/packages/expo-video/ios/Utils/RunOnMainThread.swift
@@ -1,0 +1,11 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Foundation
+
+internal func runOnMainThread(_ operation: @escaping () -> Void) {
+  if Thread.isMainThread {
+    operation()
+  } else {
+    DispatchQueue.main.async(execute: operation)
+  }
+}

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -13,6 +13,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   lazy var audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(owner: self)
   lazy var seeker: VideoPlayerSeeker = VideoPlayerSeeker(player: self)
   private var tracksLoadingTask: Task<(), Never>?
+  private let didRelease = Mutex(false)
 
   var loop = false
   var audioMixingMode: AudioMixingMode = .auto {
@@ -181,19 +182,18 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   deinit {
-    observer?.notifyPlayerDeinit(player: self)
-    observer?.cleanup()
-    NowPlayingManager.shared.unregisterPlayer(self)
-    VideoManager.shared.unregister(videoPlayer: self)
+    releasePlayer()
+  }
 
-    videoSourceLoader.cancelCurrentTask()
-    tracksLoadingTask?.cancel()
-
-    // We have to replace from the main thread because of KVOs (see comment in VideoSourceLoader).
-    // Moreover, in this case we have to keep a strong reference to AVPlayer and remove its item
-    // If we don't do this AVPlayer doesn't get deallocated
-    DispatchQueue.main.async { [ref] in
-      ref.replaceCurrentItem(with: nil)
+  override func sharedObjectWillRelease() {
+    if Thread.isMainThread {
+      releasePlayer()
+    } else {
+      // Strong self capture is intentional: it keeps the player alive until the teardown
+      // has run on the main thread, so `deinit` can never race with it.
+      DispatchQueue.main.async {
+        self.releasePlayer()
+      }
     }
   }
 
@@ -225,7 +225,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     // sometimes the KVOs will try to deliver updates after the item has been changed or player deallocated,
     // which causes crashes.
     DispatchQueue.main.async { [weak self] in
-      guard let self else {
+      guard let self, !self.hasBeenReleased else {
         return
       }
       self.ref.replaceCurrentItem(with: playerItem)
@@ -262,7 +262,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     // sometimes the KVOs will try to deliver updates after the item has been changed or player deallocated,
     // which causes crashes.
     DispatchQueue.main.async { [weak self] in
-      guard let self else {
+      guard let self, !self.hasBeenReleased else {
         return
       }
       self.ref.replaceCurrentItem(with: playerItem)
@@ -321,6 +321,45 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       dangerousPropertiesStore.ownerIsReplacing = false
     }
     return
+  }
+
+  private func releasePlayer() {
+    let alreadyReleased = didRelease.withLock { didRelease in
+      defer {
+        didRelease = true
+      }
+      return didRelease
+    }
+    guard !alreadyReleased else {
+      return
+    }
+
+    observer?.notifyPlayerDeinit(player: self)
+    observer?.cleanup()
+    observer = nil
+    NowPlayingManager.shared.unregisterPlayer(self)
+    VideoManager.shared.unregister(videoPlayer: self)
+
+    videoSourceLoader.cancelCurrentTask()
+    tracksLoadingTask?.cancel()
+
+    // We have to replace from the main thread because of KVOs (see comment in VideoSourceLoader).
+    // Moreover, in this case we have to keep a strong reference to AVPlayer and remove its item
+    // If we don't do this AVPlayer doesn't get deallocated
+    let clear = { [ref] in
+      ref.pause()
+      ref.replaceCurrentItem(with: nil)
+    }
+
+    if Thread.isMainThread {
+      clear()
+    } else {
+      DispatchQueue.main.async(execute: clear)
+    }
+  }
+
+  private var hasBeenReleased: Bool {
+    return didRelease.withLock { $0 }
   }
 
   private func getBufferedPosition() -> Double {
@@ -399,6 +438,9 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onLoadedPlayerItem(player: AVPlayer, playerItem: AVPlayerItem?) {
+    guard !hasBeenReleased else {
+      return
+    }
     // Loading tracks requires doing some long tasks, this callback can be called from the main thread
     // Which could cause hangs
     tracksLoadingTask?.cancel()

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -186,14 +186,10 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   override func sharedObjectWillRelease() {
-    if Thread.isMainThread {
-      releasePlayer()
-    } else {
-      // Strong self capture is intentional: it keeps the player alive until the teardown
-      // has run on the main thread, so `deinit` can never race with it.
-      DispatchQueue.main.async {
-        self.releasePlayer()
-      }
+    // Strong self capture is intentional: it keeps the player alive until the teardown
+    // has run on the main thread, so `deinit` can never race with it.
+    runOnMainThread {
+      self.releasePlayer()
     }
   }
 
@@ -346,15 +342,9 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     // We have to replace from the main thread because of KVOs (see comment in VideoSourceLoader).
     // Moreover, in this case we have to keep a strong reference to AVPlayer and remove its item
     // If we don't do this AVPlayer doesn't get deallocated
-    let clear = { [ref] in
+    runOnMainThread { [ref] in
       ref.pause()
       ref.replaceCurrentItem(with: nil)
-    }
-
-    if Thread.isMainThread {
-      clear()
-    } else {
-      DispatchQueue.main.async(execute: clear)
     }
   }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/47569
SDK57 introduced some changes to SharedObject lifecycle - the information of the shared object releasing is delivered in `sharedObjectWillRelease` while the `deinit` itself is run later. 

# How

Implement `sharedObjectWillRelease` and move the release logic there. Also some threading improvements

# Test Plan

Tested in BareExpo on iOS
