### PR TITLE
[updates] Don't set isUpdatePending when a download completes with no new update

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
+- Fix `isUpdatePending` incorrectly becoming `true` after a fetch or check that finds no new update to download. ([#47830](https://github.com/expo/expo/pull/47830) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
@@ -21,7 +21,10 @@ sealed class UpdatesStateEvent(val type: UpdatesStateEventType) {
   }
   class Download : UpdatesStateEvent(UpdatesStateEventType.Download)
   class DownloadProgress(val progress: Double) : UpdatesStateEvent(UpdatesStateEventType.DownloadProgress)
+
+  // download finished with no update available, so nothing is pending
   class DownloadComplete : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+
   class DownloadCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
   class DownloadCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
   class DownloadError(private val errorMessage: String) : UpdatesStateEvent(UpdatesStateEventType.DownloadError) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -215,7 +215,7 @@ class UpdatesStateMachine(
         is UpdatesStateEvent.DownloadComplete -> context.copyAndIncrementSequenceNumber(
           isDownloading = false,
           downloadError = null,
-          isUpdatePending = true,
+          isUpdatePending = false,
           downloadProgress = 1.0,
           downloadStartTime = null,
           downloadFinishTime = null

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -117,7 +117,7 @@ final class FetchUpdateProcedure: StateMachineProcedure {
 
         if didRollBackToEmbedded {
           self.successBlock(FetchUpdateResult.rollBackToEmbedded)
-          procedureContext.processStateEvent(.downloadComplete)
+          procedureContext.processStateEvent(.downloadCompleteWithRollback)
           procedureContext.onComplete()
           return
         }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -33,7 +33,10 @@ internal enum UpdatesStateEvent {
   case checkCompleteWithRollback(rollbackCommitTime: Date)
   case checkError(errorMessage: String)
   case download
+
+  // download finished with no update available, so nothing is pending
   case downloadComplete
+
   case downloadCompleteWithUpdate(manifest: [String: Any])
   case downloadCompleteWithRollback
   case downloadError(errorMessage: String)
@@ -497,7 +500,7 @@ internal class UpdatesStateMachine {
       return context.copyAndIncrementSequenceNumber {
         $0.isDownloading = false
         $0.downloadError = nil
-        $0.isUpdatePending = true
+        $0.isUpdatePending = false
         $0.downloadProgress = 1.0
         $0.downloadStartTime = nil
         $0.downloadFinishTime = nil


### PR DESCRIPTION
# Why

Fixes [ENG-23675](https://linear.app/expo/issue/ENG-23675/investigate-isupdatepending-after-channel-switch-reload).

After a channel switch (`setUpdateRequestHeadersOverride` → `fetchUpdateAsync` → `reloadAsync`), `isUpdatePending` could come back `true` on the next load even though no new update had been downloaded, surfacing a spurious "An update is available" banner.

Root cause: the updates state machine's bare `downloadComplete` event unconditionally set `isUpdatePending = true`. That event is emitted on paths where the download finished **without** producing a new launchable update — a `fetchUpdateAsync` that finds nothing new (server had nothing, or the update was rejected by the selection policy), and the startup no-update-while-downloading path. So a no-op fetch (which the demo's overlay triggers automatically after a check reports availability) flipped `isUpdatePending` on with nothing actually pending.

This contradicts the documented contract of `isUpdatePending`: *"True if a new available update is available and has been downloaded."*

# How

`downloadComplete` now sets `isUpdatePending = false`. Nothing was downloaded on that path, so nothing is pending. A genuinely downloaded update or a rollback continues to flow through `downloadCompleteWithUpdate` / `downloadCompleteWithRollback`, which set `isUpdatePending = true` — so real pending updates are unaffected.

- **iOS** – `UpdatesStateMachine` reducer flips the flag; `FetchUpdateProcedure`'s rollback branch now emits `.downloadCompleteWithRollback` (a pending rollback) instead of the generic `.downloadComplete`. This matches what Android already does and revives the previously-unused `.downloadCompleteWithRollback` event on iOS.
- **Android** – one-line reducer mirror. Its procedures already emit `DownloadCompleteWithRollback()` / bare `DownloadComplete()` correctly, so no procedure changes were needed.

`downloadProgress` behavior is intentionally left as-is (`1.0`) to keep both platforms identical.

# Test Plan

Verified against Keith's [pancake-theory](https://github.com/keith-kurak/pancake-theory) repro: channel surf → reload no longer shows the "An update is available" banner, and `isUpdatePending` stays `false`.

# Checklist

- [x] I added a changelog.md entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for npx expo prebuild & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
