### PR TITLE
[observe] Add reportError for caught non-fatal errors

### DIFF
--- a/apps/observe-tester/app/(tabs)/debug/index.tsx
+++ b/apps/observe-tester/app/(tabs)/debug/index.tsx
@@ -12,6 +12,7 @@ import { JSErrorsSection } from '@/components/JSErrorsSection';
 import { LogEventsSection } from '@/components/LogEventsSection';
 import { NetworkRequestObserverSection } from '@/components/NetworkRequestObserverSection';
 import { RenderErrorSection } from '@/components/RenderErrorSection';
+import { ReportErrorSection } from '@/components/ReportErrorSection';
 import CrashTester from '@/modules/crash-tester';
 import { useTheme } from '@/utils/theme';
 
@@ -38,6 +39,8 @@ export default function Debug() {
       <CrashReportsSection />
       {CrashTester != null ? <Divider /> : null}
       <JSErrorsSection />
+      <Divider />
+      <ReportErrorSection />
       <Divider />
       <RenderErrorSection />
       <Divider />

--- a/apps/observe-tester/components/ReportErrorSection.tsx
+++ b/apps/observe-tester/components/ReportErrorSection.tsx
@@ -1,0 +1,67 @@
+import { Observe } from 'expo-observe';
+import { StyleSheet, Text } from 'react-native';
+
+import { Button } from '@/components/Button';
+import { useTheme } from '@/utils/theme';
+
+// Demonstrates the public `Observe.reportError` API: reporting an error your own code caught and
+// handled. Unlike the JavaScript errors section (which exercises the automatic global handler and
+// error boundary), these are explicit reports a developer makes from a `try`/`catch`, recorded as
+// non-fatal `exception` events.
+
+// A realistic caught-and-handled failure: a network call throws, the app recovers, and reports it.
+function reportCaughtError() {
+  try {
+    throw new Error('Failed to sync cart: request timed out');
+  } catch (error) {
+    Observe.reportError(error);
+  }
+}
+
+// `Observe.reportError` accepts any thrown value, not just `Error`. A non-`Error` throw is
+// stringified into the message and carries no stacktrace.
+function reportNonError() {
+  try {
+    throw 'unexpected string rejection';
+  } catch (error) {
+    Observe.reportError(error);
+  }
+}
+
+export function ReportErrorSection() {
+  const theme = useTheme();
+
+  return (
+    <>
+      <Text style={[styles.sectionTitle, { color: theme.text.default }]}>Report caught errors</Text>
+      <Text style={[styles.sectionHint, { color: theme.text.secondary }]}>
+        Report an error your code caught and handled with `Observe.reportError`. Each is recorded as
+        a non-fatal `exception` event in the current session.
+      </Text>
+      <Button
+        title="Report a caught Error"
+        description="try/catch around a real Error, reported with its stacktrace"
+        onPress={reportCaughtError}
+        theme="secondary"
+      />
+      <Button
+        title="Report a non-Error throw"
+        description="A thrown string, stringified into the message with no stacktrace"
+        onPress={reportNonError}
+        theme="secondary"
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  sectionHint: {
+    fontSize: 13,
+    marginBottom: 16,
+  },
+});

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -25,5 +25,6 @@
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Remove the unstable, development-only `triggerCrash` and `simulateCrashReport` APIs. ([#46924](https://github.com/expo/expo/pull/46924) by [@Ubax](https://github.com/Ubax))
+- Add a `caught` source to the private `reportError` for errors reported from user code. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
 - Add private `getForegroundSession` ([#46657](https://github.com/expo/expo/pull/46657) by [@Ubax](https://github.com/Ubax))
 - Add session shared object API ([#46652](https://github.com/expo/expo/pull/46652) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/ErrorReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/ErrorReport.kt
@@ -55,7 +55,8 @@ data class ErrorReport(
 /** How the error was captured. A closed set so the `expo.error.source` attribute stays consistent. */
 enum class ErrorSource(val rawValue: String) : Enumerable {
   GLOBAL("global"),
-  ERROR_BOUNDARY("errorBoundary")
+  ERROR_BOUNDARY("errorBoundary"),
+  REPORTED_BY_USER("reportedByUser")
 }
 
 /**

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/jserrors/ErrorReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/jserrors/ErrorReportTest.kt
@@ -42,4 +42,19 @@ class ErrorReportTest {
     val attributes = report.toLogRecord(sessionId = "s").attributes ?: ""
     assertFalse(attributes.contains("expo.error.component_stack"))
   }
+
+  @Test
+  fun `tags a user-reported error with the reportedByUser source at error severity`() {
+    val report = ErrorReport(
+      source = ErrorSource.REPORTED_BY_USER,
+      type = "TypeError",
+      message = "nope",
+      stacktrace = "at f (app.js:1:1)",
+      isFatal = false
+    )
+    val record = report.toLogRecord(sessionId = "s")
+    val attributes = record.attributes ?: ""
+    assertTrue(attributes.contains("\"expo.error.source\":\"reportedByUser\""))
+    assertEquals("error", record.severity)
+  }
 }

--- a/packages/expo-app-metrics/ios/LogEvents/ErrorReport.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/ErrorReport.swift
@@ -17,6 +17,7 @@ struct ErrorReport {
   enum Source: String, Enumerable {
     case global
     case errorBoundary
+    case reportedByUser
   }
 
   /// Builds the `exception` log event for the live path.

--- a/packages/expo-app-metrics/ios/Tests/ErrorReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/ErrorReportTests.swift
@@ -36,4 +36,20 @@ struct ErrorReportTests {
     let attributes = try! #require(report.toLogRecord().attributes?.value as? [String: Any])
     #expect(attributes.keys.contains("expo.error.component_stack") == false)
   }
+
+  @Test
+  func `tags a user-reported error with the reportedByUser source at error severity`() {
+    let report = ErrorReport(
+      source: .reportedByUser,
+      type: "TypeError",
+      message: "nope",
+      stacktrace: "at f (app.js:1:1)",
+      isFatal: false
+    )
+    let record = report.toLogRecord()
+    let attributes = try! #require(record.attributes?.value as? [String: Any])
+    #expect(attributes["expo.error.source"] as? String == "reportedByUser")
+    #expect(attributes["expo.error.is_fatal"] as? Bool == false)
+    #expect(record.severity == .error)
+  }
 }

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -557,7 +557,7 @@ export interface ExpoAppMetricsModuleType {
    * @private This API is unstable and may change without notice.
    */
   reportError(error: {
-    source: 'global' | 'errorBoundary';
+    source: 'global' | 'errorBoundary' | 'reportedByUser';
     type?: string;
     message: string;
     stacktrace?: string;

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
 - Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))
 - Add `filteredParams` configuration option to navigation integrations ([#47488](https://github.com/expo/expo/pull/47488) by [@Ubax](https://github.com/Ubax))
+- Add `reportError` to report caught, non-fatal errors from your own `try`/`catch` blocks. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -18,6 +18,7 @@ const mockAppMetrics = {
   markFirstRender: jest.fn(),
   markInteractive: jest.fn(),
   setGlobalAttributes: jest.fn(),
+  reportError: jest.fn(),
 };
 
 jest.mock('expo', () => ({
@@ -370,5 +371,86 @@ describe('module Proxy', () => {
     Observe.setGlobalAttributes({ tier: 'pro' });
     expect(mockAppMetrics.setGlobalAttributes).toHaveBeenCalledWith({ tier: 'pro' });
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a caught Error as a non-fatal reportedByUser-source error', () => {
+    const Observe = loadModule();
+    const error = new Error('boom');
+    Observe.reportError(error);
+    expect(mockAppMetrics.reportError).toHaveBeenCalledWith({
+      source: 'reportedByUser',
+      type: 'Error',
+      message: 'boom',
+      stacktrace: error.stack,
+      isFatal: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a non-Error thrown value with String() and no type or stacktrace', () => {
+    const Observe = loadModule();
+    Observe.reportError('just a string');
+    expect(mockAppMetrics.reportError).toHaveBeenCalledWith({
+      source: 'reportedByUser',
+      message: 'just a string',
+      isFatal: false,
+    });
+  });
+
+  it('stringifies a plain object with Error-like keys instead of forwarding non-string fields', () => {
+    const Observe = loadModule();
+    // A plain object whose `message`/`name` are non-strings must not be forwarded into the native
+    // string fields (which would fail the record decode and drop the report).
+    Observe.reportError({ message: 404, name: 500, stack: {} });
+    expect(mockAppMetrics.reportError).toHaveBeenCalledWith({
+      source: 'reportedByUser',
+      message: '[object Object]',
+      isFatal: false,
+    });
+  });
+
+  it('falls back to String() when an Error carries a non-string message', () => {
+    const Observe = loadModule();
+    const error = new Error('real');
+    // A caller can mutate an Error's fields to non-strings; those must not reach native as-is.
+    (error as { message: unknown }).message = 404;
+    Observe.reportError(error);
+    const [[payload]] = mockAppMetrics.reportError.mock.calls;
+    expect(typeof payload.message).toBe('string');
+    expect(payload.source).toBe('reportedByUser');
+    expect(payload.isFatal).toBe(false);
+  });
+
+  it('never throws when reading the thrown value throws (a getter that throws)', () => {
+    const Observe = loadModule();
+    const error = new Error('outer');
+    Object.defineProperty(error, 'message', {
+      get() {
+        throw new Error('getter blew up');
+      },
+    });
+    // reportError is called from a catch block, so it must never throw back into the caller.
+    expect(() => Observe.reportError(error)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('never throws when String() on the thrown value throws (a throwing toString)', () => {
+    const Observe = loadModule();
+    const hostile = {
+      toString() {
+        throw new Error('toString blew up');
+      },
+    };
+    expect(() => Observe.reportError(hostile)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('never throws when the native reportError call throws', () => {
+    const Observe = loadModule();
+    mockAppMetrics.reportError.mockImplementationOnce(() => {
+      throw new Error('native rejected the payload');
+    });
+    expect(() => Observe.reportError(new Error('boom'))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -5,6 +5,7 @@ import { initRouterIntegration } from './integrations/expo-router/init';
 import { isRouterInstalled } from './integrations/expo-router/router';
 import { initReactNavigationIntegration } from './integrations/react-navigation/init';
 import { isReactNavigationInstalled } from './integrations/react-navigation/reactNavigation';
+import { reportCaughtError } from './reportCaughtError';
 import type { ObserveConfig, ObserveModule } from './types';
 
 const native = requireNativeModule<ObserveModule>('ExpoObserve');
@@ -45,6 +46,10 @@ const Observe: ObserveModule = new Proxy(native, {
         }
         return target.configure(config);
       };
+    }
+
+    if (prop === 'reportError') {
+      return (error: unknown) => reportCaughtError(error);
     }
 
     // On Android, the native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report

--- a/packages/expo-observe/src/module.web.ts
+++ b/packages/expo-observe/src/module.web.ts
@@ -1,6 +1,7 @@
 import { NativeModule, registerWebModule } from 'expo';
 import AppMetrics, { type LogEventOptions, type MetricAttributes } from 'expo-app-metrics';
 
+import { reportCaughtError } from './reportCaughtError';
 import type {
   ObserveConfig,
   ObserveIntegrationsConfig,
@@ -17,6 +18,9 @@ class ExpoObserveModule extends NativeModule<ObserveModuleEvents> implements Obs
   }
   logEvent(name: string, options?: LogEventOptions): void {
     AppMetrics.logEvent(name, options);
+  }
+  reportError(error: unknown): void {
+    reportCaughtError(error);
   }
   markFirstRender(): void {
     AppMetrics.markFirstRender();

--- a/packages/expo-observe/src/reportCaughtError.ts
+++ b/packages/expo-observe/src/reportCaughtError.ts
@@ -1,0 +1,57 @@
+import AppMetrics from 'expo-app-metrics';
+
+/**
+ * The `reportError` payload shape sent to the native AppMetrics module. The native record types
+ * `type`/`stacktrace` as optional strings and `message` as a required string, so a non-string value
+ * would fail the record decode and drop the report. Every field is normalized to a string here.
+ */
+type NormalizedReportedError = {
+  type?: string;
+  message: string;
+  stacktrace?: string;
+};
+
+/** Returns `value` when it's a string, otherwise `undefined`, so non-string fields never reach native. */
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Normalizes an arbitrary caught value into the fields the native `reportError` expects, the way the
+ * global `ErrorUtils` handler does.
+ */
+function normalizeReportedError(error: unknown): NormalizedReportedError {
+  // Only a real `Error` contributes name/message/stack, and each only when it's actually a string;
+  // an `Error` with non-string fields would otherwise reach the native string fields (e.g. a mutated
+  // `message`) and fail the record decode.
+  if (error instanceof Error) {
+    return {
+      type: stringOrUndefined(error.name),
+      message: stringOrUndefined(error.message) ?? String(error),
+      stacktrace: stringOrUndefined(error.stack),
+    };
+  }
+  // Any non-Error throw (a string, a plain object, a number) becomes its stringification, no stack.
+  return { message: String(error) };
+}
+
+/**
+ * Reports a caught value as a non-fatal `reportedByUser`-source error through the AppMetrics module,
+ * shared by the native and web `Observe.reportError` implementations.
+ *
+ * Never throws: it's called from a `catch` block, so a failure here (a pathological thrown value, or
+ * a native call that rejects the payload) must not turn a handled error into an unhandled one.
+ */
+export function reportCaughtError(error: unknown): void {
+  try {
+    AppMetrics.reportError({
+      source: 'reportedByUser',
+      ...normalizeReportedError(error),
+      isFatal: false,
+    });
+  } catch (reportingError) {
+    if (__DEV__) {
+      console.warn('[expo-observe] `reportError` failed to record the error:', reportingError);
+    }
+  }
+}

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -137,6 +137,27 @@ export declare class ObserveModule extends NativeModule<ObserveModuleEvents> {
    */
   logEvent(name: string, options?: LogEventOptions): void;
   /**
+   * Reports an error your code caught and handled, recorded as a non-fatal `exception` event. Use it
+   * to keep visibility into failures you recover from, which never reach the automatic global handler
+   * or an error boundary.
+   *
+   * The thrown value is normalized: an `Error`'s `name`, `message`, and `stack` are captured; any
+   * other value (a string, a plain object) is stringified as the message.
+   *
+   * @param error The caught value. An `Error` is preferred, but any thrown value is accepted.
+   *
+   * @example
+   * ```ts
+   * try {
+   *   await syncCart();
+   * } catch (error) {
+   *   Observe.reportError(error);
+   * }
+   * ```
+   */
+  // eslint-disable-next-line handle-callback-err -- `error` is the caught value to report, not a Node callback error.
+  reportError(error: unknown): void;
+  /**
    * Marks the first render of the app. Used to compute the `cold_ttr` and
    * `warm_ttr` metrics.
    */


### PR DESCRIPTION
# Why

Error capture in `expo-app-metrics` is fully automatic today, through two internal paths that both feed the private native `reportError`:

- `source: 'global'` — the React Native `ErrorUtils` global handler (fatal or non-fatal)
- `source: 'errorBoundary'` — the `AppMetricsErrorBoundary` (always non-fatal)

There is no way for a developer to report an error they caught and handled in their own `try`/`catch`. This adds a public API to record those handled, non-fatal errors so they flow to `/v1/logs` alongside the automatically-captured ones.

# How

Adds a public `Observe.reportError(error: unknown): void`.

It normalizes the caught value the same way the global `ErrorUtils` handler does: an `Error`'s `name`, `message`, and `stack` are captured (each only when it's actually a string); any other thrown value (a string, a plain object) is stringified as the message via `String(error)` and carries no stack. The result is recorded as a non-fatal `exception` log event tagged `expo.error.source = 'reportedByUser'`, reusing the existing non-fatal log pipeline end to end (no new dispatch wiring).

- **expo-observe**: an explicit `reportError` case in the `module.ts` `Proxy` (so the public shape stays decoupled from the native payload) and a matching `module.web.ts` implementation, both delegating to a shared `reportCaughtError` helper; plus a typed public declaration on `ObserveModule` with TSDoc + `@example`.
- **expo-app-metrics**: a new `reportedByUser` case added to the `source` closed set across TS, Swift (`ErrorReport.Source`), and Kotlin (`ErrorSource`). `reportError` itself already handles the non-fatal async path on both platforms, so no other native change is needed.

**Robustness** (`reportError` is called from a `catch` block, so it must not make a handled error worse):
- Only a real `Error` contributes `name`/`message`/`stack`, and each only when it's a string — so a non-`Error` object with Error-like non-string fields (e.g. `throw { message: 404 }`) can't reach the native string fields and fail the record decode.
- The whole report flow never throws: a pathological thrown value (a throwing getter or `toString`) or a native call that rejects the payload is swallowed, with a `console.warn` in `__DEV__` only.

A follow-up will add an optional `attributes` argument; that requires the `@Record` macro to accept `[String: Any]` fields, tracked in ENG-25264.

# Test Plan

- `et check-packages expo-observe expo-app-metrics` → all checks pass (build, typecheck, lint, test), no warnings.
- JS: `expo-observe` module tests cover a caught `Error` (name/message/stack, non-fatal, `source: 'reportedByUser'`), a non-`Error` throw (stringified message, no stack), a plain object with non-string Error-like fields, and the never-throws cases (throwing getter, throwing `toString`, native call throwing). 62 passed.
- Native: `ErrorReportTests` (iOS) and `ErrorReportTest` (Android) assert a `reportedByUser`-source error is tagged `expo.error.source = 'reportedByUser'` at `error` severity. Both suites pass.
- Verified end-to-end on an Android emulator via the observe-tester app (`Report caught errors` section on the Debug tab): the recorded session logs show the two `exception` events with `expo.error.source = 'reportedByUser'`.