### PR TITLE
Add jsBundleFilePathLoader parameter to ExpoReactHostFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- **`expo`**
+  - [Android] Add `jsBundleFilePathLoader` parameter to `ExpoReactHostFactory`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -33,6 +33,7 @@ object ExpoReactHostFactory {
     override val jsMainModulePath: String,
     private val jsBundleAssetPath: String?,
     private val jsBundleFilePath: String? = null,
+    private val jsBundleFilePathLoader: (() -> String?)? = null,
     private val useDevSupport: Boolean,
     override val bindingsInstaller: BindingsInstaller? = null,
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder =
@@ -44,7 +45,7 @@ object ExpoReactHostFactory {
       get() =
         hostHandlers.asSequence()
           .mapNotNull { it.getJSBundleFile(useDevSupport) }
-          .firstOrNull() ?: jsBundleFilePath
+          .firstOrNull() ?: jsBundleFilePathLoader?.invoke() ?: jsBundleFilePath
 
     val hostDelegateJSBundleAssetPath: String?
       get() =
@@ -102,6 +103,7 @@ object ExpoReactHostFactory {
     jsMainModulePath: String = ".expo/.virtual-metro-entry",
     jsBundleAssetPath: String = "index.android.bundle",
     jsBundleFilePath: String? = null,
+    jsBundleFilePathLoader: (() -> String?)? = null,
     useDevSupport: Boolean = ReactBuildConfig.DEBUG,
     bindingsInstaller: BindingsInstaller? = null
   ): ReactHost {
@@ -117,6 +119,7 @@ object ExpoReactHostFactory {
         jsMainModulePath,
         jsBundleAssetPath,
         jsBundleFilePath,
+        jsBundleFilePathLoader,
         useDevSupport,
         bindingsInstaller,
         hostHandlers = hostHandlers


### PR DESCRIPTION
# Why

Sometimes, applications developed in brownfield mode require dynamic modification of the file path of the JS bundle. By adding `jsBundleFilePathLoader`, developers can more easily control the source of the Bundle.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
