### PR TITLE
[autolinking][ios] Fix HEADER_SEARCH_PATHS corruption when Xcodeproj normalized the setting to an Array

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Preserve inherited header search paths when Xcodeproj normalizes `HEADER_SEARCH_PATHS` into an Array. ([#47892](https://github.com/expo/expo/pull/47892) by [@joedeleeuw](https://github.com/joedeleeuw))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -896,6 +896,8 @@ module Expo
         installer.pods_project.targets.each do |target|
           target.build_configurations.each do |config|
             existing = config.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)'
+            # Xcodeproj normalizes known multi-value settings to Arrays when serializing.
+            existing = existing.join(' ') if existing.is_a?(Array)
             unless existing.include?(paths_string)
               config.build_settings['HEADER_SEARCH_PATHS'] = "#{existing} #{paths_string}"
             end


### PR DESCRIPTION
# Why

Xcodeproj can normalize `HEADER_SEARCH_PATHS` to an Array; interpolating it corrupts inherited paths. Fixes #47891.

# How

Join Array values before checking or appending paths.

# Test Plan

- the #47891 Ruby repro now outputs `$(inherited) "/tmp/a" "/tmp/b" "/tmp/c"`
- `ruby -c packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb`
- `git diff --check upstream/main..HEAD`

# Checklist

- [x] added a changelog entry
- [ ] verified `npx expo prebuild` and EAS Build
- [ ] documentation style guide applies
