### PR TITLE
[docs] Deduplicate eas/* function reference into shared MDX partials

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -9,6 +9,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { EASFunctionDescription } from '~/ui/components/EASFunctionDescription';
 
 Creating custom builds for EAS Build helps customize the build process for your project.
 
@@ -907,8 +908,6 @@ steps:
 
 Checks out your project source files.
 
-For example, a build config with the following `steps` will check out the project and list the files in the **assets** directory:
-
 ```yaml upload.yml
 build:
   name: List files
@@ -919,16 +918,12 @@ build:
         run: ls assets
 ```
 
-<BoxLink
-  title="eas/checkout source code"
-  description="View the source code for the eas/checkout function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
-/>
+<EASFunctionDescription name="checkout" />
 
 #### `eas/use_npm_token`
 
-Configures node package managers (npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
+Configures Node package managers (bun, npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
+
 Set `NPM_TOKEN` in your project's secrets, and this function will configure the build environment by creating **.npmrc** with the token.
 
 ```yaml example.yml
@@ -944,16 +939,11 @@ build:
         run: npm install # <---- Can now install private packages
 ```
 
-<BoxLink
-  title="eas/use_npm_token source code"
-  description="View the source code for the eas/use_npm_token function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
-/>
+<EASFunctionDescription name="use_npm_token" />
 
 #### `eas/install_node_modules`
 
-Installs node modules using the package manager (npm, pnpm, or Yarn) detected based on your project. Works with monorepos.
+Installs node_modules using the package manager (bun, npm, pnpm, or Yarn) detected based on your project. Works with monorepos.
 
 ```yaml example.yml
 build:
@@ -965,12 +955,7 @@ build:
     # @end #
 ```
 
-<BoxLink
-  title="eas/install_node_modules source code"
-  description="View the source code for the eas/install_node_modules function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
-/>
+<EASFunctionDescription name="install_node_modules" />
 
 #### `eas/restore_build_cache`
 
@@ -1110,7 +1095,7 @@ build:
 
 #### `eas/prebuild`
 
-Runs the `expo prebuild` command using the package manager (npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.
+Runs the `expo prebuild` command using the package manager (bun, npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.
 
 ```yaml example.yml
 build:
@@ -1139,18 +1124,7 @@ build:
     # @end #
 ```
 
-| Property               | Type      | Description                                                                                                                              |
-| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | -         | The name of the step in the reusable function that shows in the build logs. Defaults to `Prebuild`.                                      |
-| `inputs.clean`         | `boolean` | Optional input defining whether the function should use `--clean` flag when running the command. Defaults to false                       |
-| `inputs.apple_team_id` | `boolean` | Optional input defining Apple team ID which should be used when doing prebuild. It should be specified for iOS builds using credentials. |
-
-<BoxLink
-  title="eas/prebuild source code"
-  description="View the source code for the eas/resolve_apple_team_id_from_credentials function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
-/>
+<EASFunctionDescription name="prebuild" />
 
 #### `eas/configure_eas_update`
 
@@ -1700,11 +1674,9 @@ build:
 
 #### `eas/upload_artifact`
 
-Uploads build artifacts from provided paths.
+Uploads files from the job's workspace as an artifact attached to the run. Uploaded artifacts appear in the run's **Artifacts** section and can be retrieved in a later job with [`eas/download_artifact`](/eas/workflows/syntax/#easdownload_artifact).
 
 > **Warning** **You can currently upload each artifact type only once per build job.**<br />If you use [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts) while having [`buildArtifactPaths`](/eas/json/#buildartifactpaths) configured in your build profile and the step finds and uploads some build artifacts, any following `eas/upload_artifact` step will fail.<br />To solve this, for now, we recommend removing `buildArtifactPaths` from custom build's profiles and uploading artifacts manually with `eas/upload_artifact` in the YAML if you need to call it there.
-
-For example, a build config with the following `steps` will upload an artifact to the EAS servers:
 
 ```yaml upload.yml
 build:
@@ -1725,28 +1697,7 @@ build:
             assets/*.png
 ```
 
-| Input          | Type      | Description                                                                                                                                                                                                                                                                                                                      |
-| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`         | `string`  | Required. Path or newline-delimited list of paths to the artifacts to upload to EAS servers. You can use `*` wildcard and other [glob patterns](https://github.com/isaacs/node-glob#glob-primer).                                                                                                                                |
-| `type`         | `string`  | The type of artifact that is uploaded to the EAS servers. Allowed values are `application-archive` and `build-artifact` (build jobs only), and `other` (a generic artifact). Defaults to `application-archive` in build jobs, and to `other` when there is no build (for example, in a workflow custom job). See the note below. |
-| `name`         | `string`  | A name for the artifact. In workflows, it can be used to reference the artifact from [`eas/download_artifact`](/eas/workflows/syntax/#easdownload_artifact).                                                                                                                                                                     |
-| `metadata`     | `json`    | Arbitrary metadata to attach to a generic (`other`) artifact.                                                                                                                                                                                                                                                                    |
-| `ignore_error` | `boolean` | When `true`, an upload failure is logged but does not fail the step. Defaults to `false`.                                                                                                                                                                                                                                        |
-
-This function sets the following output:
-
-| Output        | Type     | Description                      |
-| ------------- | -------- | -------------------------------- |
-| `artifact_id` | `string` | The ID of the uploaded artifact. |
-
-> **info** The `application-archive` and `build-artifact` types require a build to attach to. Using them in a job without a build (such as a custom [workflow](/eas/workflows/get-started/) job) fails with an error like `Uploading application archives outside of builds is not supported`. Use `type: other` to upload a generic artifact in that case.
-
-<BoxLink
-  title="eas/upload_artifact source code"
-  description="View the source code for the eas/upload_artifact function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadArtifact.ts"
-/>
+<EASFunctionDescription name="upload_artifact" />
 
 #### `eas/install_maestro`
 
@@ -1844,11 +1795,10 @@ build:
 
 #### `eas/send_slack_message`
 
-Sends a specified message to a configured [Slack webhook URL](https://api.slack.com/messaging/webhooks), which then posts it in the related Slack channel.
-The message can be specified as plain text or as a [Slack Block Kit](https://api.slack.com/block-kit) message.
-With both cases, you can reference build job properties and [use other steps outputs](#use-output-from-one-step-to-another) in the message for dynamic evaluation.
+Sends a specified message to a configured [Slack webhook URL](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks), which then posts it in the related Slack channel. The message can be specified as plaintext or as a [Slack Block Kit](https://docs.slack.dev/block-kit) message.
+
+You can reference build job properties and [use other steps outputs](#use-output-from-one-step-to-another) in the message for dynamic evaluation.
 For example, `'Build URL: ${ eas.job.expoBuildUrl }'`, `Build finished with status: ${ steps.run_fastlane.status_text }`, `Build failed with error: ${ steps.run_gradle.error_text }`.
-Either "message" or "payload" has to be specified, but not both.
 
 ```yaml send-slack-message.yml
 build:
@@ -1950,22 +1900,15 @@ build:
                     value: another_thing
 ```
 
-| Input            | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `message`        | `string` | The text of the message you want to send. For example, `'This is the content of the message'`.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                                        |
-| `payload`        | `string` | The contents of the message you want to send defined using [Slack Block Kit](https://api.slack.com/block-kit) layout.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                 |
-| `slack_hook_url` | `string` | The URL of the previously configured Slack webhook URL, which will post your message to the specified channel. You can provide the plain URL like `slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'`, use EAS secrets like `slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }`, or set the `SLACK_HOOK_URL` secret, which will serve as a default webhook URL (in this last case, there is no need to provide `slack_hook_url` input). |
+<EASFunctionDescription name="send_slack_message" />
 
-<BoxLink
-  title="eas/send_slack_message source code"
-  description="View the source code for the eas/send_slack_message function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
-/>
+The following functions connect your build to [PostHog](/guides/using-posthog/). Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key, while the other functions use a PostHog personal API key with the scopes noted for each one. For setup, see [Using PostHog](/guides/using-posthog/), and for complete workflows, see [PostHog recipes for EAS Workflows](/guides/using-posthog/recipes).
 
 #### `eas/posthog_capture_event`
 
-Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline. Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key. The other PostHog functions use a personal API key with the scope noted for each one. When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
+Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline.
+
+When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
 
 ```yaml posthog-capture-event.yml
 build:
@@ -1981,21 +1924,7 @@ build:
             profile: production
 ```
 
-| Input          | Type      | Description                                                                                                                                                                                  |
-| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `event`        | `string`  | Required. The name of the event to send.                                                                                                                                                     |
-| `distinct_id`  | `string`  | The person to attribute the event to. When omitted, the event is sent anonymously and does not create a person profile.                                                                      |
-| `properties`   | `json`    | Properties to attach to the event.                                                                                                                                                           |
-| `api_key`      | `string`  | PostHog project API key. Defaults to the `EXPO_PUBLIC_POSTHOG_API_KEY` environment variable set by `eas integrations:posthog:connect`, falling back to `POSTHOG_API_KEY` if that is not set. |
-| `host`         | `string`  | PostHog host. Defaults to the `EXPO_PUBLIC_POSTHOG_HOST` environment variable, or `https://us.posthog.com`.                                                                                  |
-| `ignore_error` | `boolean` | When `true`, a failure to send the event is logged but does not fail the step. Defaults to `false`.                                                                                          |
-
-<BoxLink
-  title="eas/posthog_capture_event source code"
-  description="View the source code for the eas/posthog_capture_event function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/capturePosthogEvent.ts"
-/>
+<EASFunctionDescription name="posthog_capture_event" />
 
 #### `eas/posthog_flag_rollout`
 
@@ -2012,27 +1941,11 @@ build:
           rollout_percentage: 25
 ```
 
-| Input                | Type      | Description                                                                                                                                                                                                                                                             |
-| -------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flag`               | `string`  | Required. The key of the feature flag to update.                                                                                                                                                                                                                        |
-| `active`             | `boolean` | Whether the flag is enabled.                                                                                                                                                                                                                                            |
-| `rollout_percentage` | `number`  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. The function applies it to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, the function applies it to the first condition. |
-| `payload`            | `json`    | Payload to attach to the flag.                                                                                                                                                                                                                                          |
-| `variant`            | `string`  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                                                 |
-| `api_key`            | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                                                 |
-| `project_id`         | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                                      |
-| `ignore_error`       | `boolean` | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.                           |
-
-<BoxLink
-  title="eas/posthog_flag_rollout source code"
-  description="View the source code for the eas/posthog_flag_rollout function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/rolloutPosthogFlag.ts"
-/>
+<EASFunctionDescription name="posthog_flag_rollout" />
 
 #### `eas/posthog_wait_for_metric`
 
-Pauses the build until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate on a metric, such as holding until the error count over the last few minutes stays low. The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses.
+Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate on a metric, such as holding until the error count over the last few minutes stays low. The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses.
 
 > **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
 
@@ -2048,32 +1961,11 @@ build:
           threshold: 10
 ```
 
-| Input              | Type     | Description                                                                                                                       |
-| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `query`            | `string` | Required. A HogQL query. The first column of the first row must be a single number.                                               |
-| `operator`         | `string` | Required. Comparison operator. One of `lt`, `lte`, `gt`, `gte`, or `eq`. The step clears when `value <operator> threshold` holds. |
-| `threshold`        | `number` | Required. The value to compare the query result against.                                                                          |
-| `timeout_seconds`  | `number` | Maximum time to wait, in seconds. Defaults to `600`.                                                                              |
-| `interval_seconds` | `number` | Time between checks, in seconds. Defaults to `30`.                                                                                |
-| `api_key`          | `string` | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope.            |
-| `project_id`       | `string` | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                |
-
-This function sets the following output:
-
-| Output  | Type     | Description                                     |
-| ------- | -------- | ----------------------------------------------- |
-| `value` | `string` | The metric value that satisfied the comparison. |
-
-<BoxLink
-  title="eas/posthog_wait_for_metric source code"
-  description="View the source code for the eas/posthog_wait_for_metric function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogMetric.ts"
-/>
+<EASFunctionDescription name="posthog_wait_for_metric" />
 
 #### `eas/posthog_wait_for_query`
 
-Pauses the build until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead. The step clears when the first column of the first row is `true` or a nonzero number.
+Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead. The step clears when the first column of the first row is `true` or a nonzero number.
 
 > **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
 
@@ -2087,24 +1979,11 @@ build:
           query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
 ```
 
-| Input              | Type     | Description                                                                                                            |
-| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `query`            | `string` | Required. A HogQL query. The step clears when the first column of the first row is `true` or a nonzero number.         |
-| `timeout_seconds`  | `number` | Maximum time to wait, in seconds. Defaults to `600`.                                                                   |
-| `interval_seconds` | `number` | Time between checks, in seconds. Defaults to `30`.                                                                     |
-| `api_key`          | `string` | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope. |
-| `project_id`       | `string` | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                     |
-
-<BoxLink
-  title="eas/posthog_wait_for_query source code"
-  description="View the source code for the eas/posthog_wait_for_query function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogQuery.ts"
-/>
+<EASFunctionDescription name="posthog_wait_for_query" />
 
 #### `eas/posthog_annotation`
 
-Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds and releases next to the metrics they affect.
+Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds, releases, and other milestones next to the metrics they affect.
 
 ```yaml posthog-annotation.yml
 build:
@@ -2116,24 +1995,11 @@ build:
           content: Published a production build
 ```
 
-| Input          | Type      | Description                                                                                                                                                  |
-| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `content`      | `string`  | Required. The annotation text.                                                                                                                               |
-| `date_marker`  | `string`  | The ISO 8601 timestamp the annotation is pinned to. Defaults to the current time.                                                                            |
-| `api_key`      | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `annotation:write` scope.                                 |
-| `project_id`   | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                           |
-| `ignore_error` | `boolean` | When `true`, a network error or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error always fails the step. |
-
-<BoxLink
-  title="eas/posthog_annotation source code"
-  description="View the source code for the eas/posthog_annotation function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/createPosthogAnnotation.ts"
-/>
+<EASFunctionDescription name="posthog_annotation" />
 
 #### `eas/posthog_upload_sourcemaps`
 
-Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are on disk. Configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
 
 > **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
 
@@ -2152,19 +2018,7 @@ build:
           directory: dist
 ```
 
-| Input          | Type      | Description                                                                                                              |
-| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `directory`    | `string`  | The directory that contains the bundle and source maps, relative to the working directory. Defaults to `dist`.           |
-| `api_key`      | `string`  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires source map upload access. |
-| `project_id`   | `string`  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                       |
-| `ignore_error` | `boolean` | When `true`, a failed upload is logged but does not fail the step. Defaults to `false`.                                  |
-
-<BoxLink
-  title="eas/posthog_upload_sourcemaps source code"
-  description="View the source code for the eas/posthog_upload_sourcemaps function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadPosthogSourcemaps.ts"
-/>
+<EASFunctionDescription name="posthog_upload_sourcemaps" />
 
 ### Using built-in EAS functions to build an app
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -9,6 +9,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { EASFunctionDescription } from '~/ui/components/EASFunctionDescription';
 
 Creating custom builds for EAS Build helps customize the build process for your project.
@@ -742,10 +743,10 @@ All-in-one function that installs Maestro, prepares a testing environment (Andro
 
 > **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [Project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
 
-| Input       | Type     | Description                                                                                                                                                                                                                        |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://docs.maestro.dev/getting-started/writing-your-first-flow) to run.                                                                                     |
-| `app_path`  | `string` | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/\*simulator/\*.app** for iOS. |
+| Input       | Type     | Required    | Description                                                                                                                                                                                                                        |
+| ----------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flow_path` | `string` | <YesIcon /> | Path (or multiple paths, each in a separate line) to [Maestro flows](https://docs.maestro.dev/getting-started/writing-your-first-flow) to run.                                                                                     |
+| `app_path`  | `string` | <NoIcon />  | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/\*simulator/\*.app** for iOS. |
 
 ```yaml build-and-test.yml
 build:
@@ -992,12 +993,12 @@ build:
     # @end #
 ```
 
-| Property              | Type     | Description                                                                                                                                                        |
-| --------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                                     |
-| `inputs.key`          | `string` | Required. The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
-| `inputs.restore_keys` | `string` | Optional. A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
-| `inputs.path`         | `string` | Required. The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
+| Property              | Type     | Required    | Description                                                                                                                                                |
+| --------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                             |
+| `inputs.key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.                |
+| `inputs.restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix.   |
+| `inputs.path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                        |
 
 <BoxLink
   title="eas/restore_build_cache source code"
@@ -1030,11 +1031,11 @@ build:
     # @end #
 ```
 
-| Property      | Type     | Description                                                                                                                                                                                                                 |
-| ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`        | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                                 |
-| `inputs.key`  | `string` | Required. The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
-| `inputs.path` | `string` | Required. The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
+| Property      | Type     | Required    | Description                                                                                                                                                                                                     |
+| ------------- | -------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                     |
+| `inputs.key`  | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
+| `inputs.path` | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                             |
 
 <BoxLink
   title="eas/save_build_cache source code"
@@ -1081,10 +1082,10 @@ build:
           apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
 ```
 
-| Property             | Type     | Description                                                                                                                                                                                     |
-| -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | `string` | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                                               |
-| `inputs.credentials` | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS. |
+| Property             | Type     | Required   | Description                                                                                                                                                                                     |
+| -------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | `string` | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                                               |
+| `inputs.credentials` | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                         |
 
 <BoxLink
   title="eas/resolve_apple_team_id_from_credentials source code"
@@ -1159,11 +1160,11 @@ build:
     # @end #
 ```
 
-| Property                 | Type     | Description                                                                                                                                                              |
-| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                   | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                                          |
-| `inputs.runtime_version` | `string` | Optional input defining runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version. |
-| `inputs.channel`         | `string` | Optional input defining channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                    |
+| Property                 | Type     | Required   | Description                                                                                                                                                  |
+| ------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                   | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                              |
+| `inputs.runtime_version` | `string` | <NoIcon /> | Runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version.             |
+| `inputs.channel`         | `string` | <NoIcon /> | Channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                                |
 
 <BoxLink
   title="eas/configure_eas_update source code"
@@ -1190,10 +1191,10 @@ build:
     # @end #
 ```
 
-| Property             | Type   | Description                                                                                                                                                                                             |
-| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | -      | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                                                   |
-| `inputs.credentials` | `json` | Optional input defining the app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android. |
+| Property             | Type   | Required   | Description                                                                                                                                                                                 |
+| -------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | -      | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                                       |
+| `inputs.credentials` | `json` | <NoIcon /> | The app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android.             |
 
 <BoxLink
   title="eas/inject_android_credentials source code"
@@ -1225,11 +1226,11 @@ build:
     # @end #
 ```
 
-| Property                     | Type     | Description                                                                                                                                                                                                     |
-| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                                            |
-| `inputs.build_configuration` | `string` | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
-| `inputs.credentials`         | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
+| Property                     | Type     | Required   | Description                                                                                                                                                                                                     |
+| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                                            |
+| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds.                         |
+| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                                         |
 
 <BoxLink
   title="eas/configure_ios_credentials source code"
@@ -1277,11 +1278,11 @@ build:
     # @end #
 ```
 
-| Property              | Type     | Description                                                                                                          |
-| --------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
-| `name`                | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure Android version`. |
-| `inputs.version_code` | `string` | Optional input defining `versionCode` of your Android build. Defaults to `${ eas.job.version.versionCode }`          |
-| `inputs.version_name` | `string` | Optional input defining `versionName` of your Android build. Defaults to `${ eas.job.version.versionName }`.         |
+| Property              | Type     | Required   | Description                                                                                                          |
+| --------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| `name`                | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure Android version`. |
+| `inputs.version_code` | `string` | <NoIcon /> | `versionCode` of your Android build. Defaults to `${ eas.job.version.versionCode }`.                                 |
+| `inputs.version_name` | `string` | <NoIcon /> | `versionName` of your Android build. Defaults to `${ eas.job.version.versionName }`.                                 |
 
 <BoxLink
   title="eas/configure_android_version source code"
@@ -1339,13 +1340,13 @@ build:
     # @end #
 ```
 
-| Property                     | Type     | Description                                                                                                                                                                                                     |
-| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                                                |
-| `inputs.build_number`        | `string` | Optional input defining the build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`                                                                                  |
-| `inputs.app_version`         | `string` | Optional input defining the app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                        |
-| `inputs.build_configuration` | `string` | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
-| `inputs.credentials`         | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
+| Property                     | Type     | Required   | Description                                                                                                                                                                                                     |
+| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                                                |
+| `inputs.build_number`        | `string` | <NoIcon /> | The build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`.                                                                                                         |
+| `inputs.app_version`         | `string` | <NoIcon /> | The app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                                                |
+| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds.                         |
+| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                                         |
 
 <BoxLink
   title="eas/configure_ios_version source code"
@@ -1390,10 +1391,10 @@ build:
     # @end #
 ```
 
-| Property         | Type     | Description                                                                                                                                                                             |
-| ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`           | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                                                   |
-| `inputs.command` | `string` | Optional input defining the Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object. |
+| Property         | Type     | Required   | Description                                                                                                                                                                     |
+| ---------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                                           |
+| `inputs.command` | `string` | <NoIcon /> | The Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object.                 |
 
 <BoxLink
   title="eas/run_gradle source code"
@@ -1542,15 +1543,15 @@ build:
         # @end #
 ```
 
-| Property                     | Type      | Description                                                                                                                                                                                                                                                              |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                       | -         | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                                                |
-| `inputs.template`            | `string`  | Optional input defining the Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                      |
-| `inputs.credentials`         | `json`    | Optional input defining the app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                   |
-| `inputs.build_configuration` | `string`  | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value. |
-| `inputs.scheme`              | `string`  | Optional input defining the Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                     |
-| `inputs.clean`               | `boolean` | Optional input defining whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                      |
-| `inputs.extra`               | `json`    | Optional input defining extra values which should be provided to the template.                                                                                                                                                                                           |
+| Property                     | Type      | Required   | Description                                                                                                                                                                                                                                                              |
+| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                       | -         | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                                                |
+| `inputs.template`            | `string`  | <NoIcon /> | The Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                                               |
+| `inputs.credentials`         | `json`    | <NoIcon /> | The app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                                           |
+| `inputs.build_configuration` | `string`  | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value.                         |
+| `inputs.scheme`              | `string`  | <NoIcon /> | The Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                                             |
+| `inputs.clean`               | `boolean` | <NoIcon /> | Whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                                              |
+| `inputs.extra`               | `json`    | <NoIcon /> | Extra values which should be provided to the template.                                                                                                                                                                                                                   |
 
 <BoxLink
   title="eas/generate_gymfile_from_template source code"
@@ -1725,9 +1726,9 @@ build:
           path: ${ eas.env.HOME }/.maestro/tests
 ```
 
-| Input             | Type     | Description                                                                                                           |
-| ----------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `maestro_version` | `string` | Maestro version to install (for example, 1.35.0). If not provided, `install_maestro` will install the latest version. |
+| Input             | Type     | Required   | Description                                                                                                           |
+| ----------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| `maestro_version` | `string` | <NoIcon /> | Maestro version to install (for example, 1.35.0). If not provided, `install_maestro` will install the latest version. |
 
 <BoxLink
   title="eas/install_maestro source code"
@@ -1755,10 +1756,10 @@ build:
     # ... Maestro setup and tests
 ```
 
-| Input                  | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `device_name`          | `string` | Name for the created device. You can customize it if starting multiple emulators.                                                                                                                                                                                                                                                                                                                                                                       |
-| `system_image_package` | `string` | Android package path to use for the emulator. For example, `system-images;android-30;default;x86_64`.<br />To get a list of available system images, run [`sdkmanager --list`](https://developer.android.com/tools/sdkmanager#list) on a local computer. VMs run on x86_64 architecture, so always choose `x86_64` package variants. The [`sdkmanager` tool](https://developer.android.com/tools/sdkmanager) comes from Android SDK command-line tools. |
+| Input                  | Type     | Required   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device_name`          | `string` | <NoIcon /> | Name for the created device. You can customize it if starting multiple emulators.                                                                                                                                                                                                                                                                                                                                                                       |
+| `system_image_package` | `string` | <NoIcon /> | Android package path to use for the emulator. For example, `system-images;android-30;default;x86_64`.<br />To get a list of available system images, run [`sdkmanager --list`](https://developer.android.com/tools/sdkmanager#list) on a local computer. VMs run on x86_64 architecture, so always choose `x86_64` package variants. The [`sdkmanager` tool](https://developer.android.com/tools/sdkmanager) comes from Android SDK command-line tools. |
 
 <BoxLink
   title="eas/start_android_emulator source code"
@@ -1782,9 +1783,9 @@ build:
     # ... Maestro setup and tests
 ```
 
-| Input               | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `device_identifier` | `string` | Name or UDID of the Simulator you want to start. Examples include `iPhone [XY] Pro`, `AEF997BB-222C-4379-89BA-D21070B1D787`.<br />**Note:** Available Simulators are different for every image. If you change the image, the Simulator for a given name may become unavailable. For instance, an Xcode 14 image will have iPhone 14 Simulators, while an Xcode 15 image will have iPhone 15 simulators. In general, we encourage not providing this input. See [runner images](/build/eas-json/#selecting-a-base-image) for more information. |
+| Input               | Type     | Required   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device_identifier` | `string` | <NoIcon /> | Name or UDID of the Simulator you want to start. Examples include `iPhone [XY] Pro`, `AEF997BB-222C-4379-89BA-D21070B1D787`.<br />**Note:** Available Simulators are different for every image. If you change the image, the Simulator for a given name may become unavailable. For instance, an Xcode 14 image will have iPhone 14 Simulators, while an Xcode 15 image will have iPhone 15 simulators. In general, we encourage not providing this input. See [runner images](/build/eas-json/#selecting-a-base-image) for more information. |
 
 <BoxLink
   title="eas/start_ios_simulator source code"

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -993,12 +993,12 @@ build:
     # @end #
 ```
 
-| Property              | Type     | Required    | Description                                                                                                                                                |
-| --------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                             |
-| `inputs.key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.                |
-| `inputs.restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix.   |
-| `inputs.path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                        |
+| Property              | Type     | Required    | Description                                                                                                                                              |
+| --------------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                           |
+| `inputs.key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
+| `inputs.restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
+| `inputs.path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
 
 <BoxLink
   title="eas/restore_build_cache source code"
@@ -1031,11 +1031,11 @@ build:
     # @end #
 ```
 
-| Property      | Type     | Required    | Description                                                                                                                                                                                                     |
-| ------------- | -------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`        | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                     |
+| Property      | Type     | Required    | Description                                                                                                                                                                                                       |
+| ------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | -        | <NoIcon />  | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                       |
 | `inputs.key`  | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
-| `inputs.path` | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                             |
+| `inputs.path` | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
 
 <BoxLink
   title="eas/save_build_cache source code"
@@ -1082,10 +1082,10 @@ build:
           apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
 ```
 
-| Property             | Type     | Required   | Description                                                                                                                                                                                     |
-| -------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | `string` | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                                               |
-| `inputs.credentials` | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                         |
+| Property             | Type     | Required   | Description                                                                                                                                                             |
+| -------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | `string` | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                       |
+| `inputs.credentials` | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS. |
 
 <BoxLink
   title="eas/resolve_apple_team_id_from_credentials source code"
@@ -1160,11 +1160,11 @@ build:
     # @end #
 ```
 
-| Property                 | Type     | Required   | Description                                                                                                                                                  |
-| ------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                   | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                              |
-| `inputs.runtime_version` | `string` | <NoIcon /> | Runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version.             |
-| `inputs.channel`         | `string` | <NoIcon /> | Channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                                |
+| Property                 | Type     | Required   | Description                                                                                                                                      |
+| ------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                   | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                  |
+| `inputs.runtime_version` | `string` | <NoIcon /> | Runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version. |
+| `inputs.channel`         | `string` | <NoIcon /> | Channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                    |
 
 <BoxLink
   title="eas/configure_eas_update source code"
@@ -1191,10 +1191,10 @@ build:
     # @end #
 ```
 
-| Property             | Type   | Required   | Description                                                                                                                                                                                 |
-| -------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | -      | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                                       |
-| `inputs.credentials` | `json` | <NoIcon /> | The app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android.             |
+| Property             | Type   | Required   | Description                                                                                                                                                                     |
+| -------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | -      | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                           |
+| `inputs.credentials` | `json` | <NoIcon /> | The app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android. |
 
 <BoxLink
   title="eas/inject_android_credentials source code"
@@ -1226,11 +1226,11 @@ build:
     # @end #
 ```
 
-| Property                     | Type     | Required   | Description                                                                                                                                                                                                     |
-| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                                            |
-| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds.                         |
-| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                                         |
+| Property                     | Type     | Required   | Description                                                                                                                                                                             |
+| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                    |
+| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
+| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
 
 <BoxLink
   title="eas/configure_ios_credentials source code"
@@ -1340,13 +1340,13 @@ build:
     # @end #
 ```
 
-| Property                     | Type     | Required   | Description                                                                                                                                                                                                     |
-| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                                                |
-| `inputs.build_number`        | `string` | <NoIcon /> | The build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`.                                                                                                         |
-| `inputs.app_version`         | `string` | <NoIcon /> | The app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                                                |
-| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds.                         |
-| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                                         |
+| Property                     | Type     | Required   | Description                                                                                                                                                                             |
+| ---------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                        |
+| `inputs.build_number`        | `string` | <NoIcon /> | The build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`.                                                                                 |
+| `inputs.app_version`         | `string` | <NoIcon /> | The app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                        |
+| `inputs.build_configuration` | `string` | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
+| `inputs.credentials`         | `json`   | <NoIcon /> | The app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
 
 <BoxLink
   title="eas/configure_ios_version source code"
@@ -1391,10 +1391,10 @@ build:
     # @end #
 ```
 
-| Property         | Type     | Required   | Description                                                                                                                                                                     |
-| ---------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`           | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                                           |
-| `inputs.command` | `string` | <NoIcon /> | The Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object.                 |
+| Property         | Type     | Required   | Description                                                                                                                                                     |
+| ---------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | -        | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                           |
+| `inputs.command` | `string` | <NoIcon /> | The Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object. |
 
 <BoxLink
   title="eas/run_gradle source code"
@@ -1543,15 +1543,15 @@ build:
         # @end #
 ```
 
-| Property                     | Type      | Required   | Description                                                                                                                                                                                                                                                              |
-| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                       | -         | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                                                |
-| `inputs.template`            | `string`  | <NoIcon /> | The Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                                               |
-| `inputs.credentials`         | `json`    | <NoIcon /> | The app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                                           |
-| `inputs.build_configuration` | `string`  | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value.                         |
-| `inputs.scheme`              | `string`  | <NoIcon /> | The Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                                             |
-| `inputs.clean`               | `boolean` | <NoIcon /> | Whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                                              |
-| `inputs.extra`               | `json`    | <NoIcon /> | Extra values which should be provided to the template.                                                                                                                                                                                                                   |
+| Property                     | Type      | Required   | Description                                                                                                                                                                                                                                      |
+| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                       | -         | <NoIcon /> | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                        |
+| `inputs.template`            | `string`  | <NoIcon /> | The Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                      |
+| `inputs.credentials`         | `json`    | <NoIcon /> | The app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                   |
+| `inputs.build_configuration` | `string`  | <NoIcon /> | The Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value. |
+| `inputs.scheme`              | `string`  | <NoIcon /> | The Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                     |
+| `inputs.clean`               | `boolean` | <NoIcon /> | Whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                      |
+| `inputs.extra`               | `json`    | <NoIcon /> | Extra values which should be provided to the template.                                                                                                                                                                                           |
 
 <BoxLink
   title="eas/generate_gymfile_from_template source code"

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -11,6 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
+import { EASFunctionDescription } from '~/ui/components/EASFunctionDescription';
 
 A workflow is a configurable automated process made up of one or more jobs. You must create a YAML file to define your workflow configuration.
 
@@ -1787,12 +1788,7 @@ jobs:
         # @end #
 ```
 
-<BoxLink
-  title="eas/checkout source code"
-  description="View the source code for the eas/checkout function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
-/>
+<EASFunctionDescription name="checkout" />
 
 #### `eas/install_node_modules`
 
@@ -1808,12 +1804,7 @@ jobs:
       # @end #
 ```
 
-<BoxLink
-  title="eas/install_node_modules source code"
-  description="View the source code for the eas/install_node_modules function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
-/>
+<EASFunctionDescription name="install_node_modules" />
 
 #### `eas/download_build`
 
@@ -1829,14 +1820,7 @@ jobs:
           extensions: [apk, aab, ipa, app] # Optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
 ```
 
-| Property     | Type     | Required    | Default                        | Description                                                                |
-| ------------ | -------- | ----------- | ------------------------------ | -------------------------------------------------------------------------- |
-| `build_id`   | string   | <YesIcon /> | –                              | The ID of the build to download. Must be a valid UUID.                     |
-| `extensions` | string[] | <NoIcon />  | `["apk", "aab", "ipa", "app"]` | List of file extensions to look for in the downloaded artifact or archive. |
-
-**Outputs:**
-
-- `artifact_path`: The absolute path to the matching application archive. This output can be used as input into other steps in your workflow. For example, to upload or process the artifact further.
+<EASFunctionDescription name="download_build" />
 
 Example usage:
 
@@ -1859,13 +1843,6 @@ jobs:
         run: |
           echo "Artifact path: ${{ steps.download_build.outputs.artifact_path }}"
 ```
-
-<BoxLink
-  title="eas/download_build source code"
-  description="View the source code for the eas/download_build function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadBuild.ts"
-/>
 
 #### `eas/prebuild`
 
@@ -1898,17 +1875,7 @@ jobs:
       # @end #
 ```
 
-| Property        | Type      | Description                                                                                                                                 |
-| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clean`         | `boolean` | Optional property defining whether the function should use `--clean` flag when running the command. Defaults to false.                      |
-| `apple_team_id` | `string`  | Optional property defining Apple team ID which should be used when doing prebuild. It should be specified for iOS builds using credentials. |
-
-<BoxLink
-  title="eas/prebuild source code"
-  description="View the source code for the eas/prebuild function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
-/>
+<EASFunctionDescription name="prebuild" />
 
 #### `eas/restore_cache`
 
@@ -1945,18 +1912,7 @@ jobs:
       # @end #
 ```
 
-| Property       | Type     | Required    | Description                                                                                                                                              |
-| -------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
-| `restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
-| `path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
-
-<BoxLink
-  title="eas/restore_cache source code"
-  description="View the source code for the eas/restore_cache function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/restoreCache.ts"
-/>
+<EASFunctionDescription name="restore_cache" />
 
 #### `eas/save_cache`
 
@@ -1983,23 +1939,13 @@ jobs:
       # @end #
 ```
 
-| Property | Type     | Required    | Description                                                                                                                                                                                                       |
-| -------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`    | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
-| `path`   | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
-
-<BoxLink
-  title="eas/save_cache source code"
-  description="View the source code for the eas/save_cache function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/saveCache.ts"
-/>
+<EASFunctionDescription name="save_cache" />
 
 #### `eas/send_slack_message`
 
 Sends a specified message to a configured [Slack webhook URL](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks), which then posts it in the related Slack channel. The message can be specified as plaintext or as a [Slack Block Kit](https://docs.slack.dev/block-kit) message.
 
-With both cases, you can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}`, `Build finished with status: ${{ after.build_android.status }}`.
+You can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}`, `Build finished with status: ${{ after.build_android.status }}`.
 
 Either `message` or `payload` has to be specified, but not both.
 
@@ -2015,18 +1961,7 @@ jobs:
           slack_hook_url: ${{ env.ANOTHER_SLACK_HOOK_URL }}
 ```
 
-| Property         | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `message`        | `string` | The text of the message you want to send. For example, `'This is the content of the message'`.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                                  |
-| `payload`        | `json`   | The contents of the message you want to send which are defined using [Slack Block Kit](https://docs.slack.dev/block-kit) layout.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                |
-| `slack_hook_url` | `string` | The previously configured Slack webhook URL, which will post your message to the specified channel. Provide it using [EAS Environment Variables](/eas/environment-variables/manage/#manage-environment-variables) like `slack_hook_url: ${{ env.ANOTHER_SLACK_HOOK_URL }}`, or set the `SLACK_HOOK_URL` Environment Variable, which will serve as a default webhook URL (in this last case, there is no need to provide the `slack_hook_url` property). |
-
-<BoxLink
-  title="eas/send_slack_message source code"
-  description="View the source code for the eas/send_slack_message function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
-/>
+<EASFunctionDescription name="send_slack_message" />
 
 #### `eas/use_npm_token`
 
@@ -2047,12 +1982,7 @@ jobs:
         run: npm install # <---- Can now install private packages
 ```
 
-<BoxLink
-  title="eas/use_npm_token source code"
-  description="View the source code for the eas/use_npm_token function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
-/>
+<EASFunctionDescription name="use_npm_token" />
 
 #### `eas/upload_artifact`
 
@@ -2080,26 +2010,7 @@ jobs:
 
 ##### Properties
 
-| Property       | Type    | Required    | Description                                                                                                                                                                                                                                                     |
-| -------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`         | string  | <YesIcon /> | Path or newline-delimited list of paths to upload. Supports `*` and other [glob patterns](https://github.com/isaacs/node-glob#glob-primer).                                                                                                                     |
-| `type`         | string  | <NoIcon />  | Artifact type. In custom jobs use `other` (a generic artifact). Defaults to `other` when the job has no build platform, and to `application-archive` in build jobs. The build-scoped values `application-archive` and `build-artifact` only work in build jobs. |
-| `name`         | string  | <NoIcon />  | Name for the artifact, used to reference it from [`eas/download_artifact`](#easdownload_artifact).                                                                                                                                                              |
-| `metadata`     | json    | <NoIcon />  | Arbitrary metadata to attach to a generic (`other`) artifact.                                                                                                                                                                                                   |
-| `ignore_error` | boolean | <NoIcon />  | When `true`, an upload failure is logged but does not fail the step. Defaults to `false`.                                                                                                                                                                       |
-
-##### Outputs
-
-| Property      | Type   | Description                                                                                         |
-| ------------- | ------ | --------------------------------------------------------------------------------------------------- |
-| `artifact_id` | string | The ID of the uploaded artifact. Can be passed to [`eas/download_artifact`](#easdownload_artifact). |
-
-<BoxLink
-  title="eas/upload_artifact source code"
-  description="View the source code for the eas/upload_artifact function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadArtifact.ts"
-/>
+<EASFunctionDescription name="upload_artifact" />
 
 #### `eas/download_artifact`
 
@@ -2117,16 +2028,7 @@ jobs:
 
 ##### Properties
 
-| Property      | Type   | Required   | Description                                                                      |
-| ------------- | ------ | ---------- | -------------------------------------------------------------------------------- |
-| `name`        | string | <NoIcon /> | The name of the artifact to download. Required if `artifact_id` is not provided. |
-| `artifact_id` | string | <NoIcon /> | The ID of the artifact to download. Required if `name` is not provided.          |
-
-##### Outputs
-
-| Property        | Type   | Description                                                                                                                                            |
-| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `artifact_path` | string | The path to the downloaded artifact. This output can be used as input into other steps in your workflow. For example, to send or process the artifact. |
+<EASFunctionDescription name="download_artifact" />
 
 ##### Example
 
@@ -2148,18 +2050,11 @@ jobs:
         run: echo ${{ steps.download_artifact.outputs.artifact_path }}
 ```
 
-<BoxLink
-  title="eas/download_artifact source code"
-  description="View the source code for the eas/download_artifact function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadArtifact.ts"
-/>
-
 The following functions connect your workflow to [PostHog](/guides/using-posthog/). Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key, while the other functions use a PostHog personal API key with the scopes noted for each one. For setup, see [Using PostHog](/guides/using-posthog/), and for complete workflows, see [PostHog recipes for EAS Workflows](/guides/using-posthog/recipes).
 
 #### `eas/posthog_capture_event`
 
-Sends an analytics event to PostHog. Use it to mark deploys, updates, and other workflow milestones on your PostHog timeline.
+Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline.
 
 When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons), which keeps workflow events out of your list of people.
 
@@ -2178,21 +2073,7 @@ jobs:
 
 ##### Properties
 
-| Property       | Type    | Required    | Description                                                                                                                                                                                  |
-| -------------- | ------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `event`        | string  | <YesIcon /> | The name of the event to send.                                                                                                                                                               |
-| `distinct_id`  | string  | <NoIcon />  | The person to attribute the event to. When omitted, the event is sent anonymously and does not create a person profile.                                                                      |
-| `properties`   | json    | <NoIcon />  | Properties to attach to the event.                                                                                                                                                           |
-| `api_key`      | string  | <NoIcon />  | PostHog project API key. Defaults to the `EXPO_PUBLIC_POSTHOG_API_KEY` environment variable set by `eas integrations:posthog:connect`, falling back to `POSTHOG_API_KEY` if that is not set. |
-| `host`         | string  | <NoIcon />  | PostHog host. Defaults to the `EXPO_PUBLIC_POSTHOG_HOST` environment variable, or `https://us.posthog.com`.                                                                                  |
-| `ignore_error` | boolean | <NoIcon />  | When `true`, a failure to send the event is logged but does not fail the step. Defaults to `false`.                                                                                          |
-
-<BoxLink
-  title="eas/posthog_capture_event source code"
-  description="View the source code for the eas/posthog_capture_event function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/capturePosthogEvent.ts"
-/>
+<EASFunctionDescription name="posthog_capture_event" />
 
 #### `eas/posthog_flag_rollout`
 
@@ -2212,23 +2093,7 @@ jobs:
 
 ##### Properties
 
-| Property             | Type    | Required    | Description                                                                                                                                                                                                                                                             |
-| -------------------- | ------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flag`               | string  | <YesIcon /> | The key of the feature flag to update.                                                                                                                                                                                                                                  |
-| `active`             | boolean | <NoIcon />  | Whether the flag is enabled.                                                                                                                                                                                                                                            |
-| `rollout_percentage` | number  | <NoIcon />  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. The function applies it to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, the function applies it to the first condition. |
-| `payload`            | json    | <NoIcon />  | Payload to attach to the flag.                                                                                                                                                                                                                                          |
-| `variant`            | string  | <NoIcon />  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                                                 |
-| `api_key`            | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                                                 |
-| `project_id`         | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                                      |
-| `ignore_error`       | boolean | <NoIcon />  | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.                           |
-
-<BoxLink
-  title="eas/posthog_flag_rollout source code"
-  description="View the source code for the eas/posthog_flag_rollout function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/rolloutPosthogFlag.ts"
-/>
+<EASFunctionDescription name="posthog_flag_rollout" />
 
 #### `eas/posthog_wait_for_metric`
 
@@ -2253,28 +2118,7 @@ jobs:
 
 ##### Properties
 
-| Property           | Type   | Required    | Description                                                                                                             |
-| ------------------ | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `query`            | string | <YesIcon /> | A HogQL query. The first column of the first row must be a single number.                                               |
-| `operator`         | string | <YesIcon /> | Comparison operator. One of `lt`, `lte`, `gt`, `gte`, or `eq`. The step clears when `value <operator> threshold` holds. |
-| `threshold`        | number | <YesIcon /> | The value to compare the query result against.                                                                          |
-| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                    |
-| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                      |
-| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope.  |
-| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                      |
-
-##### Outputs
-
-| Property | Type   | Description                                     |
-| -------- | ------ | ----------------------------------------------- |
-| `value`  | string | The metric value that satisfied the comparison. |
-
-<BoxLink
-  title="eas/posthog_wait_for_metric source code"
-  description="View the source code for the eas/posthog_wait_for_metric function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogMetric.ts"
-/>
+<EASFunctionDescription name="posthog_wait_for_metric" />
 
 #### `eas/posthog_wait_for_query`
 
@@ -2297,24 +2141,11 @@ jobs:
 
 ##### Properties
 
-| Property           | Type   | Required    | Description                                                                                                            |
-| ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `query`            | string | <YesIcon /> | A HogQL query. The step clears when the first column of the first row is `true` or a nonzero number.                   |
-| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                   |
-| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                     |
-| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope. |
-| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                     |
-
-<BoxLink
-  title="eas/posthog_wait_for_query source code"
-  description="View the source code for the eas/posthog_wait_for_query function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogQuery.ts"
-/>
+<EASFunctionDescription name="posthog_wait_for_query" />
 
 #### `eas/posthog_annotation`
 
-Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking deploys and releases next to the metrics they affect.
+Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds, releases, and other milestones next to the metrics they affect.
 
 ```yaml
 jobs:
@@ -2329,20 +2160,7 @@ jobs:
 
 ##### Properties
 
-| Property       | Type    | Required    | Description                                                                                                                                                  |
-| -------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `content`      | string  | <YesIcon /> | The annotation text.                                                                                                                                         |
-| `date_marker`  | string  | <NoIcon />  | The ISO 8601 timestamp the annotation is pinned to. Defaults to the current time.                                                                            |
-| `api_key`      | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `annotation:write` scope.                                 |
-| `project_id`   | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                           |
-| `ignore_error` | boolean | <NoIcon />  | When `true`, a network error or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error always fails the step. |
-
-<BoxLink
-  title="eas/posthog_annotation source code"
-  description="View the source code for the eas/posthog_annotation function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/createPosthogAnnotation.ts"
-/>
+<EASFunctionDescription name="posthog_annotation" />
 
 #### `eas/posthog_upload_sourcemaps`
 
@@ -2366,19 +2184,7 @@ jobs:
 
 ##### Properties
 
-| Property       | Type    | Required   | Description                                                                                                              |
-| -------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `directory`    | string  | <NoIcon /> | The directory that contains the bundle and source maps, relative to the working directory. Defaults to `dist`.           |
-| `api_key`      | string  | <NoIcon /> | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires source map upload access. |
-| `project_id`   | string  | <NoIcon /> | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                       |
-| `ignore_error` | boolean | <NoIcon /> | When `true`, a failed upload is logged but does not fail the step. Defaults to `false`.                                  |
-
-<BoxLink
-  title="eas/posthog_upload_sourcemaps source code"
-  description="View the source code for the eas/posthog_upload_sourcemaps function on GitHub."
-  Icon={GithubIcon}
-  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadPosthogSourcemaps.ts"
-/>
+<EASFunctionDescription name="posthog_upload_sourcemaps" />
 
 ## Built-in shell functions
 

--- a/docs/scenes/eas-functions/_checkout.mdx
+++ b/docs/scenes/eas-functions/_checkout.mdx
@@ -1,0 +1,10 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+<BoxLink
+  title="eas/checkout source code"
+  description="View the source code for the eas/checkout function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
+/>

--- a/docs/scenes/eas-functions/_downloadArtifact.mdx
+++ b/docs/scenes/eas-functions/_downloadArtifact.mdx
@@ -1,0 +1,22 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { NoIcon } from '~/ui/components/DocIcons';
+
+| Property      | Type   | Required   | Description                                                                      |
+| ------------- | ------ | ---------- | -------------------------------------------------------------------------------- |
+| `name`        | string | <NoIcon /> | The name of the artifact to download. Required if `artifact_id` is not provided. |
+| `artifact_id` | string | <NoIcon /> | The ID of the artifact to download. Required if `name` is not provided.          |
+
+##### Outputs
+
+| Property        | Type   | Description                                                                                                                                            |
+| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `artifact_path` | string | The path to the downloaded artifact. This output can be used as input into other steps in your workflow. For example, to send or process the artifact. |
+
+<BoxLink
+  title="eas/download_artifact source code"
+  description="View the source code for the eas/download_artifact function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadArtifact.ts"
+/>

--- a/docs/scenes/eas-functions/_downloadBuild.mdx
+++ b/docs/scenes/eas-functions/_downloadBuild.mdx
@@ -1,0 +1,22 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property     | Type     | Required    | Default                        | Description                                                                |
+| ------------ | -------- | ----------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `build_id`   | string   | <YesIcon /> | –                              | The ID of the build to download. Must be a valid UUID.                     |
+| `extensions` | string[] | <NoIcon />  | `["apk", "aab", "ipa", "app"]` | List of file extensions to look for in the downloaded artifact or archive. |
+
+##### Outputs
+
+| Property        | Type   | Description                                                                                                                                                       |
+| --------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `artifact_path` | string | The absolute path to the matching application archive. This output can be used as input into other steps. For example, to upload or process the artifact further. |
+
+<BoxLink
+  title="eas/download_build source code"
+  description="View the source code for the eas/download_build function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadBuild.ts"
+/>

--- a/docs/scenes/eas-functions/_installNodeModules.mdx
+++ b/docs/scenes/eas-functions/_installNodeModules.mdx
@@ -1,0 +1,10 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+<BoxLink
+  title="eas/install_node_modules source code"
+  description="View the source code for the eas/install_node_modules function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogAnnotation.mdx
+++ b/docs/scenes/eas-functions/_posthogAnnotation.mdx
@@ -1,0 +1,19 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property       | Type    | Required    | Description                                                                                                                                                  |
+| -------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `content`      | string  | <YesIcon /> | The annotation text.                                                                                                                                         |
+| `date_marker`  | string  | <NoIcon />  | The ISO 8601 timestamp the annotation is pinned to. Defaults to the current time.                                                                            |
+| `api_key`      | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `annotation:write` scope.                                 |
+| `project_id`   | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                           |
+| `ignore_error` | boolean | <NoIcon />  | When `true`, a network error or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error always fails the step. |
+
+<BoxLink
+  title="eas/posthog_annotation source code"
+  description="View the source code for the eas/posthog_annotation function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/createPosthogAnnotation.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogCaptureEvent.mdx
+++ b/docs/scenes/eas-functions/_posthogCaptureEvent.mdx
@@ -1,0 +1,20 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property       | Type    | Required    | Description                                                                                                                                                                                  |
+| -------------- | ------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event`        | string  | <YesIcon /> | The name of the event to send.                                                                                                                                                               |
+| `distinct_id`  | string  | <NoIcon />  | The person to attribute the event to. When omitted, the event is sent anonymously and does not create a person profile.                                                                      |
+| `properties`   | json    | <NoIcon />  | Properties to attach to the event.                                                                                                                                                           |
+| `api_key`      | string  | <NoIcon />  | PostHog project API key. Defaults to the `EXPO_PUBLIC_POSTHOG_API_KEY` environment variable set by `eas integrations:posthog:connect`, falling back to `POSTHOG_API_KEY` if that is not set. |
+| `host`         | string  | <NoIcon />  | PostHog host. Defaults to the `EXPO_PUBLIC_POSTHOG_HOST` environment variable, or `https://us.posthog.com`.                                                                                  |
+| `ignore_error` | boolean | <NoIcon />  | When `true`, a failure to send the event is logged but does not fail the step. Defaults to `false`.                                                                                          |
+
+<BoxLink
+  title="eas/posthog_capture_event source code"
+  description="View the source code for the eas/posthog_capture_event function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/capturePosthogEvent.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogFlagRollout.mdx
+++ b/docs/scenes/eas-functions/_posthogFlagRollout.mdx
@@ -1,0 +1,22 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property             | Type    | Required    | Description                                                                                                                                                                                                                                                             |
+| -------------------- | ------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flag`               | string  | <YesIcon /> | The key of the feature flag to update.                                                                                                                                                                                                                                  |
+| `active`             | boolean | <NoIcon />  | Whether the flag is enabled.                                                                                                                                                                                                                                            |
+| `rollout_percentage` | number  | <NoIcon />  | Percentage of users the flag rolls out to, as an integer from `0` to `100`. The function applies it to the flag's catch-all release condition and preserves other conditions. When the flag has no catch-all condition, the function applies it to the first condition. |
+| `payload`            | json    | <NoIcon />  | Payload to attach to the flag.                                                                                                                                                                                                                                          |
+| `variant`            | string  | <NoIcon />  | Variant key to store the `payload` under on a multivariate flag. Defaults to the flag's `true` payload.                                                                                                                                                                 |
+| `api_key`            | string  | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `feature_flag:read` and `feature_flag:write` scopes.                                                                                                                 |
+| `project_id`         | string  | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                                                                                                                                                                      |
+| `ignore_error`       | boolean | <NoIcon />  | When `true`, a network error, a missing flag, or an unexpected response is logged but does not fail the step. Defaults to `false`. A permissions error, or invalid input such as an out-of-range `rollout_percentage`, always fails the step.                           |
+
+<BoxLink
+  title="eas/posthog_flag_rollout source code"
+  description="View the source code for the eas/posthog_flag_rollout function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/rolloutPosthogFlag.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogUploadSourcemaps.mdx
+++ b/docs/scenes/eas-functions/_posthogUploadSourcemaps.mdx
@@ -1,0 +1,18 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { NoIcon } from '~/ui/components/DocIcons';
+
+| Property       | Type    | Required   | Description                                                                                                              |
+| -------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `directory`    | string  | <NoIcon /> | The directory that contains the bundle and source maps, relative to the working directory. Defaults to `dist`.           |
+| `api_key`      | string  | <NoIcon /> | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires source map upload access. |
+| `project_id`   | string  | <NoIcon /> | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                       |
+| `ignore_error` | boolean | <NoIcon /> | When `true`, a failed upload is logged but does not fail the step. Defaults to `false`.                                  |
+
+<BoxLink
+  title="eas/posthog_upload_sourcemaps source code"
+  description="View the source code for the eas/posthog_upload_sourcemaps function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadPosthogSourcemaps.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogWaitForMetric.mdx
+++ b/docs/scenes/eas-functions/_posthogWaitForMetric.mdx
@@ -1,0 +1,27 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property           | Type   | Required    | Description                                                                                                             |
+| ------------------ | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `query`            | string | <YesIcon /> | A HogQL query. The first column of the first row must be a single number.                                               |
+| `operator`         | string | <YesIcon /> | Comparison operator. One of `lt`, `lte`, `gt`, `gte`, or `eq`. The step clears when `value <operator> threshold` holds. |
+| `threshold`        | number | <YesIcon /> | The value to compare the query result against.                                                                          |
+| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                    |
+| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                      |
+| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope.  |
+| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                      |
+
+##### Outputs
+
+| Property | Type   | Description                                     |
+| -------- | ------ | ----------------------------------------------- |
+| `value`  | string | The metric value that satisfied the comparison. |
+
+<BoxLink
+  title="eas/posthog_wait_for_metric source code"
+  description="View the source code for the eas/posthog_wait_for_metric function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogMetric.ts"
+/>

--- a/docs/scenes/eas-functions/_posthogWaitForQuery.mdx
+++ b/docs/scenes/eas-functions/_posthogWaitForQuery.mdx
@@ -1,0 +1,19 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property           | Type   | Required    | Description                                                                                                            |
+| ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `query`            | string | <YesIcon /> | A HogQL query. The step clears when the first column of the first row is `true` or a nonzero number.                   |
+| `timeout_seconds`  | number | <NoIcon />  | Maximum time to wait, in seconds. Defaults to `600`.                                                                   |
+| `interval_seconds` | number | <NoIcon />  | Time between checks, in seconds. Defaults to `30`.                                                                     |
+| `api_key`          | string | <NoIcon />  | PostHog personal API key. Defaults to the `POSTHOG_CLI_API_KEY` environment variable. Requires the `query:read` scope. |
+| `project_id`       | string | <NoIcon />  | PostHog project ID. Defaults to the `POSTHOG_CLI_PROJECT_ID` environment variable.                                     |
+
+<BoxLink
+  title="eas/posthog_wait_for_query source code"
+  description="View the source code for the eas/posthog_wait_for_query function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/waitForPosthogQuery.ts"
+/>

--- a/docs/scenes/eas-functions/_prebuild.mdx
+++ b/docs/scenes/eas-functions/_prebuild.mdx
@@ -1,0 +1,15 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+| Property        | Type      | Description                                                                                                                                 |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clean`         | `boolean` | Optional property defining whether the function should use `--clean` flag when running the command. Defaults to false.                      |
+| `apple_team_id` | `string`  | Optional property defining Apple team ID which should be used when doing prebuild. It should be specified for iOS builds using credentials. |
+
+<BoxLink
+  title="eas/prebuild source code"
+  description="View the source code for the eas/prebuild function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
+/>

--- a/docs/scenes/eas-functions/_restoreCache.mdx
+++ b/docs/scenes/eas-functions/_restoreCache.mdx
@@ -1,0 +1,17 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property       | Type     | Required    | Description                                                                                                                                              |
+| -------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
+| `restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
+| `path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
+
+<BoxLink
+  title="eas/restore_cache source code"
+  description="View the source code for the eas/restore_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/restoreCache.ts"
+/>

--- a/docs/scenes/eas-functions/_saveCache.mdx
+++ b/docs/scenes/eas-functions/_saveCache.mdx
@@ -1,0 +1,16 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon } from '~/ui/components/DocIcons';
+
+| Property | Type     | Required    | Description                                                                                                                                                                                                       |
+| -------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`    | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
+| `path`   | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
+
+<BoxLink
+  title="eas/save_cache source code"
+  description="View the source code for the eas/save_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/saveCache.ts"
+/>

--- a/docs/scenes/eas-functions/_sendSlackMessage.mdx
+++ b/docs/scenes/eas-functions/_sendSlackMessage.mdx
@@ -1,0 +1,16 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+| Property         | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message`        | `string` | The text of the message you want to send. For example, `'This is the content of the message'`.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                                  |
+| `payload`        | `json`   | The contents of the message you want to send which are defined using [Slack Block Kit](https://docs.slack.dev/block-kit) layout.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                |
+| `slack_hook_url` | `string` | The previously configured Slack webhook URL, which will post your message to the specified channel. Provide it using [EAS Environment Variables](/eas/environment-variables/manage/#manage-environment-variables) like `slack_hook_url: ${{ env.ANOTHER_SLACK_HOOK_URL }}`, or set the `SLACK_HOOK_URL` Environment Variable, which will serve as a default webhook URL (in this last case, there is no need to provide the `slack_hook_url` property). |
+
+<BoxLink
+  title="eas/send_slack_message source code"
+  description="View the source code for the eas/send_slack_message function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
+/>

--- a/docs/scenes/eas-functions/_uploadArtifact.mdx
+++ b/docs/scenes/eas-functions/_uploadArtifact.mdx
@@ -1,0 +1,25 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+| Property       | Type    | Required    | Description                                                                                                                                                                                                                                                     |
+| -------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`         | string  | <YesIcon /> | Path or newline-delimited list of paths to upload. Supports `*` and other [glob patterns](https://github.com/isaacs/node-glob#glob-primer).                                                                                                                     |
+| `type`         | string  | <NoIcon />  | Artifact type. In custom jobs use `other` (a generic artifact). Defaults to `other` when the job has no build platform, and to `application-archive` in build jobs. The build-scoped values `application-archive` and `build-artifact` only work in build jobs. |
+| `name`         | string  | <NoIcon />  | Name for the artifact, used to reference it from [`eas/download_artifact`](/eas/workflows/syntax/#easdownload_artifact).                                                                                                                                        |
+| `metadata`     | json    | <NoIcon />  | Arbitrary metadata to attach to a generic (`other`) artifact.                                                                                                                                                                                                   |
+| `ignore_error` | boolean | <NoIcon />  | When `true`, an upload failure is logged but does not fail the step. Defaults to `false`.                                                                                                                                                                       |
+
+##### Outputs
+
+| Property      | Type   | Description                                                                                                               |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `artifact_id` | string | The ID of the uploaded artifact. Can be passed to [`eas/download_artifact`](/eas/workflows/syntax/#easdownload_artifact). |
+
+<BoxLink
+  title="eas/upload_artifact source code"
+  description="View the source code for the eas/upload_artifact function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadArtifact.ts"
+/>

--- a/docs/scenes/eas-functions/_useNpmToken.mdx
+++ b/docs/scenes/eas-functions/_useNpmToken.mdx
@@ -1,0 +1,10 @@
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+<BoxLink
+  title="eas/use_npm_token source code"
+  description="View the source code for the eas/use_npm_token function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
+/>

--- a/docs/ui/components/EASFunctionDescription.tsx
+++ b/docs/ui/components/EASFunctionDescription.tsx
@@ -1,0 +1,49 @@
+import { ComponentType } from 'react';
+
+import Checkout from '~/scenes/eas-functions/_checkout.mdx';
+import DownloadArtifact from '~/scenes/eas-functions/_downloadArtifact.mdx';
+import DownloadBuild from '~/scenes/eas-functions/_downloadBuild.mdx';
+import InstallNodeModules from '~/scenes/eas-functions/_installNodeModules.mdx';
+import PosthogAnnotation from '~/scenes/eas-functions/_posthogAnnotation.mdx';
+import PosthogCaptureEvent from '~/scenes/eas-functions/_posthogCaptureEvent.mdx';
+import PosthogFlagRollout from '~/scenes/eas-functions/_posthogFlagRollout.mdx';
+import PosthogUploadSourcemaps from '~/scenes/eas-functions/_posthogUploadSourcemaps.mdx';
+import PosthogWaitForMetric from '~/scenes/eas-functions/_posthogWaitForMetric.mdx';
+import PosthogWaitForQuery from '~/scenes/eas-functions/_posthogWaitForQuery.mdx';
+import Prebuild from '~/scenes/eas-functions/_prebuild.mdx';
+import RestoreCache from '~/scenes/eas-functions/_restoreCache.mdx';
+import SaveCache from '~/scenes/eas-functions/_saveCache.mdx';
+import SendSlackMessage from '~/scenes/eas-functions/_sendSlackMessage.mdx';
+import UploadArtifact from '~/scenes/eas-functions/_uploadArtifact.mdx';
+import UseNpmToken from '~/scenes/eas-functions/_useNpmToken.mdx';
+
+const FUNCTIONS: Record<string, ComponentType> = {
+  checkout: Checkout,
+  download_artifact: DownloadArtifact,
+  download_build: DownloadBuild,
+  install_node_modules: InstallNodeModules,
+  posthog_annotation: PosthogAnnotation,
+  posthog_capture_event: PosthogCaptureEvent,
+  posthog_flag_rollout: PosthogFlagRollout,
+  posthog_upload_sourcemaps: PosthogUploadSourcemaps,
+  posthog_wait_for_metric: PosthogWaitForMetric,
+  posthog_wait_for_query: PosthogWaitForQuery,
+  prebuild: Prebuild,
+  restore_cache: RestoreCache,
+  save_cache: SaveCache,
+  send_slack_message: SendSlackMessage,
+  upload_artifact: UploadArtifact,
+  use_npm_token: UseNpmToken,
+};
+
+type EASFunctionName = keyof typeof FUNCTIONS;
+
+export function EASFunctionDescription({ name }: { name: EASFunctionName }) {
+  const Content = FUNCTIONS[name];
+  if (!Content) {
+    throw new Error(
+      `Unknown EAS function "${String(name)}". Valid names: ${Object.keys(FUNCTIONS).join(', ')}`
+    );
+  }
+  return <Content />;
+}


### PR DESCRIPTION
# Why

eas/* function reference tables are duplicated across `syntax.mdx` (workflows) and `schema.mdx` (custom builds). When one gets updated the other drifts.

# How

16 MDX partials in `docs/scenes/eas-functions/` hold the shared content (property tables, outputs tables, BoxLinks). A single `EASFunctionDescription` component maps a `name` prop to the right partial.

Descriptions and YAML examples stay in each page since the two pages use different YAML dialects (`uses:`/`with:` vs `eas/fn:`/`inputs:`).


# Test Plan

CI passes.

# Checklist

- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)