### PR TITLE
[docs] Add param filtering section to observe docs

### DIFF
--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -69,6 +69,22 @@ export default function Home() {
 
 </Step>
 
+## Filter sensitive URL parameters
+
+By default, the integration includes the resolved `url` and all serializable route and query parameters in `routeParams`. If your app includes sensitive values in URL parameters, pass their keys to `filteredParams`:
+
+```tsx src/app/_layout.tsx
+import { Observe } from 'expo-observe';
+
+Observe.configure({
+  integrations: {
+    'expo-router': {
+      filteredParams: ['userId', 'token'],
+    },
+  },
+});
+```
+
 ## Metrics
 
 ### Per-route first render (`cold_ttr`)
@@ -83,6 +99,7 @@ Emitted at most once per screen instance within a session.
 | ------------- | --------- | ------------------------------------------------------------------------------ |
 | `routeName`   | `string`  | Route pattern, for example `/(tabs)/sessions/[sessionId]`.                     |
 | `url`         | `string`  | Resolved pathname for the navigation.                                          |
+| `urlHidden`   | `boolean` | Present as `true` when `url` is omitted because a parameter was filtered.      |
 | `routeParams` | `object`  | Resolved route params (for example, `{ sessionId: 'abc' }`).                   |
 | `isAppLaunch` | `boolean` | `true` when measured against process start, `false` for subsequent navigation. |
 
@@ -92,11 +109,12 @@ Emitted at most once per screen instance within a session.
 
 **Event params:**
 
-| Param         | Type     | Description                                                  |
-| ------------- | -------- | ------------------------------------------------------------ |
-| `routeName`   | `string` | Route pattern, for example `/(tabs)/sessions/[sessionId]`.   |
-| `url`         | `string` | Resolved pathname for the navigation.                        |
-| `routeParams` | `object` | Resolved route params (for example, `{ sessionId: 'abc' }`). |
+| Param         | Type      | Description                                                               |
+| ------------- | --------- | ------------------------------------------------------------------------- |
+| `routeName`   | `string`  | Route pattern, for example `/(tabs)/sessions/[sessionId]`.                |
+| `url`         | `string`  | Resolved pathname for the navigation.                                     |
+| `urlHidden`   | `boolean` | Present as `true` when `url` is omitted because a parameter was filtered. |
+| `routeParams` | `object`  | Resolved route params (for example, `{ sessionId: 'abc' }`).              |
 
 ### Per-route time to interactive (`tti`)
 
@@ -104,12 +122,13 @@ Emitted at most once per screen instance within a session.
 
 **Event params:**
 
-| Param         | Type     | Description                                                          |
-| ------------- | -------- | -------------------------------------------------------------------- |
-| `routeName`   | `string` | Route pattern, for example `/(tabs)/sessions/[sessionId]`.           |
-| `url`         | `string` | Resolved pathname.                                                   |
-| `routeParams` | `object` | Resolved route params.                                               |
-| `...`         | `any`    | Any custom params passed via `markInteractive({ params: { ... } })`. |
+| Param         | Type      | Description                                                               |
+| ------------- | --------- | ------------------------------------------------------------------------- |
+| `routeName`   | `string`  | Route pattern, for example `/(tabs)/sessions/[sessionId]`.                |
+| `url`         | `string`  | Resolved pathname.                                                        |
+| `urlHidden`   | `boolean` | Present as `true` when `url` is omitted because a parameter was filtered. |
+| `routeParams` | `object`  | Resolved route params.                                                    |
+| `...`         | `any`     | Any custom params passed via `markInteractive({ params: { ... } })`.      |
 
 ## Notes and troubleshooting
 

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -71,6 +71,8 @@ export default function Home() {
 
 ## Filter sensitive URL parameters
 
+> **info** Available in **SDK 57 and later**.
+
 By default, the integration includes the resolved `url` and all serializable route and query parameters in `routeParams`. If your app includes sensitive values in URL parameters, pass their keys to `filteredParams`:
 
 ```tsx src/app/_layout.tsx
@@ -84,6 +86,8 @@ Observe.configure({
   },
 });
 ```
+
+The integration removes filtered keys from `routeParams`, and the event omits `url` and includes `urlHidden: true` instead. `routeName` is not affected because it is a pattern and never contains parameter values.
 
 ## Metrics
 

--- a/docs/pages/eas/observe/integrations/react-navigation.mdx
+++ b/docs/pages/eas/observe/integrations/react-navigation.mdx
@@ -137,6 +137,8 @@ export default function Home() {
 
 ## Filter sensitive route parameters
 
+> **info** Available in **SDK 57 and later**.
+
 By default, the integration includes all serializable focused route parameters in `routeParams`. If your app includes sensitive values in route parameters, pass their keys to `filteredParams`:
 
 ```tsx App.tsx
@@ -150,6 +152,8 @@ Observe.configure({
   },
 });
 ```
+
+The integration removes filtered keys from `routeParams` and includes `urlHidden: true` on the event. `routeName` is not affected because it is built from route names and never contains parameter values.
 
 ## Metrics
 

--- a/docs/pages/eas/observe/integrations/react-navigation.mdx
+++ b/docs/pages/eas/observe/integrations/react-navigation.mdx
@@ -135,6 +135,22 @@ export default function Home() {
 
 </Step>
 
+## Filter sensitive route parameters
+
+By default, the integration includes all serializable focused route parameters in `routeParams`. If your app includes sensitive values in route parameters, pass their keys to `filteredParams`:
+
+```tsx App.tsx
+import { Observe } from 'expo-observe';
+
+Observe.configure({
+  integrations: {
+    'react-navigation': {
+      filteredParams: ['userId', 'token'],
+    },
+  },
+});
+```
+
 ## Metrics
 
 ### Per-screen first render (`cold_ttr`)
@@ -148,6 +164,7 @@ Emitted at most once per screen instance within a session.
 | Param         | Type      | Description                                                                    |
 | ------------- | --------- | ------------------------------------------------------------------------------ |
 | `routeName`   | `string`  | Route-name path (for example, `/Tabs/Sessions`).                               |
+| `urlHidden`   | `boolean` | Present as `true` when a route parameter was filtered.                         |
 | `routeParams` | `object`  | Focused route params (for example, `{ sessionId: 'abc' }`).                    |
 | `isAppLaunch` | `boolean` | `true` when measured against process start, `false` for subsequent navigation. |
 
@@ -157,10 +174,11 @@ Emitted at most once per screen instance within a session.
 
 **Event params:**
 
-| Param         | Type     | Description                                                 |
-| ------------- | -------- | ----------------------------------------------------------- |
-| `routeName`   | `string` | Route-name path (for example, `/Tabs/Sessions`).            |
-| `routeParams` | `object` | Focused route params (for example, `{ sessionId: 'abc' }`). |
+| Param         | Type      | Description                                                 |
+| ------------- | --------- | ----------------------------------------------------------- |
+| `routeName`   | `string`  | Route-name path (for example, `/Tabs/Sessions`).            |
+| `urlHidden`   | `boolean` | Present as `true` when a route parameter was filtered.      |
+| `routeParams` | `object`  | Focused route params (for example, `{ sessionId: 'abc' }`). |
 
 ### Per-screen time to interactive (`tti`)
 
@@ -168,11 +186,12 @@ Emitted at most once per screen instance within a session.
 
 **Event params:**
 
-| Param         | Type     | Description                                              |
-| ------------- | -------- | -------------------------------------------------------- |
-| `routeName`   | `string` | Route-name path (for example, `/Tabs/Sessions`).         |
-| `routeParams` | `object` | Focused route params.                                    |
-| `...`         | `any`    | Any custom params passed via `markInteractive({ ... })`. |
+| Param         | Type      | Description                                              |
+| ------------- | --------- | -------------------------------------------------------- |
+| `routeName`   | `string`  | Route-name path (for example, `/Tabs/Sessions`).         |
+| `urlHidden`   | `boolean` | Present as `true` when a route parameter was filtered.   |
+| `routeParams` | `object`  | Focused route params.                                    |
+| `...`         | `any`     | Any custom params passed via `markInteractive({ ... })`. |
 
 ## Notes and troubleshooting
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
