### PR TITLE
[iOS][JSI] Unify runtime task and serial executors

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))
 - [iOS] `getExpoNativeState` now probes with the specialized `hasNativeState<jsi::NativeState>` and dynamic-casts the raw pointer once, avoiding a redundant `dynamic_pointer_cast` on the shared object argument unwrap hot path. ([#46712](https://github.com/expo/expo/pull/46712) by [@tsapeta](https://github.com/tsapeta))
 - Added a script to clear local build caches and artifacts.
+- [iOS] Unified the per-runtime task executor and serial executor into a single `JavaScriptRuntimeExecutor` type. ([#47916](https://github.com/expo/expo/pull/47916) by [@tsapeta](https://github.com/tsapeta))
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -137,6 +137,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] `JavaScriptNativeState` can now back any `jsi::NativeState` subtype via a `void *` factory, so consumers without Swift/C++ interop (e.g. `expo-modules-core`) can supply their own pointee. `expo::NativeState` ships from the xcframework as a public C++ header. ([#46330](https://github.com/expo/expo/pull/46330) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Ignore already-settled promises. ([#46765](https://github.com/expo/expo/pull/46765) by [@jakex7](https://github.com/jakex7))
 - [iOS] `getExpoNativeState` now probes with the specialized `hasNativeState<jsi::NativeState>` and dynamic-casts the raw pointer once, avoiding a redundant `dynamic_pointer_cast` on the shared object argument unwrap hot path. ([#46712](https://github.com/expo/expo/pull/46712) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Unified the per-runtime task executor and serial executor into a single `JavaScriptRuntimeExecutor` type. ([#47916](https://github.com/expo/expo/pull/47916) by [@tsapeta](https://github.com/tsapeta))
 
 ## 56.0.7 — 2026-05-20
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
@@ -25,21 +25,21 @@ extension Task where Failure == any Error {
   internal static func immediate_polyfill(
     name: String? = nil,
     priority: TaskPriority? = nil,
-    executorPreference taskExecutor: JavaScriptRuntimeTaskExecutor,
+    executorPreference runtimeExecutor: JavaScriptRuntimeExecutor,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
   ) -> Task<Success, any Error> {
     if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
       return Task.immediate(
         name: name,
         priority: priority,
-        executorPreference: taskExecutor,
+        executorPreference: runtimeExecutor,
         operation: operation
       )
     } else if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
       // In the polyfill always use the highest priority and hope it executes earlier.
       return Task(
         name: name,
-        executorPreference: taskExecutor,
+        executorPreference: runtimeExecutor,
         priority: .high,
         operation: operation
       )

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -93,13 +93,12 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
   }
 }
 
-/// Task executor dedicated to a specific JavaScript runtime.
+/// Executor dedicated to a specific JavaScript runtime.
 ///
 /// Unlike ``JavaScriptExecutor``, which only provides actor isolation and runs jobs inline,
-/// this executor routes every job through the runtime scheduler. Using it as a task's executor
-/// preference makes that task re-enter through the runtime's JavaScript thread after suspension
-/// points.
-internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sendable {
+/// this executor routes every job through the runtime scheduler. It can be used as both a serial
+/// executor and a task executor preference.
+internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, TaskExecutor, @unchecked Sendable {
   private weak let runtime: JavaScriptRuntime?
 
   init(runtime: JavaScriptRuntime) {
@@ -108,7 +107,7 @@ internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sen
 
   // MARK: - TaskExecutor
 
-  func enqueue(_ job: UnownedJob) {
+  override func enqueue(_ job: UnownedJob) {
     runtime?.runOrSchedule(priority: .immediate) {
       if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
         job.runSynchronously(on: self.asUnownedTaskExecutor())
@@ -117,7 +116,7 @@ internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sen
         // so fall back to running the job on a serial executor. The executor passed here only
         // affects isolation checks; the job already runs on the runtime's JavaScript thread
         // because `runOrSchedule` routed it there.
-        job.runSynchronously(on: JavaScriptActor.shared.unownedExecutor)
+        job.runSynchronously(on: self.asUnownedSerialExecutor())
       }
     }
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -100,13 +100,12 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
   }
 }
 
-/// Task executor dedicated to a specific JavaScript runtime.
+/// Executor dedicated to a specific JavaScript runtime.
 ///
 /// Unlike ``JavaScriptExecutor``, which only provides actor isolation and runs jobs inline,
-/// this executor routes every job through the runtime scheduler. Using it as a task's executor
-/// preference makes that task re-enter through the runtime's JavaScript thread after suspension
-/// points.
-internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sendable {
+/// this executor routes every job through the runtime scheduler. It can be used as both a serial
+/// executor and a task executor preference.
+internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, TaskExecutor, @unchecked Sendable {
   private weak let runtime: JavaScriptRuntime?
 
   init(runtime: JavaScriptRuntime) {
@@ -115,7 +114,7 @@ internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sen
 
   // MARK: - TaskExecutor
 
-  func enqueue(_ job: UnownedJob) {
+  override func enqueue(_ job: UnownedJob) {
     runtime?.runOrSchedule(priority: .immediate) {
       if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
         job.runSynchronously(on: self.asUnownedTaskExecutor())
@@ -124,7 +123,7 @@ internal final class JavaScriptRuntimeTaskExecutor: TaskExecutor, @unchecked Sen
         // so fall back to running the job on a serial executor. The executor passed here only
         // affects isolation checks; the job already runs on the runtime's JavaScript thread
         // because `runOrSchedule` routed it there.
-        job.runSynchronously(on: JavaScriptActor.shared.unownedExecutor)
+        job.runSynchronously(on: self.asUnownedSerialExecutor())
       }
     }
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -53,8 +53,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     return id
   }()
 
-  /// Executor preference for tasks that must return to this runtime's JavaScript thread.
-  private lazy var taskExecutor = JavaScriptRuntimeTaskExecutor(runtime: self)
+  /// Executor for tasks that must return to this runtime's JavaScript thread.
+  private lazy var runtimeExecutor = JavaScriptRuntimeExecutor(runtime: self)
 
   /// Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
   /// on the caller's thread — for the React-backed runtime, use
@@ -470,7 +470,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> Void
   ) {
     schedule(priority: priority) {
-      Task.immediate_polyfill(executorPreference: taskExecutor) {
+      Task.immediate_polyfill(executorPreference: runtimeExecutor) {
         try await closure()
       }
     }
@@ -531,7 +531,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     let callerRunLoop = NonisolatedUnsafeVar(CFRunLoopGetCurrent())
 
     func body() {
-      Task.immediate_polyfill(priority: .high, executorPreference: taskExecutor) {
+      Task.immediate_polyfill(priority: .high, executorPreference: runtimeExecutor) {
         do {
           result.value = .success(try await closure())
         } catch {
@@ -585,13 +585,13 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     if isOnJavaScriptThread() {
       return try await Task.immediate_polyfill(
         priority: .high,
-        executorPreference: taskExecutor,
+        executorPreference: runtimeExecutor,
         operation: closure
       ).value
     }
     return try await withUnsafeThrowingContinuation { continuation in
       scheduler.scheduleTask(.ImmediatePriority) {
-        Task.immediate_polyfill(priority: .high, executorPreference: self.taskExecutor) { @JavaScriptActor in
+        Task.immediate_polyfill(priority: .high, executorPreference: self.runtimeExecutor) { @JavaScriptActor in
           do {
             continuation.resume(returning: try await closure())
           } catch {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -66,8 +66,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     return id
   }()
 
-  /// Executor preference for tasks that must return to this runtime's JavaScript thread.
-  private lazy var taskExecutor = JavaScriptRuntimeTaskExecutor(runtime: self)
+  /// Executor for tasks that must return to this runtime's JavaScript thread.
+  private lazy var runtimeExecutor = JavaScriptRuntimeExecutor(runtime: self)
 
   /// Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
   /// on the caller's thread — for the React-backed runtime, use
@@ -496,7 +496,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> Void
   ) {
     schedule(priority: priority) {
-      Task.immediate_polyfill(executorPreference: taskExecutor) {
+      Task.immediate_polyfill(executorPreference: runtimeExecutor) {
         try await closure()
       }
     }
@@ -557,7 +557,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     let callerRunLoop = NonisolatedUnsafeVar(CFRunLoopGetCurrent())
 
     func body() {
-      Task.immediate_polyfill(priority: .high, executorPreference: taskExecutor) {
+      Task.immediate_polyfill(priority: .high, executorPreference: runtimeExecutor) {
         do {
           result.value = .success(try await closure())
         } catch {
@@ -611,13 +611,13 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     if isOnJavaScriptThread() {
       return try await Task.immediate_polyfill(
         priority: .high,
-        executorPreference: taskExecutor,
+        executorPreference: runtimeExecutor,
         operation: closure
       ).value
     }
     return try await withUnsafeThrowingContinuation { continuation in
       scheduler.scheduleTask(.ImmediatePriority) {
-        Task.immediate_polyfill(priority: .high, executorPreference: self.taskExecutor) { @JavaScriptActor in
+        Task.immediate_polyfill(priority: .high, executorPreference: self.runtimeExecutor) { @JavaScriptActor in
           do {
             continuation.resume(returning: try await closure())
           } catch {
@@ -652,7 +652,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     return Task.immediate_polyfill(
       name: name,
       priority: priority,
-      executorPreference: taskExecutor,
+      executorPreference: runtimeExecutor,
       operation: operation
     )
   }


### PR DESCRIPTION
# Why

The supported iOS 18 path uses a `TaskExecutor`, while the compatibility path for older systems needs a runtime-specific `SerialExecutor`. Both must represent the same runtime scheduler and use identical enqueue behavior, so keeping separate executor implementations would duplicate state and make their behavior easier to diverge.

# How

- Renamed `JavaScriptRuntimeTaskExecutor` to `JavaScriptRuntimeExecutor`.
- Made the runtime executor inherit from `JavaScriptExecutor` and conform to `TaskExecutor` in its base definition.
- Kept one `enqueue` implementation that runs jobs using the task executor on supported systems and the serial executor otherwise.
- Updated `JavaScriptRuntime` and the `Task.immediate` polyfill to use the unified executor.

This is a preparatory refactor; the pre-iOS 18 compatibility behavior is introduced by the next stack layer.

# Test Plan

Validation:

- `swift build --target ExpoModulesJSI`
- `xcrun swift-format lint --strict --parallel` on the changed Swift files
- the executor-preference and JavaScript-thread affinity tests from the preceding PR continue to cover the iOS 18 behavior

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
