### PR TITLE
chore: Update to `2g@^0.4.3`

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -53,7 +53,7 @@
     "test:playwright": "playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
-    "2g": "^0.4.1",
+    "2g": "^0.4.3",
     "@expo/code-signing-certificates": "^0.0.6",
     "@expo/config": "workspace:~56.0.9",
     "@expo/config-plugins": "workspace:~56.0.8",

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -71,7 +71,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "2g": "^0.4.1",
+    "2g": "^0.4.3",
     "@babel/code-frame": "^7.20.0",
     "@babel/core": "^7.20.0",
     "@babel/generator": "^7.20.5",

--- a/packages/@expo/metro-file-map/package.json
+++ b/packages/@expo/metro-file-map/package.json
@@ -35,7 +35,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "2g": "^0.4.1",
+    "2g": "^0.4.3",
     "debug": "^4.3.4",
     "fb-watchman": "^2.0.2",
     "invariant": "^2.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1812,8 +1812,8 @@ importers:
   packages/@expo/cli:
     dependencies:
       2g:
-        specifier: ^0.4.1
-        version: 0.4.1(typescript@6.0.3)
+        specifier: ^0.4.3
+        version: 0.4.3(typescript@6.0.3)
       '@expo/code-signing-certificates':
         specifier: ^0.0.6
         version: 0.0.6
@@ -2592,8 +2592,8 @@ importers:
   packages/@expo/metro-config:
     dependencies:
       2g:
-        specifier: ^0.4.1
-        version: 0.4.1(typescript@6.0.3)
+        specifier: ^0.4.3
+        version: 0.4.3(typescript@6.0.3)
       '@babel/code-frame':
         specifier: ^7.20.0
         version: 7.29.0
@@ -2704,8 +2704,8 @@ importers:
   packages/@expo/metro-file-map:
     dependencies:
       2g:
-        specifier: ^0.4.1
-        version: 0.4.1(typescript@6.0.3)
+        specifier: ^0.4.3
+        version: 0.4.3(typescript@6.0.3)
       debug:
         specifier: ^4.3.4
         version: 4.4.3
@@ -4461,42 +4461,6 @@ importers:
       memfs:
         specifier: ^3.2.0
         version: 3.6.0
-
-  packages/submit-expo-feedback:
-    devDependencies:
-      '@expo/config':
-        specifier: workspace:*
-        version: link:../@expo/config
-      '@expo/package-manager':
-        specifier: workspace:*
-        version: link:../@expo/package-manager
-      '@types/jest':
-        specifier: ^29.2.1
-        version: 29.5.14
-      '@types/prompts':
-        specifier: ^2.0.6
-        version: 2.4.9
-      '@vercel/ncc':
-        specifier: ^0.38.3
-        version: 0.38.4
-      agent-cli-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
-      arg:
-        specifier: ^5.0.2
-        version: 5.0.2
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
-      ci-info:
-        specifier: ^3.3.0
-        version: 3.9.0
-      expo-module-scripts:
-        specifier: workspace:*
-        version: link:../expo-module-scripts
-      prompts:
-        specifier: ^2.3.2
-        version: 2.4.2
 
   packages/expo-file-system:
     dependencies:
@@ -6380,6 +6344,42 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4
 
+  packages/submit-expo-feedback:
+    devDependencies:
+      '@expo/config':
+        specifier: workspace:*
+        version: link:../@expo/config
+      '@expo/package-manager':
+        specifier: workspace:*
+        version: link:../@expo/package-manager
+      '@types/jest':
+        specifier: ^29.2.1
+        version: 29.5.14
+      '@types/prompts':
+        specifier: ^2.0.6
+        version: 2.4.9
+      '@vercel/ncc':
+        specifier: ^0.38.3
+        version: 0.38.4
+      agent-cli-detector:
+        specifier: ^0.1.2
+        version: 0.1.2
+      arg:
+        specifier: ^5.0.2
+        version: 5.0.2
+      chalk:
+        specifier: ^4.0.0
+        version: 4.1.2
+      ci-info:
+        specifier: ^3.3.0
+        version: 3.9.0
+      expo-module-scripts:
+        specifier: workspace:*
+        version: link:../expo-module-scripts
+      prompts:
+        specifier: ^2.3.2
+        version: 2.4.2
+
   packages/unimodules-app-loader:
     devDependencies:
       expo-module-scripts:
@@ -6596,8 +6596,8 @@ importers:
 
 packages:
 
-  2g@0.4.1:
-    resolution: {integrity: sha512-m5lYjdNmgCDvDgW2xmCawbnmbgl2WpSHg1cfEAwtgLJB1pHqL36cJaL4a1X6JpKVIJbucHjDIIZMGYHnV9ng7w==}
+  2g@0.4.3:
+    resolution: {integrity: sha512-aGeKeZycrF3KxgN/1ReXA8gfAh0vDNfAlu7WJhesqKEtPVaLyhmvqrBGZbNfJflqZTSQSNEc8xxSM8I48Lu5UQ==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.8.0'
@@ -15598,7 +15598,7 @@ packages:
 
 snapshots:
 
-  2g@0.4.1(typescript@6.0.3):
+  2g@0.4.3(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
## Summary

Follow-up to #47655

I've missed that `2g record` was not instantiating the IPC sub-pipe correctly for child processes/workers. This meant that any explicit `LOG_EVENTS` target had no socket to capture child thread log events.

This is fixed in https://github.com/kitten/2g/pull/16 which also makes the debug mode more consistent in these cases, and ensures that children are less likely to receive our public env vars.

> [!NOTE]
> No changelog added, since this is entirely internal and just an update

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
