### PR TITLE
[router] Improve the event types in standard navigation integration

### DIFF
--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -8,7 +8,6 @@ import { withLayoutContext } from '../layouts/withLayoutContext';
 import {
   useNavigationBuilder,
   type DefaultRouterOptions,
-  type EventMapBase,
   type NavigationAction,
   type NavigationState,
   type RouterFactory,
@@ -57,7 +56,7 @@ type StandardRouterNavigatorComponent<
       StandardRouterNavigatorProps<State, NavigatorOptions, EventMap, NavigatorProps, RouterOptions>
     >,
     State,
-    EventMap & EventMapBase
+    EventMap
   >
 >;
 
@@ -209,12 +208,11 @@ export function unstable_integrateWithRouter<
     );
   }
 
-  return withLayoutContext<
-    NavigatorOptions,
-    typeof StandardRouterNavigator,
-    State,
-    EventMap & EventMapBase
-  >(StandardRouterNavigator, undefined, options?.useOnlyUserDefinedScreens);
+  return withLayoutContext<NavigatorOptions, typeof StandardRouterNavigator, State, EventMap>(
+    StandardRouterNavigator,
+    undefined,
+    options?.useOnlyUserDefinedScreens
+  );
 }
 
 /**

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -32,7 +32,7 @@ export type StandardUseNavigationBuilderOptions<
   string | undefined,
   State,
   NavigatorOptions,
-  EventMap & StandardNavigatorEventMapBase,
+  EventMap,
   // `useNavigationBuilder` itself types the screenListeners `navigation` argument as `any`.
   any
 >;


### PR DESCRIPTION
# Why

The generic for `EventMap` was unnecessarily intersected with `EventMapBase`. Since `EventMapBase` is just a `Record` all key specific information from user-defined `EventMap` was lost. Since `EventMap` already extends `StandardNavigatorEventMapBase` this seems unnecessary.

# How

Change `EventMap & EventMapBase` to `EventMap` in code

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
