### PR TITLE
[cli] include detected sandbox in feedback

### DIFF
--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -42,7 +42,8 @@
     "chalk": "^4.0.0",
     "ci-info": "^3.3.0",
     "expo-module-scripts": "workspace:*",
-    "prompts": "^2.3.2"
+    "prompts": "^2.3.2",
+    "sandbox-cli-detector": "^0.2.0"
   },
   "engines": {
     "node": "^22.13.0 || ^24.3.0 || ^26.0.0 || >=27.0.0"

--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "submit-expo-feedback",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Send feedback to the Expo team",
   "keywords": [
     "expo",

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -313,7 +313,7 @@ describe('feedback submission', () => {
       signal: timeoutSignal,
       headers: expect.objectContaining({
         'Content-Type': 'application/json',
-        'User-Agent': 'submit-expo-feedback/0.0.1',
+        'User-Agent': 'submit-expo-feedback/0.0.2',
         'expo-session': 'session-secret',
       }),
       body: JSON.stringify({

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -22,6 +22,15 @@ jest.mock('agent-cli-detector', () => ({
     },
   })),
 }));
+jest.mock('sandbox-cli-detector', () => ({
+  detectSandbox: jest.fn(() => ({
+    detected: true,
+    sandbox: {
+      id: 'e2b',
+      name: 'E2B',
+    },
+  })),
+}));
 jest.mock('ci-info', () => ({
   ...jest.requireActual('ci-info'),
   isCI: false,
@@ -322,6 +331,13 @@ describe('feedback submission', () => {
           id: 'codex',
           name: 'Codex',
           sessionId: 'test-session',
+        },
+      },
+      sandboxEnvironment: {
+        detected: true,
+        sandbox: {
+          id: 'e2b',
+          name: 'E2B',
         },
       },
       project: {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import path from 'path';
 import prompts from 'prompts';
+import { detectSandbox } from 'sandbox-cli-detector';
 
 const CLI_NAME = 'submit-expo-feedback';
 const FEEDBACK_TIMEOUT_MS = 15_000;
@@ -40,6 +41,7 @@ type FeedbackMetadata = {
     version: string;
   };
   agentEnvironment: ReturnType<typeof getAgentEnvironment>;
+  sandboxEnvironment: ReturnType<typeof getSandboxEnvironment>;
   ci?: {
     name: string | null;
     isPr: boolean | null;
@@ -124,7 +126,7 @@ async function runAsync(): Promise<void> {
 
   console.log(
     chalk.dim(
-      'Submitting feedback with available agent, environment, project, and Expo account metadata.'
+      'Submitting feedback with available agent, sandbox, environment, project, and Expo account metadata.'
     )
   );
   await sendFeedbackAsync({
@@ -201,6 +203,7 @@ export async function createFeedbackMetadataAsync(
       version: getPackageVersion(),
     },
     agentEnvironment: getAgentEnvironment(),
+    sandboxEnvironment: getSandboxEnvironment(),
     ci: ciInfo.isCI
       ? {
           name: ciInfo.name ?? null,
@@ -226,6 +229,15 @@ function getAgentEnvironment() {
   return {
     detected: result.detected,
     agent: result.agent,
+  };
+}
+
+function getSandboxEnvironment() {
+  const result = detectSandbox();
+
+  return {
+    detected: result.detected,
+    sandbox: result.sandbox,
   };
 }
 
@@ -446,8 +458,8 @@ function printHelp(): void {
     Send feedback to the Expo team. If no message is provided, you will be prompted.
 
   {bold Data collection}
-    Feedback includes available agent/session identifiers, environment details,
-    Expo project metadata, and Expo account identifiers.
+    Feedback includes available agent/session identifiers, sandbox and environment
+    details, Expo project metadata, and Expo account identifiers.
 
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6379,6 +6379,9 @@ importers:
       prompts:
         specifier: ^2.3.2
         version: 2.4.2
+      sandbox-cli-detector:
+        specifier: ^0.2.0
+        version: 0.2.0
 
   packages/unimodules-app-loader:
     devDependencies:
@@ -14279,6 +14282,11 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sandbox-cli-detector@0.2.0:
+    resolution: {integrity: sha512-4lyHX0ZU0AZKwjgZ1InxZAa3PNpyEb8rOQ+Zss1ReYmhNzW0Q+h1zE5nvniXN0HaAWZaZE1zgVNEirb0R7LmNg==}
+    engines: {node: '>=18.18'}
+    hasBin: true
 
   sass@1.98.0:
     resolution: {integrity: sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==}
@@ -24153,6 +24161,8 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sandbox-cli-detector@0.2.0: {}
 
   sass@1.98.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,3 +62,4 @@ minimumReleaseAgeExclude:
   - 'babel-preset-expo'
   - 'jest-expo'
   - '2g'
+  - 'sandbox-cli-detector'


### PR DESCRIPTION
Adds sandbox detection metadata to submit-expo-feedback, including detection status and sandbox ID/name when available. Updates the data-collection messaging and adds payload test coverage. Adds sandbox-cli-detector v0.2.0 with the required pnpm release-age exception. Tested with Jest, typecheck, lint, depscheck, formatting, and the bundled build.