### PR TITLE
[video] Add videoChangeFrameRateStrategy player builder option on Android

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Added the `controllerAutoShow` prop to `VideoView` to control whether the native controls auto-show on play. ([#46665](https://github.com/expo/expo/pull/46665) by [@stevesouth](https://github.com/stevesouth))
 - [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection. ([#46992](https://github.com/expo/expo/pull/46992) by [@vargajacint](https://github.com/vargajacint))
+- [Android] Added the `videoChangeFrameRateStrategy` player builder option to control whether ExoPlayer may change the display refresh rate to match the video frame rate. On adaptive refresh rate displays (Pixel 9/10) the default matching can cap the entire app UI at 30Hz while a 30 fps video is visible. ([#47873](https://github.com/expo/expo/pull/47873) by [@invivek26](https://github.com/invivek26))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/enums/VideoChangeFrameRateStrategy.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/enums/VideoChangeFrameRateStrategy.kt
@@ -1,0 +1,16 @@
+package expo.modules.video.enums
+
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import expo.modules.kotlin.types.Enumerable
+
+@UnstableApi
+enum class VideoChangeFrameRateStrategy(val value: String) : Enumerable {
+  OFF("off"),
+  ONLY_IF_SEAMLESS("onlyIfSeamless");
+
+  fun toMedia3Strategy(): Int = when (this) {
+    OFF -> C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF
+    ONLY_IF_SEAMLESS -> C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -86,6 +86,11 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
         setSeekForwardIncrementMs((it).toLong(DurationUnit.MILLISECONDS).coerceIn(1, 999_000))
       }
     }.build()
+    .apply {
+      playerBuilderOptions?.videoChangeFrameRateStrategy?.let {
+        setVideoChangeFrameRateStrategy(it.toMedia3Strategy())
+      }
+    }
 
   internal val firstFrameEventGenerator: FirstFrameEventGenerator
   val serviceConnection = PlaybackServiceConnection(WeakReference(this), appContext)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -88,7 +88,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     }.build()
     .apply {
       playerBuilderOptions?.videoChangeFrameRateStrategy?.let {
-        setVideoChangeFrameRateStrategy(it.toMedia3Strategy())
+        videoChangeFrameRateStrategy = it.toMedia3Strategy()
       }
     }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/PlayerBuilderOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/PlayerBuilderOptions.kt
@@ -3,6 +3,7 @@ package expo.modules.video.records
 import androidx.media3.common.util.UnstableApi
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.video.enums.VideoChangeFrameRateStrategy
 import java.io.Serializable
 import kotlin.time.Duration
 import expo.modules.kotlin.types.OptimizedRecord
@@ -11,5 +12,6 @@ import expo.modules.kotlin.types.OptimizedRecord
 @OptimizedRecord
 class PlayerBuilderOptions(
   @Field var seekBackwardIncrement: Duration? = null,
-  @Field var seekForwardIncrement: Duration? = null
+  @Field var seekForwardIncrement: Duration? = null,
+  @Field var videoChangeFrameRateStrategy: VideoChangeFrameRateStrategy? = null
 ) : Record, Serializable

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -825,6 +825,20 @@ export type ScrubbingModeOptions = {
 };
 
 /**
+ * Determines whether the player is allowed to call [`Surface.setFrameRate`](https://developer.android.com/reference/android/view/Surface#setFrameRate(float,%20int))
+ * to match the display refresh rate to the frame rate of the video being played.
+ * - `'onlyIfSeamless'`: the display refresh rate is changed only when the switch is seamless (no visual interruption). This is the ExoPlayer default.
+ * - `'off'`: the player never calls `Surface.setFrameRate`.
+ *
+ * > On devices with adaptive refresh rate displays (for example, Pixel 9 and 10 series), the platform can respond to a 30 fps video
+ * > by lowering the display render rate and capping the rendering of the entire app, including scrolling and animations, at 30 Hz
+ * > for as long as the video is visible. Set this option to `'off'` to keep the UI running at the full refresh rate, for example
+ * > in a vertical video feed. Frame rate matching mainly benefits TV-class displays, where mismatched rates cause judder.
+ * @platform android
+ */
+export type VideoChangeFrameRateStrategy = 'off' | 'onlyIfSeamless';
+
+/**
  * Options to apply to the player builder before the native constructor is invoked
  * @platform android
  */
@@ -842,6 +856,13 @@ export type PlayerBuilderOptions = {
    * @platform android
    */
   seekForwardIncrement?: number;
+
+  /**
+   * Determines whether the player is allowed to change the display refresh rate to match the frame rate of the video.
+   * @default 'onlyIfSeamless'
+   * @platform android
+   */
+  videoChangeFrameRateStrategy?: VideoChangeFrameRateStrategy;
 };
 
 /**


### PR DESCRIPTION
# Why

On Android devices with adaptive refresh rate (ARR) displays — Pixel 9/10 series on Android 15+ — playing a fixed-frame-rate video through expo-video can cap the **entire app UI** at the video's frame rate.

ExoPlayer's default `VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS` calls `Surface.setFrameRate(contentFps, FIXED_SOURCE)` on the video surface. On ARR panels a render-rate change inside the same display mode is always seamless, so SurfaceFlinger honors a 30 fps vote by dropping the display render rate to 30 Hz **and** applying a per-uid frame rate override, which caps all of the app's rendering — scrolling, gestures, animations — at 30 fps while the video is visible. In a vertical video feed (TikTok-style pager) this makes swiping feel very janky: the pager animates at 30 fps on a 120 Hz panel, except during brief touch boosts.

Observed on a Pixel 10 Pro (Android 16, expo-video 56.1.4, media3 1.9.0) while a 30 fps HLS stream played in a `VideoView` with `surfaceType="surfaceView"`:

```
# dumpsys SurfaceFlinger
SurfaceView[...](BLAST)#156648 requestedFrameRate: {30.00 Hz FrameRateCompatibility::ExactOrMultiple ...} uid=10544
FrameRateOverrides=
    setFrameRate=
        (uid, frameRate)={10544, 30.00 Hz}

# logcat
SurfaceFlinger: setDesiredMode ... {mode={fps=30.00 Hz, modePtr={id=1, vsyncRate=120.00 Hz ...}}}
```

The issue is sneakily content-dependent: 30 fps content divides 120 Hz so the vote is honored; 23.976 fps content cannot be matched, so the same code stays at 120 Hz and looks perfectly smooth in testing.

Frame-rate matching is a judder optimization that mainly benefits TV-class displays. ExoPlayer added `VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF` exactly so apps can opt out (google/ExoPlayer@0097a79c2d221dc55ef1147f6f3144f2735a997a; see also androidx/media#3120 where the media3 team applied `OFF` as a mitigation), but expo-video currently provides no way to reach it.

# How

- Added a `VideoChangeFrameRateStrategy` enum (`'off' | 'onlyIfSeamless'`) mapped to the corresponding `C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_*` constants.
- Added an optional `videoChangeFrameRateStrategy` field to `PlayerBuilderOptions` (Android-only, like the existing seek increment options).
- Applied it via `ExoPlayer.setVideoChangeFrameRateStrategy(...)` right after the player is built.
- Default behavior is unchanged when the option is omitted (ExoPlayer keeps its `ONLY_IF_SEAMLESS` default).

# Test Plan

On a Pixel 9/10 (or any ARR device) playing an exactly-30 fps video:

1. Create a player with `useVideoPlayer(source, setup, { videoChangeFrameRateStrategy: 'off' })` and render it in a `VideoView` with `surfaceType="surfaceView"`.
2. `adb shell dumpsys SurfaceFlinger | grep -E "requestedFrameRate|FrameRateOverrides"` — the video layer reports `0.00 Hz Default` instead of `30.00 Hz ExactOrMultiple`, and no per-uid override is applied.
3. Scrolling/UI animations over the playing video render at the panel's full refresh rate (verifiable with a screen recording: per-second emitted frame counts stay at ~120 instead of ~30).
4. Omitting the option (or passing `'onlyIfSeamless'`) reproduces the previous behavior.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no plugin/prebuild changes)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)