### PR TITLE
[widgets] Make deprecated config fields optional

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))
+- Make deprecated root-level widget config fields optional. ([#47933](https://github.com/expo/expo/pull/47933) by [@eliotgevers](https://github.com/eliotgevers))
 - [iOS][plugin] Only add the `aps-environment` entitlement when `enablePushNotifications` is enabled, and keep a pre-existing value. ([#47645](https://github.com/expo/expo/pull/47645) by [@kadikraman](https://github.com/kadikraman))
 - [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
 - Fix blank widget when JSX children mix a `.map()` array with sibling elements. ([#47888](https://github.com/expo/expo/pull/47888) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
+++ b/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
@@ -5,9 +5,9 @@ export type WidgetConfig = {
   displayName: string;
   description: string;
   // @deprecated: use `ios.supportedFamilies` instead.
-  supportedFamilies: WidgetFamily[];
+  supportedFamilies?: WidgetFamily[];
   // @deprecated: use `ios.contentMarginsDisabled` instead.
-  contentMarginsDisabled: boolean;
+  contentMarginsDisabled?: boolean;
   // @deprecated: use `ios.configuration` instead.
   configuration?: {
     title: string;


### PR DESCRIPTION
# Why

`WidgetConfig` marks the root-level `supportedFamilies` and `contentMarginsDisabled` fields as deprecated in favor of their `ios` equivalents, but still requires both fields.

This forces typed configurations using `ios.supportedFamilies` to duplicate the same value at the root and provide `contentMarginsDisabled: false`.

The plugin runtime already:

- reads `ios.supportedFamilies` before falling back to the deprecated root field
- only applies `.contentMarginsDisabled()` when the resolved value is truthy

The type should not require deprecated fields that the runtime does not require.

# What changed

- Made the deprecated root-level `supportedFamilies` field optional.
- Made the deprecated root-level `contentMarginsDisabled` field optional.
- Kept `ios.supportedFamilies` required when an `ios` configuration is provided.
- Made no runtime changes.

Existing root-level configurations remain valid, while configurations using the current iOS-specific shape no longer need duplicate values.

# Test plan

Ran a focused TypeScript check verifying that:

- a widget using only `ios.supportedFamilies` type-checks
- an existing widget using the root-level fields still type-checks
- an `ios` configuration without `supportedFamilies` fails type-checking
- `contentMarginsDisabled` can be omitted

Also ran `git diff --check`.
