### PR TITLE
[docs] Add AI tools video to additional resources, skills, and MCP pages

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: July 6, 2026
+modificationDate: July 15, 2026
 title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---

--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -2,6 +2,7 @@
 title: Using Model Context Protocol (MCP) with Expo
 sidebar_title: MCP Server
 description: A guide on integrating Model Context Protocol with Expo projects to enhance AI model capabilities.
+hasVideoLink: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -22,6 +23,13 @@ Expo MCP Server is a remote MCP server hosted by Expo that integrates with popul
   videoId="dp9dpIgDxZQ"
   title="Introducing Expo MCP Server: for accurate, context-aware AI responses"
   description="Enhance your AI-assisted tools for building apps with Expo."
+/>
+
+<VideoBoxLink
+  videoId="WLGAuwagI8o"
+  time={364}
+  title="The 3 tools you need to build mobile apps with AI"
+  description="Watch an AI agent use MCP servers while building a mobile app with Expo."
 />
 
 ## What does Expo MCP Server do?

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -2,6 +2,7 @@
 title: Expo Skills for AI agents
 sidebar_title: Expo Skills
 description: A list of official AI agent skills provided by Expo for building, deploying, and debugging Expo and React Native apps.
+hasVideoLink: true
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
@@ -12,8 +13,16 @@ import { ExpoSkillsTable } from '~/ui/components/ExpoSkillsTable';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug Expo and React Native apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
+
+<VideoBoxLink
+  videoId="WLGAuwagI8o"
+  time={61}
+  title="The 3 tools you need to build mobile apps with AI"
+  description="Learn how Expo Skills teach an AI agent to build a habit tracker app from scratch."
+/>
 
 ## Install Expo Skills
 

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -479,6 +479,12 @@ export const LIVE_STREAMS = [
 
 export const YOUTUBE_VIDEOS = [
   {
+    title: 'The 3 tools you need to build mobile apps with AI',
+    event: 'Expo Tutorials',
+    videoId: 'WLGAuwagI8o',
+    uploadDate: '2026-07-13',
+  },
+  {
     title: 'Introducing "Observe": Performance monitoring for React Native apps',
     event: 'Expo Tutorials',
     videoId: '5JqK9JLD140',

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -47,6 +47,7 @@ export function VideoBoxLink({
           'hocus:bg-subtle hocus:shadow-sm',
           'max-sm:flex-col',
           '[&+hr]:mt-6!',
+          '[&+&]:mt-3',
           className
         )}
         aria-label={`Watch video: ${title} (opens in new tab)`}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add AI tools video to additional resources, skills, and MCP pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2610" height="746" alt="CleanShot 2026-07-15 at 23 59 29@2x" src="https://github.com/user-attachments/assets/b8af5f63-e1f0-48ea-b2c8-b0fcd651a143" />

<img width="2534" height="702" alt="CleanShot 2026-07-16 at 00 04 57@2x" src="https://github.com/user-attachments/assets/5b22676d-8ed0-42cf-81d2-114f9dacfd7a" />

<img width="2410" height="1148" alt="CleanShot 2026-07-16 at 00 06 53@2x" src="https://github.com/user-attachments/assets/6ffd2da6-eb7b-42ca-9a8c-cf9c360f1d76" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
