### PR TITLE
[cli] add feedback subject option

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -166,6 +166,38 @@ describe('project metadata', () => {
       reactNativePackageVersion: '0.85.3',
     });
   });
+
+  it('includes a trimmed feedback subject when provided', async () => {
+    projectRoot = createTempDir();
+    writeJson(path.join(projectRoot, 'package.json'), {
+      name: 'not-an-expo-app',
+      version: '1.0.0',
+    });
+
+    await expect(
+      createFeedbackMetadataAsync(
+        projectRoot,
+        null,
+        'docs',
+        ' https://docs.expo.dev/router/introduction/ '
+      )
+    ).resolves.toMatchObject({
+      category: 'docs',
+      subject: 'https://docs.expo.dev/router/introduction/',
+    });
+  });
+
+  it('omits an empty feedback subject', async () => {
+    projectRoot = createTempDir();
+    writeJson(path.join(projectRoot, 'package.json'), {
+      name: 'not-an-expo-app',
+      version: '1.0.0',
+    });
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'docs', '   ');
+
+    expect(metadata).not.toHaveProperty('subject');
+  });
 });
 
 describe('user metadata', () => {
@@ -232,7 +264,7 @@ describe('feedback submission', () => {
       userId: 'user-id',
       username: 'expo-user',
     };
-    const metadata = await createFeedbackMetadataAsync(projectRoot, session, 'mcp');
+    const metadata = await createFeedbackMetadataAsync(projectRoot, session, 'mcp', 'expo-mcp');
 
     await sendFeedbackAsync({
       feedback: 'please make errors clearer',
@@ -256,6 +288,7 @@ describe('feedback submission', () => {
     expect(AbortSignal.timeout).toHaveBeenCalledWith(15_000);
     expect(metadata).toMatchObject({
       category: 'mcp',
+      subject: 'expo-mcp',
       agentEnvironment: {
         detected: true,
         agent: {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -34,6 +34,7 @@ type ConfigFilePaths = {
 
 type FeedbackMetadata = {
   category: FeedbackCategory;
+  subject?: string;
   cli: {
     name: typeof CLI_NAME;
     version: string;
@@ -90,9 +91,11 @@ async function runAsync(): Promise<void> {
       '--help': Boolean,
       '--version': Boolean,
       '--category': String,
+      '--subject': String,
       '-h': '--help',
       '-v': '--version',
       '-c': '--category',
+      '-s': '--subject',
     },
     {
       argv: process.argv.slice(2),
@@ -112,7 +115,12 @@ async function runAsync(): Promise<void> {
 
   const { category, feedback } = await resolveFeedbackAsync(args._, args['--category']);
   const session = getSession();
-  const metadata = await createFeedbackMetadataAsync(process.cwd(), session, category);
+  const metadata = await createFeedbackMetadataAsync(
+    process.cwd(),
+    session,
+    category,
+    args['--subject']
+  );
 
   console.log(
     chalk.dim(
@@ -180,10 +188,14 @@ export async function resolveFeedbackAsync(
 export async function createFeedbackMetadataAsync(
   projectRoot: string,
   session = getSession(),
-  category: FeedbackCategory = 'unknown'
+  category: FeedbackCategory = 'unknown',
+  subjectValue?: string
 ): Promise<FeedbackMetadata> {
+  const subject = normalizeSubject(subjectValue);
+
   return {
     category,
+    ...(subject ? { subject } : {}),
     cli: {
       name: CLI_NAME,
       version: getPackageVersion(),
@@ -439,6 +451,8 @@ function printHelp(): void {
 
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
+    --subject, -s <subject>    Specific docs URL, skill, CLI command, MCP server, or other subject
+                               the feedback is about
     --version, -v              Version number
     --help, -h                 Usage info
 `);
@@ -452,6 +466,11 @@ function resolveFeedbackCategory(value?: string): FeedbackCategory {
   throw new CommandError(
     `Invalid feedback category "${value}". Expected one of: ${FEEDBACK_CATEGORIES.join(', ')}.`
   );
+}
+
+function normalizeSubject(value?: string): string | undefined {
+  const subject = value?.trim();
+  return subject || undefined;
 }
 
 function getPackageVersion(): string {


### PR DESCRIPTION
Adds an optional `--subject` / `-s` argument to `submit-expo-feedback` for identifying the specific docs page, skill, CLI command, MCP server, or other item the feedback is about. The subject is trimmed, omitted when empty, and included in feedback metadata. Adds tests for subject normalization and payload metadata.

Tested with `pnpm --filter submit-expo-feedback test`, `pnpm --filter submit-expo-feedback typecheck`, and `pnpm --filter submit-expo-feedback lint`.