### PR TITLE
[expo-web-browser] web browser add handling of  an error on auth-session start

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `openAuthSessionAsync` hanging forever when the authentication session fails to start. ([#47653](https://github.com/expo/expo/issues/47653))
+- [iOS] Fixed `openAuthSessionAsync` hanging forever when the authentication session fails to start. ([#47653](https://github.com/expo/expo/issues/47653)) ([#47896](https://github.com/expo/expo/pull/47896) by [@HubertBer](https://github.com/HubertBer))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `openAuthSessionAsync` hanging forever when the authentication session fails to start. ([#47653](https://github.com/expo/expo/issues/47653))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-21

--- a/packages/expo-web-browser/ios/WebAuthSession.swift
+++ b/packages/expo-web-browser/ios/WebAuthSession.swift
@@ -61,7 +61,10 @@ final internal class WebAuthSession {
 
   func open(_ promise: Promise) {
     authSession?.presentationContextProvider = presentationContextProvider
-    authSession?.start()
+    guard authSession?.start() == true else {
+      promise.reject(WebAuthSessionFailedToStartException())
+      return
+    }
     self.promise = promise
   }
 

--- a/packages/expo-web-browser/ios/WebBrowserExceptions.swift
+++ b/packages/expo-web-browser/ios/WebBrowserExceptions.swift
@@ -20,3 +20,9 @@ final class WebBrowserNotOpenException: Exception {
   }
 }
 
+final class WebAuthSessionFailedToStartException: Exception {
+  override var reason: String {
+    "The authentication session could not be started."
+  }
+}
+


### PR DESCRIPTION
# Why
In #47653 a problem with auth-session start was encountered, which was not handled and led to a promise that doesn't resolve and doesn't reject.

# How
Added check if `authSession?.start()` was true. Reject if not.

# Test Plan
- [x] Checked for regression in bare-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
