### PR TITLE
[image-picker] Fix typo in videoMaxDuration documentation

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix a typo in the `videoMaxDuration` documentation ("browser-dependant" → "browser-dependent"). ([#47911](https://github.com/expo/expo/pull/47911) by [@chinesepowered](https://github.com/chinesepowered))
 - [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-image-picker/src/ImagePicker.types.ts
+++ b/packages/expo-image-picker/src/ImagePicker.types.ts
@@ -517,7 +517,7 @@ export type ImagePickerOptions = {
    * - **On iOS**, when `allowsEditing` is set to `true`, maximum duration is limited to 10 minutes.
    *   This limit is applied automatically, if `0` or no value is specified.
    * - **On Android**, effect of this option depends on support of installed camera app.
-   * - **On Web** this option has no effect - the limit is browser-dependant.
+   * - **On Web** this option has no effect - the limit is browser-dependent.
    */
   videoMaxDuration?: number;
   /**


### PR DESCRIPTION
# Why

The `videoMaxDuration` TSDoc in `expo-image-picker` misspells "browser-dependent" as "browser-dependant". This comment ships in the generated SDK reference on docs.expo.dev.

# How

One-word spelling fix in the doc comment; no code, type, or API change.

- `ImagePicker.types.ts`: "the limit is browser-**dependant**" → "browser-**dependent**"

# Test Plan

Documentation-comment spelling fix only, verified by inspecting the surrounding TSDoc. No runtime behavior changes; existing tests are unaffected.

# Checklist

- [x] I added a changelog entry.
- [ ] This diff includes tests to cover new functionality. _(N/A — doc-comment fix)_
- [x] This diff will work correctly with `npx expo prebuild` & EAS Build. _(N/A — no native/config change)_
