### PR TITLE
[package-manager] Disable package manager release age gates for trusted installs

### DIFF
--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolve through package manager release age gates (npm `min-release-age`, pnpm `minimumReleaseAge`, Yarn `npmMinimalAgeGate`, Bun `install.minimumReleaseAge`) during trusted installs. ([#44479](https://github.com/expo/expo/issues/44479))
+- Resolve through package manager release age gates (npm `min-release-age`, pnpm `minimumReleaseAge`, Yarn `npmMinimalAgeGate`, Bun `install.minimumReleaseAge`) during trusted installs. ([#47992](https://github.com/expo/expo/pull/47992) by [@soreavis](https://github.com/soreavis))
 
 ### 💡 Others
 

--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve through package manager release age gates (npm `min-release-age`, pnpm `minimumReleaseAge`, Yarn `npmMinimalAgeGate`, Bun `install.minimumReleaseAge`) during trusted installs. ([#44479](https://github.com/expo/expo/issues/44479))
+
 ### 💡 Others
 
 ## 1.12.0 — 2026-05-20

--- a/packages/@expo/package-manager/src/node/BunPackageManager.ts
+++ b/packages/@expo/package-manager/src/node/BunPackageManager.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { resolveWorkspaceRoot, BUN_LOCK_FILE, BUN_TEXT_LOCK_FILE } from '../utils/nodeManagers';
 import { BasePackageManager } from './BasePackageManager';
 
+// Resolve through Bun's `install.minimumReleaseAge` gate (Bun >=1.3) - Expo installs pin known versions (#44479).
+// Keep the `=` form: Bun <=1.2 would treat a separate `0` argument as a package name.
+const MIN_RELEASE_AGE_OVERRIDE = '--minimum-release-age=0';
+
 export class BunPackageManager extends BasePackageManager {
   readonly name = 'bun';
   readonly bin = 'bun';
@@ -27,7 +31,7 @@ export class BunPackageManager extends BasePackageManager {
   }
 
   installAsync(namesOrFlags: string[] = []) {
-    return this.runAsync(['install', ...namesOrFlags]);
+    return this.runAsync(['install', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addAsync(namesOrFlags: string[] = []) {
@@ -35,7 +39,7 @@ export class BunPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', ...namesOrFlags]);
+    return this.runAsync(['add', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addDevAsync(namesOrFlags: string[] = []) {
@@ -43,7 +47,7 @@ export class BunPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', '--dev', ...namesOrFlags]);
+    return this.runAsync(['add', '--dev', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addGlobalAsync(namesOrFlags: string[] = []) {
@@ -51,7 +55,7 @@ export class BunPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', '--global', ...namesOrFlags]);
+    return this.runAsync(['add', '--global', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   removeAsync(namesOrFlags: string[]) {

--- a/packages/@expo/package-manager/src/node/NpmPackageManager.ts
+++ b/packages/@expo/package-manager/src/node/NpmPackageManager.ts
@@ -13,6 +13,33 @@ export class NpmPackageManager extends BasePackageManager {
   readonly bin = 'npm';
   readonly lockFile = NPM_LOCK_FILE;
 
+  private npmVersionPromise?: Promise<string>;
+
+  /**
+   * Resolve through npm's `min-release-age` gate - Expo installs pin known versions (#44479).
+   * npm 11.0-11.9 warns about the unknown env config on every command, so only set it when
+   * npm >=11.10 understands the setting.
+   */
+  private async withMinReleaseAgeEnvAsync(): Promise<NodeJS.ProcessEnv> {
+    try {
+      this.npmVersionPromise ??= this.versionAsync();
+      const [major = 0, minor = 0] = (await this.npmVersionPromise).split('.').map(Number);
+      if (major > 11 || (major === 11 && minor >= 10)) {
+        return { npm_config_min_release_age: '0', ...this.options.env };
+      }
+    } catch {
+      // Run without the override and let the install itself surface any real error
+    }
+    return this.options.env ?? {};
+  }
+
+  installAsync(flags: string[] = []) {
+    return createPendingSpawnAsync(
+      () => this.withMinReleaseAgeEnvAsync(),
+      (env) => this.runAsync(['install', ...flags], { env })
+    );
+  }
+
   workspaceRoot() {
     const root = resolveWorkspaceRoot(this.ensureCwdDefined('workspaceRoot'));
     if (root) {
@@ -35,11 +62,16 @@ export class NpmPackageManager extends BasePackageManager {
     const { flags, versioned, unversioned } = this.parsePackageSpecs(namesOrFlags);
 
     return createPendingSpawnAsync(
-      () => this.updatePackageFileAsync(versioned, 'dependencies'),
-      () =>
+      async () => {
+        await this.updatePackageFileAsync(versioned, 'dependencies');
+        return this.withMinReleaseAgeEnvAsync();
+      },
+      (env) =>
         !unversioned.length
-          ? this.runAsync(['install', ...flags])
-          : this.runAsync(['install', '--save', ...flags, ...unversioned.map((spec) => spec.raw)])
+          ? this.runAsync(['install', ...flags], { env })
+          : this.runAsync(['install', '--save', ...flags, ...unversioned.map((spec) => spec.raw)], {
+              env,
+            })
     );
   }
 
@@ -51,16 +83,17 @@ export class NpmPackageManager extends BasePackageManager {
     const { flags, versioned, unversioned } = this.parsePackageSpecs(namesOrFlags);
 
     return createPendingSpawnAsync(
-      () => this.updatePackageFileAsync(versioned, 'devDependencies'),
-      () =>
+      async () => {
+        await this.updatePackageFileAsync(versioned, 'devDependencies');
+        return this.withMinReleaseAgeEnvAsync();
+      },
+      (env) =>
         !unversioned.length
-          ? this.runAsync(['install', ...flags])
-          : this.runAsync([
-              'install',
-              '--save-dev',
-              ...flags,
-              ...unversioned.map((spec) => spec.raw),
-            ])
+          ? this.runAsync(['install', ...flags], { env })
+          : this.runAsync(
+              ['install', '--save-dev', ...flags, ...unversioned.map((spec) => spec.raw)],
+              { env }
+            )
     );
   }
 
@@ -69,7 +102,10 @@ export class NpmPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['install', '--global', ...namesOrFlags]);
+    return createPendingSpawnAsync(
+      () => this.withMinReleaseAgeEnvAsync(),
+      (env) => this.runAsync(['install', '--global', ...namesOrFlags], { env })
+    );
   }
 
   removeAsync(namesOrFlags: string[]) {

--- a/packages/@expo/package-manager/src/node/PnpmPackageManager.ts
+++ b/packages/@expo/package-manager/src/node/PnpmPackageManager.ts
@@ -2,6 +2,9 @@ import env from '../utils/env';
 import { resolveWorkspaceRoot, PNPM_LOCK_FILE } from '../utils/nodeManagers';
 import { BasePackageManager } from './BasePackageManager';
 
+// Resolve through pnpm's `minimumReleaseAge` gate (on by default since pnpm 11) - Expo installs pin known versions (#44479)
+const MIN_RELEASE_AGE_OVERRIDE = '--config.minimumReleaseAge=0';
+
 export class PnpmPackageManager extends BasePackageManager {
   readonly name = 'pnpm';
   readonly bin = 'pnpm';
@@ -26,7 +29,7 @@ export class PnpmPackageManager extends BasePackageManager {
       namesOrFlags.unshift('--no-frozen-lockfile');
     }
 
-    return this.runAsync(['install', ...namesOrFlags]);
+    return this.runAsync(['install', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addAsync(namesOrFlags: string[] = []) {
@@ -34,7 +37,7 @@ export class PnpmPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', ...namesOrFlags]);
+    return this.runAsync(['add', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addDevAsync(namesOrFlags: string[] = []) {
@@ -42,7 +45,7 @@ export class PnpmPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', '--save-dev', ...namesOrFlags]);
+    return this.runAsync(['add', '--save-dev', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   addGlobalAsync(namesOrFlags: string[] = []) {
@@ -50,7 +53,7 @@ export class PnpmPackageManager extends BasePackageManager {
       return this.installAsync();
     }
 
-    return this.runAsync(['add', '--global', ...namesOrFlags]);
+    return this.runAsync(['add', '--global', ...namesOrFlags, MIN_RELEASE_AGE_OVERRIDE]);
   }
 
   removeAsync(namesOrFlags: string[]) {

--- a/packages/@expo/package-manager/src/node/YarnPackageManager.ts
+++ b/packages/@expo/package-manager/src/node/YarnPackageManager.ts
@@ -8,9 +8,29 @@ export class YarnPackageManager extends BasePackageManager {
   readonly bin = 'yarnpkg';
   readonly lockFile = YARN_LOCK_FILE;
 
+  private yarnVersionPromise?: Promise<string>;
+
   /** Check if Yarn is running in offline mode, and add the `--offline` flag */
   private async withOfflineFlagAsync(namesOrFlags: string[]): Promise<string[]> {
     return (await isYarnOfflineAsync()) ? [...namesOrFlags, '--offline'] : namesOrFlags;
+  }
+
+  /**
+   * Resolve through Yarn's `npmMinimalAgeGate` quarantine (on by default since Yarn 4.15) -
+   * Expo installs pin known versions (#44479). Yarn <4.10 exits with a usage error when this
+   * setting is present in the environment, so only set it when the version supports it.
+   */
+  private async withDisabledAgeGateEnvAsync(): Promise<NodeJS.ProcessEnv> {
+    try {
+      this.yarnVersionPromise ??= this.versionAsync();
+      const [major = 0, minor = 0] = (await this.yarnVersionPromise).split('.').map(Number);
+      if (major > 4 || (major === 4 && minor >= 10)) {
+        return { YARN_NPM_MINIMAL_AGE_GATE: '0', ...this.options.env };
+      }
+    } catch {
+      // Run without the override and let the install itself surface any real error
+    }
+    return this.options.env ?? {};
   }
 
   workspaceRoot() {
@@ -29,8 +49,11 @@ export class YarnPackageManager extends BasePackageManager {
 
   installAsync(flags: string[] = []) {
     return createPendingSpawnAsync(
-      () => this.withOfflineFlagAsync(['install']),
-      (args) => this.runAsync([...args, ...flags])
+      async () => ({
+        args: await this.withOfflineFlagAsync(['install']),
+        env: await this.withDisabledAgeGateEnvAsync(),
+      }),
+      ({ args, env }) => this.runAsync([...args, ...flags], { env })
     );
   }
 
@@ -40,8 +63,11 @@ export class YarnPackageManager extends BasePackageManager {
     }
 
     return createPendingSpawnAsync(
-      () => this.withOfflineFlagAsync(['add', ...namesOrFlags]),
-      (args) => this.runAsync(args)
+      async () => ({
+        args: await this.withOfflineFlagAsync(['add', ...namesOrFlags]),
+        env: await this.withDisabledAgeGateEnvAsync(),
+      }),
+      ({ args, env }) => this.runAsync(args, { env })
     );
   }
 
@@ -51,8 +77,11 @@ export class YarnPackageManager extends BasePackageManager {
     }
 
     return createPendingSpawnAsync(
-      () => this.withOfflineFlagAsync(['add', '--dev', ...namesOrFlags]),
-      (args) => this.runAsync(args)
+      async () => ({
+        args: await this.withOfflineFlagAsync(['add', '--dev', ...namesOrFlags]),
+        env: await this.withDisabledAgeGateEnvAsync(),
+      }),
+      ({ args, env }) => this.runAsync(args, { env })
     );
   }
 
@@ -62,8 +91,11 @@ export class YarnPackageManager extends BasePackageManager {
     }
 
     return createPendingSpawnAsync(
-      () => this.withOfflineFlagAsync(['global', 'add', ...namesOrFlags]),
-      (args) => this.runAsync(args)
+      async () => ({
+        args: await this.withOfflineFlagAsync(['global', 'add', ...namesOrFlags]),
+        env: await this.withDisabledAgeGateEnvAsync(),
+      }),
+      ({ args, env }) => this.runAsync(args, { env })
     );
   }
 

--- a/packages/@expo/package-manager/src/node/__tests__/BunPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/BunPackageManager-test.ts
@@ -149,6 +149,30 @@ describe('BunPackageManager', () => {
     });
   });
 
+  describe('minimumReleaseAge', () => {
+    it('disables the release age gate when installing', async () => {
+      const bun = new BunPackageManager({ cwd: projectRoot });
+      await bun.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'bun',
+        ['install', '--minimum-release-age=0'],
+        expect.anything()
+      );
+    });
+
+    it('disables the release age gate when adding packages', async () => {
+      const bun = new BunPackageManager({ cwd: projectRoot });
+      await bun.addAsync(['expo']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'bun',
+        ['add', 'expo', '--minimum-release-age=0'],
+        expect.anything()
+      );
+    });
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const bun = new BunPackageManager({ cwd: projectRoot });
@@ -156,7 +180,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['install'],
+        ['install', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -167,7 +191,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['install', '--ignore-scripts'],
+        ['install', '--ignore-scripts', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -213,7 +237,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['install'],
+        ['install', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -224,7 +248,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '@react-navigation/native'],
+        ['add', '@react-navigation/native', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -235,7 +259,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '@react-navigation/native', '@react-navigation/drawer'],
+        ['add', '@react-navigation/native', '@react-navigation/drawer', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -248,7 +272,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['install'],
+        ['install', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -259,7 +283,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '--dev', 'eslint'],
+        ['add', '--dev', 'eslint', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -270,7 +294,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '--dev', 'eslint', 'prettier'],
+        ['add', '--dev', 'eslint', 'prettier', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -283,7 +307,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['install'],
+        ['install', '--minimum-release-age=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -294,7 +318,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '--global', 'expo-cli@^5'],
+        ['add', '--global', 'expo-cli@^5', '--minimum-release-age=0'],
         expect.anything()
       );
     });
@@ -305,7 +329,7 @@ describe('BunPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'bun',
-        ['add', '--global', 'expo-cli@^5', 'eas-cli'],
+        ['add', '--global', 'expo-cli@^5', 'eas-cli', '--minimum-release-age=0'],
         expect.anything()
       );
     });

--- a/packages/@expo/package-manager/src/node/__tests__/NpmPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/NpmPackageManager-test.ts
@@ -51,6 +51,71 @@ describe('NpmPackageManager', () => {
     });
   });
 
+  describe('minReleaseAge', () => {
+    it('disables the release age gate for npm 11.10 and newer', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.resolve({ stdout: '11.17.0\n' }))
+            : mockSpawnPromise()
+        );
+
+      const npm = new NpmPackageManager({ cwd: projectRoot });
+      await npm.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        ['install'],
+        expect.objectContaining({
+          env: expect.objectContaining({ npm_config_min_release_age: '0' }),
+        })
+      );
+    });
+
+    it('does not set the release age variable for npm older than 11.10', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.resolve({ stdout: '11.9.0\n' }))
+            : mockSpawnPromise()
+        );
+
+      const npm = new NpmPackageManager({ cwd: projectRoot });
+      await npm.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        ['install'],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ npm_config_min_release_age: expect.anything() }),
+        })
+      );
+    });
+
+    it('installs without the release age variable when the version probe fails', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.reject(new Error('npm not found')))
+            : mockSpawnPromise()
+        );
+
+      const npm = new NpmPackageManager({ cwd: projectRoot });
+      await npm.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        ['install'],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ npm_config_min_release_age: expect.anything() }),
+        })
+      );
+    });
+  });
+
   describe('runBinAsync', () => {
     it('executes npx with the expected command and options', async () => {
       const npm = new NpmPackageManager({ cwd: projectRoot });

--- a/packages/@expo/package-manager/src/node/__tests__/PnpmPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/PnpmPackageManager-test.ts
@@ -162,6 +162,30 @@ describe('PnpmPackageManager', () => {
     });
   });
 
+  describe('minimumReleaseAge', () => {
+    it('disables the release age gate when installing', async () => {
+      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      await pnpm.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'pnpm',
+        ['install', '--config.minimumReleaseAge=0'],
+        expect.anything()
+      );
+    });
+
+    it('disables the release age gate when adding packages', async () => {
+      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      await pnpm.addAsync(['expo']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'pnpm',
+        ['add', 'expo', '--config.minimumReleaseAge=0'],
+        expect.anything()
+      );
+    });
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const pnpm = new PnpmPackageManager({ cwd: projectRoot });
@@ -169,7 +193,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['install'],
+        ['install', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -180,7 +204,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['install', '--ignore-scripts'],
+        ['install', '--ignore-scripts', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -192,7 +216,7 @@ describe('PnpmPackageManager', () => {
 
         expect(spawnAsync).toHaveBeenCalledWith(
           'pnpm',
-          ['install'],
+          ['install', '--config.minimumReleaseAge=0'],
           expect.objectContaining({ cwd: projectRoot })
         );
       });
@@ -205,7 +229,7 @@ describe('PnpmPackageManager', () => {
 
         expect(spawnAsync).toHaveBeenCalledWith(
           'pnpm',
-          ['install', '--no-frozen-lockfile'],
+          ['install', '--no-frozen-lockfile', '--config.minimumReleaseAge=0'],
           expect.objectContaining({ cwd: projectRoot })
         );
       });
@@ -218,7 +242,7 @@ describe('PnpmPackageManager', () => {
 
         expect(spawnAsync).toHaveBeenCalledWith(
           'pnpm',
-          ['install', '--frozen-lockfile'],
+          ['install', '--frozen-lockfile', '--config.minimumReleaseAge=0'],
           expect.objectContaining({ cwd: projectRoot })
         );
       });
@@ -265,7 +289,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['install'],
+        ['install', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -276,7 +300,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '@react-navigation/native'],
+        ['add', '@react-navigation/native', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -287,7 +311,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '@react-navigation/native', '@react-navigation/drawer'],
+        ['add', '@react-navigation/native', '@react-navigation/drawer', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -300,7 +324,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['install'],
+        ['install', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -311,7 +335,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '--save-dev', 'eslint'],
+        ['add', '--save-dev', 'eslint', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -322,7 +346,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '--save-dev', 'eslint', 'prettier'],
+        ['add', '--save-dev', 'eslint', 'prettier', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -335,7 +359,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['install'],
+        ['install', '--config.minimumReleaseAge=0'],
         expect.objectContaining({ cwd: projectRoot })
       );
     });
@@ -346,7 +370,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '--global', 'expo-cli@^5'],
+        ['add', '--global', 'expo-cli@^5', '--config.minimumReleaseAge=0'],
         expect.anything()
       );
     });
@@ -357,7 +381,7 @@ describe('PnpmPackageManager', () => {
 
       expect(spawnAsync).toHaveBeenCalledWith(
         'pnpm',
-        ['add', '--global', 'expo-cli@^5', 'eas-cli'],
+        ['add', '--global', 'expo-cli@^5', 'eas-cli', '--config.minimumReleaseAge=0'],
         expect.anything()
       );
     });

--- a/packages/@expo/package-manager/src/node/__tests__/YarnPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/YarnPackageManager-test.ts
@@ -149,6 +149,71 @@ describe('YarnPackageManager', () => {
     });
   });
 
+  describe('npmMinimalAgeGate', () => {
+    it('disables the age gate for yarn 4.10 and newer', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.resolve({ stdout: '4.17.1\n' }))
+            : mockSpawnPromise()
+        );
+
+      const yarn = new YarnPackageManager({ cwd: projectRoot });
+      await yarn.addAsync(['expo']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'yarnpkg',
+        ['add', 'expo'],
+        expect.objectContaining({
+          env: expect.objectContaining({ YARN_NPM_MINIMAL_AGE_GATE: '0' }),
+        })
+      );
+    });
+
+    it('does not set the age gate variable for yarn classic', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.resolve({ stdout: '1.22.22\n' }))
+            : mockSpawnPromise()
+        );
+
+      const yarn = new YarnPackageManager({ cwd: projectRoot });
+      await yarn.addAsync(['expo']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'yarnpkg',
+        ['add', 'expo'],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ YARN_NPM_MINIMAL_AGE_GATE: expect.anything() }),
+        })
+      );
+    });
+
+    it('installs without the age gate variable when the version probe fails', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation((_command, args) =>
+          args?.[0] === '--version'
+            ? mockSpawnPromise(Promise.reject(new Error('yarn not found')))
+            : mockSpawnPromise()
+        );
+
+      const yarn = new YarnPackageManager({ cwd: projectRoot });
+      await yarn.addAsync(['expo']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'yarnpkg',
+        ['add', 'expo'],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ YARN_NPM_MINIMAL_AGE_GATE: expect.anything() }),
+        })
+      );
+    });
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const yarn = new YarnPackageManager({ cwd: projectRoot });


