### PR TITLE
[ios][camera] Add utils tests

### DIFF
--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -212,6 +212,31 @@ struct ExpoCameraUtils {
     return mutableMetadata
   }
 
+  struct EncodedImage {
+    let data: Data
+    let width: Double
+    let height: Double
+    let base64: String?
+  }
+
+  // Records the capture orientation as an EXIF tag instead of rotating the pixels, so viewers display
+  // it upright. Free of the file system so it can be unit tested.
+  static func encodeForSave(image: UIImage, metadata: [String: Any]?, quality: Double, includeBase64: Bool) throws -> EncodedImage {
+    var metadata = metadata ?? [:]
+    metadata[kCGImagePropertyOrientation as String] = toExifOrientation(orientation: image.imageOrientation)
+
+    guard let data = data(from: image, with: metadata, quality: Float(quality)) else {
+      throw CameraSavingImageException("Image data could not be processed")
+    }
+
+    return EncodedImage(
+      data: data,
+      width: image.size.width,
+      height: image.size.height,
+      base64: includeBase64 ? data.base64EncodedString() : nil
+    )
+  }
+
   /**
    Saves the image as a file.
    */
@@ -220,31 +245,30 @@ struct ExpoCameraUtils {
       throw CameraSavingImageException("Failed to locate `cacheDirectory`")
     }
 
-    var result = [String: Any]()
     let directory = URL(fileURLWithPath: cachesDirectory.path).appendingPathComponent("Camera")
     let filename = UUID().uuidString.appending(".jpg")
     let fileUrl = directory.appendingPathComponent(filename)
 
     FileSystemUtilities.ensureDirExists(at: directory)
 
-    // Record the capture orientation as an EXIF tag instead of rotating the pixels so viewers display it upright.
-    var metadata = options.metadata ?? [:]
-    metadata[kCGImagePropertyOrientation as String] = toExifOrientation(orientation: image.imageOrientation)
-
-    guard let data = data(from: image, with: metadata, quality: Float(options.quality)) else {
-      throw CameraSavingImageException("Image data could not be processed")
-    }
-
-    result["url"] = fileUrl.absoluteString
-    result["width"] = image.size.width
-    result["height"] = image.size.height
-    result["base64"] = options.base64 ? data.base64EncodedString() : nil
+    let encoded = try encodeForSave(
+      image: image,
+      metadata: options.metadata,
+      quality: options.quality,
+      includeBase64: options.base64
+    )
 
     do {
-      try data.write(to: fileUrl, options: .atomic)
+      try encoded.data.write(to: fileUrl, options: .atomic)
     } catch let error {
       throw CameraSavingImageException(error.localizedDescription)
     }
