### PR TITLE
[brownfield][android] Add support Fused Library

### DIFF
--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "expo-app",
     "slug": "expo-app",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "expo-app",
@@ -43,14 +43,7 @@
           },
           "android": {
             "publishing": [
-              { "type": "localMaven" },
-              {
-                "type": "remotePrivate",
-                "name": "GitHubPackages",
-                "url": "https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test",
-                "username": "gabrieldonadel",
-                "password": { "variable": "GITHUB_TOKEN" }
-              }
+              { "type": "localMaven" }
             ]
           }
         }

--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "expo-app",
     "slug": "expo-app",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "expo-app",
@@ -40,6 +40,18 @@
         {
           "ios": {
             "buildReactNativeFromSource": false
+          },
+          "android": {
+            "publishing": [
+              { "type": "localMaven" },
+              {
+                "type": "remotePrivate",
+                "name": "GitHubPackages",
+                "url": "https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test",
+                "username": "gabrieldonadel",
+                "password": { "variable": "GITHUB_TOKEN" }
+              }
+            ]
           }
         }
       ]

--- a/apps/brownfield-tester/isolated/android/app/build.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/app/build.gradle.kts
@@ -18,20 +18,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-        packagingOptions {
-            pickFirsts.addAll(
-                listOf(
-                    "lib/arm64-v8a/libc++_shared.so",
-                    "lib/armeabi-v7a/libc++_shared.so",
-                    "lib/x86/libc++_shared.so",
-                    "lib/x86_64/libc++_shared.so",
-                    "**/libworklets.so",
-                    // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
-                    // and `com.facebook.react:react-android`. Same library, picking either copy.
-                    "**/libfbjni.so"
-                )
+    packagingOptions {
+        pickFirsts.addAll(
+            listOf(
+                "lib/arm64-v8a/libc++_shared.so",
+                "lib/armeabi-v7a/libc++_shared.so",
+                "lib/x86/libc++_shared.so",
+                "lib/x86_64/libc++_shared.so",
+                "**/libworklets.so",
+                // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
+                // and `com.facebook.react:react-android`. Same library, picking either copy.
+                "**/libfbjni.so"
             )
-        }
+        )
+    }
 
     buildTypes {
         release {

--- a/apps/brownfield-tester/isolated/android/app/build.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/app/build.gradle.kts
@@ -18,17 +18,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    packagingOptions {
-        pickFirsts.addAll(
-            listOf(
-                "lib/arm64-v8a/libc++_shared.so",
-                "lib/armeabi-v7a/libc++_shared.so",
-                "lib/x86/libc++_shared.so",
-                "lib/x86_64/libc++_shared.so",
-                "**/libworklets.so"
+        packagingOptions {
+            pickFirsts.addAll(
+                listOf(
+                    "lib/arm64-v8a/libc++_shared.so",
+                    "lib/armeabi-v7a/libc++_shared.so",
+                    "lib/x86/libc++_shared.so",
+                    "lib/x86_64/libc++_shared.so",
+                    "**/libworklets.so",
+                    // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
+                    // and `com.facebook.react:react-android`. Same library, picking either copy.
+                    "**/libfbjni.so"
+                )
             )
-        )
-    }
+        }
 
     buildTypes {
         release {
@@ -62,8 +65,11 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
-    implementation(libs.brownfield)
-    implementation(libs.expo.brownfield)
+    // Single fat AAR per buildType — `brownfield-fused-release` strips dev tooling
+    // (expo-dev-menu / launcher / client); `brownfield-fused-debug` keeps them so
+    // the dev menu, Metro reload, and red-box error overlay work locally.
+    releaseImplementation(libs.brownfield.release)
+    debugImplementation(libs.brownfield.debug)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestActivity.kt
+++ b/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestActivity.kt
@@ -3,7 +3,6 @@ package dev.expo.brownfieldintegratedtester
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import expo.modules.brownfield.BrownfieldMessage
 import expo.modules.brownfield.BrownfieldMessaging
 import expo.modules.brownfield.BrownfieldState
@@ -12,7 +11,7 @@ import host.exp.exponent.brownfield.BrownfieldActivity
 import java.util.Timer
 import kotlin.concurrent.timerTask
 
-open class BrownfieldTestActivity : BrownfieldActivity(), DefaultHardwareBackBtnHandler {
+open class BrownfieldTestActivity : BrownfieldActivity() {
   // Listeners
   private var messagingListenerId: String? = null
   private var stateListeners: MutableList<Removable?> = mutableListOf()
@@ -140,9 +139,5 @@ open class BrownfieldTestActivity : BrownfieldActivity(), DefaultHardwareBackBtn
         java.time.LocalDateTime.now()
             .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"))
     BrownfieldState.set("time", timeString)
-  }
-
-  override fun invokeDefaultOnBackPressed() {
-    TODO("Not yet implemented")
   }
 }

--- a/apps/brownfield-tester/isolated/android/gradle/libs.versions.toml
+++ b/apps/brownfield-tester/isolated/android/gradle/libs.versions.toml
@@ -24,8 +24,8 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-brownfield = { group = "host.exp.exponent", name = "brownfield", version = "1.0.0" }
-expo-brownfield = { group = "expo.modules.brownfield", name = "expo.modules.brownfield", version = "0.1.0" }
+brownfield-release = { group = "host.exp.exponent", name = "brownfield-fused-release", version = "1.0.0" }
+brownfield-debug = { group = "host.exp.exponent", name = "brownfield-fused-debug", version = "1.0.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/apps/brownfield-tester/isolated/android/settings.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/settings.gradle.kts
@@ -18,6 +18,14 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
         maven { url = uri("https://www.jitpack.io") }
+        // maven {
+        //     url = uri("https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test")
+        //     credentials {
+        //         username = System.getenv("GITHUB_ACTOR") ?: "gabrieldonadel"
+        //         password = System.getenv("GITHUB_TOKEN") ?: ""
+        //     }
+        // }
+
     }
 }
 

--- a/apps/brownfield-tester/isolated/android/settings.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/settings.gradle.kts
@@ -18,14 +18,6 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
         maven { url = uri("https://www.jitpack.io") }
-        // maven {
-        //     url = uri("https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test")
-        //     credentials {
-        //         username = System.getenv("GITHUB_ACTOR") ?: "gabrieldonadel"
-        //         password = System.getenv("GITHUB_TOKEN") ?: ""
-        //     }
-        // }
-
     }
 }
 

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -77,7 +77,7 @@ jobs:
         working_directory: ../brownfield-tester/expo-app
         run: |
           npx expo prebuild --clean -p android
-          npx expo-brownfield build:android --repo MavenLocal --verbose
+          npx expo-brownfield build:android --fused --repo MavenLocal --verbose
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -225,6 +225,137 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
   ]}
 />
 
+## Publishing artifacts
+
+Brownfield Android artifacts are pushed to one or more Maven repositories declared via `android.publishing` in your app config. The repository types supported are:
+
+| `type`            | Description                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `localMaven`      | Publishes to `~/.m2/repository`. Default. Useful for local host-app integration during development.                       |
+| `localDirectory`  | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.        |
+| `remotePublic`    | Publishes to a public Maven repository with no authentication.                                                            |
+| `remotePrivate`   | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, Sonatype Nexus…). Credentials can be inline strings or environment-variable references. |
+
+`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object — `{ "variable": "SOME_ENV_VAR" }` — that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
+
+### Publishing to GitHub Packages
+
+GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication is `GITHUB_ACTOR` (the user/bot name) + a [personal access token](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with `write:packages` and `read:packages` scopes (in GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo).
+
+Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packages URL for your test repository:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-brownfield",
+        {
+          "android": {
+            "group": "com.example",
+            "libraryName": "brownfield",
+            "publishing": [
+              { "type": "localMaven" },
+              {
+                "type": "remotePrivate",
+                "name": "GitHubPackages",
+                "url": "https://maven.pkg.github.com/<owner>/<repo>",
+                "username": { "variable": "GITHUB_ACTOR" },
+                "password": { "variable": "GITHUB_TOKEN" }
+              }
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository`, invoked via:
+
+<Terminal cmd={['$ npx expo-brownfield build:android --fused --repo GitHubPackages']} />
+
+### Publishing only the fused artifacts
+
+The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20–40 artifacts per release). To publish a small, curated set instead, use `--fused` — the fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat-AAR sibling(s):
+
+| Invocation                                   | Coordinates published                                                                                                   |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--fused --release`                          | `<group>:<libraryName>-fused-release:<version>`                                                                          |
+| `--fused --debug`                            | `<group>:<libraryName>-fused-debug:<version>`                                                                            |
+| `--fused --all` (default with `--fused`)     | Both of the above (two Gradle invocations under the hood, one per variant)                                              |
+
+That's at most two Maven coordinates published per release — independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR; see [Fused mode](#fused-mode) for the full denylist + allowlist.
+
+### Sample GitHub Actions workflow
+
+```yaml .github/workflows/publish-brownfield.yml
+name: Publish brownfield fused AAR
+
+on:
+  push:
+    tags:
+      - 'brownfield-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - run: npm ci
+      - run: npx expo prebuild --platform android
+      - run: npx expo-brownfield build:android --fused --release --repo GitHubPackages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Trigger via `git tag brownfield-v1.0.0 && git push --tags` (or manually via the Actions tab). The workflow's built-in `GITHUB_TOKEN` is scoped to the workflow's own repo, so publishing to a third-party repo requires a PAT in a repo secret instead.
+
+### Consumer setup (host Android app)
+
+The host app's `settings.gradle.kts` (or per-module `build.gradle.kts`) declares the same GitHub Packages URL + credentials. The host app's CI/local builds must have `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars set or pulled from `~/.gradle/gradle.properties`.
+
+```kotlin android/settings.gradle.kts
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url = uri("https://maven.pkg.github.com/<owner>/<repo>")
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+          ?: providers.gradleProperty("gpr.user").get()
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+          ?: providers.gradleProperty("gpr.token").get()
+      }
+    }
+  }
+}
+```
+
+```kotlin android/app/build.gradle.kts
+dependencies {
+  releaseImplementation("com.example:brownfield-fused-release:1.0.0")
+  debugImplementation("com.example:brownfield-fused-debug:1.0.0")
+}
+```
+
+`releaseImplementation` / `debugImplementation` pair the variants automatically — Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and just publish the release sibling with `--fused --release`.
+
 ## CLI
 
 The `expo-brownfield` library includes a CLI for building and publishing to Maven repositories (Android) and XCFrameworks (iOS).
@@ -244,6 +375,7 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 | `-d, --debug`          | Build in debug mode                            |
 | `-r, --release`        | Build in release mode                          |
 | `-a, --all`            | Build in both debug and release mode (default) |
+| `--fused`              | Publish a single fat AAR via AGP Fused Library |
 | `-l, --library`        | Specify brownfield library name                |
 | `--repo, --repository` | Specify Maven repositories to publish to       |
 | `-t, --task`           | Specify Gradle publish tasks to run            |

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -298,14 +298,17 @@ Not everything is fused into the AAR. The build keeps three kinds of dependencie
 - **`androidx.*` libraries** — AGP Fused Library's class rewriter can't resolve `android:` framework attributes in their styleables, so all of AndroidX stays external except chains that must be fused for validation reasons (`androidx.camera`, `androidx.media3` by default).
 - **Auto-detected KMP umbrella modules** — pom-only coordinates whose variants all redirect to a platform module.
 
-Four Gradle properties tune this behavior when a project's dependency graph needs it:
+The published metadata also annotates the `react-android` and `hermes-android` dependency edges with the sibling's build type, so a host app always resolves the same React Native variant the fused AAR's native libraries were linked against, even when a debug host consumes the release AAR.
 
-| Property                              | Effect                                                                                                                                                                   |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `brownfield.fused.skip`               | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                                                               |
-| `brownfield.fused.strip-packages`     | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup. |
-| `brownfield.fused.androidx-fuse`      | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                                                      |
-| `brownfield.fused.exclude-transitive` | Extra dependency groups to keep external (declared in the POM instead of fused).                                                                                         |
+Five Gradle properties tune this behavior when a project's dependency graph needs it:
+
+| Property                              | Effect                                                                                                                                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brownfield.fused.skip`               | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                                                                                         |
+| `brownfield.fused.strip-packages`     | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup.                           |
+| `brownfield.fused.androidx-fuse`      | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                                                                                |
+| `brownfield.fused.exclude-transitive` | Extra dependency groups to keep external (declared in the POM instead of fused).                                                                                                                   |
+| `brownfield.fused.host-provided`      | Dependency groups the host app already ships (Glide, Compose, and so on). Kept out of the AAR like `exclude-transitive`, but also not declared in the POM, so the host's own version is untouched. |
 
 Pass them as `-P` Gradle properties when invoking a fused publish task directly from the **android** directory:
 
@@ -317,6 +320,8 @@ Pass them as `-P` Gradle properties when invoking a fused publish task directly 
     '    -Pbrownfield.fused.strip-packages=expo.modules.camera.',
   ]}
 />
+
+> **Note**: Before fusing, check which libraries your host app already uses. If the host ships its own Glide (`expo-image` fuses Glide), Jetpack Compose (`@expo/ui`), or similar, the fused AAR's copy will collide with the host's at build time (duplicate classes) or force-upgrade it through the POM. Prefer leaving those Expo modules out of the project, or mark the shared groups as `brownfield.fused.host-provided` and align versions manually.
 
 ### Sample GitHub Actions workflow
 

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -391,6 +391,12 @@ dependencies {
 
 `releaseImplementation`/`debugImplementation` pair the variants automatically. Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and publish only the release sibling with `--fused --release`.
 
+A few host app requirements and tips:
+
+- **`minSdk` must be at least 24** (React Native's floor). Hosts targeting a lower API level fail at manifest merge when they consume the AAR.
+- **Permissions merge in from the fused modules.** For example, media-related Expo modules declare storage permissions. If your host enforces a permission allowlist, strip unwanted entries in the host manifest with `tools:node="remove"` (or reconcile attribute conflicts with `tools:replace`).
+- **The AAR ships native libraries for every ABI enabled at publish time.** Without filtering, a host APK grows by all four ABIs' worth of React Native libraries. Constrain ABIs when publishing (`reactNativeArchitectures=arm64-v8a` in the Expo project's **gradle.properties**) or filter in the host with `ndk.abiFilters`/APK splits.
+
 ## CLI
 
 The `expo-brownfield` library includes a CLI for building and publishing to Maven repositories (Android) and XCFrameworks (iOS).

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -227,20 +227,20 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
 
 ## Publishing artifacts
 
-Brownfield Android artifacts are pushed to one or more Maven repositories declared via `android.publishing` in your app config. The repository types supported are:
+The `expo-brownfield` CLI pushes Android artifacts to one or more Maven repositories, declared via `android.publishing` in your app config. The supported repository types are:
 
-| `type`            | Description                                                                                                              |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `localMaven`      | Publishes to `~/.m2/repository`. Default. Useful for local host-app integration during development.                       |
-| `localDirectory`  | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.        |
-| `remotePublic`    | Publishes to a public Maven repository with no authentication.                                                            |
-| `remotePrivate`   | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, Sonatype Nexus…). Credentials can be inline strings or environment-variable references. |
+| `type`           | Description                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `localMaven`     | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                        |
+| `localDirectory` | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.            |
+| `remotePublic`   | Publishes to a public Maven repository with no authentication.                                                               |
+| `remotePrivate`  | Publishes to an authenticated remote Maven repository. Credentials can be inline strings or environment-variable references. |
 
-`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object — `{ "variable": "SOME_ENV_VAR" }` — that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
+`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object (`{ "variable": "SOME_ENV_VAR" }`) that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
 
 ### Publishing to GitHub Packages
 
-GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication is `GITHUB_ACTOR` (the user/bot name) + a [personal access token](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with `write:packages` and `read:packages` scopes (in GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo).
+GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication uses `GITHUB_ACTOR` (the user or bot name) and a [personal access token (PAT)](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with the `write:packages` and `read:packages` scopes. In GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo.
 
 Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packages URL for your test repository:
 
@@ -272,21 +272,51 @@ Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packa
 }
 ```
 
-The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository`, invoked via:
+The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the release publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository` (and `publishBrownfieldDebugPublicationToGitHubPackagesRepository` for the debug sibling). The default invocation runs both:
 
 <Terminal cmd={['$ npx expo-brownfield build:android --fused --repo GitHubPackages']} />
 
 ### Publishing only the fused artifacts
 
-The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20–40 artifacts per release). To publish a small, curated set instead, use `--fused` — the fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat-AAR sibling(s):
+The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20 to 40 artifacts per release). To publish a small, curated set instead, use `--fused`. The fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat AAR sibling(s). A repository (`--repo`) or an explicit task (`-t`) is always required, as there is no default:
 
-| Invocation                                   | Coordinates published                                                                                                   |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--fused --release`                          | `<group>:<libraryName>-fused-release:<version>`                                                                          |
-| `--fused --debug`                            | `<group>:<libraryName>-fused-debug:<version>`                                                                            |
-| `--fused --all` (default with `--fused`)     | Both of the above (two Gradle invocations under the hood, one per variant)                                              |
+| Invocation                                             | Coordinates published                                                      |
+| ------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `--fused --release --repo <name>`                      | `<group>:<libraryName>-fused-release:<version>`                            |
+| `--fused --debug --repo <name>`                        | `<group>:<libraryName>-fused-debug:<version>`                              |
+| `--fused --all --repo <name>` (default with `--fused`) | Both of the above (two Gradle invocations under the hood, one per variant) |
 
-That's at most two Maven coordinates published per release — independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR; see [Fused mode](#fused-mode) for the full denylist + allowlist.
+That's at most two Maven coordinates published per release, independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR.
+
+### Fused mode
+
+`--fused` publishes through two extra Gradle subprojects that prebuild always generates — `:<libraryName>-fused-release` and `:<libraryName>-fused-debug` — each producing one fat AAR via [AGP's Fused Library plugin](https://developer.android.com/build/publish-library/fused-library) (a Preview feature; the CLI temporarily forces AGP 8.13 for these builds). The subprojects are inert during normal builds: their build scripts only activate when the CLI passes `-Pbrownfield.fused=true`, so `npx expo run:android` and IDE sync pay no extra configuration cost. If you invoke a fused Gradle task directly instead of through the CLI, pass `-Pbrownfield.fused=true` yourself.
+
+Not everything is fused into the AAR. The build keeps three kinds of dependencies external and declares them as ordinary Maven dependencies in the published POM and Gradle Module Metadata, where the host app resolves them itself:
+
+- **The brownfield host baseline** — the React Native runtime (`react-android`, `hermes-android`, `fbjni`, `soloader`, `yoga`), the Kotlin stdlib, and host-provided commons (Material Components, Guava, Fresco, OkHttp, Okio). Fusing these would duplicate classes the host already ships.
+- **`androidx.*` libraries** — AGP Fused Library's class rewriter can't resolve `android:` framework attributes in their styleables, so all of AndroidX stays external except chains that must be fused for validation reasons (`androidx.camera`, `androidx.media3` by default).
+- **Auto-detected KMP umbrella modules** — pom-only coordinates whose variants all redirect to a platform module.
+
+Four Gradle properties tune this behavior when a project's dependency graph needs it:
+
+| Property                              | Effect                                                                                                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `brownfield.fused.skip`               | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                                                               |
+| `brownfield.fused.strip-packages`     | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup. |
+| `brownfield.fused.androidx-fuse`      | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                                                      |
+| `brownfield.fused.exclude-transitive` | Extra dependency groups to keep external (declared in the POM instead of fused).                                                                                         |
+
+Pass them as `-P` Gradle properties when invoking a fused publish task directly from the **android** directory:
+
+<Terminal
+  cmd={[
+    '$ ./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal \\',
+    '    -Pbrownfield.fused=true \\',
+    '    -Pbrownfield.fused.skip=expo-camera \\',
+    '    -Pbrownfield.fused.strip-packages=expo.modules.camera.',
+  ]}
+/>
 
 ### Sample GitHub Actions workflow
 
@@ -327,7 +357,7 @@ Trigger via `git tag brownfield-v1.0.0 && git push --tags` (or manually via the 
 
 ### Consumer setup (host Android app)
 
-The host app's `settings.gradle.kts` (or per-module `build.gradle.kts`) declares the same GitHub Packages URL + credentials. The host app's CI/local builds must have `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars set or pulled from `~/.gradle/gradle.properties`.
+The host app's **settings.gradle.kts** (or per-module **build.gradle.kts**) declares the same GitHub Packages URL and credentials. The host app's CI/local builds must have the `GITHUB_ACTOR` and `GITHUB_TOKEN` env vars set or pulled from **~/.gradle/gradle.properties**.
 
 ```kotlin android/settings.gradle.kts
 dependencyResolutionManagement {
@@ -338,9 +368,9 @@ dependencyResolutionManagement {
       url = uri("https://maven.pkg.github.com/<owner>/<repo>")
       credentials {
         username = providers.environmentVariable("GITHUB_ACTOR").orNull
-          ?: providers.gradleProperty("gpr.user").get()
+          ?: providers.gradleProperty("gpr.user").orNull
         password = providers.environmentVariable("GITHUB_TOKEN").orNull
-          ?: providers.gradleProperty("gpr.token").get()
+          ?: providers.gradleProperty("gpr.token").orNull
       }
     }
   }
@@ -354,7 +384,7 @@ dependencies {
 }
 ```
 
-`releaseImplementation` / `debugImplementation` pair the variants automatically — Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and just publish the release sibling with `--fused --release`.
+`releaseImplementation`/`debugImplementation` pair the variants automatically. Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and publish only the release sibling with `--fused --release`.
 
 ## CLI
 
@@ -370,16 +400,16 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 
 <Terminal cmd={['$ npx expo-brownfield build:android [options]']} />
 
-| Option                 | Description                                    |
-| ---------------------- | ---------------------------------------------- |
-| `-d, --debug`          | Build in debug mode                            |
-| `-r, --release`        | Build in release mode                          |
-| `-a, --all`            | Build in both debug and release mode (default) |
-| `--fused`              | Publish a single fat AAR via AGP Fused Library |
-| `-l, --library`        | Specify brownfield library name                |
-| `--repo, --repository` | Specify Maven repositories to publish to       |
-| `-t, --task`           | Specify Gradle publish tasks to run            |
-| `--verbose`            | Include all logs from subprocesses             |
+| Option                 | Description                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `-d, --debug`          | Build in debug mode                                                                       |
+| `-r, --release`        | Build in release mode                                                                     |
+| `-a, --all`            | Build in both debug and release mode (default)                                            |
+| `--fused`              | Publish a single fat AAR per variant via AGP Fused Library. See [Fused mode](#fused-mode) |
+| `-l, --library`        | Specify brownfield library name                                                           |
+| `--repo, --repository` | Specify Maven repositories to publish to                                                  |
+| `-t, --task`           | Specify Gradle publish tasks to run                                                       |
+| `--verbose`            | Include all logs from subprocesses                                                        |
 
 #### `build:ios`
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add hostProvidedFrameworks option to skip Frameworks provided by the host app ([#46355](https://github.com/expo/expo/pull/46355) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Add support Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add hostProvidedFrameworks option to skip Frameworks provided by the host app ([#46355](https://github.com/expo/expo/pull/46355) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [android] Add support for publishing a single fused AAR via AGP Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Add support for publishing a single fused AAR via AGP Fused Library ([#47921](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add hostProvidedFrameworks option to skip Frameworks provided by the host app ([#46355](https://github.com/expo/expo/pull/46355) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [android] Add support Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Add support for publishing a single fused AAR via AGP Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/cli/src/commands/build-android.ts
+++ b/packages/expo-brownfield/cli/src/commands/build-android.ts
@@ -17,8 +17,9 @@ const buildAndroid = async (command: Command) => {
   }
   printAndroidConfig(config);
 
+  const extraGradleArgs = config.fused ? ['-Pbrownfield.fused=true'] : [];
   for (const task of config.tasks) {
-    await runTask(task, config.verbose, config.dryRun);
+    await runTask(task, config.verbose, config.dryRun, extraGradleArgs);
   }
 };
 

--- a/packages/expo-brownfield/cli/src/index.ts
+++ b/packages/expo-brownfield/cli/src/index.ts
@@ -16,6 +16,7 @@ program
   .option('-d, --debug', 'build debug variant')
   .option('-r, --release', 'build release variant')
   .option('-a, --all', 'build both debug and release variants')
+  .option('--fused', 'publish a single fat AAR per variant via AGP Fused Library')
   .option('--verbose', 'forward all output to the terminal')
   .option('-l, --library <library>', 'name of the brownfield library')
   .option('-t, --task <task...>', 'publishing task to be run (multiple can be passed)')

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -7,9 +7,20 @@ import CLIError from './error';
 import { withSpinner } from './spinner';
 import type { AndroidConfig, BuildVariant } from './types';
 
-export const buildPublishingTask = (variant: BuildVariant, repository: string): string => {
+export const buildPublishingTask = (
+  variant: BuildVariant,
+  repository: string,
+  fusedOpts: { fused: boolean; library: string } = { fused: false, library: '' }
+): string => {
   const repositoryName = repository === 'MavenLocal' ? repository : `${repository}Repository`;
-  return `publishBrownfield${variant}PublicationTo${repositoryName}`;
+  const task = `publishBrownfield${variant}PublicationTo${repositoryName}`;
+  // In `--fused` mode, route the task to the matching sibling subproject:
+  // `:<lib>-fused-release` for Release, `:<lib>-fused-debug` for Debug.
+  if (fusedOpts.fused) {
+    const siblingSuffix = variant === 'Debug' ? 'debug' : 'release';
+    return `:${fusedOpts.library}-fused-${siblingSuffix}:${task}`;
+  }
+  return task;
 };
 
 export const findBrownfieldLibrary = (): string | undefined => {
@@ -93,15 +104,28 @@ export const processTasks = (stdout: string): string[] => {
   );
 };
 
-export const runTask = async (task: string, verbose: boolean, dryRun: boolean) => {
+export const runTask = async (
+  task: string,
+  verbose: boolean,
+  dryRun: boolean,
+  extraGradleArgs: string[] = []
+) => {
+  // For fused tasks, forward the variant as a Gradle property so
+  // `setupFusedModeStripping` applies the right strip prefixes.
+  const fusedVariantMatch = task.match(/:[^:]+-fused-(release|debug):/);
+  const perTaskArgs = fusedVariantMatch
+    ? [...extraGradleArgs, `-Pbrownfield.fused.variant=${fusedVariantMatch[1]}`]
+    : extraGradleArgs;
+
+  const args = [task, ...perTaskArgs];
   if (dryRun) {
-    console.log(`./gradlew ${task}`);
+    console.log(`./gradlew ${args.join(' ')}`);
     return;
   }
 
   return withSpinner({
     operation: () =>
-      spawnAsync('./gradlew', [task], {
+      spawnAsync('./gradlew', args, {
         cwd: path.join(process.cwd(), 'android'),
         stdio: verbose ? 'inherit' : 'pipe',
       }),

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -70,6 +70,7 @@ export const printAndroidConfig = (config: AndroidConfig) => {
   console.log(chalk.bold('Resolved build configuration'));
   console.log(` - Build variant: ${chalk.blue(config.variant)}`);
   console.log(` - Library: ${chalk.blue(config.library)}`);
+  console.log(` - Fused: ${chalk.blue(config.fused)}`);
   console.log(` - Verbose: ${chalk.blue(config.verbose)}`);
   console.log(` - Dry run: ${chalk.blue(config.dryRun)}`);
   console.log(` - Tasks:`);
@@ -110,12 +111,17 @@ export const runTask = async (
   dryRun: boolean,
   extraGradleArgs: string[] = []
 ) => {
-  // For fused tasks, forward the variant as a Gradle property so
-  // `setupFusedModeStripping` applies the right strip prefixes.
-  const fusedVariantMatch = task.match(/:[^:]+-fused-(release|debug):/);
-  const perTaskArgs = fusedVariantMatch
-    ? [...extraGradleArgs, `-Pbrownfield.fused.variant=${fusedVariantMatch[1]}`]
-    : extraGradleArgs;
+  // Fused-shaped tasks (e.g. passed manually via -t without --fused) must still
+  // activate fused mode in Gradle: without `-Pbrownfield.fused=true` the fused
+  // sibling subprojects are inert (no publications) and the conditional AGP
+  // force-bump in the root build.gradle never applies, so the build would fail
+  // mid-execution under the version catalog's AGP.
+  const fusedProperty = '-Pbrownfield.fused=true';
+  const isFusedTask = /(?:^|:)[^:\s]+-fused-(?:release|debug):/.test(task);
+  const perTaskArgs =
+    isFusedTask && !extraGradleArgs.includes(fusedProperty)
+      ? [...extraGradleArgs, fusedProperty]
+      : extraGradleArgs;
 
   const args = [task, ...perTaskArgs];
   if (dryRun) {

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -12,7 +12,8 @@ export const buildPublishingTask = (
   repository: string,
   fusedOpts: { fused: boolean; library: string } = { fused: false, library: '' }
 ): string => {
-  const repositoryName = repository === 'MavenLocal' ? repository : `${repository}Repository`;
+  const repositoryName =
+    repository.toLowerCase() === 'mavenlocal' ? 'MavenLocal' : `${repository}Repository`;
   const task = `publishBrownfield${variant}PublicationTo${repositoryName}`;
   // In `--fused` mode, route the task to the matching sibling subproject:
   // `:<lib>-fused-release` for Release, `:<lib>-fused-debug` for Debug.

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -171,7 +171,7 @@ const resolveTaskArray = (
   const tasks: string[] = options.task ?? [];
   let repositories: string[] = options.repository ?? [];
   if (tasks.length === 0 && repositories.length === 0) {
-    repositories = resolveLocalRepositoriesFromAppConfig();
+    repositories = resolveLocalRepositoriesFromAppConfig(!!options.verbose);
     if (repositories.length > 0) {
       console.info(
         `No --repo or --task specified; defaulting to local repositories from the app config: ${repositories.join(', ')}`
@@ -189,7 +189,7 @@ const resolveTaskArray = (
   return Array.from(new Set([...tasks, ...repoTasks]));
 };
 
-const resolveLocalRepositoriesFromAppConfig = (): string[] => {
+const resolveLocalRepositoriesFromAppConfig = (verbose: boolean): string[] => {
   let publishing: unknown;
   try {
     const { exp } = getConfig(process.cwd(), { skipSDKVersionRequirement: true });
@@ -197,9 +197,16 @@ const resolveLocalRepositoriesFromAppConfig = (): string[] => {
       (entry): entry is [string, any] => Array.isArray(entry) && entry[0] === 'expo-brownfield'
     );
     publishing = plugin?.[1]?.android?.publishing;
-  } catch {
+  } catch (error) {
     // App config could not be evaluated here — fall through to the plugin's
     // default publishing target below.
+    if (verbose) {
+      console.warn(
+        `Could not read \`android.publishing\` from the app config, falling back to MavenLocal: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
   }
 
   const entries =

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -18,12 +18,15 @@ import type {
 const HOST_PROVIDED_FRAMEWORKS_KEY = 'ios.brownfieldHostProvidedFrameworks';
 
 export const resolveBuildConfigAndroid = (options: OptionValues): AndroidConfig => {
-  const variant = resolveVariant(options);
+  const fused = !!options.fused;
+  const variant: BuildVariant = resolveVariant(options);
+  const library = resolveLibrary(options);
   return {
     ...resolveCommonConfig(options),
-    library: resolveLibrary(options),
-    tasks: resolveTaskArray(options, variant),
+    library,
+    tasks: resolveTaskArray(options, variant, { fused, library }),
     variant,
+    fused,
   };
 };
 
@@ -159,10 +162,19 @@ const resolveLibrary = (options: OptionValues): string => {
   return options.library || findBrownfieldLibrary();
 };
 
-const resolveTaskArray = (options: OptionValues, variant: BuildVariant): string[] => {
+const resolveTaskArray = (
+  options: OptionValues,
+  variant: BuildVariant,
+  fusedOpts: { fused: boolean; library: string }
+): string[] => {
   const tasks: string[] = options.task ?? [];
-  const repoTasks = (options.repository ?? []).map((repo: string) =>
-    buildPublishingTask(variant, repo)
+  const repositories: string[] = options.repository ?? [];
+  // In `--fused` mode, `--all` expands to separate Debug + Release task
+  // invocations against the matching sibling subprojects.
+  const variantsForRepoTasks: BuildVariant[] =
+    fusedOpts.fused && variant === 'All' ? ['Debug', 'Release'] : [variant];
+  const repoTasks = repositories.flatMap((repo) =>
+    variantsForRepoTasks.map((v) => buildPublishingTask(v, repo, fusedOpts))
   );
 
   return Array.from(new Set([...tasks, ...repoTasks]));

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -1,4 +1,5 @@
 import type { OptionValues } from 'commander';
+import { getConfig } from 'expo/config';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -168,7 +169,15 @@ const resolveTaskArray = (
   fusedOpts: { fused: boolean; library: string }
 ): string[] => {
   const tasks: string[] = options.task ?? [];
-  const repositories: string[] = options.repository ?? [];
+  let repositories: string[] = options.repository ?? [];
+  if (tasks.length === 0 && repositories.length === 0) {
+    repositories = resolveLocalRepositoriesFromAppConfig();
+    if (repositories.length > 0) {
+      console.info(
+        `No --repo or --task specified; defaulting to local repositories from the app config: ${repositories.join(', ')}`
+      );
+    }
+  }
   // In `--fused` mode, `--all` expands to separate Debug + Release task
   // invocations against the matching sibling subprojects.
   const variantsForRepoTasks: BuildVariant[] =
@@ -178,6 +187,33 @@ const resolveTaskArray = (
   );
 
   return Array.from(new Set([...tasks, ...repoTasks]));
+};
+
+const resolveLocalRepositoriesFromAppConfig = (): string[] => {
+  let publishing: unknown;
+  try {
+    const { exp } = getConfig(process.cwd(), { skipSDKVersionRequirement: true });
+    const plugin = exp.plugins?.find(
+      (entry): entry is [string, any] => Array.isArray(entry) && entry[0] === 'expo-brownfield'
+    );
+    publishing = plugin?.[1]?.android?.publishing;
+  } catch {
+    // App config could not be evaluated here — fall through to the plugin's
+    // default publishing target below.
+  }
+
+  const entries =
+    Array.isArray(publishing) && publishing.length > 0 ? publishing : [{ type: 'localMaven' }];
+  const repositories = entries.flatMap((entry) => {
+    if (entry?.type === 'localMaven') {
+      return ['MavenLocal'];
+    }
+    if (entry?.type === 'localDirectory' && typeof entry?.name === 'string') {
+      return [entry.name];
+    }
+    return [];
+  });
+  return Array.from(new Set(repositories));
 };
 
 const resolveVariant = (options: OptionValues): BuildVariant => {

--- a/packages/expo-brownfield/cli/src/utils/error.ts
+++ b/packages/expo-brownfield/cli/src/utils/error.ts
@@ -20,7 +20,8 @@ type ErrorType =
 class CLIError {
   private static readonly errorSymbol: string = '✖';
   private static readonly errorMessages: Record<ErrorType, string> = {
-    'android-task-repo': 'At least one task or repository must be specified',
+    'android-task-repo':
+      'At least one task or repository must be specified. The app config declares no local Maven repositories to default to, and remote repositories are never published to implicitly — pass `--repo <name>` or `-t <gradle task>` explicitly.',
     'android-directory-not-found': 'Cannot find `android` directory in the project',
     'android-library-unknown-error': 'Unknown error occurred while finding brownfield library',
     'android-library-not-found': 'Could not find brownfield library in the project',

--- a/packages/expo-brownfield/cli/src/utils/prebuild.ts
+++ b/packages/expo-brownfield/cli/src/utils/prebuild.ts
@@ -17,14 +17,24 @@ export const validatePrebuild = async (
 
   if (!checkPrebuild(platform)) {
     console.info(`${chalk.yellow(`⚠ Prebuild for platform: ${platform} is missing`)}`);
-    const response = await prompts({
-      type: 'confirm',
-      name: 'shouldRunPrebuild',
-      message: 'Do you want to run the prebuild now?',
-      initial: false,
-    });
 
-    if (response.shouldRunPrebuild) {
+    let shouldRunPrebuild: boolean;
+    if (isInteractive()) {
+      const response = await prompts({
+        type: 'confirm',
+        name: 'shouldRunPrebuild',
+        message: 'Do you want to run the prebuild now?',
+        initial: false,
+      });
+      shouldRunPrebuild = !!response.shouldRunPrebuild;
+    } else {
+      console.info(
+        `Non-interactive shell detected; running \`npx expo prebuild --platform ${platform}\` automatically`
+      );
+      shouldRunPrebuild = true;
+    }
+
+    if (shouldRunPrebuild) {
       await withSpinner({
         operation: () => spawnAsync('npx', ['expo', 'prebuild', '--platform', platform]),
         loaderMessage: `Running 'npx expo prebuild' for platform: ${platform}...`,
@@ -108,4 +118,8 @@ export const validatePackageInstalled = (): void => {
 const checkPrebuild = (platform: Platform): boolean => {
   const nativeDirectory = path.join(process.cwd(), platform);
   return fs.existsSync(nativeDirectory);
+};
+
+const isInteractive = (): boolean => {
+  return !!process.stdin.isTTY && !!process.stdout.isTTY;
 };

--- a/packages/expo-brownfield/cli/src/utils/types.ts
+++ b/packages/expo-brownfield/cli/src/utils/types.ts
@@ -20,6 +20,7 @@ export interface AndroidConfig extends CommonConfig {
   library: string;
   tasks: string[];
   variant: BuildVariant;
+  fused: boolean;
 }
 
 export interface PackageConfiguration {

--- a/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
+++ b/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
@@ -4,6 +4,7 @@ exports[`build:android command with prebuild should infer and print build config
 "Resolved build configuration
  - Build variant: All
  - Library: brownfield
+ - Fused: false
  - Verbose: false
  - Dry run: true
  - Tasks:

--- a/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
+++ b/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
@@ -21,6 +21,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -41,6 +43,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -61,6 +65,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
@@ -363,6 +363,54 @@ describe('build:android command', () => {
     });
 
     /**
+     * Command: npx expo-brownfield build:android --repo MavenLocal --fused --dry-run
+     * Expected behavior: With --fused, repo tasks are routed to the per-variant
+     * fused sibling subprojects and -Pbrownfield.fused=true is forwarded to Gradle
+     */
+    it('should properly handle --fused option', async () => {
+      // Default variant (--all) expands to one task per fused sibling
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: ['--repo', 'MavenLocal', '--fused', '--dry-run'],
+        stdout: [
+          BUILD_ANDROID.FUSED,
+          `./gradlew :brownfield-fused-debug:publishBrownfieldDebugPublicationToMavenLocal -Pbrownfield.fused=true`,
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+
+      // Single variant targets a single sibling
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: ['--repo', 'MavenLocal', '--fused', '--release', '--dry-run'],
+        stdout: [
+          BUILD_ANDROID.BUILD_VARIANT_RELEASE,
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+    });
+
+    /**
+     * Command: npx expo-brownfield build:android -t <fused task> --dry-run (no --fused)
+     * Expected behavior: A fused task passed manually still activates fused mode in
+     * Gradle — without -Pbrownfield.fused=true the fused subprojects are inert and
+     * the AGP force-bump never applies
+     */
+    it('should forward the fused property for manually passed fused tasks', async () => {
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: [
+          '-t',
+          ':brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal',
+          '--dry-run',
+        ],
+        stdout: [
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+    });
+
+    /**
      * Command: npx expo-brownfield build:android
      * Expected behavior: The CLI should print an error message and exit
      */

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
@@ -88,40 +88,25 @@ describe('build:android command', () => {
     });
 
     /**
-     * Command: npx expo-brownfield build:android
-     * Expected behavior: The CLI should fail if prebuild is cancelled
+     * Command: npx expo-brownfield build:android (non-interactive stdin)
+     * Expected behavior: The CLI must not hang on the prebuild prompt in
+     * non-TTY contexts (CI); it runs `npx expo prebuild` automatically and
+     * continues. NOTE: mutates TEMP_DIR (creates android/) — keep this the
+     * last test in the "without prebuild" block.
      */
-    it('should fail if prebuild is cancelled', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
-      const { exitCode, stdout, stderr } = await executeCommandAsync(
+    it('should automatically run prebuild in a non-interactive shell', async () => {
+      const { exitCode, stdout } = await executeCommandAsync(
         TEMP_DIR,
         'bash',
-        ['-c', `yes no | node ${CLI_PATH} build:android --repo MavenLocal`],
+        ['-c', `node ${CLI_PATH} build:android --repo MavenLocal --dry-run < /dev/null`],
         { ignoreErrors: true }
       );
-      expect(exitCode).not.toBe(0);
       expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain(ERROR.MISSING_PREBUILD());
-    });
-
-    /**
-     * Command: npx expo-brownfield build:android
-     * Expected behavior: The CLI should validate and ask for prebuild
-     */
-    it('should validate and ask for prebuild', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
-      const { exitCode, stdout, stderr } = await executeCommandAsync(
-        TEMP_DIR,
-        'bash',
-        ['-c', `yes no | node ${CLI_PATH} build:android --repo MavenLocal`],
-        { ignoreErrors: true }
-      );
-      expect(exitCode).not.toBe(0);
-      expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
+      expect(stdout).not.toContain(BUILD.PREBUILD_PROMPT);
+      expect(stdout).toContain(BUILD.PREBUILD_AUTO('android'));
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain(`./gradlew publishBrownfieldAllPublicationToMavenLocal`);
+      expectPrebuild(TEMP_DIR, 'android');
     });
   });
 
@@ -411,14 +396,33 @@ describe('build:android command', () => {
     });
 
     /**
-     * Command: npx expo-brownfield build:android
-     * Expected behavior: The CLI should print an error message and exit
+     * Command: npx expo-brownfield build:android (no --repo / -t)
+     * Expected behavior: The CLI derives the local publish targets from the
+     * app config's `android.publishing` (default: localMaven) instead of
+     * erroring. Remote repositories are never published to by default.
      */
-    it('should print an error message and exit if no tasks or repositories are specified', async () => {
+    it('should default to local repositories from the app config when no tasks or repositories are specified', async () => {
       await buildAndroidTest({
         directory: TEMP_DIR_PREBUILD,
-        successExit: false,
-        stderr: [ERROR.MISSING_TASKS_OR_REPOSITORIES()],
+        args: ['--dry-run'],
+        stdout: [
+          BUILD_ANDROID.DEFAULT_REPOSITORIES('MavenLocal'),
+          `./gradlew publishBrownfieldAllPublicationToMavenLocal`,
+        ],
+      });
+    });
+
+    /**
+     * Command: npx expo-brownfield build:android --repo mavenlocal --dry-run
+     * Expected behavior: The built-in Maven local target matches
+     * case-insensitively — `mavenlocal` must not produce the broken
+     * `...TomavenLocalRepository` task name
+     */
+    it('should treat the MavenLocal repository name case-insensitively', async () => {
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: ['--repo', 'mavenlocal', '--dry-run'],
+        stdout: [`./gradlew publishBrownfieldAllPublicationToMavenLocal`],
       });
     });
   });

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-ios.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-ios.test.ts
@@ -92,20 +92,24 @@ describe('build:ios command', () => {
 
     /**
      * Command: npx expo-brownfield build:ios
-     * Expected behavior: The CLI should validate and ask for prebuild
+     * Expected behavior: The CLI runs prebuild automatically in non-TTY
+     * contexts (CI) instead of hanging on the prompt. The command still exits
+     * non-zero: the pod-install prompt is also non-interactive and CocoaPods
+     * has not been installed. NOTE: mutates TEMP_DIR (creates ios/) — keep
+     * this the last test in the "without prebuild" block.
      */
-    it('should validate and ask for prebuild', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
+    it('should automatically run prebuild in a non-interactive shell', async () => {
       const { exitCode, stdout, stderr } = await executeCommandAsync(
         TEMP_DIR,
         'bash',
-        ['-c', `yes no | node ${CLI_PATH} build:ios`],
+        ['-c', `node ${CLI_PATH} build:ios < /dev/null`],
         { ignoreErrors: true }
       );
-      expect(exitCode).not.toBe(0);
       expect(stdout).toContain(BUILD.PREBUILD_WARNING('ios'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
+      expect(stdout).not.toContain(BUILD.PREBUILD_PROMPT);
+      expect(stdout).toContain(BUILD.PREBUILD_AUTO('ios'));
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain(ERROR.MISSING_POD_INSTALL());
     });
   });
 

--- a/packages/expo-brownfield/e2e/cli/__tests__/index.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/index.test.ts
@@ -20,19 +20,21 @@ describe('basic cli tests', () => {
   }, 600000);
 
   /**
-   * Command: npx expo-brownfield tasks:android
-   * Expected behavior: The CLI should display an error message
+   * Command: npx expo-brownfield build:android --repo MavenLocal --dry-run
+   * Expected behavior: The command is routed to the android handler; the
+   * missing prebuild is run automatically (non-interactive stdin) and the
+   * resolved configuration is printed
    */
   it('should correctly parse passed commands', async () => {
-    const { exitCode, stderr } = await executeCommandAsync(
+    const { exitCode, stdout } = await executeCommandAsync(
       TEMP_DIR,
       'bash',
-      ['-c', `yes no | node ${CLI_PATH} build:android --repo MavenLocal`],
+      ['-c', `node ${CLI_PATH} build:android --repo MavenLocal --dry-run < /dev/null`],
       { ignoreErrors: true }
     );
-    // Expect error because we haven't run prebuild
-    expect(exitCode).not.toBe(0);
-    expect(stderr).toContain(ERROR.MISSING_PREBUILD());
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Resolved build configuration');
+    expect(stdout).toContain(`./gradlew publishBrownfieldAllPublicationToMavenLocal`);
   });
 
   /**

--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -1,5 +1,5 @@
-import { BUILD, ERROR, TASKS_ANDROID } from '../../utils/output';
-import { CLI_PATH, executeCommandAsync } from '../../utils/process';
+import { ERROR, TASKS_ANDROID } from '../../utils/output';
+
 import { createTempProject, cleanUpProject } from '../../utils/project';
 import { buildTestCommon, expectPrebuild, tasksAndroidTest } from '../../utils/test';
 
@@ -87,42 +87,6 @@ describe('tasks:android command', () => {
       });
     });
 
-    /**
-     * Command: npx expo-brownfield build:ios
-     * Expected behavior: The CLI should fail if prebuild is cancelled
-     */
-    it('should fail if prebuild is cancelled', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
-      const { exitCode, stdout, stderr } = await executeCommandAsync(
-        TEMP_DIR,
-        'bash',
-        ['-c', `yes no | node ${CLI_PATH} tasks:android`],
-        { ignoreErrors: true }
-      );
-      expect(exitCode).not.toBe(0);
-      expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain(ERROR.MISSING_PREBUILD());
-    });
-
-    /**
-     * Command: npx expo-brownfield tasks:android
-     * Expected behavior: The CLI should validate and ask for prebuild
-     */
-    it('should validate and ask for prebuild', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
-      const { exitCode, stdout, stderr } = await executeCommandAsync(
-        TEMP_DIR,
-        'bash',
-        ['-c', `yes no | node ${CLI_PATH} tasks:android`],
-        { ignoreErrors: true }
-      );
-      expect(exitCode).not.toBe(0);
-      expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-    });
   });
 
   /**

--- a/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
@@ -50,6 +50,64 @@ describe('plugin templates', () => {
 
   /**
    * Expected behavior:
+   * - Both fused sibling subprojects are emitted, one per variant, with
+   *   interpolated values resolved and the inert-by-default property guard
+   * - settings.gradle includes the fused siblings
+   * - gradle.properties contains the Fused Library preview opt-ins
+   * - The root build.gradle contains the conditional AGP force-bump
+   */
+  it('emits inert fused sibling projects for android', async () => {
+    const PACKAGE = 'com.example.test.mybrownfield';
+    const GROUP = 'io.example.test';
+    const VERSION = '2.56.173';
+    await setupAndroidPlugin(TEMP_DIR, {
+      package: PACKAGE,
+      group: GROUP,
+      version: VERSION,
+    });
+
+    for (const variant of ['release', 'debug']) {
+      expectFile({
+        projectRoot: TEMP_DIR,
+        filePath: `android/brownfield-fused-${variant}/build.gradle.kts`,
+        content: [
+          `group = "${GROUP}"`,
+          `version = "${VERSION}"`,
+          `namespace = "${PACKAGE}.fused.${variant}"`,
+          `val fusedVariant = "${variant}"`,
+          // Inert unless the CLI passes -Pbrownfield.fused=true — a plain
+          // `expo run:android` must not resolve the fused dependency graph
+          `findProperty("brownfield.fused") == "true"`,
+        ],
+      });
+    }
+
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/settings.gradle',
+      content: [
+        `include ':brownfield'`,
+        `include ':brownfield-fused-release'`,
+        `include ':brownfield-fused-debug'`,
+      ],
+    });
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/gradle.properties',
+      content: [
+        'android.experimental.fusedLibrarySupport=true',
+        'android.experimental.fusedLibrarySupport.publicationOnly=false',
+      ],
+    });
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/build.gradle',
+      content: [`findProperty('brownfield.fused') == 'true'`, 'com.android.tools.build:gradle'],
+    });
+  });
+
+  /**
+   * Expected behavior:
    * - All interpolated values are resolved in the templates for ios
    */
   it('resolves all interpolated values in templates for ios', async () => {

--- a/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
@@ -33,7 +33,7 @@ describe('plugin templates', () => {
 
     expectFile({
       projectRoot: TEMP_DIR,
-      fileName: 'build.gradle.kts',
+      filePath: 'android/brownfield/build.gradle.kts',
       content: [`group = "${GROUP}"`, `version = "${VERSION}"`, `namespace = "${PACKAGE}"`],
     });
     expectFiles({

--- a/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
@@ -1,3 +1,7 @@
+import { applyPatch } from 'diff';
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { setupPlugin as setupAndroidPlugin } from '../../utils/android';
 import { setupPlugin as setupIosPlugin } from '../../utils/ios';
 import { createTempProject, cleanUpProject, createTemplateOverrides } from '../../utils/project';
@@ -16,6 +20,35 @@ describe('plugin templates', () => {
   afterAll(async () => {
     await cleanUpProject('plugintemplates');
   }, 600000);
+
+  /**
+   * Expected behavior:
+   * - The dev-menu patches apply cleanly to the current templates. The patches
+   *   encode template lines as context, so any template edit that isn't
+   *   mirrored in the patch breaks prebuild for every expo-dev-menu user —
+   *   but only projects that actually depend on expo-dev-menu hit it, which
+   *   the temp projects here don't. Guard it directly.
+   */
+  it('applies the dev-menu patches cleanly to the current templates', () => {
+    const templatesDir = path.join(__dirname, '../../../plugin/templates');
+    const interpolate = (contents: string) =>
+      contents.replace(/\$\{\{[A-Za-z0-9]+\}\}/g, 'com.example.app');
+
+    const pairs = [
+      ['android/BrownfieldActivity.kt', 'patches/BrownfieldActivity.patch'],
+      ['android/ReactNativeHostManager.kt', 'patches/ReactNativeHostManager.patch'],
+    ];
+    for (const [template, patch] of pairs) {
+      const templateContents = interpolate(
+        fs.readFileSync(path.join(templatesDir, template), 'utf8')
+      );
+      const patchContents = fs.readFileSync(path.join(templatesDir, patch), 'utf8');
+      const result = applyPatch(templateContents, patchContents);
+      if (result === false) {
+        throw new Error(`${patch} no longer applies to ${template} — update the patch context`);
+      }
+    }
+  });
 
   /**
    * Expected behavior:

--- a/packages/expo-brownfield/e2e/utils/output.ts
+++ b/packages/expo-brownfield/e2e/utils/output.ts
@@ -24,6 +24,7 @@ export const BUILD_ANDROID = {
   BUILD_VARIANT_ALL: `- Build variant: All`,
   BUILD_VARIANT_DEBUG: `- Build variant: Debug`,
   BUILD_VARIANT_RELEASE: `- Build variant: Release`,
+  FUSED: `- Fused: true`,
   LIBRARY: `- Library: brownfieldlib`,
   TASK: [`- Tasks:`, `- task1`],
   TASKS: [`- Tasks:`, `- task1`, `- task2`, `- task3`],

--- a/packages/expo-brownfield/e2e/utils/output.ts
+++ b/packages/expo-brownfield/e2e/utils/output.ts
@@ -11,6 +11,8 @@ export const HELP_MESSAGE = {
  * Common build outputs
  */
 export const BUILD = {
+  PREBUILD_AUTO: (platform: 'android' | 'ios') =>
+    `Non-interactive shell detected; running \`npx expo prebuild --platform ${platform}\` automatically`,
   PREBUILD_PROMPT: `Do you want to run the prebuild now?`,
   PREBUILD_WARNING: (platform: 'android' | 'ios') =>
     `Prebuild for platform: ${platform} is missing`,
@@ -24,6 +26,8 @@ export const BUILD_ANDROID = {
   BUILD_VARIANT_ALL: `- Build variant: All`,
   BUILD_VARIANT_DEBUG: `- Build variant: Debug`,
   BUILD_VARIANT_RELEASE: `- Build variant: Release`,
+  DEFAULT_REPOSITORIES: (repos: string) =>
+    `No --repo or --task specified; defaulting to local repositories from the app config: ${repos}`,
   FUSED: `- Fused: true`,
   LIBRARY: `- Library: brownfieldlib`,
   TASK: [`- Tasks:`, `- task1`],
@@ -91,6 +95,7 @@ export const ERROR = {
     `error: too many arguments for '${command}'. Expected 0 arguments but got 1.`,
   MISSING_ARGUMENT: (short: string, full: string, argumentName: string) =>
     `error: option '-${short}, --${full} <${argumentName}>' argument missing`,
+  MISSING_POD_INSTALL: () => `Brownfield cannot be built without installing CocoaPods`,
   MISSING_PREBUILD: () => `Brownfield cannot be built without prebuilding the native project`,
   MISSING_TASKS_OR_REPOSITORIES: () => `Error: At least one task or repository must be specified`,
   UNKNOWN_COMMAND: (command: string) => `error: unknown command '${command}'`,

--- a/packages/expo-brownfield/e2e/utils/test.ts
+++ b/packages/expo-brownfield/e2e/utils/test.ts
@@ -144,7 +144,7 @@ export const buildTestCommon = async ({
 /**
  * Expects the prebuild to be successful at the given project root and platform
  */
-export const expectPrebuild = async (projectRoot: string, platform: 'android' | 'ios') => {
+export const expectPrebuild = (projectRoot: string, platform: 'android' | 'ios') => {
   const prebuildDir = path.join(projectRoot, platform);
   expect(fs.existsSync(prebuildDir)).toBe(true);
 
@@ -162,12 +162,10 @@ interface ExpectFileOptions {
   content?: string[] | string;
 }
 
-export const expectFile = async ({
-  projectRoot,
-  fileName,
-  filePath,
-  content,
-}: ExpectFileOptions) => {
+// NOTE: deliberately synchronous — callers don't await this helper, so if it were
+// async, failed expect()s would surface as unhandled rejections that Jest ignores
+// instead of failing the test.
+export const expectFile = ({ projectRoot, fileName, filePath, content }: ExpectFileOptions) => {
   let fullFilePath: string;
 
   if (fileName) {
@@ -219,7 +217,7 @@ type ExpectFilesOptions =
       expected: ExpectedFileName[];
     };
 
-export const expectFiles = async (options: ExpectFilesOptions) => {
+export const expectFiles = (options: ExpectFilesOptions) => {
   if ('content' in options) {
     options.fileNames.forEach((fileName) => {
       expectFile({ projectRoot: options.projectRoot, fileName, content: options.content });

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -25,35 +25,29 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   }
 
   /**
-   * In `--fused` release builds, strips dev-only entries from the autolinking-generated
-   * `ExpoModulesPackageList.kt` so the host app doesn't hit `NoClassDefFoundError`
-   * for modules excluded from the fat AAR. Extra prefixes via
-   * `-Pbrownfield.fused.strip-packages=foo.,bar.`. Inert otherwise.
+   * In `--fused` builds, strips entries from the autolinking-generated
+   * `ExpoModulesPackageList.kt` by package prefix, via
+   * `-Pbrownfield.fused.strip-packages=expo.modules.foo.,expo.modules.bar.`.
+   *
+   * This is the companion escape hatch to `-Pbrownfield.fused.skip=<project,...>`
+   * in the fused sibling's build script: a module excluded from the fat AAR still
+   * has its `Package` class referenced by `ExpoModulesPackageList.<clinit>`, which
+   * would crash the host with `NoClassDefFoundError` at startup — stripping the
+   * matching entries here keeps the package list consistent with the AAR contents.
+   * Inert unless both properties are set.
    */
   private fun setupFusedModeStripping(brownfieldProject: Project) {
     if (brownfieldProject.findProperty("brownfield.fused") != "true") return
 
     val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
 
-    // Strip prefixes that mirror the `devOnlySkipProjects` set in the release
-    // fused sibling. Kept in sync manually — if you add a module to the release
-    // skip list in `templates/android/fused/build.gradle.kts`, add its package
-    // prefix here too.
-    val fusedVariant =
-      (brownfieldProject.findProperty("brownfield.fused.variant") as? String)?.lowercase()
-    // EXPERIMENT: skip variant-based stripping entirely to test whether the
-    // "all modules physically present" tolerance also holds for the brownfield
-    // fused AAR. `-Pbrownfield.fused.strip-packages=...` still works for ad-hoc
-    // overrides.
-    val variantStripPrefixes: Set<String> = emptySet()
-    val extraStrip =
+    val stripPrefixes =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
         ?.split(',')
         ?.map { it.trim() }
         ?.filter { it.isNotEmpty() }
         ?.toSet()
         ?: emptySet()
-    val stripPrefixes = variantStripPrefixes + extraStrip
 
     if (stripPrefixes.isEmpty()) return
 
@@ -80,7 +74,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
           .joinToString("\n")
       outputFile.writeText(stripped)
       expoProject.logger.lifecycle(
-        "brownfield.fused[${fusedVariant ?: "?"}]: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
+        "brownfield.fused: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
       )
     }
   }

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -12,6 +12,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.evaluationDependsOn(":expo")
     setupDependencySubstitution(project)
+    setupFusedModeStripping(project)
 
     project.afterEvaluate { project ->
       setupSourceSets(project)
@@ -20,6 +21,67 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
       setupCopyingNativeLibsForType(project, "Debug")
       setupHostAppArtifactForwardingForRelease(project)
       wireDevLauncherTasks(project)
+    }
+  }
+
+  /**
+   * In `--fused` release builds, strips dev-only entries from the autolinking-generated
+   * `ExpoModulesPackageList.kt` so the host app doesn't hit `NoClassDefFoundError`
+   * for modules excluded from the fat AAR. Extra prefixes via
+   * `-Pbrownfield.fused.strip-packages=foo.,bar.`. Inert otherwise.
+   */
+  private fun setupFusedModeStripping(brownfieldProject: Project) {
+    if (brownfieldProject.findProperty("brownfield.fused") != "true") return
+
+    val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
+
+    // Strip prefixes that mirror the `devOnlySkipProjects` set in the release
+    // fused sibling. Kept in sync manually — if you add a module to the release
+    // skip list in `templates/android/fused/build.gradle.kts`, add its package
+    // prefix here too.
+    val fusedVariant =
+      (brownfieldProject.findProperty("brownfield.fused.variant") as? String)?.lowercase()
+    // EXPERIMENT: skip variant-based stripping entirely to test whether the
+    // "all modules physically present" tolerance also holds for the brownfield
+    // fused AAR. `-Pbrownfield.fused.strip-packages=...` still works for ad-hoc
+    // overrides.
+    val variantStripPrefixes: Set<String> = emptySet()
+    val extraStrip =
+      (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.toSet()
+        ?: emptySet()
+    val stripPrefixes = variantStripPrefixes + extraStrip
+
+    if (stripPrefixes.isEmpty()) return
+
+    // `:expo` is already evaluated (forced by `evaluationDependsOn(":expo")` at the
+    // top of `apply`), so we read the task directly — no afterEvaluate needed.
+    val task = expoProject.tasks.findByName("generatePackagesList") ?: return
+    task.doLast {
+      val outputFile =
+        expoProject.layout.buildDirectory
+          .file("generated/expo/src/main/java/expo/modules/ExpoModulesPackageList.kt")
+          .get()
+          .asFile
+      if (!outputFile.exists()) {
+        expoProject.logger.warn(
+          "brownfield.fused: ExpoModulesPackageList.kt not found at ${outputFile.path}; nothing to strip"
+        )
+        return@doLast
+      }
+      val original = outputFile.readText()
+      val stripped =
+        original
+          .lineSequence()
+          .filter { line -> stripPrefixes.none { prefix -> line.contains(prefix) } }
+          .joinToString("\n")
+      outputFile.writeText(stripped)
+      expoProject.logger.lifecycle(
+        "brownfield.fused[${fusedVariant ?: "?"}]: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
+      )
     }
   }
 

--- a/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation("expo.modules:expo-autolinking-plugin-shared")
   implementation("org.json:json:20250517")
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:8.5.0")
+  compileOnly("com.android.tools.build:gradle:9.0.0")
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
@@ -14,7 +14,10 @@ dependencies {
   implementation("expo.modules:expo-autolinking-plugin-shared")
   implementation("org.json:json:20250517")
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:9.0.0")
+  // Matches FUSED_AGP_VERSION in the config plugin — the newest AGP the plugin can
+  // run against (forced in fused mode). Compiling against a newer major than the
+  // runtime AGP risks NoSuchMethodError on changed APIs.
+  compileOnly("com.android.tools.build:gradle:8.13.0")
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
@@ -13,6 +13,14 @@ import org.gradle.api.tasks.TaskProvider
  */
 internal fun setupPrebuiltsCopying(rootProject: Project) {
   rootProject.afterEvaluate {
+    // In `--fused` mode the user is publishing a single fat AAR via Fused Library that
+    // already merges every Expo module's classes/resources/jni inside it — the
+    // per-module mavenLocal/remote re-publish loop below would emit redundant
+    // coordinates next to the fat AAR. Skip.
+    if (rootProject.findProperty("brownfield.fused") == "true") {
+      return@afterEvaluate
+    }
+
     val configExtension = getConfigExtension(rootProject)
 
     if (configExtension.publications.isEmpty) {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
@@ -14,8 +14,61 @@ const withGradlePropertiesPlugin: ConfigPlugin = (config) => {
       }
     }
 
+    // Opt into AGP's Fused Library Preview. The `.publicationOnly=false` flag lets
+    // `include(project(...))` resolve sibling subprojects directly (no mavenLocal
+    // round-trip). No-op in non-fused mode.
+    const hasFusedOptIn = config.modResults.some(
+      (item) =>
+        item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
+    );
+    const hasFusedPubFlag = config.modResults.some(
+      (item) =>
+        item.type === 'property' &&
+        item.key === 'android.experimental.fusedLibrarySupport.publicationOnly'
+    );
+    if (!hasFusedOptIn || !hasFusedPubFlag) {
+      config.modResults = [
+        ...config.modResults,
+        ...getFusedLibrarySupportConfiguration(hasFusedOptIn, hasFusedPubFlag),
+      ];
+    }
+
     return config;
   });
+};
+
+const getFusedLibrarySupportConfiguration = (
+  hasFusedOptIn: boolean,
+  hasFusedPubFlag: boolean
+): AndroidConfig.Properties.PropertiesItem[] => {
+  const items: AndroidConfig.Properties.PropertiesItem[] = [];
+  if (!hasFusedOptIn) {
+    items.push(
+      {
+        type: 'comment',
+        value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+      },
+      {
+        type: 'property',
+        key: 'android.experimental.fusedLibrarySupport',
+        value: 'true',
+      }
+    );
+  }
+  if (!hasFusedPubFlag) {
+    items.push(
+      {
+        type: 'comment',
+        value: 'Allow `com.android.fused-library` to include sibling project deps directly',
+      },
+      {
+        type: 'property',
+        key: 'android.experimental.fusedLibrarySupport.publicationOnly',
+        value: 'false',
+      }
+    );
+  }
+  return items;
 };
 
 const getDevMenuReleaseConfiguration = (): AndroidConfig.Properties.PropertiesItem[] => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectBuildGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectBuildGradlePlugin.ts
@@ -7,25 +7,61 @@ const EXPO_APPLY_STATEMENT = 'apply plugin: "expo-root-project"';
 const PLUGIN_CLASSPATH = 'expo.modules:publish';
 const PLUGIN_NAME = 'expo-brownfield-publish';
 
+// AGP 8.12.0's Fused Library plugin's `rewriteClasses` task uses an ASM API version
+// below 9 at the call site and can't read `PermittedSubclasses` bytecode attributes
+// emitted for every Kotlin `sealed class`. AGP 8.13.0+ raises the hardcoded API
+// version. Bump only when the user opts into fused mode via `--fused` (which passes
+// `-Pbrownfield.fused=true`), so default builds keep using the version catalog's AGP.
+const FUSED_AGP_VERSION = '8.13.0';
+const FUSED_AGP_MARKER = 'brownfield.fused';
+
 const withProjectBuildGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withProjectBuildGradle(config, (config) => {
-    if (config.modResults.contents.includes(PLUGIN_CLASSPATH)) {
-      return config;
+    let lines = config.modResults.contents.split('\n');
+
+    if (!config.modResults.contents.includes(FUSED_AGP_MARKER)) {
+      lines = addFusedAgpResolutionStrategy(lines);
     }
 
-    let lines = config.modResults.contents.split('\n');
-    lines = addPluginClasspathStatement(lines);
-    lines = addApplyStatement(lines);
-    lines = addPublicationConfiguration(
-      lines,
-      pluginConfig.publishing,
-      pluginConfig.projectRoot,
-      pluginConfig.libraryName
-    );
+    if (!config.modResults.contents.includes(PLUGIN_CLASSPATH)) {
+      lines = addPluginClasspathStatement(lines);
+      lines = addApplyStatement(lines);
+      lines = addPublicationConfiguration(
+        lines,
+        pluginConfig.publishing,
+        pluginConfig.projectRoot,
+        pluginConfig.libraryName
+      );
+    }
+
     config.modResults.contents = lines.join('\n');
 
     return config;
   });
+};
+
+const addFusedAgpResolutionStrategy = (lines: string[]): string[] => {
+  // Appended as a sibling top-level `buildscript { ... }` block. Gradle merges multiple
+  // top-level buildscript blocks, so this composes with the project's existing one
+  // without clobbering it. The `findProperty` check makes the override conditional on
+  // `-Pbrownfield.fused=true` (set by `expo-brownfield build:android --fused`); without
+  // the flag the resolution-strategy block never runs and AGP stays at the catalog
+  // version.
+  const block = [
+    '',
+    'buildscript {',
+    '  // expo-brownfield: bump AGP only when `--fused` is active (CLI passes',
+    `  // -P${FUSED_AGP_MARKER}=true). AGP 8.12.0's Fused Library can't read Kotlin`,
+    '  // sealed-class bytecode (PermittedSubclasses requires ASM API >= 9, fixed',
+    `  // in AGP ${FUSED_AGP_VERSION}).`,
+    `  if (findProperty('${FUSED_AGP_MARKER}') == 'true') {`,
+    '    configurations.classpath {',
+    `      resolutionStrategy.force 'com.android.tools.build:gradle:${FUSED_AGP_VERSION}'`,
+    '    }',
+    '  }',
+    '}',
+  ];
+  return [...lines, ...block];
 };
 
 const addPluginClasspathStatement = (lines: string[]): string[] => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { applyPatchToFile, checkPlugin, mkdir } from '../../common';
 import type { PluginConfig } from '../types';
-import { createFileFromTemplate } from '../utils';
+import { createFileFromTemplate, createFileFromTemplateAs } from '../utils';
 
 const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withAndroidManifest(config, (config) => {
@@ -15,9 +15,20 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     const brownfieldMainPath = path.join(brownfieldPath, 'src/main/');
     const brownfieldSourcesPath = path.join(brownfieldMainPath, pluginConfig.packagePath);
 
+    const fusedReleasePath = path.join(
+      pluginConfig.projectRoot,
+      `android/${pluginConfig.libraryName}-fused-release`
+    );
+    const fusedDebugPath = path.join(
+      pluginConfig.projectRoot,
+      `android/${pluginConfig.libraryName}-fused-debug`
+    );
+
     // Create directory for the brownfield library sources
     // (and all intermediate directories)
     mkdir(brownfieldSourcesPath, true);
+    mkdir(fusedReleasePath, true);
+    mkdir(fusedDebugPath, true);
 
     // Add files from templates to the brownfield library:
     // - AndroidManifest.xml
@@ -48,6 +59,27 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     });
     createFileFromTemplate('proguard-rules.pro', brownfieldPath);
     createFileFromTemplate('consumer-rules.pro', brownfieldPath);
+
+    // Emit the fused siblings' build.gradle.kts files. Same template at
+    // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts —
+    // `fusedVariant` is the only difference: substituted as "release" or "debug",
+    // the script then branches on `isReleaseVariant` for the few places the two
+    // siblings differ (dev-only skip, namespace suffix, publication name).
+    const fusedTemplate = path.join('fused', 'build.gradle.kts');
+    const fusedBaseVars = {
+      packageId: pluginConfig.package,
+      groupId: pluginConfig.group,
+      version: pluginConfig.version,
+      libraryName: pluginConfig.libraryName,
+    };
+    createFileFromTemplateAs(fusedTemplate, fusedReleasePath, 'build.gradle.kts', {
+      ...fusedBaseVars,
+      fusedVariant: 'release',
+    });
+    createFileFromTemplateAs(fusedTemplate, fusedDebugPath, 'build.gradle.kts', {
+      ...fusedBaseVars,
+      fusedVariant: 'debug',
+    });
 
     // Adjust ReactNativeHostManager and BrownfieldActivity to initialize dev menu
     if (checkPlugin(config, 'expo-dev-menu')) {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -63,8 +63,8 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     // Emit the fused siblings' build.gradle.kts files. Same template at
     // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts —
     // `fusedVariant` is the only difference: substituted as "release" or "debug",
-    // the script then branches on `isReleaseVariant` for the few places the two
-    // siblings differ (dev-only skip, namespace suffix, publication name).
+    // it drives the namespace suffix, publication name, and which build type the
+    // sibling resolves and fuses.
     const fusedTemplate = path.join('fused', 'build.gradle.kts');
     const fusedBaseVars = {
       packageId: pluginConfig.package,

--- a/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
@@ -10,8 +10,17 @@ const withSettingsGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConf
   });
 };
 
+// Two fused sibling Gradle subprojects (sourceless, applies `com.android.fused-library`)
+// are always emitted — one per variant — so each can be targeted on demand by
+// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. They're
+// idle in default mode — no tasks run, nothing is built.
 const getBrownfieldIncludeStatement = (libraryName: string) => {
-  return `include ':${libraryName}'\n`;
+  return [
+    `include ':${libraryName}'`,
+    `include ':${libraryName}-fused-release'`,
+    `include ':${libraryName}-fused-debug'`,
+    '',
+  ].join('\n');
 };
 
 const getBrownfieldPluginIncludeStatement = () => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
@@ -4,23 +4,32 @@ import type { PluginConfig } from '../types';
 
 const withSettingsGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withSettingsGradle(config, (config) => {
-    config.modResults.contents += getBrownfieldIncludeStatement(pluginConfig.libraryName);
-    config.modResults.contents += getBrownfieldPluginIncludeStatement();
+    // Append line-by-line so re-running prebuild without --clean (or after
+    // upgrading from a version without the fused siblings) adds only what's
+    // missing instead of duplicating the whole block.
+    for (const line of getBrownfieldIncludeStatements(pluginConfig.libraryName)) {
+      if (!config.modResults.contents.includes(line)) {
+        config.modResults.contents += `${line}\n`;
+      }
+    }
+    if (!config.modResults.contents.includes('includeBuild(brownfieldPluginsPath)')) {
+      config.modResults.contents += getBrownfieldPluginIncludeStatement();
+    }
     return config;
   });
 };
 
 // Two fused sibling Gradle subprojects (sourceless, applies `com.android.fused-library`)
 // are always emitted — one per variant — so each can be targeted on demand by
-// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. They're
-// idle in default mode — no tasks run, nothing is built.
-const getBrownfieldIncludeStatement = (libraryName: string) => {
+// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. Their
+// build scripts are inert unless the CLI passes `-Pbrownfield.fused=true`, so in
+// default mode they register no publications and resolve nothing.
+const getBrownfieldIncludeStatements = (libraryName: string) => {
   return [
     `include ':${libraryName}'`,
     `include ':${libraryName}-fused-release'`,
     `include ':${libraryName}-fused-debug'`,
-    '',
-  ].join('\n');
+  ];
 };
 
 const getBrownfieldPluginIncludeStatement = () => {

--- a/packages/expo-brownfield/plugin/src/common/filesystem.ts
+++ b/packages/expo-brownfield/plugin/src/common/filesystem.ts
@@ -15,6 +15,11 @@ const interpolateVariables = (str: string, variables: Record<string, unknown>): 
   let match = variableRegex.exec(str);
   while (match) {
     const variable = match[0].slice(3, -2);
+    if (!(variable in variables)) {
+      throw new Error(
+        `The expo-brownfield template variable "${variable}" has no value, so the generated file would contain the literal string "undefined" and fail to build. This usually means the plugin passed an incomplete variable set for this template — report this at https://github.com/expo/expo/issues.`
+      );
+    }
     str = str.replace(match[0], String(variables[variable]));
     match = variableRegex.exec(str);
   }

--- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
+++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
@@ -1,8 +1,11 @@
 package ${{packageId}}
 
+import android.app.Activity
 import android.app.Application
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
+import com.facebook.react.ReactPackage
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import expo.modules.ApplicationLifecycleDispatcher
 
 object BrownfieldLifecycleDispatcher {
@@ -15,9 +18,24 @@ object BrownfieldLifecycleDispatcher {
   }
 }
 
-open class BrownfieldActivity : AppCompatActivity() {
+// DefaultHardwareBackBtnHandler is declared here because ReactDelegate.onHostResume()
+// hard-casts the host Activity to it — without the interface on the base class, every
+// subclass would crash with ClassCastException on first resume.
+open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
   override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
     BrownfieldLifecycleDispatcher.onConfigurationChanged(this.application, newConfig)
+  }
+
+  open fun showReactNativeFragment(
+    rootComponent: String = "main",
+    additionalPackages: List<ReactPackage> = emptyList(),
+  ) {
+    (this as Activity).showReactNativeFragment(rootComponent, additionalPackages)
+  }
+
+  @Suppress("DEPRECATION")
+  override fun invokeDefaultOnBackPressed() {
+    super.onBackPressed()
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
+++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
@@ -34,8 +34,13 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandl
     (this as Activity).showReactNativeFragment(rootComponent, additionalPackages)
   }
 
-  @Suppress("DEPRECATION")
+  // React Native calls this when JS has no back handler. Don't call
+  // super.onBackPressed() here: it re-dispatches through the
+  // OnBackPressedDispatcher, whose RN callback (setUpNativeBackHandling)
+  // forwards back to JS — an infinite native <-> JS ping-pong that makes the
+  // back button dead. Finishing the activity is the default back action for a
+  // brownfield React Native screen: it returns to the previous host screen.
   override fun invokeDefaultOnBackPressed() {
-    super.onBackPressed()
+    finish()
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
+++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
@@ -9,10 +9,12 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import expo.modules.ApplicationLifecycleDispatcher
 
 object BrownfieldLifecycleDispatcher {
+  @JvmStatic
   fun onApplicationCreate(application: Application) {
     ApplicationLifecycleDispatcher.onApplicationCreate(application)
   }
 
+  @JvmStatic
   fun onConfigurationChanged(application: Application, newConfig: Configuration) {
     ApplicationLifecycleDispatcher.onConfigurationChanged(application, newConfig)
   }

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
@@ -58,9 +58,15 @@ class ReactNativeHostManager {
     loadReactNative(application)
     BrownfieldLifecycleDispatcher.onApplicationCreate(application)
 
+    // Pass `useDevSupport` explicitly (default is `ReactBuildConfig.DEBUG`). The
+    // brownfield's own `BuildConfig.DEBUG` follows the fused sibling's variant
+    // (true in `-fused-debug`, false in `-fused-release`) — using it ensures
+    // dev support fires correctly regardless of which RN variant the consumer
+    // resolves.
     reactHost = ExpoReactHostFactory.getDefaultReactHost(
       context = application.applicationContext,
-      packageList = PackageList(application).packages + additionalPackages
+      packageList = PackageList(application).packages + additionalPackages,
+      useDevSupport = BuildConfig.DEBUG
     )
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
+++ b/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
@@ -41,6 +41,7 @@
 -keepclassmembers class * {
     @expo.modules.core.interfaces.DoNotStrip *;
 }
+-keep interface expo.modules.kotlin.records.Record
 -keep class * implements expo.modules.kotlin.records.Record { *; }
 -keep class * extends expo.modules.kotlin.sharedobjects.SharedObject
 -keep enum * implements expo.modules.kotlin.types.Enumerable { *; }

--- a/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
+++ b/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
@@ -1,0 +1,66 @@
+# Consumer ProGuard rules shipped inside the brownfield AAR (and aggregated into the
+# fused AAR via AGP Fused Library). The host app's R8/ProGuard reads these rules to
+# avoid stripping classes that the runtime loads via reflection.
+#
+# Mirrors the relevant subset of expo-modules-core/android/proguard-rules.pro and
+# adds keep rules for ReactActivityLifecycleListener (silently disabled features
+# like edge-to-edge depend on it).
+
+# Expo Module Services — reflection-loaded via Service.construct() in
+# expo.modules.kotlin.services.ServicesRegistry. Stripping their constructors
+# causes `NoSuchMethodException` / `Array is empty` at startup.
+-keep interface expo.modules.kotlin.services.Service
+-keep class * implements expo.modules.kotlin.services.Service {
+    <init>(...);
+}
+
+# Expo Module Package classes — referenced by FQN in the autolinking-generated
+# `ExpoModulesPackageList.<clinit>`. Stripping causes `NoClassDefFoundError`.
+-keep class * implements expo.modules.core.interfaces.Package {
+    public <init>(...);
+}
+
+# Expo Modules — public constructors + the `definition()` method must survive
+# obfuscation/minification for the registry to instantiate them.
+-keep,allowoptimization,allowobfuscation class * extends expo.modules.kotlin.modules.Module {
+    public <init>();
+    public expo.modules.kotlin.modules.ModuleDefinitionData definition();
+}
+
+# ReactActivityLifecycleListener implementations — Expo modules return these from
+# `createReactActivityLifecycleListeners()` (e.g. `EdgeToEdgePackage` enables
+# edge-to-edge via its lifecycle hook). Lost listeners = silently disabled
+# features in the host app.
+-keep class * implements expo.modules.core.interfaces.ReactActivityLifecycleListener
+-keepclassmembers class * implements expo.modules.core.interfaces.ReactActivityLifecycleListener {
+    public <init>(...);
+}
+
+# DoNotStrip + Record + Enumerable patterns from expo-modules-core.
+-keep @expo.modules.core.interfaces.DoNotStrip class *
+-keepclassmembers class * {
+    @expo.modules.core.interfaces.DoNotStrip *;
+}
+-keep class * implements expo.modules.kotlin.records.Record { *; }
+-keep class * extends expo.modules.kotlin.sharedobjects.SharedObject
+-keep enum * implements expo.modules.kotlin.types.Enumerable { *; }
+-keepnames class kotlin.Pair
+
+# ExpoView constructors — Expo view modules call these via reflection from the
+# kotlin view registry.
+-keepclassmembers class * implements expo.modules.kotlin.views.ExpoView {
+    public <init>(android.content.Context);
+    public <init>(android.content.Context, expo.modules.kotlin.AppContext);
+}
+-keepnames class * implements expo.modules.kotlin.views.ExpoView { *; }
+
+# View event delegation fields read via reflection from the kotlin view runtime.
+-keepclassmembers class * {
+    expo.modules.kotlin.viewevent.ViewEventCallback *;
+}
+-keepclassmembers class * {
+    expo.modules.kotlin.viewevent.ViewEventDelegate *;
+}
+
+# ComposeProps implementations loaded reflectively for Compose-based views.
+-keep class * implements expo.modules.kotlin.views.ComposeProps { *; }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -148,13 +148,27 @@ if (findProperty("brownfield.fused") == "true") {
       ?.toSet()
       ?: emptySet()
 
+  // Groups the HOST app already ships at its own version (e.g. Glide, Compose).
+  // Like exclude-transitive these stay out of the fused AAR, but they are also
+  // NOT re-declared in the published POM/module metadata — re-declaring them at
+  // Expo's resolved version would force-upgrade the host's copy during its own
+  // dependency resolution:
+  //   brownfield.fused.host-provided=com.github.bumptech.glide,androidx.compose
+  val hostProvidedGroups: Set<String> =
+    (project.findProperty("brownfield.fused.host-provided") as? String)
+      ?.split(',')
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() }
+      ?.toSet()
+      ?: emptySet()
+
   // Populated below by walking the aggregator's resolution and detecting KMP-style
   // pom-only umbrellas that trip AGP fused-library's "parent dependency not
   // included" validation. A function rather than a val: `autoExcludedGroups` keeps
   // growing during the walk and lazy consumers (configureEach) need the live view.
   val autoExcludedGroups = mutableSetOf<String>()
   fun effectiveExcludedGroups(): Set<String> =
-    hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
+    hostPlatformBaseline + excludedGroupsExtra + hostProvidedGroups + autoExcludedGroups
 
   // True → coord stays external in the POM. AndroidX uses an allowlist; the
   // RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
@@ -312,11 +326,14 @@ if (findProperty("brownfield.fused") == "true") {
   // modules (okhttp, okio, kotlin-stdlib, annotation artifacts) are captured too;
   // the AAR-filtered artifactView walk below never sees them. Pure umbrellas are
   // skipped (their `-android` children carry the content) and so are BOM/platform
-  // modules, which aren't plain runtime dependencies.
+  // modules, which aren't plain runtime dependencies. Host-provided groups are
+  // skipped entirely: the host ships its own version, and re-declaring ours would
+  // force-upgrade it.
   expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
     val id = component.id
     if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
     if (id.group !in effectiveExcludedGroups()) return@forEach
+    if (hostProvidedGroups.any { id.group == it || id.group.startsWith("$it.") }) return@forEach
     if ((id.group to id.module) in pureUmbrellaComponents) return@forEach
     if (id.module.endsWith("-bom")) return@forEach
     externalDepsForConsumer.add(Triple(id.group, id.module, id.version))
@@ -495,11 +512,25 @@ if (findProperty("brownfield.fused") == "true") {
             val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
               ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
             externalDepsForConsumer.forEach { (group, module, version) ->
-              deps.add(mutableMapOf(
+              val entry = mutableMapOf<String, Any?>(
                 "group" to group,
                 "module" to module,
                 "version" to mutableMapOf("requires" to version),
-              ))
+              )
+              // react-android / hermes-android reach the metadata through this
+              // injection (the natural edges are excluded from the fused
+              // configurations), so the BuildTypeAttr annotation MUST be applied
+              // here — the annotate-in-place loop above never sees them. Without
+              // it, a debug host consuming a release fused AAR resolves debug RN
+              // against the AAR's release-linked codegen `.so` files and crashes
+              // at startup (SIGSEGV in folly RawProps).
+              if ((group to module) in perVariantAbiCoords) {
+                entry["attributes"] = mutableMapOf<String, Any?>(
+                  "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+                )
+                annotatedCount++
+              }
+              deps.add(entry)
             }
           } else {
             logger.warn(

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -4,6 +4,14 @@
 // One sibling subproject per variant — `:<libraryName>-fused-release` and
 // `-fused-debug` — both rendered from this template; `{{fusedVariant}}` is the
 // only delta.
+//
+// INERT BY DEFAULT: everything below the `brownfield.fused` guard only runs when
+// the CLI passes `-Pbrownfield.fused=true` (`expo-brownfield build:android --fused`).
+// Without the property this project registers no publications and resolves no
+// dependencies, so plain builds (`expo run:android`, IDE sync) pay no configuration
+// cost and non-fused `publishBrownfield<V>PublicationTo<X>` invocations can't
+// accidentally trigger a fat-AAR build through Gradle's cross-project task-name
+// matching.
 
 plugins {
   id("com.android.fused-library")
@@ -14,491 +22,528 @@ group = "${{groupId}}"
 
 version = "${{version}}"
 
-val fusedVariant = "${{fusedVariant}}"
-val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
-
 androidFusedLibrary {
   namespace = "${{packageId}}.fused.${{fusedVariant}}"
   minSdk = 24
   aarMetadata { minCompileSdk = 36 }
 }
 
-// No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
-// `-menu-interface`) is included in BOTH variants:
-//   - For `-fused-release`, AGP fused-library compiles each module's release source
-//     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
-//     `src/disableInRelease` source set in release builds — it provides STUB
-//     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
-//     references resolve at runtime, but with no functional dev tooling. Footprint
-//     stays small and no manual entry-stripping is needed.
-//   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
-//     source set → real dev tooling, Metro reload, red-box overlay, etc.
-// `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
-// all; including them adds nothing to the AAR.
-val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
-  ?.split(',')
-  ?.map { it.trim() }
-  ?.filter { it.isNotEmpty() }
-  ?.toSet()
-  ?: emptySet()
-val fusedSkipProjects = extraSkip
-
-// Force sibling evaluation before resolving include() targets and walking their
-// runtime classpaths — without this, plugin detection and classpath resolution
-// see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
-rootProject.subprojects.forEach {
-  if (it.path == project.path) return@forEach
-  if (it.name == "${{libraryName}}-fused-release") return@forEach
-  if (it.name == "${{libraryName}}-fused-debug") return@forEach
-  evaluationDependsOn(it.path)
+// AGP `com.android.fused-library` auto-registers a `maven` publication at the same
+// coords as our explicit `brownfield<V>` one. `publishToMavenLocal` runs both — the
+// `maven` one overwrites our annotated metadata. Disable it unconditionally so a
+// manual `./gradlew publishToMavenLocal` in non-fused mode can't build the fat AAR
+// either.
+tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
+  enabled = false
 }
 
-// `androidx.*` allowlist — these must be fused because their transitive chains
-// span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
-// on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
-// as a side-effect of fusing an Expo module, and AGP fused-library's "parent
-// dependency not included" validation then demands its AndroidX parent be
-// fused too — which requires the whole `androidx.camera` chain to be fused).
-// Auto-detection can't see these because they're regular Maven parent links,
-// not KMP `available-at` redirects.
-//
-// Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
-// another autolinked module pulls a new AndroidX chain with the same pattern.
-val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
-val androidxFuseAllowlistExtra: Set<String> =
-  (project.findProperty("brownfield.fused.androidx-fuse") as? String)
-    ?.split(',')
-    ?.map { it.trim() }
-    ?.filter { it.isNotEmpty() }
-    ?.toSet()
-    ?: emptySet()
-val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+if (findProperty("brownfield.fused") == "true") {
+  val fusedVariant = "${{fusedVariant}}"
+  val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
 
-// Android brownfield host platform baseline — NOT a list of application
-// libraries. These are the foundational pieces that, by definition of being a
-// React Native Android brownfield host, the integrating app already provides
-// on its classpath:
-//
-//   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
-//     `yoga`. The host links variant-specific `.so` files against these;
-//     fusing them either duplicate-classes with the host's copies or pins
-//     the wrong variant's native libs. AGP fused-library's "parent
-//     dependency not included" validation also enforces this transitively
-//     (e.g. `fbjni`'s parent is `hermes-android`).
-//
-//   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
-//     modern Android app pulls these via its own build.
-//
-//   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
-//     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
-//     Beyond duplication risk, AGP fused-library's class rewriter can't
-//     resolve `android:*` framework-attr references in styleables (Material's
-//     `AppBarLayout_android_background` etc.), so fusing Material Design fails
-//     `rewriteClasses` outright.
-//
-// This list encodes structural facts about the brownfield host — not
-// application-specific library choices. If you're adding a NEW group here,
-// it should be because every brownfield host inherently has it (e.g. AGP
-// raised the minimum platform baseline), not because a specific app uses it.
-val hostPlatformBaseline = setOf(
-  "com.facebook.react",
-  "com.facebook.hermes",
-  "com.facebook.fbjni",
-  "com.facebook.soloader",
-  "com.facebook.yoga",
-  "com.facebook.fresco",
-  "org.jetbrains.kotlin",
-  "org.jetbrains.kotlinx",
-  "com.google.android.material",
-  "com.google.guava",
-  "com.squareup.okhttp3",
-  "com.squareup.okio",
-)
-
-// Extra groups the user wants kept OUT of the fused AAR — auto-detection below
-// handles the common KMP-umbrella case, this is only for edge cases:
-//   brownfield.fused.exclude-transitive=some.group,another.group
-val excludedGroupsExtra: Set<String> =
-  (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+  // No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
+  // `-menu-interface`) is included in BOTH variants:
+  //   - For `-fused-release`, AGP fused-library compiles each module's release source
+  //     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
+  //     `src/disableInRelease` source set in release builds — it provides STUB
+  //     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
+  //     references resolve at runtime, but with no functional dev tooling. Footprint
+  //     stays small and no manual entry-stripping is needed.
+  //   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
+  //     source set → real dev tooling, Metro reload, red-box overlay, etc.
+  // `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
+  // all; including them adds nothing to the AAR.
+  //
+  // Modules skipped via `-Pbrownfield.fused.skip` stay referenced by the autolinking-
+  // generated `ExpoModulesPackageList` — pair the skip with
+  // `-Pbrownfield.fused.strip-packages=<package prefixes>` so the host doesn't hit
+  // `NoClassDefFoundError` at startup.
+  val fusedSkipProjects: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
     ?.split(',')
     ?.map { it.trim() }
     ?.filter { it.isNotEmpty() }
     ?.toSet()
     ?: emptySet()
 
-// Populated below by walking the aggregator's resolution and detecting KMP-style
-// pom-only umbrellas that trip AGP fused-library's "parent dependency not
-// included" validation.
-val autoExcludedGroups = mutableSetOf<String>()
-val effectiveExcludedGroups: Set<String> get() =
-  hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
-
-// True → coord stays external in the POM. AndroidX uses an allowlist; the
-// RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
-// denylist.
-fun isGroupDenied(group: String): Boolean {
-  val denylist = effectiveExcludedGroups
-  if (denylist.any { group == it || group.startsWith("$it.") }) return true
-  if (group == "androidx" || group.startsWith("androidx.")) {
-    return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+  // Force sibling evaluation before resolving include() targets and walking their
+  // runtime classpaths — without this, plugin detection and classpath resolution
+  // see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
+  rootProject.subprojects.forEach {
+    if (it.path == project.path) return@forEach
+    if (it.name == "${{libraryName}}-fused-release") return@forEach
+    if (it.name == "${{libraryName}}-fused-debug") return@forEach
+    evaluationDependsOn(it.path)
   }
-  return false
-}
 
-// Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
-// match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
-// compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
-configurations.all {
-  if (name.startsWith("fusedRuntime")) {
+  // `androidx.*` allowlist — these must be fused because their transitive chains
+  // span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
+  // on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
+  // as a side-effect of fusing an Expo module, and AGP fused-library's "parent
+  // dependency not included" validation then demands its AndroidX parent be
+  // fused too — which requires the whole `androidx.camera` chain to be fused).
+  // Auto-detection can't see these because they're regular Maven parent links,
+  // not KMP `available-at` redirects.
+  //
+  // Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
+  // another autolinked module pulls a new AndroidX chain with the same pattern.
+  val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
+  val androidxFuseAllowlistExtra: Set<String> =
+    (project.findProperty("brownfield.fused.androidx-fuse") as? String)
+      ?.split(',')
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() }
+      ?.toSet()
+      ?: emptySet()
+  val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+
+  // Android brownfield host platform baseline — NOT a list of application
+  // libraries. These are the foundational pieces that, by definition of being a
+  // React Native Android brownfield host, the integrating app already provides
+  // on its classpath:
+  //
+  //   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
+  //     `yoga`. The host links variant-specific `.so` files against these;
+  //     fusing them either duplicate-classes with the host's copies or pins
+  //     the wrong variant's native libs. AGP fused-library's "parent
+  //     dependency not included" validation also enforces this transitively
+  //     (e.g. `fbjni`'s parent is `hermes-android`).
+  //
+  //   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
+  //     modern Android app pulls these via its own build.
+  //
+  //   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
+  //     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
+  //     Beyond duplication risk, AGP fused-library's class rewriter can't
+  //     resolve `android:*` framework-attr references in styleables (Material's
+  //     `AppBarLayout_android_background` etc.), so fusing Material Design fails
+  //     `rewriteClasses` outright.
+  //
+  // This list encodes structural facts about the brownfield host — not
+  // application-specific library choices. If you're adding a NEW group here,
+  // it should be because every brownfield host inherently has it (e.g. AGP
+  // raised the minimum platform baseline), not because a specific app uses it.
+  val hostPlatformBaseline = setOf(
+    "com.facebook.react",
+    "com.facebook.hermes",
+    "com.facebook.fbjni",
+    "com.facebook.soloader",
+    "com.facebook.yoga",
+    "com.facebook.fresco",
+    "org.jetbrains.kotlin",
+    "org.jetbrains.kotlinx",
+    "com.google.android.material",
+    "com.google.guava",
+    "com.squareup.okhttp3",
+    "com.squareup.okio",
+  )
+
+  // Extra groups the user wants kept OUT of the fused AAR — auto-detection below
+  // handles the common KMP-umbrella case, this is only for edge cases:
+  //   brownfield.fused.exclude-transitive=some.group,another.group
+  val excludedGroupsExtra: Set<String> =
+    (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+      ?.split(',')
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() }
+      ?.toSet()
+      ?: emptySet()
+
+  // Populated below by walking the aggregator's resolution and detecting KMP-style
+  // pom-only umbrellas that trip AGP fused-library's "parent dependency not
+  // included" validation. A function rather than a val: `autoExcludedGroups` keeps
+  // growing during the walk and lazy consumers (configureEach) need the live view.
+  val autoExcludedGroups = mutableSetOf<String>()
+  fun effectiveExcludedGroups(): Set<String> =
+    hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
+
+  // True → coord stays external in the POM. AndroidX uses an allowlist; the
+  // RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
+  // denylist.
+  fun isGroupDenied(group: String): Boolean {
+    val denylist = effectiveExcludedGroups()
+    if (denylist.any { group == it || group.startsWith("$it.") }) return true
+    if (group == "androidx" || group.startsWith("androidx.")) {
+      return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+    }
+    return false
+  }
+
+  // Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
+  // match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
+  // compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
+  configurations.all {
+    if (name.startsWith("fusedRuntime")) {
+      attributes {
+        attribute(
+          com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+          project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
+        )
+      }
+    }
+  }
+
+  // Aggregator configuration: depends on every autolinked module, resolved locally
+  // to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
+  // resolution. `BuildTypeAttr` picks the matching variant per module.
+  val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
     attributes {
+      attribute(
+        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
+      )
+      attribute(
+        org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
+      )
+      attribute(
+        org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
+      )
       attribute(
         com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
         project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
       )
     }
+    // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
+    // comparator and cascade into lenient resolution returning zero artifacts.
+    // Guava is denylisted anyway (host provides it), so just drop it here.
+    exclude(group = "com.google.guava", module = "guava")
   }
-}
 
-// Aggregator configuration: depends on every autolinked module, resolved locally
-// to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
-// resolution. `BuildTypeAttr` picks the matching variant per module.
-val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
-  isCanBeResolved = true
-  isCanBeConsumed = false
-  attributes {
-    attribute(
-      org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
-    )
-    attribute(
-      org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
-    )
-    attribute(
-      org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
-    )
-    attribute(
-      com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
-      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
-    )
+  // `project.path` inside a `Project` extension function resolves to the RECEIVER
+  // (Project.getProject() returns `this`), not the script's project. Capture it in
+  // an outer `val` so the self-check compares against THIS fused module.
+  val thisProjectPath: String = project.path
+
+  // `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
+  // `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
+  // which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
+  fun Project.hasAndroidLibraryPlugin(): Boolean {
+    if (plugins.hasPlugin("com.android.library")) return true
+    if (plugins.toList().any { p ->
+          val n = p.javaClass.name
+          (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
+            n.endsWith("LibraryPlugin")
+        }) return true
+    val android = extensions.findByName("android") ?: return false
+    return android.javaClass.name.contains("Library", ignoreCase = true)
   }
-  // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
-  // comparator and cascade into lenient resolution returning zero artifacts.
-  // Guava is denylisted anyway (host provides it), so just drop it here.
-  exclude(group = "com.google.guava", module = "guava")
-}
 
-// `project.path` inside a `Project` extension function resolves to the RECEIVER
-// (Project.getProject() returns `this`), not the script's project. Capture it in
-// an outer `val` so the self-check compares against THIS fused module.
-val thisProjectPath: String = project.path
-
-// `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
-// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
-// which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
-fun Project.hasAndroidLibraryPlugin(): Boolean {
-  if (plugins.hasPlugin("com.android.library")) return true
-  if (plugins.toList().any { p ->
-        val n = p.javaClass.name
-        (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
-          n.endsWith("LibraryPlugin")
-      }) return true
-  val android = extensions.findByName("android") ?: return false
-  return android.javaClass.name.contains("Library", ignoreCase = true)
-}
-
-fun Project.isFusableAndroidLibrary(): Boolean {
-  if (path == thisProjectPath) return false
-  if (name == "${{libraryName}}") return false
-  if (name == "${{libraryName}}-fused-release") return false
-  if (name == "${{libraryName}}-fused-debug") return false
-  if (name in fusedSkipProjects) return false
-  if (!hasAndroidLibraryPlugin()) return false
-  return true
-}
-
-val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
-logger.lifecycle(
-  "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
-    fusableSubprojects.joinToString(", ") { it.name }
-)
-
-dependencies {
-  fusableSubprojects.forEach { sub ->
-    add("brownfieldFusedExpoAggregator", sub)
+  fun Project.isFusableAndroidLibrary(): Boolean {
+    if (path == thisProjectPath) return false
+    if (name == "${{libraryName}}") return false
+    if (name == "${{libraryName}}-fused-release") return false
+    if (name == "${{libraryName}}-fused-debug") return false
+    if (name in fusedSkipProjects) return false
+    if (!hasAndroidLibraryPlugin()) return false
+    return true
   }
-}
 
-// Recorded by the aggregator walk: coords whose group is in `effectiveExcludedGroups`
-// — the consumer-side resolution needs to declare these as transitive deps even
-// though we don't fuse them into the AAR. Used by the metadata + POM post-
-// processors below.
-val externalDepsForConsumer = mutableListOf<Triple<String, String, String>>()
-
-// AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
-// graph once and records two cases:
-//
-//   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
-//      (`available-at`) to another module. The umbrella has no content of its
-//      own, only a pointer; fusing the `-android` child while the umbrella
-//      stays external trips AGP's "parent dependency not included" validation.
-//      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
-//      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
-//      mix of redirect and content variants — they don't match and stay
-//      fusable.
-//
-//   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
-//      in styleables that reference `android:*` framework attrs (e.g.
-//      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
-//      rewriter can't resolve framework attrs in the merged R, so fusing them
-//      makes `rewriteClasses` fail. Excluding at the configuration level here
-//      stops them from being pulled in via project-dep transitive walks.
-expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
-  val id = component.id
-  if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
-  val group = id.group
-  if (group == "androidx" || group.startsWith("androidx.")) {
-    val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
-    if (!inAllowlist) autoExcludedGroups.add(group)
-    return@forEach
-  }
-  val variants = component.variants
-  if (variants.isEmpty()) return@forEach
-  val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
-  if (isPureUmbrella) autoExcludedGroups.add(group)
-}
-if (autoExcludedGroups.isNotEmpty()) {
+  val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
   logger.lifecycle(
-    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
-      "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
-      autoExcludedGroups.sorted().joinToString(", ")
+    "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
+      fusableSubprojects.joinToString(", ") { it.name }
   )
-}
 
-// Excludes that must reach EVERY configuration the fused-library plugin walks,
-// including the runtime classpaths of `include(project(...))` targets. Scoping
-// to just `fusedRuntime` isn't enough — fused-library reads from included
-// projects' own configs which a scoped exclude can't touch. The aggregator is
-// intentionally exempt so the transitive-AAR walk below can still record the
-// resolved versions of excluded groups for POM/.module injection.
-configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
-  // AGP Fused Library rejects any `androidx.databinding:*` dep, including
-  // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
-  exclude(group = "androidx.databinding", module = "viewbinding")
-  exclude(group = "androidx.databinding", module = "databinding-common")
-  exclude(group = "androidx.databinding", module = "databinding-runtime")
-  exclude(group = "androidx.databinding", module = "databinding-adapters")
-  exclude(group = "androidx.databinding", module = "databinding-ktx")
-
-  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
-  effectiveExcludedGroups.forEach { g -> exclude(group = g) }
-}
-
-// Walk the aggregator's resolved artifacts to collect external AAR coords for
-// `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
-// modern `artifactView` API — the legacy `lenientConfiguration` throws before
-// you can read the lenient surface, masking the real failure.
-val transitiveAarIncludes: Set<String> = run {
-  val collected = mutableSetOf<String>()
-  val excludedGroups = effectiveExcludedGroups
-  val artifactView = expoAggregator.incoming.artifactView {
-    isLenient = true
-    attributes {
-      attribute(
-        org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
-        "aar"
-      )
+  dependencies {
+    fusableSubprojects.forEach { sub ->
+      add("brownfieldFusedExpoAggregator", sub)
     }
   }
-  artifactView.artifacts.artifacts.forEach { result ->
-    val id = result.id.componentIdentifier
+
+  // Coords whose group is excluded from fusing — the consumer-side resolution needs
+  // these declared as transitive deps in the published POM/.module even though they
+  // aren't fused into the AAR. LinkedHashSet: insertion order for stable output,
+  // set semantics so a coord reachable through several modules is recorded once.
+  val externalDepsForConsumer = linkedSetOf<Triple<String, String, String>>()
+
+  // Pure-umbrella coords recorded during auto-detection: the umbrella itself has no
+  // content (every variant redirects elsewhere), so it must not be re-declared for
+  // consumers — its `-android` child is recorded instead.
+  val pureUmbrellaComponents = mutableSetOf<Pair<String, String>>()
+
+  // AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
+  // graph once and records two cases:
+  //
+  //   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
+  //      (`available-at`) to another module. The umbrella has no content of its
+  //      own, only a pointer; fusing the `-android` child while the umbrella
+  //      stays external trips AGP's "parent dependency not included" validation.
+  //      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
+  //      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
+  //      mix of redirect and content variants — they don't match and stay
+  //      fusable.
+  //
+  //   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
+  //      in styleables that reference `android:*` framework attrs (e.g.
+  //      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
+  //      rewriter can't resolve framework attrs in the merged R, so fusing them
+  //      makes `rewriteClasses` fail. Excluding at the configuration level here
+  //      stops them from being pulled in via project-dep transitive walks.
+  expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+    val id = component.id
     if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
-    if (result.file.extension != "aar") return@forEach
     val group = id.group
-    // Record coords from excluded groups so we can inject them as transitive
-    // deps in the published POM/.module — must happen before any filter rejects them.
-    if (group in excludedGroups) {
-      externalDepsForConsumer.add(Triple(group, id.module, id.version))
+    if (group == "androidx" || group.startsWith("androidx.")) {
+      val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
+      if (!inAllowlist) autoExcludedGroups.add(group)
+      return@forEach
     }
-    if (isGroupDenied(group)) return@forEach
-    if (rootProject.findProject(":${id.module}") != null) return@forEach
-    // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
-    // These coords bake the build type into the artifactId, so they have no
-    // cross-variant counterpart and AGP fused-library's internal resolution trips
-    // trying to look them up. The consumer's own resolution picks the matching
-    // variant naturally via Gradle Module Metadata.
-    if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
-    collected += "${group}:${id.module}:${id.version}"
+    val variants = component.variants
+    if (variants.isEmpty()) return@forEach
+    val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
+    if (isPureUmbrella) {
+      autoExcludedGroups.add(group)
+      pureUmbrellaComponents.add(group to id.module)
+    }
   }
-  logger.lifecycle(
-    "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
-  )
-  collected
-}
-
-dependencies {
-  // User's BrownfieldActivity / Fragment / Host code.
-  include(project(":${{libraryName}}"))
-
-  // Every autolinked Android module (Expo + RN community).
-  rootProject.subprojects.forEach { sub ->
-    if (!sub.isFusableAndroidLibrary()) return@forEach
-    include(project(sub.path))
+  if (autoExcludedGroups.isNotEmpty()) {
+    logger.lifecycle(
+      "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
+        "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
+        autoExcludedGroups.sorted().joinToString(", ")
+    )
   }
 
-  // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
-  // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
-  transitiveAarIncludes.forEach { coord -> include(coord) }
-}
+  // Second pass, after `autoExcludedGroups` is complete: record every excluded-group
+  // coordinate for the POM/.module injection — at the component level so JAR-only
+  // modules (okhttp, okio, kotlin-stdlib, annotation artifacts) are captured too;
+  // the AAR-filtered artifactView walk below never sees them. Pure umbrellas are
+  // skipped (their `-android` children carry the content) and so are BOM/platform
+  // modules, which aren't plain runtime dependencies.
+  expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+    val id = component.id
+    if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+    if (id.group !in effectiveExcludedGroups()) return@forEach
+    if ((id.group to id.module) in pureUmbrellaComponents) return@forEach
+    if (id.module.endsWith("-bom")) return@forEach
+    externalDepsForConsumer.add(Triple(id.group, id.module, id.version))
+  }
 
-publishing {
-  // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
-  // publish plugin skips fused modules (no `LibraryExtension`), so without this
-  // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
-  repositories {
-    val rootPublishConfig =
-      rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
-    rootPublishConfig?.publications?.forEach { pubConfig ->
-      when (pubConfig.type.get()) {
-        "localMaven" -> mavenLocal()
-        "localDirectory", "remotePublic" -> maven {
-          name = pubConfig.name
-          url = uri(pubConfig.url.get())
-          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
-        }
-        "remotePrivate" -> maven {
-          name = pubConfig.name
-          url = uri(pubConfig.url.get())
-          credentials {
-            username = pubConfig.username.get()
-            password = pubConfig.password.get()
+  // Excludes that must reach EVERY configuration the fused-library plugin walks,
+  // including the runtime classpaths of `include(project(...))` targets. Scoping
+  // to just `fusedRuntime` isn't enough — fused-library reads from included
+  // projects' own configs which a scoped exclude can't touch. The aggregator is
+  // intentionally exempt so the transitive-AAR walk below can still see the
+  // resolved artifacts of excluded groups.
+  configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
+    // AGP Fused Library rejects any `androidx.databinding:*` dep, including
+    // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
+    exclude(group = "androidx.databinding", module = "viewbinding")
+    exclude(group = "androidx.databinding", module = "databinding-common")
+    exclude(group = "androidx.databinding", module = "databinding-runtime")
+    exclude(group = "androidx.databinding", module = "databinding-adapters")
+    exclude(group = "androidx.databinding", module = "databinding-ktx")
+
+    fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+    effectiveExcludedGroups().forEach { g -> exclude(group = g) }
+  }
+
+  // Walk the aggregator's resolved artifacts to collect external AAR coords for
+  // `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
+  // modern `artifactView` API — the legacy `lenientConfiguration` throws before
+  // you can read the lenient surface, masking the real failure.
+  val transitiveAarIncludes: Set<String> = run {
+    val collected = mutableSetOf<String>()
+    val artifactView = expoAggregator.incoming.artifactView {
+      isLenient = true
+      attributes {
+        attribute(
+          org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
+          "aar"
+        )
+      }
+    }
+    artifactView.artifacts.artifacts.forEach { result ->
+      val id = result.id.componentIdentifier
+      if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+      if (result.file.extension != "aar") return@forEach
+      val group = id.group
+      if (isGroupDenied(group)) return@forEach
+      if (rootProject.findProject(":${id.module}") != null) return@forEach
+      // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
+      // These coords bake the build type into the artifactId, so they have no
+      // cross-variant counterpart and AGP fused-library's internal resolution trips
+      // trying to look them up. The consumer's own resolution picks the matching
+      // variant naturally via Gradle Module Metadata.
+      if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
+      collected += "${group}:${id.module}:${id.version}"
+    }
+    logger.lifecycle(
+      "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
+    )
+    collected
+  }
+
+  dependencies {
+    // User's BrownfieldActivity / Fragment / Host code.
+    include(project(":${{libraryName}}"))
+
+    // Every autolinked Android module (Expo + RN community).
+    rootProject.subprojects.forEach { sub ->
+      if (!sub.isFusableAndroidLibrary()) return@forEach
+      include(project(sub.path))
+    }
+
+    // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
+    // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
+    transitiveAarIncludes.forEach { coord -> include(coord) }
+  }
+
+  publishing {
+    // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
+    // publish plugin skips fused modules (no `LibraryExtension`), so without this
+    // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
+    repositories {
+      val rootPublishConfig =
+        rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
+      rootPublishConfig?.publications?.forEach { pubConfig ->
+        when (pubConfig.type.get()) {
+          "localMaven" -> mavenLocal()
+          "localDirectory", "remotePublic" -> maven {
+            name = pubConfig.name
+            url = uri(pubConfig.url.get())
+            isAllowInsecureProtocol = pubConfig.allowInsecure.get()
           }
-          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+          "remotePrivate" -> maven {
+            name = pubConfig.name
+            url = uri(pubConfig.url.get())
+            credentials {
+              username = pubConfig.username.get()
+              password = pubConfig.password.get()
+            }
+            isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+          }
+        }
+      }
+    }
+
+    publications {
+      register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
+        afterEvaluate { from(components["fusedLibraryComponent"]) }
+        // Fused-library emits skip-list modules into the POM using Gradle project names
+        // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
+        // can't be resolved by consumers. Strip them.
+        pom.withXml {
+          val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
+            ?: return@withXml
+          val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
+            val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
+              ?.let { (it as? groovy.util.Node)?.text() }
+            artifactId in fusedSkipProjects
+          }
+          toRemove.forEach { deps.remove(it) }
         }
       }
     }
   }
 
-  publications {
-    register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
-      afterEvaluate { from(components["fusedLibraryComponent"]) }
-      // Fused-library emits skip-list modules into the POM using Gradle project names
-      // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
-      // can't be resolved by consumers. Strip them.
-      pom.withXml {
-        val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
-          ?: return@withXml
-        val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
-          val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
-            ?.let { (it as? groovy.util.Node)?.text() }
-          artifactId in fusedSkipProjects
+  // Annotate `react-android` / `hermes-android` dependency edges in the published
+  // Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
+  // matching resolves the same RN variant the brownfield's codegen `.so` files were
+  // linked against. Mismatch manifests as either SIGSEGV at component-descriptor
+  // init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
+  // only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
+  val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
+  afterEvaluate {
+    tasks.named(metadataTaskName).configure {
+      doLast {
+        val moduleFile = outputs.files.singleFile
+        if (!moduleFile.exists()) return@doLast
+        @Suppress("UNCHECKED_CAST")
+        val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
+        val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
+        var annotatedCount = 0
+        var strippedCount = 0
+        val perVariantAbiCoords = setOf(
+          "com.facebook.react" to "react-android",
+          "com.facebook.hermes" to "hermes-android",
+        )
+        variants.forEach { variant ->
+          val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
+          // Drop natural-emission entries whose group the user excluded — the inject
+          // step below adds the variant-specific coord with the actual resolved
+          // version, avoiding the KMP-parent-vs-`-android`-child duplication that
+          // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
+          // Also drop skip-list modules: fused-library emits them under unresolvable
+          // Gradle project names, and Gradle consumers read the .module file over the
+          // POM, so the POM-level strip alone isn't enough.
+          val before = deps.size
+          deps.removeAll { dep ->
+            val g = dep["group"] as? String
+            val m = dep["module"] as? String
+            (g != null && g in effectiveExcludedGroups()) || (m != null && m in fusedSkipProjects)
+          }
+          strippedCount += before - deps.size
+          deps.forEach { dep ->
+            val key = (dep["group"] as? String) to (dep["module"] as? String)
+            if (key in perVariantAbiCoords && dep["attributes"] == null) {
+              dep["attributes"] = mutableMapOf<String, Any?>(
+                "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+              )
+              annotatedCount++
+            }
+          }
         }
-        toRemove.forEach { deps.remove(it) }
-      }
-    }
-  }
-}
-
-// AGP `com.android.fused-library` auto-registers a `maven` publication alongside
-// our explicit `brownfield<V>` one at the same coords. `publishToMavenLocal` runs
-// both — the `maven` one overwrites our annotated metadata. Disable it.
-tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
-  enabled = false
-}
-
-// Annotate `react-android` / `hermes-android` dependency edges in the published
-// Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
-// matching resolves the same RN variant the brownfield's codegen `.so` files were
-// linked against. Mismatch manifests as either SIGSEGV at component-descriptor
-// init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
-// only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
-val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
-afterEvaluate {
-  tasks.named(metadataTaskName).configure {
-    doLast {
-      val moduleFile = outputs.files.singleFile
-      if (!moduleFile.exists()) return@doLast
-      @Suppress("UNCHECKED_CAST")
-      val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
-      val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
-      var annotatedCount = 0
-      var strippedCount = 0
-      val perVariantAbiCoords = setOf(
-        "com.facebook.react" to "react-android",
-        "com.facebook.hermes" to "hermes-android",
-      )
-      variants.forEach { variant ->
-        val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
-        // Drop natural-emission entries whose group the user excluded — the inject
-        // step below adds the variant-specific coord with the actual resolved
-        // version, avoiding the KMP-parent-vs-`-android`-child duplication that
-        // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
-        val before = deps.size
-        deps.removeAll { dep ->
-          val g = dep["group"] as? String ?: return@removeAll false
-          g in effectiveExcludedGroups
-        }
-        strippedCount += before - deps.size
-        deps.forEach { dep ->
-          val key = (dep["group"] as? String) to (dep["module"] as? String)
-          if (key in perVariantAbiCoords && dep["attributes"] == null) {
-            dep["attributes"] = mutableMapOf<String, Any?>(
-              "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+        // Inject the excluded transitives so the consumer can resolve them.
+        if (externalDepsForConsumer.isNotEmpty()) {
+          val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
+          if (runtimeVariant != null) {
+            @Suppress("UNCHECKED_CAST")
+            val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
+              ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
+            externalDepsForConsumer.forEach { (group, module, version) ->
+              deps.add(mutableMapOf(
+                "group" to group,
+                "module" to module,
+                "version" to mutableMapOf("requires" to version),
+              ))
+            }
+          } else {
+            logger.warn(
+              "brownfield.fused[${fusedVariant}]: 'runtimePublication' variant not found in " +
+                "module metadata — skipped injecting ${externalDepsForConsumer.size} external " +
+                "dependencies. Consumers may fail to resolve excluded-group transitives; this " +
+                "usually means the AGP fused-library plugin changed its published variant names."
             )
-            annotatedCount++
           }
         }
+        moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
+        logger.lifecycle(
+          "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
+            "BuildTypeAttr=${fusedVariant}, stripped $strippedCount excluded entries, " +
+            "injected ${externalDepsForConsumer.size} external transitives in module metadata"
+        )
       }
-      // Inject the user-excluded transitives so the consumer can resolve them.
-      if (externalDepsForConsumer.isNotEmpty()) {
-        val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
-        if (runtimeVariant != null) {
-          @Suppress("UNCHECKED_CAST")
-          val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
-            ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
-          externalDepsForConsumer.forEach { (group, module, version) ->
-            deps.add(mutableMapOf(
-              "group" to group,
-              "module" to module,
-              "version" to mutableMapOf("requires" to version),
-            ))
-          }
-        }
-      }
-      moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
-      logger.lifecycle(
-        "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
-          "BuildTypeAttr=${fusedVariant}, stripped $strippedCount user-excluded entries, " +
-          "injected ${externalDepsForConsumer.size} user-excluded transitives in module metadata"
-      )
     }
-  }
-  // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
-  // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
-  // whose coords aren't in the resolved configurations. Our `configureEach` exclude
-  // removes them, so the injection has to happen post-consistency-check.
-  val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
-  tasks.named(pomTaskName).configure {
-    doLast {
-      if (externalDepsForConsumer.isEmpty()) return@doLast
-      val pomFile = outputs.files.singleFile
-      if (!pomFile.exists()) return@doLast
-      val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
-        """    <dependency>
+    // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
+    // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
+    // whose coords aren't in the resolved configurations. Our `configureEach` exclude
+    // removes them, so the injection has to happen post-consistency-check.
+    val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
+    tasks.named(pomTaskName).configure {
+      doLast {
+        if (externalDepsForConsumer.isEmpty()) return@doLast
+        val pomFile = outputs.files.singleFile
+        if (!pomFile.exists()) return@doLast
+        val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
+          """    <dependency>
       <groupId>${group}</groupId>
       <artifactId>${module}</artifactId>
       <version>${version}</version>
       <scope>runtime</scope>
     </dependency>"""
+        }
+        val xml = pomFile.readText()
+        val updated = if (xml.contains("</dependencies>")) {
+          xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
+        } else {
+          xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
+        }
+        pomFile.writeText(updated)
       }
-      val xml = pomFile.readText()
-      val updated = if (xml.contains("</dependencies>")) {
-        xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
-      } else {
-        xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
-      }
-      pomFile.writeText(updated)
     }
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -1,0 +1,504 @@
+// Fuses every autolinked Android module + the brownfield library into a single
+// publishable AAR via AGP's `com.android.fused-library` (Preview, AGP 8.13+).
+//
+// One sibling subproject per variant — `:<libraryName>-fused-release` and
+// `-fused-debug` — both rendered from this template; `{{fusedVariant}}` is the
+// only delta.
+
+plugins {
+  id("com.android.fused-library")
+  id("maven-publish")
+}
+
+group = "${{groupId}}"
+
+version = "${{version}}"
+
+val fusedVariant = "${{fusedVariant}}"
+val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
+
+androidFusedLibrary {
+  namespace = "${{packageId}}.fused.${{fusedVariant}}"
+  minSdk = 24
+  aarMetadata { minCompileSdk = 36 }
+}
+
+// No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
+// `-menu-interface`) is included in BOTH variants:
+//   - For `-fused-release`, AGP fused-library compiles each module's release source
+//     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
+//     `src/disableInRelease` source set in release builds — it provides STUB
+//     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
+//     references resolve at runtime, but with no functional dev tooling. Footprint
+//     stays small and no manual entry-stripping is needed.
+//   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
+//     source set → real dev tooling, Metro reload, red-box overlay, etc.
+// `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
+// all; including them adds nothing to the AAR.
+val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
+  ?.split(',')
+  ?.map { it.trim() }
+  ?.filter { it.isNotEmpty() }
+  ?.toSet()
+  ?: emptySet()
+val fusedSkipProjects = extraSkip
+
+// Force sibling evaluation before resolving include() targets and walking their
+// runtime classpaths — without this, plugin detection and classpath resolution
+// see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
+rootProject.subprojects.forEach {
+  if (it.path == project.path) return@forEach
+  if (it.name == "${{libraryName}}-fused-release") return@forEach
+  if (it.name == "${{libraryName}}-fused-debug") return@forEach
+  evaluationDependsOn(it.path)
+}
+
+// `androidx.*` allowlist — these must be fused because their transitive chains
+// span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
+// on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
+// as a side-effect of fusing an Expo module, and AGP fused-library's "parent
+// dependency not included" validation then demands its AndroidX parent be
+// fused too — which requires the whole `androidx.camera` chain to be fused).
+// Auto-detection can't see these because they're regular Maven parent links,
+// not KMP `available-at` redirects.
+//
+// Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
+// another autolinked module pulls a new AndroidX chain with the same pattern.
+val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
+val androidxFuseAllowlistExtra: Set<String> =
+  (project.findProperty("brownfield.fused.androidx-fuse") as? String)
+    ?.split(',')
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?.toSet()
+    ?: emptySet()
+val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+
+// Android brownfield host platform baseline — NOT a list of application
+// libraries. These are the foundational pieces that, by definition of being a
+// React Native Android brownfield host, the integrating app already provides
+// on its classpath:
+//
+//   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
+//     `yoga`. The host links variant-specific `.so` files against these;
+//     fusing them either duplicate-classes with the host's copies or pins
+//     the wrong variant's native libs. AGP fused-library's "parent
+//     dependency not included" validation also enforces this transitively
+//     (e.g. `fbjni`'s parent is `hermes-android`).
+//
+//   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
+//     modern Android app pulls these via its own build.
+//
+//   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
+//     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
+//     Beyond duplication risk, AGP fused-library's class rewriter can't
+//     resolve `android:*` framework-attr references in styleables (Material's
+//     `AppBarLayout_android_background` etc.), so fusing Material Design fails
+//     `rewriteClasses` outright.
+//
+// This list encodes structural facts about the brownfield host — not
+// application-specific library choices. If you're adding a NEW group here,
+// it should be because every brownfield host inherently has it (e.g. AGP
+// raised the minimum platform baseline), not because a specific app uses it.
+val hostPlatformBaseline = setOf(
+  "com.facebook.react",
+  "com.facebook.hermes",
+  "com.facebook.fbjni",
+  "com.facebook.soloader",
+  "com.facebook.yoga",
+  "com.facebook.fresco",
+  "org.jetbrains.kotlin",
+  "org.jetbrains.kotlinx",
+  "com.google.android.material",
+  "com.google.guava",
+  "com.squareup.okhttp3",
+  "com.squareup.okio",
+)
+
+// Extra groups the user wants kept OUT of the fused AAR — auto-detection below
+// handles the common KMP-umbrella case, this is only for edge cases:
+//   brownfield.fused.exclude-transitive=some.group,another.group
+val excludedGroupsExtra: Set<String> =
+  (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+    ?.split(',')
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?.toSet()
+    ?: emptySet()
+
+// Populated below by walking the aggregator's resolution and detecting KMP-style
+// pom-only umbrellas that trip AGP fused-library's "parent dependency not
+// included" validation.
+val autoExcludedGroups = mutableSetOf<String>()
+val effectiveExcludedGroups: Set<String> get() =
+  hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
+
+// True → coord stays external in the POM. AndroidX uses an allowlist; the
+// RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
+// denylist.
+fun isGroupDenied(group: String): Boolean {
+  val denylist = effectiveExcludedGroups
+  if (denylist.any { group == it || group.startsWith("$it.") }) return true
+  if (group == "androidx" || group.startsWith("androidx.")) {
+    return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+  }
+  return false
+}
+
+// Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
+// match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
+// compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
+configurations.all {
+  if (name.startsWith("fusedRuntime")) {
+    attributes {
+      attribute(
+        com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+        project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
+      )
+    }
+  }
+}
+
+// Aggregator configuration: depends on every autolinked module, resolved locally
+// to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
+// resolution. `BuildTypeAttr` picks the matching variant per module.
+val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+  attributes {
+    attribute(
+      org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
+    )
+    attribute(
+      org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
+    )
+    attribute(
+      org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
+    )
+    attribute(
+      com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
+    )
+  }
+  // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
+  // comparator and cascade into lenient resolution returning zero artifacts.
+  // Guava is denylisted anyway (host provides it), so just drop it here.
+  exclude(group = "com.google.guava", module = "guava")
+}
+
+// `project.path` inside a `Project` extension function resolves to the RECEIVER
+// (Project.getProject() returns `this`), not the script's project. Capture it in
+// an outer `val` so the self-check compares against THIS fused module.
+val thisProjectPath: String = project.path
+
+// `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
+// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
+// which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
+fun Project.hasAndroidLibraryPlugin(): Boolean {
+  if (plugins.hasPlugin("com.android.library")) return true
+  if (plugins.toList().any { p ->
+        val n = p.javaClass.name
+        (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
+          n.endsWith("LibraryPlugin")
+      }) return true
+  val android = extensions.findByName("android") ?: return false
+  return android.javaClass.name.contains("Library", ignoreCase = true)
+}
+
+fun Project.isFusableAndroidLibrary(): Boolean {
+  if (path == thisProjectPath) return false
+  if (name == "${{libraryName}}") return false
+  if (name == "${{libraryName}}-fused-release") return false
+  if (name == "${{libraryName}}-fused-debug") return false
+  if (name in fusedSkipProjects) return false
+  if (!hasAndroidLibraryPlugin()) return false
+  return true
+}
+
+val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
+logger.lifecycle(
+  "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
+    fusableSubprojects.joinToString(", ") { it.name }
+)
+
+dependencies {
+  fusableSubprojects.forEach { sub ->
+    add("brownfieldFusedExpoAggregator", sub)
+  }
+}
+
+// Recorded by the aggregator walk: coords whose group is in `effectiveExcludedGroups`
+// — the consumer-side resolution needs to declare these as transitive deps even
+// though we don't fuse them into the AAR. Used by the metadata + POM post-
+// processors below.
+val externalDepsForConsumer = mutableListOf<Triple<String, String, String>>()
+
+// AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
+// graph once and records two cases:
+//
+//   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
+//      (`available-at`) to another module. The umbrella has no content of its
+//      own, only a pointer; fusing the `-android` child while the umbrella
+//      stays external trips AGP's "parent dependency not included" validation.
+//      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
+//      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
+//      mix of redirect and content variants — they don't match and stay
+//      fusable.
+//
+//   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
+//      in styleables that reference `android:*` framework attrs (e.g.
+//      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
+//      rewriter can't resolve framework attrs in the merged R, so fusing them
+//      makes `rewriteClasses` fail. Excluding at the configuration level here
+//      stops them from being pulled in via project-dep transitive walks.
+expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+  val id = component.id
+  if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+  val group = id.group
+  if (group == "androidx" || group.startsWith("androidx.")) {
+    val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
+    if (!inAllowlist) autoExcludedGroups.add(group)
+    return@forEach
+  }
+  val variants = component.variants
+  if (variants.isEmpty()) return@forEach
+  val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
+  if (isPureUmbrella) autoExcludedGroups.add(group)
+}
+if (autoExcludedGroups.isNotEmpty()) {
+  logger.lifecycle(
+    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
+      "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
+      autoExcludedGroups.sorted().joinToString(", ")
+  )
+}
+
+// Excludes that must reach EVERY configuration the fused-library plugin walks,
+// including the runtime classpaths of `include(project(...))` targets. Scoping
+// to just `fusedRuntime` isn't enough — fused-library reads from included
+// projects' own configs which a scoped exclude can't touch. The aggregator is
+// intentionally exempt so the transitive-AAR walk below can still record the
+// resolved versions of excluded groups for POM/.module injection.
+configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
+  // AGP Fused Library rejects any `androidx.databinding:*` dep, including
+  // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
+  exclude(group = "androidx.databinding", module = "viewbinding")
+  exclude(group = "androidx.databinding", module = "databinding-common")
+  exclude(group = "androidx.databinding", module = "databinding-runtime")
+  exclude(group = "androidx.databinding", module = "databinding-adapters")
+  exclude(group = "androidx.databinding", module = "databinding-ktx")
+
+  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+  effectiveExcludedGroups.forEach { g -> exclude(group = g) }
+}
+
+// Walk the aggregator's resolved artifacts to collect external AAR coords for
+// `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
+// modern `artifactView` API — the legacy `lenientConfiguration` throws before
+// you can read the lenient surface, masking the real failure.
+val transitiveAarIncludes: Set<String> = run {
+  val collected = mutableSetOf<String>()
+  val excludedGroups = effectiveExcludedGroups
+  val artifactView = expoAggregator.incoming.artifactView {
+    isLenient = true
+    attributes {
+      attribute(
+        org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
+        "aar"
+      )
+    }
+  }
+  artifactView.artifacts.artifacts.forEach { result ->
+    val id = result.id.componentIdentifier
+    if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+    if (result.file.extension != "aar") return@forEach
+    val group = id.group
+    // Record coords from excluded groups so we can inject them as transitive
+    // deps in the published POM/.module — must happen before any filter rejects them.
+    if (group in excludedGroups) {
+      externalDepsForConsumer.add(Triple(group, id.module, id.version))
+    }
+    if (isGroupDenied(group)) return@forEach
+    if (rootProject.findProject(":${id.module}") != null) return@forEach
+    // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
+    // These coords bake the build type into the artifactId, so they have no
+    // cross-variant counterpart and AGP fused-library's internal resolution trips
+    // trying to look them up. The consumer's own resolution picks the matching
+    // variant naturally via Gradle Module Metadata.
+    if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
+    collected += "${group}:${id.module}:${id.version}"
+  }
+  logger.lifecycle(
+    "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
+  )
+  collected
+}
+
+dependencies {
+  // User's BrownfieldActivity / Fragment / Host code.
+  include(project(":${{libraryName}}"))
+
+  // Every autolinked Android module (Expo + RN community).
+  rootProject.subprojects.forEach { sub ->
+    if (!sub.isFusableAndroidLibrary()) return@forEach
+    include(project(sub.path))
+  }
+
+  // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
+  // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
+  transitiveAarIncludes.forEach { coord -> include(coord) }
+}
+
+publishing {
+  // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
+  // publish plugin skips fused modules (no `LibraryExtension`), so without this
+  // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
+  repositories {
+    val rootPublishConfig =
+      rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
+    rootPublishConfig?.publications?.forEach { pubConfig ->
+      when (pubConfig.type.get()) {
+        "localMaven" -> mavenLocal()
+        "localDirectory", "remotePublic" -> maven {
+          name = pubConfig.name
+          url = uri(pubConfig.url.get())
+          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+        }
+        "remotePrivate" -> maven {
+          name = pubConfig.name
+          url = uri(pubConfig.url.get())
+          credentials {
+            username = pubConfig.username.get()
+            password = pubConfig.password.get()
+          }
+          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+        }
+      }
+    }
+  }
+
+  publications {
+    register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
+      afterEvaluate { from(components["fusedLibraryComponent"]) }
+      // Fused-library emits skip-list modules into the POM using Gradle project names
+      // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
+      // can't be resolved by consumers. Strip them.
+      pom.withXml {
+        val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
+          ?: return@withXml
+        val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
+          val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
+            ?.let { (it as? groovy.util.Node)?.text() }
+          artifactId in fusedSkipProjects
+        }
+        toRemove.forEach { deps.remove(it) }
+      }
+    }
+  }
+}
+
+// AGP `com.android.fused-library` auto-registers a `maven` publication alongside
+// our explicit `brownfield<V>` one at the same coords. `publishToMavenLocal` runs
+// both — the `maven` one overwrites our annotated metadata. Disable it.
+tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
+  enabled = false
+}
+
+// Annotate `react-android` / `hermes-android` dependency edges in the published
+// Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
+// matching resolves the same RN variant the brownfield's codegen `.so` files were
+// linked against. Mismatch manifests as either SIGSEGV at component-descriptor
+// init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
+// only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
+val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
+afterEvaluate {
+  tasks.named(metadataTaskName).configure {
+    doLast {
+      val moduleFile = outputs.files.singleFile
+      if (!moduleFile.exists()) return@doLast
+      @Suppress("UNCHECKED_CAST")
+      val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
+      val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
+      var annotatedCount = 0
+      var strippedCount = 0
+      val perVariantAbiCoords = setOf(
+        "com.facebook.react" to "react-android",
+        "com.facebook.hermes" to "hermes-android",
+      )
+      variants.forEach { variant ->
+        val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
+        // Drop natural-emission entries whose group the user excluded — the inject
+        // step below adds the variant-specific coord with the actual resolved
+        // version, avoiding the KMP-parent-vs-`-android`-child duplication that
+        // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
+        val before = deps.size
+        deps.removeAll { dep ->
+          val g = dep["group"] as? String ?: return@removeAll false
+          g in effectiveExcludedGroups
+        }
+        strippedCount += before - deps.size
+        deps.forEach { dep ->
+          val key = (dep["group"] as? String) to (dep["module"] as? String)
+          if (key in perVariantAbiCoords && dep["attributes"] == null) {
+            dep["attributes"] = mutableMapOf<String, Any?>(
+              "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+            )
+            annotatedCount++
+          }
+        }
+      }
+      // Inject the user-excluded transitives so the consumer can resolve them.
+      if (externalDepsForConsumer.isNotEmpty()) {
+        val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
+        if (runtimeVariant != null) {
+          @Suppress("UNCHECKED_CAST")
+          val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
+            ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
+          externalDepsForConsumer.forEach { (group, module, version) ->
+            deps.add(mutableMapOf(
+              "group" to group,
+              "module" to module,
+              "version" to mutableMapOf("requires" to version),
+            ))
+          }
+        }
+      }
+      moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
+      logger.lifecycle(
+        "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
+          "BuildTypeAttr=${fusedVariant}, stripped $strippedCount user-excluded entries, " +
+          "injected ${externalDepsForConsumer.size} user-excluded transitives in module metadata"
+      )
+    }
+  }
+  // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
+  // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
+  // whose coords aren't in the resolved configurations. Our `configureEach` exclude
+  // removes them, so the injection has to happen post-consistency-check.
+  val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
+  tasks.named(pomTaskName).configure {
+    doLast {
+      if (externalDepsForConsumer.isEmpty()) return@doLast
+      val pomFile = outputs.files.singleFile
+      if (!pomFile.exists()) return@doLast
+      val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
+        """    <dependency>
+      <groupId>${group}</groupId>
+      <artifactId>${module}</artifactId>
+      <version>${version}</version>
+      <scope>runtime</scope>
+    </dependency>"""
+      }
+      val xml = pomFile.readText()
+      val updated = if (xml.contains("</dependencies>")) {
+        xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
+      } else {
+        xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
+      }
+      pomFile.writeText(updated)
+    }
+  }
+}

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -14,8 +14,8 @@ index dda8db9d25..ee263e78e2 100644
 +import expo.modules.devmenu.api.DevMenuApi
 
  object BrownfieldLifecycleDispatcher {
-   fun onApplicationCreate(application: Application) {
-@@ -43,4 +45,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+   // @JvmStatic so Java hosts can call BrownfieldLifecycleDispatcher.onApplicationCreate(this)
+@@ -47,4 +49,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
    override fun invokeDefaultOnBackPressed() {
      finish()
    }

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -15,9 +15,9 @@ index dda8db9d25..ee263e78e2 100644
 
  object BrownfieldLifecycleDispatcher {
    fun onApplicationCreate(application: Application) {
-@@ -38,4 +40,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+@@ -43,4 +45,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
    override fun invokeDefaultOnBackPressed() {
-     super.onBackPressed()
+     finish()
    }
 +
 +  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -14,8 +14,8 @@ index dda8db9d25..ee263e78e2 100644
 +import expo.modules.devmenu.api.DevMenuApi
 
  object BrownfieldLifecycleDispatcher {
-   // @JvmStatic so Java hosts can call BrownfieldLifecycleDispatcher.onApplicationCreate(this)
-@@ -47,4 +49,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+   @JvmStatic
+@@ -45,4 +47,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
    override fun invokeDefaultOnBackPressed() {
      finish()
    }

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -2,18 +2,22 @@ diff --git a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivit
 index dda8db9d25..ee263e78e2 100644
 --- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
 +++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
-@@ -4,6 +4,8 @@ import android.app.Application
+@@ -3,9 +3,11 @@ package ${{packageId}}
+ import android.app.Activity
+ import android.app.Application
  import android.content.res.Configuration
- import androidx.appcompat.app.AppCompatActivity
- import expo.modules.ApplicationLifecycleDispatcher
 +import android.view.KeyEvent
+ import androidx.appcompat.app.AppCompatActivity
+ import com.facebook.react.ReactPackage
+ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
+ import expo.modules.ApplicationLifecycleDispatcher
 +import expo.modules.devmenu.api.DevMenuApi
- 
+
  object BrownfieldLifecycleDispatcher {
    fun onApplicationCreate(application: Application) {
-@@ -20,4 +22,15 @@ open class BrownfieldActivity : AppCompatActivity() {
-     super.onConfigurationChanged(newConfig)
-     BrownfieldLifecycleDispatcher.onConfigurationChanged(this.application, newConfig)
+@@ -38,4 +40,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+   override fun invokeDefaultOnBackPressed() {
+     super.onBackPressed()
    }
 +
 +  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
@@ -2,7 +2,7 @@ diff --git a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostMa
 index a9fbbe7d70..f7561327e7 100644
 --- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
 +++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
-@@ -12,6 +12,16 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+@@ -13,6 +13,16 @@
  import com.facebook.react.modules.core.DeviceEventManagerModule
  import expo.modules.ExpoReactHostFactory
  import expo.modules.brownfield.BrownfieldNavigationState
@@ -19,9 +19,9 @@ index a9fbbe7d70..f7561327e7 100644
  
  class ReactNativeHostManager {
    companion object {
-@@ -61,13 +71,44 @@ class ReactNativeHostManager {
-       context = application.applicationContext,
-       packageList = PackageList(application).packages + additionalPackages
+@@ -68,13 +78,44 @@
+       packageList = PackageList(application).packages + additionalPackages,
+       useDevSupport = BuildConfig.DEBUG
      )
 +
 +    if (BuildConfig.DEBUG) {
@@ -66,13 +66,13 @@ index a9fbbe7d70..f7561327e7 100644
    setUpNativeBackHandling()
  }
  
-@@ -97,3 +138,30 @@ fun Activity.setUpNativeBackHandling() {
+@@ -104,3 +145,30 @@
  
    componentActivity.onBackPressedDispatcher?.addCallback(componentActivity, backCallback)
  }
 +
 +internal fun maybeGetAppInfoFromManifest(
-+  application: Application, 
++  application: Application,
 +  reactHost: ReactHost?,
 +  activity: Activity
 +) {


### PR DESCRIPTION
# Why

In its current state `npx expo-brownfield build:android` publishes ~30 separate Maven coordinates per release (one per autolinked Expo Android module). This PR adds an opt-in single-fat-AAR mode so consumers only need to publish (and depend on) one AAR per variant.

# How

Add new `--fused` flag to `expo-brownfield build:android`. When set, the CLI targets the new sibling Gradle subprojects emitted by the config plugin,`<library>-fused-release` and `<library>-fused-debug`, producing a single AAR containing every autolinked module + each module's transitive Maven dependencies (ExoPlayer for expo-video, CameraX for expo-camera, etc.).
Key pieces:

- **Inert by default.** Prebuild always emits the two fused siblings, but their build scripts only activate when the CLI passes `-Pbrownfield.fused=true`. Normal builds and IDE sync pay no configuration cost, and non-fused publishes can't accidentally trigger a fat-AAR build via Gradle's cross-project task-name matching.
- **One sibling per variant.** `-fused-release` and `-fused-debug` publish distinct coordinates so hosts wire them as `releaseImplementation` / `debugImplementation`. A `BuildTypeAttr` override makes the debug sibling actually fuse debug bytecode (AGP's fused-library resolves everything as release by default).
- **Fused-only side effects.** The same property skips the publish plugin's per-module re-publish loop and force-bumps AGP to 8.13 just for fused builds (8.12's `rewriteClasses` can't read Kotlin sealed-class bytecode).
- **Fused contents are discovered, not hardcoded.** The sibling resolves the autolinked dependency graph and includes every module plus their external AARs (ExoPlayer, CameraX, Glide, ...). Three groups stay external: the brownfield host baseline (RN runtime, Kotlin stdlib, Material/Guava/OkHttp/Okio), `androidx.*` (AGP's class rewriter can't resolve framework attrs in their styleables; `androidx.camera`/`media3` are allowlisted), and auto-detected pom-only KMP umbrella modules. Everything external is re-declared in the published POM/`.module` so consumers resolve it themselves.
- **Variant-safe RN resolution.** Published metadata annotates the `react-android`/`hermes-android` edges with the sibling's build type, so consumers link the same RN variant the fused codegen `.so` files were built against (a mismatch crashes at startup).
- **Escape hatches.** `-Pbrownfield.fused.skip`, `strip-packages`, `androidx-fuse`, and `exclude-transitive` cover dependency graphs the auto-detection can't; documented in the new Fused mode docs section.
- **Runtime fixes along the way.** `BrownfieldActivity` implements `DefaultHardwareBackBtnHandler` and finishes on default back (avoids an infinite native/JS back-press loop), consumer ProGuard rules ship in the AAR so host R8 keeps reflection-loaded Expo classes, and the dev-menu patch passes `useDevSupport` explicitly so dev tooling follows the AAR variant.


# Test Plan

Automated:

- CLI e2e: fused task construction routed to the sibling subprojects, `--all` expanding to one Gradle invocation per variant, `-Pbrownfield.fused=true` forwarding (including for tasks passed via `-t`), plus existing snapshot/dry-run coverage.
- Plugin e2e: both fused siblings emitted with correct group/version/namespace/variant substitutions and the inert-by-default guard, settings.gradle includes, gradle.properties Fused Library opt-ins, and the conditional AGP force block. (Also fixed the suite's `expectFile` helper, which was async-but-unawaited, so its content assertions actually fail tests now.)

Manual, in `apps/brownfield-tester/expo-app`:

```sh
# Default — publishes both siblings
npx expo-brownfield build:android --fused --repo MavenLocal --verbose

# Or per variant
npx expo-brownfield build:android --fused --release --repo MavenLocal --verbose
npx expo-brownfield build:android --fused --debug   --repo MavenLocal --verbose
``