### PR TITLE
[ios][camera] Add native test suite

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -345,6 +345,8 @@ PODS:
     - ExpoModulesCore
   - ExpoCamera (56.0.7):
     - ExpoModulesCore
+  - ExpoCamera/Tests (56.0.7):
+    - ExpoModulesCore
   - ExpoCameraBarcodeScanning (56.0.7):
     - ExpoCamera
     - ZXingObjC/OneD
@@ -3361,6 +3363,7 @@ DEPENDENCIES:
   - ExpoBrownfield (from `../../../packages/expo-brownfield/ios`)
   - ExpoCalendar (from `../../../packages/expo-calendar/ios`)
   - ExpoCamera (from `../../../packages/expo-camera/ios`)
+  - ExpoCamera/Tests (from `../../../packages/expo-camera/ios`)
   - ExpoCameraBarcodeScanning (from `../../../packages/expo-camera/ios`)
   - ExpoCellular (from `../../../packages/expo-cellular/ios`)
   - ExpoClipboard (from `../../../packages/expo-clipboard/ios`)
@@ -4039,7 +4042,7 @@ SPEC CHECKSUMS:
   ExpoBrightness: db4e1904c09d8cad3e120cd82466fdb3cfb8ff85
   ExpoBrownfield: c9213f348af9d80b746838ac6485beecbdb6c5e8
   ExpoCalendar: abe02062604dad8fac03539ea769e29870d4feee
-  ExpoCamera: fc1d2688e9824984e28cf606062da40d2d80b13e
+  ExpoCamera: 81c10b3e5d0652becc62d496b36e41bd9e8f4dd4
   ExpoCameraBarcodeScanning: a6a8781886a0cf5ebe78184dcc895c0c88e1b8b5
   ExpoCellular: 61e540ab0138c7f441639b51a27b3cca2bbc5ae8
   ExpoClipboard: 40221903a1caa68259e022517af49d12962821fe
@@ -4102,7 +4105,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: dd9a9191125ffe9f57c224173db85afb0210cd23
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   JestMockSchema: 96b4cfec246644f6323d1c30693b6a02044be1e6
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -110,6 +110,8 @@ PODS:
     - ExpoModulesCore
   - ExpoCamera (56.0.7):
     - ExpoModulesCore
+  - ExpoCamera/Tests (56.0.7):
+    - ExpoModulesCore
   - ExpoCameraBarcodeScanning (56.0.7):
     - ExpoCamera
     - ZXingObjC/OneD
@@ -4159,6 +4161,7 @@ DEPENDENCIES:
   - ExpoBrightness (from `../../../packages/expo-brightness/ios`)
   - ExpoCalendar (from `../../../packages/expo-calendar/ios`)
   - ExpoCamera (from `../../../packages/expo-camera/ios`)
+  - ExpoCamera/Tests (from `../../../packages/expo-camera/ios`)
   - ExpoCameraBarcodeScanning (from `../../../packages/expo-camera/ios`)
   - ExpoCellular (from `../../../packages/expo-cellular/ios`)
   - ExpoClipboard (from `../../../packages/expo-clipboard/ios`)
@@ -4744,7 +4747,7 @@ SPEC CHECKSUMS:
   ExpoBlur: caddd80171e5f8f3581ff3d865e99c6465047240
   ExpoBrightness: db4e1904c09d8cad3e120cd82466fdb3cfb8ff85
   ExpoCalendar: abe02062604dad8fac03539ea769e29870d4feee
-  ExpoCamera: fc1d2688e9824984e28cf606062da40d2d80b13e
+  ExpoCamera: 81c10b3e5d0652becc62d496b36e41bd9e8f4dd4
   ExpoCameraBarcodeScanning: a6a8781886a0cf5ebe78184dcc895c0c88e1b8b5
   ExpoCellular: 61e540ab0138c7f441639b51a27b3cca2bbc5ae8
   ExpoClipboard: 40221903a1caa68259e022517af49d12962821fe
