### PR TITLE
[router] Remove `useOnlyUserDefinedScreens` from `withLayoutContext`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- Remove `useOnlyUserDefinedScreens` from `withLayoutContext` ([#47983](https://github.com/expo/expo/pull/47983) by [@Ubax](https://github.com/Ubax))
 - Move `@testing-library/jest-dom` and `@testing-library/user-event` from `dependencies` to `devDependencies` ([#47820](https://github.com/expo/expo/pull/47820) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Rewrite native tabs using standard-navigation ([#46457](https://github.com/expo/expo/pull/46457) by [@Ubax](https://github.com/Ubax))
 - [Internal] Split `useLoaderData()` into a document cache and a per-mount Suspense store ([#47365](https://github.com/expo/expo/pull/47365) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -113,7 +113,6 @@ export function useFilterScreenChildren(
  *
  * @param Nav - The navigator component to wrap.
  * @param processor - A function that processes the screens before passing them to the navigator.
- * @param useOnlyUserDefinedScreens - If true, all screens not specified as navigator's children will be ignored.
  *
  *  @example
  * ```tsx app/_layout.tsx
@@ -144,11 +143,7 @@ export function withLayoutContext<
   T extends ComponentType<any>,
   TState extends NavigationState,
   TEventMap extends EventMapBase,
->(
-  Nav: T,
-  processor?: (options: ScreenProps[]) => ScreenProps[],
-  useOnlyUserDefinedScreens: boolean = false
-) {
+>(Nav: T, processor?: (options: ScreenProps[]) => ScreenProps[]) {
   return Object.assign(
     forwardRef(({ children: userDefinedChildren, ...props }: any, ref) => {
       const contextKey = useContextKey();
@@ -160,7 +155,7 @@ export function withLayoutContext<
 
       const processed = processor ? processor(screens ?? []) : screens;
 
-      const sorted = useSortedScreens(processed ?? [], guardedRedirects, useOnlyUserDefinedScreens);
+      const sorted = useSortedScreens(processed ?? [], guardedRedirects);
 
       // Prevent throwing an error when there are no screens.
       if (!sorted.length) {

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import React, { use, useCallback, useMemo, useRef } from 'react';
-import type { NavigatorArgs } from 'standard-navigation';
+import React, { use, useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { useRouteNode } from '../Route';
+import { router } from '../imperative-api';
 import type {
   ParamListBase,
   TabNavigationState,
   TabRouterOptions,
 } from '../react-navigation/native';
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
+import type {
+  StandardNavigatorContentProps,
+  StandardNavigatorDescriptor,
+} from '../standard-navigation/types';
 import { getAllChildrenNotOfType, getAllChildrenOfType } from '../utils/children';
 import { NativeBottomTabsRouter } from './NativeBottomTabsRouter';
 import { NativeTabTrigger } from './NativeTabTrigger';
@@ -46,9 +51,13 @@ function NativeTabsContent({
   rippleColor,
   disableIndicator,
   labelVisibilityMode,
+  redirectToRouteName,
   ...rest
-}: NavigatorArgs<NativeTabOptions, NativeTabNavigationEventMap> &
-  Omit<InternalNativeTabsProps, 'screenListeners'>) {
+}: StandardNavigatorContentProps<
+  NativeTabOptions,
+  NativeTabNavigationEventMap,
+  Omit<InternalNativeTabsProps, 'screenListeners'>
+>) {
   if (use(NativeTabsContext)) {
     throw new Error(
       'Nesting Native Tabs inside each other is not supported natively. Use JS tabs for nesting instead.'
@@ -60,9 +69,14 @@ function NativeTabsContent({
   const visibleTabs = useMemo(
     () =>
       routes
-        // The <NativeTab.Trigger> always sets `hidden` to defined boolean value.
-        // If it is not defined, then it was not specified, and we should hide the tab.
-        .filter((route) => descriptors[route.key]!.options?.hidden !== true)
+        // Every filesystem route is registered in state; only routes declared by a
+        // non-hidden <NativeTabs.Trigger> become tab items.
+        .filter((route) => {
+          const descriptor = descriptors[
+            route.key
+          ]! as StandardNavigatorDescriptor<NativeTabOptions>;
+          return descriptor.routeSource === 'layout' && descriptor.options?.hidden !== true;
+        })
         .map(
           (route): NativeTabsViewTabItem => ({
             options: descriptors[route.key]!.options,
@@ -82,15 +96,27 @@ function NativeTabsContent({
     [visibleTabs]
   );
 
-  if (visibleFocusedTabIndex < 0) {
-    if (process.env.NODE_ENV !== 'production') {
-      const focusedRoute = routes[state.index];
-      throw new Error(
-        `The focused tab in NativeTabsView cannot be displayed. Make sure path is correct and the route is not hidden. Route: "${focusedRoute?.href ?? focusedRoute?.name}"`
-      );
-    }
-  }
   const focusedIndex = visibleFocusedTabIndex >= 0 ? visibleFocusedTabIndex : 0;
+
+  // The focused route can be hidden or have no trigger at all — for example a path pointing at a
+  // route without a tab, or a trigger hidden while focused. Redirect to the router's initial tab,
+  // falling back to the first visible tab. `replace` keeps the unreachable route out of history.
+  // TODO(@ubax): Show a formsheet for hidden tabs which are focused (Tabs + Stack in one).
+  const redirectTabHref = useMemo(() => {
+    const redirectTab =
+      visibleTabs.find(
+        (tab) =>
+          tab.name === redirectToRouteName ||
+          tab.name.replace(/\/index$/, '') === redirectToRouteName
+      ) ?? visibleTabs[0];
+    return routes.find((route) => route.key === redirectTab?.routeKey)?.href;
+  }, [redirectToRouteName, routes, visibleTabs]);
+  useEffect(() => {
+    if (visibleFocusedTabIndex < 0 && redirectTabHref != null) {
+      router.replace(redirectTabHref);
+    }
+  }, [visibleFocusedTabIndex, redirectTabHref]);
+
   const provenanceRef = useRef(0);
 
   const onTabChange = useCallback(
@@ -147,6 +173,10 @@ function NativeTabsContent({
   > &
     Record<Exclude<keyof typeof rest, keyof NativeTabsViewProps>, never> = rest;
 
+  if (visibleTabs.length === 0) {
+    return null;
+  }
+
   return (
     <NativeTabsContext value>
       <NativeTabsView
@@ -170,9 +200,10 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
   NativeTabNavigationEventMap,
   Omit<InternalNativeTabsProps, 'screenListeners'>,
   TabRouterOptions
->(NativeTabsContent, NativeBottomTabsRouter, { useOnlyUserDefinedScreens: true });
+>(NativeTabsContent, NativeBottomTabsRouter);
 
 export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
+  const routeNode = useRouteNode();
   const triggerChildren = useMemo(
     () =>
       getAllChildrenOfType(props.children, NativeTabTrigger).filter((child) => !child.props.hidden),
@@ -252,6 +283,8 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
       children={triggerChildren}
       nonTriggerChildren={nonTriggerChildren}
       screenOptions={screenOptions}
+      initialRouteName={routeNode?.initialRouteName}
+      redirectToRouteName={routeNode?.initialRouteName}
       // Passed to TabRouter
       backBehavior={backBehavior}
     />

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -1,5 +1,5 @@
 import { screen, fireEvent } from '@testing-library/react-native';
-import { act } from 'react';
+import { act, useState } from 'react';
 import { View } from 'react-native';
 import { Tabs } from 'react-native-screens';
 
@@ -27,10 +27,6 @@ const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
 
 describe('Native Bottom Tabs Navigation', () => {
-  function expectNoRenders() {
-    expect(TabsScreen).not.toHaveBeenCalled();
-  }
-
   function expectOneRender() {
     expect(TabsScreen).toHaveBeenCalledTimes(2);
   }
@@ -74,7 +70,7 @@ describe('Native Bottom Tabs Navigation', () => {
           <Link href="/" testID="index-index-link" />
           <Link href="/second" testID="index-second-link" />
           <Link href="/hidden" testID="index-hidden-link" />
-          <Link href="/not-specified" testID="index-not-specified-link" />
+          <Link href="/notSpecified" testID="index-not-specified-link" />
         </View>
       ),
       second: () => (
@@ -82,7 +78,7 @@ describe('Native Bottom Tabs Navigation', () => {
           <Link href="/" testID="second-index-link" />
           <Link href="/second" testID="second-second-link" />
           <Link href="/hidden" testID="second-hidden-link" />
-          <Link href="/not-specified" testID="second-not-specified-link" />
+          <Link href="/notSpecified" testID="second-not-specified-link" />
         </View>
       ),
       hidden: () => <View testID="hidden" />,
@@ -137,29 +133,227 @@ describe('Native Bottom Tabs Navigation', () => {
     expectSecondTabFocused();
   });
 
-  it('when Link is pressed to a hidden tab, no navigation occurs', async () => {
+  it('when Link is pressed to a hidden tab, it redirects to the initial tab', async () => {
     act(() => fireEvent.press(screen.getByTestId('index-hidden-link')));
-    expectNoRenders();
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
 
     TabsScreen.mockClear();
     act(() => router.push('/second'));
     expectSecondTabFocused(2);
 
-    TabsScreen.mockClear();
     act(() => fireEvent.press(screen.getByTestId('second-hidden-link')));
-    expectNoRenders();
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
   });
 
-  it('when Link is pressed to a not-specified tab, no navigation occurs', () => {
+  it('when Link is pressed to a not-specified tab, it redirects to the initial tab', () => {
     act(() => fireEvent.press(screen.getByTestId('index-not-specified-link')));
-    expectNoRenders();
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
 
     TabsScreen.mockClear();
     act(() => router.push('/second'));
     expectSecondTabFocused();
 
+    act(() => fireEvent.press(screen.getByTestId('second-not-specified-link')));
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
+  });
+
+  it('redirects to the initial tab when router.push targets a hidden or not-specified route', () => {
+    act(() => router.push('/hidden'));
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
+
+    act(() => router.push('/notSpecified'));
+    expect(lastHostSelectedKey()).toMatch(/^index-[-\w]+/);
+    expect(screen).toHavePathname('/');
+  });
+});
+
+describe('Native Bottom Tabs trigger changes', () => {
+  it('renders only routes with visible triggers', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="hidden" hidden />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+      hidden: () => <View testID="hidden" />,
+      notSpecified: () => <View testID="not-specified" />,
+    });
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen.queryByTestId('hidden')).toBeNull();
+    expect(screen.queryByTestId('not-specified')).toBeNull();
+    expect(TabsScreen).toHaveBeenCalledTimes(1);
+    expect(TabsScreen.mock.calls[0]![0].screenKey).toMatch(/^index-[-\w]+/);
+  });
+
+  it('removes a tab item when its trigger is removed and redirects navigation to it', () => {
+    let setShowSecond!: (show: boolean) => void;
+    function Layout() {
+      const [showSecond, set] = useState(true);
+      setShowSecond = set;
+      return (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" />
+          {showSecond && <NativeTabs.Trigger name="second" />}
+        </NativeTabs>
+      );
+    }
+    renderRouter({
+      _layout: Layout,
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
     TabsScreen.mockClear();
-    act(() => fireEvent.press(screen.getByTestId('second-hidden-link')));
-    expectNoRenders();
+    act(() => setShowSecond(false));
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen.queryByTestId('second')).toBeNull();
+    expect(TabsScreen).toHaveBeenCalledTimes(1);
+    expect(TabsScreen.mock.calls[0]![0].screenKey).toMatch(/^index-[-\w]+/);
+
+    act(() => router.push('/second'));
+    expect(screen).toHavePathname('/');
+    expect(screen.getByTestId('index')).toBeVisible();
+  });
+
+  it('redirects to the initial tab when deep linking to a route without a visible tab', () => {
+    renderRouter(
+      {
+        _layout: () => (
+          <NativeTabs>
+            <NativeTabs.Trigger name="index" />
+          </NativeTabs>
+        ),
+        index: () => <View testID="index" />,
+        notSpecified: () => <View testID="not-specified" />,
+      },
+      { initialUrl: '/notSpecified' }
+    );
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen.queryByTestId('not-specified')).toBeNull();
+    expect(screen).toHavePathname('/');
+  });
+
+  it('respects initialRouteName when redirecting from a route without a visible tab', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { initialRouteName: 'second' },
+          default: () => (
+            <NativeTabs>
+              <NativeTabs.Trigger name="index" />
+              <NativeTabs.Trigger name="second" />
+            </NativeTabs>
+          ),
+        },
+        index: () => <View testID="index" />,
+        second: () => <View testID="second" />,
+        notSpecified: () => <View testID="not-specified" />,
+      },
+      { initialUrl: '/notSpecified' }
+    );
+
+    expect(screen.getByTestId('second')).toBeVisible();
+    expect(screen.queryByTestId('not-specified')).toBeNull();
+    expect(screen).toHavePathname('/second');
+  });
+
+  it('respects an initialRouteName that targets a directory index route', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { initialRouteName: 'second/index' },
+          default: () => (
+            <NativeTabs>
+              <NativeTabs.Trigger name="index" />
+              <NativeTabs.Trigger name="second" />
+            </NativeTabs>
+          ),
+        },
+        index: () => <View testID="index" />,
+        'second/index': () => <View testID="second" />,
+        notSpecified: () => <View testID="not-specified" />,
+      },
+      { initialUrl: '/notSpecified' }
+    );
+
+    expect(screen.getByTestId('second')).toBeVisible();
+    expect(screen).toHavePathname('/second');
+  });
+
+  it('shows and navigates a tab whose trigger names a directory index route', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+      'second/index': () => <View testID="second" />,
+    });
+
+    // The trigger name `second` matches the route `second/index`.
+    expect(TabsScreen).toHaveBeenCalledTimes(2);
+
+    act(() => router.push('/second'));
+
+    expect(screen).toHavePathname('/second');
+    expect(screen.getByTestId('second')).toBeVisible();
+  });
+
+  it('redirects to the initial tab when the focused trigger is hidden dynamically', () => {
+    let setHidden!: (hidden: boolean) => void;
+    function Layout() {
+      const [hidden, set] = useState(false);
+      setHidden = set;
+      return (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" hidden={hidden} />
+        </NativeTabs>
+      );
+    }
+    renderRouter({
+      _layout: Layout,
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
+
+    act(() => router.push('/second'));
+    expect(screen).toHavePathname('/second');
+
+    TabsScreen.mockClear();
+    act(() => setHidden(true));
+
+    expect(screen).toHavePathname('/');
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen.queryByTestId('second')).toBeNull();
+    expect(TabsScreen).toHaveBeenCalled();
+    for (const call of TabsScreen.mock.calls) {
+      expect(call[0].screenKey).toMatch(/^index-[-\w]+/);
+    }
+  });
+
+  it('renders no tab UI when every trigger is hidden', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" hidden />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+    });
+
+    expect(screen.queryByTestId('index')).toBeNull();
+    expect(TabsScreen).not.toHaveBeenCalled();
   });
 });

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -227,7 +227,9 @@ describe('First focused tab', () => {
       expect(screen.getByTestId('first')).toBeVisible();
       expect(screen.getByTestId('second')).toBeVisible();
       expect(screen.queryByTestId('index')).toBeNull();
-      expect(NativeTabsView).toHaveBeenCalledTimes(1);
+      // Two renders: the hidden `index` route is registered and initially focused, then the
+      // navigator redirects to the first visible tab.
+      expect(NativeTabsView).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -480,6 +480,7 @@ export interface NativeTabsProps extends PropsWithChildren {
 
 export interface InternalNativeTabsProps extends NativeTabsProps {
   nonTriggerChildren?: React.ReactNode;
+  redirectToRouteName?: string;
 }
 export interface OnTabChangeEventPayload {
   /**
@@ -517,6 +518,7 @@ export interface NativeTabsViewProps extends Omit<
   | 'badgeTextColor'
   | 'rippleColor'
   | 'disableIndicator'
+  | 'redirectToRouteName'
   | 'labelVisibilityMode'
 > {
   focusedIndex: number;

--- a/packages/expo-router/src/standard-navigation/__tests__/docs-examples.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/docs-examples.test.tsx
@@ -80,7 +80,6 @@ function typecheck(_value: unknown) {}
   };
 
   const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
-    useOnlyUserDefinedScreens: true,
     createProps: ({ state, dispatch }) => ({
       activeRouteKey: state.routes[state.index]!.key,
       preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -41,15 +41,6 @@ const StandardTabs = unstable_createStandardRouterNavigator<
   TestEventMap,
   { tintColor?: string },
   TabRouterOptions
->(NavigatorContent, TabRouter, { useOnlyUserDefinedScreens: true });
-
-// Same navigator, but without restricting to user-defined screens (the default).
-const StandardTabsAll = unstable_createStandardRouterNavigator<
-  TestOptions,
-  TabNavigationState<ParamListBase>,
-  TestEventMap,
-  object,
-  TabRouterOptions
 >(NavigatorContent, TabRouter);
 
 const lastArgs = (): NavigatorArgs<TestOptions, TestEventMap> & Record<string, unknown> =>
@@ -190,26 +181,12 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
     expect(lastArgs().tintColor).toBe('rebeccapurple');
   });
 
-  it('respects useOnlyUserDefinedScreens by filtering undeclared routes', () => {
+  it('always registers undeclared filesystem routes', () => {
     renderRouter({
       _layout: () => (
         <StandardTabs>
           <StandardTabs.Screen name="index" />
         </StandardTabs>
-      ),
-      index: () => <View testID="index" />,
-      second: () => <View testID="second" />,
-    });
-
-    expect(lastArgs().state.routes.map((r) => r.name)).toEqual(['index']);
-  });
-
-  it('includes undeclared matched routes when useOnlyUserDefinedScreens is false', () => {
-    renderRouter({
-      _layout: () => (
-        <StandardTabsAll>
-          <StandardTabsAll.Screen name="index" />
-        </StandardTabsAll>
       ),
       index: () => <View testID="index" />,
       second: () => <View testID="second" />,
@@ -225,9 +202,9 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
   it('distinguishes declared and inferred routes via descriptor routeSource', () => {
     renderRouter({
       _layout: () => (
-        <StandardTabsAll>
-          <StandardTabsAll.Screen name="index" />
-        </StandardTabsAll>
+        <StandardTabs>
+          <StandardTabs.Screen name="index" />
+        </StandardTabs>
       ),
       index: () => <View testID="index" />,
       second: () => <View testID="second" />,
@@ -330,7 +307,6 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
       TabRouterOptions,
       { focusedName: string }
     >(NavigatorContent, TabRouter, {
-      useOnlyUserDefinedScreens: true,
       createProps: ({ state }) => ({ focusedName: state.routes[state.index]!.name }),
     });
 
@@ -363,7 +339,6 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
       TabRouterOptions,
       { goToSecond: () => void }
     >(NavigatorContent, TabRouter, {
-      useOnlyUserDefinedScreens: true,
       createProps: ({ dispatch }) => ({
         goToSecond: () => dispatch(TabActions.jumpTo('second')),
       }),
@@ -413,7 +388,7 @@ describe('preloaded routes projected through the integration (StackRouter)', () 
     TestEventMap,
     object,
     StackRouterOptions
-  >(NavigatorContent, StackRouter, { useOnlyUserDefinedScreens: true });
+  >(NavigatorContent, StackRouter);
 
   const renderStack = () =>
     renderRouter({
@@ -641,7 +616,6 @@ describe('custom-navigators guide example', () => {
     TabRouterOptions,
     CreatePropsProps
   >(TabsContent, TabRouter, {
-    useOnlyUserDefinedScreens: true,
     createProps: ({ state, dispatch }) => ({
       activeRouteKey: state.routes[state.index]!.key,
       preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),

--- a/packages/expo-router/src/standard-navigation/__tests__/useBuildHref.integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useBuildHref.integration.test.ios.tsx
@@ -33,7 +33,7 @@ const StandardTabs = unstable_createStandardRouterNavigator<
   Record<string, never>,
   object,
   TabRouterOptions
->(NavigatorContent, TabRouter, { useOnlyUserDefinedScreens: true });
+>(NavigatorContent, TabRouter);
 
 describe('useBuildHref (integration)', () => {
   it('resolves real hrefs (index → /, group segment stripped) for navigator routes', () => {

--- a/packages/expo-router/src/standard-navigation/__tests__/useStandardActions.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useStandardActions.test.ios.tsx
@@ -107,7 +107,7 @@ describe('useStandardActions (integration)', () => {
     Record<string, never>,
     object,
     TabRouterOptions
-  >(NavigatorContent, TabRouter, { useOnlyUserDefinedScreens: true });
+  >(NavigatorContent, TabRouter);
 
   it('navigate() switches the focused route in a real navigator', () => {
     renderRouter({

--- a/packages/expo-router/src/standard-navigation/__tests__/useStandardEmitter.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useStandardEmitter.test.ios.tsx
@@ -134,7 +134,7 @@ describe('useStandardEmitter (integration)', () => {
     IntegrationEventMap,
     object,
     TabRouterOptions
-  >(NavigatorContent, TabRouter, { useOnlyUserDefinedScreens: true });
+  >(NavigatorContent, TabRouter);
 
   it('delivers an emitted event to the targeted screen listener', () => {
     const ping = jest.fn();

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -210,9 +210,7 @@ export function unstable_integrateWithRouter<
   }
 
   return withLayoutContext<NavigatorOptions, typeof StandardRouterNavigator, State, EventMap>(
-    StandardRouterNavigator,
-    undefined,
-    options?.useOnlyUserDefinedScreens
+    StandardRouterNavigator
   );
 }
 

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -83,13 +83,7 @@ type CreatePropsOption<State extends NavigationState, CreateProps extends object
 export type IntegrateWithRouterOptions<
   State extends NavigationState = NavigationState,
   CreateProps extends object = object,
-> = {
-  /**
-   * When `true`, only screens explicitly declared as `<Navigator.Screen>` children are rendered;
-   * routes discovered from the filesystem that were not declared are ignored.
-   */
-  useOnlyUserDefinedScreens?: boolean;
-} & CreatePropsOption<State, CreateProps>;
+> = CreatePropsOption<State, CreateProps>;
 
 /**
  * A standard-navigation descriptor extended with Expo Router route information.

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -180,22 +180,11 @@ function getSortedChildren(
  */
 export function useSortedScreens(
   order: ScreenProps[],
-  guardedRedirects: Map<string, Href | undefined> = new Map(),
-  useOnlyUserDefinedScreens: boolean = false
+  guardedRedirects: Map<string, Href | undefined> = new Map()
 ): React.ReactNode[] {
   const node = useRouteNode();
 
-  const nodeChildren = node?.children ?? [];
-  const children = useOnlyUserDefinedScreens
-    ? nodeChildren.filter((child) =>
-        order.some(
-          (userDefinedScreen) =>
-            userDefinedScreen.name === child.route ||
-            `${userDefinedScreen.name}/index` === child.route
-        )
-      )
-    : nodeChildren;
-
+  const children = node?.children ?? [];
   const sorted = children.length ? getSortedChildren(children, order, node?.initialRouteName) : [];
   return React.useMemo(() => {
     const screensWithGuarded = sorted.map((value) => {


### PR DESCRIPTION
# Why

Remove `useOnlyUserDefinedScreens` from `withLayoutContext` and use `routeSource` to hide native tab when its Trigger is not specified.

# How

1. Remove `useOnlyUserDefinedScreens` and its logic
2. Filter routes in native-tabs to be `descriptor.routeSource === 'layout'`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>