### PR TITLE
[splash-screen] Fix typo in hideAsync documentation

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix a typo in the `hideAsync` documentation ("compatability" → "compatibility"). ([#47922](https://github.com/expo/expo/pull/47922) by [@chinesepowered](https://github.com/chinesepowered))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-05-23

--- a/packages/expo-splash-screen/src/SplashScreen.ts
+++ b/packages/expo-splash-screen/src/SplashScreen.ts
@@ -40,7 +40,7 @@ export function setOptions(options: SplashScreenOptions): void {}
 export function hide(): void {}
 
 /**
- * Hides the native splash screen immediately. This method is provided for backwards compatability. See the
+ * Hides the native splash screen immediately. This method is provided for backwards compatibility. See the
  * ["Usage"](#usage) section for an example.
  */
 export async function hideAsync(): Promise<void> {}


### PR DESCRIPTION
# Why

The `hideAsync` TSDoc in `expo-splash-screen` misspells "compatibility" as "compatability". This comment ships in the generated SDK reference on docs.expo.dev.

# How

One-word spelling fix in the doc comment; no code, type, or API change.

- `SplashScreen.ts`: "provided for backwards **compatability**" → "backwards **compatibility**"

# Test Plan

Documentation-comment spelling fix only, verified by inspecting the surrounding TSDoc. No runtime behavior changes; existing tests are unaffected.

# Checklist

- [x] I added a changelog entry.
- [ ] This diff includes tests to cover new functionality. _(N/A — doc-comment fix)_
- [x] This diff will work correctly with `npx expo prebuild` & EAS Build. _(N/A — no native/config change)_
