### PR TITLE
[android][cli] Fix parsing ADB device serials with spaces

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix parsing ADB device serials containing spaces.
 - Avoid writing a 500 response when a DevTools plugin server request has already started or aborted. ([#47192](https://github.com/expo/expo/pull/47192) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Pass a fetch API `Request` to DevTools plugin WebSocket handlers instead of `IncomingMessage`. ([#47410](https://github.com/expo/expo/pull/47410) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Use `loadModule` for MCP and DevTools plugin server module loading. ([#47139](https://github.com/expo/expo/pull/47139) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -257,6 +257,8 @@ describe(getAttachedDevicesAsync, () => {
           'adb-00000XXX000XXX-YzXxxx._adb-tls-connect._tcp. device product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
           // authorized & offline
           'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp. offline product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
+          // authorized with a duplicate mDNS service name
+          'adb-00000XXX000XXX-YzXxxx (2)._adb-tls-connect._tcp device product:cheetah model:Pixel_7_Pro device:cheetah transport_id:3',
           // Emulator
           'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
           '',
@@ -293,6 +295,14 @@ describe(getAttachedDevicesAsync, () => {
         pid: 'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp.',
         type: 'device',
         connectionType: 'Network',
+      },
+      {
+        connectionType: 'Network',
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_7_Pro',
+        pid: 'adb-00000XXX000XXX-YzXxxx (2)._adb-tls-connect._tcp',
+        type: 'device',
       },
       {
         isAuthorized: true,

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -228,7 +228,14 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
       // unauthorized: ['FA8251A00719', 'unauthorized', 'usb:338690048X', 'transport_id:5']
       // authorized: ['FA8251A00719', 'device', 'usb:336592896X', 'product:walleye', 'model:Pixel_2', 'device:walleye', 'transport_id:4']
       // emulator: ['emulator-5554', 'offline', 'transport_id:1']
-      const props = line.split(' ').filter(Boolean);
+      // ADB device serials may contain spaces, so split on the connection state.
+      // States: https://android.googlesource.com/platform/packages/modules/adb/+/refs/tags/android-17.0.0_r1/adb.cpp#144
+      const match = line.match(
+        /^(.+?) +(offline|bootloader|device|host|recovery|rescue|sideload|unauthorized|authorizing|connecting|detached|any)(?: +(.*))?$/
+      );
+      const props = match
+        ? [match[1]!, match[2]!, ...(match[3]?.split(' ').filter(Boolean) ?? [])]
+        : [];
       const type = line.includes('emulator') ? 'emulator' : 'device';
 
       let connectionType;


### PR DESCRIPTION
# Why

I couldn't launch an expo app on my wirelessly connected Android device:

```
[ADB] Couldn't reverse port 8081: adb: device 'adb-XXX-XXX' not found
Error: adb: device 'adb-XXX-XXX' not found
```

It's due to a ` (2)` in the device id which messes up the parser.

```
$ adb devices -l
List of devices attached
adb-XXX-XXX (2)._adb-tls-connect._tcp device product:XXX model:XXXX device:XXX transport_id:1
```

# How

Instead of splitting device lines on spaces, use a regex to find a valid state as 2nd argument (e.g., `device` or `offline`) and consider everything before it as the serial, preserving the full value:

```adb-XXX-XXX (2)._adb-tls-connect._tcp```

Valid states can be found at https://android.googlesource.com/platform/packages/modules/adb/+/refs/tags/android-17.0.0_r1/adb.cpp#144

# Test Plan

- Added a test case for a device serial containing a space.
- Ran `et check-packages @expo/cli`.
- Verified the full serial works with `adb get-state`.
- Verified `adb reverse tcp:8081 tcp:8081` succeeds for the affected device.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
