### PR TITLE
fix(ci) fix flaky FileSystemFileTest by retaining app context

### DIFF
--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -192,8 +192,16 @@ class FileSystemFileTest {
       ): EnumSet<Permission> = permissions
     }
 
+  // FileSystemPath/SharedObject holds its runtime, MainRuntime holds its AppContext, and
+  // AppContext holds its ReactContext all through WeakReferences. Without a strong reference
+  // kept here for the lifetime of the test, this context graph can be garbage-collected
+  // mid-test, making permission checks fail spuriously with ReactContextLost or
+  // InvalidPermissionException instead of the behavior under test.
+  private val retainedContexts = mutableListOf<Any>()
+
   private fun createAppContext(permissionService: FilePermissionService): AppContext {
     val reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
+    retainedContexts.add(reactContext)
     return AppContext(
       object : ModulesProvider {
         override fun getModulesMap(): Map<Class<out Module>, String?> = emptyMap()
@@ -203,6 +211,7 @@ class FileSystemFileTest {
       WeakReference(reactContext)
     ).also {
       it.services.register(FilePermissionService::class.java, permissionService)
+      retainedContexts.add(it)
     }
   }
 


### PR DESCRIPTION
# Why

`expo-file-system:testDebugUnitTest` is red on `main` (Android Unit Tests run on `a960d6809`): `FileSystemFileTest > renameRejectsChildNameThatEscapesParentDirectory` fails with `InvalidPermissionException` instead of the expected path-escape rejection.

This is a latent GC race in the test, not a product bug. `FileSystemPath`/`SharedObject` holds its runtime, `MainRuntime` holds its `AppContext`, and `AppContext` holds its `ReactContext` — all through `WeakReference`s (by design, so shared objects never keep the React context alive). The test helper created these as local temporaries and kept no strong reference, so a GC between setup and the assertion collects the whole context graph mid-test and the permission check fails with `ReactContextLost`/`InvalidPermissionException` before reaching the behavior under test. The extra context allocations added by the new tests in #47176 shifted GC timing enough to surface it — #47176's own CI run passed, and the failure appeared on a later commit that only touched docs.

# How

Test-only fix: the test instance now strongly retains the `BridgeReactContext` and `AppContext` it creates (JUnit creates a fresh instance per test method, so the graph stays alive exactly for each test's duration). Product code is untouched — strong-referencing there would reintroduce the context leak the weak references exist to prevent.

# Test Plan

- **Red (deterministic repro):** with a temporary `System.gc()` forced after setup in the rename test, it fails exactly like CI: `unexpected exception type thrown; expected:<UnableToCreateException> but was:<Exceptions.ReactContextLost>`.
- **Green:** with the fix, the same forced-GC run passes (`BUILD SUCCESSFUL`), and with the temporary GC removed the full suite `./gradlew :expo-file-system:testDebugUnitTest` passes — 0 failures/errors across all test classes.

# Checklist

- No CHANGELOG entry: test-infrastructure fix, no user-facing change.
- Not applicable to `npx expo prebuild` / EAS Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
