### PR TITLE
[cli] Improve CI speed by adding more shards for Playwright on Windows

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -239,7 +239,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     env:
       # Change bun, npm, and pnpm caches to the much faster D:\ drive
       # See: https://github.com/twpayne/chezmoi/pull/4064


### PR DESCRIPTION
# Why

The Playwright E2E tests for Windows still take quite a bit of time on CI (8+ mins).

# How

Add more shards to the Playwright E2E runs on CI (from 2 to 4), matching Ubuntu runs.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
