### PR TITLE
fix(expo-sqlite): set isStepCalled in getFirstSync and generatorSync

### DIFF
--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -554,6 +554,7 @@ class SQLiteExecuteSyncResultImpl<T> {
         'The SQLite cursor has been shifted and is unable to retrieve the first row without being reset. Invoke `resetSync()` to reset the cursor first if you want to retrieve the first row.'
       );
     }
+    this.isStepCalled = true;
     const columnNames = this.getColumnNamesSync();
     const firstRowValues = this.popFirstRowValues();
     if (firstRowValues != null) {
@@ -589,6 +590,7 @@ class SQLiteExecuteSyncResultImpl<T> {
   }
 
   *generatorSync(): IterableIterator<T> {
+    this.isStepCalled = true;
     const columnNames = this.getColumnNamesSync();
     const firstRowValues = this.popFirstRowValues();
     if (firstRowValues != null) {


### PR DESCRIPTION
## Why

`SQLiteExecuteSyncResultImpl.getFirstSync()` checks `this.isStepCalled` to prevent double-retrieval but **never sets it to `true`** after advancing the cursor. This means:

1. A second call to `getFirstSync()` passes the guard silently. On the second call, `popFirstRowValues()` returns `null` (already consumed), so `stepSync()` is called — advancing the cursor — and row 2 is returned as if it were row 1.
2. `generatorSync()` (the `for...of` path) also never sets `isStepCalled = true`, so after partial iteration `getAllSync()` or `getFirstSync()` can be called again on an already-advanced cursor without an error being thrown.

The async counterparts (`getFirstAsync`, `generatorAsync`) both correctly set `this.isStepCalled = true`. This PR aligns the sync path.

**Failure scenario:**
```ts
const stmt = db.prepareSync('SELECT id FROM items');
const result = stmt.executeSync();
const first = result.getFirstSync();   // returns row 1 ✓
const again = result.getFirstSync();   // should throw, but instead returns row 2 ✗
```

## What changed

`packages/expo-sqlite/src/SQLiteStatement.ts` — two one-line additions:
- `getFirstSync()`: add `this.isStepCalled = true` after the guard, matching `getFirstAsync()`
- `generatorSync()`: add `this.isStepCalled = true` at the top, matching `generatorAsync()`

## Testing

Verify with:
```ts
const stmt = db.prepareSync('SELECT id FROM t ORDER BY id');
const r = stmt.executeSync<{ id: number }>();
r.getFirstSync(); // row 1
// Before fix: second call returns row 2 silently
// After fix: throws "cursor has been shifted" error
r.getFirstSync();
```