### PR TITLE
[router] Fix `expo-router/head` and `expo-router/stack` resolution

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [android] Remove navigation state restoration across activity recreation. ([#47422](https://github.com/expo/expo/pull/47422) by [@Ubax](https://github.com/Ubax))
 - Fix `renderRouter` ignoring `overrides` and listing duplicate routes when an override key matches a file in `appDir`. ([#47287](https://github.com/expo/expo/pull/47287) by [@wwdrew](https://github.com/wwdrew))
 - Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
+- [android][ios] Fix `expo-router/head` and `expo-router/stack` resolution on native platforms. ([#47870](https://github.com/expo/expo/pull/47870) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -136,11 +136,11 @@
     },
     "./head": {
       "types": {
-        "expo-source": "./src/head/ExpoHead.tsx",
-        "default": "./build/head/ExpoHead.d.ts"
+        "expo-source": "./src/head/index.ts",
+        "default": "./build/head/index.d.ts"
       },
-      "expo-source": "./src/head/ExpoHead.tsx",
-      "default": "./build/head/ExpoHead.js"
+      "expo-source": "./src/head/index.ts",
+      "default": "./build/head/index.js"
     },
     "./html": {
       "types": {
@@ -176,11 +176,11 @@
     },
     "./stack": {
       "types": {
-        "expo-source": "./src/layouts/Stack.tsx",
-        "default": "./build/layouts/Stack.d.ts"
+        "expo-source": "./src/stack.ts",
+        "default": "./build/stack.d.ts"
       },
-      "expo-source": "./src/layouts/Stack.tsx",
-      "default": "./build/layouts/Stack.js"
+      "expo-source": "./src/stack.ts",
+      "default": "./build/stack.js"
     },
     "./tabs": {
       "types": {

--- a/packages/expo-router/src/head/index.ts
+++ b/packages/expo-router/src/head/index.ts
@@ -1,1 +1,2 @@
 export * from './ExpoHead';
+export { Head as default } from './ExpoHead';

--- a/packages/expo-router/src/stack.ts
+++ b/packages/expo-router/src/stack.ts
@@ -1,0 +1,2 @@
+export * from './layouts/Stack';
+export { default } from './layouts/Stack';


### PR DESCRIPTION
# Why

As part of the changes in #46801, an exports map was added to `expo-router/package.json` which included `./head` and `./stack`. When Metro resolves through an exports map, it doesn't apply platform extension resolution.

This caused the web implementation (the default, non-platform-suffixed `ExpoHead.tsx`) to be bundled for Android/iOS. Since there is no `<HelmetProvider>` on native, any route rendering `<Head>` crashed at startup with `TypeError: Cannot read property 'add' of undefined`.

The `./stack` export had the same issue in reverse; web was bundling the native `<Stack>` instead of `Stack.web.tsx`.

# How

Both exports in the exports map now point to a barrel file whose extension-less relative import Metro _can_ platform-resolve. This is the same way the legacy root `head.js`/`stack.js` shims worked before the exports map was added. Additionally, the `./head` barrel explicitly re-exports `Head` as the default export, mirroring the old root export.

As a follow-up, we should consider whether the legacy root shims (`head.js`, `stack.js`, etc.) can be removed now that the exports map covers these subpaths.

# Test Plan

- `cd apps/router-e2e && pnpm expo prebuild && E2E_ROUTER_SRC=static-rendering pnpm expo run:ios` should run the app without `TypeError: Cannot read property 'add' of undefined`.
- `E2E_ROUTER_SRC=static-rendering pnpm expo export -p ios` should produce an iOS bundle that includes `ExpoHead.ios.js` instead of the web helmet implementation.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
