### PR TITLE
[cli] clarify submit-expo-feedback subject help

### DIFF
--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "submit-expo-feedback",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Send feedback to the Expo team",
   "keywords": [
     "expo",

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -8,6 +8,7 @@ import {
   getProjectMetadata,
   getUserMetadataAsync,
   resolveFeedbackAsync,
+  runExpoFeedbackAsync,
   sendFeedbackAsync,
 } from '../cli';
 
@@ -42,6 +43,32 @@ function writeJson(filePath: string, value: unknown): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(value, null, 2));
 }
+
+describe('help output', () => {
+  it('explains the expected subject for each category', async () => {
+    const originalArgv = process.argv;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    process.argv = ['node', 'submit-expo-feedback', '--help'];
+
+    try {
+      await runExpoFeedbackAsync();
+
+      const helpOutput = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(helpOutput).toContain('| Category   | Subject');
+      expect(helpOutput).toContain('| skills     | Exact skill name, such as expo-router');
+      expect(helpOutput).toContain('| docs       | Full Expo documentation URL');
+      expect(helpOutput).toContain('| mcp        | Exact MCP tool name used');
+      expect(helpOutput).toContain('| expo-cli   | Full Expo CLI command, such as npx expo install');
+      expect(helpOutput).toContain('| eas-cli    | Full EAS CLI command, such as eas build');
+      expect(helpOutput).toContain(
+        '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
+      );
+    } finally {
+      process.argv = originalArgv;
+      consoleLogSpy.mockRestore();
+    }
+  });
+});
 
 describe('feedback message resolution', () => {
   beforeEach(() => {

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -304,7 +304,7 @@ describe('feedback submission', () => {
       signal: timeoutSignal,
       headers: expect.objectContaining({
         'Content-Type': 'application/json',
-        'User-Agent': 'submit-expo-feedback/0.0.0',
+        'User-Agent': 'submit-expo-feedback/0.0.1',
         'expo-session': 'session-secret',
       }),
       body: JSON.stringify({

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -451,10 +451,19 @@ function printHelp(): void {
 
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
-    --subject, -s <subject>    Specific docs URL, skill, CLI command, MCP server, or other subject
-                               the feedback is about
+    --subject, -s <subject>    Exact item the feedback is about, based on the category
     --version, -v              Version number
     --help, -h                 Usage info
+
+  {bold Subject by category}
+    | Category   | Subject                                                           |
+    | ---------- | ----------------------------------------------------------------- |
+    | skills     | Exact skill name, such as expo-router                             |
+    | docs       | Full Expo documentation URL                                       |
+    | mcp        | Exact MCP tool name used                                          |
+    | expo-cli   | Full Expo CLI command, such as npx expo install                   |
+    | eas-cli    | Full EAS CLI command, such as eas build                           |
+    | unknown    | Concise Expo product, package, feature, or topic, or leave empty  |
 `);
 }
 


### PR DESCRIPTION
## Summary

- clarify what agents should pass to `--subject` / `-s` for each feedback category
- add CLI help-output regression coverage
- bump `submit-expo-feedback` from `0.0.0` to `0.0.1`

## Terminal output

ANSI styling omitted:

```text
  Usage
    $ npx submit-expo-feedback <message>

  Info
    Send feedback to the Expo team. If no message is provided, you will be prompted.

  Data collection
    Feedback includes available agent/session identifiers, environment details,
    Expo project metadata, and Expo account identifiers.

  Options
    --category, -c <category>  Feedback category (skills, expo-cli, eas-cli, mcp, docs, unknown)
    --subject, -s <subject>    Exact item the feedback is about, based on the category
    --version, -v              Version number
    --help, -h                 Usage info

  Subject by category
    | Category   | Subject                                                           |
    | ---------- | ----------------------------------------------------------------- |
    | skills     | Exact skill name, such as expo-router                             |
    | docs       | Full Expo documentation URL                                       |
    | mcp        | Exact MCP tool name used                                          |
    | expo-cli   | Full Expo CLI command, such as npx expo install                   |
    | eas-cli    | Full EAS CLI command, such as eas build                           |
    | unknown    | Concise Expo product, package, feature, or topic, or leave empty  |
```

## Test plan

- `git diff --check`
- `pnpm --filter submit-expo-feedback test -- --runInBand` *(not run: workspace dependencies are not installed, so `jest` is unavailable)*
