### PR TITLE
feat(metro-config,cli): Add missing resolver, bundling, and asset events

### DIFF
--- a/packages/@expo/cli/src/start/interface/KeyPressHandler.ts
+++ b/packages/@expo/cli/src/start/interface/KeyPressHandler.ts
@@ -1,6 +1,5 @@
 import * as Log from '../../log';
 import { logCmdError } from '../../utils/errors';
-import { event } from './events';
 
 const CTRL_C = '\u0003';
 
@@ -38,7 +37,6 @@ export class KeyPressHandler {
     }
     this.isHandlingKeyPress = true;
     try {
-      event('key_pressed', { key });
       await this.onPress(key);
     } catch (error: any) {
       await logCmdError(error);

--- a/packages/@expo/cli/src/start/interface/events.ts
+++ b/packages/@expo/cli/src/start/interface/events.ts
@@ -3,10 +3,19 @@ import type { SerializedError } from '2g';
 
 declare module '2g' {
   interface EventRegistry {
-    'interface:key_pressed': { key: string };
-    'interface:banners_failed': { error: SerializedError };
-    'interface:action_failed': { error: SerializedError };
+    'cli-interface:toggle-dev-menu': Record<string, never>;
+    'cli-interface:open-more-tools': Record<string, never>;
+    'cli-interface:open-platform': { platform: string; target: string };
+    'cli-interface:toggle-runtime-mode': Record<string, never>;
+    'cli-interface:clear-terminal': Record<string, never>;
+    'cli-interface:open-debugger': Record<string, never>;
+    'cli-interface:reload': Record<string, never>;
+    'cli-interface:open-editor': Record<string, never>;
+    'cli-interface:run-menu-action': { action: string };
+    'cli-interface:send-dev-command': { commandName: string };
+    'cli-interface:banners-failed': { error: SerializedError };
+    'cli-interface:action-failed': { error: SerializedError };
   }
 }
 
-export const event = events.debug('interface');
+export const event = events.debug('cli-interface');

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -55,7 +55,7 @@ export async function printDevToolsPluginCliBannersAsync(
 
     return bannerItems.length;
   } catch (error: any) {
-    event('banners_failed', { error: event.error(error as Error) });
+    event('banners-failed', { error: event.error(error as Error) });
     return 0;
   }
 }
