### PR TITLE
[cli] add agent feedback nudge to non-interactive output

### DIFF
--- a/packages/@expo/cli/src/index.ts
+++ b/packages/@expo/cli/src/index.ts
@@ -4,6 +4,8 @@ import arg from 'arg';
 import chalk from 'chalk';
 import { boolish } from 'getenv';
 
+import { installAgentFeedback } from './utils/agentFeedback';
+
 // Bridge the legacy `EXPO_DEBUG`/`DEBUG=expo:*` switches onto `2g`'s `LOG_DEBUG` so existing
 // muscle memory keeps surfacing debug events. This must run before `installEventLogger()` so the
 // debug flag is honored when the session activates.
@@ -66,17 +68,19 @@ const args = arg(
 const isSubcommand = !!(args._[0] && commands[args._[0]]);
 const command = isSubcommand ? args._[0]! : defaultCmd;
 const commandArgs = isSubcommand ? args._.slice(1) : args._;
+const commandName = args['--version']
+  ? '--version'
+  : args['--help'] && !isSubcommand
+    ? '--help'
+    : command;
 
 // Setup event logger output before any console output. This single install handles explicit
 // LOG_EVENTS targets, parent IPC, and bounded command sessions in 2g's precedence order.
 installEventLogger({
-  command: args['--version']
-    ? 'expo --version'
-    : args['--help'] && !isSubcommand
-      ? 'expo --help'
-      : `expo ${command}`,
+  command: `expo ${commandName}`,
   version: process.env.__EXPO_VERSION,
 });
+installAgentFeedback(commandName);
 
 if (args['--version']) {
   // Version is added in the build script.

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -2,6 +2,7 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import * as Log from '../log';
+import { printAgentFeedback } from '../utils/agentFeedback';
 import { env } from '../utils/env';
 import { isInteractive, shouldReduceLogs } from '../utils/interactive';
 import { profile } from '../utils/profile';
@@ -170,4 +171,5 @@ export async function startAsync(
       isInteractive() ? chalk.dim(` Press Ctrl+C to exit.`) : ''
     }`
   );
+  printAgentFeedback();
 }

--- a/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
@@ -27,7 +27,7 @@ it('prints a compact feedback command when an agent exits in non-interactive mod
   const onExit = once.mock.calls[0]![1]! as () => void;
   onExit();
   expect(write).toHaveBeenCalledWith(
-    '\nExpo CLI issue? Report it: npx --yes submit-expo-feedback --category expo-cli --subject "export" "<what happened and how to reproduce>"\n'
+    '\nExpo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "export" "<what happened and how to reproduce>"\n'
   );
 });
 

--- a/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
@@ -1,0 +1,50 @@
+import { installAgentFeedback } from '../agentFeedback';
+import { isInteractive } from '../interactive';
+import { getAgentTelemetryContext } from '../telemetry/utils/agent';
+
+jest.mock('../interactive');
+jest.mock('../telemetry/utils/agent');
+
+const mockIsInteractive = jest.mocked(isInteractive);
+const mockGetAgentTelemetryContext = jest.mocked(getAgentTelemetryContext);
+
+beforeEach(() => {
+  mockIsInteractive.mockReturnValue(false);
+  mockGetAgentTelemetryContext.mockReturnValue({ id: 'codex', sessionId: undefined });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('prints a compact feedback command when an agent exits in non-interactive mode', () => {
+  const once = jest.spyOn(process, 'once').mockImplementation(() => process);
+  const write = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+  installAgentFeedback('export');
+
+  expect(once).toHaveBeenCalledWith('exit', expect.any(Function));
+  const onExit = once.mock.calls[0]![1]! as () => void;
+  onExit();
+  expect(write).toHaveBeenCalledWith(
+    '\nExpo CLI issue? Report it: npx --yes submit-expo-feedback --category expo-cli --subject "export" "<what happened and how to reproduce>"\n'
+  );
+});
+
+it('does not install the footer in interactive mode', () => {
+  mockIsInteractive.mockReturnValue(true);
+  const once = jest.spyOn(process, 'once').mockImplementation(() => process);
+
+  installAgentFeedback('export');
+
+  expect(once).not.toHaveBeenCalled();
+});
+
+it('does not install the footer when no agent is detected', () => {
+  mockGetAgentTelemetryContext.mockReturnValue(null);
+  const once = jest.spyOn(process, 'once').mockImplementation(() => process);
+
+  installAgentFeedback('export');
+
+  expect(once).not.toHaveBeenCalled();
+});

--- a/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/agentFeedback-test.ts
@@ -1,4 +1,4 @@
-import { installAgentFeedback } from '../agentFeedback';
+import { installAgentFeedback, printAgentFeedback } from '../agentFeedback';
 import { isInteractive } from '../interactive';
 import { getAgentTelemetryContext } from '../telemetry/utils/agent';
 
@@ -28,6 +28,23 @@ it('prints a compact feedback command when an agent exits in non-interactive mod
   onExit();
   expect(write).toHaveBeenCalledWith(
     '\nExpo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "export" "<what happened and how to reproduce>"\n'
+  );
+});
+
+it('prints feedback once when a long-running command is ready', () => {
+  const once = jest.spyOn(process, 'once').mockImplementation(() => process);
+  const removeListener = jest.spyOn(process, 'removeListener').mockImplementation(() => process);
+  const write = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+  installAgentFeedback('start');
+  const onExit = once.mock.calls[0]![1]! as () => void;
+  printAgentFeedback();
+  onExit();
+
+  expect(removeListener).toHaveBeenCalledWith('exit', onExit);
+  expect(write).toHaveBeenCalledTimes(1);
+  expect(write).toHaveBeenCalledWith(
+    '\nExpo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "start" "<what happened and how to reproduce>"\n'
   );
 });
 

--- a/packages/@expo/cli/src/utils/agentFeedback.ts
+++ b/packages/@expo/cli/src/utils/agentFeedback.ts
@@ -8,7 +8,7 @@ export function installAgentFeedback(command: string): void {
 
   process.once('exit', () => {
     process.stdout.write(
-      `\nExpo CLI issue? Report it: npx --yes submit-expo-feedback --category expo-cli --subject ${JSON.stringify(command)} "<what happened and how to reproduce>"\n`
+      `\nExpo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject ${JSON.stringify(command)} "<what happened and how to reproduce>"\n`
     );
   });
 }

--- a/packages/@expo/cli/src/utils/agentFeedback.ts
+++ b/packages/@expo/cli/src/utils/agentFeedback.ts
@@ -1,14 +1,27 @@
 import { isInteractive } from './interactive';
 import { getAgentTelemetryContext } from './telemetry/utils/agent';
 
+let pendingFeedback: (() => void) | undefined;
+
 export function installAgentFeedback(command: string): void {
   if (isInteractive() || !getAgentTelemetryContext()) {
     return;
   }
 
-  process.once('exit', () => {
+  const print = () => {
+    if (pendingFeedback !== print) {
+      return;
+    }
+    pendingFeedback = undefined;
+    process.removeListener('exit', print);
     process.stdout.write(
       `\nExpo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject ${JSON.stringify(command)} "<what happened and how to reproduce>"\n`
     );
-  });
+  };
+  pendingFeedback = print;
+  process.once('exit', print);
+}
+
+export function printAgentFeedback(): void {
+  pendingFeedback?.();
 }

--- a/packages/@expo/cli/src/utils/agentFeedback.ts
+++ b/packages/@expo/cli/src/utils/agentFeedback.ts
@@ -1,0 +1,14 @@
+import { isInteractive } from './interactive';
+import { getAgentTelemetryContext } from './telemetry/utils/agent';
+
+export function installAgentFeedback(command: string): void {
+  if (isInteractive() || !getAgentTelemetryContext()) {
+    return;
+  }
+
+  process.once('exit', () => {
+    process.stdout.write(
+      `\nExpo CLI issue? Report it: npx --yes submit-expo-feedback --category expo-cli --subject ${JSON.stringify(command)} "<what happened and how to reproduce>"\n`
+    );
+  });
+}


### PR DESCRIPTION
Adds a compact feedback command to the end of short-lived Expo CLI output, or once the dev server is ready for `expo start`, when running non-interactively under a detected coding agent.
It reuses `agent-cli-detector`, includes the Expo command name as the feedback subject, and leaves interactive and non-agent executions unchanged.
Tests cover exit-time output, deduplicated dev-server-ready output, and both gating conditions; the package typecheck, lint, focused tests, and built-CLI smoke tests pass.

## Example agent output

Long-running dev server:

```text
Starting project at /Users/davidmokos/Developer/experiments/friend-draw
Metro is running in CI mode, reloads are disabled. Remove CI=true to enable watch mode.
Starting Metro Bundler

Waiting on http://localhost:8082

Logs for your project will appear below.

Expo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "start" "<what happened and how to reproduce>"
(node:39610) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Successful export:

```text
Starting Metro Bundler
Android Bundled 4821ms index.js (614 modules)
Exporting 42 assets
Exported to: dist

Expo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "export" "<what happened and how to reproduce>"
```

Failed install:

```text
› Installing 1 SDK 56.0.0 compatible native module using npm
npm error code ERESOLVE
npm error unable to resolve dependency tree

Expo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "install" "<what happened and how to reproduce>"
```

Version command:

```text
56.1.12

Expo CLI issue? Report it: npx --yes submit-expo-feedback@latest --category expo-cli --subject "--version" "<what happened and how to reproduce>"
```

> [!IMPORTANT]
> Do not merge this PR until [#47904](https://github.com/expo/expo/pull/47904) has been published to npm; merging #47904 alone is not sufficient.