+
+    var result = [String: Any]()
+    result["url"] = fileUrl.absoluteString
+    result["width"] = encoded.width
+    result["height"] = encoded.height
+    result["base64"] = encoded.base64
     return result
   }
 }

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -45,18 +45,7 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
 
   func setSettings(_ newSettings: [String: [AVMetadataObject.ObjectType]]) {
     for (key, value) in newSettings where key == BARCODE_TYPES_KEY {
-      // AVFoundation distinguishes `.itf14` (14-digit ITF) from `.interleaved2of5`
-      // (generic Interleaved 2 of 5), and sometimes reports a given barcode under
-      // either type. Android's ML Kit uses a single `FORMAT_ITF` for both. To mirror
-      // that behavior and avoid silently dropping detections, when `.itf14` is
-      // requested we also register `.interleaved2of5` so both variants are scanned
-      // for and the delegate's type-match succeeds. Results are normalized back to
-      // `itf14` by `BarcodeType.toBarcodeType(type:)`, called from
-      // `BarcodeScannerUtils.avMetadataCodeObjectToDictionary`.
-      var augmentedValue = value
-      if augmentedValue.contains(.itf14) && !augmentedValue.contains(.interleaved2of5) {
-        augmentedValue.append(.interleaved2of5)
-      }
+      let augmentedValue = BarcodeScannerUtils.augmentedBarcodeTypes(value)
       let previousTypes = Set(settings[BARCODE_TYPES_KEY] ?? [])
       let newTypes = Set(augmentedValue)
       if previousTypes != newTypes {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -25,6 +25,16 @@ class BarcodeScannerUtils {
     return [BARCODE_TYPES_KEY: Array(validTypes.values)]
   }
 
+  // AVFoundation reports Interleaved 2 of 5 codes as either .itf14 or .interleaved2of5. Registering
+  // both when itf14 is requested mirrors Android ML Kit's single FORMAT_ITF and avoids dropping scans.
+  static func augmentedBarcodeTypes(_ types: [AVMetadataObject.ObjectType]) -> [AVMetadataObject.ObjectType] {
+    var augmented = types
+    if augmented.contains(.itf14) && !augmented.contains(.interleaved2of5) {
+      augmented.append(.interleaved2of5)
+    }
+    return augmented
+  }
+
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = BarcodeType.toBarcodeType(type: barcodeScannerResult.type).rawValue

--- a/packages/expo-camera/ios/Tests/BarcodeScannerUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeScannerUtilsTests.swift
@@ -1,9 +1,26 @@
 import Testing
+import AVFoundation
 
 @testable import ExpoCamera
 
-@Suite("BarcodeScannerUtils.normalizeBarcodeValue")
+@Suite("BarcodeScannerUtils")
 struct BarcodeScannerUtilsTests {
+  @Test
+  func `registers interleaved2of5 alongside itf14 to match ML Kit FORMAT_ITF`() {
+    #expect(BarcodeScannerUtils.augmentedBarcodeTypes([.itf14]) == [.itf14, .interleaved2of5])
+  }
+
+  @Test
+  func `does not duplicate interleaved2of5 when already requested`() {
+    let types: [AVMetadataObject.ObjectType] = [.itf14, .interleaved2of5]
+    #expect(BarcodeScannerUtils.augmentedBarcodeTypes(types) == types)
+  }
+
+  @Test
+  func `leaves types without itf14 unchanged`() {
+    #expect(BarcodeScannerUtils.augmentedBarcodeTypes([.qr, .ean13]) == [.qr, .ean13])
+  }
+
   @Test
   func `drops the leading zero iOS adds when reporting upc_a as ean13`() {
     #expect(BarcodeScannerUtils.normalizeBarcodeValue("0123456789012", isEAN13: true) == "123456789012")

--- a/packages/expo-camera/ios/Tests/BarcodeTypeTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeTypeTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import AVFoundation
+import Vision
 
 @testable import ExpoCamera
 
@@ -30,5 +31,38 @@ struct BarcodeTypeTests {
   @Test
   func `unknown object types fall back to aztec`() {
     #expect(BarcodeType.toBarcodeType(type: .face) == .aztec)
+  }
+
+  @Test(arguments: [
+    (BarcodeType.aztec, AVMetadataObject.ObjectType.aztec),
+    (.qr, .qr),
+    (.ean13, .ean13),
+    (.ean8, .ean8),
+    (.pdf417, .pdf417),
+    (.itf14, .itf14),
+    (.upc_a, .ean13),
+    (.upc_e, .upce),
+    (.code39, .code39),
+    (.code93, .code93),
+    (.datamatrix, .dataMatrix),
+    (.code128, .code128),
+    (.codabar, .codabar),
+  ] as [(BarcodeType, AVMetadataObject.ObjectType)])
+  func `maps expo barcode types to AVFoundation object types`(
+    barcodeType: BarcodeType,
+    expected: AVMetadataObject.ObjectType
+  ) {
+    #expect(barcodeType.toMetadataObjectType() == expected)
+  }
+
+  @available(iOS 16.0, *)
+  @Test
+  func `maps expo barcode types to Vision symbologies`() {
+    #expect(VNBarcodeType.upc_a.toSymbology() == .ean13)
+    #expect(VNBarcodeType.upc_e.toSymbology() == .upce)
+    #expect(VNBarcodeType.datamatrix.toSymbology() == .dataMatrix)
+    #expect(VNBarcodeType.codabar.toSymbology() == .codabar)
+    #expect(VNBarcodeType.qr.toSymbology() == .qr)
+    #expect(VNBarcodeType.itf14.toSymbology() == .itf14)
   }
 }

--- a/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import UIKit
 import AVFoundation
+import ImageIO
 
 @testable import ExpoCamera
 
@@ -59,6 +60,20 @@ struct ExpoCameraUtilsTests {
   }
 
   @Test(arguments: [
+    (UIInterfaceOrientation.portrait, UIDeviceOrientation.portrait),
+    (.portraitUpsideDown, .portraitUpsideDown),
+    (.landscapeLeft, .landscapeRight),
+    (.landscapeRight, .landscapeLeft),
+    (.unknown, .unknown),
+  ] as [(UIInterfaceOrientation, UIDeviceOrientation)])
+  func `maps interface orientation to physical device orientation reversing landscape`(
+    interface: UIInterfaceOrientation,
+    expected: UIDeviceOrientation
+  ) {
+    #expect(ExpoCameraUtils.physicalOrientation(for: interface) == expected)
+  }
+
+  @Test(arguments: [
     (UIDeviceOrientation.portrait, "portrait"),
     (.landscapeLeft, "landscapeLeft"),
     (.landscapeRight, "landscapeRight"),
@@ -87,5 +102,44 @@ struct ExpoCameraUtilsTests {
     #expect(cropped.cgImage?.height == 30)
     #expect(cropped.imageOrientation == .right)
     #expect(cropped.scale == 1)
+  }
+
+  @Test
+  func `encodeForSave writes the capture orientation and returns display dimensions`() throws {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
+
+    let encoded = try ExpoCameraUtils.encodeForSave(image: image, metadata: nil, quality: 1, includeBase64: false)
+
+    #expect(encoded.width == 300)
+    #expect(encoded.height == 400)
+    #expect(encoded.base64 == nil)
+
+    let source = try #require(CGImageSourceCreateWithData(encoded.data as CFData, nil))
+    let props = try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+    #expect(props[kCGImagePropertyOrientation] as? Int == 6)
+  }
+
+  @Test
+  func `encodeForSave includes base64 only when requested`() throws {
+    let image = makeImage(bufferWidth: 100, bufferHeight: 100, orientation: .up)
+
+    let withBase64 = try ExpoCameraUtils.encodeForSave(image: image, metadata: nil, quality: 1, includeBase64: true)
+    let withoutBase64 = try ExpoCameraUtils.encodeForSave(image: image, metadata: nil, quality: 1, includeBase64: false)
+
+    #expect(withBase64.base64?.isEmpty == false)
+    #expect(withoutBase64.base64 == nil)
+  }
+
+  private func makeImage(bufferWidth: Int, bufferHeight: Int, orientation: UIImage.Orientation) -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let base = UIGraphicsImageRenderer(
+      size: CGSize(width: bufferWidth, height: bufferHeight),
+      format: format
+    ).image { context in
+      UIColor.gray.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: bufferWidth, height: bufferHeight))
+    }
+    return UIImage(cgImage: base.cgImage!, scale: 1, orientation: orientation)
   }
 }


### PR DESCRIPTION
# Why

Cover the remaining camera utilities so the save path, orientation tables, and the reverse barcode mappings are covered too.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Extracted the save path encoding from saveImage into ExpoCameraUtils.encodeForSave, leaving saveImage as to deal only with the file system.
- Extracted the itf14 to interleaved2of5 augmentation from BarcodeScanner.setSettings into BarcodeScannerUtils.augmentedBarcodeTypes.
- Added tests for the orientation, crop, encodeForSave, the reverse barcode mappings (toMetadataObjectType and toSymbology), and the itf14 augmentation.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tests are passing