### PR TITLE
[docs] Fix repeated-word typos in SwiftUI UI docs and EAS iOS build schema

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -119,45 +119,45 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 | Component                                                         | Description                                                                                     |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
-| [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
-| [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
-| [`Button`](swift-ui/button)                                       | Button component for displaying native buttons.                                                     |
-| [`ColorPicker`](swift-ui/colorpicker)                             | ColorPicker component for selecting colors.                                                         |
-| [`ConfirmationDialog`](swift-ui/confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
-| [`ContextMenu`](swift-ui/contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
-| [`ControlGroup`](swift-ui/controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
-| [`DatePicker`](swift-ui/datepicker)                               | DatePicker component for selecting dates and times.                                                 |
-| [`DisclosureGroup`](swift-ui/disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
-| [`Divider`](swift-ui/divider)                                     | Divider component for creating visual separators.                                                   |
-| [`Form`](swift-ui/form)                                           | Form component for collecting user input in a structured layout.                                    |
-| [`Gauge`](swift-ui/gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
-| [`Group`](swift-ui/group)                                         | Group component for grouping views without affecting layout.                                        |
-| [`Host`](swift-ui/host)                                           | Host component that enables SwiftUI components in React Native.                                     |
-| [`HStack`](swift-ui/hstack)                                       | HStack component for horizontal layouts.                                                            |
-| [`Image`](swift-ui/image)                                         | Image component for displaying SF Symbols.                                                          |
-| [`Label`](swift-ui/label)                                         | Label component for displaying text with an icon.                                                   |
-| [`LazyHStack`](swift-ui/lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
-| [`LazyVStack`](swift-ui/lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
-| [`Link`](swift-ui/link)                                           | Link component for displaying clickable links.                                                      |
-| [`List`](swift-ui/list)                                           | List component for displaying scrollable lists of items.                                            |
-| [`Menu`](swift-ui/menu)                                           | Menu component for displaying dropdown menus.                                                       |
-| [`Namespace`](swift-ui/namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
-| [`Overlay`](swift-ui/overlay)                                     | Overlay component for layering content on top of another view.                                      |
-| [`Picker`](swift-ui/picker)                                       | Picker component for selecting options from a list.                                                 |
-| [`Popover`](swift-ui/popover)                                     | Popover component for displaying content in a floating overlay.                                     |
-| [`ProgressView`](swift-ui/progressview)                           | ProgressView component for displaying progress indicators.                                          |
-| [`RNHostView`](swift-ui/rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
-| [`ScrollView`](swift-ui/scrollview)                               | ScrollView component for scrollable content.                                                        |
-| [`Section`](swift-ui/section)                                     | Section component for grouping content within lists and forms.                                      |
-| [`SecureField`](swift-ui/securefield)                             | SecureField component for password input.                                                           |
-| [`Slider`](swift-ui/slider)                                       | Slider component for selecting values from a range.                                                 |
-| [`Spacer`](swift-ui/spacer)                                       | Spacer component for flexible spacing.                                                              |
-| [`SwipeActions`](swift-ui/swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
-| [`TabView`](swift-ui/tabview)                                     | TabView component for paged or tabbed content.                                                      |
-| [`Text`](swift-ui/text)                                           | Text component for displaying styled text with support for nested texts.                            |
-| [`TextField`](swift-ui/textfield)                                 | TextField component for text input.                                                                 |
-| [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                     |
-| [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                              |
-| [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                           |
+| [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                        |
+| [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                      |
+| [`Button`](swift-ui/button)                                       | Button component for displaying native buttons.                                                 |
+| [`ColorPicker`](swift-ui/colorpicker)                             | ColorPicker component for selecting colors.                                                     |
+| [`ConfirmationDialog`](swift-ui/confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                               |
+| [`ContextMenu`](swift-ui/contextmenu)                             | ContextMenu component for displaying context menus.                                             |
+| [`ControlGroup`](swift-ui/controlgroup)                           | ControlGroup component for grouping interactive controls.                                       |
+| [`DatePicker`](swift-ui/datepicker)                               | DatePicker component for selecting dates and times.                                             |
+| [`DisclosureGroup`](swift-ui/disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                    |
+| [`Divider`](swift-ui/divider)                                     | Divider component for creating visual separators.                                               |
+| [`Form`](swift-ui/form)                                           | Form component for collecting user input in a structured layout.                                |
+| [`Gauge`](swift-ui/gauge)                                         | Gauge component for displaying progress with visual indicators.                                 |
+| [`Group`](swift-ui/group)                                         | Group component for grouping views without affecting layout.                                    |
+| [`Host`](swift-ui/host)                                           | Host component that enables SwiftUI components in React Native.                                 |
+| [`HStack`](swift-ui/hstack)                                       | HStack component for horizontal layouts.                                                        |
+| [`Image`](swift-ui/image)                                         | Image component for displaying SF Symbols.                                                      |
+| [`Label`](swift-ui/label)                                         | Label component for displaying text with an icon.                                               |
+| [`LazyHStack`](swift-ui/lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                               |
+| [`LazyVStack`](swift-ui/lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                 |
+| [`Link`](swift-ui/link)                                           | Link component for displaying clickable links.                                                  |
+| [`List`](swift-ui/list)                                           | List component for displaying scrollable lists of items.                                        |
+| [`Menu`](swift-ui/menu)                                           | Menu component for displaying dropdown menus.                                                   |
+| [`Namespace`](swift-ui/namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                              |
+| [`Overlay`](swift-ui/overlay)                                     | Overlay component for layering content on top of another view.                                  |
+| [`Picker`](swift-ui/picker)                                       | Picker component for selecting options from a list.                                             |
+| [`Popover`](swift-ui/popover)                                     | Popover component for displaying content in a floating overlay.                                 |
+| [`ProgressView`](swift-ui/progressview)                           | ProgressView component for displaying progress indicators.                                      |
+| [`RNHostView`](swift-ui/rnhostview)                               | A component that enables React Native views inside SwiftUI.                                     |
+| [`ScrollView`](swift-ui/scrollview)                               | ScrollView component for scrollable content.                                                    |
+| [`Section`](swift-ui/section)                                     | Section component for grouping content within lists and forms.                                  |
+| [`SecureField`](swift-ui/securefield)                             | SecureField component for password input.                                                       |
+| [`Slider`](swift-ui/slider)                                       | Slider component for selecting values from a range.                                             |
+| [`Spacer`](swift-ui/spacer)                                       | Spacer component for flexible spacing.                                                          |
+| [`SwipeActions`](swift-ui/swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.            |
+| [`TabView`](swift-ui/tabview)                                     | TabView component for paged or tabbed content.                                                  |
+| [`Text`](swift-ui/text)                                           | Text component for displaying styled text with support for nested texts.                        |
+| [`TextField`](swift-ui/textfield)                                 | TextField component for text input.                                                             |
+| [`Toggle`](swift-ui/toggle)                                       | Toggle component for displaying native toggles.                                                 |
+| [`VStack`](swift-ui/vstack)                                       | VStack component for vertical layouts.                                                          |
+| [`ZStack`](swift-ui/zstack)                                       | ZStack component for overlapping layouts.                                                       |
 
 {/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -116,8 +116,8 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 
 ### SwiftUI
 
-| Component                                                         | Description                                                                                         |
-| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Component                                                         | Description                                                                                     |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
 | [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
 | [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -118,7 +118,7 @@ See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacem
 
 | Component                                                         | Description                                                                                         |
 | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`AccessoryWidgetBackground`](swift-ui/accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
 | [`Alert`](swift-ui/alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
 | [`BottomSheet`](swift-ui/bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
 | [`Button`](swift-ui/button)                                       | Button component for displaying native buttons.                                                     |

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/accessorywidgetbackground.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/accessorywidgetbackground.mdx
@@ -1,6 +1,6 @@
 ---
 title: AccessoryWidgetBackground
-description: A SwiftUI adaptive background view that provides a standard appearance based on the the widget's environment.
+description: A SwiftUI adaptive background view that provides a standard appearance based on the widget's environment.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['ios', 'expo-go']
@@ -9,7 +9,7 @@ platforms: ['ios', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI AccessoryWidgetBackground matches the official SwiftUI [AccessoryWidgetBackground API](https://developer.apple.com/documentation/widgetkit/accessorywidgetbackground) and creates an adaptive background view that provides a standard appearance based on the the widget's environment.
+Expo UI AccessoryWidgetBackground matches the official SwiftUI [AccessoryWidgetBackground API](https://developer.apple.com/documentation/widgetkit/accessorywidgetbackground) and creates an adaptive background view that provides a standard appearance based on the widget's environment.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -70,45 +70,45 @@ For more information, see the following resources:
 | Component                                                | Description                                                                                     |
 | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
-| [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
-| [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
-| [`Button`](button)                                       | Button component for displaying native buttons.                                                     |
-| [`ColorPicker`](colorpicker)                             | ColorPicker component for selecting colors.                                                         |
-| [`ConfirmationDialog`](confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                                   |
-| [`ContextMenu`](contextmenu)                             | ContextMenu component for displaying context menus.                                                 |
-| [`ControlGroup`](controlgroup)                           | ControlGroup component for grouping interactive controls.                                           |
-| [`DatePicker`](datepicker)                               | DatePicker component for selecting dates and times.                                                 |
-| [`DisclosureGroup`](disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                        |
-| [`Divider`](divider)                                     | Divider component for creating visual separators.                                                   |
-| [`Form`](form)                                           | Form component for collecting user input in a structured layout.                                    |
-| [`Gauge`](gauge)                                         | Gauge component for displaying progress with visual indicators.                                     |
-| [`Group`](group)                                         | Group component for grouping views without affecting layout.                                        |
-| [`Host`](host)                                           | Host component that enables SwiftUI components in React Native.                                     |
-| [`HStack`](hstack)                                       | HStack component for horizontal layouts.                                                            |
-| [`Image`](image)                                         | Image component for displaying SF Symbols.                                                          |
-| [`Label`](label)                                         | Label component for displaying text with an icon.                                                   |
-| [`LazyHStack`](lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                                   |
-| [`LazyVStack`](lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                     |
-| [`Link`](link)                                           | Link component for displaying clickable links.                                                      |
-| [`List`](list)                                           | List component for displaying scrollable lists of items.                                            |
-| [`Menu`](menu)                                           | Menu component for displaying dropdown menus.                                                       |
-| [`Namespace`](namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                                  |
-| [`Overlay`](overlay)                                     | Overlay component for layering content on top of another view.                                      |
-| [`Picker`](picker)                                       | Picker component for selecting options from a list.                                                 |
-| [`Popover`](popover)                                     | Popover component for displaying content in a floating overlay.                                     |
-| [`ProgressView`](progressview)                           | ProgressView component for displaying progress indicators.                                          |
-| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside SwiftUI.                                         |
-| [`ScrollView`](scrollview)                               | ScrollView component for scrollable content.                                                        |
-| [`Section`](section)                                     | Section component for grouping content within lists and forms.                                      |
-| [`SecureField`](securefield)                             | SecureField component for password input.                                                           |
-| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                                 |
-| [`Spacer`](spacer)                                       | Spacer component for flexible spacing.                                                              |
-| [`SwipeActions`](swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.                |
-| [`TabView`](tabview)                                     | TabView component for paged or tabbed content.                                                      |
-| [`Text`](text)                                           | Text component for displaying styled text with support for nested texts.                            |
-| [`TextField`](textfield)                                 | TextField component for text input.                                                                 |
-| [`Toggle`](toggle)                                       | Toggle component for displaying native toggles.                                                     |
-| [`VStack`](vstack)                                       | VStack component for vertical layouts.                                                              |
-| [`ZStack`](zstack)                                       | ZStack component for overlapping layouts.                                                           |
+| [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                        |
+| [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                      |
+| [`Button`](button)                                       | Button component for displaying native buttons.                                                 |
+| [`ColorPicker`](colorpicker)                             | ColorPicker component for selecting colors.                                                     |
+| [`ConfirmationDialog`](confirmationdialog)               | ConfirmationDialog component for presenting confirmation prompts.                               |
+| [`ContextMenu`](contextmenu)                             | ContextMenu component for displaying context menus.                                             |
+| [`ControlGroup`](controlgroup)                           | ControlGroup component for grouping interactive controls.                                       |
+| [`DatePicker`](datepicker)                               | DatePicker component for selecting dates and times.                                             |
+| [`DisclosureGroup`](disclosuregroup)                     | DisclosureGroup component for displaying expandable content.                                    |
+| [`Divider`](divider)                                     | Divider component for creating visual separators.                                               |
+| [`Form`](form)                                           | Form component for collecting user input in a structured layout.                                |
+| [`Gauge`](gauge)                                         | Gauge component for displaying progress with visual indicators.                                 |
+| [`Group`](group)                                         | Group component for grouping views without affecting layout.                                    |
+| [`Host`](host)                                           | Host component that enables SwiftUI components in React Native.                                 |
+| [`HStack`](hstack)                                       | HStack component for horizontal layouts.                                                        |
+| [`Image`](image)                                         | Image component for displaying SF Symbols.                                                      |
+| [`Label`](label)                                         | Label component for displaying text with an icon.                                               |
+| [`LazyHStack`](lazyhstack)                               | LazyHStack component for lazy horizontal layouts.                                               |
+| [`LazyVStack`](lazyvstack)                               | LazyVStack component for lazy vertical layouts.                                                 |
+| [`Link`](link)                                           | Link component for displaying clickable links.                                                  |
+| [`List`](list)                                           | List component for displaying scrollable lists of items.                                        |
+| [`Menu`](menu)                                           | Menu component for displaying dropdown menus.                                                   |
+| [`Namespace`](namespace)                                 | A Namespace component that allows you create Namespaces in SwiftUI                              |
+| [`Overlay`](overlay)                                     | Overlay component for layering content on top of another view.                                  |
+| [`Picker`](picker)                                       | Picker component for selecting options from a list.                                             |
+| [`Popover`](popover)                                     | Popover component for displaying content in a floating overlay.                                 |
+| [`ProgressView`](progressview)                           | ProgressView component for displaying progress indicators.                                      |
+| [`RNHostView`](rnhostview)                               | A component that enables React Native views inside SwiftUI.                                     |
+| [`ScrollView`](scrollview)                               | ScrollView component for scrollable content.                                                    |
+| [`Section`](section)                                     | Section component for grouping content within lists and forms.                                  |
+| [`SecureField`](securefield)                             | SecureField component for password input.                                                       |
+| [`Slider`](slider)                                       | Slider component for selecting values from a range.                                             |
+| [`Spacer`](spacer)                                       | Spacer component for flexible spacing.                                                          |
+| [`SwipeActions`](swipeactions)                           | SwipeActions component for adding leading and trailing swipe actions to row content.            |
+| [`TabView`](tabview)                                     | TabView component for paged or tabbed content.                                                  |
+| [`Text`](text)                                           | Text component for displaying styled text with support for nested texts.                        |
+| [`TextField`](textfield)                                 | TextField component for text input.                                                             |
+| [`Toggle`](toggle)                                       | Toggle component for displaying native toggles.                                                 |
+| [`VStack`](vstack)                                       | VStack component for vertical layouts.                                                          |
+| [`ZStack`](zstack)                                       | ZStack component for overlapping layouts.                                                       |
 
 {/* @generated:ui-component-table:end */}

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -69,7 +69,7 @@ For more information, see the following resources:
 
 | Component                                                | Description                                                                                         |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the the widget's environment. |
+| [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
 | [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
 | [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |
 | [`Button`](button)                                       | Button component for displaying native buttons.                                                     |

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -67,8 +67,8 @@ For more information, see the following resources:
 
 {/* @generated:ui-component-table. Do not edit by hand. Run `pnpm generate-ui-component-tables`. */}
 
-| Component                                                | Description                                                                                         |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Component                                                | Description                                                                                     |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [`AccessoryWidgetBackground`](accessorywidgetbackground) | Adaptive background view that provides a standard appearance based on the widget's environment. |
 | [`Alert`](alert)                                         | Alert component for presenting native iOS alert dialogs.                                            |
 | [`BottomSheet`](bottomsheet)                             | BottomSheet component that presents content from the bottom of the screen.                          |

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -72,7 +72,7 @@ export default [
       "Xcode project's scheme. If a project:",
       '   - Has multiple schemes, you should set this value.',
       '   - Has only one scheme, it will be detected automatically.',
-      '   - Have multiple schemes schemes and if this value is **not** set, EAS CLI will prompt you to select one of them.',
+      '   - Have multiple schemes and if this value is **not** set, EAS CLI will prompt you to select one of them.',
     ],
   },
   {


### PR DESCRIPTION
# Why

A few repeated-word typos in the unversioned docs are visible on docs.expo.dev:

- "based on **the the** widget's environment" appears 4× in the SwiftUI `AccessoryWidgetBackground` docs.
- "Have **multiple schemes schemes**" in the EAS Build iOS schema description (surfaced in the eas.json reference).

# How

Text-only fixes to the **unversioned** docs (versioned snapshots are auto-generated, so they're left untouched):

- `sdk/ui/index.mdx`, `sdk/ui/swift-ui/index.mdx`, `sdk/ui/swift-ui/accessorywidgetbackground.mdx` (frontmatter `description` + body): "the the widget's environment" → "the widget's environment"
- `schemas/unversioned/eas-json-build-ios-schema.js`: "multiple schemes schemes" → "multiple schemes"

# Test Plan

Documentation-only wording fixes, verified by inspecting each occurrence. No code or behavior changes.

# Checklist

- [ ] I added a changelog entry. _(N/A — docs-only change; no package changelog applies)_
- [ ] This diff includes tests to cover new functionality. _(N/A — docs-only)_