@@ -4814,7 +4817,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 9c084a6e3fdd40f70d498576a8540d94aee5a76e
+  hermes-engine: 42f0ed2cf70592b35e2ca49a6b725d31c8ad4136
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-camera/ios/Common/CapturedPhotoProcessor.swift
+++ b/packages/expo-camera/ios/Common/CapturedPhotoProcessor.swift
@@ -1,0 +1,141 @@
+import UIKit
+
+struct CaptureRequest {
+  let exif: Bool
+  let quality: Double
+  let imageType: PictureFormat
+  let additionalExif: [String: Any]?
+}
+
+struct CapturedPhotoProcessor {
+  struct Result {
+    let data: Data
+    let width: Double
+    let height: Double
+    let exif: [String: Any]?
+  }
+
+  func process(image: UIImage, sourceMetadata: [String: Any], request: CaptureRequest) throws -> Result {
+    let width = image.size.width
+    let height = image.size.height
+
+    guard request.exif else {
+      let data = request.imageType == .png
+        ? image.pngData()
+        : image.jpegData(compressionQuality: request.quality)
+      guard let data else {
+        throw CameraSavingImageException("Image data could not be processed")
+      }
+      return Result(data: data, width: width, height: height, exif: nil)
+    }
+
+    guard let exifDict = sourceMetadata[kCGImagePropertyExifDictionary as String] as? [String: Any] else {
+      throw CameraSavingImageException("Failed to process EXIF data")
+    }
+
+    var updatedExif = ExpoCameraUtils.updateExif(
+      metadata: exifDict,
+      with: ["Orientation": ExpoCameraUtils.toExifOrientation(orientation: image.imageOrientation)]
+    )
+    // Pixel dimensions describe the unrotated buffer, not the display size.
+    if let cgImage = image.cgImage {
+      updatedExif[kCGImagePropertyExifPixelXDimension as String] = cgImage.width
+      updatedExif[kCGImagePropertyExifPixelYDimension as String] = cgImage.height
+    }
+
+    var updatedMetadata = sourceMetadata
+    updatedMetadata[kCGImagePropertyOrientation as String] =
+      ExpoCameraUtils.toExifOrientation(orientation: image.imageOrientation)
+
+    if let additionalExif = request.additionalExif {
+      for (key, value) in additionalExif {
+        updatedExif[key] = value
+      }
+
+      let gpsDict = Self.createGPSDict(additionalExif: additionalExif)
+      if updatedMetadata[kCGImagePropertyGPSDictionary as String] == nil {
+        updatedMetadata[kCGImagePropertyGPSDictionary as String] = gpsDict
+      } else if var existingGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? [String: Any] {
+        existingGpsDict.merge(gpsDict) { _, new in new }
+        updatedMetadata[kCGImagePropertyGPSDictionary as String] = existingGpsDict
+      }
+    }
+
+    updatedMetadata[kCGImagePropertyExifDictionary as String] = updatedExif
+
+    guard let data = ExpoCameraUtils.data(
+      from: image,
+      with: updatedMetadata,
+      quality: Float(request.quality)
+    ) else {
+      throw CameraSavingImageException("Image data could not be processed")
+    }
+
+    return Result(data: data, width: width, height: height, exif: updatedExif)
+  }
+
+  private static func createGPSDict(additionalExif: [String: Any]) -> [String: Any] {
+    var gpsDict = [String: Any]()
+
+    if let latitude = additionalExif["GPSLatitude"], let latValue = toDouble(latitude) {
+      gpsDict[kCGImagePropertyGPSLatitude as String] = abs(latValue)
+      gpsDict[kCGImagePropertyGPSLatitudeRef as String] = latValue >= 0 ? "N" : "S"
+    }
+
+    if let longitude = additionalExif["GPSLongitude"], let lonValue = toDouble(longitude) {
+      gpsDict[kCGImagePropertyGPSLongitude as String] = abs(lonValue)
+      gpsDict[kCGImagePropertyGPSLongitudeRef as String] = lonValue >= 0 ? "E" : "W"
+    }
+
+    if let altitude = additionalExif["GPSAltitude"], let altValue = toDouble(altitude) {
+      gpsDict[kCGImagePropertyGPSAltitude as String] = abs(altValue)
+      gpsDict[kCGImagePropertyGPSAltitudeRef as String] = altValue >= 0 ? 0 : 1
+    }
+
+    if let speed = additionalExif["GPSSpeed"], let speedValue = toDouble(speed) {
+      gpsDict[kCGImagePropertyGPSSpeed as String] = speedValue
+    }
+    if let speedRef = additionalExif["GPSSpeedRef"] as? String {
+      gpsDict[kCGImagePropertyGPSSpeedRef as String] = speedRef
+    }
+
+    if let imgDirection = additionalExif["GPSImgDirection"], let dirValue = toDouble(imgDirection) {
+      gpsDict[kCGImagePropertyGPSImgDirection as String] = dirValue
+    }
+    if let imgDirectionRef = additionalExif["GPSImgDirectionRef"] as? String {
+      gpsDict[kCGImagePropertyGPSImgDirectionRef as String] = imgDirectionRef
+    }
+
+    if let destBearing = additionalExif["GPSDestBearing"], let bearingValue = toDouble(destBearing) {
+      gpsDict[kCGImagePropertyGPSDestBearing as String] = bearingValue
+    }
+    if let destBearingRef = additionalExif["GPSDestBearingRef"] as? String {
+      gpsDict[kCGImagePropertyGPSDestBearingRef as String] = destBearingRef
+    }
+
+    if let dateStamp = additionalExif["GPSDateStamp"] as? String {
+      gpsDict[kCGImagePropertyGPSDateStamp as String] = dateStamp
+    }
+
+    if let timeStamp = additionalExif["GPSTimeStamp"] as? String {
+      gpsDict[kCGImagePropertyGPSTimeStamp as String] = timeStamp
+    }
+
+    if let hPositioningError = additionalExif["GPSHPositioningError"], let errorValue = toDouble(hPositioningError) {
+      gpsDict[kCGImagePropertyGPSHPositioningError as String] = errorValue
+    }
+
+    return gpsDict
+  }
+
+  private static func toDouble(_ value: Any) -> Double? {
+    if let doubleValue = value as? Double {
+      return doubleValue
+    } else if let intValue = value as? Int {
+      return Double(intValue)
+    } else if let floatValue = value as? Float {
+      return Double(floatValue)
+    }
+    return nil
+  }
+}

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -189,71 +189,28 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
 
     takenImage = ExpoCameraUtils.crop(image: takenImage, to: croppedSize)
 
