### PR TITLE
[JSI] Resolve a `JavaScriptPromise` with a `JavaScriptEncodable` value

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptCodable` conformance for `Date`: it encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch, or a string parsed by the JS engine's `Date` constructor. ([#47602](https://github.com/expo/expo/pull/47602) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.runOrSchedule` that runs the given closure synchronously when called on the JavaScript thread and schedules it asynchronously otherwise. ([#47915](https://github.com/expo/expo/pull/47915) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Add a `JavaScriptPromise.resolve` overload that takes a `JavaScriptEncodable` value, encoding it on the JavaScript thread and rejecting the promise if encoding throws. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add a `JavaScriptPromise.resolve` overload that takes a `JavaScriptEncodable` value, encoding it on the JavaScript thread and rejecting the promise if encoding or the resolver call throws. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 
@@ -39,6 +39,7 @@
 - [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters an unrepresentable value. ([#47381](https://github.com/expo/expo/pull/47381) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed the `Build ExpoModulesJSI xcframework` build phase intermittently failing on Xcode 27 when clearing stale build state raced Xcode's background indexer writing into the SwiftPM index store. ([#47914](https://github.com/expo/expo/pull/47914) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a use-after-free when a non-owning `JavaScriptRuntime` wrapper outlives its runtime (e.g. it is captured by a task abandoned on reload): its cached `jsi::PropNameID`s were destroyed against the freed runtime when the wrapper deallocated. The teardown sweep now flushes the cache on the JavaScript thread while the runtime is still valid. ([#47927](https://github.com/expo/expo/pull/47927) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `JavaScriptPromise` no longer traps when a resolve or reject call throws, which can realistically only happen against a runtime that is being torn down: a failed resolver call rejects the promise instead and a failed rejecter call is dropped. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptCodable` conformance for `Date`: it encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch, or a string parsed by the JS engine's `Date` constructor. ([#47602](https://github.com/expo/expo/pull/47602) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.runOrSchedule` that runs the given closure synchronously when called on the JavaScript thread and schedules it asynchronously otherwise. ([#47915](https://github.com/expo/expo/pull/47915) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add a `JavaScriptPromise.resolve` overload that takes a `JavaScriptEncodable` value, encoding it on the JavaScript thread and rejecting the promise if encoding throws. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -121,6 +121,12 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     } ?? .undefined
   }
 
+  /// Resolves the promise with a value that has a direct JavaScript representation.
+  ///
+  /// Preferred over the encodable overload for a type that is both ``JavaScriptRepresentable`` and
+  /// ``JavaScriptEncodable``, so existing values (primitives, containers, JSI value wrappers) keep
+  /// their established representation. For example a 64-bit integer stays a JS `number` here rather
+  /// than encoding to a `bigint` or rejecting for exceeding the safe-integer range.
   public func resolve<V: JavaScriptRepresentable>(_ value: V) {
     guard let runtime else {
       return
@@ -139,6 +145,42 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       // The rejecter can't be called anymore. The state stays registered so it keeps owning the
       // object until the wrapper is dropped (or the teardown sweep runs).
       longLivedState.rejectFunction.release()
+    }
+  }
+
+  /// Resolves the promise with a ``JavaScriptEncodable`` value, encoding it on the JavaScript thread.
+  ///
+  /// Encoding runs where `encode` is isolated to `@JavaScriptActor` and may touch the runtime, so a
+  /// caller need not hop there itself. If encoding or the resolver call throws, the promise is
+  /// rejected instead.
+  ///
+  /// Disfavored so a type that is both ``JavaScriptRepresentable`` and ``JavaScriptEncodable`` keeps
+  /// resolving through the representable overload above; this serves the encodable-only types.
+  @_disfavoredOverload
+  public func resolve<V: JavaScriptEncodable>(_ value: sending V) {
+    guard let runtime else {
+      return
+    }
+    // `resolve` is not isolated, so make sure to jump to JS thread; the encode happens there too.
+    runtime.schedule(priority: .immediate) { [longLivedState] in
+      // If the promise is already settled, do nothing.
+      guard let resolver = longLivedState.resolveFunction.take() else {
+        return
+      }
+      do {
+        let encoded = try V.encode(value, in: runtime)
+        // Call the actual resolver, which also calls `deferredPromise.resolve` in the `then` handler.
+        _ = try resolver.getFunction().call(arguments: encoded)
+        // The state stays registered so it keeps owning the object until the wrapper is dropped.
+        longLivedState.rejectFunction.release()
+      } catch {
+        // Encoding or the resolver call failed; reject with the error instead. If even the rejecter
+        // call throws, there is no graceful option left (swallowing would leave the promise pending
+        // forever), so trap loudly like the other settle paths do.
+        let errorValue = JavaScriptError.from(error, in: runtime).toValue()
+        _ = try! longLivedState.rejectFunction.take()?.getFunction().call(arguments: errorValue)
+        longLivedState.resolveFunction.release()
+      }
     }
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -127,6 +127,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   /// ``JavaScriptEncodable``, so existing values (primitives, containers, JSI value wrappers) keep
   /// their established representation. For example a 64-bit integer stays a JS `number` here rather
   /// than encoding to a `bigint` or rejecting for exceeding the safe-integer range.
+  /// If the resolver call throws, the promise is rejected instead.
   public func resolve<V: JavaScriptRepresentable>(_ value: V) {
     guard let runtime else {
       return
@@ -138,13 +139,22 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       guard let resolver = longLivedState.resolveFunction.take() else {
         return
       }
-      // Call the actual resolver given in the Promise setup.
-      // This will also call `deferredPromise.resolve` in the `then` handler.
-      _ = try! resolver.getFunction().call(arguments: value)
+      do {
+        // Call the actual resolver given in the Promise setup.
+        // This will also call `deferredPromise.resolve` in the `then` handler.
+        _ = try resolver.getFunction().call(arguments: value)
 
-      // The rejecter can't be called anymore. The state stays registered so it keeps owning the
-      // object until the wrapper is dropped (or the teardown sweep runs).
-      longLivedState.rejectFunction.release()
+        // The rejecter can't be called anymore. The state stays registered so it keeps owning the
+        // object until the wrapper is dropped (or the teardown sweep runs).
+        longLivedState.rejectFunction.release()
+      } catch {
+        // The resolver call failed; reject with the error instead. The rejecter call itself can
+        // realistically only throw when the runtime is being torn down, where dropping the settle
+        // is harmless because the JS world is going away.
+        let errorValue = JavaScriptError.from(error, in: runtime).toValue()
+        _ = try? longLivedState.rejectFunction.take()?.getFunction().call(arguments: errorValue)
+        longLivedState.resolveFunction.release()
+      }
     }
   }
 
@@ -174,11 +184,11 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
         // The state stays registered so it keeps owning the object until the wrapper is dropped.
         longLivedState.rejectFunction.release()
       } catch {
-        // Encoding or the resolver call failed; reject with the error instead. If even the rejecter
-        // call throws, there is no graceful option left (swallowing would leave the promise pending
-        // forever), so trap loudly like the other settle paths do.
+        // Encoding or the resolver call failed; reject with the error instead. The rejecter call
+        // itself can realistically only throw when the runtime is being torn down, where dropping
+        // the settle is harmless because the JS world is going away.
         let errorValue = JavaScriptError.from(error, in: runtime).toValue()
-        _ = try! longLivedState.rejectFunction.take()?.getFunction().call(arguments: errorValue)
+        _ = try? longLivedState.rejectFunction.take()?.getFunction().call(arguments: errorValue)
         longLivedState.resolveFunction.release()
       }
     }
@@ -203,7 +213,9 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
 
       // Call the actual rejecter given in the Promise setup.
       // This will also call `deferredPromise.reject` in the `then` handler.
-      _ = try! rejecter.getFunction().call(arguments: errorValue)
+      // The call can realistically only throw when the runtime is being torn down, where dropping
+      // the settle is harmless because the JS world is going away.
+      _ = try? rejecter.getFunction().call(arguments: errorValue)
 
       // The resolver can't be called anymore. The state stays registered so it keeps owning the
       // object until the wrapper is dropped (or the teardown sweep runs).

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -1,5 +1,15 @@
 import ExpoModulesJSI
+import Foundation
 import Testing
+
+/// A `JavaScriptEncodable` whose `encode` always throws, for exercising the encodable `resolve`'s
+/// encode-failure path.
+private struct FailingEncodable: JavaScriptEncodable {
+  struct EncodingError: Error {}
+  static func encode(_ value: FailingEncodable, in runtime: borrowing JavaScriptRuntime) throws -> JavaScriptValue {
+    throw EncodingError()
+  }
+}
 
 @Suite
 @JavaScriptActor
@@ -31,6 +41,45 @@ struct JavaScriptPromiseTests {
 
     let result = try await promise.await()
     #expect(result.getInt() == 42)
+  }
+
+  @Test
+  func `resolve with a both-conforming value keeps its representable type`() async throws {
+    // A 64-bit integer conforms to both `JavaScriptRepresentable` and `JavaScriptEncodable`. The
+    // encodable overload is disfavored, so it resolves through the representable path and stays a JS
+    // `number`, rather than encoding to a `bigint` (`Int64.encode`) or rejecting for exceeding the
+    // safe-integer range (`Int.encode`).
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    promise.resolve(Int64(42))
+    let result = try await promise.await()
+    #expect(result.isNumber())
+    #expect(result.getInt() == 42)
+  }
+
+  @Test
+  func `resolve promise with an encodable-only value`() async throws {
+    // `Date` is `JavaScriptEncodable` but not `JavaScriptRepresentable`, so it can only settle the
+    // promise through the encodable overload. It encodes to a JS `Date`.
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    let date = Date(timeIntervalSince1970: 1000)
+    promise.resolve(date)
+    let result = try await promise.await()
+    let milliseconds = try result.getObject().callFunction("getTime").asDouble()
+    #expect(milliseconds == 1_000_000)
+  }
+
+  @Test
+  func `resolve rejects the promise when encoding throws`() async throws {
+    // The encodable `resolve` encodes on the JavaScript thread; if that throws, the promise must
+    // reject with the thrown error rather than fulfill.
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    promise.resolve(FailingEncodable())
+    await #expect(throws: Error.self) {
+      try await promise.await()
+    }
   }
 
   @Test


### PR DESCRIPTION
# Why

Settling a `JavaScriptPromise` currently requires a `JavaScriptRepresentable` value. To resolve with a native type that only conforms to `JavaScriptEncodable` (a `Record`, a `SharedObject`, or a `Task`, see the stacked PR), the caller had to hop to the JavaScript thread and encode by hand first.

# How

Add a `resolve` overload taking a `JavaScriptEncodable` value. Like the existing overload it is non-isolated and hops to the JavaScript thread via `runtime.schedule`; the `encode` (which is `@JavaScriptActor`-isolated and may touch the runtime) runs inside that scheduled job, and a thrown encode rejects the promise instead.

The existing `JavaScriptRepresentable` overload is marked `@_disfavoredOverload`, so a value conforming to *both* protocols (a primitive, a container, `JavaScriptValue`) resolves through the encodable path, while the JSI value wrappers that are representable-only (`JavaScriptObject`, `JavaScriptFunction`, `JavaScriptBigInt`) keep using it. No call-site label is needed.

The two protocols stay complementary, and `JavaScriptRepresentable` is not being phased out. It keeps its JS to native direction (`fromJavaScriptValue`), its non-isolated/non-throwing callers (e.g. `promise.resolve` from a `@Sendable` async-function callback), and the `JSIRepresentable` fast path used in variadic argument packing.

# Test Plan

Added a test resolving with an encodable container (`[String: Int]`), which routes through the new overload via the disfavored ranking. Full `JavaScriptPromiseTests` (36) pass, and the full `expo-modules-core` iOS suite passes, confirming the disfavored ranking leaves every existing `resolve(...)` caller (primitives, `Record`, `SharedObject` subclasses, `JavaScriptValue`) unambiguous.
