### PR TITLE
[core][Android] Introduce `ConverterContext`

### DIFF
--- a/apps/bare-expo/modules/test-expo-ui/android/src/main/java/expo/modules/testexpoui/TestExpoUiModule.kt
+++ b/apps/bare-expo/modules/test-expo-ui/android/src/main/java/expo/modules/testexpoui/TestExpoUiModule.kt
@@ -11,8 +11,8 @@ class TestExpoUiModule : Module() {
     Name("TestExpoUi")
 
     OnCreate {
-      ModifierRegistry.register("customBorder") { map, _, _, _ ->
-        customBorderModifier(recordFromMap<CustomBorderParams>(map))
+      ModifierRegistry.register("customBorder") { map, _, converterContext, _ ->
+        customBorderModifier(recordFromMap<CustomBorderParams>(map, converterContext))
       }
     }
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Android] Removed the deprecated `AppContext.hostingRuntimeContext` property. Use `AppContext.runtime` instead. ([#46964](https://github.com/expo/expo/pull/46964) by [@wenszel](https://github.com/wenszel))
 - [Android] Removed the deprecated `AppContext.errorManager` property. Use `AppContext.jsLogger` instead. ([#46964](https://github.com/expo/expo/pull/46964) by [@wenszel](https://github.com/wenszel))
 - [Android] Replaced the old `ArrayBuffer` interface with a concrete class, so `NativeArrayBuffer` and `JavaScriptArrayBuffer` no longer share a common `ArrayBuffer` supertype. ([#47106](https://github.com/expo/expo/pull/47106) by [@barthap](https://github.com/barthap))
+- [Android] Introduce `ConverterContext`. ([#47850](https://github.com/expo/expo/pull/47850) by [@jakex7](https://github.com/jakex7))
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
@@ -3,6 +3,7 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.types.testConverterContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
@@ -19,28 +20,28 @@ class JavaScriptFunctionTest {
   @Test
   fun should_be_able_to_return_value() = withJSIInterop {
     val function = evaluateScript("() => { return 21 }").getFunction<Int>()
-    val result = function()
+    val result = function(converterContext = testConverterContext)
     Truth.assertThat(result).isEqualTo(21)
   }
 
   @Test
   fun should_be_able_to_accept_simple_data() = withJSIInterop {
     val function = evaluateScript("(a, b) => { return a + b }").getFunction<Int>()
-    val result = function(20, 50)
+    val result = function(20, 50, converterContext = testConverterContext)
     Truth.assertThat(result).isEqualTo(70)
   }
 
   @Test
   fun should_be_able_to_accept_complex_data() = withJSIInterop {
     val function = evaluateScript("(object) => { return object.k1 }").getFunction<String>()
-    val result = function(mapOf("k1" to "expo"))
+    val result = function(mapOf("k1" to "expo"), converterContext = testConverterContext)
     Truth.assertThat(result).isEqualTo("expo")
   }
 
   @Test
   fun should_be_accepted_as_a_function_arg() = withSingleModule({
     Function("decorate") { jsFunction: JavaScriptFunction<String> ->
-      "${jsFunction()}${jsFunction()}"
+      "${jsFunction(converterContext = testConverterContext)}${jsFunction(converterContext = testConverterContext)}"
     }
   }) {
     val result = call("decorate", "() => 'foo'").getString()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.TypeConverterProviderImpl
 import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
+import expo.modules.kotlin.types.testConverterContext
 import org.junit.Ignore
 import org.junit.Test
 import kotlin.reflect.typeOf
@@ -108,8 +109,8 @@ class RecordConversionStrategyBenchmarkTest {
     )
 
     // Warm up lazy propertyDescriptors
-    reflectionStrategy.convertFromMap(sampleMap, null, false)
-    introspectableStrategy.convertFromMap(sampleMap, null, false)
+    reflectionStrategy.convertFromMap(sampleMap, testConverterContext, false)
+    introspectableStrategy.convertFromMap(sampleMap, testConverterContext, false)
 
     var reflectionTotal = 0.nanoseconds
     var introspectableTotal = 0.nanoseconds
@@ -117,14 +118,14 @@ class RecordConversionStrategyBenchmarkTest {
     repeat(numberOfTries) {
       val reflectionTime = measureTime {
         repeat(numberOfCalls) {
-          reflectionStrategy.convertFromMap(sampleMap, null, false)
+          reflectionStrategy.convertFromMap(sampleMap, testConverterContext, false)
         }
       }
       reflectionTotal += reflectionTime / numberOfCalls
 
       val introspectableTime = measureTime {
         repeat(numberOfCalls) {
-          introspectableStrategy.convertFromMap(sampleMap, null, false)
+          introspectableStrategy.convertFromMap(sampleMap, testConverterContext, false)
         }
       }
       introspectableTotal += introspectableTime / numberOfCalls
@@ -150,7 +151,7 @@ class RecordConversionStrategyBenchmarkTest {
             TypeConverterProviderImpl,
             typeDescriptor
           )
-          strategy.convertFromMap(sampleMap, null, false)
+          strategy.convertFromMap(sampleMap, testConverterContext, false)
         }
       }
       reflectionTotal += reflectionTime / numberOfCalls
@@ -162,7 +163,7 @@ class RecordConversionStrategyBenchmarkTest {
             TypeConverterProviderImpl,
             typeDescriptor
           )
-          strategy.convertFromMap(sampleMap, null, false)
+          strategy.convertFromMap(sampleMap, testConverterContext, false)
         }
       }
       introspectableTotal += introspectableTime / numberOfCalls

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/types/TestConverterContext.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/types/TestConverterContext.kt
@@ -1,0 +1,8 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import io.mockk.mockk
+
+internal val testConverterContext = mockk<ConverterContext>(relaxed = true)
+
+internal inline fun <reified T> convert(value: Dynamic): T = convert(value, testConverterContext)

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
@@ -1,8 +1,8 @@
 package expo.modules.kotlin.views
 
 import com.facebook.react.bridge.ReadableMap
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.recycle
+import expo.modules.kotlin.types.ConverterContext
 
 /**
  * A marker interface for props classes that are used to pass data to Compose views.
@@ -12,7 +12,7 @@ interface ComposeProps
 
 inline fun <reified Props : ComposeProps> createComposeProps(
   propsMap: ReadableMap?,
-  appContext: AppContext? = null
+  converterContext: ConverterContext
 ): Props {
   val propsParsingStrategy = toPropsParsingStrategy<Props>()
   var propsInstance = propsParsingStrategy.createNewInstance()
@@ -33,7 +33,7 @@ inline fun <reified Props : ComposeProps> createComposeProps(
         prop.copyPropsWithNewValue(
           prop = this,
           currentProps = propsInstance,
-          appContext = appContext
+          converterContext = converterContext
         ) ?: propsInstance
         ) as Props
     }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -3,11 +3,11 @@ package expo.modules.kotlin.views
 import android.view.View
 import androidx.compose.runtime.MutableState
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.ConverterContext
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.full.memberFunctions
 
@@ -18,12 +18,12 @@ class ComposeViewProp(
 ) : AnyViewProp(name, anyType) {
   private var _isStateProp = false
 
-  override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
-    set(prop = prop as Any, onView = onView, appContext = appContext)
+  override fun set(prop: Dynamic, onView: View, converterContext: ConverterContext) {
+    set(prop = prop as Any, onView = onView, converterContext = converterContext)
   }
 
   @Suppress("UNCHECKED_CAST")
-  override fun set(prop: Any?, onView: View, appContext: AppContext?) {
+  override fun set(prop: Any?, onView: View, converterContext: ConverterContext) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
@@ -32,7 +32,8 @@ class ComposeViewProp(
       if (onView is ComposeFunctionHolder<*>) {
         // Use current props state, not the initial props instance
         val currentProps = onView.propsMutableState.value
-        val result = copyPropsWithNewValue(prop, currentProps, appContext) ?: return@exceptionDecorator
+        val result = copyPropsWithNewValue(prop, currentProps, converterContext)
+          ?: return@exceptionDecorator
         // Set the new props instance back to the onView
         (onView.propsMutableState as MutableState<Any?>).value = result
         return@exceptionDecorator
@@ -40,7 +41,7 @@ class ComposeViewProp(
 
       val mutableState = propertyGetter(props)
       if (mutableState is MutableState<*>) {
-        (mutableState as MutableState<Any?>).value = type.convert(prop, appContext)
+        (mutableState as MutableState<Any?>).value = type.convert(prop, converterContext)
       } else {
         logger.warn("⚠️ Property $name is not a MutableState in ${onView::class.java}")
       }
@@ -48,7 +49,7 @@ class ComposeViewProp(
   }
 
   @PublishedApi
-  internal fun copyPropsWithNewValue(prop: Any?, currentProps: Any, appContext: AppContext?): Any? {
+  internal fun copyPropsWithNewValue(prop: Any?, currentProps: Any, converterContext: ConverterContext): Any? {
     // TODO(@lukmccall): We should remove the copy call
     val copy = currentProps::class.memberFunctions.firstOrNull { it.name == "copy" }
     if (copy == null) {
@@ -57,7 +58,7 @@ class ComposeViewProp(
     }
     val instanceParam = copy.instanceParameter!!
     val newPropParam = copy.parameters.firstOrNull { it.name == name } ?: return null
-    return copy.callBy(mapOf(instanceParam to currentProps, newPropParam to type.convert(prop, appContext)))
+    return copy.callBy(mapOf(instanceParam to currentProps, newPropParam to type.convert(prop, converterContext)))
   }
 
   fun asStateProp(): ComposeViewProp {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -5,12 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.HandlerThread
-import android.view.View
-import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.network.OkHttpClientProvider
-import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
@@ -34,6 +31,7 @@ import expo.modules.kotlin.services.FilePermissionService
 import expo.modules.kotlin.services.Service
 import expo.modules.kotlin.services.ServicesRegistry
 import expo.modules.kotlin.tracing.trace
+import expo.modules.kotlin.types.ConverterContext
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,10 +46,17 @@ class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   reactContextHolder: WeakReference<ReactApplicationContext>
-) : CurrentActivityProvider {
+) : CurrentActivityProvider, ConverterContext {
   // The main context used in the app.
   // Modules attached to this context will be available on the main js context.
-  val runtime = MainRuntime(this, reactContextHolder)
+  override val runtime = MainRuntime(this, reactContextHolder)
+
+  override val applicationContext: Context
+    get() {
+      return requireNotNull(reactContext) {
+        "The app context should be created with valid react context."
+      }.applicationContext
+    }
 
   private val uiRuntimeHolder = lazy { WorkletRuntime(this, reactContextHolder) }
   val uiRuntime
@@ -350,19 +355,6 @@ class AppContext(
       EventName.ON_NEW_INTENT,
       intent
     )
-  }
-
-  @Suppress("UNCHECKED_CAST")
-  @UiThread
-  fun <T : View> findView(viewTag: Int): T? {
-    val reactContext = runtime.reactContext ?: return null
-    return UIManagerHelper
-      .getUIManagerForReactTag(reactContext, viewTag)
-      ?.resolveView(viewTag) as? T
-  }
-
-  internal fun assertMainThread() {
-    Utils.assertMainThread()
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -103,7 +103,7 @@ class ModuleHolder<T : Module>(
     val method = definition.syncFunctions[methodName]
       ?: throw MethodNotFoundException()
 
-    return method.callUserImplementation(args)
+    return method.callUserImplementation(args, module.appContext)
   }
 
   fun post(eventName: EventName) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Utils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Utils.kt
@@ -16,9 +16,4 @@ object Utils {
   }
 }
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun AppContext?.toStrongReference(): AppContext {
-  return this ?: throw Exceptions.AppContextLost()
-}
-
 fun <T : Any> T?.weak() = WeakReference<T>(this)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
@@ -21,6 +21,16 @@ class Exceptions {
   class AppContextLost : CodedException(message = "The app context has been lost")
 
   /**
+   * The converter context is no longer available.
+   */
+  class ConverterContextLost : CodedException(message = "The converter context has been lost")
+
+  /**
+   * The runtime is no longer available.
+   */
+  class RuntimeLost : CodedException(message = "The runtime has been lost")
+
+  /**
    * The react app context is no longer available.
    */
   class ReactContextLost : CodedException(message = "The react context has been lost")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -9,6 +9,7 @@ import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 /**
@@ -64,7 +65,7 @@ abstract class AnyFunction(
    * @throws `CodedException` if conversion isn't possible
    */
   @Throws(CodedException::class)
-  protected fun convertArgs(args: Array<Any?>, appContext: AppContext? = null, forceConversion: Boolean = false): Array<out Any?> {
+  protected fun convertArgs(args: Array<Any?>, converterContext: ConverterContext, forceConversion: Boolean = false): Array<out Any?> {
     if (requiredArgumentsCount > args.size || args.size > desiredArgsTypes.size) {
       throw InvalidArgsNumberException(args.size, desiredArgsTypes.size, requiredArgumentsCount)
     }
@@ -80,7 +81,7 @@ abstract class AnyFunction(
       exceptionDecorator({ cause ->
         ArgumentCastException(desiredType.typeDescriptor, index, element?.javaClass.toString(), cause)
       }) {
-        finalArgs[index] = desiredType.convert(element, appContext, forceConversion)
+        finalArgs[index] = desiredType.convert(element, converterContext, forceConversion)
       }
     }
     return finalArgs

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JNIFunctionBody
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.ReturnType
 
 class SyncFunctionComponent(
@@ -14,16 +15,16 @@ class SyncFunctionComponent(
   private val returnType: ReturnType,
   private val body: (args: Array<out Any?>) -> Any?
 ) : AnyFunction(name, argTypes) {
-  fun callUserImplementation(args: Array<Any?>, appContext: AppContext? = null): Any? {
-    return body(convertArgs(args, appContext))
+  fun callUserImplementation(args: Array<Any?>, converterContext: ConverterContext): Any? {
+    return body(convertArgs(args, converterContext))
   }
 
-  internal fun getJNIFunctionBody(moduleName: String, appContext: AppContext?): JNIFunctionBody {
+  internal fun getJNIFunctionBody(moduleName: String, converterContext: ConverterContext): JNIFunctionBody {
     return JNIFunctionBody { args ->
       return@JNIFunctionBody exceptionDecorator({
         FunctionCallException(name, moduleName, it)
       }) {
-        val result = callUserImplementation(args, appContext)
+        val result = callUserImplementation(args, converterContext)
         return@exceptionDecorator returnType.convertToJS(result)
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -2,7 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.JSTypeConverterProvider
 import expo.modules.kotlin.types.TypeConverterProviderImpl
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
@@ -18,7 +18,7 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
 
   private external fun invoke(thisValue: JavaScriptObject?, args: Array<Any?>, expectedReturnType: ExpectedType): Any?
 
-  operator fun invoke(vararg args: Any?, thisValue: JavaScriptObject? = null, appContext: AppContext? = null): ReturnType {
+  operator fun invoke(vararg args: Any?, thisValue: JavaScriptObject? = null, converterContext: ConverterContext): ReturnType {
     // TODO(@lukmccall): check current thread
     val convertedArgs = args
       .map { JSTypeConverterProvider.convertToJSValue(it) }
@@ -32,7 +32,7 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
     val expectedReturnType = converter.getCppRequiredTypes()
     val result = invoke(thisValue, convertedArgs, expectedReturnType)
     @Suppress("UNCHECKED_CAST")
-    return converter.convert(result, appContext, false) as ReturnType
+    return converter.convert(result, converterContext, false) as ReturnType
   }
 
   @Throws(Throwable::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.records
 import android.util.Log
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.allocators.ObjectConstructor
 import expo.modules.kotlin.allocators.ObjectConstructorFactory
 import expo.modules.kotlin.exception.DynamicCastException
@@ -14,6 +13,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import expo.modules.kotlin.types.TypeConverter
 import expo.modules.kotlin.types.TypeConverterProvider
@@ -39,8 +39,8 @@ abstract class RecordConversionStrategy<T : Record>(
     return objectConstructorFactory.get(clazz)
   }
 
-  abstract fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T
-  abstract fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T
+  abstract fun convertFromReadableMap(jsMap: ReadableMap, context: ConverterContext, forceConversion: Boolean): T
+  abstract fun convertFromMap(map: Map<String, Any?>, context: ConverterContext, forceConversion: Boolean): T
 }
 
 class ReflectionRecordConversionStrategy<T : Record>(
@@ -77,7 +77,7 @@ class ReflectionRecordConversionStrategy<T : Record>(
       .toMap()
   }
 
-  override fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertFromReadableMap(jsMap: ReadableMap, context: ConverterContext, forceConversion: Boolean): T {
     val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
@@ -109,7 +109,7 @@ class ReflectionRecordConversionStrategy<T : Record>(
     return instance as T
   }
 
-  override fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertFromMap(map: Map<String, Any?>, context: ConverterContext, forceConversion: Boolean): T {
     val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
@@ -210,7 +210,7 @@ class IntrospectableRecordConversionStrategy<T : Record>(
       }
   }
 
-  override fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertFromReadableMap(jsMap: ReadableMap, context: ConverterContext, forceConversion: Boolean): T {
     val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
@@ -238,7 +238,7 @@ class IntrospectableRecordConversionStrategy<T : Record>(
     return instance as T
   }
 
-  override fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertFromMap(map: Map<String, Any?>, context: ConverterContext, forceConversion: Boolean): T {
     val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
@@ -288,13 +288,13 @@ class RecordTypeConverter<T : Record>(
     ReflectionRecordConversionStrategy(converterProvider, typeDescriptor)
   }
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): T =
     exceptionDecorator({ cause -> RecordCastException(typeDescriptor, cause) }) {
       val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
       return@exceptionDecorator conversionStrategy.convertFromReadableMap(jsMap, context, forceConversion)
     }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): T {
     if (value is ReadableMap) {
       return conversionStrategy.convertFromReadableMap(value, context, forceConversion)
     }
@@ -327,12 +327,12 @@ class RecordTypeConverter<T : Record>(
  * This function handles numeric type normalization since JS numbers come as Double in Kotlin Maps.
  */
 @PublishedApi
-internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: RecordTypeConverter<T>, appContext: AppContext? = null): T {
-  return converter.conversionStrategy.convertFromMap(map, appContext, forceConversion = false)
+internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: RecordTypeConverter<T>, converterContext: ConverterContext): T {
+  return converter.conversionStrategy.convertFromMap(map, converterContext, forceConversion = false)
 }
 
-inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>, appContext: AppContext? = null): T {
+inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>, converterContext: ConverterContext): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   @Suppress("UNCHECKED_CAST")
-  return recordFromMap(map, converter as RecordTypeConverter<T>, appContext = appContext)
+  return recordFromMap(map, converter as RecordTypeConverter<T>, converterContext = converterContext)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -1,11 +1,11 @@
 package expo.modules.kotlin.sharedobjects
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.IncorrectRefTypeException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
-import expo.modules.kotlin.toStrongReference
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.NonNullableTypeConverter
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
@@ -13,7 +13,7 @@ class SharedObjectTypeConverter<T : SharedObject>(
   val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<T>() {
   @Suppress("UNCHECKED_CAST")
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): T {
     val id = SharedObjectId(
       if (value is Dynamic) {
         value.asInt()
@@ -22,8 +22,8 @@ class SharedObjectTypeConverter<T : SharedObject>(
       }
     )
 
-    val appContext = context.toStrongReference()
-    val result = id.toNativeObject(appContext.runtime)
+    val runtime = context.runtime ?: throw Exceptions.RuntimeLost()
+    val result = id.toNativeObject(runtime)
     return result as T
   }
 
@@ -37,7 +37,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
 ) : NonNullableTypeConverter<T>() {
   private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(typeDescriptor)
 
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): T {
     val sharedObject = sharedObjectTypeConverter.convert(value, context, forceConversion)
 
     if (!checkType(sharedObject)) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
@@ -28,12 +27,12 @@ class AnyType(
       ?: TypeConverterProviderImpl.obtainTypeConverter(typeDescriptor)
   }
 
-  fun convert(value: Any?, appContext: AppContext? = null, forceConversion: Boolean = false): Any? {
+  fun convert(value: Any?, converterContext: ConverterContext, forceConversion: Boolean = false): Any? {
     // We can skip conversion if we already did it on the C++ side.
     if (!forceConversion && converter.isTrivial() && value !is Dynamic) {
       return value
     }
-    return converter.convert(value, appContext, forceConversion)
+    return converter.convert(value, converterContext, forceConversion)
   }
 
   fun getCppRequiredTypes(): ExpectedType = converter.getCppRequiredTypes()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -4,9 +4,8 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.exception.DynamicCastException
+import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
@@ -17,7 +16,7 @@ import expo.modules.kotlin.jni.ExpectedType
  * In that way, we produce the same output for JSI and bridge implementation.
  */
 class AnyTypeConverter : DynamicAwareTypeConverters<Any>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Any {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Any {
     return when (value.type) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
@@ -28,7 +27,7 @@ class AnyTypeConverter : DynamicAwareTypeConverters<Any>() {
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Any = value
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Any = value
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
@@ -20,7 +19,7 @@ class ArrayTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Array<*> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Array<*> {
     val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
@@ -37,7 +36,7 @@ class ArrayTypeConverter(
     return array
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Array<*> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Array<*> {
     return if (arrayElementConverter.isTrivial() && !forceConversion) {
       value as Array<*>
     } else {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ByteArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ByteArrayTypeConverter.kt
@@ -2,12 +2,13 @@
 
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class ByteArrayTypeConverter : NonNullableTypeConverter<ByteArray>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): ByteArray = value as ByteArray
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): ByteArray =
+    value as ByteArray
+
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.UINT8_TYPED_ARRAY)
   override fun isTrivial() = false
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -8,10 +8,8 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.DynamicCastException
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -358,7 +356,7 @@ private fun parseCssColorFunction(value: String): Color? {
 // endregion
 
 class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Color {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
       ReadableType.String -> colorFromString(
@@ -384,7 +382,7 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Color {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Color {
     return when (value) {
       is Int -> {
         colorFromInt(value)
@@ -441,13 +439,13 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
     return ColorCompat.valueOf(normalizedValue.toColorInt())
   }
 
-  private fun colorFromReadableMap(value: ReadableMap, context: AppContext?): Color {
-    val reactContext = context?.reactContext ?: throw Exceptions.ReactContextLost()
+  private fun colorFromReadableMap(value: ReadableMap, converterContext: ConverterContext): Color {
+    val context = converterContext.applicationContext
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      return ColorPropConverter.getColorInstance(value, reactContext)
+      return ColorPropConverter.getColorInstance(value, context)
         ?: throw UnexpectedException("ColorPropConverter returned null for a non-null color value.")
     }
-    val colorInt = ColorPropConverter.getColor(value, reactContext)
+    val colorInt = ColorPropConverter.getColor(value, context)
       ?: throw UnexpectedException("ColorPropConverter returned null for a non-null color value.")
     return ColorCompat.valueOf(colorInt)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ConverterContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ConverterContext.kt
@@ -1,0 +1,31 @@
+package expo.modules.kotlin.types
+
+import android.content.Context
+import android.view.View
+import androidx.annotation.UiThread
+import com.facebook.react.uimanager.UIManagerHelper
+import expo.modules.kotlin.Utils
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.runtime.Runtime
+
+/**
+ * Provides the application context and JavaScript runtime that may be used during type conversion.
+ */
+interface ConverterContext {
+  val applicationContext: Context
+  val runtime: Runtime?
+
+  @Suppress("UNCHECKED_CAST")
+  @UiThread
+  fun <T : View> findView(viewTag: Int): T? {
+    val runtime = runtime ?: throw Exceptions.RuntimeLost()
+    val reactContext = runtime.reactContext ?: return null
+    return UIManagerHelper
+      .getUIManagerForReactTag(reactContext, viewTag)
+      ?.resolveView(viewTag) as? T
+  }
+
+  fun assertMainThread() {
+    Utils.assertMainThread()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -16,7 +15,7 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 class DateTypeConverter : DynamicAwareTypeConverters<LocalDate>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): LocalDate {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): LocalDate {
     return when (value.type) {
       ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
       ReadableType.Number -> convertFromLong(value.asDouble().toLong())
@@ -24,7 +23,7 @@ class DateTypeConverter : DynamicAwareTypeConverters<LocalDate>() {
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): LocalDate {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): LocalDate {
     return when (value) {
       is String -> LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
       is Long -> convertFromLong(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import kotlin.time.Duration
@@ -10,14 +9,14 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 class DurationTypeConverter : DynamicAwareTypeConverters<Duration>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Duration {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Duration {
     if (value.type != ReadableType.Number) {
       throw IllegalArgumentException("Expected a number, but received ${value.type}")
     }
     return value.asDouble().toDuration(DurationUnit.SECONDS)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Duration {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Duration {
     return (value as Double).toDuration(DurationUnit.SECONDS)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -4,7 +4,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.unwrap
 import java.lang.ref.WeakReference
@@ -17,7 +17,7 @@ data object IncompatibleValue : DeferredValue()
 class UnconvertedValue(
   private val unconvertedValue: Any,
   private val typeConverter: TypeConverter<*>,
-  context: AppContext?
+  context: ConverterContext
 ) : DeferredValue() {
   private val contextHolder = WeakReference(context)
 
@@ -25,7 +25,8 @@ class UnconvertedValue(
 
   fun getConvertedValue(): Any {
     if (convertedValue == null) {
-      convertedValue = typeConverter.convert(unconvertedValue, contextHolder.get(), forceConversion = true)
+      val context = contextHolder.get() ?: throw Exceptions.ConverterContextLost()
+      convertedValue = typeConverter.convert(unconvertedValue, context, forceConversion = true)
     }
 
     return convertedValue!!

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
@@ -10,7 +9,7 @@ private fun createDeferredValue(
   wasConverted: Boolean,
   typeConverter: TypeConverter<*>,
   expectedType: ExpectedType,
-  context: AppContext?
+  context: ConverterContext
 ): DeferredValue {
   for (type in expectedType.getPossibleTypes()) {
     if (wasConverted) {
@@ -26,7 +25,7 @@ private fun createDeferredValue(
   return IncompatibleValue
 }
 
-private fun tryToConvert(typeConverter: TypeConverter<*>, value: Any, context: AppContext?): Any? {
+private fun tryToConvert(typeConverter: TypeConverter<*>, value: Any, context: ConverterContext): Any? {
   return try {
     if (typeConverter.isTrivial() && value !is Dynamic) {
       value
@@ -44,7 +43,7 @@ private fun tryToConvert(typeConverter: TypeConverter<*>, value: Any, context: A
 
 private fun createDeferredValues(
   value: Any,
-  context: AppContext?,
+  context: ConverterContext,
   list: List<Pair<ExpectedType, TypeConverter<*>>>,
   typeList: List<TypeDescriptor>
 ): List<DeferredValue> {
@@ -81,7 +80,7 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   private val secondType = secondTypeConverter.getCppRequiredTypes()
 
   // This converter it's always forcing the conversion of children converters - the `forceConversion` is ignored.
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Either<FirstType, SecondType> {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): Either<FirstType, SecondType> {
     val typeList = listOf(firstJavaType, secondJavaType)
 
     val deferredValues = createDeferredValues(
@@ -128,7 +127,7 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
 
   override fun isTrivial(): Boolean = false
 
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): EitherOfThree<FirstType, SecondType, ThirdType> {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): EitherOfThree<FirstType, SecondType, ThirdType> {
     val typeList = listOf(firstJavaType, secondJavaType, thirdJavaType)
     val deferredValues = createDeferredValues(
       value,
@@ -179,7 +178,7 @@ class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : A
 
   override fun isTrivial(): Boolean = false
 
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
     val typeList = listOf(firstJavaType, secondJavaType, thirdJavaType, fourthJavaType)
     val deferredValues = createDeferredValues(
       value,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
@@ -35,7 +34,7 @@ class EnumTypeConverter(
 
   override fun isTrivial() = false
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Enum<*> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Enum<*> {
     if (userFields.isEmpty()) {
       return convertEnumWithoutParameter(
         value.asString() ?: throw DynamicCastException(String::class.java),
@@ -52,7 +51,7 @@ class EnumTypeConverter(
     throw IncompatibleArgTypeException(value.type.toClass(), enumClass)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Enum<*> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Enum<*> {
     if (userFields.isEmpty()) {
       return convertEnumWithoutParameter(value as String, enumConstants)
     } else if (userFields.size == 1) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptFunction
@@ -9,7 +8,7 @@ import expo.modules.kotlin.types.descriptors.TypeDescriptor
 class JavaScriptFunctionTypeConverter<T : Any>(
   val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<JavaScriptFunction<T>>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): JavaScriptFunction<T> {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): JavaScriptFunction<T> {
     @Suppress("UNCHECKED_CAST")
     val jsFunction = value as JavaScriptFunction<T>
     jsFunction.returnType = requireNotNull(typeDescriptor.params.first())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
@@ -21,7 +20,7 @@ class ListTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): List<*> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): List<*> {
     if (value.type != ReadableType.Array) {
       return listOf(
         exceptionDecorator({ cause ->
@@ -41,7 +40,7 @@ class ListTypeConverter(
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): List<*> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): List<*> {
     return if (elementConverter.isTrivial() && !forceConversion) {
       value as List<*>
     } else {
@@ -60,7 +59,7 @@ class ListTypeConverter(
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): List<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: ConverterContext, forceConversion: Boolean): List<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.ReadableMap
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
@@ -27,12 +26,12 @@ class MapTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Map<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Map<*, *> {
     val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
     return convertFromReadableMap(jsMap, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Map<*, *> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Map<*, *> {
     return if (valueConverter.isTrivial() && !forceConversion) {
       value as Map<*, *>
     } else {
@@ -51,7 +50,7 @@ class MapTypeConverter(
     }
   }
 
-  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): Map<*, *> {
+  private fun convertFromReadableMap(jsMap: ReadableMap, context: ConverterContext, forceConversion: Boolean): Map<*, *> {
     val result = mutableMapOf<String, Any?>()
 
     jsMap.entryIterator.forEach { (key, value) ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/NullableTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/NullableTypeConverter.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
@@ -10,7 +9,7 @@ class NullableTypeConverter<Type : Any>(
   private val innerConverter: TypeConverter<Type>
 ) : TypeConverter<Type> {
 
-  override fun convert(value: Any?, context: AppContext?, forceConversion: Boolean): Type? {
+  override fun convert(value: Any?, context: ConverterContext, forceConversion: Boolean): Type? {
     if (value == null || value is Dynamic && value.isNull) {
       return null
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
@@ -29,12 +28,12 @@ class PairTypeConverter(
     )
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Pair<*, *> {
     val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Pair<*, *> {
     if (value is ReadableArray) {
       return convertFromReadableArray(value, context, forceConversion)
     }
@@ -42,14 +41,14 @@ class PairTypeConverter(
     return value as Pair<*, *>
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: ConverterContext, forceConversion: Boolean): Pair<*, *> {
     return Pair(
       convertElement(context, jsArray, 0, forceConversion),
       convertElement(context, jsArray, 1, forceConversion)
     )
   }
 
-  private fun convertElement(context: AppContext?, array: ReadableArray, index: Int, forceConversion: Boolean): Any? {
+  private fun convertElement(context: ConverterContext, array: ReadableArray, index: Int, forceConversion: Boolean): Any? {
     return array.getDynamic(index).recycle {
       exceptionDecorator({ cause ->
         CollectionElementCastException(pairType, pairType.params[index], type, cause)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -4,17 +4,18 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.MapArguments
 import expo.modules.core.arguments.ReadableArguments
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class ReadableArgumentsTypeConverter() : DynamicAwareTypeConverters<ReadableArguments>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): ReadableArguments {
-    return MapArguments((value.asMap() ?: throw DynamicCastException(ReadableMap::class)).toHashMap())
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): ReadableArguments {
+    return MapArguments(
+      (value.asMap() ?: throw DynamicCastException(ReadableMap::class)).toHashMap()
+    )
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): ReadableArguments {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): ReadableArguments {
     return MapArguments((value as ReadableMap).toHashMap())
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
@@ -20,12 +19,12 @@ class SetTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Set<*> {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Set<*> {
     val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Set<*> {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Set<*> {
     return if (elementConverter.isTrivial() && !forceConversion) {
       (value as List<*>).toSet()
     } else {
@@ -44,7 +43,7 @@ class SetTypeConverter(
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): Set<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: ConverterContext, forceConversion: Boolean): Set<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.exception.UnsupportedClass
 import expo.modules.kotlin.jni.CppType
@@ -15,7 +14,7 @@ interface TypeConverter<Type : Any> {
   /**
    * Tries to convert from [Any]? (can be also [Dynamic]) to the desired type.
    */
-  fun convert(value: Any?, context: AppContext? = null, forceConversion: Boolean = false): Type?
+  fun convert(value: Any?, context: ConverterContext, forceConversion: Boolean = false): Type?
 
   /**
    * Returns a list of [ExpectedType] types that can be converted to the desired type.
@@ -34,11 +33,11 @@ interface TypeConverter<Type : Any> {
 }
 
 abstract class NonNullableTypeConverter<Type : Any>() : TypeConverter<Type> {
-  override fun convert(value: Any?, context: AppContext?, forceConversion: Boolean): Type {
+  override fun convert(value: Any?, context: ConverterContext, forceConversion: Boolean): Type {
     return convertNonNullable(value ?: throw NullArgumentException(), context, forceConversion)
   }
 
-  abstract fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Type
+  abstract fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): Type
 }
 
 /**
@@ -47,15 +46,15 @@ abstract class NonNullableTypeConverter<Type : Any>() : TypeConverter<Type> {
  * stop using the bridge to pass data between JS and Kotlin.
  */
 abstract class DynamicAwareTypeConverters<T : Any>() : NonNullableTypeConverter<T>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T =
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): T =
     if (value is Dynamic) {
       convertFromDynamic(value, context, forceConversion)
     } else {
       convertFromAny(value, context, forceConversion)
     }
 
-  abstract fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T
-  abstract fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T
+  abstract fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): T
+  abstract fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): T
 }
 
 inline fun <reified T : Any> createTrivialTypeConverter(
@@ -63,11 +62,11 @@ inline fun <reified T : Any> createTrivialTypeConverter(
   crossinline dynamicFallback: (Dynamic) -> T = { throw UnsupportedClass(T::class) }
 ): TypeConverter<T> {
   return object : DynamicAwareTypeConverters<T>() {
-    override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T {
+    override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): T {
       return dynamicFallback(value)
     }
 
-    override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T {
+    override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): T {
       return value as T
     }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.exception.toCodedException
@@ -42,7 +41,7 @@ class TypeConverterCollection<Type : Any>(
     return this
   }
 
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Type {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): Type {
     val possibleConverters = converters
       .map { (key, converter) -> key to converter }
       .filter { (key, _) -> key.jClass.toBoxedIfPrimitive().isInstance(value) }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.ReadableArguments
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.ArrayBuffer
@@ -66,17 +65,17 @@ inline fun <reified T : Any> obtainTypeConverter(): TypeConverter<T> {
   return TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>()) as TypeConverter<T>
 }
 
-inline fun <reified T> convert(value: Dynamic, context: AppContext? = null): T {
+inline fun <reified T> convert(value: Dynamic, context: ConverterContext): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   return converter.convert(value, context) as T
 }
 
-inline fun <reified T> convert(value: Any?, context: AppContext? = null): T {
+inline fun <reified T> convert(value: Any?, context: ConverterContext): T {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   return converter.convert(value, context) as T
 }
 
-fun convert(value: Dynamic, type: KType, context: AppContext? = null): Any? {
+fun convert(value: Dynamic, type: KType, context: ConverterContext): Any? {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(type.toTypeDescriptor())
   return converter.convert(value, context)
 }
@@ -90,6 +89,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
   private fun getCachedConverter(inputType: TypeDescriptor): TypeConverter<*>? {
     return cachedConverters[inputType.jClass]
   }
+
   private fun getCachedPrimitiveArrayConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
     return cachedPrimitiveArrayConverters[typeDescriptor.jClass]
   }
@@ -112,7 +112,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     if (jClass.isArray || Array::class.java.isAssignableFrom(jClass)) {
       return if (isPrimitiveArray(typeDescriptor)) {
-        getCachedPrimitiveArrayConverter(typeDescriptor) ?: throw MissingTypeConverter(typeDescriptor)
+        getCachedPrimitiveArrayConverter(typeDescriptor)
+          ?: throw MissingTypeConverter(typeDescriptor)
       } else {
         ArrayTypeConverter(this, typeDescriptor)
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptTypedArray
@@ -20,7 +19,9 @@ import expo.modules.kotlin.typedarray.Uint8ClampedArray
 open class BaseTypeArrayConverter<T : TypedArray>(
   val typedArrayWrapper: (rawArray: JavaScriptTypedArray) -> T
 ) : NonNullableTypeConverter<T>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): T =
+    wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
+
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.TYPED_ARRAY)
   override fun isTrivial() = false
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
@@ -1,11 +1,11 @@
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class UnitTypeConverter : NonNullableTypeConverter<Unit>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean) = Unit
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean) =
+    Unit
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefinedTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefinedTypeConverter.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
@@ -16,7 +15,7 @@ class ValueOrUndefinedTypeConverter(
     }
   )
 
-  override fun convert(value: Any?, context: AppContext?, forceConversion: Boolean): ValueOrUndefined<*>? {
+  override fun convert(value: Any?, context: ConverterContext, forceConversion: Boolean): ValueOrUndefined<*>? {
     return if (value is ValueOrUndefined.Undefined) {
       ValueOrUndefined.Undefined
     } else {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
@@ -1,21 +1,21 @@
 package expo.modules.kotlin.types.io
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.io.File
 
 class FileTypeConverter : DynamicAwareTypeConverters<File>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): File {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): File {
     val path = value.asString()
       ?: throw Exceptions.IllegalArgument("Cannot convert ${value.type} to File")
     return File(path)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): File {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): File {
     val path = value as String
     return File(path)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
@@ -3,21 +3,21 @@ package expo.modules.kotlin.types.io
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.nio.file.Path
 import java.nio.file.Paths
 
 @RequiresApi(Build.VERSION_CODES.O)
 class PathTypeConverter : DynamicAwareTypeConverters<Path>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Path {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Path {
     val stringPath = value.asString()
     return Paths.get(stringPath)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Path {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Path {
     val stringPath = value as String
     return Paths.get(stringPath)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
@@ -1,19 +1,19 @@
 package expo.modules.kotlin.types.net
 
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URL
 
 class URLTypConverter : DynamicAwareTypeConverters<URL>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): URL {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): URL {
     val stringURL = value.asString()
     return URL(stringURL)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): URL {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): URL {
     val stringURL = value as String
     return URL(stringURL)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
@@ -1,22 +1,22 @@
 package expo.modules.kotlin.types.net
 
 import android.net.Uri
+import androidx.core.net.toUri
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URI
-import androidx.core.net.toUri
-import expo.modules.kotlin.exception.DynamicCastException
 
 class UriTypeConverter : DynamicAwareTypeConverters<Uri>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Uri {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): Uri {
     val stringUri = value.asString()
     return stringUri?.toUri() ?: throw DynamicCastException(Uri::class)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Uri {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): Uri {
     val stringUri = value as String
     return stringUri.toUri()
   }
@@ -27,12 +27,12 @@ class UriTypeConverter : DynamicAwareTypeConverters<Uri>() {
 }
 
 class JavaURITypeConverter : DynamicAwareTypeConverters<URI>() {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): URI {
+  override fun convertFromDynamic(value: Dynamic, context: ConverterContext, forceConversion: Boolean): URI {
     val stringUri = value.asString()
     return URI.create(stringUri)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): URI {
+  override fun convertFromAny(value: Any, context: ConverterContext, forceConversion: Boolean): URI {
     val stringUri = value as String
     return URI.create(stringUri)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/SerializableTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/SerializableTypeConverter.kt
@@ -1,13 +1,13 @@
 package expo.modules.kotlin.types.worklets
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.worklets.Serializable
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.NonNullableTypeConverter
 
 class SerializableTypeConverter : NonNullableTypeConverter<Serializable>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Serializable {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): Serializable {
     return value as Serializable
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
@@ -1,15 +1,15 @@
 package expo.modules.kotlin.types.worklets
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.worklets.Serializable
 import expo.modules.kotlin.jni.worklets.Worklet
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.NonNullableTypeConverter
 import expo.modules.kotlin.types.TypeConverter
 
 class WorkletTypeConverter(
   private val serializableTypeConverter: TypeConverter<Serializable>
 ) : NonNullableTypeConverter<Worklet>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Worklet {
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): Worklet {
     val serializable = serializableTypeConverter.convert(value, context, forceConversion)
       ?: throw IllegalArgumentException("Cannot convert '$value' to Serializable.")
     if (serializable.type != Serializable.ValueType.Worklet) {
@@ -18,6 +18,7 @@ class WorkletTypeConverter(
 
     return Worklet(serializable)
   }
+
   override fun getCppRequiredTypes() = serializableTypeConverter.getCppRequiredTypes()
   override fun isTrivial() = false
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
@@ -2,16 +2,16 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.ConverterContext
 
 abstract class AnyViewProp(
   val name: String,
   internal val type: AnyType
 ) {
-  abstract fun set(prop: Dynamic, onView: View, appContext: AppContext? = null)
+  abstract fun set(prop: Dynamic, onView: View, converterContext: ConverterContext)
 
-  abstract fun set(prop: Any?, onView: View, appContext: AppContext? = null)
+  abstract fun set(prop: Any?, onView: View, converterContext: ConverterContext)
 
   abstract val isNullable: Boolean
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -2,10 +2,10 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.Dynamic
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.ConverterContext
 
 open class ConcreteViewProp<ViewType : View, PropType>(
   name: String,
@@ -14,20 +14,20 @@ open class ConcreteViewProp<ViewType : View, PropType>(
 ) : AnyViewProp(name, propType) {
   private var _isStateProp = false
 
-  override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop, onView, appContext)
+  override fun set(prop: Dynamic, onView: View, converterContext: ConverterContext) {
+    setPropDirectly(prop, onView, converterContext)
   }
 
-  override fun set(prop: Any?, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop, onView, appContext)
+  override fun set(prop: Any?, onView: View, converterContext: ConverterContext) {
+    setPropDirectly(prop, onView, converterContext)
   }
 
-  private fun setPropDirectly(prop: Any?, onView: View, appContext: AppContext?) {
+  private fun setPropDirectly(prop: Any?, onView: View, converterContext: ConverterContext) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
       @Suppress("UNCHECKED_CAST")
-      setter(onView as ViewType, type.convert(prop, appContext) as PropType)
+      setter(onView as ViewType, type.convert(prop, converterContext) as PropType)
     }
   }
 
@@ -49,11 +49,11 @@ class ConcreteViewPropWithDefault<ViewType : View, PropType>(
   private val defaultValue: PropType
 ) : ConcreteViewProp<ViewType, PropType>(name, propType, setter) {
   @Suppress("UNCHECKED_CAST")
-  override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
+  override fun set(prop: Dynamic, onView: View, converterContext: ConverterContext) {
     if (prop.isNull) {
       setter(onView as ViewType, defaultValue)
       return
     }
-    super.set(prop, onView, appContext)
+    super.set(prop, onView, converterContext)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -1,23 +1,21 @@
 package expo.modules.kotlin.views
 
 import android.view.View
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
-import expo.modules.kotlin.toStrongReference
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.NonNullableTypeConverter
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class ViewTypeConverter<T : View>(
   val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<T>() {
-  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
-    val appContext = context.toStrongReference()
-    appContext.assertMainThread()
+  override fun convertNonNullable(value: Any, context: ConverterContext, forceConversion: Boolean): T {
+    context.assertMainThread()
 
     val viewTag = value as Int
-    val view = appContext.findView<T>(viewTag)
+    val view = context.findView<T>(viewTag)
       ?: throw Exceptions.ViewNotFound(typeDescriptor.jClass, viewTag)
 
     return view

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -21,7 +21,7 @@ import org.robolectric.annotation.Config
 internal class ColorTypeConverterTest {
   private val androidContext = ApplicationProvider.getApplicationContext<Application>()
   private val converterContext = mockk<ConverterContext> {
-    every { context } returns androidContext
+    every { applicationContext } returns androidContext
   }
 
   @Test
@@ -126,7 +126,7 @@ internal class ColorTypeConverterTest {
 
     val color = convert<Color>(platformColor, converterContext)
     val expectedColor = TypedValue().let {
-      converterContext.context.theme.resolveAttribute(android.R.attr.textColorPrimary, it, true)
+      converterContext.applicationContext.theme.resolveAttribute(android.R.attr.textColorPrimary, it, true)
       it.data
     }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
 import expo.modules.assertThrows
-import expo.modules.kotlin.AppContext
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
@@ -20,8 +19,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24, 30])
 internal class ColorTypeConverterTest {
-  private val appContext = mockk<AppContext> {
-    every { reactContext } returns ApplicationProvider.getApplicationContext<Application>()
+  private val androidContext = ApplicationProvider.getApplicationContext<Application>()
+  private val converterContext = mockk<ConverterContext> {
+    every { context } returns androidContext
   }
 
   @Test
@@ -115,7 +115,7 @@ internal class ColorTypeConverterTest {
   fun `converts from Android PlatformColor color`() {
     val platformColor = DynamicFromObject(platformColor("@android:color/white"))
 
-    val color = convert<Color>(platformColor, appContext)
+    val color = convert<Color>(platformColor, converterContext)
 
     Truth.assertThat(ColorCompat.toArgb(color)).isEqualTo(Color.WHITE)
   }
@@ -124,9 +124,9 @@ internal class ColorTypeConverterTest {
   fun `converts from Android PlatformColor attr`() {
     val platformColor = DynamicFromObject(platformColor("?android:attr/textColorPrimary"))
 
-    val color = convert<Color>(platformColor, appContext)
+    val color = convert<Color>(platformColor, converterContext)
     val expectedColor = TypedValue().let {
-      appContext.reactContext?.theme?.resolveAttribute(android.R.attr.textColorPrimary, it, true)
+      converterContext.context.theme.resolveAttribute(android.R.attr.textColorPrimary, it, true)
       it.data
     }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/TestConverterContext.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/TestConverterContext.kt
@@ -1,0 +1,16 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import io.mockk.mockk
+import kotlin.reflect.KType
+
+internal val testConverterContext = mockk<ConverterContext>(relaxed = true)
+
+internal inline fun <reified T> convert(value: Dynamic): T = convert(value, testConverterContext)
+
+internal inline fun <reified T> convert(value: Any?): T = convert(value, testConverterContext)
+
+internal fun convert(value: Dynamic, type: KType): Any? = convert(value, type, testConverterContext)
+
+internal fun <T : Any> TypeConverter<T>.convert(value: Any?): T? =
+  convert(value, testConverterContext)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -6,10 +6,11 @@ import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.types.testConverterContext
 import expo.modules.kotlin.types.toAnyType
 import io.mockk.mockk
 import org.junit.Test
-import expo.modules.kotlin.types.OptimizedRecord
 
 class ConcreteViewPropTest {
   @Test
@@ -23,7 +24,7 @@ class ConcreteViewPropTest {
       providedView = view
     }
 
-    prop.set(DynamicFromObject(10.0), mockedView)
+    prop.set(DynamicFromObject(10.0), mockedView, testConverterContext)
 
     Truth.assertThat(providedValue).isEqualTo(10)
     Truth.assertThat(providedView).isSameInstanceAs(mockedView)
@@ -54,7 +55,8 @@ class ConcreteViewPropTest {
           putString("name", "name")
         }
       ),
-      mockedView
+      mockedView,
+      testConverterContext
     )
 
     Truth.assertThat(providedValue?.id).isEqualTo("1234")

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewTypeConverterTest.kt
@@ -1,0 +1,27 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.view.View
+import expo.modules.assertThrows
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.types.ConverterContext
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
+import io.mockk.mockk
+import org.junit.Test
+
+internal class ViewTypeConverterTest {
+  @Test
+  fun `throws RuntimeLost when the converter context has no runtime`() {
+    val converterContext = object : ConverterContext {
+      override val applicationContext = mockk<Context>()
+      override val runtime = null
+
+      override fun assertMainThread() = Unit
+    }
+    val converter = ViewTypeConverter<View>(typeDescriptorOf<View>())
+
+    assertThrows<Exceptions.RuntimeLost> {
+      converter.convert(1, converterContext)
+    }
+  }
+}

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
@@ -77,6 +77,7 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.recordFromMap
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.views.ComposableScope
@@ -88,7 +89,7 @@ import expo.modules.ui.convertibles.resolveAnimatable
 typealias ModifierType = Map<String, Dynamic>
 typealias ModifierList = List<ModifierType>
 typealias ModifierEventDispatcher = (String, Map<String, Any?>) -> Unit
-typealias ModifierFactory = @Composable (ModifierType, ComposableScope?, AppContext?, ModifierEventDispatcher) -> Modifier
+typealias ModifierFactory = @Composable (ModifierType, ComposableScope?, ConverterContext, ModifierEventDispatcher) -> Modifier
 
 // region Modifier Params
 
@@ -578,15 +579,15 @@ object ModifierRegistry {
     }
 
     register("graphicsLayer") { map, _, appContext, _ ->
-      val rotationX = resolveAnimatable(map, "rotationX", 0f)
-      val rotationY = resolveAnimatable(map, "rotationY", 0f)
-      val rotationZ = resolveAnimatable(map, "rotationZ", 0f)
-      val scaleX = resolveAnimatable(map, "scaleX", 1f)
-      val scaleY = resolveAnimatable(map, "scaleY", 1f)
-      val alphaVal = resolveAnimatable(map, "alpha", 1f)
-      val translationX = resolveAnimatable(map, "translationX", 0f)
-      val translationY = resolveAnimatable(map, "translationY", 0f)
-      val shadowElevation = resolveAnimatable(map, "shadowElevation", 0f)
+      val rotationX = resolveAnimatable(map, "rotationX", 0f, appContext)
+      val rotationY = resolveAnimatable(map, "rotationY", 0f, appContext)
+      val rotationZ = resolveAnimatable(map, "rotationZ", 0f, appContext)
+      val scaleX = resolveAnimatable(map, "scaleX", 1f, appContext)
+      val scaleY = resolveAnimatable(map, "scaleY", 1f, appContext)
+      val alphaVal = resolveAnimatable(map, "alpha", 1f, appContext)
+      val translationX = resolveAnimatable(map, "translationX", 0f, appContext)
+      val translationY = resolveAnimatable(map, "translationY", 0f, appContext)
+      val shadowElevation = resolveAnimatable(map, "shadowElevation", 0f, appContext)
 
       // Non-animatable params parsed via Record
       val params = recordFromMap<GraphicsLayerParams>(map, appContext)

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimatableFloat.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimatableFloat.kt
@@ -6,9 +6,10 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import expo.modules.kotlin.types.ConverterContext
 
 @Composable
-fun resolveAnimatable(map: Map<String, Any?>, key: String, default: Float): Float {
+fun resolveAnimatable(map: Map<String, Any?>, key: String, default: Float, converterContext: ConverterContext): Float {
   val raw = map[key]
   val targetValue = when {
     raw is Number -> raw.toFloat()
@@ -18,7 +19,7 @@ fun resolveAnimatable(map: Map<String, Any?>, key: String, default: Float): Floa
   }
   val spec: AnimationSpec<Float> = when {
     raw is Map<*, *> && raw["\$animated"] == true ->
-      parseAnimationSpec(raw["animationSpec"]) ?: spring()
+      parseAnimationSpec(raw["animationSpec"], converterContext) ?: spring()
     else -> snap()
   }
   val animated by animateFloatAsState(targetValue, spec, label = key)

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimationSpecParams.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimationSpecParams.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.core.tween
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.recordFromMap
+import expo.modules.kotlin.types.ConverterContext
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.OptimizedRecord
 
@@ -85,14 +86,14 @@ internal data class KeyframesSpecParams(
 }
 
 @Suppress("UNCHECKED_CAST")
-internal fun parseAnimationSpec(raw: Any?): AnimationSpec<Float>? {
+internal fun parseAnimationSpec(raw: Any?, converterContext: ConverterContext): AnimationSpec<Float>? {
   if (raw !is Map<*, *>) return null
   val map = raw as Map<String, Any?>
   return when (raw["\$type"]) {
-    "spring" -> recordFromMap<SpringSpecParams>(map).toAnimationSpec()
-    "tween" -> recordFromMap<TweenSpecParams>(map).toAnimationSpec()
-    "snap" -> recordFromMap<SnapSpecParams>(map).toAnimationSpec()
-    "keyframes" -> recordFromMap<KeyframesSpecParams>(map).toAnimationSpec(raw)
+    "spring" -> recordFromMap<SpringSpecParams>(map, converterContext).toAnimationSpec()
+    "tween" -> recordFromMap<TweenSpecParams>(map, converterContext).toAnimationSpec()
+    "snap" -> recordFromMap<SnapSpecParams>(map, converterContext).toAnimationSpec()
+    "keyframes" -> recordFromMap<KeyframesSpecParams>(map, converterContext).toAnimationSpec(raw)
     else -> null
   }
 }


### PR DESCRIPTION
# Why

Currently converters receive `AppContext` for some converters (SharedObject and View) that accesses runtime. In widgets we don't need SO/View, but need the `Color` converter that requires `Context`.

# How

Instead of optional `AppContext`, pass `ConverterContext` which provides `Context` and optionally `Runtime` for SO/View. With this, `expo-widgets` can implement a ConverterContext that provides only the `Context`. 

# Test Plan

* Tests should pass

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>