@@ -220,12 +220,14 @@ export class DevServerManagerActions {
       const value = await selectAsync(chalk`Dev tools {dim (native only)}`, menuItems);
       const menuItem = menuItems.find((item) => item.value === value);
       if (menuItem?.action) {
+        event('run-menu-action', { action: menuItem.value });
         menuItem.action();
       } else if (menuItem?.value) {
+        event('send-dev-command', { commandName: menuItem.value });
         this.devServerManager.broadcastMessage('sendDevCommand', { name: menuItem.value });
       }
     } catch (error: any) {
-      event('action_failed', { error: event.error(error as Error) });
+      event('action-failed', { error: event.error(error as Error) });
       // do nothing
     } finally {
       printHelp();

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -11,6 +11,7 @@ import type { DevServerManager } from '../server/DevServerManager';
 import { KeyPressHandler } from './KeyPressHandler';
 import type { StartOptions } from './commandsTable';
 import { BLT, printHelp, printUsage } from './commandsTable';
+import { event } from './events';
 import { DevServerManagerActions } from './interactiveActions';
 
 const CTRL_C = '\u0003';
@@ -101,8 +102,10 @@ export async function startInterfaceAsync(
     if (isWebSocketsEnabled) {
       switch (key) {
         case 'm':
+          event('toggle-dev-menu', {});
           return actions.toggleDevMenu();
         case 'M':
+          event('open-more-tools', {});
           return actions.openMoreToolsAsync();
       }
     }
@@ -113,6 +116,10 @@ export async function startInterfaceAsync(
       const platform = key.toLowerCase() === 'i' ? 'ios' : 'android';
 
       const shouldPrompt = ['I', 'A'].includes(key);
+      event('open-platform', {
+        platform,
+        target: shouldPrompt ? 'prompt' : PLATFORM_SETTINGS[platform]!.launchTarget,
+      });
       if (shouldPrompt) {
         Log.clear();
       }
@@ -142,6 +149,7 @@ export async function startInterfaceAsync(
 
     switch (key) {
       case 's': {
+        event('toggle-runtime-mode', {});
         Log.clear();
         if (await devServerManager.toggleRuntimeMode()) {
           usageOptions.devClient = devServerManager.options.devClient;
@@ -151,6 +159,7 @@ export async function startInterfaceAsync(
         break;
       }
       case 'w': {
+        event('open-platform', { platform: 'web', target: 'desktop' });
         try {
           await devServerManager.ensureProjectPrerequisiteAsync(WebSupportProjectPrerequisite);
           if (!platforms.includes('web')) {
@@ -187,14 +196,18 @@ export async function startInterfaceAsync(
         break;
       }
       case 'c':
+        event('clear-terminal', {});
         Log.clear();
         await actions.printDevServerInfoAsync(usageOptions);
         return;
       case 'j':
+        event('open-debugger', {});
         return actions.openJsInspectorAsync();
       case 'r':
+        event('reload', {});
         return actions.reloadApp();
       case 'o':
+        event('open-editor', {});
         Log.log(`${BLT} Opening the editor...`);
         return openInEditorAsync(devServerManager.projectRoot);
     }

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -37,6 +37,7 @@ const event = events('devserver');
 
 export type MessageSocket = {
   broadcast: (method: string, params?: Record<string, any> | undefined) => void;
+  getClientCount?: () => number;
 };
 
 export type ServerLike = {
@@ -349,7 +350,14 @@ export abstract class BundlerDevServer {
     method: 'reload' | 'devMenu' | 'sendDevCommand',
     params?: Record<string, any>
   ) {
-    this.getInstance()?.messageSocket.broadcast(method, params);
+    const instance = this.getInstance();
+    debugEvent('send_command', {
+      method,
+      commandName: getCommandName(params),
+      bundler: this.name,
+      receiverCount: instance?.messageSocket.getClientCount?.() ?? null,
+    });
+    instance?.messageSocket.broadcast(method, params);
   }
 
   /** Get the running dev server instance. */
@@ -589,4 +597,8 @@ export abstract class BundlerDevServer {
     }
     return this.platformManagers[platform] as PlatformManagers[Platform];
   }
+}
+
+function getCommandName(params?: Record<string, any>): string | undefined {
+  return typeof params?.name === 'string' ? params.name : undefined;
 }

--- a/packages/@expo/cli/src/start/server/events.ts
+++ b/packages/@expo/cli/src/start/server/events.ts
@@ -12,6 +12,12 @@ declare module '2g' {
     'devserver:dev_client_url_invalid_protocol': { protocol: string };
     'devserver:dev_client_url': { url: string; manifestUrl: string };
     'devserver:devices_saved': { ids: string[] };
+    'devserver:send_command': {
+      method: string;
+      commandName?: string;
+      bundler: string;
+      receiverCount: number | null;
+    };
   }
 }
 

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -38,6 +38,15 @@ type ClientLogLevel =
 
 declare module '2g' {
   interface EventRegistry {
+    'metro:bundling:start': {
+      id: string | null;
+      platform: string | null;
+      environment: string | null;
+      entry: string;
+      bundleType: string;
+      dev: boolean;
+      minify: boolean;
+    };
     'metro:bundling:done': {
       id: string | null;
       platform?: null | string;
@@ -450,6 +459,15 @@ export class MetroTerminalReporter extends TerminalReporter {
             environment: evt.bundleDetails.customTransformOptions?.environment ?? null,
             entry,
           },
+        });
+        event('bundling:start', {
+          id: evt.buildID ?? null,
+          platform: evt.bundleDetails.platform ?? null,
+          environment: evt.bundleDetails.customTransformOptions?.environment ?? null,
+          entry,
+          bundleType: evt.bundleDetails.bundleType,
+          dev: evt.bundleDetails.dev,
+          minify: evt.bundleDetails.minify,
         });
         return;
       }

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -1,11 +1,24 @@
+import { events, SerializedError } from '2g';
 import { parse } from 'node:url';
 import { type WebSocket, WebSocketServer, type RawData as WebSocketRawData } from 'ws';
 
 import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
-import { event } from '../hmrEvents';
 import { createBroadcaster } from './utils/createSocketBroadcaster';
 import { createSocketMap, type SocketId } from './utils/createSocketMap';
 import { parseRawMessage, serializeMessage } from './utils/socketMessages';
+
+declare module '2g' {
+  interface EventRegistry {
+    'command_socket:connected': {
+      clientId: string;
+      host?: string;
+    };
+    'command_socket:disconnected': {
+      clientId: string;
+      error?: SerializedError;
+    };
+  }
+}
 
 type MessageSocketOptions = {
   logger: {
@@ -15,6 +28,8 @@ type MessageSocketOptions = {
 };
 
 const CLIENT_BROADCAST_ALLOWED_METHODS = new Set(['reload', 'devMenu']);
+
+const event = events.debug('command_socket');
 
 /**
  * Client "command" server that dispatches basic commands to connected clients.
@@ -39,9 +54,22 @@ export function createMessagesSocket(options: MessageSocketOptions) {
       });
     }
 
+    event('connected', {
+      clientId: client.id,
+      host: req.headers.host,
+    });
+
     // Register disconnect handlers
-    socket.on('close', client.terminate);
-    socket.on('error', client.terminate);
+    socket.on('close', () => {
+      client.terminate();
+      event('disconnected', { clientId: client.id });
+    });
+
+    socket.on('error', (error) => {
+      client.terminate();
+      event('disconnected', { clientId: client.id, error: event.error(error as Error) });
+    });
+
     // Register message handler
     socket.on(
       'message',
@@ -61,6 +89,7 @@ export function createMessagesSocket(options: MessageSocketOptions) {
 
       broadcast(null, serializeMessage({ method, params }));
     },
+    getClientCount: () => clients.map.size,
   };
 }
 
@@ -97,7 +126,6 @@ function createClientMessageHandler(
     // Handle broadcast messages
     if (messageIsBroadcast(message)) {
       if (!isTrustedClient || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) {
-        event('untrusted_broadcast_refused', { method: message.method });
         return;
       }
       return broadcast(null, data.toString());

--- a/packages/@expo/cli/src/start/server/metro/hmrEvents.ts
+++ b/packages/@expo/cli/src/start/server/metro/hmrEvents.ts
@@ -5,7 +5,6 @@ declare module '2g' {
   interface EventRegistry {
     'hmr:broadcast_failed': { socketId: string; error: SerializedError };
     'hmr:socket_not_found': { id: string };
-    'hmr:untrusted_broadcast_refused': { method: string };
     'hmr:message_parse_failed': { error: SerializedError };
     'hmr:protocol_version_mismatch': { expected: number; received: unknown };
     'hmr:events_unknown_message': { type: string };

--- a/packages/@expo/cli/src/start/server/metro/resolveEvents.ts
+++ b/packages/@expo/cli/src/start/server/metro/resolveEvents.ts
@@ -12,10 +12,16 @@ declare module '2g' {
     'resolve:tsconfig_baseurl': { module: string; resolved: string };
     'resolve:tsconfig_parse_failed': { path: string; error: string };
     'resolve:resolvers_appended': { count: number; hasCustom: boolean };
-    'resolve:module': { module: string; platform: string | null; type: string };
+    'resolve:module': {
+      module: string;
+      originModulePath: string;
+      platform: string | null;
+      type: string;
+    };
     'resolve:resolver_threw': {
       name: string;
       module: string;
+      originModulePath: string;
       platform: string | null;
       env: string;
       origin: string;

--- a/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
@@ -98,7 +98,12 @@ export function withMetroResolvers(
         const done = event.span();
         const resolution = firstResolver(universalContext, moduleName, platform);
         if (resolution) {
-          done('module', { module: moduleName, platform, type: resolution.type });
+          done('module', {
+            module: moduleName,
+            originModulePath: context.originModulePath,
+            platform,
+            type: resolution.type,
+          });
         }
         return resolution;
       },

--- a/packages/@expo/metro-config/src/transform-worker/events.ts
+++ b/packages/@expo/metro-config/src/transform-worker/events.ts
@@ -18,6 +18,9 @@ declare module '2g' {
 
     // per-file sub-phase spans (nested under transform:file)
     'transform:babel': { file: string };
+    'transform:asset_data': { file: string; platform: string | null; files: string[] };
+    'transform:asset_hashes': { file: string; files: string[] };
+    'transform:asset_hash_file': { file: string };
     'transform:import_support': { file: string };
     'transform:constant_folding': { file: string };
     'transform:collect_dependencies': { file: string; count: number };

--- a/packages/@expo/metro-config/src/transform-worker/getAssets.ts
+++ b/packages/@expo/metro-config/src/transform-worker/getAssets.ts
@@ -13,6 +13,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { debugEvent } from './events';
+
 type ExpoAssetData = AssetData & {
   fileHashes?: string[];
 };
@@ -33,15 +35,22 @@ function getMD5ForData(data: string[]) {
   return hash.digest('hex');
 }
 
-function getMD5ForFilePathAsync(path: string) {
-  return new Promise<string>((resolve, reject) => {
+function debugEventPaths(files: readonly string[]) {
+  return { toJSON: () => files.map((file) => debugEvent.path(file).toJSON()) };
+}
+
+async function getMD5ForFilePathAsync(filePath: string) {
+  const done = debugEvent.span();
+  const hash = await new Promise<string>((resolve, reject) => {
     const output = crypto.createHash('md5');
-    const input = fs.createReadStream(path);
+    const input = fs.createReadStream(filePath);
     input.on('error', (err) => reject(err));
     output.on('error', (err) => reject(err));
     output.once('readable', () => resolve(output.read().toString('hex')));
     input.pipe(output);
   });
+  done('asset_hash_file', { file: debugEvent.path(filePath) });
+  return hash;
 }
 
 function isHashedAssetData(asset: ExpoAssetData): asset is HashedAssetData {
@@ -97,6 +106,7 @@ export async function getUniversalAssetData(
   publicPath: string,
   isHosted: boolean = false
 ): Promise<HashedAssetData> {
+  const assetDataDone = debugEvent.span();
   const metroAssetData = await getAssetData(
     assetPath,
     localPath,
@@ -104,7 +114,18 @@ export async function getUniversalAssetData(
     platform,
     publicPath
   );
+  assetDataDone('asset_data', {
+    file: debugEvent.path(assetPath),
+    platform: platform ?? null,
+    files: debugEventPaths(metroAssetData.files),
+  });
+
+  const assetHashesDone = debugEvent.span();
   const data = await ensureOtaAssetHashesAsync(metroAssetData);
+  assetHashesDone('asset_hashes', {
+    file: debugEvent.path(assetPath),
+    files: debugEventPaths(data.files),
+  });
 
   // NOTE(EvanBacon): This is where we modify the asset to include a hash in the name for web cache invalidation.
   if ((isHosted || platform === 'web') && publicPath.includes('?export_path=')) {


### PR DESCRIPTION
# Why

Benchmarking/profiling a bundling request, there's a few events and details we're missing here that are almost crucial to get good data out of the existing spans and events.

# How

- We didn't have an event for the asset pipeline, but the timings here can be significant since they're IO-bound
- We didn't add `originModulePath` to the resolver events, which makes them hard to interpret and put into context
- We didn't have a bundling start event, which made it hard/impossible to correlate a build to its events
- We didn't actually capture CLI interactive actions in events (just key presses, which isn't as helpful)
- We didn't capture connections and disconnections on the command socket (`/message`)

# Test Plan

- Manually verified by running

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
