### PR TITLE
[iOS][JSI] Flush cached PropNameIDs when the runtime tears down

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Preserve the `code` on the JavaScript error when an async function rejects with a `JavaScriptThrowable` (e.g. an `Exception`), instead of stringifying it and dropping the `code` — mirroring the synchronous throw path. ([#47259](https://github.com/expo/expo/pull/47259) by [@wwdrew](https://github.com/wwdrew))
 - [iOS] Return `NSNull` instead of trapping in the deprecated `JavaScriptValue.getAny()` when it encounters a unrepresentable value. ([#47381](https://github.com/expo/expo/pull/47381) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed the `Build ExpoModulesJSI xcframework` build phase intermittently failing on Xcode 27 when clearing stale build state raced Xcode's background indexer writing into the SwiftPM index store. ([#47914](https://github.com/expo/expo/pull/47914) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed a use-after-free when a non-owning `JavaScriptRuntime` wrapper outlives its runtime (e.g. it is captured by a task abandoned on reload): its cached `jsi::PropNameID`s were destroyed against the freed runtime when the wrapper deallocated. The teardown sweep now flushes the cache on the JavaScript thread while the runtime is still valid. ([#47927](https://github.com/expo/expo/pull/47927) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -715,13 +715,18 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       // collection keeps it alive for the sweep; it does not retain the runtime.
       let longLivedObjects = self.longLivedObjects
       let nativeState = JavaScriptNativeState()
-      nativeState.setDeallocator { nativeState in
+      nativeState.setDeallocator { [weak self] nativeState in
         // Fires as the teardown object is released on the JavaScript thread with the runtime still
         // valid, so releasing JSI state here is safe. Mirrors the caveat on `AppContext.NativeState`:
         // a future cross-runtime path that could drop this state from another thread would have to
         // hop back to the JavaScript thread first.
         JavaScriptActor.assumeIsolated {
           longLivedObjects.clear()
+          // Also flush the cached `jsi::PropNameID`s: a non-owning wrapper can outlive its runtime
+          // (e.g. captured by a task abandoned on reload) and would otherwise destroy them against
+          // the freed runtime when it deallocates. `self` is weak so the teardown object doesn't
+          // retain the wrapper; the owning wrapper clears its own registry in `deinit`.
+          self?.propNameIdsRegistry.removeAll()
         }
       }
       let object = createObject()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -936,6 +936,28 @@ struct JavaScriptRuntimeTests {
     #expect(tracked.released == false)
     #expect(runtime.longLivedObjects.count == 1)
   }
+
+  @Test
+  func `non-owning wrapper outliving its runtime does not destroy cached PropNameIDs against freed memory`() throws {
+    // A non-owning wrapper's `deinit` returns early, so its stored `propNameIdsRegistry` is
+    // destroyed whenever the wrapper deallocates. If the wrapper outlives its runtime (e.g. it is
+    // captured by a task abandoned on reload), the cached `jsi::PropNameID` destructors used to run
+    // against the freed Hermes runtime, a use-after-free. Now the teardown sweep flushes the
+    // registry on the JS thread while the runtime is still valid.
+    var wrapper: JavaScriptRuntime? = nil
+    do {
+      let baseRuntime = JavaScriptRuntime()
+      wrapper = baseRuntime.withUnsafePointee { JavaScriptRuntime(unsafePointer: $0) }
+      // Creating a promise populates the wrapper's registry with cached "Promise" and "then" IDs.
+      _ = try JavaScriptPromise(wrapper!)
+      // Leaving the scope destroys the Hermes runtime while the wrapper is still alive; its
+      // teardown sweep must flush the cached PropNameIDs before Hermes is destroyed.
+    }
+    // Deallocating the wrapper here must not touch the freed runtime. Reaching the end of the test
+    // without a crash is the assertion.
+    wrapper = nil
+    _ = wrapper
+  }
 }
 
 /// Tasks captured by `holdSchedulerTask` instead of being executed, emulating a React


### PR DESCRIPTION
# Why

A non-owning `JavaScriptRuntime` wrapper that outlives its underlying runtime (for example, one captured by a task abandoned on reload) destroys its stored `propNameIdsRegistry` whenever the wrapper deallocates. That runs the `jsi::PropNameID` destructors against the already-freed Hermes runtime, a use-after-free that crashes with SIGSEGV in `facebook::jsi::Pointer::~Pointer()`.

So far this has only surfaced in unit tests, where owner-plus-adopted-wrapper pairs are created and torn down constantly; there are no known production reports. The production-shaped path exists, though (a wrapper captured by a task abandoned on reload), so it is worth fixing at the source.

The latent bug also makes the JS-thread-affinity PR stack (#47915, #47900, #47916, #47917) crash reliably in the `expo-modules-jsi` test suite: task executor preferences change where completed task contexts (which retain captured runtime wrappers across suspensions) get released, so non-owning wrappers now regularly deallocate on a cooperative-pool thread after the owning wrapper destroyed the runtime. Landing this fix first unblocks that stack.

# How

The runtime's teardown sweep (the `JavaScriptNativeState` deallocator that already clears long-lived objects on the JavaScript thread while the runtime is still valid) now also flushes the wrapper's cached `PropNameID`s. The wrapper is captured weakly so the teardown object does not retain it; when the teardown fires as part of the owning wrapper's own deinit cascade, the weak reference reads `nil`, which is fine because the owning `deinit` already clears the registry itself before destroying the runtime.

# Test Plan

- Added a regression test that reproduces the exact scenario: a non-owning wrapper whose registry was populated (via `JavaScriptPromise` caching the `Promise` and `then` IDs) outlives the standalone runtime that created it. Without the fix it crashes with SIGSEGV; with the fix the suite passes.
- `pnpm test:integration -only-testing:Tests/JavaScriptRuntimeTests` passes (64 tests).
- Cherry-picked onto the affinity stack tip: the previously reliable SIGSEGV in `JavaScriptRuntimeTests` is gone (68 tests run to completion).