### PR TITLE
[ui] Add editable anchor types to the menuAnchor modifier on Android

### DIFF
--- a/apps/native-component-list/src/screens/UI/ExposedDropdownMenuBoxScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/ExposedDropdownMenuBoxScreen.android.tsx
@@ -73,9 +73,17 @@ export default function ExposedDropdownMenuBoxScreen() {
   const [selected4, setSelected4] = React.useState('ts');
   const [expanded4, setExpanded4] = React.useState(false);
 
+  const [selected5, setSelected5] = React.useState('');
+  const [expanded5, setExpanded5] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const autocompleteText = useNativeState('');
+
   const selectedLabel = LANGUAGES.find((l) => l.value === selected)?.label ?? '';
   const selectedLabel3 = LANGUAGES.find((l) => l.value === selected3)?.label ?? '';
   const selectedLabel4 = LANGUAGES.find((l) => l.value === selected4)?.label ?? '';
+  const filteredLanguages = LANGUAGES.filter((lang) =>
+    lang.label.toLowerCase().includes(query.trim().toLowerCase())
+  );
 
   return (
     <Page>
@@ -204,6 +212,46 @@ export default function ExposedDropdownMenuBoxScreen() {
           </ExposedDropdownMenuBox>
         </Host>
         <Text>Selected: {selected4}</Text>
+      </Section>
+
+      <Section title="Editable (autocomplete)">
+        <Host matchContents>
+          <ExposedDropdownMenuBox expanded={expanded5} onExpandedChange={setExpanded5}>
+            <TextField
+              value={autocompleteText}
+              onValueChange={(text) => {
+                setQuery(text);
+                setExpanded5(true);
+              }}
+              modifiers={[menuAnchor('primaryEditable')]}
+            />
+            <ExposedDropdownMenu expanded={expanded5} onDismissRequest={() => setExpanded5(false)}>
+              {filteredLanguages.length === 0 ? (
+                <DropdownMenuItem enabled={false}>
+                  <DropdownMenuItem.Text>
+                    <ComposeText>No matches</ComposeText>
+                  </DropdownMenuItem.Text>
+                </DropdownMenuItem>
+              ) : (
+                filteredLanguages.map((lang) => (
+                  <DropdownMenuItem
+                    key={lang.value}
+                    onClick={() => {
+                      autocompleteText.value = lang.label;
+                      setQuery(lang.label);
+                      setSelected5(lang.value);
+                      setExpanded5(false);
+                    }}>
+                    <DropdownMenuItem.Text>
+                      <ComposeText>{lang.label}</ComposeText>
+                    </DropdownMenuItem.Text>
+                  </DropdownMenuItem>
+                ))
+              )}
+            </ExposedDropdownMenu>
+          </ExposedDropdownMenuBox>
+        </Host>
+        <Text>Selected: {selected5 || '(none)'}</Text>
       </Section>
     </Page>
   );

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🎉 New features
 
+- [jetpack-compose] Added the `primaryEditable` and `secondaryEditable` anchor types to the `menuAnchor` modifier, so an editable text field (autocomplete) gets a non-focusable menu popup and keeps the cursor and IME key events while the menu is open. ([#47930](https://github.com/expo/expo/pull/47930) by [@yassineDr12](https://github.com/yassineDr12))
 - [iOS] Added the `ignoreSafeArea="container"` option to `<Host>`, which ignores the device and container safe area insets (notch, home indicator, status and navigation bars) while still avoiding the keyboard. Use it to keep a `matchContents` host pinned to a screen edge interactive. ([#47619](https://github.com/expo/expo/pull/47619) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added the SwiftUI `redacted`, `unredacted`, `privacySensitive`, and `invalidatableContent` modifiers, mapping SwiftUI's redaction family for native skeleton-loading and sensitive-content states. ([#47269](https://github.com/expo/expo/pull/47269) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Added a `modifiers` prop to `ListItem` to override its default `buttonStyle(.plain)`. ([#47124](https://github.com/expo/expo/pull/47124) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
@@ -301,7 +301,9 @@ internal data class ToggleableParams(
 ) : Record
 
 internal enum class MenuAnchorType(val value: String) : Enumerable {
-  PRIMARY_NOT_EDITABLE("primaryNotEditable")
+  PRIMARY_NOT_EDITABLE("primaryNotEditable"),
+  PRIMARY_EDITABLE("primaryEditable"),
+  SECONDARY_EDITABLE("secondaryEditable")
 }
 
 internal data class MenuAnchorParams(
@@ -800,6 +802,8 @@ object ModifierRegistry {
         Modifier.menuAnchor(
           type = when (params.type) {
             MenuAnchorType.PRIMARY_NOT_EDITABLE -> ExposedDropdownMenuAnchorType.PrimaryNotEditable
+            MenuAnchorType.PRIMARY_EDITABLE -> ExposedDropdownMenuAnchorType.PrimaryEditable
+            MenuAnchorType.SECONDARY_EDITABLE -> ExposedDropdownMenuAnchorType.SecondaryEditable
           },
           enabled = params.enabled
         )

--- a/packages/expo-ui/src/jetpack-compose/modifiers/index.ts
+++ b/packages/expo-ui/src/jetpack-compose/modifiers/index.ts
@@ -306,10 +306,20 @@ export const matchParentSize = () => createModifier('matchParentSize');
 /**
  * Marks a composable as the anchor for an `ExposedDropdownMenuBox`.
  * Only works when used inside `ExposedDropdownMenuBox`.
- * @param type - Anchor type. Currently only `'primaryNotEditable'` is supported.
+ * @param type - Anchor type, matching Compose's `ExposedDropdownMenuAnchorType`. Defaults to `'primaryNotEditable'`.
+ * - `'primaryNotEditable'`: a read-only text field — taps toggle the menu, and the menu popup is a
+ *   focusable window.
+ * - `'primaryEditable'`: an editable text field (autocomplete) — taps focus the field for typing, and
+ *   the menu popup is created non-focusable so the field keeps window focus (cursor rendering and IME
+ *   key events keep working) while the menu is open.
+ * - `'secondaryEditable'`: a secondary element of an editable text field, such as its trailing icon —
+ *   taps toggle the menu without moving focus away from the field.
  * @param enabled - Whether the anchor is enabled. Defaults to `true`.
  */
-export const menuAnchor = (type?: 'primaryNotEditable', enabled?: boolean) =>
+export const menuAnchor = (
+  type?: 'primaryNotEditable' | 'primaryEditable' | 'secondaryEditable',
+  enabled?: boolean
+) =>
   createModifier('menuAnchor', {
     ...(type && { type }),
     ...(typeof enabled === 'boolean' && { enabled }),


### PR DESCRIPTION
# Why

`@expo/ui`'s `menuAnchor` modifier only accepts `'primaryNotEditable'`. That makes the Material 3 **editable** exposed-dropdown pattern (autocomplete: an editable text field inside `ExposedDropdownMenuBox`) subtly broken, because M3 derives the menu popup's window flags from the box scope's anchor type (`popupPropertiesForAnchorType` in `ExposedDropdownMenu.android.kt`), and only *editable* anchor types get `FLAG_NOT_FOCUSABLE`.

With no `menuAnchor` (or the `primaryNotEditable` one) applied, the anchor type stays `PrimaryNotEditable` and the menu popup is a **focusable window** that takes window focus from the activity while open (typing still *appears* to work because `FLAG_ALT_FOCUSABLE_IM` keeps the IME bound to the field). Two consequences for any autocomplete built on these primitives:

1. **The text cursor disappears** while the menu is open — Compose only renders the cursor while its window has focus.
2. **Backspace breaks, but only after typing a space.** While the IME has a composing region (mid-word), deletes go through the InputConnection and reach the field. After a space ends composition, Gboard sends backspace as a raw `KEYCODE_DEL` key event, which is dispatched to the focused popup window and never reaches the field — no `onValueChange` fires, and the key tap's `ACTION_OUTSIDE` triggers `onDismissRequest` instead, so the first backspace closes the menu and only the second one deletes a character.

Applying `menuAnchor('primaryEditable')` to the field fixes both: M3 then creates the popup with `FLAG_NOT_FOCUSABLE`, the activity keeps window focus, the cursor stays visible, and IME key events reach the field.

# How

- Added `PRIMARY_EDITABLE("primaryEditable")` and `SECONDARY_EDITABLE("secondaryEditable")` to the `MenuAnchorType` enum in `ModifierRegistry.kt`, mapping 1:1 to Compose's `ExposedDropdownMenuAnchorType.PrimaryEditable` / `.SecondaryEditable`.
- Widened the `type` parameter union of the `menuAnchor` modifier in `src/jetpack-compose/modifiers/index.ts` and replaced the "Currently only `'primaryNotEditable'` is supported" doc comment with a description of the three anchor types and their focus semantics.
- Added an "Editable (autocomplete)" example to `ExposedDropdownMenuBoxScreen.android.tsx` in native-component-list: an editable `TextField` with `menuAnchor('primaryEditable')`, live filtering via `onValueChange`, and item selection writing back to the field through its `useNativeState` value.

No behavior change for existing callers: `'primaryNotEditable'` remains the default and its code path is untouched.

# Test Plan

- Verified `primaryEditable` end to end in a production Expo SDK 57 app (patched `@expo/ui@57.0.7` + `expo.autolinking.android.buildFromSource: ["expo-ui"]`), on a physical Android device with Gboard: with `menuAnchor('primaryEditable', false)` on an editable `OutlinedTextField` inside `ExposedDropdownMenuBox`, the cursor stays visible while the menu is open and backspace deletes on the first press in all IME states (including immediately after a space). Before the change, the same screen showed both failure modes described above.
- `secondaryEditable` is the same mechanical 1:1 mapping, added for API completeness (M3 uses it for the trailing icon of an editable field); it was not exercised on a device.
- Parse/type sanity-checked the edited TS files. I could not run `et check-packages @expo/ui` or `et gdad -p "expo-ui/jetpack-compose/modifiers"` locally — happy to iterate if CI or docs regen flags anything.

# Checklist

- [x] Documentation is up to date to reflect these changes (doc comment updated; `et gdad` docs regen not run locally — see Test Plan).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
