### PR TITLE
[docs] Remove unused number props from Prerequisites/Requirement usage

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -13,14 +13,14 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 ## Prerequisites
 
-<Prerequisites numberOfRequirements={5}>
-  <Requirement number={1} title="Sign up for a Google Play Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for a Google Play Developer account">
     A Google Play Developer account is required to submit your app to the Google Play Store. Sign up on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
   </Requirement>
-  <Requirement number={2} title="Create an app on Google Play Console">
+  <Requirement title="Create an app on Google Play Console">
     Create an app by clicking **Create app** in the [Google Play Console](https://play.google.com/apps/publish/).
   </Requirement>
-  <Requirement number={3} title="Create a Google Service Account key and upload it to EAS">
+  <Requirement title="Create a Google Service Account key and upload it to EAS">
     EAS requires a Google Service Account key to submit on your behalf. Follow the [Creating a Google Service Account key](https://expo.fyi/creating-google-service-account) guide to create one. Then, upload the key to your project's credentials with the EAS dashboard or EAS CLI:
 
     <Tabs>
@@ -44,7 +44,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
     </Tabs>
 
   </Requirement>
-  <Requirement number={4} title="Include a package name in app config">
+  <Requirement title="Include a package name in app config">
     Include your app's package name in **app.json**:
 
     ```json app.json
@@ -56,7 +56,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
     ```
 
   </Requirement>
-  <Requirement number={5} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and log in with your Expo account:
 
     <Terminal

--- a/docs/pages/submit/ios-manual.mdx
+++ b/docs/pages/submit/ios-manual.mdx
@@ -14,21 +14,21 @@ If you already have a **.ipa** file, skip to [Upload an existing build with Tran
 
 ## Prerequisites
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Sign up for an Apple Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for an Apple Developer account">
     A paid Apple Developer membership is required to submit apps to the Apple App Store. Sign up on
     the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="Install Xcode">
+  <Requirement title="Install Xcode">
     Xcode must be installed on a Mac. See [Set up
     Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman)
     for instructions.
   </Requirement>
-  <Requirement number={3} title="Generate the ios directory">
+  <Requirement title="Generate the ios directory">
     Your project needs an **ios** directory. If you use
     [CNG](/workflow/continuous-native-generation/), run `npx expo prebuild` to generate it.
   </Requirement>
-  <Requirement number={4} title="Create an app record in App Store Connect">
+  <Requirement title="Create an app record in App Store Connect">
     An app record in [App Store Connect](https://appstoreconnect.apple.com/) with a matching bundle
     identifier is required. If you haven't created one, sign in to App Store Connect, click the blue
     **+** next to **Apps**, and choose **New App**.

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -17,11 +17,11 @@ import { CODE } from '~/ui/components/Text';
 
 ## Prerequisites
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Sign up for an Apple Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for an Apple Developer account">
     A paid Apple Developer account is required to submit apps to the Apple App Store. Sign up on the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="Include a bundle identifier in app config">
+  <Requirement title="Include a bundle identifier in app config">
     Include your app's bundle identifier in **app.json**:
 
     ```json app.json
@@ -33,7 +33,7 @@ import { CODE } from '~/ui/components/Text';
     ```
 
   </Requirement>
-  <Requirement number={3} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and log in with your Expo account:
 
     <Terminal


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/47681

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove unused number props from Prerequisites/Requirement usage from multiple EAS Submit guides. We automatically calculate and display a number of requirements per component usage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Preview of the visual changes unaffect:

<img width="2386" height="666" alt="CleanShot 2026-07-20 at 17 26 58@2x" src="https://github.com/user-attachments/assets/de24e48a-8690-404a-87bb-effddb86b59f" />

<img width="2154" height="1694" alt="CleanShot 2026-07-20 at 17 27 03@2x" src="https://github.com/user-attachments/assets/56863c23-bd07-4a2f-a936-7c5367bf568c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
