### PR TITLE
[JSI] Encode `Task` to a JavaScript `Promise`

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -19,6 +19,8 @@
 - [iOS] Add a `JavaScriptCodable` conformance for `Date`: it encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch, or a string parsed by the JS engine's `Date` constructor. ([#47602](https://github.com/expo/expo/pull/47602) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.runOrSchedule` that runs the given closure synchronously when called on the JavaScript thread and schedules it asynchronously otherwise. ([#47915](https://github.com/expo/expo/pull/47915) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptPromise.resolve` overload that takes a `JavaScriptEncodable` value, encoding it on the JavaScript thread and rejecting the promise if encoding or the resolver call throws. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add a `JavaScriptEncodable` conformance for `Task` that encodes it to a JS `Promise` settling with the task's result, so native code can hand JavaScript a promise as a value. ([#47861](https://github.com/expo/expo/pull/47861) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Split the `Array`, `Optional`, and `Dictionary` `JavaScriptCodable` conformances into separate `JavaScriptDecodable` and `JavaScriptEncodable` halves so an encode-only element type such as `Task` can be carried through a container's encode. ([#47861](https://github.com/expo/expo/pull/47861) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Containers.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Containers.swift
@@ -1,15 +1,15 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-// `JavaScriptCodable` conformances for the standard container and wrapper types — `Array`,
-// `Optional`, and `Dictionary` — each conditional on its element/wrapped type conforming, and
-// each recursing statically into that element's conversion.
+// `JavaScriptCodable` conformances for the standard container and wrapper types (`Array`,
+// `Optional`, `Dictionary`), each recursing statically into its element/wrapped type's conversion.
 //
-// `JavaScriptCodable` is a composition type alias, so a conformance clause spells out both halves:
-// `extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScriptCodable`.
+// The decodable and encodable halves are separate conditional conformances, each gated only on the
+// half it needs. A type conforming to both still gets both halves, but an encode-only element type
+// (e.g. `Task`, which has no `decode`) can still be carried through a container's encode.
 
 // MARK: - Array
 
-extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScriptCodable {
+extension Array: JavaScriptDecodable where Element: JavaScriptDecodable {
   @JavaScriptActor
   @inlinable
   public static func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
@@ -26,7 +26,9 @@ extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScr
       return try Element.decode(element, in: runtime)
     }
   }
+}
 
+extension Array: JavaScriptEncodable where Element: JavaScriptEncodable {
   @JavaScriptActor
   @inlinable
   public static func encode(_ value: [Element], in runtime: borrowing JavaScriptRuntime) throws
@@ -42,7 +44,7 @@ extension Array: JavaScriptDecodable, JavaScriptEncodable where Element: JavaScr
 
 // MARK: - Optional
 
-extension Optional: JavaScriptDecodable, JavaScriptEncodable where Wrapped: JavaScriptCodable {
+extension Optional: JavaScriptDecodable where Wrapped: JavaScriptDecodable {
   // Optional copies nothing itself, so it overrides the zero-copy overload too and forwards the
   // borrowed value straight through — a wrapped primitive argument stays fully zero-copy.
   @JavaScriptActor
@@ -66,7 +68,9 @@ extension Optional: JavaScriptDecodable, JavaScriptEncodable where Wrapped: Java
     }
     return try Wrapped.decode(value, in: runtime)
   }
+}
 
+extension Optional: JavaScriptEncodable where Wrapped: JavaScriptEncodable {
   @JavaScriptActor
   @inlinable
   public static func encode(_ value: Wrapped?, in runtime: borrowing JavaScriptRuntime) throws
@@ -82,7 +86,7 @@ extension Optional: JavaScriptDecodable, JavaScriptEncodable where Wrapped: Java
 
 // MARK: - Dictionary
 
-extension Dictionary: JavaScriptDecodable, JavaScriptEncodable where Key == String, Value: JavaScriptCodable {
+extension Dictionary: JavaScriptDecodable where Key == String, Value: JavaScriptDecodable {
   @JavaScriptActor
   @inlinable
   public static func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws
@@ -102,7 +106,9 @@ extension Dictionary: JavaScriptDecodable, JavaScriptEncodable where Key == Stri
     }
     return result
   }
+}
 
+extension Dictionary: JavaScriptEncodable where Key == String, Value: JavaScriptEncodable {
   @JavaScriptActor
   @inlinable
   public static func encode(_ value: [String: Value], in runtime: borrowing JavaScriptRuntime) throws

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Task.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Task.swift
@@ -1,0 +1,35 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+// `JavaScriptEncodable` conformance for `Task`, encoding it to a JavaScript `Promise`. This lets
+// native code hand JavaScript a promise as a value: the return of a synchronous `@JS func` whose
+// result type is `Task`, or a `Task` nested inside another encoded value. `createAsyncFunction`
+// only wraps a function's own return in a promise, so a `Task` is how to produce one anywhere else.
+//
+// Encode-only: a promise decodes by awaiting it through `JavaScriptPromise`, not by reconstructing
+// a `Task`. One conditional conformance covers throwing and non-throwing tasks (Swift forbids two
+// conformances even with disjoint bounds, and `Task.value` is `async throws` for any `Failure`).
+
+/// Encodes a `Task` to a JavaScript promise that settles with the task's result.
+extension Task: JavaScriptEncodable where Success: JavaScriptEncodable, Failure: Error {
+  /// Returns a pending promise immediately and settles it on the JavaScript thread once the task
+  /// completes: fulfilling with the encoded `Success` value, or rejecting with the thrown error.
+  @JavaScriptActor
+  public static func encode(_ value: Task<Success, Failure>, in runtime: borrowing JavaScriptRuntime) throws
+    -> JavaScriptValue
+  {
+    let promise = try JavaScriptPromise(copy runtime)
+    // A detached task awaits the result off the JavaScript thread, then settles the promise. It must
+    // not inherit `@JavaScriptActor`: that actor runs jobs synchronously on the current thread rather
+    // than hopping to the JS thread, so a resumed continuation would land on whatever thread the task
+    // finished on. `resolve`/`reject` hop to the JS thread internally (and the encodable `resolve`
+    // encodes there), so settling from here is safe regardless of this task's thread.
+    Task<Void, Never>.detached {
+      do {
+        promise.resolve(try await value.value)
+      } catch {
+        promise.reject(error)
+      }
+    }
+    return promise.asValue()
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableTaskTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableTaskTests.swift
@@ -1,0 +1,84 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Testing
+
+@Suite("JavaScriptCodable+Task")
+@JavaScriptActor
+struct JavaScriptCodableTaskTests {
+  let runtime = JavaScriptRuntime()
+
+  @Test
+  func `encodes a task as a promise object`() throws {
+    let task = Task<Int, any Error> {
+      return 42
+    }
+    let encoded = try Task.encode(task, in: runtime)
+    #expect(encoded.isObject())
+  }
+
+  @Test
+  func `resolves with the encoded success value`() async throws {
+    let task = Task<Int, any Error> {
+      return 42
+    }
+    let result = try await Task.encode(task, in: runtime).getPromise().await()
+    #expect(result.getInt() == 42)
+  }
+
+  @Test
+  func `resolves with a value produced after suspension`() async throws {
+    let task = Task<String, any Error> {
+      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+      return "done"
+    }
+    let result = try await Task.encode(task, in: runtime).getPromise().await()
+    #expect(result.getString() == "done")
+  }
+
+  @Test
+  func `rejects when the task throws`() async throws {
+    struct TestError: Error {}
+    let task = Task<Int, any Error> {
+      throw TestError()
+    }
+    let promise = try Task.encode(task, in: runtime).getPromise()
+    await #expect(throws: Error.self) {
+      try await promise.await()
+    }
+  }
+
+  @Test
+  func `encodes a non-throwing task`() async throws {
+    let task = Task<Int, Never> {
+      return 7
+    }
+    let result = try await Task.encode(task, in: runtime).getPromise().await()
+    #expect(result.getInt() == 7)
+  }
+
+  @Test
+  func `encodes a task whose success is itself codable`() async throws {
+    let task = Task<[String: Int], any Error> {
+      return ["answer": 42]
+    }
+    let result = try await Task.encode(task, in: runtime).getPromise().await()
+    #expect(result.getObject().getProperty("answer").getInt() == 42)
+  }
+
+  @Test
+  func `encodes a task nested inside a container`() async throws {
+    // The motivating case: a promise handed to JS as a *value* rather than a function's own return.
+    let tasks = [
+      Task<Int, any Error> { return 1 },
+      Task<Int, any Error> { return 2 },
+    ]
+    let encoded = try [Task<Int, any Error>].encode(tasks, in: runtime)
+    let array = encoded.getArray()
+    #expect(array.length == 2)
+    let first = try await array.getValue(at: 0).getPromise().await()
+    let second = try await array.getValue(at: 1).getPromise().await()
+    #expect(first.getInt() == 1)
+    #expect(second.getInt() == 2)
+  }
+}


### PR DESCRIPTION
# Why

Expo Modules v2 drops the trailing-`Promise` argument. A function that returns a JavaScript promise now has three shapes, and this PR adds the third one.

**1. Standard async Swift function.** The function body is `async throws`; the runtime wraps its return in a promise automatically. This is the common case.

```swift
@JS
func download(url: URL) async throws -> DownloadResult {
  return try await self.downloader.download(url)
}
```

**2. Bridging a delegate or completion handler with `withCheckedContinuation`.** When the result arrives through a callback that fires once, wrap it in a continuation inside a standard async function.

```swift
@JS
func download(url: URL) async throws -> DownloadResult {
  return try await withCheckedThrowingContinuation { continuation in
    self.downloader.download(url) { result in
      continuation.resume(with: result)
    }
  }
}
```

**3. Synchronous function returning a `Task` (this PR).** The function returns immediately with a handle; the `Task` encodes to a promise that settles with its result. Useful when the work is naturally a `Task`, or when a promise is needed as a *value* nested inside another encoded result rather than as the function's own return.

```swift
@JS
func download(url: URL) -> Task<DownloadResult, any Error> {
  return Task {
    try await self.downloader.download(url)
  }
}
```

All three settle a JS promise:

```js
const result = await ExpoModule.download(url);
```

# How

Add a `JavaScriptEncodable` conformance for `Task`. `encode` returns a pending `JavaScriptPromise` synchronously; a detached task awaits the result off the JavaScript thread and settles the promise via `resolve`/`reject`, which hop to the JS thread and encode there.

- The detached task must not inherit `@JavaScriptActor`: that actor's serial executor runs jobs synchronously on the *current* thread rather than hopping to the JS thread, so an actor-isolated continuation would resume on whatever thread the awaited task finished on, not the JS thread. `resolve`/`reject` handle the hop (and the encode) internally, so settling from the detached task is safe.
- One conformance (`where Failure: Error`) covers throwing and non-throwing tasks; `Task.value` is `async throws` for any `Failure: Error`. Swift forbids two conformances even with disjoint bounds.
- Encode-only: a JS promise decodes by awaiting via `JavaScriptPromise`, not by reconstructing a `Task`.

To let a `Task` flow through containers, `Array`/`Optional`/`Dictionary` are split into separate `JavaScriptDecodable` and `JavaScriptEncodable` halves, each gated only on the half its element provides.

No new teardown guarding: `JavaScriptPromise`'s settle path already guards on a `weak` runtime and its `LongLivedState` owns the JSI values, so a settle after teardown is a safe no-op.

# Test Plan

`Tests/JavaScriptCodableTaskTests.swift` (7 tests) covers encode-to-promise, resolve, resolve-after-suspension, reject-on-throw, non-throwing task, codable `Success`, and a `Task` nested in an array. Existing container tests and the full `expo-modules-core` iOS suite still pass; lint clean.