-    let width = takenImage.size.width
-    let height = takenImage.size.height
-    var processedImageData: Data?
-
-    var response = [String: Any]()
-
-    if options.exif {
-      guard let exifDict = metadata[kCGImagePropertyExifDictionary as String] as? [String: Any] else {
-        throw CameraSavingImageException("Failed to process EXIF data")
-      }
-
-      var updatedExif = ExpoCameraUtils.updateExif(
-        metadata: exifDict,
-        with: ["Orientation": ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)]
-      )
-
-      if let cgImage = takenImage.cgImage {
-        updatedExif[kCGImagePropertyExifPixelXDimension as String] = cgImage.width
-        updatedExif[kCGImagePropertyExifPixelYDimension as String] = cgImage.height
-      }
-      response["exif"] = updatedExif
-
-      var updatedMetadata = metadata
-      updatedMetadata[kCGImagePropertyOrientation as String] =
-        ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)
-
-      if let additionalExif = options.additionalExif {
-        for (key, value) in additionalExif {
-          updatedExif[key] = value
-        }
-
-        let gpsDict = createGPSDict(additionalExif: options.additionalExif)
-
-        if updatedMetadata[kCGImagePropertyGPSDictionary as String] == nil {
-          updatedMetadata[kCGImagePropertyGPSDictionary as String] = gpsDict
-        } else if var existingGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? [String: Any] {
-          existingGpsDict.merge(gpsDict) { _, new in
-            new
-          }
-          updatedMetadata[kCGImagePropertyGPSDictionary as String] = existingGpsDict
-        }
-      }
-
-      updatedMetadata[kCGImagePropertyExifDictionary as String] = updatedExif
-      processedImageData = ExpoCameraUtils.data(
-        from: takenImage,
-        with: updatedMetadata,
-        quality: Float(options.quality))
-    } else {
-      if options.imageType == .png {
-        processedImageData = takenImage.pngData()
-      } else {
-        processedImageData = takenImage.jpegData(compressionQuality: options.quality)
-      }
-    }
-
-    guard let processedImageData else {
-      throw CameraSavingImageException("Image data could not be processed")
-    }
+    let request = CaptureRequest(
+      exif: options.exif,
+      quality: options.quality,
+      imageType: options.imageType,
+      additionalExif: options.additionalExif
+    )
+    let result = try CapturedPhotoProcessor().process(
+      image: takenImage,
+      sourceMetadata: metadata,
+      request: request
+    )
 
     if options.pictureRef {
-      if let image = UIImage(data: processedImageData) {
+      if let image = UIImage(data: result.data) {
         return PictureRef(image)
       }
       throw CameraSavingImageException("Failed to create UIImage from processed data")
+    }
+
+    var response = [String: Any]()
+    if let exif = result.exif {
+      response["exif"] = exif
     }
 
     let path = FileSystemUtilities.generatePathInCache(
@@ -262,13 +219,13 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
       extension: options.imageType.toExtension()
     )
 
-    response["uri"] = ExpoCameraUtils.write(data: processedImageData, to: path)
-    response["width"] = width
-    response["height"] = height
+    response["uri"] = ExpoCameraUtils.write(data: result.data, to: path)
+    response["width"] = result.width
+    response["height"] = result.height
     response["format"] = options.imageType.rawValue
 
     if options.base64 {
-      response["base64"] = processedImageData.base64EncodedString()
+      response["base64"] = result.data.base64EncodedString()
     }
 
     if options.fastMode {
@@ -281,74 +238,5 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
   func cleanup() {
     photoCapturedContinuation?.resume(throwing: CameraUnmountedException())
     self.photoCapturedContinuation = nil
-  }
-
-  private func createGPSDict(additionalExif: [String: Any]?) -> [String: Any] {
-    guard let additionalExif else {
-      return [:]
-    }
-
-    var gpsDict = [String: Any]()
-
-    if let latitude = additionalExif["GPSLatitude"], let latValue = toDouble(latitude) {
-      gpsDict[kCGImagePropertyGPSLatitude as String] = abs(latValue)
-      gpsDict[kCGImagePropertyGPSLatitudeRef as String] = latValue >= 0 ? "N" : "S"
-    }
-
-    if let longitude = additionalExif["GPSLongitude"], let lonValue = toDouble(longitude) {
-      gpsDict[kCGImagePropertyGPSLongitude as String] = abs(lonValue)
-      gpsDict[kCGImagePropertyGPSLongitudeRef as String] = lonValue >= 0 ? "E" : "W"
-    }
-
-    if let altitude = additionalExif["GPSAltitude"], let altValue = toDouble(altitude) {
-      gpsDict[kCGImagePropertyGPSAltitude as String] = abs(altValue)
-      gpsDict[kCGImagePropertyGPSAltitudeRef as String] = altValue >= 0 ? 0 : 1
-    }
-
-    if let speed = additionalExif["GPSSpeed"], let speedValue = toDouble(speed) {
-      gpsDict[kCGImagePropertyGPSSpeed as String] = speedValue
-    }
-    if let speedRef = additionalExif["GPSSpeedRef"] as? String {
-      gpsDict[kCGImagePropertyGPSSpeedRef as String] = speedRef
-    }
-
-    if let imgDirection = additionalExif["GPSImgDirection"], let dirValue = toDouble(imgDirection) {
-      gpsDict[kCGImagePropertyGPSImgDirection as String] = dirValue
-    }
-    if let imgDirectionRef = additionalExif["GPSImgDirectionRef"] as? String {
-      gpsDict[kCGImagePropertyGPSImgDirectionRef as String] = imgDirectionRef
-    }
-
-    if let destBearing = additionalExif["GPSDestBearing"], let bearingValue = toDouble(destBearing) {
-      gpsDict[kCGImagePropertyGPSDestBearing as String] = bearingValue
-    }
-    if let destBearingRef = additionalExif["GPSDestBearingRef"] as? String {
-      gpsDict[kCGImagePropertyGPSDestBearingRef as String] = destBearingRef
-    }
-
-    if let dateStamp = additionalExif["GPSDateStamp"] as? String {
-      gpsDict[kCGImagePropertyGPSDateStamp as String] = dateStamp
-    }
-
-    if let timeStamp = additionalExif["GPSTimeStamp"] as? String {
-      gpsDict[kCGImagePropertyGPSTimeStamp as String] = timeStamp
-    }
-
-    if let hPositioningError = additionalExif["GPSHPositioningError"], let errorValue = toDouble(hPositioningError) {
-      gpsDict[kCGImagePropertyGPSHPositioningError as String] = errorValue
-    }
-
-    return gpsDict
-  }
-
-  private func toDouble(_ value: Any) -> Double? {
-    if let doubleValue = value as? Double {
-      return doubleValue
-    } else if let intValue = value as? Int {
-      return Double(intValue)
-    } else if let floatValue = value as? Float {
-      return Double(floatValue)
-    }
-    return nil
   }
 }

--- a/packages/expo-camera/ios/ExpoCamera.podspec
+++ b/packages/expo-camera/ios/ExpoCamera.podspec
@@ -24,12 +24,21 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
-  s.exclude_files = "barcode-scanning/**"
+  s.exclude_files = "barcode-scanning/**", "Tests/**"
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"
   else
     s.source_files = "**/*.{h,m,swift}"
+  end
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.requires_app_host = false
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
   end
 end

--- a/packages/expo-camera/ios/Tests/CapturedPhotoProcessorTests.swift
+++ b/packages/expo-camera/ios/Tests/CapturedPhotoProcessorTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import UIKit
+import ImageIO
+
+@testable import ExpoCamera
+
+@Suite("CapturedPhotoProcessor")
+struct CapturedPhotoProcessorTests {
+  // A UIImage whose CGImage is the sensor buffer; `orientation` is the display transform.
+  private func makeImage(bufferWidth: Int, bufferHeight: Int, orientation: UIImage.Orientation) -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let renderer = UIGraphicsImageRenderer(
+      size: CGSize(width: bufferWidth, height: bufferHeight),
+      format: format
+    )
+    let base = renderer.image { context in
+      UIColor.darkGray.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: bufferWidth, height: bufferHeight))
+    }
+    return UIImage(cgImage: base.cgImage!, scale: 1, orientation: orientation)
+  }
+
+  @Test
+  func `portrait capture keeps the real orientation tag and buffer pixel dimensions`() throws {
+    // Portrait: landscape sensor buffer tagged .right (EXIF 6).
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
+    let request = CaptureRequest(exif: true, quality: 1, imageType: .jpg, additionalExif: nil)
+
+    let result = try CapturedPhotoProcessor().process(
+      image: image,
+      sourceMetadata: [kCGImagePropertyExifDictionary as String: [String: Any]()],
+      request: request
+    )
+
+    #expect(result.width == 300)
+    #expect(result.height == 400)
+
+    let exif = try #require(result.exif)
+    #expect(exif["Orientation"] as? Int == 6)
+    #expect(exif[kCGImagePropertyExifPixelXDimension as String] as? Int == 400)
+    #expect(exif[kCGImagePropertyExifPixelYDimension as String] as? Int == 300)
+  }
+
+  // Orientation tag varies by device orientation; pixel dimensions always describe the 400x300 buffer.
+  @Test(arguments: [
+    (UIImage.Orientation.up, 1, 400.0, 300.0),
+    (.down, 3, 400.0, 300.0),
+    (.left, 8, 300.0, 400.0),
+    (.upMirrored, 2, 400.0, 300.0),
+    (.downMirrored, 4, 400.0, 300.0),
+    (.leftMirrored, 5, 300.0, 400.0),
+    (.rightMirrored, 7, 300.0, 400.0),
+  ] as [(UIImage.Orientation, Int, Double, Double)])
+  func `orientation tag varies and pixel dimensions are never transposed`(
+    orientation: UIImage.Orientation,
+    exifOrientation: Int,
+    expectedWidth: Double,
+    expectedHeight: Double
+  ) throws {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: orientation)
+    let request = CaptureRequest(exif: true, quality: 1, imageType: .jpg, additionalExif: nil)
+
+    let result = try CapturedPhotoProcessor().process(
+      image: image,
+      sourceMetadata: [kCGImagePropertyExifDictionary as String: [String: Any]()],
+      request: request
+    )
+
+    #expect(result.width == expectedWidth)
+    #expect(result.height == expectedHeight)
+
+    let exif = try #require(result.exif)
+    #expect(exif["Orientation"] as? Int == exifOrientation)
+    #expect(exif[kCGImagePropertyExifPixelXDimension as String] as? Int == 400)
+    #expect(exif[kCGImagePropertyExifPixelYDimension as String] as? Int == 300)
+  }
+
+  @Test
+  func `capture without exif returns display dimensions and no exif dictionary`() throws {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
+    let request = CaptureRequest(exif: false, quality: 1, imageType: .jpg, additionalExif: nil)
+
+    let result = try CapturedPhotoProcessor().process(image: image, sourceMetadata: [:], request: request)
+
+    #expect(result.width == 300)
+    #expect(result.height == 400)
+    #expect(result.exif == nil)
+    #expect(!result.data.isEmpty)
+  }
+
+  @Test
+  func `encoded file matches the reported buffer dimensions and orientation tag`() throws {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
+    let request = CaptureRequest(exif: true, quality: 1, imageType: .jpg, additionalExif: nil)
+
+    let result = try CapturedPhotoProcessor().process(
+      image: image,
+      sourceMetadata: [kCGImagePropertyExifDictionary as String: [String: Any]()],
+      request: request
+    )
+
+    let source = try #require(CGImageSourceCreateWithData(result.data as CFData, nil))
+    let props = try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+
+    #expect(props[kCGImagePropertyPixelWidth] as? Int == 400)
+    #expect(props[kCGImagePropertyPixelHeight] as? Int == 300)
+    #expect(props[kCGImagePropertyOrientation] as? Int == 6)
+  }
+
+  @Test
+  func `additionalExif is reflected in the returned exif and encoded as GPS metadata`() throws {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
+    let additionalExif: [String: Any] = ["GPSLatitude": 37.33, "GPSLongitude": -122.03]
+    let request = CaptureRequest(exif: true, quality: 1, imageType: .jpg, additionalExif: additionalExif)
+
+    let result = try CapturedPhotoProcessor().process(
+      image: image,
+      sourceMetadata: [kCGImagePropertyExifDictionary as String: [String: Any]()],
+      request: request
+    )
+
+    // The returned exif reflects the additional keys, so the response and the file agree.
+    let exif = try #require(result.exif)
+    #expect(exif["GPSLatitude"] as? Double == 37.33)
+
+    // The encoded file carries a GPS dictionary with the mapped coordinates and hemisphere refs.
+    let source = try #require(CGImageSourceCreateWithData(result.data as CFData, nil))
+    let props = try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+    let gps = try #require(props[kCGImagePropertyGPSDictionary] as? [CFString: Any])
+    #expect(gps[kCGImagePropertyGPSLatitude] as? Double == 37.33)
+    #expect(gps[kCGImagePropertyGPSLatitudeRef] as? String == "N")
+    #expect(gps[kCGImagePropertyGPSLongitude] as? Double == 122.03)
+    #expect(gps[kCGImagePropertyGPSLongitudeRef] as? String == "W")
+  }
+}


### PR DESCRIPTION
# Why

expo-camera had no iOS native unit tests, so the recent capture orientation regression (#47823) shipped with nothing to catch it. This creates a native test target for the package and starts moving  logic out of the module DSL into a plain, testable type.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Added a test_spec to ExpoCamera.podspec. 
- Extracted the photo capture logic (display dimensions, EXIF, orientation, additionalExif and GPS, encoding) into a new
CapturedPhotoProcessor value type with no AVFoundation, AppContext, or Module DSL dependency.
- Covered the capture in CapturedPhotoProcessorTests: each orientation, the non-exif path, a round trip that re-decodes the written bytes, and additionalExif with GPS.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tests are green