### PR TITLE
[CI] Fix `Test iOS Static Frameworks` build by disabling expo-router nav check

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -3,7 +3,7 @@ name: Test iOS Static Frameworks
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * SUN' # 0:00 AM UTC time every Sunday
+    - cron: "0 0 * * SUN" # 0:00 AM UTC time every Sunday
   pull_request:
     paths:
       - .github/workflows/ios-static-frameworks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
@@ -48,6 +48,8 @@ jobs:
           TURBO_TEAM: expo
       - name: 🍏 Build iOS Project
         working-directory: ./apps/bare-expo
+        env:
+          EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK: 1
         run: |
           set -o pipefail
           jq '.["ios.useFrameworks"] = "static" | .["ios.buildReactNativeFromSource"] = "true"' ios/Podfile.properties.json > temp.json && mv temp.json ios/Podfile.properties.json
@@ -58,5 +60,5 @@ jobs:
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
-          channel: '#expo-ios'
+          channel: "#expo-ios"
           author_name: Static Frameworks iOS Test (minimal-tester)

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -3,7 +3,7 @@ name: Test iOS Static Frameworks
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 0 * * SUN" # 0:00 AM UTC time every Sunday
+    - cron: '0 0 * * SUN' # 0:00 AM UTC time every Sunday
   pull_request:
     paths:
       - .github/workflows/ios-static-frameworks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
@@ -60,5 +60,5 @@ jobs:
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
-          channel: "#expo-ios"
+          channel: '#expo-ios'
           author_name: Static Frameworks iOS Test (minimal-tester)


### PR DESCRIPTION
# Why
The `Test iOS Static Frameworks` workflow has been failing on its weekly Sunday schedule since ~2026-07-03. 

# How
Added `EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK: 1`

# Test Plan
CI
