### PR TITLE
[widgets][ios] Add Grid and GridRow support to the widget renderer

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add `Grid` and `Grid.Row` support to the widget renderer. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@Michillas](https://github.com/Michillas))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add `Grid` and `Grid.Row` support to the widget renderer. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@Michillas](https://github.com/Michillas))
+- [iOS] Add `Grid` and `Grid.Row` support to the widget renderer. ([#47919](https://github.com/expo/expo/pull/47919) by [@Michillas](https://github.com/Michillas))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - Expose shared directory for images. ([#46339](https://github.com/expo/expo/pull/46339) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -81,6 +81,10 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(UnevenRoundedRectangleView.self, UnevenRoundedRectangleViewProps.self)
     case "GaugeView":
       render(GaugeView.self, GaugeProps.self)
+    case "GridView":
+      render(GridView.self, GridProps.self, updateProps: updateChildren)
+    case "GridRowView":
+      render(WidgetGridRowView.self, WidgetGridRowProps.self, updateProps: updateChildren)
     case "ChartView":
       render(ChartView.self, ChartProps.self)
     case "Button":
@@ -156,6 +160,24 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       } else if let child = props["children"] as? [String: Any] {
         initialProps.children = [WidgetsDynamicView(name: name, kind: kind, node: child, entryIndex: entryIndex, environmentString: environmentString)]
       }
+    }
+  }
+}
+
+// ExpoUI's GridRowProps is not a UIBaseViewProps, which the render/updateChildren
+// machinery requires, so GridRow gets a widgets-local wrapper.
+final class WidgetGridRowProps: UIBaseViewProps {}
+
+struct WidgetGridRowView: ExpoSwiftUI.View {
+  @ObservedObject var props: WidgetGridRowProps
+
+  var body: some View {
+    if #available(iOS 16.0, *) {
+      GridRow {
+        Children()
+      }
+    } else {
+      EmptyView()
     }
   }
 }


### PR DESCRIPTION
# Why

`@expo/ui` exports `Grid` / `Grid.Row` (and the `gridCellColumns` / `gridCellUnsizedAxes` / `gridColumnAlignment` / `gridCellAnchor` modifiers), and ExpoUI ships the native `GridView` / `GridRowView`. But `WidgetsDynamicView` has no case for them, so any `Grid` subtree inside an `expo-widgets` layout silently renders as `EmptyView` (or the RedBox in debug). Grid is the natural SwiftUI tool for column-aligned widget layouts (e.g. a weekly calendar where header cells and multi-day spanning bars must share the same 7-column grid).

# How

- Map `"GridView"` to ExpoUI's existing `GridView` / `GridProps`.
- Map `"GridRowView"` to a small widgets-local wrapper (`WidgetGridRowView` with `WidgetGridRowProps: UIBaseViewProps`), because ExpoUI's `GridRowProps` is a plain `ExpoSwiftUI.ViewProps` and the renderer's `render`/`updateChildren` machinery requires `UIBaseViewProps`. Same `Children()` pattern as the existing widget Button views.

# Test Plan

Used a widget layout with a `Grid` of a header `Grid.Row` (7 day columns) plus lane rows whose segments span columns via `gridCellColumns` in a real app (iOS 18, 2x4 widget). Before: only the non-Grid header rendered. After: the grid renders and columns align, including spanning cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)