### PR DESCRIPTION
# Why

Closes #44479

All four package managers now ship a release age gate that blocks resolving versions published less than N minutes/days ago, and two of them turned it on by default: pnpm `minimumReleaseAge` (24h by default since pnpm 11) and Yarn `npmMinimalAgeGate` (`1d` by default since Yarn 4.15). npm has `min-release-age` (11.10+, off by default) and Bun has `install.minimumReleaseAge` (1.3+, off by default). The day after any Expo package publishes, `npx expo install` fails for every pnpm 11 / Yarn 4.15+ project — and `expo install --fix` fails the same way, which is the loop reported in the issue.

Following the direction in https://github.com/expo/expo/pull/45770#discussion_r3241884723: no post-validation — the gate is disabled proactively for the spawned install, since `expo install` resolves versions pinned for the SDK and is fundamentally a trusted install. Surfacing the gate errors instead turned out not to be consistently possible: npm's common case produces no error at all (an unpinned range silently resolves to an older version), npm's pinned case fails with the generic `ENOVERSIONS`/`ETARGET` shapes that also mean "package doesn't exist", pnpm 10.x still uses the generic `ERR_PNPM_NO_MATCHING_VERSION` (the dedicated `ERR_PNPM_NO_MATURE_MATCHING_VERSION` is v11-only), and Bun has no stable error signature.

