### PR TITLE
[docs] Document non-interactive `eas init` for access token flows

### DIFF
--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -27,7 +27,7 @@ For example, once you obtain a token, you can run the following EAS CLI command 
 
 <Terminal cmd={['$ EXPO_TOKEN=my_token eas build']} />
 
-> **info** Commands that run with an access token require the project to already be linked to an EAS project. If `extra.eas.projectId` is not set in your [app config](/workflow/configuration), commands such as `eas build` fail with an `EAS project not configured` error. To configure it, run `EXPO_TOKEN=my_token eas init --force --non-interactive` (or `EXPO_TOKEN=my_token eas init --id <your-project-id>`) first.
+> **info** Commands that run with an access token require the project to already be linked to an EAS project. If `extra.eas.projectId` is not set in your [app config](/workflow/configuration), commands such as `eas build` fail with an `EAS project not configured` error. To configure it, run `EXPO_TOKEN=my_token eas init --force --non-interactive` first.
 
 If you are using GitHub Actions, [you can configure the `token` property](https://github.com/expo/expo-github-action#configuration-options) to include this environment variable in all the job steps.
 

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -27,6 +27,8 @@ For example, once you obtain a token, you can run the following EAS CLI command 
 
 <Terminal cmd={['$ EXPO_TOKEN=my_token eas build']} />
 
+> **info** Commands that run with an access token require the project to already be linked to an EAS project. If `extra.eas.projectId` is not set in your [app config](/workflow/configuration), commands such as `eas build` fail with an `EAS project not configured` error. To configure it, run `EXPO_TOKEN=my_token eas init --force --non-interactive` (or `EXPO_TOKEN=my_token eas init --id <your-project-id>`) first.
+
 If you are using GitHub Actions, [you can configure the `token` property](https://github.com/expo/expo-github-action#configuration-options) to include this environment variable in all the job steps.
 
 Common situations where access tokens are useful:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25190

# How

<!--
How did you build this feature or fix this bug and why?
-->

Document non-interactive `eas init` for access token flows under Access tokens usage section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2432" height="1070" alt="CleanShot 2026-07-16 at 19 29 00@2x" src="https://github.com/user-attachments/assets/a41547d8-467b-48ca-ba53-95cfc3976ff1" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
