### PR TITLE
[JSI] Stop `JavaScriptActor.assumeIsolated` from boxing its operation

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 💡 Others
 
+- [iOS] `JavaScriptActor.assumeIsolated` no longer heap-allocates a closure box per call by keeping its `operation` non-escaping, making synchronous host calls ~1.6× faster. ([#47837](https://github.com/expo/expo/pull/47837) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Sync host functions no longer allocate a `JavaScriptRef` per call: the arguments buffer is now built inside the synchronous `assumeIsolated` closure instead of being boxed to cross the closure boundary, removing a heap allocation and its retain/release/dealloc from every host call (measured ~10% faster on the no-op `@JS` host-call floor). ([#46949](https://github.com/expo/expo/pull/46949) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptUnownedValue` and `JavaScriptValuesBuffer` now cache the runtime as the immortal `facebook.jsi.IRuntime` instead of the ARC-managed `JavaScriptRuntime` wrapper, removing per-call retain/release on the argument-decode hot path (measured ~16% faster `addNumbers`, ~24% faster `addStrings`). ([#46678](https://github.com/expo/expo/pull/46678) by [@tsapeta](https://github.com/tsapeta))
 - `NativeArrayBuffer` arguments no longer copy the buffer when it's already native-backed. ([#46448](https://github.com/expo/expo/pull/46448) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-/// Name of the JavaScript thread created by React Native. Copied from `RCTJSThreadManager.mm`.
-private let jsThreadName = "com.facebook.react.runtime.JavaScript"
-
 /// Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
 /// Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
 /// without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
@@ -23,25 +20,56 @@ public actor JavaScriptActor: GlobalActor {
   /// An equivalent of `MainActor.assumeIsolated`, but for the `JavaScriptActor`. Assumes that the currently executing
   /// synchronous function is actually executing on the JavaScript thread and invokes an isolated version of the operation,
   /// allowing synchronous access to JavaScript runtime state without hopping through asynchronous boundaries.
-  ///
-  /// See https://stackoverflow.com/a/79346971 for more information about the implementation.
-  public static func assumeIsolated<T: ~Copyable>(_ operation: @JavaScriptActor () throws -> T) rethrows -> T {
-    typealias YesActor = @JavaScriptActor () throws -> T
-    typealias NoActor = () throws -> T
+  /// The nonthrowing overload keeps `operation` nonescaping so its captured context can remain stack-allocated.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public static func assumeIsolated<T: ~Copyable>(_ operation: @JavaScriptActor () -> T) -> T {
+    typealias IsolatedRunner = @JavaScriptActor (@JavaScriptActor () -> T) -> T
+    typealias NonisolatedRunner = (@JavaScriptActor () -> T) -> T
 
     // This will crash if the current context cannot be isolated.
-    shared.executor.checkIsolated()
+    checkIsolated()
 
-    // To do the unsafe cast, we have to pretend it's @escaping.
-    return try withoutActuallyEscaping(operation) { (_ fn: @escaping YesActor) throws -> T in
-      let rawFn = unsafeBitCast(fn, to: NoActor.self)
-      return try rawFn()
-    }
+    // Cast the capture-free runner rather than `operation` itself. `operation` remains nonescaping,
+    // so its captures can stay in the caller's stack frame.
+    let runner = unsafeBitCast(runIsolated as IsolatedRunner, to: NonisolatedRunner.self)
+    return runner(operation)
   }
 
-  /// Stops program execution if the actor's executor is not isolating the current context.
+  /// Throwing counterpart to the nonthrowing overload above. The generic error type keeps
+  /// `operation` nonescaping while preserving the exact error it can throw.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public static func assumeIsolated<T: ~Copyable, E: Error>(
+    _ operation: @JavaScriptActor () throws(E) -> T
+  ) throws(E) -> T {
+    // Casting a `throws(E)` function value requires newer OS runtime support. Wrapping the
+    // operation in the nonthrowing fast path keeps this backdeployable and stack-allocated.
+    let result: Result<T, E> = assumeIsolated {
+      return Result(catching: operation)
+    }
+    return try result.get()
+  }
+
+  /// In debug builds, asserts if the actor's executor is not isolating the current context.
+  @inlinable
+  @inline(__always)
   public static func checkIsolated() {
-    shared.executor.checkIsolated()
+    // Using `assert` instead of `precondition` because this check is a heuristic based on
+    // thread name, not a precise isolation guarantee. Worklet runtimes legitimately run on
+    // the UI thread, which would cause a false-positive crash with `precondition`.
+    assert(
+      // JavaScript thread name copied from `RCTJSThreadManager.mm`.
+      Thread.current.name == "com.facebook.react.runtime.JavaScript" || !Thread.isMultiThreaded()
+        || ProcessInfo.processInfo.processName == "xctest",
+      "JavaScriptActor operations must be run on the JavaScript thread"
+    )
+  }
+
+  @JavaScriptActor
+  @usableFromInline
+  internal static func runIsolated<T: ~Copyable>(_ operation: @JavaScriptActor () -> T) -> T {
+    return operation()
   }
 }
 
@@ -57,20 +85,11 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
     return UnownedSerialExecutor(ordinary: self)
   }
 
