### PR TITLE
[router] Keep fully guarded navigators mounted

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- Keep fully guarded navigators mounted while hiding their protected content. ([#TODO](https://github.com/expo/expo/pull/TODO) by [@Ubax](https://github.com/Ubax))
 - Unset `nativeContainerStyle` in transparent presentations ([#48154](https://github.com/expo/expo/pull/48154) by [@Ubax](https://github.com/Ubax))
 - [android] Disable safe area insets in Native Tabs on Android when tab bar is hidden. ([#47611](https://github.com/expo/expo/pull/47611) by [@debitan](https://github.com/debitan))
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### 🐛 Bug fixes
 
-- Keep fully guarded navigators mounted while hiding their protected content. ([#TODO](https://github.com/expo/expo/pull/TODO) by [@Ubax](https://github.com/Ubax))
+- Redirect fully guarded navigators to parent ([#47984](https://github.com/expo/expo/pull/47984) by [@Ubax](https://github.com/Ubax))
 - Unset `nativeContainerStyle` in transparent presentations ([#48154](https://github.com/expo/expo/pull/48154) by [@Ubax](https://github.com/Ubax))
 - [android] Disable safe area insets in Native Tabs on Android when tab bar is hidden. ([#47611](https://github.com/expo/expo/pull/47611) by [@debitan](https://github.com/debitan))
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -770,9 +770,7 @@ describe('all routes guarded', () => {
         setId = setState;
         return (
           <Stack id={undefined}>
-            <Stack.Protected
-              guard={false}
-              redirectTo={{ pathname: '/login/[id]', params: { id } }}>
+            <Stack.Protected guard={false} redirectTo={{ pathname: '/login/[id]', params: { id } }}>
               <Stack.Screen name="secret" />
             </Stack.Protected>
           </Stack>

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -576,6 +576,373 @@ it('works with tabs', () => {
   expect(screen.queryByLabelText('protected, tab, 2 of 2')).toBeVisible();
 });
 
+describe('all routes guarded', () => {
+  let consoleWarnSpy: jest.SpyInstance<void, Parameters<typeof console.warn>>;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('renders nothing without crashing when every route is guarded from the start', () => {
+    renderRouter({
+      _layout: function Layout() {
+        return (
+          <>
+            <Text testID="layout">layout</Text>
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="index" />
+                <Stack.Screen name="second" />
+              </Stack.Protected>
+            </Stack>
+          </>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      second: () => <Text testID="second">second</Text>,
+    });
+
+    expect(screen.getByTestId('layout')).toBeVisible();
+    expect(screen.queryByTestId('index')).toBeNull();
+    expect(screen.queryByTestId('second')).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'All routes in this navigator are protected. Ensure at least one route is accessible.'
+    );
+    // The navigator itself stays mounted (previously it rendered null when all
+    // its routes were guarded).
+    expect(JSON.stringify(screen.toJSON())).toContain('RNSScreenStack');
+  });
+
+  it('keeps navigation state when all guards flip false and back to true', () => {
+    let setGuard: Dispatch<SetStateAction<boolean>>;
+
+    renderRouter({
+      _layout: function Layout() {
+        const [guard, setState] = useState(true);
+        setGuard = setState;
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard={guard}>
+              <Stack.Screen name="index" />
+              <Stack.Screen name="second" />
+            </Stack.Protected>
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      second: () => <Text testID="second">second</Text>,
+    });
+
+    act(() => router.push('/second'));
+    expect(screen.getByTestId('second')).toBeVisible();
+    expect(screen).toHavePathname('/second');
+
+    const stateBefore = store.state!.routes[0]!.state!;
+    const focusedKeyBefore = stateBefore.routes[stateBefore.index!]!.key;
+
+    // Guard everything: content hides but the navigator must stay mounted.
+    act(() => {
+      setGuard(false);
+    });
+
+    expect(screen.queryByTestId('index')).toBeNull();
+    expect(screen.queryByTestId('second')).toBeNull();
+
+    // Restore access: the same navigation state is still there, not reinitialized.
+    act(() => {
+      setGuard(true);
+    });
+
+    expect(screen.getByTestId('second')).toBeVisible();
+    expect(screen).toHavePathname('/second');
+    const stateAfter = store.state!.routes[0]!.state!;
+    expect(stateAfter.routes[stateAfter.index!]!.key).toBe(focusedKeyBefore);
+    // Non-focused guarded history entries are pruned while the guard is down,
+    // so only the focused route survives the flip.
+    expect(stateAfter.routes).toHaveLength(1);
+  });
+
+  it('redirects to the parent anchor when all nested guards flip false', () => {
+    let setGuard: Dispatch<SetStateAction<boolean>>;
+
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: 'index' },
+          default: () => <Stack id={undefined} />,
+        },
+        index: () => <Text testID="index">index</Text>,
+        'nested/_layout': function NestedLayout() {
+          const [guard, setState] = useState(true);
+          setGuard = setState;
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={guard}>
+                <Stack.Screen name="index" />
+                <Stack.Screen name="second" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        'nested/index': () => <Text testID="nested-index">nested index</Text>,
+        'nested/second': () => <Text testID="second">second</Text>,
+      },
+      { initialUrl: '/nested/second' }
+    );
+
+    expect(screen.getByTestId('second')).toBeVisible();
+
+    act(() => setGuard(false));
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen).toHavePathname('/');
+  });
+
+  it('does not redirect when the parent anchor is the fully guarded navigator', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: 'nested' },
+          default: () => <Stack id={undefined} />,
+        },
+        index: () => <Text testID="index">index</Text>,
+        'nested/_layout': function NestedLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="index" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        'nested/index': () => <Text testID="nested-index">nested index</Text>,
+      },
+      { initialUrl: '/nested' }
+    );
+
+    expect(screen.queryByTestId('nested-index')).toBeNull();
+    expect(screen).toHavePathname('/nested');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'All routes in this navigator are protected. Ensure at least one route is accessible.'
+    );
+  });
+
+  it('skips a self-targeting parent anchor and redirects to the grandparent anchor', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: 'home' },
+          default: () => <Stack id={undefined} />,
+        },
+        home: () => <Text testID="home">home</Text>,
+        'nested/_layout': {
+          unstable_settings: { anchor: 'deep' },
+          default: () => <Stack id={undefined} />,
+        },
+        'nested/deep/_layout': function DeepLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="index" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        'nested/deep/index': () => <Text testID="deep-index">deep index</Text>,
+      },
+      { initialUrl: '/nested/deep' }
+    );
+
+    expect(screen.getByTestId('home')).toBeVisible();
+    expect(screen).toHavePathname('/home');
+  });
+
+  it('uses updated params from an object redirectTo', () => {
+    let setId: Dispatch<SetStateAction<string>>;
+
+    renderRouter({
+      _layout: function Layout() {
+        const [id, setState] = useState('one');
+        setId = setState;
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected
+              guard={false}
+              redirectTo={{ pathname: '/login/[id]', params: { id } }}>
+              <Stack.Screen name="secret" />
+            </Stack.Protected>
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+      'login/[id]': () => <Text testID="login">login</Text>,
+    });
+
+    act(() => setId('two'));
+    act(() => router.push('/secret'));
+
+    expect(screen.getByTestId('login')).toBeVisible();
+    expect(screen).toHavePathname('/login/two');
+  });
+
+  it('preserves a parent anchor whose name ends in index', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: 'reindex' },
+          default: () => <Stack id={undefined} />,
+        },
+        reindex: () => <Text testID="reindex">reindex</Text>,
+        'nested/_layout': function NestedLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="index" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        'nested/index': () => <Text testID="nested-index">nested index</Text>,
+      },
+      { initialUrl: '/nested' }
+    );
+
+    expect(screen.getByTestId('reindex')).toBeVisible();
+    expect(screen).toHavePathname('/reindex');
+  });
+
+  it('redirects out of a pathless group to the parent index', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: 'index' },
+          default: () => <Stack id={undefined} />,
+        },
+        index: () => <Text testID="index">index</Text>,
+        '(app)/_layout': function AppLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        '(app)/secret': () => <Text testID="secret">secret</Text>,
+      },
+      { initialUrl: '/secret' }
+    );
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(screen).toHavePathname('/');
+  });
+
+  it('redirects to the configured pathless group when groups share a URL', () => {
+    renderRouter(
+      {
+        _layout: {
+          unstable_settings: { anchor: '(two)' },
+          default: () => (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack>
+          ),
+        },
+        '(one)/_layout': () => <Stack id={undefined} />,
+        '(one)/index': () => <Text testID="one">one</Text>,
+        '(two)/_layout': () => <Stack id={undefined} />,
+        '(two)/index': () => <Text testID="two">two</Text>,
+        secret: () => <Text testID="secret">secret</Text>,
+      },
+      { initialUrl: '/secret' }
+    );
+
+    expect(screen.getByTestId('two')).toBeVisible();
+    expect(screen.queryByTestId('one')).toBeNull();
+    expect(screen).toHavePathname('/');
+  });
+
+  it('preserves params in a dynamic parent anchor', () => {
+    renderRouter(
+      {
+        _layout: () => <Stack id={undefined} />,
+        '[id]/_layout': {
+          unstable_settings: { anchor: 'index' },
+          default: () => <Stack id={undefined} />,
+        },
+        '[id]/index': () => <Text testID="profile">profile</Text>,
+        '[id]/nested/_layout': function NestedLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false}>
+                <Stack.Screen name="index" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        '[id]/nested/index': () => <Text testID="nested-index">nested index</Text>,
+      },
+      { initialUrl: '/alice/nested' }
+    );
+
+    expect(screen.getByTestId('profile')).toBeVisible();
+    expect(screen).toHavePathname('/alice');
+  });
+
+  it('does not render guarded content when pushing directly to a route guarded with no destination', () => {
+    renderRouter({
+      _layout: function Layout() {
+        return (
+          <Stack id={undefined}>
+            <Stack.Protected guard={false}>
+              <Stack.Screen name="index" />
+              <Stack.Screen name="second" />
+            </Stack.Protected>
+          </Stack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      second: () => <Text testID="second">second</Text>,
+    });
+
+    act(() => router.push('/second'));
+
+    expect(screen.queryByTestId('index')).toBeNull();
+    expect(screen.queryByTestId('second')).toBeNull();
+  });
+
+  it('redirects out of a fully guarded nested navigator via redirectTo', () => {
+    renderRouter(
+      {
+        _layout: () => <Stack id={undefined} />,
+        index: () => <Text testID="index">index</Text>,
+        login: () => <Text testID="login">login</Text>,
+        'nested/_layout': function NestedLayout() {
+          return (
+            <Stack id={undefined}>
+              <Stack.Protected guard={false} redirectTo="/login">
+                <Stack.Screen name="secret" />
+              </Stack.Protected>
+            </Stack>
+          );
+        },
+        'nested/secret': () => <Text testID="secret">secret</Text>,
+      },
+      { initialUrl: '/nested/secret' }
+    );
+
+    expect(screen.getByTestId('login')).toBeVisible();
+    expect(screen).toHavePathname('/login');
+  });
+});
+
 describe('routes without /index suffix', () => {
   describe('Protected', () => {
     it('should protect dynamic routes without explicit /index suffix', () => {

--- a/packages/expo-router/src/layouts/GuardContext.tsx
+++ b/packages/expo-router/src/layouts/GuardContext.tsx
@@ -3,59 +3,18 @@
 import { createContext, use, useMemo, type ReactNode } from 'react';
 
 import type { RouteNode } from '../Route';
-import { sortRoutesWithInitial } from '../Route';
-import { getContextKey, stripInvisibleSegmentsFromPath } from '../matchers';
+import { LocalRouteParamsContext, sortRoutesWithInitial } from '../Route';
+import { getContextKey } from '../matchers';
 import type { Href } from '../types';
 
-export const GuardContext = createContext<Map<string, Href> | null>(null);
+export type GuardedRedirects = Map<string, Href | undefined>;
+// `Href` = guarded with a redirect, `null` = guarded with no available destination.
+export type GuardRedirect = Href | null;
+// Per route name; a missing entry means the route is unguarded.
+export type ResolvedGuards = Map<string, GuardRedirect>;
 
-export function useGuardRedirect(routeName: string): Href | undefined {
-  const guards = use(GuardContext);
-  if (!guards) {
-    return undefined;
-  }
-  return guards.get(routeName) ?? guards.get(routeName.replace(/\/index$/, ''));
-}
-
-function matchesRouteName(route: string, name: string) {
-  return route === name || route === `${name}/index` || route.replace(/\/index$/, '') === name;
-}
-
-function routeNodeToHref(route: Pick<RouteNode, 'contextKey'>): Href {
-  return (stripInvisibleSegmentsFromPath(getContextKey(route.contextKey)) || '/') as Href;
-}
-
-function serializeGuardedRedirects(guardedRedirects: Map<string, Href | undefined>): string {
-  return Array.from(guardedRedirects.entries())
-    .map(([name, href]) => `${name}=${href ?? ''}`)
-    .join('|');
-}
-
-function resolveDefaultHref(
-  node: Pick<RouteNode, 'children' | 'initialRouteName'>,
-  guardedRedirects: Map<string, Href | undefined>
-) {
-  const children = [...node.children].sort(sortRoutesWithInitial(node.initialRouteName));
-  const anchor = node.initialRouteName
-    ? children.find((child) => matchesRouteName(child.route, node.initialRouteName!))
-    : null;
-
-  if (
-    anchor &&
-    !guardedRedirects.has(anchor.route) &&
-    !guardedRedirects.has(anchor.route.replace(/\/index$/, ''))
-  ) {
-    return routeNodeToHref(anchor);
-  }
-
-  const firstAvailable = children.find(
-    (child) =>
-      !guardedRedirects.has(child.route) &&
-      !guardedRedirects.has(child.route.replace(/\/index$/, ''))
-  );
-
-  return firstAvailable ? routeNodeToHref(firstAvailable) : undefined;
-}
+export const GuardContext = createContext<ResolvedGuards | null>(null);
+const GuardRedirectFallbackContext = createContext<GuardRedirectFallback[]>([]);
 
 export function GuardContextProvider({
   node,
@@ -63,26 +22,138 @@ export function GuardContextProvider({
   children,
 }: {
   node: RouteNode | null;
-  guardedRedirects: Map<string, Href | undefined>;
+  guardedRedirects: GuardedRedirects;
   children: ReactNode;
 }) {
-  const signature = useMemo(() => serializeGuardedRedirects(guardedRedirects), [guardedRedirects]);
+  const parentFallbacks = use(GuardRedirectFallbackContext);
+  const params = use(LocalRouteParamsContext);
+  const guardConfigurationKey = serializeGuardedRedirects(guardedRedirects);
+  const { fallbacks, resolvedGuards } = useMemo(
+    () => computeGuardState(node, guardedRedirects, params, parentFallbacks),
+    [
+      node,
+      node?.children,
+      node?.contextKey,
+      node?.initialRouteName,
+      params,
+      parentFallbacks,
+      guardConfigurationKey,
+    ]
+  );
 
-  const resolved = useMemo(() => {
-    const defaultHref = node
-      ? resolveDefaultHref(
-          { children: node.children, initialRouteName: node.initialRouteName },
-          guardedRedirects
-        )
-      : '/';
+  return (
+    <GuardRedirectFallbackContext value={fallbacks}>
+      <GuardContext value={resolvedGuards}>{children}</GuardContext>
+    </GuardRedirectFallbackContext>
+  );
+}
 
-    return new Map<string, Href>(
-      Array.from(
-        guardedRedirects,
-        ([name, redirectTo]) => [name, redirectTo ?? defaultHref] as const
-      ).filter((entry): entry is [string, Href] => entry[1] != null)
-    );
-  }, [signature, node?.children, node?.initialRouteName]);
+function computeGuardState(
+  node: RouteNode | null,
+  guardedRedirects: GuardedRedirects,
+  params: object | undefined,
+  parentFallbacks: GuardRedirectFallback[]
+) {
+  const navigatorFallback = getNavigatorFallback(node, guardedRedirects, params);
+  const inheritedFallbacks = removeFallbacksTargetingNavigator(parentFallbacks, node);
+  const fallbacks = navigatorFallback
+    ? [navigatorFallback, ...inheritedFallbacks]
+    : inheritedFallbacks;
 
-  return <GuardContext value={resolved}>{children}</GuardContext>;
+  return {
+    fallbacks,
+    resolvedGuards: resolveGuardRedirects(guardedRedirects, fallbacks[0]?.href),
+  };
+}
+
+export function useGuardRedirect(routeName: string): GuardRedirect | undefined {
+  const guards = use(GuardContext);
+  if (!guards) {
+    return undefined;
+  }
+
+  if (guards.has(routeName)) {
+    return guards.get(routeName) ?? null;
+  }
+
+  const normalizedRouteName = normalizeRouteName(routeName);
+  return guards.has(normalizedRouteName) ? (guards.get(normalizedRouteName) ?? null) : undefined;
+}
+
+export function normalizeRouteName(routeName: string): string {
+  return routeName.replace(/\/index$/, '');
+}
+
+type GuardRedirectFallback = {
+  href: Href;
+  targetRouteContextKey: string | null;
+};
+
+function getNavigatorFallback(
+  node: RouteNode | null,
+  guardedRedirects: GuardedRedirects,
+  params: object | undefined
+): GuardRedirectFallback | undefined {
+  if (!node) {
+    return { href: '/' as Href, targetRouteContextKey: null };
+  }
+
+  const route = findDefaultRedirectRouteInNavigator(node, guardedRedirects);
+  if (!route) {
+    return undefined;
+  }
+
+  const pathname = normalizeRouteName(getContextKey(route.contextKey)) || '/';
+  return {
+    href: Object.keys(params ?? {}).length ? ({ pathname, params } as Href) : (pathname as Href),
+    targetRouteContextKey: route.contextKey,
+  };
+}
+
+function removeFallbacksTargetingNavigator(
+  fallbacks: GuardRedirectFallback[],
+  node: RouteNode | null
+): GuardRedirectFallback[] {
+  // Route identity is required because pathless groups can share the same visible URL.
+  return fallbacks.filter((fallback) => fallback.targetRouteContextKey !== node?.contextKey);
+}
+
+function findDefaultRedirectRouteInNavigator(
+  node: Pick<RouteNode, 'children' | 'initialRouteName'>,
+  guardedRedirects: GuardedRedirects
+): RouteNode | undefined {
+  const children = [...node.children].sort(sortRoutesWithInitial(node.initialRouteName));
+  const anchor = node.initialRouteName
+    ? children.find(
+        (child) =>
+          child.route === node.initialRouteName ||
+          normalizeRouteName(child.route) === node.initialRouteName
+      )
+    : undefined;
+
+  if (anchor && !isRouteGuarded(anchor.route, guardedRedirects)) {
+    return anchor;
+  }
+
+  return children.find((child) => !isRouteGuarded(child.route, guardedRedirects));
+}
+
+export function isRouteGuarded(routeName: string, guards: ReadonlyMap<string, unknown>): boolean {
+  return guards.has(routeName) || guards.has(normalizeRouteName(routeName));
+}
+
+function resolveGuardRedirects(
+  guardedRedirects: GuardedRedirects,
+  fallbackHref: Href | undefined
+): ResolvedGuards {
+  return new Map<string, GuardRedirect>(
+    Array.from(
+      guardedRedirects,
+      ([name, redirectTo]) => [name, redirectTo ?? fallbackHref ?? null] as const
+    )
+  );
+}
+
+function serializeGuardedRedirects(guardedRedirects: GuardedRedirects): string {
+  return JSON.stringify(Array.from(guardedRedirects.entries()));
 }

--- a/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
+++ b/packages/expo-router/src/layouts/useClearGuardedRoutes.ts
@@ -8,12 +8,7 @@ import {
   type ParamListBase,
   type StackNavigationState,
 } from '../react-navigation/routers';
-import type { Href } from '../types';
-import { GuardContext } from './GuardContext';
-
-function isGuardedRouteName(guards: Map<string, Href>, name: string): boolean {
-  return guards.has(name) || guards.has(name.replace(/\/index$/, ''));
-}
+import { GuardContext, isRouteGuarded } from './GuardContext';
 
 /**
  * Lets a stack navigator clear its own guarded routes from history, based on the guard context.
@@ -36,14 +31,14 @@ export function useClearGuardedRoutes(
     const focusedName = state.routes[state.index]?.name;
     // If focused route becomes guarded then we let the redirect fire
     const hasGuardedRoute = state.routes.some(
-      (route) => route.name !== focusedName && isGuardedRouteName(guards, route.name)
+      (route) => route.name !== focusedName && isRouteGuarded(route.name, guards)
     );
     if (!hasGuardedRoute) {
       return;
     }
 
     const allowedNames = state.routeNames.filter(
-      (name) => name === focusedName || !isGuardedRouteName(guards, name)
+      (name) => name === focusedName || !isRouteGuarded(name, guards)
     );
 
     const { routes, index } = getRoutesForRouteNames(state, allowedNames, { routeParamList: {} });

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -16,7 +16,7 @@ import type { ScreenProps } from '../useScreens';
 import { useSortedScreens } from '../useScreens';
 import { isProtectedReactElement, Protected } from '../views/Protected';
 import { isScreen, Screen } from '../views/Screen';
-import { GuardContextProvider } from './GuardContext';
+import { GuardContextProvider, normalizeRouteName, type GuardedRedirects } from './GuardContext';
 import { IsWithinLayoutContext } from './IsWithinLayoutContext';
 
 export function useFilterScreenChildren(
@@ -34,7 +34,7 @@ export function useFilterScreenChildren(
     const customChildren: any[] = [];
 
     const screens: (ScreenProps & { name: string })[] = [];
-    const guardedRedirects = new Map<string, Href | undefined>();
+    const guardedRedirects: GuardedRedirects = new Map();
 
     function flattenChild(child: ReactNode, exclude = false, redirectTo?: Href) {
       if (isScreen(child, contextKey)) {
@@ -84,14 +84,13 @@ export function useFilterScreenChildren(
     // Add an assertion for development
     if (process.env.NODE_ENV !== 'production') {
       // Assert if names are not unique
-      const normalizeName = (name: unknown) =>
-        typeof name === 'string' ? name.replace(/\/index$/, '') : name;
-
       const screenNames =
         screens?.map(
           (screen) => screen && typeof screen === 'object' && 'name' in screen && screen.name
         ) ?? [];
-      const allNames = screenNames.map(normalizeName);
+      const allNames = screenNames.map((name) =>
+        typeof name === 'string' ? normalizeRouteName(name) : name
+      );
       if (new Set(allNames).size !== allNames.length) {
         throw new Error('Screen names must be unique: ' + allNames);
       }

--- a/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
@@ -5,6 +5,7 @@ import { Button, Platform, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from '../../hooks';
 import { router } from '../../imperative-api';
 import Stack from '../../layouts/Stack';
+import type { ParamListBase, StackNavigationState } from '../../react-navigation/native';
 import { renderRouter } from '../../testing-library';
 import { useNavigation } from '../../useNavigation';
 import { Slot } from '../../views/Navigator';
@@ -656,11 +657,11 @@ describe('prefetch', () => {
   });
 
   it.each([false, true])('prefetches a protected route when guard is %s', (guard) => {
-    renderRouter({
+    const result = renderRouter({
       index: () => {
         return <Link prefetch href="/test" />;
       },
-      test: () => null,
+      test: () => <Text testID="guarded-content">guarded</Text>,
       _layout: () => (
         <Stack>
           <Stack.Protected guard={guard}>
@@ -670,43 +671,22 @@ describe('prefetch', () => {
       ),
     });
 
-    expect(screen).toHaveRouterState({
-      index: 0,
-      key: expect.any(String),
-      preloadedRoutes: [],
-      routeNames: ['__root', '+not-found', '_sitemap'],
-      routes: [
-        {
-          key: expect.any(String),
-          name: '__root',
-          params: undefined,
-          state: {
-            index: 0,
-            key: expect.any(String),
-            preloadedRoutes: [
-              {
-                key: expect.any(String),
-                name: 'test',
-                params: {},
-              },
-            ],
-            routeNames: ['test', 'index'],
-            routes: [
-              {
-                key: expect.any(String),
-                name: 'index',
-                params: undefined,
-                path: '/',
-              },
-            ],
-            stale: false,
-            type: 'stack',
-          },
-        },
-      ],
-      stale: false,
-      type: 'stack',
-    });
+    // The preloaded guarded route must not leak its content.
+    expect(screen.queryByTestId('guarded-content')).toBeNull();
+
+    // Guarded routes stay registered in the navigator, so the prefetch preloads
+    // the route like any other. Its content still renders nothing while guarded.
+    const innerState = result.getRouterState()?.routes[0]?.state;
+    if (innerState?.type !== 'stack') {
+      throw new Error('Expected a stack navigator');
+    }
+    expect((innerState as StackNavigationState<ParamListBase>).preloadedRoutes).toEqual([
+      {
+        key: expect.stringMatching(/^test-/),
+        name: 'test',
+        params: {},
+      },
+    ]);
   });
 });
 

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -220,7 +220,7 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
     expect(routeSourceByName).toEqual({ index: 'layout', second: 'filesystem' });
   });
 
-  it('keeps Protected screens whose guard is false hidden', () => {
+  it('keeps Protected screens whose guard is false registered but hidden', () => {
     renderRouter({
       _layout: () => (
         <StandardTabs>
@@ -239,6 +239,7 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
 
     expect(args.state.routes.map((route) => route.name)).toEqual(['index', 'second']);
     expect(args.descriptors[second.key]!.options).toMatchObject({ hidden: true });
+    expect(screen.queryByTestId('second')).toBeNull();
   });
 
   it('propagates route params into state and href', () => {

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -9,7 +9,7 @@ import { useColorSchemeChangesIfNeeded } from './global-state/utils';
 // Direct import to prevent a require cycle
 import { useCurrentRouteInfo } from './hooks/useCurrentRouteInfo';
 import EXPO_ROUTER_IMPORT_MODE from './import-mode';
-import { useGuardRedirect } from './layouts/GuardContext';
+import { isRouteGuarded, useGuardRedirect, type GuardedRedirects } from './layouts/GuardContext';
 import { Redirect } from './link/Redirect';
 import { ZoomTransitionEnabler } from './link/zoom/ZoomTransitionEnabler';
 import { ZoomTransitionTargetContextProvider } from './link/zoom/zoom-transition-context-providers';
@@ -33,7 +33,7 @@ import {
   type ScreenListeners,
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
-import type { Href, UnknownOutputParams } from './types';
+import type { UnknownOutputParams } from './types';
 import { EmptyRoute } from './views/EmptyRoute';
 import {
   SuspenseFallback as DefaultSuspenseFallback,
@@ -180,7 +180,7 @@ function getSortedChildren(
  */
 export function useSortedScreens(
   order: ScreenProps[],
-  guardedRedirects: Map<string, Href | undefined> = new Map()
+  guardedRedirects: GuardedRedirects = new Map()
 ): React.ReactNode[] {
   const node = useRouteNode();
 
@@ -189,17 +189,8 @@ export function useSortedScreens(
   return React.useMemo(() => {
     const screensWithGuarded = sorted.map((value) => {
       const route = value.route.route;
-      const isGuarded =
-        guardedRedirects.has(route) || guardedRedirects.has(route.replace(/\/index$/, ''));
-      return { ...value, isGuarded };
+      return { ...value, isGuarded: isRouteGuarded(route, guardedRedirects) };
     });
-    const allScreensGuarded =
-      screensWithGuarded.length > 0 && screensWithGuarded.every((item) => item.isGuarded);
-
-    if (allScreensGuarded) {
-      return [];
-    }
-
     return screensWithGuarded.map((value) => {
       return routeToScreen(value.route, value.props, value.isGuarded, value.routeSource);
     });
@@ -319,7 +310,8 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     const isFocused = navigation.isFocused();
     const store = useExpoRouterStore();
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
-    const guardRedirect = useGuardRedirect(value.route);
+    const redirectHref = useGuardRedirect(value.route);
+    const isGuarded = redirectHref !== undefined;
 
     const ResolvedSuspenseFallback =
       EXPO_ROUTER_IMPORT_MODE === 'lazy'
@@ -330,7 +322,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         ? (LayoutSuspenseFallback ?? InheritedSuspenseFallback)
         : InheritedSuspenseFallback;
 
-    if (isFocused && !guardRedirect) {
+    if (isFocused && !isGuarded) {
       const state = navigation.getState();
       const isLeaf = !(state && 'state' in state.routes[state.index]!);
       if (isLeaf && stateForPath) store.setFocusedState(stateForPath);
@@ -345,9 +337,9 @@ export function getQualifiedRouteComponent(value: RouteNode) {
           // if the component itself didn’t rerender and the route info changed.
           // Otherwise, the update from the `if` above will handle it,
           // and this won’t cause a redundant second update.
-          if (isLeaf && stateForPath && !guardRedirect) store.setFocusedState(stateForPath);
+          if (isLeaf && stateForPath && !isGuarded) store.setFocusedState(stateForPath);
         }),
-      [navigation, guardRedirect]
+      [navigation, isGuarded]
     );
 
     useEffect(() => {
@@ -364,13 +356,24 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       });
     }, [navigation]);
 
+    useEffect(() => {
+      if (__DEV__ && isFocused && isGuarded && redirectHref == null) {
+        console.warn(
+          'All routes in this navigator are protected. Ensure at least one route is accessible.'
+        );
+      }
+    }, [isFocused, isGuarded, redirectHref]);
+
     const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;
 
-    if (guardRedirect) {
+    if (isGuarded) {
+      // A `null` href means guarded with no destination to redirect to (every
+      // candidate is also guarded): render nothing but keep the screen registered
+      // so the navigator and its state stay mounted.
       return (
         <Route node={value} params={route?.params}>
-          <Redirect href={guardRedirect} />
+          {redirectHref != null ? <Redirect href={redirectHref} /> : null}
         </Route>
       );
     }


### PR DESCRIPTION
# Why

At the moment when all routes in navigator are protected the filtering passes empty `routeNames` array, so navigator does not register. Since we want to remove the `routeNames` change detection behavior, we need to replace this with redirect to parent instead

# How

1. Pass fallback from parent to children via context
2. Redirect to parent when no redirect is possible in current navigator

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>