### PR TITLE
[router] Fix the require cycle

### DIFF
--- a/packages/expo-router/oxlint.config.mjs
+++ b/packages/expo-router/oxlint.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig({
   extends: [base],
   ignorePatterns: base.ignorePatterns,
   rules: {
+    'import/no-cycle': 'error',
     // expo-router passes `children` via props in a number of places (notably tests); accepted here.
     'react/no-children-prop': 'off',
   },

--- a/packages/expo-router/src/link/Redirect.tsx
+++ b/packages/expo-router/src/link/Redirect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from '../hooks';
+import { useRouter } from '../hooks/useRouter';
 import type { Href } from '../types';
 import { useFocusEffect } from '../useFocusEffect';
 import { useIsPreview } from './preview/PreviewRouteContext';

--- a/packages/expo-router/src/link/useLoadedNavigation.ts
+++ b/packages/expo-router/src/link/useLoadedNavigation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 
-import { store } from '../global-state/router-store';
+import { store } from '../global-state/store';
 import type { NavigationProp, NavigationState } from '../react-navigation/native';
 import { useNavigation } from '../react-navigation/native';
 


### PR DESCRIPTION
# Why

There is a require cycle in router code 

> Require cycle: ../../packages/expo-router/build/useScreens.js -> ../../packages/expo-router/build/link/Redirect.js -> ../../packages/expo-router/build/hooks/index.js -> ../../packages/expo-router/build/hooks/useLoaderData.js -> ../../packages/expo-router/build/useScreens.js·

# How

1. Fix the require cycle
2. Add lint rule `import/no-cycle`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
