### PR TITLE
Rename download completion state

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/updates/UpdatesStateEvent.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/updates/UpdatesStateEvent.kt
@@ -13,7 +13,7 @@ data class UpdatesStateEvent(
     CheckCompleteWithRollback("checkCompleteWithRollback"),
     CheckError("checkError"),
     Download("download"),
-    DownloadComplete("downloadComplete"),
+    DownloadCompleteUnavailable("downloadCompleteUnavailable"),
     DownloadCompleteWithUpdate("downloadCompleteWithUpdate"),
     DownloadCompleteWithRollback("downloadCompleteWithRollback"),
     DownloadError("downloadError"),

--- a/packages/expo-app-metrics/ios/Updates/UpdatesStateEvent.swift
+++ b/packages/expo-app-metrics/ios/Updates/UpdatesStateEvent.swift
@@ -9,7 +9,7 @@ struct UpdatesStateEvent {
     case checkCompleteWithRollback = "checkCompleteWithRollback"
     case checkError = "checkError"
     case download = "download"
-    case downloadComplete = "downloadComplete"
+    case downloadCompleteUnavailable = "downloadCompleteUnavailable"
     case downloadCompleteWithUpdate = "downloadCompleteWithUpdate"
     case downloadCompleteWithRollback = "downloadCompleteWithRollback"
     case downloadError = "downloadError"

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Rename `downloadComplete` to `downloadCompleteUnavailable` in native update state events. ([#47899](https://github.com/expo/expo/pull/47899) by [@kudo](https://github.com/kudo))
 - [Android] Use `OkHttpClientProvider` instead of raw `OkHttpClient` in `FileDownloader` so React Native's shared client and its interceptors are applied. ([#46926](https://github.com/expo/expo/pull/46926) by [@cortinico](https://github.com/cortinico))
 - [Android] Log purge completion errors via `android.util.Log.e` directly instead of `logger.error`, so the failure path doesn't re-enter the `PersistentFileLog` dispatch queue from inside one of its own tasks. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -167,7 +167,7 @@ class UpdatesStateMachineInstrumentationTest {
   }
 
   @Test
-  fun test_handleDownloadAndDownloadComplete() {
+  fun test_handleCompletedDownloadWithUpdate() {
     val testStateChangeEventManager = TestStateChangeEventManager()
     val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
@@ -211,7 +211,7 @@ class UpdatesStateMachineInstrumentationTest {
     Assert.assertEquals(UpdatesStateValue.Downloading, machine.getState())
     Assert.assertEquals(0.5, testStateChangeEventManager.lastContext!!.downloadProgress, 0.001)
 
-    machine.processEventTest(UpdatesStateEvent.DownloadComplete())
+    machine.processEventTest(UpdatesStateEvent.DownloadCompleteUnavailable())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
     Assert.assertEquals(1.0, testStateChangeEventManager.lastContext!!.downloadProgress, 0.001)
   }
@@ -284,7 +284,7 @@ class UpdatesStateMachineInstrumentationTest {
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
 
     Assert.assertThrows(AssertionError::class.java) {
-      machine.processEventTest(UpdatesStateEvent.DownloadComplete())
+      machine.processEventTest(UpdatesStateEvent.DownloadCompleteUnavailable())
     }
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -116,7 +116,7 @@ class FetchUpdateProcedure(
       callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
     } else {
       if (availableUpdate == null) {
-        procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+        procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteUnavailable())
         callback(IUpdatesController.FetchUpdateResult.Failure())
       } else {
         procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -194,7 +194,7 @@ class StartupProcedure(
             logger.info("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
             // TODO: handle rollbacks properly, but this works for now
             if (procedureContext.getCurrentState() == UpdatesStateValue.Downloading) {
-              procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+              procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteUnavailable())
             }
           }
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
@@ -22,11 +22,10 @@ sealed class UpdatesStateEvent(val type: UpdatesStateEventType) {
   class Download : UpdatesStateEvent(UpdatesStateEventType.Download)
   class DownloadProgress(val progress: Double) : UpdatesStateEvent(UpdatesStateEventType.DownloadProgress)
 
-  // download finished with no update available, so nothing is pending
-  class DownloadComplete : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+  class DownloadCompleteUnavailable : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
 
-  class DownloadCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
-  class DownloadCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+  class DownloadCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
+  class DownloadCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
   class DownloadError(private val errorMessage: String) : UpdatesStateEvent(UpdatesStateEventType.DownloadError) {
     val error: UpdatesStateError
       get() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
@@ -21,9 +21,7 @@ sealed class UpdatesStateEvent(val type: UpdatesStateEventType) {
   }
   class Download : UpdatesStateEvent(UpdatesStateEventType.Download)
   class DownloadProgress(val progress: Double) : UpdatesStateEvent(UpdatesStateEventType.DownloadProgress)
-
   class DownloadCompleteUnavailable : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
-
   class DownloadCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
   class DownloadCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.DownloadCompleteUnavailable)
   class DownloadError(private val errorMessage: String) : UpdatesStateEvent(UpdatesStateEventType.DownloadError) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEventType.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEventType.kt
@@ -13,7 +13,7 @@ enum class UpdatesStateEventType(val type: String) {
   CheckError("checkError"),
   Download("download"),
   DownloadProgress("downloadProgress"),
-  DownloadComplete("downloadComplete"),
+  DownloadCompleteUnavailable("downloadCompleteUnavailable"),
   DownloadError("downloadError"),
   Restart("restart")
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -79,7 +79,7 @@ class UpdatesStateMachine(
       is UpdatesStateEvent.Check -> mapOf("type" to event.type.type)
       is UpdatesStateEvent.CheckCompleteUnavailable -> mapOf("type" to event.type.type)
       is UpdatesStateEvent.Download -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.DownloadComplete -> mapOf("type" to event.type.type)
+      is UpdatesStateEvent.DownloadCompleteUnavailable -> mapOf("type" to event.type.type)
       is UpdatesStateEvent.DownloadCompleteWithRollback -> mapOf("type" to event.type.type)
       is UpdatesStateEvent.Restart -> mapOf("type" to event.type.type)
       is UpdatesStateEvent.StartStartup -> mapOf("type" to event.type.type)
@@ -137,7 +137,7 @@ class UpdatesStateMachine(
     val updatesStateAllowedEvents: Map<UpdatesStateValue, Set<UpdatesStateEventType>> = mapOf(
       UpdatesStateValue.Idle to setOf(UpdatesStateEventType.StartStartup, UpdatesStateEventType.EndStartup, UpdatesStateEventType.Check, UpdatesStateEventType.Download, UpdatesStateEventType.Restart),
       UpdatesStateValue.Checking to setOf(UpdatesStateEventType.CheckCompleteAvailable, UpdatesStateEventType.CheckCompleteUnavailable, UpdatesStateEventType.CheckError),
-      UpdatesStateValue.Downloading to setOf(UpdatesStateEventType.DownloadComplete, UpdatesStateEventType.DownloadError, UpdatesStateEventType.DownloadProgress),
+      UpdatesStateValue.Downloading to setOf(UpdatesStateEventType.DownloadCompleteUnavailable, UpdatesStateEventType.DownloadError, UpdatesStateEventType.DownloadProgress),
       UpdatesStateValue.Restarting to setOf()
     )
 
@@ -154,7 +154,7 @@ class UpdatesStateMachine(
       UpdatesStateEventType.CheckError to UpdatesStateValue.Idle,
       UpdatesStateEventType.Download to UpdatesStateValue.Downloading,
       UpdatesStateEventType.DownloadProgress to UpdatesStateValue.Downloading,
-      UpdatesStateEventType.DownloadComplete to UpdatesStateValue.Idle,
+      UpdatesStateEventType.DownloadCompleteUnavailable to UpdatesStateValue.Idle,
       UpdatesStateEventType.DownloadError to UpdatesStateValue.Idle,
       UpdatesStateEventType.Restart to UpdatesStateValue.Restarting
     )
@@ -212,7 +212,7 @@ class UpdatesStateMachine(
         is UpdatesStateEvent.DownloadProgress -> context.copyAndIncrementSequenceNumber(
           downloadProgress = event.progress
         )
-        is UpdatesStateEvent.DownloadComplete -> context.copyAndIncrementSequenceNumber(
+        is UpdatesStateEvent.DownloadCompleteUnavailable -> context.copyAndIncrementSequenceNumber(
           isDownloading = false,
           downloadError = null,
           isUpdatePending = false,

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -130,7 +130,7 @@ final class FetchUpdateProcedure: StateMachineProcedure {
         }
 
         self.successBlock(FetchUpdateResult.failure)
-        procedureContext.processStateEvent(.downloadComplete)
+        procedureContext.processStateEvent(.downloadCompleteUnavailable)
         procedureContext.onComplete()
         return
       }

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -230,7 +230,7 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
       )
       // TODO: handle rollbacks properly, but this works for now
       if self.procedureContext.getCurrentState() == .downloading {
-        self.procedureContext.processStateEvent(.downloadComplete)
+        self.procedureContext.processStateEvent(.downloadCompleteUnavailable)
       }
       // Otherwise, we don't need to call the state machine here, it already transitioned to .checkCompleteUnavailable
     }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -33,9 +33,7 @@ internal enum UpdatesStateEvent {
   case checkCompleteWithRollback(rollbackCommitTime: Date)
   case checkError(errorMessage: String)
   case download
-
   case downloadCompleteUnavailable
-
   case downloadCompleteWithUpdate(manifest: [String: Any])
   case downloadCompleteWithRollback
   case downloadError(errorMessage: String)

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -34,8 +34,7 @@ internal enum UpdatesStateEvent {
   case checkError(errorMessage: String)
   case download
 
-  // download finished with no update available, so nothing is pending
-  case downloadComplete
+  case downloadCompleteUnavailable
 
   case downloadCompleteWithUpdate(manifest: [String: Any])
   case downloadCompleteWithRollback
@@ -52,7 +51,7 @@ internal enum UpdatesStateEvent {
     case checkError
     case download
     case downloadProgress
-    case downloadComplete
+    case downloadCompleteUnavailable
     case downloadError
     case restart
   }
@@ -77,12 +76,12 @@ internal enum UpdatesStateEvent {
       return .download
     case .downloadProgress:
       return .downloadProgress
-    case .downloadComplete:
-      return .downloadComplete
+    case .downloadCompleteUnavailable:
+      return .downloadCompleteUnavailable
     case .downloadCompleteWithUpdate:
-      return .downloadComplete
+      return .downloadCompleteUnavailable
     case .downloadCompleteWithRollback:
-      return .downloadComplete
+      return .downloadCompleteUnavailable
     case .downloadError:
       return .downloadError
     case .restart:
@@ -110,7 +109,7 @@ internal enum UpdatesStateEvent {
       fallthrough
     case .download:
       fallthrough
-    case .downloadComplete:
+    case .downloadCompleteUnavailable:
       fallthrough
     case .downloadCompleteWithRollback:
       fallthrough
@@ -496,7 +495,7 @@ internal class UpdatesStateMachine {
       return context.copyAndIncrementSequenceNumber {
         $0.downloadProgress = progress
       }
-    case .downloadComplete:
+    case .downloadCompleteUnavailable:
       return context.copyAndIncrementSequenceNumber {
         $0.isDownloading = false
         $0.downloadError = nil
@@ -556,7 +555,7 @@ internal class UpdatesStateMachine {
   private static let updatesStateAllowedEvents: [UpdatesStateValue: Set<UpdatesStateEvent.InternalType>] = [
     .idle: [.startStartup, .endStartup, .check, .download, .restart],
     .checking: [.checkCompleteAvailable, .checkCompleteUnavailable, .checkError],
-    .downloading: [.downloadComplete, .downloadError, .downloadProgress],
+    .downloading: [.downloadCompleteUnavailable, .downloadError, .downloadProgress],
     .restarting: []
   ]
 
@@ -573,7 +572,7 @@ internal class UpdatesStateMachine {
     .checkError: .idle,
     .download: .downloading,
     .downloadProgress: .downloading,
-    .downloadComplete: .idle,
+    .downloadCompleteUnavailable: .idle,
     .downloadError: .idle,
     .restart: .restarting
   ]

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -106,7 +106,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.context.isUpdatePending) == false
       }
 
-      it("should handle download and downloadComplete") {
+      it("should handle a completed download with an update") {
         let testStateChangeEventManager = TestStateChangeEventManager()
         let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
@@ -136,7 +136,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.getStateForTesting()) == .downloading
         expect(testStateChangeEventManager.lastContext?.downloadProgress) == 0.5
 
-        machine.processEventForTesting(.downloadComplete)
+        machine.processEventForTesting(.downloadCompleteUnavailable)
         expect(machine.getStateForTesting()) == .idle
         expect(testStateChangeEventManager.lastContext?.downloadProgress) == 1
       }
@@ -194,7 +194,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.processEventForTesting(.download)).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
 
-        expect(machine.processEventForTesting(.downloadComplete)).to(throwAssertion())
+        expect(machine.processEventForTesting(.downloadCompleteUnavailable)).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
       }
 


### PR DESCRIPTION
# Why

`downloadComplete` is used when no update is available, so its name was unclear.

# How

Renamed it to `downloadCompleteUnavailable` in the native update state machines and app-metrics parsers. Updated tests and the changelog.

# Test Plan

- Ran Swift syntax parsing for the changed Swift files.
- Confirmed the old name is absent from native and TypeScript sources.
- Android Gradle compilation did not start locally because the app could not resolve its React Native Gradle plugin.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)