### PR TITLE
[android][task-manager] Clear headless task manager on context destroy

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix a crash when a task execution request is evaluated re-entrantly, by making its completion callback fire exactly once. ([#47594](https://github.com/expo/expo/pull/47594) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -242,6 +242,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
     // It may be called with null when the host activity is destroyed.
     if (taskManager == null) {
       sTaskManagers.remove(appScopeKey);
+      sHeadlessTaskManagers.remove(appScopeKey);
       return;
     }
 
@@ -611,9 +612,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   private void invalidateAppRecord(String appScopeKey) {
     HeadlessAppLoader appLoader = getAppLoader();
     if (appLoader != null) {
-      if (getAppLoader().invalidateApp(appScopeKey)) {
-        sHeadlessTaskManagers.remove(appScopeKey);
-      }
+      appLoader.invalidateApp(appScopeKey);
     }
   }
 


### PR DESCRIPTION
# Why
Fixes: [#47673](https://github.com/expo/expo/issues/47673), https://github.com/expo/expo/issues/47024

There was a problem in `expo-location` which occurred after force-stop on stock Android ([#47673](https://github.com/expo/expo/issues/47673)) and on swipe-close on custom Android ([#47673](https://github.com/expo/expo/issues/47673)) . After going back to the app the event queue was emptied, and since then no other events were handled

It turned out to be an `expo-task-manager` problem: it removes the `headlessTaskManager` after `invalidateApp`, which would be correct if the context weren't alive (then the app would just be reloaded on the next event). But because the context is still alive, no new task manager is created (that only happens on module create / onCreate), and `getTaskManager()` returns null

# How
Moved removing the `headlessTaskManager` from after invalidating the app to `onDestroy` - `setTaskManager(null)` now clears both maps, so the headless manager lives as long as its context, same as the foreground one

There was also an alternative where the `headlessTaskManager` could be moved to `sTaskManagers` when the activity takes it over, but moving it to `onDestroy` is better since it follows the same flow as the regular `taskManager`

# Test Plan 

Tested on BareExpo Playground