-  /// Stops program execution if the executor is not isolating the current context.
+  /// Runtime hook used by Swift's actor data-race checks for synchronous entry into
+  /// `@JavaScriptActor` code. Do not remove: the `SerialExecutor` default always fails
+  /// when there is no active Swift task carrying this executor.
   func checkIsolated() {
-    // Using `assert` instead of `precondition` because this check is a heuristic based on
-    // thread name, not a precise isolation guarantee. Worklet runtimes legitimately run on
-    // the UI thread, which would cause a false-positive crash with `precondition`.
-    assert(isIsolatingCurrentContext() == true, "JavaScriptActor operations must be run on the JavaScript thread")
-  }
-
-  /// Checks whether the executor isolates the current context, i.e. the current thread is a JavaScript thread.
-  /// The condition is also met when running tests and in single threaded environments.
-  func isIsolatingCurrentContext() -> Bool? {
-    // We must be careful as it relies on the thread name given by React Native.
-    return Thread.current.name == jsThreadName || !Thread.isMultiThreaded()
-      || ProcessInfo.processInfo.processName == "xctest"
+    JavaScriptActor.checkIsolated()
   }
 }
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
@@ -59,6 +59,17 @@ struct JavaScriptActorTests {
   }
 
   @Test
+  func `assumeIsolated preserves typed error`() {
+    struct CustomError: Error {}
+
+    #expect(throws: CustomError.self) {
+      try JavaScriptActor.assumeIsolated { () throws(CustomError) -> Int in
+        throw CustomError()
+      }
+    }
+  }
+
+  @Test
   func `assumeIsolated can modify captured variables`() {
     var counter = 0
     JavaScriptActor.assumeIsolated {


### PR DESCRIPTION
## Why

The synchronous host-function trampolines wrap their body in `JavaScriptActor.assumeIsolated`. Profiling a no-op `@JS` host call (release, on device) showed a per-call heap allocation (`swift_allocObject`) plus its retain/release dominating the Swift-side cost. The cause: `assumeIsolated` routed its `operation` through `withoutActuallyEscaping`, which defeats closure stack promotion and forces the operation's captured context onto the heap every call.

## How

Keep `operation` non-escaping in both overloads:

- The non-throwing overload casts a capture-free static runner (`runIsolated`) from isolated to non-isolated and passes `operation` to it as an ordinary non-escaping argument. With no reabstraction thunk over `operation`, its captures stay on the caller's stack and no box is allocated.
- The throwing overload becomes typed-throws (`throws(E)`) and delegates to the non-throwing fast path via `Result(catching:)`, avoiding `withoutActuallyEscaping` while preserving the exact error type. Typed throws also sidesteps the newer-OS runtime support that casting a `throws` function value would require.

Both are `@_alwaysEmitIntoClient @inline(__always)`, so the runner indirection and casts fold away at `-O`. This benefits every `assumeIsolated { … }` caller, not just the host-function trampolines. No behavior change: `checkIsolated()` keeps the same thread-name assertion.

## Test Plan

- `swift build` of `expo-modules-jsi` is clean; added `JavaScriptActorTests` coverage (runs under the package's iOS `xcodebuild test` suite).
- On device (release), the no-op `@JS` host call dropped from ~168 ns/call to ~103 ns/call after this change (~1.6x).
