### PR TITLE
[video][ios] Reduce main thread load when loading videos

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 💡 Others
 
+- [iOS] Reduce main thread load when loading videos.
 - [Android] Removed outdated ExoPlayer changelog references and aligned Android media dependencies with AndroidX Media3 (`1.9.1`). ([#45368](https://github.com/expo/expo/pull/45368) by [@saisreelasyaappali](https://github.com/saisreelasyaappali))
 - Replace `TimeoutID` typing on `_timeUpdateLoop` ([#46730](https://github.com/expo/expo/pull/46730) by [@kitten](https://github.com/kitten))
 - When `source` of `useVideoPlayer` changes use `replaceAsync` instead of re-creating the player. ([#46495](https://github.com/expo/expo/pull/46495) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 💡 Others
 
-- [iOS] Reduce main thread load when loading videos.
+- [iOS] Reduce main thread load when loading videos. ([#47975](https://github.com/expo/expo/pull/47975) by [@behenate](https://github.com/behenate))
 - [Android] Removed outdated ExoPlayer changelog references and aligned Android media dependencies with AndroidX Media3 (`1.9.1`). ([#45368](https://github.com/expo/expo/pull/45368) by [@saisreelasyaappali](https://github.com/saisreelasyaappali))
 - Replace `TimeoutID` typing on `_timeUpdateLoop` ([#46730](https://github.com/expo/expo/pull/46730) by [@kitten](https://github.com/kitten))
 - When `source` of `useVideoPlayer` changes use `replaceAsync` instead of re-creating the player. ([#46495](https://github.com/expo/expo/pull/46495) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
+++ b/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
@@ -51,7 +51,10 @@ internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserv
     #endif
 
     guard hasStalePlayerReference, !isPresenting else {
-      controller.player = player?.ref
+      // Skip redundant assignments to avoid re-creating KVOs
+      if controller.player !== player?.ref {
+        controller.player = player?.ref
+      }
       return false
     }
 

--- a/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
+++ b/packages/expo-video/ios/OrientationAVPlayerViewControllerWrapper.swift
@@ -51,7 +51,7 @@ internal final class OrientationAVPlayerViewControllerWrapper: VideoPlayerObserv
     #endif
 
     guard hasStalePlayerReference, !isPresenting else {
-      // Skip redundant assignments to avoid re-creating KVOs
+      // Reassigning the same `AVPlayer` tears down and recreates the controller's KVO observers for no benefit.
       if controller.player !== player?.ref {
         controller.player = player?.ref
       }

--- a/packages/expo-video/ios/VideoLoadingActor.swift
+++ b/packages/expo-video/ios/VideoLoadingActor.swift
@@ -6,8 +6,9 @@ import Foundation
  Global actor for video source and track loading.
 
  Creating `AVURLAsset`/`AVPlayerItem` and parsing tracks costs 10-20ms+ and must never run on
- the main thread. Tasks on the default (global) executor are not enough to guarantee that:
- the runtime is free to run even a detached task's job on the main thread.
+ the main thread. Plain `Task {}` doesn't guarantee that: an unstructured task inherits the
+ enclosing actor, so one created from a `@MainActor` context runs on the main thread. Similarly,
+ under `NonisolatedNonsendingByDefault` nonisolated async functions run on the caller's actor, which can also be the main one.
  The loading pipeline should always run on this actor.
  */
 @globalActor

--- a/packages/expo-video/ios/VideoLoadingActor.swift
+++ b/packages/expo-video/ios/VideoLoadingActor.swift
@@ -1,0 +1,45 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/**
+ Global actor for video source and track loading.
+
+ Creating `AVURLAsset`/`AVPlayerItem` and parsing tracks costs 10-20ms+ and must never run on
+ the main thread. Tasks on the default (global) executor are not enough to guarantee that:
+ the runtime is free to run even a detached task's job on the main thread.
+ The loading pipeline should always run on this actor.
+ */
+@globalActor
+internal actor VideoLoadingActor {
+  static let shared = VideoLoadingActor()
+
+  private nonisolated let executor = DispatchQueueSerialExecutor(
+    queue: DispatchQueue(label: "expo.video.loading", qos: .userInitiated)
+  )
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    executor.asUnownedSerialExecutor()
+  }
+}
+
+/**
+ Executor, which never executes on the main thread
+ */
+internal final class DispatchQueueSerialExecutor: SerialExecutor {
+  private let queue: DispatchQueue
+
+  init(queue: DispatchQueue) {
+    self.queue = queue
+  }
+
+  func enqueue(_ job: UnownedJob) {
+    queue.async {
+      job.runSynchronously(on: self.asUnownedSerialExecutor())
+    }
+  }
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -42,7 +42,7 @@ class VideoPlayerItem: AVPlayerItem {
     // and cause it to go into .error state triggering the `onStatusChange` event.
     do {
       try await asset.prepareForLoadingIfNeeded()
-      _ = try await asset.load(
+      let (_, _, _, _, _, characteristics) = try await asset.load(
         .duration,
         .preferredTransform,
         .isPlayable,
@@ -50,7 +50,7 @@ class VideoPlayerItem: AVPlayerItem {
         .tracks,
         .availableMediaCharacteristicsWithMediaSelectionOptions
       )
-      for characteristic in try await asset.load(.availableMediaCharacteristicsWithMediaSelectionOptions) {
+      for characteristic in characteristics {
         _ = try await asset.loadMediaSelectionGroup(for: characteristic)
       }
     } catch {

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -28,6 +28,7 @@ class VideoPlayerItem: AVPlayerItem {
     self.createTracksLoadingTask()
   }
 
+  @VideoLoadingActor
   init?(videoSource: VideoSource, urlOverride: URL? = nil) async throws {
     guard let url = urlOverride ?? videoSource.uri else {
       return nil
@@ -41,7 +42,17 @@ class VideoPlayerItem: AVPlayerItem {
     // and cause it to go into .error state triggering the `onStatusChange` event.
     do {
       try await asset.prepareForLoadingIfNeeded()
-      _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
+      _ = try await asset.load(
+        .duration,
+        .preferredTransform,
+        .isPlayable,
+        .hasProtectedContent,
+        .tracks,
+        .availableMediaCharacteristicsWithMediaSelectionOptions
+      )
+      for characteristic in try await asset.load(.availableMediaCharacteristicsWithMediaSelectionOptions) {
+        _ = try await asset.loadMediaSelectionGroup(for: characteristic)
+      }
     } catch {
         // Catch block is intentionally left empty
     }
@@ -55,7 +66,7 @@ class VideoPlayerItem: AVPlayerItem {
   }
 
   func createTracksLoadingTask() {
-    tracksLoadingTask = Task { [weak self] in
+    tracksLoadingTask = Task { @VideoLoadingActor [weak self] in
       guard let self else {
         return []
       }
@@ -79,6 +90,7 @@ class VideoPlayerItem: AVPlayerItem {
 
   // MARK: - HLS Helpers
 
+  @VideoLoadingActor
   private func loadHlsTracks(mainUrl: URL) async -> [VideoTrack] {
     let tracks: [VideoTrack]
 
@@ -101,6 +113,7 @@ class VideoPlayerItem: AVPlayerItem {
   }
 
   @available(iOS 26.0, tvOS 26, *)
+  @VideoLoadingActor
   private func loadModernHlsTracks(mainUrl: URL) async -> [VideoTrack] {
     guard let variants = try? await urlAsset.load(.variants) else {
       return []
@@ -112,6 +125,7 @@ class VideoPlayerItem: AVPlayerItem {
     }
   }
 
+  @VideoLoadingActor
   private func loadLegacyHlsTracks() async -> [VideoTrack] {
     do {
       return try await self.fetchHlsVideoTracks()
@@ -123,6 +137,7 @@ class VideoPlayerItem: AVPlayerItem {
 
   // AVKit API doesn't provide us with a list of available tracks for a HLS source. We can download the playlist file and parse it ourselves
   // it's usually very small (1-2 kB), so we won't add too much overhead
+  @VideoLoadingActor
   private func fetchHlsVideoTracks() async throws -> [VideoTrack] {
     let uri = urlAsset.effectivePlaybackURL
     var request = URLRequest(url: uri)

--- a/packages/expo-video/ios/VideoSourceLoader.swift
+++ b/packages/expo-video/ios/VideoSourceLoader.swift
@@ -61,6 +61,7 @@ internal class VideoSourceLoader {
     cancelCurrentTask()
   }
 
+  @VideoLoadingActor
   private func loadImpl(videoSource: VideoSource) async throws -> LoadingResult {
     listeners.forEach { listener in
       listener.value?.onLoadingStarted(loader: self, videoSource: videoSource)


### PR DESCRIPTION
# Why

This PR aims to clean up the source loading flow while slightly reducing the load on the main thread when loading videos.

# How

- Introduce `VideoLoadingActor.swift` - used to load the sources off the main thread in a more organised way
- Preload more asset properties so that the AVPlayer doesn't try to load them later on the main thread as it tries to play
- And avoid reassigning the same player to AVPlayerViewController, which recreates its KVOs
- The `replaceCurrentItem(with:)` still has to run on the main thread.

- The main thread is now slightly less strained when replacing the player item. The difference is not big as we were already loading most possible things on a different thread, but in some cases noticeable.

# Test Plan

Tested in BareExpo on iOS