# How

Each manager gets the one mechanism that is both effective and safe across the versions it can meet, verified empirically against npm 9.9.4 / 10.9.3 / 11.9.0 / 11.17.0, pnpm 8.15.9 / 9.15.9 / 10.15.1 / 10.34.5 / 11.15.1, Yarn 1.22.22 / 4.9.4 / 4.17.1, and Bun 1.2.23 / 1.3.14:

| Manager | Mechanism | Why this shape |
| --- | --- | --- |
| npm | `npm_config_min_release_age=0`, set only when `npm --version` reports ≥ 11.10 | Env config maps to `min-release-age`, but npm 11.0–11.9 prints `npm warn Unknown env config "min-release-age"` on every command when the variable is present (npm 9/10 ignore it silently), so the version probe is required. The probe result is cached per manager instance; a probe failure falls back to running without the override. |
| pnpm | `--config.minimumReleaseAge=0` appended to `install`/`add` | The env route (`pnpm_config_minimum_release_age`) only exists on pnpm 11; the `--config.` flag works on 10.16+ and 11, and is accepted as a no-op by pnpm 8/9/10.15. |
| Yarn | `YARN_NPM_MINIMAL_AGE_GATE=0`, set only when `yarn --version` reports ≥ 4.10 | Yarn Berry < 4.10 exits with `Usage Error: Unrecognized or legacy configuration settings found: npmMinimalAgeGate` when the variable is present, so the version probe is required. Same cached-probe/fail-open shape as npm. |
| Bun | `--minimum-release-age=0` appended to `install`/`add` | No env override exists. The `=` form is required: Bun ≤ 1.2 treats a separate `0` argument as a package name and installs a package literally called `0` (verified on 1.2.23); the `=` form is silently ignored there and disables the gate on 1.3+. |

