### PR TITLE
[video][ios] Fix source loading race conditions

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
-- [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle.
 - [iOS] Fix a race when registering video player observer delegates. ([#47976](https://github.com/expo/expo/pull/47976) by [@behenate](https://github.com/behenate))
 - [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle. ([#47828](https://github.com/expo/expo/pull/47828) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle.
 - [iOS] Fix a race when registering video player observer delegates. ([#47976](https://github.com/expo/expo/pull/47976) by [@behenate](https://github.com/behenate))
 - [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle. ([#47828](https://github.com/expo/expo/pull/47828) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle.
 - [iOS] Fix a race when registering video player observer delegates. ([#47976](https://github.com/expo/expo/pull/47976) by [@behenate](https://github.com/behenate))
 - [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle. ([#47828](https://github.com/expo/expo/pull/47828) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -336,7 +336,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
 
-    videoSourceLoader.cancelCurrentTask()
+    videoSourceLoader.close()
     tracksLoadingTask?.cancel()
 
     // We have to replace from the main thread because of KVOs (see comment in VideoSourceLoader).

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -29,6 +29,8 @@ class VideoPlayerItem: AVPlayerItem {
   }
 
   init?(videoSource: VideoSource, urlOverride: URL? = nil) async throws {
+    try Task.checkCancellation()
+
     guard let url = urlOverride ?? videoSource.uri else {
       return nil
     }
@@ -43,10 +45,13 @@ class VideoPlayerItem: AVPlayerItem {
       try await asset.prepareForLoadingIfNeeded()
       _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
     } catch {
-        // Catch block is intentionally left empty
+      // Asset errors are surfaced through the player status, but cancellation must stop obsolete work.
+      try Task.checkCancellation()
     }
 
+    try Task.checkCancellation()
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
+    try Task.checkCancellation()
     self.createTracksLoadingTask()
   }
 

--- a/packages/expo-video/ios/VideoSourceLoader.swift
+++ b/packages/expo-video/ios/VideoSourceLoader.swift
@@ -129,8 +129,24 @@ internal class VideoSourceLoader {
         return LoadingResult(value: nil, isCancelled: false)
       }
 
-      let safeUrl = try await url.toUrlWithPermissions()
+      // A resolution failure (only possible for `ph://` sources) shouldn't reject the load.
+      // Build the item with the raw, unplayable URL instead, so the player transitions to the
+      // `.error` status the same way it does for any other failing source, with `transportError`
+      // carrying the real resolution error to that status change.
+      var safeUrl: URL?
+      var resolutionError: Error?
+      do {
+        safeUrl = try await url.toUrlWithPermissions()
+      } catch let error as CancellationError {
+        throw error
+      } catch {
+        resolutionError = error
+      }
+
       let playerItem = try await VideoPlayerItem(videoSource: videoSource, urlOverride: safeUrl)
+      if let resolutionError {
+        playerItem?.urlAsset.transportError = resolutionError
+      }
 
       try Task.checkCancellation()
       return LoadingResult(value: playerItem, isCancelled: false)
@@ -205,7 +221,11 @@ internal class VideoSourceLoader {
       guard let self else {
         return
       }
-      for weakListener in listeners {
+      // Deliver only to listeners that were registered when the event was recorded (`listeners`)
+      // and still are now — a listener that unregistered in the meantime stops receiving events
+      // immediately, and one registered after the event doesn't get a transition it never observed.
+      let currentListeners = self.state.withLock { $0.listeners }
+      for weakListener in listeners.intersection(currentListeners) {
         guard let listener = weakListener.value else {
           continue
         }

--- a/packages/expo-video/ios/VideoSourceLoader.swift
+++ b/packages/expo-video/ios/VideoSourceLoader.swift
@@ -1,60 +1,120 @@
 import AVKit
+import ExpoModulesCore
+
+private struct State {
+  var isLoading = true
+  var currentSource: VideoSource?
+  var currentTask: Task<LoadingResult, Error>?
+  var currentTaskId = 0
+  var isClosed = false
+  var listeners = Set<WeakVideoSourceLoaderListener>()
+}
+
+private struct LoadContext {
+  let task: Task<LoadingResult, Error>
+  let taskId: Int
+}
+
+private struct PreviousLoad {
+  let task: Task<LoadingResult, Error>
+  let source: VideoSource?
+}
 
 internal class VideoSourceLoader {
-  private(set) var isLoading: Bool = true
-  private var currentSource: VideoSource?
-  private var currentTask: Task<LoadingResult, Error>?
+  private let state = Mutex(State())
 
-  private var listeners = Set<WeakVideoSourceLoaderListener>()
+  var isLoading: Bool {
+    return state.withLock { $0.isLoading }
+  }
 
   func registerListener(listener: VideoSourceLoaderListener) {
     let weakListener = WeakVideoSourceLoaderListener(value: listener)
-    listeners.insert(weakListener)
+    state.withLock { state in
+      // Purging dead listeners is required for correctness, not just hygiene: a wrapper keeps its
+      // `ObjectIdentifier` after its listener deallocates, and a new listener allocated at the same
+      // address would compare equal to the stale wrapper, making `insert` silently drop it.
+      state.listeners = state.listeners.filter { $0.value != nil }
+      state.listeners.insert(weakListener)
+    }
   }
 
   func unregisterListener(listener: VideoSourceLoaderListener) {
-    listeners.remove(WeakVideoSourceLoaderListener(value: listener))
+    state.withLock { state in
+      state.listeners.remove(WeakVideoSourceLoaderListener(value: listener))
+    }
   }
 
   /**
    Asynchronously loads a video item from the provided `videoSource`. If another loading operation is in progress, it will be cancelled.
 
    - Parameter videoSource: The source description for the video to load. If `nil`, the current player item will be cleared.
-   - Parameter player: The `VideoPlayer` instance whose current item will be replaced.
    */
   func load(videoSource: VideoSource) async throws -> VideoPlayerItem? {
-    isLoading = true
-    if let currentTask {
-      currentTask.cancel()
-      listeners.forEach { listener in
-        listener.value?.onLoadingCancelled(loader: self, videoSource: currentSource)
+    let loadContext: (LoadContext, PreviousLoad?)? = state.withLock { state in
+      guard !state.isClosed else {
+        return nil
       }
-    }
 
-    let newTask = Task {
-      return try await loadImpl(videoSource: videoSource)
-    }
-
-    self.currentTask = newTask
-    self.currentSource = videoSource
-    let loadingResult = try await newTask.value
-
-    if !loadingResult.isCancelled {
-      listeners.forEach { listener in
-        listener.value?.onLoadingFinished(loader: self, videoSource: videoSource, result: loadingResult.value)
+      let previousLoad: PreviousLoad?
+      if let currentTask = state.currentTask {
+        previousLoad = PreviousLoad(task: currentTask, source: state.currentSource)
+      } else {
+        previousLoad = nil
       }
+
+      state.currentTaskId += 1
+      let taskId = state.currentTaskId
+      let newTask = Task {
+        return try await self.loadImpl(videoSource: videoSource)
+      }
+
+      state.isLoading = true
+      state.currentTask = newTask
+      state.currentSource = videoSource
+
+      if let previousLoad {
+        enqueueListenerEventWhileLocked(listeners: state.listeners) { listener, loader in
+          listener.onLoadingCancelled(loader: loader, videoSource: previousLoad.source)
+        }
+      }
+      enqueueListenerEventWhileLocked(listeners: state.listeners) { listener, loader in
+        listener.onLoadingStarted(loader: loader, videoSource: videoSource)
+      }
+
+      return (LoadContext(task: newTask, taskId: taskId), previousLoad)
     }
 
-    isLoading = false
-    self.currentSource = nil
-    self.currentTask = nil
+    guard let (context, previousLoad) = loadContext else {
+      return nil
+    }
+
+    previousLoad?.task.cancel()
+
+    let loadingResult: LoadingResult
+    do {
+      loadingResult = try await context.task.value
+    } catch {
+      finishLoading(taskId: context.taskId, videoSource: videoSource)
+      throw error
+    }
+
+    guard finishLoading(
+      taskId: context.taskId,
+      videoSource: videoSource,
+      loadingResult: loadingResult
+    ) else {
+      return nil
+    }
+
     return loadingResult.value
   }
 
   func cancelCurrentTask() {
-    currentTask?.cancel()
-    currentTask = nil
-    isLoading = false
+    cancelCurrentTask(close: false)
+  }
+
+  func close() {
+    cancelCurrentTask(close: true)
   }
 
   deinit {
@@ -62,25 +122,96 @@ internal class VideoSourceLoader {
   }
 
   private func loadImpl(videoSource: VideoSource) async throws -> LoadingResult {
-    listeners.forEach { listener in
-      listener.value?.onLoadingStarted(loader: self, videoSource: videoSource)
-    }
+    do {
+      try Task.checkCancellation()
 
-    guard
-      let url = videoSource.uri
-    else {
-      return LoadingResult(value: nil, isCancelled: false)
-    }
+      guard let url = videoSource.uri else {
+        return LoadingResult(value: nil, isCancelled: false)
+      }
 
-    let safeUrl = try await url.toUrlWithPermissions()
-    let playerItem = try await VideoPlayerItem(videoSource: videoSource, urlOverride: safeUrl)
+      let safeUrl = try await url.toUrlWithPermissions()
+      let playerItem = try await VideoPlayerItem(videoSource: videoSource, urlOverride: safeUrl)
 
-    if Task.isCancelled {
-      print("The loading task has been cancelled")
+      try Task.checkCancellation()
+      return LoadingResult(value: playerItem, isCancelled: false)
+    } catch is CancellationError {
       return LoadingResult(value: nil, isCancelled: true)
     }
+  }
 
-    return LoadingResult(value: playerItem, isCancelled: false)
+  /**
+   Resets the loading state if `taskId` is still the current load.
+
+   - Returns: Whether the caller's load is still the current one and its result should be used.
+   */
+  @discardableResult
+  private func finishLoading(
+    taskId: Int,
+    videoSource: VideoSource? = nil,
+    loadingResult: LoadingResult? = nil
+  ) -> Bool {
+    return state.withLock { state in
+      guard state.currentTaskId == taskId else {
+        return false
+      }
+      state.isLoading = false
+      state.currentSource = nil
+      state.currentTask = nil
+
+      if let videoSource, let loadingResult, !loadingResult.isCancelled {
+        enqueueListenerEventWhileLocked(listeners: state.listeners) { listener, loader in
+          listener.onLoadingFinished(loader: loader, videoSource: videoSource, result: loadingResult.value)
+        }
+      } else {
+        enqueueListenerEventWhileLocked(listeners: state.listeners) { listener, loader in
+          listener.onLoadingCancelled(loader: loader, videoSource: videoSource)
+        }
+      }
+      return true
+    }
+  }
+
+  private func cancelCurrentTask(close: Bool) {
+    let currentTask = state.withLock { state in
+      state.currentTaskId += 1
+      state.isClosed = state.isClosed || close
+      state.isLoading = false
+      let currentSource = state.currentSource
+      state.currentSource = nil
+      let currentTask = state.currentTask
+      state.currentTask = nil
+
+      // Only notify when a load was actually in flight. Skipping the enqueue otherwise also keeps
+      // `deinit` (reachable only with no pending task, which retains `self`) from forming a weak
+      // reference to a deinitializing object in `enqueueListenerEventWhileLocked`.
+      if currentTask != nil {
+        enqueueListenerEventWhileLocked(listeners: state.listeners) { listener, loader in
+          listener.onLoadingCancelled(loader: loader, videoSource: currentSource)
+        }
+      }
+      return currentTask
+    }
+    currentTask?.cancel()
+  }
+
+  /**
+   Must be called while holding `state` so listener events are enqueued in state transition order.
+   */
+  private func enqueueListenerEventWhileLocked(
+    listeners: Set<WeakVideoSourceLoaderListener>,
+    event: @escaping (VideoSourceLoaderListener, VideoSourceLoader) -> Void
+  ) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        return
+      }
+      for weakListener in listeners {
+        guard let listener = weakListener.value else {
+          continue
+        }
+        event(listener, self)
+      }
+    }
   }
 }
 

--- a/packages/expo-video/ios/VideoSourceLoaderListener.swift
+++ b/packages/expo-video/ios/VideoSourceLoaderListener.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/**
+ Callbacks are delivered asynchronously on the main queue, in the order the loader's state
+ transitions happened. A terminal event (`onLoadingFinished`/`onLoadingCancelled`) may arrive
+ after the corresponding `load()` call has already returned, but always before a player item
+ replacement dispatched to the main queue afterwards.
+ */
 protocol VideoSourceLoaderListener: AnyObject {
   func onLoadingStarted(loader: VideoSourceLoader, videoSource: VideoSource?)
   func onLoadingFinished(loader: VideoSourceLoader, videoSource: VideoSource?, result: VideoPlayerItem?)

--- a/packages/expo-video/ios/VideoSourceLoaderListener.swift
+++ b/packages/expo-video/ios/VideoSourceLoaderListener.swift
@@ -14,21 +14,18 @@ extension VideoSourceLoaderListener {
 
 final class WeakVideoSourceLoaderListener: Hashable {
   private(set) weak var value: VideoSourceLoaderListener?
+  private let id: ObjectIdentifier
 
-  init(value: VideoSourceLoaderListener? = nil) {
+  init(value: VideoSourceLoaderListener) {
     self.value = value
+    self.id = ObjectIdentifier(value)
   }
 
   static func == (lhs: WeakVideoSourceLoaderListener, rhs: WeakVideoSourceLoaderListener) -> Bool {
-    guard let lhsValue = lhs.value, let rhsValue = rhs.value else {
-      return lhs.value == nil && rhs.value == nil
-    }
-    return ObjectIdentifier(lhsValue) == ObjectIdentifier(rhsValue)
+    return lhs.id == rhs.id
   }
 
   func hash(into hasher: inout Hasher) {
-    if let value {
-      hasher.combine(ObjectIdentifier(value))
-    }
+    hasher.combine(id)
   }
 }


### PR DESCRIPTION
# Why

Rapid source changes can leave multiple loading tasks in flight. A stale task can clear newer loader state or emit callbacks after the player has been released. This is very rare, but it's good to patch it up.

# How

Synchronize loader state with a Mutex and use task IDs to ignore stale completions. Close the loader when releasing the player, add cancellation checks around player item creation, and keep weak listener identities stable after deallocation.

# Test Plan

Tested in BareExpo on iOS
