### PR TITLE
[ios][audio] Add native tests

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -322,6 +322,8 @@ PODS:
     - ExpoModulesCore
   - ExpoAudio (56.0.11):
     - ExpoModulesCore
+  - ExpoAudio/Tests (56.0.11):
+    - ExpoModulesCore
   - ExpoBackgroundFetch (56.0.15):
     - ExpoModulesCore
   - ExpoBackgroundTask (56.0.15):
@@ -3353,6 +3355,7 @@ DEPENDENCIES:
   - ExpoAppMetrics/Tests (from `../../../packages/expo-app-metrics/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoAudio (from `../../../packages/expo-audio/ios`)
+  - ExpoAudio/Tests (from `../../../packages/expo-audio/ios`)
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
   - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
   - ExpoBackgroundTask/Tests (from `../../../packages/expo-background-task/ios`)
@@ -4033,7 +4036,7 @@ SPEC CHECKSUMS:
   ExpoAppleAuthentication: 3dd8ddd3016396a8171f06af8cc5e3e008e8eaf4
   ExpoAppMetrics: 5cdb64cf96504ddef0aa2b87e0be3c337416c75d
   ExpoAsset: c2e7b5ba1fe75be683282d6264e38fd7cd8defbb
-  ExpoAudio: 7774082d316ceecc2b26efeb10480bea2fa4d67e
+  ExpoAudio: 828b0248bfa4597468f69891aee39d444539d8bb
   ExpoBackgroundFetch: eff0b77ce55180ad479c5091616d6d2c3bf5ca58
   ExpoBackgroundTask: d2ab6bf83921dc84ad3995fed08d56491ca8cba8
   ExpoBattery: a42e918404ceee07a957db4312918ec0c52bc0d6

--- a/packages/expo-audio/ios/AudioStreamFileWriter.swift
+++ b/packages/expo-audio/ios/AudioStreamFileWriter.swift
@@ -77,6 +77,12 @@ internal final class AudioStreamFileWriter {
   // MARK: - WAV Header
 
   private func writeWavHeader(dataSize: UInt32) throws {
+    let header = Self.makeWavHeader(dataSize: dataSize, sampleRate: sampleRate, channels: channels, encoding: encoding)
+    try fileHandle.seek(toOffset: 0)
+    try fileHandle.write(contentsOf: header)
+  }
+
+  static func makeWavHeader(dataSize: UInt32, sampleRate: Double, channels: Int, encoding: AudioStreamEncoding) -> Data {
     let bitsPerSample: UInt16 = encoding == .int16 ? 16 : 32
     let audioFormat: UInt16 = encoding == .int16 ? 1 : 3  // 1 = PCM, 3 = IEEE float
     let sr = UInt32(sampleRate)
@@ -103,8 +109,7 @@ internal final class AudioStreamFileWriter {
     header.append(contentsOf: [0x64, 0x61, 0x74, 0x61])  // "data"
     header.appendLE(dataSize)
 
-    try fileHandle.seek(toOffset: 0)
-    try fileHandle.write(contentsOf: header)
+    return header
   }
 
   private func updateWavHeader() throws {

--- a/packages/expo-audio/ios/ExpoAudio.podspec
+++ b/packages/expo-audio/ios/ExpoAudio.podspec
@@ -26,7 +26,17 @@ Pod::Spec.new do |s|
   }
   
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = "Tests/**"
   s.tvos.exclude_files = "**/AudioRecorder.swift",
                          "**/AudioRecordingRequester.swift",
                          "**/RecordingDelegate.swift"
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.requires_app_host = false
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
+  end
 end

--- a/packages/expo-audio/ios/Tests/AudioRecordsTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioRecordsTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import AVFoundation
+
+@testable import ExpoAudio
+
+@Suite("AudioRecords")
+struct AudioRecordsTests {
+  @Test(arguments: [
+    (BitRateStrategy.constant, AVAudioBitRateStrategy_Constant),
+    (.longTermAverage, AVAudioBitRateStrategy_LongTermAverage),
+    (.variableConstrained, AVAudioBitRateStrategy_VariableConstrained),
+    (.variable, AVAudioBitRateStrategy_Variable),
+  ] as [(BitRateStrategy, String)])
+  func `maps bit rate strategy to the AVFoundation constant`(strategy: BitRateStrategy, expected: String) {
+    #expect(strategy.toAVBitRateStrategy() == expected)
+  }
+
+  @Test(arguments: [
+    (PitchCorrectionQuality.low, AVAudioTimePitchAlgorithm.varispeed),
+    (.medium, .timeDomain),
+    (.high, .spectral),
+  ] as [(PitchCorrectionQuality, AVAudioTimePitchAlgorithm)])
+  func `maps pitch correction quality to the pitch algorithm`(
+    quality: PitchCorrectionQuality,
+    expected: AVAudioTimePitchAlgorithm
+  ) {
+    #expect(quality.toPitchAlgorithm() == expected)
+  }
+
+  @Test(arguments: [
+    (AudioStreamFileFormat.wav, "wav"),
+    (.pcm, "pcm"),
+  ] as [(AudioStreamFileFormat, String)])
+  func `exposes the file extension matching the format`(format: AudioStreamFileFormat, expected: String) {
+    #expect(format.fileExtension == expected)
+  }
+}

--- a/packages/expo-audio/ios/Tests/AudioStreamFileWriterTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioStreamFileWriterTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+
+@testable import ExpoAudio
+
+@Suite("AudioStreamFileWriter.makeWavHeader")
+struct AudioStreamFileWriterTests {
+  @Test
+  func `produces a 44 byte canonical header`() {
+    let header = AudioStreamFileWriter.makeWavHeader(dataSize: 0, sampleRate: 44100, channels: 2, encoding: .int16)
+    #expect(header.count == 44)
+  }
+
+  @Test
+  func `lays out the RIFF, WAVE, fmt and data chunk tags`() {
+    let header = AudioStreamFileWriter.makeWavHeader(dataSize: 0, sampleRate: 44100, channels: 2, encoding: .int16)
+
+    #expect(tag(header, 0) == "RIFF")
+    #expect(tag(header, 8) == "WAVE")
+    #expect(tag(header, 12) == "fmt ")
+    #expect(tag(header, 36) == "data")
+    #expect(u32(header, 16) == 16)  // fmt chunk size
+  }
+
+  @Test
+  func `encodes 16-bit integer PCM format fields`() {
+    let header = AudioStreamFileWriter.makeWavHeader(dataSize: 0, sampleRate: 44100, channels: 2, encoding: .int16)
+
+    #expect(u16(header, 20) == 1)       // audioFormat: 1 = PCM
+    #expect(u16(header, 22) == 2)       // channels
+    #expect(u32(header, 24) == 44100)   // sample rate
+    #expect(u32(header, 28) == 176400)  // byteRate = 44100 * 2ch * 2 bytes
+    #expect(u16(header, 32) == 4)       // blockAlign = 2ch * 2 bytes
+    #expect(u16(header, 34) == 16)      // bitsPerSample
+  }
+
+  @Test
+  func `encodes 32-bit float format fields`() {
+    let header = AudioStreamFileWriter.makeWavHeader(dataSize: 0, sampleRate: 48000, channels: 1, encoding: .float32)
+
+    #expect(u16(header, 20) == 3)       // audioFormat: 3 = IEEE float
+    #expect(u16(header, 22) == 1)       // channels
+    #expect(u32(header, 24) == 48000)   // sample rate
+    #expect(u32(header, 28) == 192000)  // byteRate = 48000 * 1ch * 4 bytes
+    #expect(u16(header, 32) == 4)       // blockAlign = 1ch * 4 bytes
+    #expect(u16(header, 34) == 32)      // bitsPerSample
+  }
+
+  @Test
+  func `writes the data size and a matching riff size`() {
+    let header = AudioStreamFileWriter.makeWavHeader(dataSize: 1000, sampleRate: 44100, channels: 2, encoding: .int16)
+
+    #expect(u32(header, 40) == 1000)  // data chunk size
+    #expect(u32(header, 4) == 1036)   // riff size = 36 + dataSize
+  }
+
+  private func tag(_ data: Data, _ offset: Int) -> String {
+    String(decoding: data[offset..<(offset + 4)], as: UTF8.self)
+  }
+
+  private func u16(_ data: Data, _ offset: Int) -> UInt16 {
+    UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+  }
+
+  private func u32(_ data: Data, _ offset: Int) -> UInt32 {
+    UInt32(data[offset])
+      | (UInt32(data[offset + 1]) << 8)
+      | (UInt32(data[offset + 2]) << 16)
+      | (UInt32(data[offset + 3]) << 24)
+  }
+}

--- a/packages/expo-audio/ios/Tests/AudioUtilsTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioUtilsTests.swift
@@ -1,0 +1,150 @@
+import Testing
+import AVFoundation
+import AudioToolbox
+
+@testable import ExpoAudio
+
+@Suite("AudioUtils.createRecordingOptions")
+struct CreateRecordingOptionsTests {
+  private func makeOptions() -> RecordingOptions {
+    let options = RecordingOptions()
+    options.sampleRate = 44100
+    options.numberOfChannels = 2
+    options.bitRate = 128000
+    options.audioQuality = 96
+    return options
+  }
+
+  @Test
+  func `carries sample rate, channel count and bit rate into the settings`() {
+    let settings = AudioUtils.createRecordingOptions(makeOptions())
+
+    #expect(settings[AVSampleRateKey] as? Double == 44100)
+    #expect(settings[AVNumberOfChannelsKey] as? Double == 2)
+    #expect(settings[AVEncoderBitRateKey] as? Double == 128000)
+  }
+
+  @Test(arguments: [BitRateStrategy.constant, .longTermAverage])
+  func `uses the constant quality key for non-variable strategies`(strategy: BitRateStrategy) {
+    let options = makeOptions()
+    options.bitRateStrategy = strategy
+
+    let settings = AudioUtils.createRecordingOptions(options)
+
+    #expect(settings[AVEncoderAudioQualityKey] as? Int == 96)
+    #expect(settings[AVEncoderAudioQualityForVBRKey] == nil)
+    #expect(settings[AVEncoderBitRateStrategyKey] as? String == strategy.toAVBitRateStrategy())
+  }
+
+  @Test(arguments: [BitRateStrategy.variable, .variableConstrained])
+  func `uses the VBR quality key for variable strategies`(strategy: BitRateStrategy) {
+    let options = makeOptions()
+    options.bitRateStrategy = strategy
+
+    let settings = AudioUtils.createRecordingOptions(options)
+
+    #expect(settings[AVEncoderAudioQualityForVBRKey] as? Int == 96)
+    #expect(settings[AVEncoderAudioQualityKey] == nil)
+  }
+
+  @Test
+  func `omits optional PCM keys when the options leave them unset`() {
+    let settings = AudioUtils.createRecordingOptions(makeOptions())
+
+    #expect(settings[AVEncoderBitDepthHintKey] == nil)
+    #expect(settings[AVLinearPCMBitDepthKey] == nil)
+    #expect(settings[AVLinearPCMIsBigEndianKey] == nil)
+    #expect(settings[AVLinearPCMIsFloatKey] == nil)
+  }
+
+  @Test
+  func `includes optional PCM keys when the options provide them`() {
+    let options = makeOptions()
+    options.bitDepthHint = 24
+    options.linearPCMBitDepth = 16
+    options.linearPCMIsBigEndian = false
+    options.linearPCMIsFloat = true
+
+    let settings = AudioUtils.createRecordingOptions(options)
+
+    #expect(settings[AVEncoderBitDepthHintKey] as? Double == 24)
+    #expect(settings[AVLinearPCMBitDepthKey] as? Double == 16)
+    #expect(settings[AVLinearPCMIsBigEndianKey] as? Bool == false)
+    #expect(settings[AVLinearPCMIsFloatKey] as? Bool == true)
+  }
+
+  @Test(arguments: [
+    ("lpcm", kAudioFormatLinearPCM),
+    ("aac ", kAudioFormatMPEG4AAC),
+  ] as [(String, AudioFormatID)])
+  func `packs the output format string into a CoreAudio format id`(format: String, expected: AudioFormatID) {
+    let options = makeOptions()
+    options.outputFormat = format
+
+    let settings = AudioUtils.createRecordingOptions(options)
+
+    #expect(settings[AVFormatIDKey] as? AudioFormatID == expected)
+  }
+}
+
+@Suite("AudioUtils.validateAudioMode")
+struct ValidateAudioModeTests {
+  @Test
+  func `accepts a mode that plays in silent mode`() throws {
+    let mode = AudioMode()
+    mode.playsInSilentMode = true
+    mode.interruptionMode = .duckOthers
+    mode.allowsRecording = true
+    mode.shouldPlayInBackground = true
+
+    #expect(throws: Never.self) {
+      try AudioUtils.validateAudioMode(mode: mode)
+    }
+  }
+
+  @Test
+  func `rejects ducking others while not playing in silent mode`() {
+    let mode = AudioMode()
+    mode.playsInSilentMode = false
+    mode.interruptionMode = .duckOthers
+
+    #expect(throws: InvalidAudioModeException.self) {
+      try AudioUtils.validateAudioMode(mode: mode)
+    }
+  }
+
+  @Test
+  func `rejects recording while not playing in silent mode`() {
+    let mode = AudioMode()
+    mode.playsInSilentMode = false
+    mode.allowsRecording = true
+
+    #expect(throws: InvalidAudioModeException.self) {
+      try AudioUtils.validateAudioMode(mode: mode)
+    }
+  }
+
+  @Test
+  func `rejects background playback while not playing in silent mode`() {
+    let mode = AudioMode()
+    mode.playsInSilentMode = false
+    mode.shouldPlayInBackground = true
+
+    #expect(throws: InvalidAudioModeException.self) {
+      try AudioUtils.validateAudioMode(mode: mode)
+    }
+  }
+}
+
+@Suite("AudioUtils.getFileExtension")
+struct GetFileExtensionTests {
+  @Test
+  func `resolves a known audio mime type to its extension`() {
+    #expect(AudioUtils.getFileExtension(for: "audio/mpeg") == "mp3")
+  }
+
+  @Test
+  func `falls back to dat for an unrecognized mime type`() {
+    #expect(AudioUtils.getFileExtension(for: "not-a-real/mime-type") == "dat")
+  }
+}

--- a/packages/expo-audio/ios/Tests/StringConversionsTests.swift
+++ b/packages/expo-audio/ios/Tests/StringConversionsTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import AVFoundation
+
+@testable import ExpoAudio
+
+@Suite("StringConversions")
+struct StringConversionsTests {
+  @Test(arguments: [
+    (AVPlayer.Status.readyToPlay, "readyToPlay"),
+    (.failed, "failed"),
+    (.unknown, "unknown"),
+  ] as [(AVPlayer.Status, String)])
+  func `maps player status to string`(status: AVPlayer.Status, expected: String) {
+    #expect(statusToString(status: status) == expected)
+  }
+
+  @Test(arguments: [
+    (AVPlayer.TimeControlStatus.playing, "playing"),
+    (.paused, "paused"),
+    (.waitingToPlayAtSpecifiedRate, "waitingToPlayAtSpecifiedRate"),
+  ] as [(AVPlayer.TimeControlStatus, String)])
+  func `maps time control status to string`(status: AVPlayer.TimeControlStatus, expected: String) {
+    #expect(timeControlStatusString(status: status) == expected)
+  }
+
+  @Test(arguments: [
+    (AVPlayer.WaitingReason.evaluatingBufferingRate, "evaluatingBufferingRate"),
+    (.noItemToPlay, "noItemToPlay"),
+    (.toMinimizeStalls, "toMinimizeStalls"),
+  ] as [(AVPlayer.WaitingReason, String)])
+  func `maps waiting reason to string`(reason: AVPlayer.WaitingReason, expected: String) {
+    #expect(reasonForWaitingToPlayString(status: reason) == expected)
+  }
+
+  @Test
+  func `maps a nil waiting reason to unknown`() {
+    #expect(reasonForWaitingToPlayString(status: nil) == "unknown")
+  }
+}


### PR DESCRIPTION
# Why

The expo-audio iOS module had no native unit test coverage. Several pieces of pure logic in it are the kind that regress silently without ever
crashing. The recording-options mapping, the audio-mode validation rules, the player-state string conversions, and the hand-built WAV file header can all silently regress

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- createRecordingOptions — sample rate, channels and bit rate passthrough, the CBR vs VBR quality-key branch, conditional inclusion of the optional linear-PCM keys, and the FourCC output-format id checked against CoreAudio's own constants.
- validateAudioMode — the happy path plus each of the three illegal iOS mode combinations.
- The player status, time-control-status and waiting-reason string maps, and the BitRateStrategy, PitchCorrectionQuality and
AudioStreamFileFormat enum tables.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tests are passing