### PR TITLE
[ios] Only run unit tests for packages affected by the PR

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -10,6 +10,7 @@ on:
       - apps/bare-expo/ios/**
       - tools/src/commands/IosNativeUnitTests.ts
       - tools/src/commands/NativeUnitTests.ts
+      - tools/src/AffectedPackages.ts
       - Gemfile
       - Gemfile.lock
       - '!packages/@expo/cli/**'
@@ -22,6 +23,7 @@ on:
       - apps/bare-expo/ios/**
       - tools/src/commands/IosNativeUnitTests.ts
       - tools/src/commands/NativeUnitTests.ts
+      - tools/src/AffectedPackages.ts
       - Gemfile
       - Gemfile.lock
       - '!packages/@expo/cli/**'

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -38,9 +38,12 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # The PR merge commit plus its parents (base and head), enough for `--affected`
-          # to diff against the base commit.
-          fetch-depth: 2
+          # Enough history for `--affected` to diff against the base branch (same approach
+          # as .github/workflows/sdk.yml).
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --depth 100
+        if: github.event_name == 'pull_request'
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
@@ -97,7 +100,7 @@ jobs:
       # always run everything.
       - name: 🧪 Run native iOS unit tests
         timeout-minutes: 60
-        run: pnpm expotools native-unit-tests --platform ios ${{ github.event_name == 'pull_request' && format('--affected --since {0}', github.event.pull_request.base.sha) || '' }}
+        run: pnpm expotools native-unit-tests --platform ios ${{ github.event_name == 'pull_request' && format('--affected --since {0}', github.base_ref) || '' }}
       - name: Show ccache stats
         if: always()
         run: ccache -s -v

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -37,6 +37,10 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # The PR merge commit plus its parents (base and head), enough for `--affected`
+          # to diff against the base commit.
+          fetch-depth: 2
       - name: 🔨 Switch to Xcode 26.4.1
         run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
@@ -88,9 +92,12 @@ jobs:
       - name: 🥥 Install CocoaPods in `apps/bare-expo/ios`
         run: pod install
         working-directory: apps/bare-expo/ios
+      # On pull requests, only test packages affected by the PR (and their dependents);
+      # changes to the test infrastructure itself still trigger a full run. Pushes to main
+      # always run everything.
       - name: 🧪 Run native iOS unit tests
         timeout-minutes: 60
-        run: pnpm expotools native-unit-tests --platform ios
+        run: pnpm expotools native-unit-tests --platform ios ${{ github.event_name == 'pull_request' && format('--affected --since {0}', github.event.pull_request.base.sha) || '' }}
       - name: Show ccache stats
         if: always()
         run: ccache -s -v

--- a/tools/src/AffectedPackages.ts
+++ b/tools/src/AffectedPackages.ts
@@ -1,4 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
+import path from 'path';
 
 import * as Directories from './Directories';
 
@@ -33,14 +34,29 @@ export async function getAffectedPackagesAsync(
     return { type: 'infra-changed', changedFile: changedInfraFile };
   }
 
-  const { stdout } = await spawnAsync('pnpm', ['turbo', 'ls', '--affected', '--output=json'], {
+  // Invoke the turbo binary directly — going through pnpm can prepend warning banners
+  // (which may themselves contain braces) to stdout, breaking JSON extraction.
+  const turboBin = path.join(Directories.getNodeModulesDir(), '.bin', 'turbo');
+  const { stdout } = await spawnAsync(turboBin, ['ls', '--affected', '--output=json'], {
     cwd: Directories.getExpoRepositoryRootDir(),
     env: { ...process.env, TURBO_SCM_BASE: options.scmBase },
   });
-  // Skip anything a package manager may print before turbo's JSON output.
-  const json = JSON.parse(stdout.slice(stdout.indexOf('{')));
+  const json = extractJson(stdout);
   const items: { name: string }[] = json.packages?.items ?? [];
   return { type: 'packages', packageNames: new Set(items.map((item) => item.name)) };
+}
+
+// Extracts the JSON document from process output that may be surrounded by other text
+// (warnings, banners): tries each `{` as a start and accepts the one that parses to the end.
+function extractJson(output: string): any {
+  for (let index = output.indexOf('{'); index !== -1; index = output.indexOf('{', index + 1)) {
+    try {
+      return JSON.parse(output.slice(index));
+    } catch {
+      // Not the start of the JSON document — try the next brace.
+    }
+  }
+  throw new Error(`No JSON document found in the output:\n${output}`);
 }
 
 // Changed repo-relative paths since the merge base with `scmBase`, including uncommitted

--- a/tools/src/AffectedPackages.ts
+++ b/tools/src/AffectedPackages.ts
@@ -1,0 +1,64 @@
+import spawnAsync from '@expo/spawn-async';
+
+import * as Directories from './Directories';
+
+export type AffectedPackagesOptions = {
+  /** Git ref to diff against, e.g. `main` or a base commit SHA. */
+  scmBase: string;
+  /**
+   * Regexes of repo-relative paths that affect the test infrastructure itself — when any
+   * changed file matches, affected-detection is off the table and everything should run.
+   */
+  infraPathPatterns: RegExp[];
+};
+
+export type AffectedPackagesResult =
+  | { type: 'packages'; packageNames: Set<string> }
+  | { type: 'infra-changed'; changedFile: string };
+
+/**
+ * Returns the names of workspace packages affected by changes since `scmBase`, including
+ * their dependents (computed by `turbo ls --affected`, which also accounts for uncommitted
+ * changes). When a changed file matches `infraPathPatterns`, returns `infra-changed`
+ * instead — changes to the infrastructure itself must not be able to skip tests.
+ */
+export async function getAffectedPackagesAsync(
+  options: AffectedPackagesOptions
+): Promise<AffectedPackagesResult> {
+  const changedFiles = await getChangedFilesAsync(options.scmBase);
+  const changedInfraFile = changedFiles.find((file) =>
+    options.infraPathPatterns.some((pattern) => pattern.test(file))
+  );
+  if (changedInfraFile) {
+    return { type: 'infra-changed', changedFile: changedInfraFile };
+  }
+
+  const { stdout } = await spawnAsync('pnpm', ['turbo', 'ls', '--affected', '--output=json'], {
+    cwd: Directories.getExpoRepositoryRootDir(),
+    env: { ...process.env, TURBO_SCM_BASE: options.scmBase },
+  });
+  // Skip anything a package manager may print before turbo's JSON output.
+  const json = JSON.parse(stdout.slice(stdout.indexOf('{')));
+  const items: { name: string }[] = json.packages?.items ?? [];
+  return { type: 'packages', packageNames: new Set(items.map((item) => item.name)) };
+}
+
+// Changed repo-relative paths since the merge base with `scmBase`, including uncommitted
+// and untracked files so local runs see work in progress the same way turbo does.
+async function getChangedFilesAsync(scmBase: string): Promise<string[]> {
+  const cwd = Directories.getExpoRepositoryRootDir();
+  const mergeBase = (
+    await spawnAsync('git', ['merge-base', scmBase, 'HEAD'], { cwd })
+  ).stdout.trim();
+  const committed = (
+    await spawnAsync('git', ['diff', '--name-only', `${mergeBase}...HEAD`], { cwd })
+  ).stdout
+    .split('\n')
+    .filter(Boolean);
+  const workingTree = (await spawnAsync('git', ['status', '--porcelain'], { cwd })).stdout
+    .split('\n')
+    .filter(Boolean)
+    // Lines look like `XY path` or `XY old -> new` for renames — take the current path.
+    .map((line) => line.slice(3).split(' -> ').pop()!);
+  return [...new Set([...committed, ...workingTree])];
+}

