### PR TITLE
[iOS][JSI] Preserve JS thread affinity before iOS 18

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [iOS] Fixed a use-after-free when a non-owning `JavaScriptRuntime` wrapper outlives its runtime (e.g. it is captured by a task abandoned on reload): its cached `jsi::PropNameID`s were destroyed against the freed runtime when the wrapper deallocated. The teardown sweep now flushes the cache on the JavaScript thread while the runtime is still valid. ([#47927](https://github.com/expo/expo/pull/47927) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptPromise` no longer traps when a resolve or reject call throws, which can realistically only happen against a runtime that is being torn down: a failed resolver call rejects the promise instead and a failed rejecter call is dropped. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Keep asynchronous `JavaScriptRuntime.schedule` and `execute` tasks on the runtime's JavaScript thread after suspension points by using a runtime-specific task executor preference on iOS 18 and newer. ([#47900](https://github.com/expo/expo/pull/47900) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Keep asynchronous `JavaScriptRuntime.schedule` and `execute` tasks on the runtime's JavaScript thread after suspension points on iOS 16 and 17 by binding a runtime-specific serial executor while creating the task. ([#47917](https://github.com/expo/expo/pull/47917) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -128,6 +128,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value. ([#47381](https://github.com/expo/expo/pull/47381) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed the `Build ExpoModulesJSI xcframework` build phase intermittently failing on Xcode 27 when clearing stale build state raced Xcode's background indexer writing into the SwiftPM index store. ([#47914](https://github.com/expo/expo/pull/47914) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Keep asynchronous `JavaScriptRuntime.schedule` and `execute` tasks on the runtime's JavaScript thread after suspension points by using a runtime-specific task executor preference on iOS 18 and newer. Two suspensions stay outside that: returning from an actor that has an executor of its own (the main actor, for instance), and an unstructured `Task { }` started inside the work, since Swift does not pass a task executor preference to unstructured tasks. ([#47900](https://github.com/expo/expo/pull/47900) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Keep asynchronous `JavaScriptRuntime.schedule` and `execute` tasks on the runtime's JavaScript thread after suspension points on iOS 16 and 17 by binding a runtime-specific serial executor while creating the task. ([#47917](https://github.com/expo/expo/pull/47917) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
@@ -19,14 +19,15 @@ extension Task where Failure == any Error {
     }
   }
 
-  /// Starts a task that prefers the JavaScript runtime's executor when executor preferences are
-  /// available, synchronously on the caller context when the platform supports `Task.immediate`.
+  /// Starts a task that returns to the JavaScript runtime's executor after suspension points.
+  /// Uses a task executor preference when available and a runtime-specific actor executor on older
+  /// systems. Starts synchronously on the caller context when the platform supports `Task.immediate`.
   @discardableResult
   internal static func immediate_polyfill(
     name: String? = nil,
     priority: TaskPriority? = nil,
     executorPreference runtimeExecutor: JavaScriptRuntimeExecutor,
-    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: @escaping @isolated(any) @Sendable () async throws -> Success
   ) -> Task<Success, any Error> {
     if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
       return Task.immediate(
@@ -44,7 +45,9 @@ extension Task where Failure == any Error {
         operation: operation
       )
     } else {
-      return Task(name: name, priority: .high, operation: operation)
+      return JavaScriptRuntimeExecutorContext.$executor.withValue(runtimeExecutor) {
+        Task(name: name, priority: .high, operation: operation)
+      }
     }
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
@@ -19,32 +19,40 @@ extension Task where Failure == any Error {
     }
   }
 
-  /// Starts a task that prefers the JavaScript runtime's executor when executor preferences are
-  /// available, synchronously on the caller context when the platform supports `Task.immediate`.
+  /// Starts a task that returns to the JavaScript runtime's executor after suspension points.
+  /// Uses a task executor preference when available and a runtime-specific actor executor on older
+  /// systems. Starts synchronously on the caller context when the platform supports `Task.immediate`.
   @discardableResult
   internal static func immediate_polyfill(
     name: String? = nil,
     priority: TaskPriority? = nil,
     executorPreference runtimeExecutor: JavaScriptRuntimeExecutor,
-    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: @escaping @isolated(any) @Sendable () async throws -> Success
   ) -> Task<Success, any Error> {
-    if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
-      return Task.immediate(
-        name: name,
-        priority: priority,
-        executorPreference: runtimeExecutor,
-        operation: operation
-      )
-    } else if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
-      // In the polyfill always use the highest priority and hope it executes earlier.
-      return Task(
-        name: name,
-        executorPreference: runtimeExecutor,
-        priority: .high,
-        operation: operation
-      )
-    } else {
-      return Task(name: name, priority: .high, operation: operation)
+    // Gated on the executor rather than `#available` so a test can take the compatibility path for
+    // one runtime. The `#available` checks stay because the compiler still needs them to reference
+    // the newer initializers.
+    if runtimeExecutor.usesTaskExecutorPreference {
+      if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
+        return Task.immediate(
+          name: name,
+          priority: priority,
+          executorPreference: runtimeExecutor,
+          operation: operation
+        )
+      }
+      if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+        // In the polyfill always use the highest priority and hope it executes earlier.
+        return Task(
+          name: name,
+          executorPreference: runtimeExecutor,
+          priority: .high,
+          operation: operation
+        )
+      }
+    }
+    return JavaScriptRuntimeExecutorContext.$executor.withValue(runtimeExecutor) {
+      Task(name: name, priority: .high, operation: operation)
     }
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/// Runtime-specific executor inherited by tasks that need to preserve JavaScript thread affinity
+/// on systems where task executor preferences are unavailable.
+///
+/// `Task.init` reads the operation's actor isolation synchronously and the child task inherits
+/// task-local values. This lets ``JavaScriptActor/unownedExecutor`` select a stable executor for
+/// the task and any later executor derivations without relying on the getter being called after
+/// every suspension point.
+internal enum JavaScriptRuntimeExecutorContext {
+  @TaskLocal static var executor: JavaScriptRuntimeExecutor?
+}
+
 /// Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
 /// Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
 /// without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
