### PR TITLE
[iOS][JSI] Add runOrSchedule to JavaScriptRuntime

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Add `JavaScriptRef.withValue`, a non-consuming borrow accessor that reads the referenced value without taking it, so a long-lived reference can be read repeatedly. ([#47238](https://github.com/expo/expo/pull/47238) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.longLivedObjects`, a `LongLivedObjectCollection` that keeps `LongLivedObject`s (such as in-flight promises) alive across asynchronous boundaries and releases any that remain when the runtime is torn down. ([#47511](https://github.com/expo/expo/pull/47511) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptCodable` conformance for `Date`: it encodes to a JS `Date` and decodes from a JS `Date`, a number of milliseconds since the epoch, or a string parsed by the JS engine's `Date` constructor. ([#47602](https://github.com/expo/expo/pull/47602) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Add `JavaScriptRuntime.runOrSchedule` that runs the given closure synchronously when called on the JavaScript thread and schedules it asynchronously otherwise. ([#47915](https://github.com/expo/expo/pull/47915) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -598,6 +598,19 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     }
   }
 
+  /// Runs a closure synchronously when already on the JavaScript thread, or schedules it
+  /// asynchronously otherwise. Unlike ``schedule(priority:_:)``, this can reenter the caller.
+  public func runOrSchedule(
+    priority: SchedulerPriority = .normal,
+    @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () -> Void
+  ) {
+    if isOnJavaScriptThread() {
+      JavaScriptActor.assumeIsolated(closure)
+    } else {
+      schedule(priority: priority, closure)
+    }
+  }
+
   /// Checks whether the function is called on the JavaScript thread.
   @inline(__always)
   public final func isOnJavaScriptThread() -> Bool {

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -119,6 +119,43 @@ struct JavaScriptRuntimeTests {
     #expect(result == 100)
   }
 
+  @Test
+  func `runOrSchedule runs inline on the JavaScript thread and schedules otherwise`() async {
+    let scheduler = TestRuntimeScheduler()
+    let owningRuntime = await scheduler.run {
+      JavaScriptRuntime()
+    }
+    let runtime = await scheduler.run {
+      owningRuntime.withUnsafePointee { runtimePointer in
+        JavaScriptRuntime(
+          unsafePointer: runtimePointer,
+          scheduler: scheduler.opaquePointer,
+          dispatch: unsafeBitCast(scheduleOnTestRuntime, to: UnsafeRawPointer.self)
+        )
+      }
+    }
+
+    await scheduler.run {
+      nonisolated(unsafe) var didRunInline = false
+      runtime.runOrSchedule {
+        didRunInline = true
+      }
+      #expect(didRunInline)
+    }
+
+    await withCheckedContinuation { continuation in
+      runtime.runOrSchedule {
+        #expect(runtime.isOnJavaScriptThread())
+        continuation.resume()
+      }
+    }
+
+    // The wrapper borrows both the underlying JSI runtime and the scheduler context.
+    withExtendedLifetime(runtime) {}
+    withExtendedLifetime(owningRuntime) {}
+    withExtendedLifetime(scheduler) {}
+  }
+
   // The execute<R> overloads have a same-thread fast path and a cross-thread path that
   // schedules the closure onto the JS thread and pumps the caller's run loop until it
   // completes. The tests above run on `@JavaScriptActor` (the JS thread), so they only
@@ -959,6 +996,99 @@ struct JavaScriptRuntimeTests {
     _ = wrapper
   }
 }
+
+private final class TestRuntimeScheduler: @unchecked Sendable {
+  // A serial dispatch queue may use different worker threads between callbacks, but
+  // JavaScriptRuntime tracks affinity to the specific thread on which it was created.
+  private let state: State
+  private let thread: Thread
+
+  init() {
+    let state = State()
+    self.state = state
+    self.thread = Thread {
+      state.run()
+    }
+    thread.name = "expo.modules.jsi.tests.runtime"
+    thread.start()
+    state.waitUntilReady()
+  }
+
+  deinit {
+    state.stop()
+  }
+
+  var opaquePointer: UnsafeMutableRawPointer {
+    return Unmanaged.passUnretained(self).toOpaque()
+  }
+
+  func schedule(_ operation: @escaping @convention(block) () -> Void) {
+    state.schedule(operation)
+  }
+
+  func run<R: Sendable>(_ operation: @escaping @Sendable () -> R) async -> R {
+    return await withCheckedContinuation { continuation in
+      schedule {
+        continuation.resume(returning: operation())
+      }
+    }
+  }
+
+  private final class State: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let ready = DispatchSemaphore(value: 0)
+    private var operations: [@convention(block) () -> Void] = []
+    private var isStopped = false
+
+    func schedule(_ operation: @escaping @convention(block) () -> Void) {
+      condition.lock()
+      operations.append(operation)
+      condition.signal()
+      condition.unlock()
+    }
+
+    func waitUntilReady() {
+      ready.wait()
+    }
+
+    func stop() {
+      condition.lock()
+      isStopped = true
+      condition.signal()
+      condition.unlock()
+    }
+
+    func run() {
+      ready.signal()
+
+      while true {
+        condition.lock()
+        while operations.isEmpty && !isStopped {
+          condition.wait()
+        }
+        if isStopped {
+          condition.unlock()
+          return
+        }
+        let operation = operations.removeFirst()
+        condition.unlock()
+
+        operation()
+      }
+    }
+  }
+}
+
+private let scheduleOnTestRuntime:
+  @convention(c) (
+    UnsafeMutableRawPointer?, Int32, @escaping @convention(block) () -> Void
+  ) -> Void = { schedulerPointer, _, callback in
+    guard let schedulerPointer else {
+      return
+    }
+    let scheduler = Unmanaged<TestRuntimeScheduler>.fromOpaque(schedulerPointer).takeUnretainedValue()
+    scheduler.schedule(callback)
+  }
 
 /// Tasks captured by `holdSchedulerTask` instead of being executed, emulating a React
 /// `RuntimeScheduler` that is torn down with work still queued (the #47716 reload scenario).


### PR DESCRIPTION
# Why

A runtime-specific Swift executor must send jobs through the JavaScript runtime scheduler when called off-thread. When it is already on the runtime's JavaScript thread, scheduling the same job again adds an unnecessary queue hop and prevents immediate execution. `JavaScriptRuntime` did not have a single primitive expressing those two behaviors.

# How

- Added the package-scoped `JavaScriptRuntime.runOrSchedule` helper.
- Run the closure synchronously with `JavaScriptActor.assumeIsolated` when already on the JavaScript thread.
- Fall back to `schedule` when called from another thread.
- Added a dedicated-thread test scheduler and an integration test covering both paths.

# Test Plan

Added `runOrSchedule runs inline on the JavaScript thread and schedules otherwise`, which verifies synchronous reentry on the JavaScript thread and scheduler dispatch from an off-thread caller.

Validation:

- `swift build --target ExpoModulesJSI`
- `xcrun swift-format lint --strict --parallel` on the changed Swift files
