### PR TITLE
[docs][ci] Build expo-task-manager before regenerating docs API data

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,12 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo
+      - name: 🛠 Build packages required by docs API data generation
+        if: steps.expo-caches.outputs.docs-api-data-hit != 'true'
+        run: pnpm turbo build --filter expo-task-manager
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
       - name: 📝 Regenerate `unversioned` data for Docs
         if: steps.expo-caches.outputs.docs-api-data-hit != 'true'
         run: expotools generate-docs-api-data


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

CI fails https://github.com/expo/expo/actions/runs/29537139014/job/87751024883 because of `exit code 1` introduced in https://github.com/expo/expo/pull/47691.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a cache-gated `pnpm turbo build --filter expo-task-manager` step to `docs.yml` before `expotools generate-docs-api-data`, so the gitignored `build/TaskManager.d.ts` that `expo-background-fetch` and `expo-background-task` resolve their `expo-task-manager` import against exists when TypeDoc runs (missing since #46801 dropped committed build outputs).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See the docs job in this PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
