### PR TITLE
[config-plugins] Skip non-string locale values instead of writing "[object Object]"

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Skip non-string values in `locales` JSON files instead of writing `[object Object]` into `InfoPlist.strings` and `strings.xml`, and warn with the offending keys. ([#16003](https://github.com/expo/expo/issues/16003))
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Skip non-string values in `locales` JSON files instead of writing `[object Object]` into `InfoPlist.strings` and `strings.xml`, and warn with the offending keys. ([#16003](https://github.com/expo/expo/issues/16003))
+- Skip non-string values in `locales` JSON files instead of writing `[object Object]` into `InfoPlist.strings` and `strings.xml`, and warn with the offending keys. ([#47993](https://github.com/expo/expo/pull/47993) by [@soreavis](https://github.com/soreavis))
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/src/android/__tests__/Locales-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Locales-test.ts
@@ -112,4 +112,35 @@ describe('e2e: Android locales', () => {
       'https://docs.expo.dev/guides/localization/#translating-app-metadata'
     );
   });
+
+  it('skips non-string values instead of writing "[object Object]"', async () => {
+    await setLocalesAsync(
+      {
+        locales: {
+          pt: {
+            app_name: 'pt-name',
+            plugins: { 'expo-camera': { cameraPermission: 'pt-camera-nested' } } as any,
+          },
+        },
+      },
+      { projectRoot }
+    );
+
+    const strings = vol
+      .readFileSync('/app/android/app/src/main/res/values-b+pt/strings.xml')
+      .toString();
+    expect(strings).toMatchInlineSnapshot(`
+      "<resources>
+        <string name="app_name">"pt-name"</string>
+      </resources>"
+    `);
+    expect(strings).not.toMatch(/object Object/);
+
+    expect(WarningAggregator.addWarningForPlatform).toHaveBeenCalledWith(
+      'android',
+      'locales.pt',
+      'Skipped locale keys with invalid values: plugins. Values must be strings.',
+      'https://docs.expo.dev/guides/localization/#translating-app-metadata'
+    );
+  });
 });

--- a/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -76,6 +76,13 @@ describe('e2e: iOS locales', () => {
             app_name: 'de-name',
           },
         }),
+        // nested objects are invalid and must not be written as "[object Object]"
+        'lang/pt.json': JSON.stringify({
+          NSCameraUsageDescription: 'pt-camera',
+          plugins: {
+            'expo-camera': { cameraPermission: 'pt-camera-nested' },
+          },
+        }),
       },
       projectRoot
     );
@@ -143,6 +150,28 @@ describe('e2e: iOS locales', () => {
       'ios',
       'locales.xx',
       'Failed to parse JSON of locale file for language: xx',
+      'https://docs.expo.dev/guides/localization/#translating-app-metadata'
+    );
+  });
+
+  it('skips non-string values instead of writing "[object Object]"', async () => {
+    let project = getPbxproj(projectRoot);
+
+    project = await setLocalesAsync(
+      { locales: { pt: 'lang/pt.json' } },
+      { project, projectRoot }
+    );
+    fs.writeFileSync(project.filepath, project.writeSync());
+
+    const after = getDirFromFS(vol.toJSON(), projectRoot);
+    const infoPlist = after['ios/testproject/Supporting/pt.lproj/InfoPlist.strings'];
+    expect(infoPlist).toBe('NSCameraUsageDescription = "pt-camera";');
+    expect(infoPlist).not.toMatch(/object Object/);
+
+    expect(WarningAggregator.addWarningForPlatform).toHaveBeenCalledWith(
+      'ios',
+      'locales.pt',
+      'Skipped locale keys with invalid values: plugins. Values must be strings.',
       'https://docs.expo.dev/guides/localization/#translating-app-metadata'
     );
   });

