### PR TITLE
[video][ios] Fix observer delegate race

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a race when registering video player observer delegates. ([#47976](https://github.com/expo/expo/pull/47976) by [@behenate](https://github.com/behenate))
 - [iOS] Update the way the VideoPlayer releases to comply with the modified SharedObject lifecycle. ([#47828](https://github.com/expo/expo/pull/47828) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - [iOS] Re-enable the shared remote command center commands so lock screen controls keep working after expo-audio playback. ([#46753](https://github.com/expo/expo/pull/46753) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -82,25 +82,22 @@ extension VideoPlayerObserverDelegate {
   func onPlayerDeinit(player: VideoPlayer) {}
 }
 
-// Wrapper used to store WeakReferences to the observer delegate
+// Wrapper used to store WeakReferences to the observer delegate.
 final class WeakPlayerObserverDelegate: Hashable {
   private(set) weak var value: VideoPlayerObserverDelegate?
+  private let id: ObjectIdentifier
 
-  init(value: VideoPlayerObserverDelegate? = nil) {
+  init(value: VideoPlayerObserverDelegate) {
     self.value = value
+    self.id = ObjectIdentifier(value)
   }
 
   static func == (lhs: WeakPlayerObserverDelegate, rhs: WeakPlayerObserverDelegate) -> Bool {
-    guard let lhsValue = lhs.value, let rhsValue = rhs.value else {
-      return lhs.value == nil && rhs.value == nil
-    }
-    return ObjectIdentifier(lhsValue) == ObjectIdentifier(rhsValue)
+    return lhs.id == rhs.id
   }
 
   func hash(into hasher: inout Hasher) {
-    if let value {
-      hasher.combine(ObjectIdentifier(value))
-    }
+    hasher.combine(id)
   }
 }
 
@@ -112,7 +109,10 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
   var player: AVPlayer? {
     owner?.ref
   }
-  var delegates = Set<WeakPlayerObserverDelegate>()
+  private let delegatesStore = Mutex(Set<WeakPlayerObserverDelegate>())
+  var delegates: Set<WeakPlayerObserverDelegate> {
+    delegatesStore.withLock { $0 }
+  }
   private var currentItem: VideoPlayerItem?
   private var isLoadingAsynchronously = false
   private var loadedCurrentItem = false
@@ -205,11 +205,16 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
   func registerDelegate(delegate: VideoPlayerObserverDelegate) {
     let weakDelegate = WeakPlayerObserverDelegate(value: delegate)
-    delegates.insert(weakDelegate)
+    delegatesStore.withLock { delegates in
+      delegates = delegates.filter { $0.value != nil }
+      delegates.insert(weakDelegate)
+    }
   }
 
   func unregisterDelegate(delegate: VideoPlayerObserverDelegate) {
-    delegates.remove(WeakPlayerObserverDelegate(value: delegate))
+    delegatesStore.withLock { delegates in
+      delegates.remove(WeakPlayerObserverDelegate(value: delegate))
+    }
   }
 
   func notifyPlayerDeinit(player: VideoPlayer) {
@@ -220,7 +225,7 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
   func cleanup() {
     self.videoSourceLoader?.unregisterListener(listener: self)
-    delegates.removeAll()
+    delegatesStore.withLock { $0.removeAll() }
     invalidatePlayerObservers()
     invalidateCurrentPlayerItemObservers()
     stopTimeUpdates()


### PR DESCRIPTION
# Why

WeakPlayerObserverDelegate changes its hash after the weak delegate is deallocated. This corrupts the delegate Set and can crash with “Duplicate elements” when another delegate is registered.

# How

Capture the delegate’s ObjectIdentifier during initialization and use it as the stable hash identity. Protect the delegate set with a Mutex and remove deallocated wrappers before inserting a new delegate.

# Test Plan

Tested in BareExpo on IOS