--- a/tools/src/AffectedPackages.ts
+++ b/tools/src/AffectedPackages.ts
@@ -61,20 +61,33 @@ function extractJson(output: string): any {
 
 // Changed repo-relative paths since the merge base with `scmBase`, including uncommitted
 // and untracked files so local runs see work in progress the same way turbo does.
+//
+// Both git commands use `-z` (NUL-separated records). This disables `core.quotePath`, which
+// otherwise wraps paths with spaces or non-ASCII bytes in literal double quotes — those quotes
+// would defeat the `^`-anchored `INFRA_PATH_PATTERNS`, silently skipping tests for such a change.
+// It also makes rename entries unambiguous instead of relying on a ` -> ` separator that a path
+// could itself contain.
 async function getChangedFilesAsync(scmBase: string): Promise<string[]> {
   const cwd = Directories.getExpoRepositoryRootDir();
   const mergeBase = (
     await spawnAsync('git', ['merge-base', scmBase, 'HEAD'], { cwd })
   ).stdout.trim();
-  const committed = (
-    await spawnAsync('git', ['diff', '--name-only', `${mergeBase}...HEAD`], { cwd })
-  ).stdout
-    .split('\n')
-    .filter(Boolean);
-  const workingTree = (await spawnAsync('git', ['status', '--porcelain'], { cwd })).stdout
-    .split('\n')
-    .filter(Boolean)
-    // Lines look like `XY path` or `XY old -> new` for renames — take the current path.
-    .map((line) => line.slice(3).split(' -> ').pop()!);
+  const committed = splitNulRecords(
+    (await spawnAsync('git', ['diff', '-z', '--name-only', `${mergeBase}...HEAD`], { cwd })).stdout
+  );
+  // `git status --porcelain=v1 -z` emits `XY <path>` records; for a rename it's two records:
+  // `XY <new>` then `<orig>`, so the current path is always the record that starts with a status
+  // code. Take those, stripping the `XY ` prefix.
+  const workingTree = splitNulRecords(
+    (await spawnAsync('git', ['status', '--porcelain=v1', '-z'], { cwd })).stdout
+  )
+    .filter((record) => /^[ MADRCU?!]{2} /.test(record))
+    .map((record) => record.slice(3));
   return [...new Set([...committed, ...workingTree])];
+}
+
+// Splits git's `-z` output into records. The final record is NUL-terminated too, so the trailing
+// empty segment is dropped.
+function splitNulRecords(output: string): string[] {
+  return output.split('\0').filter(Boolean);
 }

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
+import { getAffectedPackagesAsync } from '../AffectedPackages';
 import * as Directories from '../Directories';
 import * as Packages from '../Packages';
 
@@ -177,6 +178,19 @@ async function isXcbeautifyAvailableAsync(): Promise<boolean> {
 
 const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
 
+// Changes to any of these paths affect how the tests themselves build and run, so
+// affected-packages detection must fall back to testing everything — the infrastructure
+// must not be able to skip its own validation.
+const INFRA_PATH_PATTERNS = [
+  /^tools\//,
+  /^apps\/bare-expo\/ios\//,
+  /^\.github\/workflows\/ios-unit-tests\.yml$/,
+  /^packages\/expo-modules-autolinking\//,
+  /^packages\/expo-module-scripts\//,
+  /^packages\/expo-modules-test-core\//,
+  /^pnpm-lock\.yaml$/,
+];
+
 async function runTestsAsync(scheme: string, destination: string, useXcbeautify: boolean) {
   const args = [
     'test',
@@ -220,9 +234,34 @@ async function runTestsAsync(scheme: string, destination: string, useXcbeautify:
   }
 }
 
-export async function iosNativeUnitTests({ packages }: { packages?: string }) {
+export async function iosNativeUnitTests({
+  packages,
+  affected,
+  since = 'main',
+}: {
+  packages?: string;
+  affected?: boolean;
+  since?: string;
+}) {
   const allPackages = await Packages.getListOfPackagesAsync();
   const packageNamesFilter = packages ? packages.split(',') : [];
+
+  // An explicit `--packages` list takes precedence over affected-packages detection.
+  let affectedFilter: Set<string> | null = null;
+  if (affected && !packageNamesFilter.length) {
+    const result = await getAffectedPackagesAsync({
+      scmBase: since,
+      infraPathPatterns: INFRA_PATH_PATTERNS,
+    });
+    if (result.type === 'infra-changed') {
+      console.log(
+        `Test infrastructure changed (${chalk.bold(result.changedFile)}) — running all iOS unit tests.\n`
+      );
+    } else {
+      affectedFilter = result.packageNames;
+      console.log(`Testing only packages affected since ${chalk.bold(since)}.\n`);
+    }
+  }
 
   const targetsToTest: string[] = [];
   const packagesToTest: string[] = [];
@@ -235,6 +274,9 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
     }
 
     if (packageNamesFilter.length > 0 && !packageNamesFilter.includes(pkg.packageName)) {
+      continue;
+    }
+    if (affectedFilter && !affectedFilter.has(pkg.packageName)) {
       continue;
     }
 
@@ -254,6 +296,10 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
       throw new Error(
         `No packages were found with the specified names: ${packageNamesFilter.join(', ')}`
       );
+    }
+    if (affectedFilter) {
+      console.log('✅ No affected packages provide iOS unit tests — nothing to run.');
+      return;
     }
     // Without this guard, an empty target list would generate a scheme with no testables and
     // `xcodebuild` would exit 0 — a vacuous success masking a broken package/test discovery.
@@ -299,6 +345,16 @@ export default (program: any) => {
     .option(
       '--packages <string>',
       '[optional] Comma-separated list of package names to run unit tests for. Defaults to all packages with unit tests.'
+    )
+    .option(
+      '--affected',
+      '[optional] Only test packages affected by changes since `--since` (including their dependents). Ignored when `--packages` is passed.',
+      false
+    )
+    .option(
+      '-s, --since <ref>',
+      '[optional] Git ref to diff against for `--affected`. Defaults to `main`.',
+      'main'
     )
     .description('Runs iOS native unit tests for each package that provides them.')
     .asyncAction(iosNativeUnitTests);

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -191,6 +191,8 @@ const INFRA_PATH_PATTERNS = [
   /^packages\/expo-module-scripts\//,
   /^packages\/expo-modules-test-core\//,
   /^pnpm-lock\.yaml$/,
+  // CocoaPods and xcodeproj come from the bundle, so gem bumps change how pods install.
+  /^Gemfile(\.lock)?$/,
 ];
 
 async function runTestsAsync(scheme: string, destination: string, useXcbeautify: boolean) {

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -180,9 +180,11 @@ const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
 
 // Changes to any of these paths affect how the tests themselves build and run, so
 // affected-packages detection must fall back to testing everything — the infrastructure
-// must not be able to skip its own validation.
+// must not be able to skip its own validation. For `tools/`, only the modules this command
+// is built from are listed (not the whole directory, which changes far too often).
 const INFRA_PATH_PATTERNS = [
-  /^tools\//,
+  /^tools\/src\/commands\/(IosNativeUnitTests|NativeUnitTests)\.ts$/,
+  /^tools\/src\/(AffectedPackages|Packages|Directories|CocoaPods)\.ts$/,
   /^apps\/bare-expo\/ios\//,
   /^\.github\/workflows\/ios-unit-tests\.yml$/,
   /^packages\/expo-modules-autolinking\//,

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -249,17 +249,27 @@ export async function iosNativeUnitTests({
   // An explicit `--packages` list takes precedence over affected-packages detection.
   let affectedFilter: Set<string> | null = null;
   if (affected && !packageNamesFilter.length) {
-    const result = await getAffectedPackagesAsync({
-      scmBase: since,
-      infraPathPatterns: INFRA_PATH_PATTERNS,
-    });
-    if (result.type === 'infra-changed') {
+    try {
+      const result = await getAffectedPackagesAsync({
+        scmBase: since,
+        infraPathPatterns: INFRA_PATH_PATTERNS,
+      });
+      if (result.type === 'infra-changed') {
+        console.log(
+          `Test infrastructure changed (${chalk.bold(result.changedFile)}) — running all iOS unit tests.\n`
+        );
+      } else {
+        affectedFilter = result.packageNames;
+        console.log(`Testing only packages affected since ${chalk.bold(since)}.\n`);
+      }
+    } catch (error: any) {
+      // Fail open: when the detection itself breaks (e.g. the merge base is unreachable in
+      // a shallow clone), running everything is always correct — just slower.
       console.log(
-        `Test infrastructure changed (${chalk.bold(result.changedFile)}) — running all iOS unit tests.\n`
+        chalk.yellow(
+          `Couldn't determine affected packages (${error.message?.trim()}) — running all iOS unit tests.\n`
+        )
       );
-    } else {
-      affectedFilter = result.packageNames;
-      console.log(`Testing only packages affected since ${chalk.bold(since)}.\n`);
     }
   }
 

--- a/tools/src/commands/NativeUnitTests.ts
+++ b/tools/src/commands/NativeUnitTests.ts
@@ -11,10 +11,14 @@ async function thisAction({
   platform,
   type = 'local',
   packages,
+  affected,
+  since,
 }: {
   platform?: PlatformName;
   type: TestType;
   packages?: string;
+  affected?: boolean;
+  since?: string;
 }) {
   if (!platform) {
     console.log(chalk.yellow("You haven't specified platform to run unit tests for!"));
@@ -32,7 +36,7 @@ async function thisAction({
   const runAndroid = platform === 'android' || platform === 'both';
   const runIos = platform === 'ios' || platform === 'both';
   if (runIos) {
-    await iosNativeUnitTests({ packages });
+    await iosNativeUnitTests({ packages, affected, since });
   }
   if (runAndroid) {
     await androidNativeUnitTests({ type, packages });
@@ -53,6 +57,16 @@ export default (program: any) => {
     .option(
       '--packages <string>',
       '[optional] Comma-separated list of package names to run unit tests for. Defaults to all packages with unit tests.'
+    )
+    .option(
+      '--affected',
+      '[optional] Only test packages affected by changes since `--since`, including their dependents. iOS only for now. Ignored when `--packages` is passed.',
+      false
+    )
+    .option(
+      '-s, --since <ref>',
+      '[optional] Git ref to diff against for `--affected`. Defaults to `main`.',
+      'main'
     )
     .description('Runs native unit tests for each unimodules that provides them.')
     .asyncAction(thisAction);


### PR DESCRIPTION
# Why

On pull requests, there's no need to build and run unit tests for all 22 packages when only one changed — testing the affected subset cuts the dominant cost (compilation, e.g. the expo-image/expo-video third-party stacks) proportionally to the change.

# How

- Adds `--affected` / `--since <ref>` to `et native-unit-tests` (iOS for now), with the detection living in expotools (`tools/src/AffectedPackages.ts`) rather than the workflow:
  - **Infra guard first**: if any changed file (committed since the merge base, or uncommitted) affects the test infrastructure, the full suite runs — the infrastructure must not be able to skip its own validation. Matched paths: `apps/bare-expo/ios/`, this workflow, `expo-modules-autolinking`, `expo-module-scripts`, `expo-modules-test-core`, `pnpm-lock.yaml`, `Gemfile(.lock)`, and — for `tools/` — only the specific modules this command is built from (`{Ios,}NativeUnitTests.ts`, `AffectedPackages/Packages/Directories/CocoaPods.ts`), not the whole directory, which churns too often.
  - Otherwise `turbo ls --affected` (same mechanism as `et check-packages`, `TURBO_SCM_BASE` = the base ref) computes changed packages **including their dependents** — verified that native podspec dependencies mirror `package.json` dependencies (e.g. expo-updates → expo-manifests/expo-structured-headers/expo-eas-client), so the workspace graph is a sound proxy for the pod graph. A change to expo-modules-core naturally fans out to everything.
  - The result is intersected with packages that provide iOS test specs; an empty intersection exits successfully without touching Xcode.
  - `--packages` takes precedence over `--affected`.
- The workflow runs `native-unit-tests --platform ios --affected --since <base branch>` on pull requests; pushes to main still run everything. It checks out with `fetch-depth: 100` and fetches the base branch to that depth (the same approach as `sdk.yml`) so the merge-base diff against the base is available.
- Works locally too: `et native-unit-tests -p ios --affected` = "test what I changed", including uncommitted work.

# Test Plan

- All three paths verified locally: an infra file changed → "running all iOS unit tests"; only `packages/expo-clipboard/src` dirty → exactly `ExpoClipboard-Unit-Tests` selected; no changes → "No affected packages provide iOS unit tests — nothing to run." with exit 0.
- This PR's own CI run exercises the infra-guard path (it touches the listed `tools/` modules and the workflow). The turbo path on a CI checkout gets its first real exercise on the first package-only PR after this lands — the failure mode is a loud error, not silently skipped tests.
- `tools` builds and lints clean.
