### PR TITLE
[media-library] Add Album.getAlbumsMetadata() and album.getAssetCount()

### DIFF
--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -271,6 +271,39 @@ export async function test(t: any) {
     });
   });
 
+  t.describe('Album getAllMetadata', () => {
+    t.it('includes metadata for a newly created album', async () => {
+      // given
+      const albumName = createAlbumName('getAllMetadata includes new album');
+      const album = await Album.create(albumName, [jpgFileLocalUri], true);
+      albumsContainer.push(album);
+
+      // when
+      const metadata = await Album.getAllMetadata();
+
+      // then
+      const entry = metadata.find((m) => m.id === album.id);
+      t.expect(entry).toBeDefined();
+      t.expect(entry?.title).toBe(albumName);
+      t.expect(entry?.type).toBe(Platform.OS === 'ios' ? AlbumType.ALBUM : null);
+    });
+  });
+
+  t.describe('Album getAssetCount', () => {
+    t.it('returns the number of assets in the album', async () => {
+      // given
+      const albumName = createAlbumName('getAssetCount');
+      const album = await Album.create(albumName, [jpgFileLocalUri, pngFileLocalUri], true);
+      albumsContainer.push(album);
+
+      // when
+      const count = await album.getAssetCount();
+
+      // then
+      t.expect(count).toBe(2);
+    });
+  });
+
   if (Platform.OS === 'ios') {
     t.describe('Album getType', () => {
       t.it('returns ALBUM for a user album', async () => {

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add filtering by `isFavorite` to `Query` ([#45769](https://github.com/expo/expo/pull/45769) by [@Wenszel](https://github.com/Wenszel))
 - Add `Query.exeForMetadata()` for cheap bulk fetch ([#46485](https://github.com/expo/expo/pull/46485) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Add `Album.getSmartAlbums()` and `Album.getType()`. ([#47822](https://github.com/expo/expo/pull/47822) by [@Wenszel](https://github.com/Wenszel))
+- Add `album.getAlbumsMetadata()` for cheap bulk album listing and `album.getAssetCount()`. ([#47836](https://github.com/expo/expo/pull/47836) by [@Wenszel](https://github.com/Wenszel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
@@ -209,6 +209,10 @@ class MediaLibraryNextModule : Module() {
         self.getAssets()
       }
 
+      AsyncFunction("getAssetCount") Coroutine { self: Album ->
+        self.getAssetCount()
+      }
+
       AsyncFunction("add") Coroutine { self: Album, assets: List<Asset> ->
         self.add(assets)
       }
@@ -223,6 +227,10 @@ class MediaLibraryNextModule : Module() {
 
       StaticAsyncFunction("getAll") Coroutine { ->
         albumQuery.getAllAlbums()
+      }
+
+      StaticAsyncFunction("getAlbumsMetadata") Coroutine { ->
+        albumQuery.getAlbumsMetadata()
       }
 
       StaticAsyncFunction("delete") Coroutine { albums: List<Album>, deleteAssets: Boolean? ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AlbumExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AlbumExtensions.kt
@@ -5,8 +5,10 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
 import expo.modules.medialibrary.next.extensions.asIterable
+import expo.modules.medialibrary.next.extensions.asSequence
 import expo.modules.medialibrary.next.extensions.getNullableString
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
+import expo.modules.medialibrary.next.records.AlbumMetadata
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -71,6 +73,39 @@ suspend fun ContentResolver.queryAllAlbumIds(): List<String> =
         .toSet()
         .toList()
     } ?: emptyList()
+  }
+
+suspend fun ContentResolver.queryAlbumsMetadata(): List<AlbumMetadata> =
+  withContext(Dispatchers.IO) {
+    val projection = arrayOf(
+      MediaStore.Files.FileColumns.BUCKET_ID,
+      MediaStore.MediaColumns.BUCKET_DISPLAY_NAME
+    )
+
+    safeQuery(EXTERNAL_CONTENT_URI, projection)?.use { cursor ->
+      ensureActive()
+      val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns.BUCKET_ID)
+      val titleColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.BUCKET_DISPLAY_NAME)
+      cursor.asSequence()
+        .mapNotNull { row ->
+          val id = row.getNullableString(idColumn)
+            ?: return@mapNotNull null // in case of malformed row, skip it instead of throwing
+          val title = row.getNullableString(titleColumn).orEmpty()
+          AlbumMetadata(id = id, title = title)
+        }
+        .toList()
+    } ?: emptyList()
+  }
+
+suspend fun ContentResolver.queryAlbumAssetsCount(bucketId: String): Int =
+  withContext(Dispatchers.IO) {
+    val projection = arrayOf(MediaStore.Files.FileColumns._ID)
+    val selection = "${MediaStore.Files.FileColumns.BUCKET_ID} = ?"
+
+    safeQuery(EXTERNAL_CONTENT_URI, projection, selection, arrayOf(bucketId))?.use { cursor ->
+      ensureActive()
+      cursor.count
+    } ?: 0
   }
 
 suspend fun ContentResolver.queryAlbumAssetsContentUris(bucketId: String): List<Uri> =

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/Album.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/Album.kt
@@ -8,6 +8,7 @@ import expo.modules.medialibrary.next.exceptions.AlbumPropertyNotFoundException
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
 import expo.modules.medialibrary.next.extensions.getOrThrow
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumAssetsContentUris
+import expo.modules.medialibrary.next.extensions.resolver.queryAlbumAssetsCount
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumFilepath
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumRelativePath
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumTitle
@@ -61,6 +62,9 @@ class Album(
     contentResolver
       .queryAlbumAssetsContentUris(id)
       .map { assetFactory.create(it) }
+
+  suspend fun getAssetCount(): Int =
+    contentResolver.queryAlbumAssetsCount(id)
 
   suspend fun delete() =
     assetDeleter.delete(

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/AlbumQuery.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/AlbumQuery.kt
@@ -5,7 +5,9 @@ import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedExcep
 import expo.modules.medialibrary.next.extensions.getOrThrow
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumId
 import expo.modules.medialibrary.next.extensions.resolver.queryAllAlbumIds
+import expo.modules.medialibrary.next.extensions.resolver.queryAlbumsMetadata
 import expo.modules.medialibrary.next.objects.album.factories.AlbumFactory
+import expo.modules.medialibrary.next.records.AlbumMetadata
 import java.lang.ref.WeakReference
 
 class AlbumQuery(val albumFactory: AlbumFactory, context: Context) {
@@ -26,4 +28,7 @@ class AlbumQuery(val albumFactory: AlbumFactory, context: Context) {
     val ids = contentResolver.queryAllAlbumIds()
     return ids.map { albumFactory.create(it) }
   }
+
+  suspend fun getAlbumsMetadata(): List<AlbumMetadata> =
+    contentResolver.queryAlbumsMetadata()
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/AlbumMetadata.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/AlbumMetadata.kt
@@ -1,0 +1,13 @@
+package expo.modules.medialibrary.next.records
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
+
+@OptimizedRecord
+data class AlbumMetadata(
+  @Field val id: String,
+  @Field val title: String,
+  // iOS only field
+  @Field val type: String? = null
+) : Record

--- a/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
@@ -217,6 +217,10 @@ public final class MediaLibraryNextModule: Module {
         try await album.getAssets()
       }
 
+      AsyncFunction("getAssetCount") { (album: Album) async throws in
+        try await album.getAssetCount()
+      }
+
       AsyncFunction("getType") { (album: Album) async throws in
         try await album.getType()
       }
@@ -236,6 +240,11 @@ public final class MediaLibraryNextModule: Module {
       StaticAsyncFunction("getAll") {
         try await permissionDelegate.checkIfFullAccessGranted()
         return try await Album.getAll(assetMapper: assetMapper)
+      }
+
+      StaticAsyncFunction("getAlbumsMetadata") {
+        try await permissionDelegate.checkIfFullAccessGranted()
+        return try await Album.getAlbumsMetadata()
       }
 
       StaticAsyncFunction("getSmartAlbums") {

--- a/packages/expo-media-library/ios/next/objects/album/Album.swift
+++ b/packages/expo-media-library/ios/next/objects/album/Album.swift
@@ -36,6 +36,11 @@ class Album: SharedObject {
     return try AlbumType.from(collection.assetCollectionType)
   }
 
+  func getAssetCount() async throws -> Int {
+    let collection = try await requirePHAssetCollection()
+    return PHAsset.fetchAssets(in: collection, options: nil).count
+  }
+
   func add(_ assets: [Asset]) async throws {
     let collection = try await requirePHAssetCollection()
     let phAssets = try resolvePHAssets(from: assets)
@@ -104,5 +109,15 @@ class Album: SharedObject {
   static func getSmartAlbums(assetMapper: AssetMapper) async throws -> [Album] {
     AssetCollectionRepository.shared.get(type: .smartAlbum)
       .map { Album(id: $0.localIdentifier, assetMapper: assetMapper) }
+  }
+
+  static func getAlbumsMetadata() async throws -> [AlbumMetadata] {
+    AssetCollectionRepository.shared.getUserAlbums().map { collection in
+      AlbumMetadata(
+        id: collection.localIdentifier,
+        title: collection.localizedTitle ?? "",
+        type: try? AlbumType.from(collection.assetCollectionType)
+      )
+    }
   }
 }

--- a/packages/expo-media-library/ios/next/objects/album/AlbumMetadata.swift
+++ b/packages/expo-media-library/ios/next/objects/album/AlbumMetadata.swift
@@ -1,0 +1,15 @@
+import ExpoModulesCore
+
+struct AlbumMetadata: Record {
+  @Field var id: String
+  @Field var title: String
+  @Field var type: AlbumType?
+
+  init() {}
+
+  init(id: String, title: String, type: AlbumType?) {
+    self.id = id
+    self.title = title
+    self.type = type
+  }
+}

--- a/packages/expo-media-library/src/next/index.ts
+++ b/packages/expo-media-library/src/next/index.ts
@@ -12,6 +12,7 @@ export {
 
 export {
   AlbumType,
+  type AlbumMetadata,
   AssetField,
   MediaSubtype,
   MediaType,

--- a/packages/expo-media-library/src/next/js/AssetAlbum.ts
+++ b/packages/expo-media-library/src/next/js/AssetAlbum.ts
@@ -2,7 +2,15 @@ import { UnavailabilityError } from 'expo';
 import { Platform } from 'react-native';
 
 import { NativeAsset, NativeAlbum } from '../native';
-import type { AlbumType, AssetInfo, Location, MediaSubtype, MediaType, Shape } from '../types';
+import type {
+  AlbumMetadata,
+  AlbumType,
+  AssetInfo,
+  Location,
+  MediaSubtype,
+  MediaType,
+  Shape,
+} from '../types';
 
 // Asset and Album construct each other, so their implementations live together to avoid Metro require-cycle warnings
 
@@ -301,6 +309,20 @@ export class Album {
   }
 
   /**
+   * Gets the number of assets contained in the album, without materializing the assets.
+   * @returns A promise resolving to the album's asset count.
+   *
+   * @example
+   * ```ts
+   * const count = await album.getAssetCount();
+   * console.log(count); // 243
+   * ```
+   */
+  getAssetCount(): Promise<number> {
+    return this.nativeAlbum.getAssetCount();
+  }
+
+  /**
    * Gets the album's type — whether it is a regular or a smart album.
    * @returns A promise resolving to an [`AlbumType`](#albumtype).
    * @platform ios
@@ -454,6 +476,25 @@ export class Album {
   static async getAll(): Promise<Album[]> {
     const natives = await NativeAlbum.getAll();
     return natives.map((a) => new Album(a.id));
+  }
+
+  /**
+   * A static function. Retrieves lightweight metadata for all albums in a single call.
+   *
+   * Returns fields that can be read cheaply from the media store, without instantiating an
+   * [`Album`](#album) per entry. Use an [`Album`](#album) instance when you need heavier data such as
+   * its assets or asset count.
+   *
+   * @returns A promise resolving to an array of [`AlbumMetadata`](#albummetadata) objects.
+   *
+   * @example
+   * ```ts
+   * const albums = await Album.getAlbumsMetadata();
+   * albums.forEach((album) => console.log(album.title));
+   * ```
+   */
+  static getAlbumsMetadata(): Promise<AlbumMetadata[]> {
+    return NativeAlbum.getAlbumsMetadata();
   }
 
   /**

--- a/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
+++ b/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
@@ -6,6 +6,7 @@ import {
 } from 'expo';
 
 import type {
+  AlbumMetadata,
   AlbumType,
   AssetField,
   AssetFieldValueMap,
@@ -121,6 +122,9 @@ class NativeAlbumWeb implements NativeAlbumClass {
   getTitle() {
     return unavailable('Album.getTitle');
   }
+  getAssetCount() {
+    return unavailable('Album.getAssetCount');
+  }
   getType(): Promise<AlbumType> {
     return unavailable('Album.getType');
   }
@@ -152,6 +156,10 @@ class NativeAlbumWeb implements NativeAlbumClass {
 
   static getAll(): Promise<NativeAlbumClass[]> {
     return unavailable('Album.getAll');
+  }
+
+  static getAlbumsMetadata(): Promise<AlbumMetadata[]> {
+    return unavailable('Album.getAlbumsMetadata');
   }
 
   static getSmartAlbums(): Promise<NativeAlbumClass[]> {

--- a/packages/expo-media-library/src/next/native/types/NativeAlbumClass.types.ts
+++ b/packages/expo-media-library/src/next/native/types/NativeAlbumClass.types.ts
@@ -1,4 +1,4 @@
-import type { AlbumType } from '../../types';
+import type { AlbumMetadata, AlbumType } from '../../types';
 import type { NativeAssetClass } from './NativeAssetClass.types';
 
 export declare class NativeAlbumClass {
@@ -6,6 +6,7 @@ export declare class NativeAlbumClass {
   id: string;
   getAssets(): Promise<NativeAssetClass[]>;
   getTitle(): Promise<string>;
+  getAssetCount(): Promise<number>;
   getType(): Promise<AlbumType>;
   delete(): Promise<void>;
   add(assets: NativeAssetClass | NativeAssetClass[]): Promise<void>;
@@ -18,5 +19,6 @@ export declare class NativeAlbumClass {
   static delete(albums: NativeAlbumClass[], deleteAssets?: boolean): Promise<void>;
   static get(title: string): Promise<NativeAlbumClass | null>;
   static getAll(): Promise<NativeAlbumClass[]>;
+  static getAlbumsMetadata(): Promise<AlbumMetadata[]>;
   static getSmartAlbums(): Promise<NativeAlbumClass[]>;
 }

--- a/packages/expo-media-library/src/next/types/Album.types.ts
+++ b/packages/expo-media-library/src/next/types/Album.types.ts
@@ -6,3 +6,18 @@ export enum AlbumType {
   ALBUM = 'album',
   SMART_ALBUM = 'smartAlbum',
 }
+
+/**
+ * Lightweight metadata for a single album, returned by [`Album.getAlbumsMetadata`](#albumgetalbumsmetadata).
+ *
+ * Contains fields that can be read cheaply from the media store, without instantiating an
+ * [`Album`](#album) per entry. Use an [`Album`](#album) instance when you need heavier data such as
+ * its assets or asset count.
+ *
+ * > `type` is only available on iOS; it is `null` on Android.
+ */
+export type AlbumMetadata = {
+  id: string;
+  title: string;
+  type: AlbumType | null;
+};


### PR DESCRIPTION
# Why

Implements the bulk-listing and asset-count parts of this feature request: https://expo.canny.io/feature-requests/p/expo-media-library-new-api-album-listing-lacks-smart-albums-asset-counts-and-bul

Listing albums with `Album.getAll()` returns shared objects, and reading anything from them requires an additional call per album. This PR adds a second rail: `Album.getAlbumsMetadata()`, which works alongside the shared-object methods to provide album data without materializing objects, and `album.getAssetCount()`, which returns the number of assets for an album.

# How

- Added `Album.getAlbumsMetadata()`
- Added `album.getAssetCount()`. On iOS it uses `PHAsset.fetchAssets(in:options:).count`. On Android it queries by `bucket_id` and counts the results with `cursor.count`. I also tried putting `COUNT(*)` into the projection, but it's not supported.

# Test Plan

Tested on BareExpo, added tests to TestSuite ✅