### PR TITLE
[localization] Fix typo in currencyCode documentation

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix a typo in the `currencyCode` documentation ("specifc" → "specific"). ([#47912](https://github.com/expo/expo/pull/47912) by [@chinesepowered](https://github.com/chinesepowered))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-21

--- a/packages/expo-localization/src/Localization.types.ts
+++ b/packages/expo-localization/src/Localization.types.ts
@@ -33,7 +33,7 @@ export type Locale = {
   /**
    * Currency code for the locale.
    * On iOS, it's the currency code from the `Region` setting under Language & Region, not for the current locale.
-   * On Android, it's the currency specifc to the locale in the list, as there are no separate settings for selecting a region.
+   * On Android, it's the currency specific to the locale in the list, as there are no separate settings for selecting a region.
    * Is `null` on Web, use a table lookup based on region instead.
    * @example
    * `'USD'`, `'EUR'`, `'PLN'`.


### PR DESCRIPTION
# Why

The `currencyCode` TSDoc in `expo-localization` misspells "specific" as "specifc". This comment ships in the generated SDK reference on docs.expo.dev.

# How

One-word spelling fix in the doc comment; no code, type, or API change.

- `Localization.types.ts`: "the currency **specifc** to the locale" → "the currency **specific** to the locale"

# Test Plan

Documentation-comment spelling fix only, verified by inspecting the surrounding TSDoc. No runtime behavior changes; existing tests are unaffected.

# Checklist

- [x] I added a changelog entry.
- [ ] This diff includes tests to cover new functionality. _(N/A — doc-comment fix)_
- [x] This diff will work correctly with `npx expo prebuild` & EAS Build. _(N/A — no native/config change)_