`remove` commands are untouched (no resolution happens). The raw `runAsync` passthrough is untouched. Precedence note, stated plainly: the env-based overrides (npm/Yarn) are outranked by a user's own exported env variable — that keeps an escape hatch — but they do override the project's `.npmrc`/`.yarnrc.yml` gate, and the pnpm/Bun CLI flags override everything for the spawned command. That is the intent: the gate keeps protecting the user's own installs, while installs the Expo CLI drives resolve the versions it pinned.

# Test Plan

- `et check-packages @expo/package-manager` green (build, typecheck, lint, test — 213 jest tests, 11 new: per-manager gate-disable assertions, plus version-gate cases for npm ≥ 11.10 / < 11.10 / probe-failure and Yarn ≥ 4.10 / classic / probe-failure).
- Live verification with a deterministic block (gate set to ~100 years so every version of the probe package is too young), per manager: blocked install fails → same install through the override succeeds. Examples: npm 11.17 `.npmrc min-release-age=36500` → `ENOVERSIONS`, then env override → clean install; pnpm 11.15.1 `pnpm-workspace.yaml minimumReleaseAge: 52560000` → blocked, then `--config.minimumReleaseAge=0` → clean; Yarn 4.17.1 `.yarnrc.yml npmMinimalAgeGate: 525600000` → "All versions satisfying … are quarantined", then env → clean; Bun 1.3.14 `bunfig.toml` gate → blocked, then `--minimum-release-age=0` → clean.
- Old-version safety, verified per mechanism: npm 11.9.0 with the env variable present warns (`npm warn Unknown env config "min-release-age"`) and without it is clean — the version gate prevents exactly this; npm 9.9.4 / 10.9.3 ignore the variable silently; pnpm 8.15.9 / 9.15.9 / 10.15.1 accept the `--config.` flag as a no-op; Yarn 4.9.4 with the env variable present hard-fails (`Usage Error`) — gated out; Bun 1.2.23 with the space-form flag installs a junk package named `0` — the `=` form avoids it and is silently ignored there.

# Checklist

- [x] Added a `CHANGELOG.md` entry (`packages/@expo/package-manager/CHANGELOG.md`)
- [x] `et check-packages @expo/package-manager` passes (build, typecheck, lint, test)
- [x] Conforms to the [contribution guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md)
