### PR TITLE
fix(expo-sqlite): set isStepCalled in sync result methods

### DIFF
--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -554,6 +554,7 @@ class SQLiteExecuteSyncResultImpl<T> {
         'The SQLite cursor has been shifted and is unable to retrieve the first row without being reset. Invoke `resetSync()` to reset the cursor first if you want to retrieve the first row.'
       );
     }
+    this.isStepCalled = true;
     const columnNames = this.getColumnNamesSync();
     const firstRowValues = this.popFirstRowValues();
     if (firstRowValues != null) {
@@ -571,6 +572,7 @@ class SQLiteExecuteSyncResultImpl<T> {
         'The SQLite cursor has been shifted and is unable to retrieve all rows without being reset. Invoke `resetSync()` to reset the cursor first if you want to retrieve all rows.'
       );
     }
+    this.isStepCalled = true;
     const firstRowValues = this.popFirstRowValues();
     if (firstRowValues == null) {
       // If the first row is empty, this SQL query may be a write operation. We should not call `statement.getAllAsync()` to write again.
@@ -589,6 +591,7 @@ class SQLiteExecuteSyncResultImpl<T> {
   }
 
   *generatorSync(): IterableIterator<T> {
+    this.isStepCalled = true;
     const columnNames = this.getColumnNamesSync();
     const firstRowValues = this.popFirstRowValues();
     if (firstRowValues != null) {


### PR DESCRIPTION
## Summary

`SQLiteExecuteSyncResultImpl` never sets `this.isStepCalled = true`, so the guard that prevents misuse after the SQLite cursor has advanced is completely ineffective in the synchronous API.

**Affected methods** in `SQLiteExecuteSyncResultImpl`:

| Method | Checks `isStepCalled` | Sets it |
|---|---|---|
| `getFirstSync()` | yes | no |
| `getAllSync()` | yes | no |
| `generatorSync()` | — | no |

The **async counterparts** in `SQLiteExecuteAsyncResultImpl` all set the flag correctly (`getFirstAsync`, `getAllAsync`, `generatorAsync`).

## Impact

Because the flag is never set, calling `getFirstSync()` followed by `getAllSync()` (or iterating with `for...of` then calling `getFirstSync()`) does **not** throw the expected cursor-shifted error. Instead, the second call silently re-reads from a partially-advanced cursor or calls `stepSync` after the cursor is exhausted, leading to incorrect results or undefined behaviour.

```ts
const result = stmt.executeSync<Row>();

result.getFirstSync();  // consumes first row, cursor advances
result.getAllSync();    // should throw, but isStepCalled is still false → proceeds silently
```

## Fix

Add `this.isStepCalled = true` at the entry point of each of the three methods, mirroring the async path.