--- a/packages/@expo/config-plugins/src/utils/locales.ts
+++ b/packages/@expo/config-plugins/src/utils/locales.ts
@@ -43,9 +43,9 @@ export async function getResolvedLocalesAsync(
         if (localizableStringsEntry) {
           localizableStringsIOS[lang] = localizableStringsEntry;
         }
-        locales[lang] = { ...rest, ...otherEntries };
+        locales[lang] = filterStringValues({ ...rest, ...otherEntries }, lang, forPlatform);
       } else {
-        locales[lang] = { ...rest, ...android };
+        locales[lang] = filterStringValues({ ...rest, ...android }, lang, forPlatform);
       }
     }
   }
@@ -105,6 +105,32 @@ function extractIosLocalizableStrings({ ios, lang }: { ios: StringsMap; lang: st
   }
 
   return { localizableStringsEntry, otherEntries };
+}
+
+/** Drop object values, which the `.strings`/`strings.xml` writers would render as `[object Object]`. */
+function filterStringValues(
+  values: Record<string, unknown>,
+  lang: string,
+  forPlatform: 'ios' | 'android'
+): LocaleJson {
+  const strings: LocaleJson = {};
+  const skipped: string[] = [];
+  for (const [key, value] of Object.entries(values)) {
+    if (typeof value === 'object') {
+      skipped.push(key);
+    } else {
+      strings[key] = value as string;
+    }
+  }
+  if (skipped.length) {
+    addWarningForPlatform(
+      forPlatform,
+      `locales.${lang}`,
+      `Skipped locale keys with invalid values: ${skipped.join(', ')}. Values must be strings.`,
+      'https://docs.expo.dev/guides/localization/#translating-app-metadata'
+    );
+  }
+  return strings;
 }
 
 function isStringsMap(value: unknown): value is StringsMap {


### PR DESCRIPTION
# Why

Related to #16003 (the docs request there stays open — this fixes the code defect surfaced in its thread).

Non-string values in a `locales` JSON file are written verbatim through a template string, so a nested object ends up as the literal text `[object Object]` inside `ios/<project>/Supporting/<lang>.lproj/InfoPlist.strings` and Android's `values-b+<lang>/strings.xml`. Several users hit this in practice while trying to localize permission usage descriptions (https://github.com/expo/expo/issues/16003#issuecomment-3026927867) — the file structure they guessed at nested translations under a `plugins` key, and instead of an error they shipped `[object Object]` as a user-facing permission prompt. Reproduced at `main`: a locale file with `"plugins": { … }` produces `plugins = "[object Object]";` in `InfoPlist.strings`.

# How

`getResolvedLocalesAsync` in `@expo/config-plugins` already validates the special `ios['Localizable.strings']` entry and warns on unparseable locale files, but every other key flows to the platform writers unvalidated. This adds a `filterStringValues` step at the two resolved-map assignment sites (shared by the iOS and Android writers): entries whose value is an object, array, or `null` are skipped, and one warning per language names the skipped keys with the localization docs link — same `addWarningForPlatform` pattern the file already uses.

Scope, deliberately narrow: arrays and `null` are skipped too (both previously produced junk output), while numbers and booleans intentionally keep their historical template-coercion so projects relying on numeric values see no change. For all-string input the output is byte-identical — all 30 existing snapshots pass untouched. Known separate issue, out of scope here: string values containing double quotes are still written unescaped into `.strings`/`strings.xml`; that predates this change and deserves its own fix.

# Test Plan

- Two new e2e tests (iOS + Android `Locales-test.ts`), written first and verified failing against the old code: a locale file with a nested `plugins` object must produce a strings file containing only the valid sibling key (exact match, no `[object Object]`) plus the warning naming the skipped key.
- `et check-packages @expo/config-plugins` green: 68 suites, 439 passed / 2 pre-existing skips, 30/30 snapshots unchanged, `tsc` and `oxlint` clean.
- Manual repro before/after with the resolver on a scratch project: before — `plugins = "[object Object]";` written; after — key skipped, warning `Skipped locale keys with invalid values: plugins. Values must be strings.` shown with the docs link.

# Checklist

- [x] Added a `CHANGELOG.md` entry (`packages/@expo/config-plugins/CHANGELOG.md`)
- [x] `et check-packages @expo/config-plugins` passes (build, typecheck, lint, test)
- [x] Conforms to the [contribution guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md)
