### PR TITLE
[ios][camera] Add barcode tests

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
@@ -469,21 +469,12 @@ export default function CameraScreen() {
 
   const renderBarcode = () => (
     <View style={styles.barcode} pointerEvents="none">
-      <Animated.View style={barcodeOverlayStyle}>
-        <Text
-          style={{
-            position: 'absolute',
-            bottom: '100%',
-            left: 0,
-            color: 'black',
-            fontSize: 12,
-            fontWeight: 'bold',
-            paddingHorizontal: 4,
-            paddingVertical: 2,
-          }}>
-          {barcodeData}
-        </Text>
-      </Animated.View>
+      <Animated.View style={barcodeOverlayStyle} />
+      {barcodeData ? (
+        <View style={styles.barcodeDataLabel}>
+          <Text style={styles.barcodeDataText}>{barcodeData}</Text>
+        </View>
+      ) : null}
     </View>
   );
 
@@ -511,7 +502,7 @@ export default function CameraScreen() {
             videoStabilizationMode={state.videoStabilizationMode}
             onMountError={handleMountError}
             barcodeScannerSettings={{
-              barcodeTypes: ['qr', 'pdf417'],
+              barcodeTypes: ['pdf417', 'codabar', 'code39'],
             }}
             onBarcodeScanned={state.barcodeScanning ? onBarcodeScanned : undefined}
           />
@@ -644,5 +635,24 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+  },
+  barcodeDataLabel: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  barcodeDataText: {
+    color: 'white',
+    fontSize: 14,
+    fontWeight: 'bold',
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    overflow: 'hidden',
   },
 });

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [iOS] Disable deferred photo delivery so responsive capture no longer hangs the capture promise on iOS 17 and later. ([#47816](https://github.com/expo/expo/pull/47816) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Preserve the capture orientation as EXIF metadata instead of rotating captured pixels, so `takePictureAsync` and `savePictureAsync` return the real orientation tag and dimensions. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Return zeroed `bounds` and `cornerPoints` from the ZXing fallback scanner so scanning a `pdf417`, `code39`, or `codabar` code no longer crashes with `Cannot read property 'origin' of undefined`. ([#47854](https://github.com/expo/expo/pull/47854) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Common/BarcodeUtils.swift
+++ b/packages/expo-camera/ios/Common/BarcodeUtils.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-struct BarcodeUtils {
+public struct BarcodeUtils {
   static func getResultFrom(_ features: [CIFeature]) -> [[AnyHashable: Any]?] {
     var result = [[AnyHashable: Any]?]()
 
@@ -22,31 +22,13 @@ struct BarcodeUtils {
     result["data"] = codeFeature.messageString
 
     if !codeFeature.bounds.isEmpty {
-      result["cornerPoints"] = [
+      result["cornerPoints"] = cornerPoints(from: [
         codeFeature.topLeft,
         codeFeature.topRight,
         codeFeature.bottomRight,
         codeFeature.bottomLeft
-      ].map { point in
-        [
-          "x": point.x,
-          "y": point.y
-        ]
-      }
-
-      let origin = codeFeature.bounds.origin
-      let size = codeFeature.bounds.size
-
-      result["bounds"] = [
-        "origin": [
-          "x": origin.x,
-          "y": origin.y
-        ],
-        "size": [
-          "width": size.width,
-          "height": size.height
-        ]
-      ]
+      ])
+      result["bounds"] = bounds(from: codeFeature.bounds)
     } else {
       addEmptyCornerPoints(to: &result)
     }
@@ -54,17 +36,19 @@ struct BarcodeUtils {
     return result
   }
 
-  static func addEmptyCornerPoints(to result: inout [String: Any]) {
-    result["cornerPoints"] = []
-    result["bounds"] = [
-      "origin": [
-        "x": 0,
-        "y": 0
-      ],
-      "size": [
-        "width": 0,
-        "height": 0
-      ]
+  static func cornerPoints(from points: [CGPoint]) -> [[String: Any]] {
+    points.map { ["x": $0.x, "y": $0.y] }
+  }
+
+  static func bounds(from rect: CGRect) -> [String: Any] {
+    [
+      "origin": ["x": rect.origin.x, "y": rect.origin.y],
+      "size": ["width": rect.size.width, "height": rect.size.height]
     ]
+  }
+
+  public static func addEmptyCornerPoints(to result: inout [String: Any]) {
+    result["cornerPoints"] = []
+    result["bounds"] = bounds(from: .zero)
   }
 }

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -11,7 +11,7 @@ struct BarcodeSettings: Record {
   }
 }
 
-enum BarcodeType: String, Enumerable {
+public enum BarcodeType: String, Enumerable {
   case aztec
   case ean13
   case ean8
@@ -62,7 +62,7 @@ enum BarcodeType: String, Enumerable {
     }
   }
 
-  static func toBarcodeType(type: AVMetadataObject.ObjectType) -> BarcodeType {
+  public static func toBarcodeType(type: AVMetadataObject.ObjectType) -> BarcodeType {
     if #available(iOS 15.4, *) {
       if type == .codabar {
         return .codabar

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -28,34 +28,16 @@ class BarcodeScannerUtils {
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = BarcodeType.toBarcodeType(type: barcodeScannerResult.type).rawValue
-    result["data"] = barcodeScannerResult.stringValue
-
-    // iOS converts upc_a to ean13 and appends a leading 0
-    if barcodeScannerResult.type == AVMetadataObject.ObjectType.ean13 {
-      let value = barcodeScannerResult.stringValue ?? ""
-      if !value.isEmpty && value.hasPrefix("0") {
-        result["data"] = value.dropFirst()
-      }
-    }
+    result["data"] = normalizeBarcodeValue(
+      barcodeScannerResult.stringValue,
+      isEAN13: barcodeScannerResult.type == .ean13
+    )
 
     if !barcodeScannerResult.corners.isEmpty {
-      var cornerPointsResult = [[String: Any]]()
-      for point in barcodeScannerResult.corners {
-        cornerPointsResult.append(["x": point.x, "y": point.y])
-      }
-      result["cornerPoints"] = cornerPointsResult
-      result["bounds"] = [
-        "origin": [
-          "x": barcodeScannerResult.bounds.origin.x,
-          "y": barcodeScannerResult.bounds.origin.y
-        ],
-        "size": [
-          "width": barcodeScannerResult.bounds.size.width,
-          "height": barcodeScannerResult.bounds.size.height
-        ]
-      ]
+      result["cornerPoints"] = BarcodeUtils.cornerPoints(from: barcodeScannerResult.corners)
+      result["bounds"] = BarcodeUtils.bounds(from: barcodeScannerResult.bounds)
     } else {
-      addEmptyCornerPoints(to: &result)
+      BarcodeUtils.addEmptyCornerPoints(to: &result)
     }
     return result
   }
@@ -64,37 +46,27 @@ class BarcodeScannerUtils {
   static func visionDataScannerObjectToDictionary(item: RecognizedItem.Barcode) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = item.observation.symbology.rawValue
-    result["data"] = item.payloadStringValue
-
-    // iOS converts upc_a to ean13 and appends a leading 0
-    if item.observation.symbology == VNBarcodeSymbology.ean13 {
-      let value = item.payloadStringValue ?? ""
-      if !value.isEmpty && value.hasPrefix("0") {
-        result["data"] = value.dropFirst()
-      }
-    }
+    result["data"] = normalizeBarcodeValue(
+      item.payloadStringValue,
+      isEAN13: item.observation.symbology == .ean13
+    )
 
     let bounds = item.bounds
-    let cornerPoints: [[String: Any]] = [bounds.bottomLeft, bounds.bottomRight, bounds.topLeft, bounds.topRight].map { point in
-      ["x": point.x, "y": point.y]
-    }
-    result["cornerPoints"] = cornerPoints
+    result["cornerPoints"] = BarcodeUtils.cornerPoints(
+      from: [bounds.bottomLeft, bounds.bottomRight, bounds.topLeft, bounds.topRight]
+    )
 
     return result
   }
 
-  static func addEmptyCornerPoints(to result: inout [String: Any]) {
-    result["cornerPoints"] = []
-    result["bounds"] = [
-      "origin": [
-        "x": 0,
-        "y": 0
-      ],
-      "size": [
-        "width": 0,
-        "height": 0
-      ]
-    ]
+  // iOS reports upc_a as ean13 with an extra leading zero; strip it so the value matches the code.
+  static func normalizeBarcodeValue(_ value: String?, isEAN13: Bool) -> String? {
+    guard let value else {
+      return nil
+    }
+    if isEAN13 && !value.isEmpty && value.hasPrefix("0") {
+      return String(value.dropFirst())
+    }
+    return value
   }
-
 }

--- a/packages/expo-camera/ios/Tests/BarcodeScannerUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeScannerUtilsTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+@testable import ExpoCamera
+
+@Suite("BarcodeScannerUtils.normalizeBarcodeValue")
+struct BarcodeScannerUtilsTests {
+  @Test
+  func `drops the leading zero iOS adds when reporting upc_a as ean13`() {
+    #expect(BarcodeScannerUtils.normalizeBarcodeValue("0123456789012", isEAN13: true) == "123456789012")
+  }
+
+  @Test
+  func `keeps a genuine ean13 value that does not start with zero`() {
+    #expect(BarcodeScannerUtils.normalizeBarcodeValue("4006381333931", isEAN13: true) == "4006381333931")
+  }
+
+  @Test
+  func `keeps a leading zero when the value is not ean13`() {
+    #expect(BarcodeScannerUtils.normalizeBarcodeValue("0123", isEAN13: false) == "0123")
+  }
+
+  @Test
+  func `passes nil through`() {
+    #expect(BarcodeScannerUtils.normalizeBarcodeValue(nil, isEAN13: true) == nil)
+  }
+
+  @Test
+  func `passes an empty ean13 value through`() {
+    #expect(BarcodeScannerUtils.normalizeBarcodeValue("", isEAN13: true) == "")
+  }
+}

--- a/packages/expo-camera/ios/Tests/BarcodeTypeTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeTypeTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import AVFoundation
+
+@testable import ExpoCamera
+
+@Suite("BarcodeType")
+struct BarcodeTypeTests {
+  @Test(arguments: [
+    (AVMetadataObject.ObjectType.aztec, BarcodeType.aztec),
+    (.qr, .qr),
+    (.ean13, .ean13),
+    (.ean8, .ean8),
+    (.pdf417, .pdf417),
+    (.itf14, .itf14),
+    (.interleaved2of5, .itf14),
+    (.upce, .upc_e),
+    (.code39, .code39),
+    (.code93, .code93),
+    (.dataMatrix, .datamatrix),
+    (.code128, .code128),
+    (.codabar, .codabar),
+  ] as [(AVMetadataObject.ObjectType, BarcodeType)])
+  func `maps AVFoundation object types to expo barcode types`(
+    type: AVMetadataObject.ObjectType,
+    expected: BarcodeType
+  ) {
+    #expect(BarcodeType.toBarcodeType(type: type) == expected)
+  }
+
+  @Test
+  func `unknown object types fall back to aztec`() {
+    #expect(BarcodeType.toBarcodeType(type: .face) == .aztec)
+  }
+}

--- a/packages/expo-camera/ios/Tests/BarcodeUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeUtilsTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import CoreGraphics
+
+@testable import ExpoCamera
+
+@Suite("BarcodeUtils")
+struct BarcodeUtilsTests {
+  @Test
+  func `maps points to x and y dictionaries in order`() {
+    let points = BarcodeUtils.cornerPoints(from: [CGPoint(x: 1, y: 2), CGPoint(x: 3, y: 4)])
+
+    #expect(points.count == 2)
+    #expect(points[0]["x"] as? CGFloat == 1)
+    #expect(points[0]["y"] as? CGFloat == 2)
+    #expect(points[1]["x"] as? CGFloat == 3)
+    #expect(points[1]["y"] as? CGFloat == 4)
+  }
+
+  @Test
+  func `maps a rect to an origin and size bounds dictionary`() {
+    let bounds = BarcodeUtils.bounds(from: CGRect(x: 1, y: 2, width: 3, height: 4))
+
+    let origin = try? #require(bounds["origin"] as? [String: Any])
+    let size = try? #require(bounds["size"] as? [String: Any])
+    #expect(origin?["x"] as? CGFloat == 1)
+    #expect(origin?["y"] as? CGFloat == 2)
+    #expect(size?["width"] as? CGFloat == 3)
+    #expect(size?["height"] as? CGFloat == 4)
+  }
+
+  @Test
+  func `empty corner points produce a zeroed bounds and empty corners`() throws {
+    var result: [String: Any] = [:]
+    BarcodeUtils.addEmptyCornerPoints(to: &result)
+
+    #expect((result["cornerPoints"] as? [Any])?.isEmpty == true)
+
+    let bounds = try #require(result["bounds"] as? [String: Any])
+    let origin = try #require(bounds["origin"] as? [String: Any])
+    let size = try #require(bounds["size"] as? [String: Any])
+    #expect(origin["x"] as? CGFloat == 0)
+    #expect(origin["y"] as? CGFloat == 0)
+    #expect(size["width"] as? CGFloat == 0)
+    #expect(size["height"] as? CGFloat == 0)
+  }
+}

--- a/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import UIKit
+import AVFoundation
+
+@testable import ExpoCamera
+
+@Suite("ExpoCameraUtils")
+struct ExpoCameraUtilsTests {
+  @Test(arguments: [
+    (UIImage.Orientation.up, 1),
+    (.down, 3),
+    (.left, 8),
+    (.right, 6),
+    (.upMirrored, 2),
+    (.downMirrored, 4),
+    (.leftMirrored, 5),
+    (.rightMirrored, 7),
+  ] as [(UIImage.Orientation, Int)])
+  func `maps UIImage orientation to EXIF orientation`(orientation: UIImage.Orientation, expected: Int) {
+    #expect(ExpoCameraUtils.toExifOrientation(orientation: orientation) == expected)
+  }
+
+  @Test(arguments: [
+    (UIImage.Orientation.up, 0),
+    (.left, 90),
+    (.right, -90),
+    (.down, 180),
+  ] as [(UIImage.Orientation, Int)])
+  func `maps UIImage orientation to export rotation degrees`(orientation: UIImage.Orientation, expected: Int) {
+    #expect(ExpoCameraUtils.exportImage(orientation: orientation) == expected)
+  }
+
+  @Test(arguments: [
+    (UIDeviceOrientation.portrait, AVCaptureVideoOrientation.portrait),
+    (.portraitUpsideDown, .portraitUpsideDown),
+    (.landscapeLeft, .landscapeRight),
+    (.landscapeRight, .landscapeLeft),
+    (.faceUp, .portrait),
+  ] as [(UIDeviceOrientation, AVCaptureVideoOrientation)])
+  func `maps device orientation to capture orientation reversing landscape`(
+    device: UIDeviceOrientation,
+    expected: AVCaptureVideoOrientation
+  ) {
+    #expect(ExpoCameraUtils.videoOrientation(for: device) == expected)
+  }
+
+  @Test(arguments: [
+    (UIInterfaceOrientation.portrait, AVCaptureVideoOrientation.portrait),
+    (.landscapeLeft, .landscapeLeft),
+    (.landscapeRight, .landscapeRight),
+    (.portraitUpsideDown, .portraitUpsideDown),
+    (.unknown, .portrait),
+  ] as [(UIInterfaceOrientation, AVCaptureVideoOrientation)])
+  func `maps interface orientation to capture orientation`(
+    interface: UIInterfaceOrientation,
+    expected: AVCaptureVideoOrientation
+  ) {
+    #expect(ExpoCameraUtils.videoOrientation(for: interface) == expected)
+  }
+
+  @Test(arguments: [
+    (UIDeviceOrientation.portrait, "portrait"),
+    (.landscapeLeft, "landscapeLeft"),
+    (.landscapeRight, "landscapeRight"),
+    (.portraitUpsideDown, "portraitUpsideDown"),
+    (.faceUp, "faceUp"),
+    (.faceDown, "faceDown"),
+    (.unknown, "unknown"),
+  ] as [(UIDeviceOrientation, String)])
+  func `maps device orientation to string`(orientation: UIDeviceOrientation, expected: String) {
+    #expect(ExpoCameraUtils.toOrientationString(orientation: orientation) == expected)
+  }
+
+  @Test
+  func `crops to the given rect and preserves scale and orientation`() throws {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let base = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 80), format: format).image { context in
+      UIColor.gray.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 100, height: 80))
+    }
+    let image = UIImage(cgImage: base.cgImage!, scale: 1, orientation: .right)
+
+    let cropped = ExpoCameraUtils.crop(image: image, to: CGRect(x: 0, y: 0, width: 40, height: 30))
+
+    #expect(cropped.cgImage?.width == 40)
+    #expect(cropped.cgImage?.height == 30)
+    #expect(cropped.imageOrientation == .right)
+    #expect(cropped.scale == 1)
+  }
+}

--- a/packages/expo-camera/ios/barcode-scanning/ExpoCameraZXingProvider.swift
+++ b/packages/expo-camera/ios/barcode-scanning/ExpoCameraZXingProvider.swift
@@ -26,7 +26,7 @@ class ExpoCameraZXingProvider: NSObject, ExpoBarcodeScannerProvider {
 
     for (type, reader) in readers {
       if let result = try? reader.decode(bitmap, hints: nil) {
-        return [["type": expoType(for: type), "data": result.text.filter { $0 != "\0" }]]
+        return [Self.barcodeResult(type: type, data: result.text.filter { $0 != "\0" })]
       }
     }
 
@@ -34,7 +34,7 @@ class ExpoCameraZXingProvider: NSObject, ExpoBarcodeScannerProvider {
     if bitmap?.rotateSupported == true, let rotated = bitmap?.rotateCounterClockwise() {
       for (type, reader) in readers {
         if let result = try? reader.decode(rotated, hints: nil) {
-          return [["type": expoType(for: type), "data": result.text.filter { $0 != "\0" }]]
+          return [Self.barcodeResult(type: type, data: result.text.filter { $0 != "\0" })]
         }
       }
     }
@@ -42,16 +42,15 @@ class ExpoCameraZXingProvider: NSObject, ExpoBarcodeScannerProvider {
     return []
   }
 
-  /// Converts a decoded reader's raw `AVMetadataObject.ObjectType` key to the short expo
-  /// `BarcodeType` string the JS event expects (e.g. "org.iso.PDF417" -> "pdf417"), matching
-  /// the native AVFoundation scan path. These are exactly the types registered in `readers`;
-  /// anything else is passed through unchanged.
-  private func expoType(for rawType: String) -> String {
-    if rawType == AVMetadataObject.ObjectType.pdf417.rawValue { return "pdf417" }
-    if rawType == AVMetadataObject.ObjectType.code39.rawValue { return "code39" }
-    if #available(iOS 15.4, *), rawType == AVMetadataObject.ObjectType.codabar.rawValue {
-      return "codabar"
-    }
-    return rawType
+  // ZXing gives no geometry, so match the AVFoundation result shape with zeroed bounds and corners
+  // rather than omitting them, which crashes consumers that read `bounds`.
+  private static func barcodeResult(type: String, data: Any) -> [String: Any] {
+    var result: [String: Any] = ["type": expoType(for: type), "data": data]
+    BarcodeUtils.addEmptyCornerPoints(to: &result)
+    return result
+  }
+
+  private static func expoType(for rawType: String) -> String {
+    BarcodeType.toBarcodeType(type: AVMetadataObject.ObjectType(rawValue: rawType)).rawValue
   }
 }


### PR DESCRIPTION
# Why

The barcode type mapping has regressed more than once (#44726, #47613), and scanning a ZXing-handled code (pdf417, code39, codabar) crashed with Cannot read property 'origin' of undefined because the fallback returned no bounds. This covers the barcode mapping and fixes the crash.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Made BarcodeType and the shared BarcodeUtils helpers public so the ZXing reuses them instead of duplicating.
- Consolidated corner point and bounds into BarcodeUtils.cornerPoints and BarcodeUtils.bounds, removed the duplicate
addEmptyCornerPoints, and extracted the ean13/upc_a leading zero handling into BarcodeScannerUtils.normalizeBarcodeValue.
- Had the ZXing provider return zeroed bounds and cornerPoints matching AVFoundation so consumers reading bounds no longer crash, and delegate its type mapping to the shared toBarcodeType.
- Fixed the ncl example to show scanned data in a fixed label instead of inside the bounding box overlay, which is invisible for geometry-less ZXing codes.
- Added tests for the type mapping, value normalization, and helpers.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tests are passing