### PR TITLE
[cli] Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fall back to AGP's `output-metadata.json` when resolving APK filenames to support projects that override `outputFileName` in `applicationVariants` ([#47083](https://github.com/expo/expo/pull/47083) by [@NikhilVashistha](https://github.com/NikhilVashistha))
 - Surface the real `xcodebuild` error on `run:ios` failure instead of printing "0 error(s)" when the build formatter parsed none. ([#47748](https://github.com/expo/expo/pull/47748) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
+- Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -225,7 +225,11 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       // https://github.com/expo/expo/blob/0dffdb15/packages/%40expo/metro-config/src/serializer/serializeChunks.ts#L422-L439
       // Alternatively, check whether `sourcesRoot` helps here
       const artifactBasename = encodeURIComponent(path.basename(artifactFilename) + '.map');
-      src = src.replace(/\/\/# sourceMappingURL=.*/g, `//# sourceMappingURL=${artifactBasename}`);
+      // Match only the trailing sourcemap directive
+      src = src.replace(
+        /(?<=^|\n)\/\/# sourceMappingURL=[^\n]*(?=\s*$)/,
+        `//# sourceMappingURL=${artifactBasename}`
+      );
       const parsedMap = typeof contents.map === 'string' ? JSON.parse(contents.map) : contents.map;
       const mapData: any = {
         ...descriptor,

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -3,6 +3,7 @@ import type { ChangeEvent } from '@expo/metro/metro-file-map/flow-types';
 import { ImmutableRequest } from 'expo-server/private';
 import { vol } from 'memfs';
 
+import type { ExportAssetMap } from '../../../../export/saveAssets';
 import type { BundlerStartOptions } from '../../BundlerDevServer';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
@@ -415,5 +416,40 @@ describe('getStaticPageAsync', () => {
     await expect(devServer['getStaticPageAsync']('/posts/123', htmlRoute)).rejects.toThrow(
       'development streaming SSR requires a request'
     );
+  });
+});
+
+describe('exportServerRouteAsync', () => {
+  it('rewrites only the trailing source map directive', async () => {
+    // https://github.com/expo/expo/issues/47960
+    const devServer = new MetroBundlerDevServer(
+      '/',
+      getPlatformBundlers('/', { web: { bundler: 'metro' } })
+    );
+    const files: ExportAssetMap = new Map();
+
+    const src = [
+      `const n='This is string data, not a comment.\\n//# sourceMappingURL=embedded.js.map\\nEnd of data.';`,
+      '//# sourceMappingURL=index.map',
+    ].join('\n');
+
+    await devServer['exportServerRouteAsync']({
+      contents: {
+        src,
+        map: JSON.stringify({ version: 3, sources: [], names: [], mappings: '' }),
+      },
+      artifactFilename: '_expo/server/render.js',
+      files,
+      includeSourceMaps: true,
+      descriptor: {},
+    });
+
+    expect(files.get('_expo/server/render.js')?.contents).toBe(
+      [
+        `const n='This is string data, not a comment.\\n//# sourceMappingURL=embedded.js.map\\nEnd of data.';`,
+        '//# sourceMappingURL=render.js.map',
+      ].join('\n')
+    );
+    expect(files.has('_expo/server/render.js.map')).toBe(true);
   });
 });


### PR DESCRIPTION
# Why

Fixes #47960. 

`expo export` rewrites the `//# sourceMappingURL=` directive in server bundles with an unanchored/unbounded global regex, which also matches any string literals containing the same directive. The regex would then match the rest of the file and replace it, corrupting the bundle output.

# How

Anchored the regex to only apply to the end of the bundle contents.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
