### PR TITLE
[expo-router] Fix TabRouter crash on partial stale:false state (missing history/preloadedRouteKeys)

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [android] Remove navigation state restoration across activity recreation. ([#47422](https://github.com/expo/expo/pull/47422) by [@Ubax](https://github.com/Ubax))
 - Fix `renderRouter` ignoring `overrides` and listing duplicate routes when an override key matches a file in `appDir`. ([#47287](https://github.com/expo/expo/pull/47287) by [@wwdrew](https://github.com/wwdrew))
 - Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
+- Fix `TabRouter.getStateForAction` crashing on a `stale: false` state that is missing `history`/`preloadedRouteKeys`. ([#47869](https://github.com/expo/expo/pull/47869) by [@kimchouard](https://github.com/kimchouard))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -315,6 +315,19 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
     },
 
     getStateForAction(state, action, { routeParamList, routeGetIdList }) {
+      // A `stale: false` state is returned verbatim by `getRehydratedState`, so a
+      // state that skipped rehydration (e.g. a foreign navigator's state adopted
+      // as-is) can reach here without `history`/`preloadedRouteKeys`. Normalize
+      // them the same way `getRehydratedState` already does so the `.filter`/
+      // `.length` reads below don't throw. Fixes #47868.
+      if (state.history === undefined || state.preloadedRouteKeys === undefined) {
+        state = {
+          ...state,
+          history: state.history ?? [],
+          preloadedRouteKeys: state.preloadedRouteKeys ?? [],
+        };
+      }
+
       switch (action.type) {
         case 'JUMP_TO':
         case 'NAVIGATE':

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -2592,3 +2592,138 @@ test('handles screen preloading', () => {
     history: [{ type: 'route', key: 'qux-test' }],
   });
 });
+
+// Regression tests for #47868: a `stale: false` state can reach
+// getStateForAction without `history`/`preloadedRouteKeys` (e.g. a foreign
+// navigator's state returned verbatim by getRehydratedState). The unguarded
+// `.filter`/`.length` reads used to throw
+// "Cannot read properties of undefined (reading 'filter'/'length')".
+
+const partialState = () =>
+  ({
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    // `history` and `preloadedRouteKeys` intentionally absent
+  }) as unknown as TabNavigationState<ParamListBase>;
+
+test('handles jump to on a state without history/preloadedRouteKeys (#47868)', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(() =>
+    router.getStateForAction(partialState(), TabActions.jumpTo('bar'), options)
+  ).not.toThrow();
+
+  expect(router.getStateForAction(partialState(), TabActions.jumpTo('bar'), options)).toEqual({
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+});
+
+test('handles navigate on a state without history/preloadedRouteKeys (#47868)', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(() =>
+    router.getStateForAction(partialState(), CommonActions.navigate('bar'), options)
+  ).not.toThrow();
+
+  expect(router.getStateForAction(partialState(), CommonActions.navigate('bar'), options)).toEqual({
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+});
+
+test('handles back on a state without history/preloadedRouteKeys (#47868)', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(() =>
+    router.getStateForAction(partialState(), CommonActions.goBack(), options)
+  ).not.toThrow();
+
+  expect(router.getStateForAction(partialState(), CommonActions.goBack(), options)).toBeNull();
+});
+
+test('leaves a complete state unchanged (#47868 guard does not trip)', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const complete: TabNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [{ type: 'route', key: 'baz' }],
+  };
+
+  expect(router.getStateForAction(complete, TabActions.jumpTo('bar'), options)).toEqual({
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: [],
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+});


### PR DESCRIPTION
# Why

Fixes #47868.

The vendored `TabRouter.getStateForAction` (`packages/expo-router/src/react-navigation/routers/TabRouter.tsx`) crashes when it receives a `stale: false` navigation state that lacks `history` and `preloadedRouteKeys`:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at Object.getStateForAction (TabRouter)
    at useTabsWithTriggers
    at Tabs
```

`getRehydratedState` returns any `stale: false` state verbatim (its fast path never checks `state.type`), so a state that skipped rehydration — e.g. a sibling navigator's state adopted as-is — reaches the action handlers without those two collections. The `JUMP_TO` / `NAVIGATE` branch then does `updatedState.preloadedRouteKeys.filter(...)` and `GO_BACK` does `state.history.length` / `state.history.slice(...)` / `state.preloadedRouteKeys.filter(...)`, all on `undefined`.

Real-world trigger (web static export): a user on a screen inside a sibling stack calls `router.dismissTo('/…')` where the target belongs to a headless `expo-router/ui` `<Tabs>` navigator. `getNavigationAction` converts the `POP_TO` into a `JUMP_TO` targeted at the tabs navigator, whose current state is a `stale: false` partial — so the read throws during render.

# How

Normalize the two optional collections at the top of `getStateForAction`, mirroring the way `getRehydratedState` already tolerates them (`state.history?.filter(...) ?? []`, `state.preloadedRouteKeys?.filter(...) ?? []`):

```ts
if (state.history === undefined || state.preloadedRouteKeys === undefined) {
  state = {
    ...state,
    history: state.history ?? [],
    preloadedRouteKeys: state.preloadedRouteKeys ?? [],
  };
}
```

This is minimal and behavior-preserving: complete states never enter the branch, and every downstream branch stays safe (`JUMP_TO`/`NAVIGATE` rebuild history via `changeIndex`; `GO_BACK` on an empty history returns `null`, handled upstream).

The issue also notes a complementary, behavior-affecting option — making `getRehydratedState`'s fast path require `state.type === this.type` before adopting a state verbatim. That changes which states take the fast path, so it deserves its own review and is deliberately **not** included here; the `getStateForAction` guard is the safe, targeted fix on its own.

# Test Plan

Added regression tests in `packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx` that dispatch `JUMP_TO`, `NAVIGATE`, and `GO_BACK` against a `stale: false` state with `history`/`preloadedRouteKeys` absent, asserting no throw and the expected navigated/`null` result, plus a complete-state case proving no behavior change. These run under the package's existing `jest` suite in CI.

The expected values in those tests were validated against the real published (patched) router: `JUMP_TO`/`NAVIGATE` → `index: 1`, `history: [baz, bar]`, `preloadedRouteKeys: []`; `GO_BACK` → `null`.

Additional executable evidence — a standalone published-package reproduction that dispatches the exact failing action shapes against the shipped router and asserts the pre-fix crash: https://github.com/kimchouard/expo-router-tabrouter-partial-state-repro

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (`build/` is generated and gitignored; nothing to commit).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). (Pure JS router logic; no native or plugin surface touched.)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (no docs changes).
