### PR TITLE
fix(cli): Correct all-null `data` being checked obscuring failure states

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Include external CSS imports in the production server manifest ([#46984](https://github.com/expo/expo/pull/46984) by [@hassankhan](https://github.com/hassankhan))
 - Fall back to AGP's `output-metadata.json` when resolving APK filenames to support projects that override `outputFileName` in `applicationVariants` ([#47083](https://github.com/expo/expo/pull/47083) by [@NikhilVashistha](https://github.com/NikhilVashistha))
 - Surface the real `xcodebuild` error on `run:ios` failure instead of printing "0 error(s)" when the build formatter parsed none. ([#47748](https://github.com/expo/expo/pull/47748) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/graphql/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/graphql/__tests__/client-test.ts
@@ -30,7 +30,7 @@ function mockJsonResponseOnce(data: unknown) {
 }
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  asMock(fetch).mockReset();
 });
 
 describe('mutate', () => {
@@ -63,5 +63,33 @@ describe('query', () => {
     expect(await query(Document, {})).toEqual({ value: 7 });
     expect(await query(Document, {})).toEqual({ value: 7 });
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns GraphQL results with all-null fields', async () => {
+    const document = graphql<{ meActor: null }>(`
+      query CurrentUser {
+        meActor {
+          id
+        }
+      }
+    `);
+
+    mockJsonResponseOnce({ meActor: null });
+
+    await expect(query(document, {})).resolves.toEqual({ meActor: null });
+  });
+
+  it('throws when the GraphQL result is null', async () => {
+    const document = graphql<Data>(`
+      query NullResult {
+        value
+      }
+    `);
+
+    mockJsonResponseOnce(null);
+    mockJsonResponseOnce(null);
+    mockJsonResponseOnce(null);
+
+    await expect(query(document, {})).rejects.toThrow('No returned query result');
   });
 });

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -151,15 +151,12 @@ export const { query, mutate } = (() => {
       }
     }
 
-    // Store the data in the cache, and only return a result if we have any values
-    if (data) {
+    // Store and return a result if the response included a non-null `data` payload.
+    if (data != null) {
       if (useCache) {
         queryCache.set(variablesKey, data);
       }
-      const keys = Object.keys(data);
-      if (keys.some((key) => data[key as keyof typeof data] != null)) {
-        return data;
-      }
+      return data;
     }
 
     // If we have an error, rethrow it wrapped in our custom errors

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18129,7 +18129,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
# Why

Resolves #47731
Regressed in #42556

This check was meant to check for all-nullish fields on `result`, but was accidentally checking `data`, which wasn't intended. An all-null result wasn't previously treated as an error, which depends on the version of `urql`'s **consumer** but isn't present in `@urql/core` by default. Usually this also only affects caching.

We rely on an all-null field for the `meActor` being `null` on an invalid/expired session.

# How

- Remove/replace `data` check for all-null values

# Test Plan

- Added unit test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
