### PR TITLE
[docs] Remove leftover ProgressTracker props in EAS tutorial and use tutorial-specific next-chapter icons

### DIFF
--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -183,8 +183,3 @@ Start the development server by running `npx expo start` from the project direct
 ## Summary
 
 <ProgressTracker name="EAS_TUTORIAL" currentChapterSlug="/tutorial/eas/android-development-build" />
-  }
-  nextChapterDescription="In the next chapter, learn how to configure a development build for iOS Simulators using EAS Build and get it running."
-  nextChapterTitle="Create and run a cloud build for iOS Simulator"
-  nextChapterLink="/tutorial/eas/ios-development-build-for-simulators/"
-/>

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -319,9 +319,3 @@ For subsequent releases in future, we can streamline the process by combining bu
 ## Summary
 
 <ProgressTracker name="EAS_TUTORIAL" currentChapterSlug="/tutorial/eas/android-production-build" />
-  }
-  nextChapterDescription="
-In the next chapter, learn about the process of creating a production build for iOS."
-  nextChapterTitle="Create a production build for iOS"
-  nextChapterLink="/tutorial/eas/ios-production-build/"
-/>

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -171,8 +171,3 @@ For future releases, we can streamline the process by combining build creation a
 ## Summary
 
 <ProgressTracker name="EAS_TUTORIAL" currentChapterSlug="/tutorial/eas/ios-production-build" />
-  }
-  nextChapterDescription="In the next chapter, learn how to use the EAS Update to send OTA updates and share previews with our team."
-  nextChapterTitle="Share previews with your team"
-  nextChapterLink="/tutorial/eas/team-development/"
-/>

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -98,8 +98,3 @@ After these steps, the app versions will be synced to EAS Build remotely. You ca
 ## Summary
 
 <ProgressTracker name="EAS_TUTORIAL" currentChapterSlug="/tutorial/eas/manage-app-versions" />
-  }
-  nextChapterDescription="In the next chapter, learn about the process of creating a production build for Android."
-  nextChapterTitle="Create a production build for Android"
-  nextChapterLink="/tutorial/eas/android-production-build/"
-/>

--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -210,8 +210,3 @@ You can now continue using **app.json** for static values and use **app.config.j
 ## Summary
 
 <ProgressTracker name="EAS_TUTORIAL" currentChapterSlug="/tutorial/eas/multiple-app-variants" />
-  }
-  nextChapterDescription="In the next chapter, learn about what are internal distribution builds, why we need them, and how to create them."
-  nextChapterTitle="Create and share internal distribution build"
-  nextChapterLink="/tutorial/eas/internal-distribution-builds/"
-/>

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -1,5 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
+import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { type ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -10,6 +12,11 @@ import { P } from '~/ui/components/Text';
 import { Checkbox } from '../Form/Checkbox';
 import { SuccessCheckmark } from './SuccessCheckmark';
 import { TUTORIAL_CHAPTERS, TUTORIAL_TRAILERS, type TutorialName } from './TutorialData';
+
+const NEXT_CHAPTER_ICONS: Partial<Record<TutorialName, typeof BookOpen02Icon>> = {
+  EAS_TUTORIAL: PlanEnterpriseIcon,
+  CICD_TUTORIAL: Dataflow03Icon,
+};
 
 type ProgressTrackerProps = {
   name: TutorialName;
@@ -94,7 +101,7 @@ export function ProgressTracker({
             { id: 'progressTrackerNext' },
             { title: nextChapterTitle ?? next.title }
           )}
-          Icon={BookOpen02Icon}
+          Icon={NEXT_CHAPTER_ICONS[name] ?? BookOpen02Icon}
         />
       </>
     </>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Broken JSX on multiple MDX pages.

<img width="1788" height="458" alt="CleanShot 2026-07-16 at 22 27 30@2x" src="https://github.com/user-attachments/assets/87761e18-1ae0-4c0b-9e1c-060977a3ea00" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove leftover `ProgressTracker` props in EAS tutorial and use tutorial-specific next-chapter icons in EAS tutorial and CI/CD tutorial.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1766" height="996" alt="CleanShot 2026-07-16 at 22 28 21@2x" src="https://github.com/user-attachments/assets/86af05a4-94d4-47de-9922-8e31bc4e336a" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
