### PR TITLE
[cli] update agent cli detector

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -79,7 +79,7 @@
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0",
     "accepts": "^1.3.8",
-    "agent-cli-detector": "^0.1.2",
+    "agent-cli-detector": "^0.1.3",
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -79,7 +79,7 @@
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0",
     "accepts": "^1.3.8",
-    "agent-cli-detector": "^0.1.3",
+    "agent-cli-detector": "^0.1.4",
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",

--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^29.2.1",
     "@types/prompts": "^2.0.6",
     "@vercel/ncc": "^0.38.3",
-    "agent-cli-detector": "^0.1.2",
+    "agent-cli-detector": "^0.1.3",
     "arg": "^5.0.2",
     "chalk": "^4.0.0",
     "ci-info": "^3.3.0",

--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^29.2.1",
     "@types/prompts": "^2.0.6",
     "@vercel/ncc": "^0.38.3",
-    "agent-cli-detector": "^0.1.3",
+    "agent-cli-detector": "^0.1.4",
     "arg": "^5.0.2",
     "chalk": "^4.0.0",
     "ci-info": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1890,8 +1890,8 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8
       agent-cli-detector:
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -6362,8 +6362,8 @@ importers:
         specifier: ^0.38.3
         version: 0.38.4
       agent-cli-detector:
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -10060,8 +10060,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-cli-detector@0.1.3:
-    resolution: {integrity: sha512-XjBe6lT5sK9xhAn0ToFvdwicsaGvzZkax1iviPnL8sFFYHoagnTTn2E4YTFiyM956iqkOkFcgcWCiER0kkShbQ==}
+  agent-cli-detector@0.1.4:
+    resolution: {integrity: sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==}
     engines: {node: '>=18.18'}
     hasBin: true
 
@@ -19197,7 +19197,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-cli-detector@0.1.3: {}
+  agent-cli-detector@0.1.4: {}
 
   aggregate-error@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1890,8 +1890,8 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8
       agent-cli-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.1.3
+        version: 0.1.3
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -6362,8 +6362,8 @@ importers:
         specifier: ^0.38.3
         version: 0.38.4
       agent-cli-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.1.3
+        version: 0.1.3
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -10060,8 +10060,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-cli-detector@0.1.2:
-    resolution: {integrity: sha512-qdZ/9JFORtTKJNhT/IczMeEfEUbUU0K5umYeiIQHX+AjHs+Y9SXVzSgaYlpZeyNMrvuh2HpZiOTpvS57iPfBkQ==}
+  agent-cli-detector@0.1.3:
+    resolution: {integrity: sha512-XjBe6lT5sK9xhAn0ToFvdwicsaGvzZkax1iviPnL8sFFYHoagnTTn2E4YTFiyM956iqkOkFcgcWCiER0kkShbQ==}
     engines: {node: '>=18.18'}
     hasBin: true
 
@@ -18129,9 +18129,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -19199,7 +19197,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-cli-detector@0.1.2: {}
+  agent-cli-detector@0.1.3: {}
 
   aggregate-error@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- update agent-cli-detector from 0.1.2 to 0.1.4 for @expo/cli and submit-expo-feedback
- the latest version adds detection signals for Rork, Bolt and Replit
