### PR TITLE
[ios][camera] Fix responsiveOrientationWhenOrientationLocked being ignored for photo and video capture

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] Fire `onMountError` instead of crashing the app when the camera can't be started, such as a device reporting zero available cameras. ([#47818](https://github.com/expo/expo/pull/47818) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Preserve the capture orientation as EXIF metadata instead of rotating captured pixels, so `takePictureAsync` and `savePictureAsync` return the real orientation tag and dimensions. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Return zeroed `bounds` and `cornerPoints` from the ZXing fallback scanner so scanning a `pdf417`, `code39`, or `codabar` code no longer crashes with `Cannot read property 'origin' of undefined`. ([#47854](https://github.com/expo/expo/pull/47854) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix `responsiveOrientationWhenOrientationLocked: false` being ignored — photos and videos captured while the app orientation is locked now follow the locked interface orientation instead of the physical device rotation. ([#47881](https://github.com/expo/expo/pull/47881) by [@jiunshinn](https://github.com/jiunshinn))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -78,6 +78,18 @@ struct ExpoCameraUtils {
     }
   }
 
+  // When responsive orientation is off, capture must follow the interface orientation,
+  // which respects the app/device orientation lock, instead of the physical device rotation.
+  static func captureOrientation(
+    responsiveWhenOrientationLocked: Bool,
+    physicalOrientation: UIDeviceOrientation,
+    interfaceOrientation: UIInterfaceOrientation
+  ) -> AVCaptureVideoOrientation {
+    return responsiveWhenOrientationLocked
+      ? videoOrientation(for: physicalOrientation)
+      : videoOrientation(for: interfaceOrientation)
+  }
+
   static func toOrientationString(orientation: UIDeviceOrientation) -> String {
     switch orientation {
     case .portrait:

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -71,9 +71,11 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
       photoCaptureOptions = options
 
       let connection = photoOutput.connection(with: .video)
-      let orientation = captureDelegate?.responsiveWhenOrientationLocked == true ?
-        captureDelegate?.physicalOrientation ?? .unknown : UIDevice.current.orientation
-      connection?.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
+      connection?.videoOrientation = ExpoCameraUtils.captureOrientation(
+        responsiveWhenOrientationLocked: captureDelegate?.responsiveWhenOrientationLocked == true,
+        physicalOrientation: captureDelegate?.physicalOrientation ?? .unknown,
+        interfaceOrientation: captureDelegate?.deviceOrientation ?? .unknown
+      )
 
       // options.mirror is deprecated but should continue to work until removed
       connection?.isVideoMirrored = captureDelegate?.presetCamera == .front &&

--- a/packages/expo-camera/ios/Current/CameraVideoRecording.swift
+++ b/packages/expo-camera/ios/Current/CameraVideoRecording.swift
@@ -5,6 +5,7 @@ import ExpoModulesCore
 protocol CameraVideoRecordingDelegate: AnyObject {
   var responsiveWhenOrientationLocked: Bool { get }
   var physicalOrientation: UIDeviceOrientation { get }
+  var deviceOrientation: UIInterfaceOrientation { get }
   var mirror: Bool { get }
   var appContext: AppContext? { get }
   var videoBitrate: Int? { get }
@@ -29,9 +30,11 @@ class CameraVideoRecording: NSObject, AVCaptureFileOutputRecordingDelegate {
     }
 
     if let connection = videoFileOutput.connection(with: .video) {
-      let orientation = await delegate?.responsiveWhenOrientationLocked == true ?
-        delegate?.physicalOrientation ?? .unknown : UIDevice.current.orientation
-      connection.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
+      connection.videoOrientation = await ExpoCameraUtils.captureOrientation(
+        responsiveWhenOrientationLocked: delegate?.responsiveWhenOrientationLocked == true,
+        physicalOrientation: delegate?.physicalOrientation ?? .unknown,
+        interfaceOrientation: delegate?.deviceOrientation ?? .unknown
+      )
       await setVideoOptions(options: options, for: connection, videoFileOutput: videoFileOutput, promise: promise)
 
       if connection.isVideoOrientationSupported && delegate?.mirror == true {

--- a/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
@@ -74,6 +74,42 @@ struct ExpoCameraUtilsTests {
   }
 
   @Test(arguments: [
+    (UIDeviceOrientation.landscapeLeft, AVCaptureVideoOrientation.landscapeRight),
+    (.landscapeRight, .landscapeLeft),
+    (.portrait, .portrait),
+    (.portraitUpsideDown, .portraitUpsideDown),
+  ] as [(UIDeviceOrientation, AVCaptureVideoOrientation)])
+  func `capture follows the physical orientation when responsive orientation is enabled`(
+    physical: UIDeviceOrientation,
+    expected: AVCaptureVideoOrientation
+  ) {
+    #expect(ExpoCameraUtils.captureOrientation(
+      responsiveWhenOrientationLocked: true,
+      physicalOrientation: physical,
+      interfaceOrientation: .portrait
+    ) == expected)
+  }
+
+  @Test(arguments: [
+    (UIInterfaceOrientation.portrait, UIDeviceOrientation.landscapeLeft, AVCaptureVideoOrientation.portrait),
+    (.portrait, .landscapeRight, .portrait),
+    (.landscapeLeft, .portrait, .landscapeLeft),
+    (.landscapeRight, .faceUp, .landscapeRight),
+    (.portraitUpsideDown, .landscapeLeft, .portraitUpsideDown),
+  ] as [(UIInterfaceOrientation, UIDeviceOrientation, AVCaptureVideoOrientation)])
+  func `capture follows the interface orientation when responsive orientation is disabled`(
+    interface: UIInterfaceOrientation,
+    physical: UIDeviceOrientation,
+    expected: AVCaptureVideoOrientation
+  ) {
+    #expect(ExpoCameraUtils.captureOrientation(
+      responsiveWhenOrientationLocked: false,
+      physicalOrientation: physical,
+      interfaceOrientation: interface
+    ) == expected)
+  }
+
+  @Test(arguments: [
     (UIDeviceOrientation.portrait, "portrait"),
     (.landscapeLeft, "landscapeLeft"),
     (.landscapeRight, "landscapeRight"),


### PR DESCRIPTION
# Why

Fixes #41019.

With `responsiveOrientationWhenOrientationLocked: false` (the default), captures were still oriented by `UIDevice.current.orientation`, which reports the physical (gyro) rotation regardless of any orientation lock. Both branches of the orientation selection therefore followed gravity, making the prop a no-op: photos taken while the app was locked to portrait but the device was held sideways came out landscape.

This contradicts the documented behavior of the prop ("when set to `true`, landscape photos will be taken if the device is turned that way, **even if the app or device orientation is locked to portrait**") — with `false`, captures should follow the locked interface orientation.

# How

- Added `ExpoCameraUtils.captureOrientation(responsiveWhenOrientationLocked:physicalOrientation:interfaceOrientation:)`:
  - `true` keeps the existing accelerometer-tracked physical orientation path, unchanged.
  - `false` now uses the window scene's interface orientation, which respects the orientation lock.
- Routed both photo capture (`CameraPhotoCapture`) and video recording (`CameraVideoRecording`) through it. `CameraVideoRecordingDelegate` now exposes the same `deviceOrientation` the photo capture delegate already had (implemented by `CameraView`).
- Unlocked apps are unaffected: their interface orientation follows the physical rotation, so the selected capture orientation is the same as before. The `false` branch only diverges when the interface and physical orientations differ — locked apps (the bug being fixed), and flat-on-a-table captures, which now follow the visible UI instead of always defaulting to portrait.

# Test Plan

**Unit tests** — added spec cases for `captureOrientation` to `ExpoCameraUtilsTests` (9 cases). Written red-first: against the previous selection logic, the disabled-branch cases fail (capture followed gravity); with the fix, all 31 tests in the `ExpoCamera-Unit-Tests` suite pass:

```
✔ Suite "BarcodeUtils" passed
✔ Suite "CapturedPhotoProcessor" passed
✔ Suite "ExpoCameraUtils" passed
✔ Suite "BarcodeScannerUtils" passed
✔ Suite "BarcodeType" passed
✔ Test run with 31 tests in 5 suites passed
```

**Device (iPhone 11 Pro, iOS 26.5, bare-expo → NCL "Capture Dimensions" screen):**

| Scenario | Result |
| - | - |
| Portrait Orientation Lock ON + device held landscape | Capture encodes as portrait (EXIF orientation 6), matching the locked UI — previously it followed the gyro and came out landscape |
| Lock OFF + UI rotated to landscape | Capture stays landscape (EXIF orientation 1, 4032×3004) — unlocked behavior unchanged |
| Lock ON + device held upright | Baseline portrait capture (EXIF orientation 6, 2272×4032), matches the preview |

All three dimension/EXIF consistency checks on the screen stay green in every scenario.

**1. Portrait Orientation Lock ON + device held landscape — the fix**

The capture is now portrait-encoded (`EXIF orientation 6`) instead of following the gyro. The captured photo (right) is intentionally rotated relative to the horizon-leveled preview (left) — with the lock on, the capture matches the locked portrait UI, which is the documented behavior of `responsiveOrientationWhenOrientationLocked: false`.

<img width="380" alt="Lock ON, device held landscape — capture encodes as portrait (EXIF orientation 6)" src="https://github.com/user-attachments/assets/384d8e15-0a8f-44f9-a21d-44637cadff90" />

**2. Lock OFF + UI rotated to landscape — no regression**

Unlocked behavior is unchanged: the capture stays landscape (`EXIF orientation 1`, 4032×3004) and matches the preview.

<img width="640" alt="Lock OFF, UI rotated to landscape — capture stays landscape (EXIF orientation 1)" src="https://github.com/user-attachments/assets/9e98838a-2fbd-4bf2-83ef-a4eb4aeb0ed7" />

**3. Lock ON + device held upright — baseline**

Portrait capture (`EXIF orientation 6`, 2272×4032), identical framing to the preview.

<img width="380" alt="Lock ON, device held upright — baseline portrait capture (EXIF orientation 6)" src="https://github.com/user-attachments/assets/051cb639-a58e-4688-aeb6-95cf616963a9" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

