### PR TITLE
[expo][iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
 - Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
-- [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets.
+- [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets. ([#47894](https://github.com/expo/expo/pull/47894) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix `Response.blob()` in `expo/fetch` throwing when the global `Blob` is react-native's implementation. ([#47538](https://github.com/expo/expo/pull/47538) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
 - Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
+- [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets.
 
 ### 💡 Others
 

--- a/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
@@ -99,6 +99,7 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 // MARK: - Launch options & routing helpers
 
+@available(iOSApplicationExtension, unavailable)
 extension ExpoAppSceneDelegate {
   /// Rebuilds the launch options that `Linking.getInitialURL()` reads from a scene's connection
   /// options. Returns `nil` when the app wasn't cold-started by a URL or a browsing-web activity,


### PR DESCRIPTION
# Why

#47628 adds `ExpoAppSceneDelegate` extension, but it also needs to be marked as unavailable in application extension.

# How

Mark `extension ExpoAppSceneDelegate` with `@available(iOSApplicationExtension, unavailable)`. 

# Test Plan

Build widgets tester

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)