### PR TITLE
[docs] Stub IntersectionObserver to silence `next/link act()` warnings

### DIFF
--- a/docs/jest.config.js
+++ b/docs/jest.config.js
@@ -5,7 +5,11 @@ const jestConfig = {
   displayName: 'docs',
   testEnvironment: 'jsdom',
   testMatch: ['**/*.test.(js|ts|tsx)'],
-  setupFilesAfterEnv: ['@testing-library/jest-dom/jest-globals', '<rootDir>/jest.axe-setup.ts'],
+  setupFilesAfterEnv: [
+    '@testing-library/jest-dom/jest-globals',
+    '<rootDir>/jest.axe-setup.ts',
+    '<rootDir>/jest.jsdom-setup.ts',
+  ],
   clearMocks: true,
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',

--- a/docs/jest.jsdom-setup.ts
+++ b/docs/jest.jsdom-setup.ts
@@ -1,0 +1,23 @@
+// jsdom implements neither IntersectionObserver nor requestIdleCallback, so next/link
+// marks every link "visible" through a setTimeout-based polyfill. In async tests those
+// timers fire outside act() and log an act() warning per rendered link. With this stub
+// in place, next/link registers an observer whose callback never fires instead.
+class IntersectionObserverStub {
+  readonly root = null;
+  readonly rootMargin = '0px';
+  readonly thresholds: readonly number[] = [];
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserverStub,
+});
+
+export {};


### PR DESCRIPTION
# Why

After #47775 added async `jest-axe` tests, every `next/link` rendered in them logs an `act(...)` console warning, because jsdom lacks `IntersectionObserver` so Next marks links visible through a `setTimeout`-based polyfill that fires outside `act()`.

# How

- Add `jest.jsdom-setup.ts` with a no-op `IntersectionObserver` stub so `next/link` registers an observer that never fires instead of scheduling timers.
- Register the stub in `setupFilesAfterEnv` in `jest.config.js`.

# Test Plan

Run `pnpm test` and confirm no `act(...)` warnings are printed (previously 3 in the `TableOfContents` suite and 6 in `Footer`). All 44 suites, 495 tests, and 32 snapshots pass unchanged.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).