### PR TITLE
[docs] Add API key restriction guidance to FCM credentials guide

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -119,6 +119,8 @@ In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config
 }
 ```
 
+> **Note**: If the API key in **google-services.json** (the `client.api_key.current_key` field) has restrictions in the [Google Cloud API Credentials console](https://console.cloud.google.com/apis/credentials), verify them. Under **API restrictions**, allow both the **FCM Registration API** and the **Firebase Installations API**, or leave the key unrestricted. If you restrict the key to Android apps under **Application restrictions**, use the SHA-1 fingerprint of the **app signing key certificate** from **Release** > **Setup** > **App Integrity** in the Google Play Console, not your upload key (Google Play re-signs your app when distributing it). With a mismatched fingerprint, the Firebase Installations API returns `403 PERMISSION_DENIED: Requests from this Android client application are blocked` and your app never gets a push token.
+
 </Step>
 
 <Step label="6">
@@ -240,6 +242,8 @@ In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config
   }
 }
 ```
+
+> **Note**: If the API key in **google-services.json** (the `client.api_key.current_key` field) has restrictions in the [Google Cloud API Credentials console](https://console.cloud.google.com/apis/credentials), verify them. Under **API restrictions**, allow both the **FCM Registration API** and the **Firebase Installations API**, or leave the key unrestricted. If you restrict the key to Android apps under **Application restrictions**, use the SHA-1 fingerprint of the **app signing key certificate** from **Release** > **Setup** > **App Integrity** in the Google Play Console, not your upload key (Google Play re-signs your app when distributing it). With a mismatched fingerprint, the Firebase Installations API returns `403 PERMISSION_DENIED: Requests from this Android client application are blocked` and your app never gets a push token.
 
 </Step>
 

--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -119,7 +119,7 @@ In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config
 }
 ```
 
-> **Note**: If the API key in **google-services.json** (the `client.api_key.current_key` field) has restrictions in the [Google Cloud API Credentials console](https://console.cloud.google.com/apis/credentials), verify them. Under **API restrictions**, allow both the **FCM Registration API** and the **Firebase Installations API**, or leave the key unrestricted. If you restrict the key to Android apps under **Application restrictions**, use the SHA-1 fingerprint of the **app signing key certificate** from **Release** > **Setup** > **App Integrity** in the Google Play Console, not your upload key (Google Play re-signs your app when distributing it). With a mismatched fingerprint, the Firebase Installations API returns `403 PERMISSION_DENIED: Requests from this Android client application are blocked` and your app never gets a push token.
+> **warning** If the API key in **google-services.json** (the `client.api_key.current_key` field) is restricted, check it in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials). Under **API restrictions**, allow the **FCM Registration API** and the **Firebase Installations API**, or leave the key unrestricted. Under **Application restrictions**, use the SHA-1 from **Release** > **Setup** > **App Integrity** > **App signing key certificate** in the Google Play Console, not your [upload key](/app-signing/app-credentials/#app-signing-by-google-play). A mismatch makes the Firebase Installations API return `403 PERMISSION_DENIED: Requests from this Android client application are blocked`, and your app never receives a push token.
 
 </Step>
 
@@ -242,8 +242,6 @@ In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config
   }
 }
 ```
-
-> **Note**: If the API key in **google-services.json** (the `client.api_key.current_key` field) has restrictions in the [Google Cloud API Credentials console](https://console.cloud.google.com/apis/credentials), verify them. Under **API restrictions**, allow both the **FCM Registration API** and the **Firebase Installations API**, or leave the key unrestricted. If you restrict the key to Android apps under **Application restrictions**, use the SHA-1 fingerprint of the **app signing key certificate** from **Release** > **Setup** > **App Integrity** in the Google Play Console, not your upload key (Google Play re-signs your app when distributing it). With a mismatched fingerprint, the Firebase Installations API returns `403 PERMISSION_DENIED: Requests from this Android client application are blocked` and your app never gets a push token.
 
 </Step>
 


### PR DESCRIPTION
# Why

Closes #18444

The old [Using FCM for Push Notifications] guide told you to verify your **google-services.json** API key's "API restrictions" in the Google Cloud console, and #18444 asked to also document "Application restrictions" — where the trap is using the upload key certificate's SHA-1 fingerprint instead of the app signing key's, which blocks the Firebase Installations API with a 403 in production builds and silently prevents push tokens (log captured in the issue). When the docs moved to the FCM V1 guide, the API restrictions paragraph was dropped too, so today neither half is documented anywhere in the push-notifications section.

This matters more now than in 2022: since May 2024, Firebase applies API restrictions to newly provisioned keys automatically, so more projects run with restricted keys.

# How

One note in the **google-services.json** step of the FCM V1 credentials guide, added to both flows (Create a new key and Use an existing key — the page already repeats its other notes per flow since each is followed standalone). It covers both halves with the current API names from Firebase's docs (the key needs the **FCM Registration API** and **Firebase Installations API** — the old page's "Firebase Cloud Messaging API" is the server send API and isn't what the client key uses), the app-signing-vs-upload-key SHA-1 distinction with the **Release** > **Setup** > **App Integrity** path used by the Google/Facebook authentication guides, and the exact 403 symptom so it's searchable.

# Test Plan

Docs-only change. `vale` (prose lint) 0 errors / 0 warnings / 0 suggestions on the page, `oxfmt --check` clean, and `pnpm lint` + `remark validate-links` outputs are identical to a clean-tree control run (the pre-existing warnings there are unrelated to this page's change). API names verified against [Firebase's API keys documentation](https://firebase.google.com/docs/projects/api-keys); the signing-key distinction against [Play App Signing documentation](https://support.google.com/googleplay/android-developer/answer/9842756); the 403 text against the log captured in #18444.

# Checklist

- [x] Docs-only PR (kept separate from code changes)
- [x] Follows the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] Conforms to the [contribution guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md)
