### PR TITLE
[updates] Fix typo in setUpdateURLAndRequestHeadersOverride documentation

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix a typo in the `setUpdateURLAndRequestHeadersOverride` documentation ("reuqest" → "request"). ([#47913](https://github.com/expo/expo/pull/47913) by [@chinesepowered](https://github.com/chinesepowered))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/src/Updates.ts
+++ b/packages/expo-updates/src/Updates.ts
@@ -352,7 +352,7 @@ export async function fetchUpdateAsync(): Promise<UpdateFetchResult> {
 }
 
 /**
- * Overrides updates URL and reuqest headers in runtime from build time.
+ * Overrides updates URL and request headers in runtime from build time.
  * This method allows you to load specific updates from a URL that you provide.
  * Use this method at your own risk, as it may cause unexpected behavior.
  * Because of the risk, this method requires `disableAntiBrickingMeasures` to be set to `true` in the **app.json** file.


### PR DESCRIPTION
# Why

The `setUpdateURLAndRequestHeadersOverride` TSDoc in `expo-updates` misspells "request" as "reuqest". This comment ships in the generated SDK reference on docs.expo.dev.

# How

One-word spelling fix in the doc comment; no code, type, or API change.

- `Updates.ts`: "Overrides updates URL and **reuqest** headers" → "**request** headers"

# Test Plan

Documentation-comment spelling fix only, verified by inspecting the surrounding TSDoc. No runtime behavior changes; existing tests are unaffected.

# Checklist

- [x] I added a changelog entry.
- [ ] This diff includes tests to cover new functionality. _(N/A — doc-comment fix)_
- [x] This diff will work correctly with `npx expo prebuild` & EAS Build. _(N/A — no native/config change)_
