### PR TITLE
fix(jsi): use UTF-8 byte lengths for property names

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
@@ -14,7 +14,7 @@ public final class JavaScriptPropNameID: JavaScriptType {
   /// Creates a PropNameID from the string.
   public init(_ runtime: JavaScriptRuntime, string: String) {
     self.runtime = runtime
-    self.pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, string, string.count)
+    self.pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, string, string.utf8.count)
   }
 
   /// Copies the data in a PropNameID as UTF8 into a string.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -404,7 +404,7 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
       guard let runtime else {
         FatalError.runtimeLost()
       }
-      let jsiValue = expo.getProperty(runtime.pointee, pointee, .forUtf8(runtime.pointee, key, key.count))
+      let jsiValue = expo.getProperty(runtime.pointee, pointee, .forUtf8(runtime.pointee, key, key.utf8.count))
       return JavaScriptValue(runtime, jsiValue)
     }
     nonmutating set(newValue) {


### PR DESCRIPTION
  Fixes non-ASCII JavaScript property names in the iOS JSI layer by passing UTF-8 byte lengths instead
  of Swift grapheme counts. Also corrects array property reads that constructed PropNameIDs with the
  wrong length.