@@ -14,6 +25,20 @@ public actor JavaScriptActor: GlobalActor {
   nonisolated private let executor = JavaScriptExecutor()
 
   nonisolated public var unownedExecutor: UnownedSerialExecutor {
+    // Task executor preferences preserve affinity without changing the global actor's executor on
+    // supported systems, so keep the documented stable-executor contract there.
+    if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+      return executor.asUnownedSerialExecutor()
+    }
+
+    // TaskExecutor is not back-deployed. For older systems, tasks spawned by JavaScriptRuntime bind
+    // their runtime-specific serial executor while Task.init captures the @JavaScriptActor isolation.
+    // Returning different executors from one actor deliberately bends Swift's executor-stability
+    // contract. Keep this compatibility path scoped to OS versions where the supported preference
+    // API is unavailable, and remove it when those deployment targets are dropped.
+    if let runtimeExecutor = JavaScriptRuntimeExecutorContext.executor {
+      return runtimeExecutor.asUnownedSerialExecutor()
+    }
     return executor.asUnownedSerialExecutor()
   }
 
@@ -96,8 +121,9 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
 /// Executor dedicated to a specific JavaScript runtime.
 ///
 /// Unlike ``JavaScriptExecutor``, which only provides actor isolation and runs jobs inline,
-/// this executor routes every job through the runtime scheduler. It can be used as both a serial
-/// executor and a task executor preference.
+/// this executor routes every job through the runtime scheduler. It is used as a task executor on
+/// systems that support executor preferences and as a serial executor for the compatibility path
+/// on older systems.
 internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, TaskExecutor, @unchecked Sendable {
   private weak let runtime: JavaScriptRuntime?
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/// Runtime-specific executor inherited by tasks that need to preserve JavaScript thread affinity
+/// on systems where task executor preferences are unavailable.
+///
+/// `Task.init` reads the operation's actor isolation synchronously and the child task inherits
+/// task-local values. This lets ``JavaScriptActor/unownedExecutor`` select a stable executor for
+/// the task and any later executor derivations without relying on the getter being called after
+/// every suspension point.
+internal enum JavaScriptRuntimeExecutorContext {
+  @TaskLocal static var executor: JavaScriptRuntimeExecutor?
+}
+
 /// Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
 /// Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
 /// without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
@@ -14,6 +25,18 @@ public actor JavaScriptActor: GlobalActor {
   nonisolated private let executor = JavaScriptExecutor()
 
   nonisolated public var unownedExecutor: UnownedSerialExecutor {
+    // TaskExecutor is not back-deployed. Where it is unavailable, tasks started by
+    // `JavaScriptRuntime` bind their runtime-specific serial executor while `Task.init` captures
+    // the `@JavaScriptActor` isolation, and this getter hands that executor back so the task
+    // returns to the runtime's JavaScript thread.
+    //
+    // Only that compatibility path binds the task-local, so on systems with task executor
+    // preferences it is always nil and the actor keeps the documented stable executor. Where it is
+    // bound, returning different executors from one actor deliberately bends Swift's
+    // executor-stability contract. Remove it when those deployment targets are dropped.
+    if let runtimeExecutor = JavaScriptRuntimeExecutorContext.executor {
+      return runtimeExecutor.asUnownedSerialExecutor()
+    }
     return executor.asUnownedSerialExecutor()
   }
 
@@ -103,10 +126,18 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
 /// Executor dedicated to a specific JavaScript runtime.
 ///
 /// Unlike ``JavaScriptExecutor``, which only provides actor isolation and runs jobs inline,
-/// this executor routes every job through the runtime scheduler. It can be used as both a serial
-/// executor and a task executor preference.
+/// this executor routes every job through the runtime scheduler. It is used as a task executor on
+/// systems that support executor preferences and as a serial executor for the compatibility path
+/// on older systems.
 internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, TaskExecutor, @unchecked Sendable {
   private weak let runtime: JavaScriptRuntime?
+
+  /// Whether tasks started for this runtime may use a task executor preference. Defaults to what
+  /// the operating system supports.
+  ///
+  /// Kept per runtime rather than process-wide so a test can cover the compatibility path for one
+  /// runtime without changing how the others behave. Write it before the runtime starts any work.
+  nonisolated(unsafe) internal var usesTaskExecutorPreference = TaskExecutorPreference.isAvailableOnThisOS
 
   init(runtime: JavaScriptRuntime) {
     self.runtime = runtime

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -67,7 +67,18 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   }()
 
   /// Executor for tasks that must return to this runtime's JavaScript thread.
-  private lazy var runtimeExecutor = JavaScriptRuntimeExecutor(runtime: self)
+  internal lazy var runtimeExecutor = JavaScriptRuntimeExecutor(runtime: self)
+
+  /// Whether asynchronous work started by this runtime may use a task executor preference.
+  ///
+  /// Exposed for tests, which lower it to cover the pre-iOS-18 compatibility path: no simulator
+  /// runtime old enough to reach that path on its own can be installed on current macOS. Set it
+  /// before starting any work on the runtime.
+  @_spi(Testing)
+  public var usesTaskExecutorPreference: Bool {
+    get { return runtimeExecutor.usesTaskExecutorPreference }
+    set { runtimeExecutor.usesTaskExecutorPreference = newValue }
+  }
 
   /// Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
   /// on the caller's thread — for the React-backed runtime, use

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/TaskExecutorPreference.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/TaskExecutorPreference.swift
@@ -1,0 +1,19 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+/// Availability of Swift task executor preferences ([SE-0417](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0417-task-executor-preference.md)).
+///
+/// The runtime uses a task executor preference to bring asynchronous work back to the JavaScript
+/// thread after a suspension point. The API is not back-deployed, so it is unavailable below iOS 18,
+/// macOS 15, watchOS 11 and tvOS 18, and the runtime falls back to a compatibility path there.
+///
+/// Kept in one place because ``JavaScriptRuntimeExecutor/usesTaskExecutorPreference`` only defaults
+/// to it: a test lowers that flag per runtime to cover the fallback on any operating system.
+internal enum TaskExecutorPreference {
+  @inline(__always)
+  internal static var isAvailableOnThisOS: Bool {
+    if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+      return true
+    }
+    return false
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -208,7 +208,6 @@ struct JavaScriptRuntimeTests {
     #expect(secondTaskExecutor == executors.0)
   }
 
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   @Test
   func `schedule async stays on JavaScript thread across suspension points`() async {
     let scheduler = TestRuntimeScheduler()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -1,4 +1,4 @@
-import ExpoModulesJSI
+@_spi(Testing) import ExpoModulesJSI
 import Foundation
 import Testing
 
@@ -214,6 +214,23 @@ struct JavaScriptRuntimeTests {
     let checkpoints = await recordSuspensionMatrix(on: scheduled.runtime)
 
     // A matrix that stopped early would pass vacuously, so check that every suspension ran.
+    #expect(checkpoints.map(\.label) == suspensionMatrixLabels)
+    expectNoThreadDrift(in: checkpoints)
+
+    withExtendedLifetime(scheduled) {}
+  }
+
+  @Test
+  func `schedule async stays on the JavaScript thread without a task executor preference`() async {
+    let scheduled = await TestRuntimeScheduler().makeRuntime()
+
+    // Takes the compatibility path on any operating system. No simulator runtime old enough to
+    // reach it on its own can be installed on current macOS, so without this the path would ship
+    // with no coverage. The flag is per runtime, so tests running alongside are unaffected.
+    scheduled.runtime.usesTaskExecutorPreference = false
+
+    let checkpoints = await recordSuspensionMatrix(on: scheduled.runtime)
+
     #expect(checkpoints.map(\.label) == suspensionMatrixLabels)
     expectNoThreadDrift(in: checkpoints)
 


### PR DESCRIPTION
# Why

Task executor preferences are not back-deployed before iOS 18. On iOS 16 and 17, the `Task.immediate` polyfill therefore creates an ordinary task that can resume on the cooperative thread pool after its first suspension point, losing the JavaScript runtime's thread affinity.

# How

- Added a task-local context that binds the runtime-specific serial executor while a runtime-owned task is created.
- Made `JavaScriptActor.unownedExecutor` select that executor only on systems where task executor preferences are unavailable.
- Kept the supported, stable global-actor executor behavior unchanged on iOS 18 and newer.
- Documented that the compatibility path deliberately bends Swift's stable actor-executor contract and scoped the risk to older deployment targets.
- Enabled the real-scheduler suspension-point affinity test for the older deployment targets.

# Test Plan

The compatibility path is covered on any operating system. `JavaScriptRuntimeExecutor` carries a
`usesTaskExecutorPreference` flag that defaults to what the OS supports, and `JavaScriptRuntime`
exposes it under the `Testing` SPI. A test lowers it for its own runtime and runs the same suspension
matrix as #47900: task start, `Task.yield()`, `Task.sleep`, a continuation resumed from another
thread, an `async let` child, a task group child, an awaited detached task, and a nonisolated async
function. Every checkpoint stays on the runtime's JavaScript thread.

The flag is per runtime rather than process-wide so a test cannot change how other runtimes behave
while it runs.

`JavaScriptActor.unownedExecutor` no longer checks availability. Only this compatibility path binds
the task-local, so the getter is unchanged wherever task executor preferences exist, and the check
would otherwise make the path unreachable from a test.

Validation:

- `pnpm test:integration` passes: 658 tests in 33 suites
- `xcrun swift-format lint --strict --parallel` on the changed Swift files
- red/green: removing the task-local binding fails only the compatibility-path test, and fails it at
  every suspension point
