### PR TITLE
[JSI][iOS] Fix xcframework build phase racing Xcode 27 indexer on cleanup

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [iOS] Awaiting a `JavaScriptPromise` that is rejected after the await begins now throws instead of resuming with the rejection value as if fulfilled. ([#47154](https://github.com/expo/expo/pull/47154) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47259](https://github.com/expo/expo/pull/47259) by [@wwdrew](https://github.com/wwdrew))
 - [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value. ([#47381](https://github.com/expo/expo/pull/47381) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed the `Build ExpoModulesJSI xcframework` build phase intermittently failing on Xcode 27 when clearing stale build state raced Xcode's background indexer writing into the SwiftPM index store. ([#47914](https://github.com/expo/expo/pull/47914) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -448,7 +448,7 @@ PLATFORMS=("${platforms_to_build[@]}")
 # generated modulemap is left intact — it was already regenerated above for the
 # cache hash, so wiping it here would just force a redundant rebuild.
 log "Clearing stale build state (DerivedData, SwiftPM) before rebuild"
-rm -rf "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH"
+safe_remove_dirs "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH"
 
 SECONDS=0
 

--- a/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
+++ b/packages/expo-modules-jsi/apple/scripts/clear-caches.sh
@@ -16,7 +16,7 @@ fi
 echo -e "${BLUE}[Expo]${RESET} Clearing ExpoModulesJSI caches and build artifacts"
 
 clean_xcframework_state "$PACKAGE_DIR"
-rm -rf \
+safe_remove_dirs \
   "${PACKAGE_DIR}/.generated" \
   "${PACKAGE_DIR}/.xcframework-slices" \
   "${PACKAGE_DIR}/.test-frameworks"

--- a/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
+++ b/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
@@ -4,13 +4,32 @@
 # clear-caches.sh. Defines the canonical slice metadata and the Info.plist
 # writer used by those scripts so the manifest is produced from a single place.
 
+# safe_remove_dirs DIR...
+# Deletes directories tolerantly. Xcode's background indexer keeps writing into
+# the SwiftPM index store under `.build`, which can make a plain `rm -rf` fail
+# with ENOTEMPTY mid-walk and abort the caller under `set -e`. Renaming each
+# directory away first (atomic within the filesystem) detaches the live path, so
+# the delete of the leftover can race harmlessly; its failure is ignored.
+safe_remove_dirs() {
+  local dir
+  for dir in "$@"; do
+    [[ -e "$dir" ]] || continue
+    local trash="${dir}.trash.$$"
+    if mv "$dir" "$trash" 2>/dev/null; then
+      rm -rf "$trash" 2>/dev/null || true
+    else
+      rm -rf "$dir" 2>/dev/null || true
+    fi
+  done
+}
+
 # clean_xcframework_state PACKAGE_DIR
 # Removes the built xcframework and the SwiftPM/Xcode build state next to the
 # package. Shared by build-xcframework.sh's --clean path and clear-caches.sh.
 clean_xcframework_state() {
   local package_dir="$1"
 
-  rm -rf \
+  safe_remove_dirs \
     "${package_dir}/Products/ExpoModulesJSI.xcframework" \
     "${package_dir}/.DerivedData" \
     "${package_dir}/.build" \


### PR DESCRIPTION
## Why

The `Build ExpoModulesJSI xcframework` CocoaPods build phase intermittently fails on Xcode 27 with errors like:

```
rm: /…/expo-modules-jsi/apple/.build/arm64-apple-macosx/debug/index/store/v5/records: Directory not empty
…
Command PhaseScriptExecution failed with a nonzero exit code
```

and, downstream, the generic `the following command failed with exit code 0 but produced no further output`.

The script's pre-build cleanup wipes `.DerivedData` and the SwiftPM `.build` tree with a plain `rm -rf`. On Xcode 27, the background indexer keeps writing into the SwiftPM index store (`.build/…/index/store/v5/records`) while the script runs. `rm -rf` unlinks the files it saw, then `rmdir` fails with `ENOTEMPTY` because the indexer just dropped a new record in. Under the script's `set -euo pipefail`, that nonzero `rm` exit aborts the whole build phase. When the script dies mid-flight, in-flight nested `xcodebuild` tasks get torn down, which is what surfaces as the exit-0-no-output failure on other builds.

## How

Added a `safe_remove_dirs` helper to the shared `xcframework-helpers.sh` that renames each directory to a `.trash.$$` sibling before deleting it:

- The `mv` is atomic within the filesystem, so once it returns nothing can add files back into the path the build recreates into; the indexer's open descriptors follow the renamed tree.
- The `rm -rf` of the trash copy may still lose the race, but its failure is swallowed with `|| true`, so it can no longer abort the caller. `mv` failures fall back to a guarded `rm -rf` of the original path.
- A `[[ -e "$dir" ]]` guard keeps a missing directory a no-op.
- `.trash.$$` (the PID) keeps concurrent invocations from stomping each other's trash.

Routed every deletion of this build state through the helper, since the same race applies wherever `.build` is wiped:

- `build-xcframework.sh`'s mid-build cleanup (the most exposed site, it runs during an Xcode build).
- `clean_xcframework_state` in the shared helper (the `--clean` path and `clear-caches.sh`).
- `clear-caches.sh`'s remaining artifact dirs (`.generated`, `.xcframework-slices`, `.test-frameworks`).

## Test Plan

- `bash -n` passes on all three scripts.
- Exercised the sourced helpers in isolation: `safe_remove_dirs` across normal nested delete, missing-dir no-op (does not trip `set -e`), multi-arg, and a concurrent writer racing the trash `rm` (returns 0, live path always gone); `clean_xcframework_state` removes all four package dirs.
- Local xcframework builds on Xcode 27 no longer intermittently fail on the cleanup step.
