### PR TITLE
[fingerprint] Skip prebuild-generated native dirs for CNG platforms

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐛 Bug fixes
 
 - Fixed unstable fingerprint for iOS precompiled modules. ([#46466](https://github.com/expo/expo/pull/46466) by [@kudo](https://github.com/kudo))
+- Skipped hashing prebuild-generated native directories for CNG platforms, so the fingerprint no longer changes after running `expo prebuild`. ([#47949](https://github.com/expo/expo/pull/47949) by [@Oupsla](https://github.com/Oupsla))
 
 ### 💡 Others
 

--- a/packages/@expo/fingerprint/src/sourcer/Bare.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Bare.ts
@@ -22,7 +22,7 @@ export async function getBareAndroidSourcesAsync(
   projectRoot: string,
   options: NormalizedOptions
 ): Promise<HashSource[]> {
-  if (options.platforms.includes('android')) {
+  if (options.platforms.includes('android') && !options.useCNGForPlatforms.android) {
     const result = await getFileBasedHashSourceAsync(projectRoot, 'android', 'bareNativeDir');
     if (result != null) {
       debug(`Adding bare native dir - ${chalk.dim('android')}`);
@@ -36,7 +36,7 @@ export async function getBareIosSourcesAsync(
   projectRoot: string,
   options: NormalizedOptions
 ): Promise<HashSource[]> {
-  if (options.platforms.includes('ios')) {
+  if (options.platforms.includes('ios') && !options.useCNGForPlatforms.ios) {
     const result = await getFileBasedHashSourceAsync(projectRoot, 'ios', 'bareNativeDir');
     if (result != null) {
       debug(`Adding bare native dir - ${chalk.dim('ios')}`);

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Bare-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Bare-test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import type { NormalizedOptions } from '../../Fingerprint.types';
 import { normalizeOptionsAsync } from '../../Options';
+import { resolveProjectWorkflowAsync } from '../../ProjectWorkflow';
 import {
   getBareAndroidSourcesAsync,
   getBareIosSourcesAsync,
@@ -24,6 +25,7 @@ jest.mock('../../ProjectWorkflow');
 describe('getBareSourcesAsync', () => {
   afterEach(() => {
     vol.reset();
+    jest.mocked(resolveProjectWorkflowAsync).mockReset();
   });
 
   it('should contain android and ios folders in bare react-native project', async () => {
@@ -33,6 +35,17 @@ describe('getBareSourcesAsync', () => {
 
     sources = await getBareIosSourcesAsync('/app', await normalizeOptionsAsync('/app'));
     expect(sources).toContainEqual(expect.objectContaining({ filePath: 'ios', type: 'dir' }));
+  });
+
+  it('should not add bare native dir sources for CNG (managed) platforms', async () => {
+    vol.fromJSON(require('./fixtures/BareReactNative70Project.json'));
+    // A CNG/managed project generates android/ and ios/ via `expo prebuild`, so their
+    // presence must not change the fingerprint. See https://github.com/expo/expo/issues/47943
+    jest.mocked(resolveProjectWorkflowAsync).mockResolvedValue('managed');
+    const options = await normalizeOptionsAsync('/app');
+
+    expect(await getBareAndroidSourcesAsync('/app', options)).toEqual([]);
+    expect(await getBareIosSourcesAsync('/app', options)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
# Why

For a **CNG (managed)** project, `@expo/fingerprint` includes the prebuild-generated `ios/` and `android/` directories as `bareNativeDir` sources whenever they happen to exist on disk. Because those directories only exist *after* `expo prebuild`, the fingerprint diverges depending on whether prebuild has run:

- Managed fingerprint (`eas update`, a Workflows `fingerprint` job — no native dirs present) → excludes them.
- Build-time fingerprint (computed *after* `expo prebuild` on EAS Build) → includes them.

The two hashes differ for the same commit, which breaks `runtimeVersion: { policy: "fingerprint" }` (update targeting + `type: repack` reuse).

Fixes #47943 — which has a full repro on a stock `create-expo-app`.

# How

`getBareAndroidSourcesAsync` / `getBareIosSourcesAsync` gated the `bareNativeDir` source only on `options.platforms.includes(platform)`. This adds `&& !options.useCNGForPlatforms[platform]`, so the generated native dirs are skipped for CNG platforms.

This is consistent with `normalizeOptionsAsync`, which already appends `android/**/*` / `ios/**/*` to the ignore paths for CNG platforms — it neutralized the dir *contents* but the dir *source entry* remained, which is the leak fixed here.

# Test Plan

Added a unit test in `Bare-test.ts`: with the project workflow mocked to `managed`, `getBareAndroidSourcesAsync` / `getBareIosSourcesAsync` now return `[]`; the existing bare-workflow test still asserts the dirs are included.

Verified end-to-end on a fresh `create-expo-app` (Expo SDK 57, `@expo/fingerprint@0.20.5`), `/ios` and `/android` gitignored (so still CNG):

```
before prebuild : 55a61c85…   bareNativeDir sources: 0
after  prebuild : ede8de39…   bareNativeDir sources: 2   (android, ios)
```

With this change the pre/post-prebuild fingerprints match.
