### PR TITLE
[sdk-57][tools] Fix prettier formatting in PublishReviewApp

### DIFF
--- a/tools/src/commands/PublishReviewApp.ts
+++ b/tools/src/commands/PublishReviewApp.ts
@@ -75,10 +75,14 @@ async function runEASUpdate(): Promise<void> {
 
   // Plain JS with an inline sourcemap so Expo Go's source code explorer can
   // show the project's source to App Review (Hermes bytecode carries neither).
-  await spawnAsync('eas', ['update', '--branch', 'main', '--no-bytecode', '--source-maps', 'inline'], {
-    cwd: NCL_DIR,
-    stdio: 'inherit',
-  });
+  await spawnAsync(
+    'eas',
+    ['update', '--branch', 'main', '--no-bytecode', '--source-maps', 'inline'],
+    {
+      cwd: NCL_DIR,
+      stdio: 'inherit',
+    }
+  );
 }
 
 async function main(options: ActionOptions): Promise<void> {


### PR DESCRIPTION
# Why

The Expotools workflow is red on every `sdk-57` push that touches `tools/`: the lint step fails with 4 prettier warnings under the zero-warnings policy (`ESLint found too many warnings (maximum: 0)`). Example failing run: the `Publish packages` push on 2026-07-15.

# How

The `spawnAsync('eas', ...)` call in `tools/src/commands/PublishReviewApp.ts` gained `--no-bytecode --source-maps inline` args on this branch, pushing the line past prettier's print width; it was committed unformatted. This applies the prettier-suggested multi-line formatting — no behavior change.

# Test Plan

`npx prettier@3.8.3 --check tools/src/commands/PublishReviewApp.ts` fails before, passes after ("All matched files use Prettier code style!"). The Expotools workflow on this PR is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
