### PR TITLE
[CI] run E2E tests when `router-e2e` is modified

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, 'sdk-*']
     paths:
       - .github/workflows/cli.yml
+      - apps/router-e2e/**
       - packages/@expo/cli/**
       - packages/@expo/metro-runtime/**
       - packages/@expo/metro-config/src/**
@@ -27,6 +28,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/cli.yml
+      - apps/router-e2e/**
       - packages/@expo/cli/**
       - packages/@expo/metro-runtime/**
       - packages/@expo/metro-config/src/**


### PR DESCRIPTION
# Why

Modifying router-e2e code can break the assertions in cli e2e and playwright tests.

# How

Run CI tests when router is modified

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
