### PR TITLE
[widgets] Fix blank widget when JSX children mix a `.map()` array with sibling elements

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))
 - [iOS][plugin] Only add the `aps-environment` entitlement when `enablePushNotifications` is enabled, and keep a pre-existing value. ([#47645](https://github.com/expo/expo/pull/47645) by [@kadikraman](https://github.com/kadikraman))
 - [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
+- Fix blank widget when JSX children mix a `.map()` array with sibling elements. ([#47888](https://github.com/expo/expo/pull/47888) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetEmittableTree.kt
+++ b/packages/expo-widgets/android/src/main/java/expo/modules/widgets/ExpoWidgetEmittableTree.kt
@@ -529,8 +529,10 @@ private fun ReadableMap.children(): List<ReadableMap> {
 private fun ReadableArray.children(): List<ReadableMap> {
   return buildList {
     for (index in 0 until size()) {
-      if (getType(index) == ReadableType.Map) {
-        getMap(index)?.let(::add)
+      when (getType(index)) {
+        ReadableType.Map -> getMap(index)?.let(::add)
+        ReadableType.Array -> getArray(index)?.let { addAll(it.children()) }
+        else -> Unit
       }
     }
   }

--- a/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
@@ -1,0 +1,90 @@
+import '../index';
+import { jsx, jsxs } from '../jsx-runtime-stub';
+
+jest.mock('@expo/ui/swift-ui', () => ({}));
+jest.mock('@expo/ui/swift-ui/modifiers', () => ({}));
+
+describe('jsx-runtime-stub children flattening', () => {
+  afterEach(() => {
+    delete globalThis.__expoWidgetLayout;
+  });
+
+  it('flattens a .map() array mixed with sibling elements into a flat children list', () => {
+    const items = ['Hello', 'World'];
+    const tree = jsxs('HStackView', {
+      children: [
+        items.map((item) => jsx('TextView', { text: item }, item)),
+        jsx('SpacerView', {}),
+      ],
+    });
+
+    expect(tree.props.children).toHaveLength(3);
+    expect(tree.props.children.map((child: any) => child.type)).toEqual([
+      'TextView',
+      'TextView',
+      'SpacerView',
+    ]);
+    expect(tree.props.children[0].props.text).toBe('Hello');
+    expect(tree.props.children[1].props.text).toBe('World');
+  });
+
+  it('flattens deeply nested children arrays while preserving order', () => {
+    const tree = jsxs('VStackView', {
+      children: [
+        jsx('TextView', { text: 'first' }),
+        [
+          jsx('TextView', { text: 'second' }),
+          [jsx('TextView', { text: 'third' }), jsx('TextView', { text: 'fourth' })],
+        ],
+        jsx('SpacerView', {}),
+      ],
+    });
+
+    expect(tree.props.children.map((child: any) => child.props.text ?? null)).toEqual([
+      'first',
+      'second',
+      'third',
+      'fourth',
+      null,
+    ]);
+  });
+
+  it('leaves a single non-array child untouched', () => {
+    const tree = jsx('HStackView', {
+      children: jsx('TextView', { text: 'only' }),
+    });
+
+    expect(Array.isArray(tree.props.children)).toBe(false);
+    expect(tree.props.children.props.text).toBe('only');
+  });
+
+  it('preserves text and conditional children in mixed arrays', () => {
+    const tree = jsxs('TextView', {
+      children: ['count: ', 5, false],
+    });
+
+    expect(tree.props.children).toEqual(['count: ', 5, false]);
+  });
+
+  it('finds and presses a button rendered inside a .map() mixed with siblings', () => {
+    const onPress = jest.fn(() => ({ id: 'pressed' }));
+
+    globalThis.__expoWidgetLayout = () =>
+      jsxs('HStackView', {
+        children: [
+          ['a', 'b'].map((label) =>
+            jsx('Button', { label, onButtonPress: label === 'b' ? onPress : () => ({}) }, label)
+          ),
+          jsx('SpacerView', {}),
+        ],
+      });
+
+    const tree = globalThis.__expoWidgetRender({}, { timestamp: 1 }) as any;
+    const target = tree.props.children[1].props.target;
+
+    const result = globalThis.__expoWidgetHandlePress({}, { timestamp: 1, target });
+
+    expect(result).toEqual({ id: 'pressed' });
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/expo-widgets/bundle/jsx-runtime-stub.ts
+++ b/packages/expo-widgets/bundle/jsx-runtime-stub.ts
@@ -49,6 +49,13 @@ function jsxProd(
     }
   }
 
+  // React flattens nested children arrays (e.g. a `.map()` result mixed with sibling
+  // elements) during reconciliation. There is no reconciler here - the element tree is
+  // serialized for the native widget parsers, which expect a flat children list.
+  if (Array.isArray(props.children)) {
+    props.children = props.children.flat(Infinity);
+  }
+
   return ReactElement(type, key, props);
 }
 

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -151,11 +151,23 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   where P: UIBaseViewProps {
     if let props = node["props"] as? [String: Any] {
       if let children = props["children"] as? [Any] {
-        let validChildren = children.compactMap { $0 as? [String: Any] }
+        let validChildren = flattenChildNodes(children)
         initialProps.children = validChildren.map { WidgetsDynamicView(name: name, kind: kind, node: $0, entryIndex: entryIndex, environmentString: environmentString) }
       } else if let child = props["children"] as? [String: Any] {
         initialProps.children = [WidgetsDynamicView(name: name, kind: kind, node: child, entryIndex: entryIndex, environmentString: environmentString)]
       }
+    }
+  }
+
+  private func flattenChildNodes(_ children: [Any]) -> [[String: Any]] {
+    return children.flatMap { child -> [[String: Any]] in
+      if let node = child as? [String: Any] {
+        return [node]
+      }
+      if let nested = child as? [Any] {
+        return flattenChildNodes(nested)
+      }
+      return []
     }
   }
 }


### PR DESCRIPTION
# Why

JSX children list that mixes a .map() array with sibling elements renders a BLANK widget.

# How

* deep-flatten array children (props.children.flat(Infinity)) at element creation in jsx runtime stub.
* handle not flattened elements on the native platforms

# Test Plan

* added `jsx-runtime.test.ts` test. 
* Tested manually in widget tester.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).