### PR TITLE
[docs] Move inline eas/* examples into shared MDX partials

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -907,56 +907,15 @@ steps:
 
 #### `eas/checkout`
 
-Checks out your project source files.
-
-```yaml upload.yml
-build:
-  name: List files
-  steps:
-    - eas/checkout
-    - run:
-        name: List assets
-        run: ls assets
-```
-
-<EASFunctionDescription name="checkout" />
+<EASFunctionDescription name="checkout" exampleMode="Custom Build" />
 
 #### `eas/use_npm_token`
 
-Configures Node package managers (bun, npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
-
-Set `NPM_TOKEN` in your project's secrets, and this function will configure the build environment by creating **.npmrc** with the token.
-
-```yaml example.yml
-build:
-  name: Install private npm modules
-  steps:
-    - eas/checkout
-    # @info #
-    - eas/use_npm_token
-    # @end #
-    - run:
-        name: Install dependencies
-        run: npm install # <---- Can now install private packages
-```
-
-<EASFunctionDescription name="use_npm_token" />
+<EASFunctionDescription name="use_npm_token" exampleMode="Custom Build" />
 
 #### `eas/install_node_modules`
 
-Installs node_modules using the package manager (bun, npm, pnpm, or Yarn) detected based on your project. Works with monorepos.
-
-```yaml example.yml
-build:
-  name: Install node modules
-  steps:
-    - eas/checkout
-    # @info #
-    - eas/install_node_modules
-    # @end #
-```
-
-<EASFunctionDescription name="install_node_modules" />
+<EASFunctionDescription name="install_node_modules" exampleMode="Custom Build" />
 
 #### `eas/restore_build_cache`
 
@@ -1096,36 +1055,7 @@ build:
 
 #### `eas/prebuild`
 
-Runs the `expo prebuild` command using the package manager (bun, npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.
-
-```yaml example.yml
-build:
-  name: Run prebuild script
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    - eas/resolve_apple_team_id_from_credentials:
-        id: resolve_apple_team_id_from_credentials
-    # @info #
-    - eas/prebuild:
-        inputs:
-          clean: false
-          apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
-    # @end #
-```
-
-```yaml example.yml
-build:
-  name: Run prebuild script
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    # @info #
-    - eas/prebuild
-    # @end #
-```
-
-<EASFunctionDescription name="prebuild" />
+<EASFunctionDescription name="prebuild" exampleMode="Custom Build" />
 
 #### `eas/configure_eas_update`
 
@@ -1679,26 +1609,7 @@ Uploads files from the job's workspace as an artifact attached to the run. Uploa
 
 > **Warning** **You can currently upload each artifact type only once per build job.**<br />If you use [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts) while having [`buildArtifactPaths`](/eas/json/#buildartifactpaths) configured in your build profile and the step finds and uploads some build artifacts, any following `eas/upload_artifact` step will fail.<br />To solve this, for now, we recommend removing `buildArtifactPaths` from custom build's profiles and uploading artifacts manually with `eas/upload_artifact` in the YAML if you need to call it there.
 
-```yaml upload.yml
-build:
-  name: Upload artifacts
-  steps:
-    - eas/checkout
-    # - ...
-    - eas/upload_artifact:
-        name: Upload application archive
-        inputs:
-          path: fixtures/app-debug.apk
-    - eas/upload_artifact:
-        name: Upload artifacts
-        inputs:
-          type: build-artifact
-          path: |
-            assets/*.jpg
-            assets/*.png
-```
-
-<EASFunctionDescription name="upload_artifact" />
+<EASFunctionDescription name="upload_artifact" exampleMode="Custom Build" />
 
 #### `eas/install_maestro`
 
@@ -1801,225 +1712,33 @@ Sends a specified message to a configured [Slack webhook URL](https://docs.slack
 You can reference build job properties and [use other steps outputs](#use-output-from-one-step-to-another) in the message for dynamic evaluation.
 For example, `'Build URL: ${ eas.job.expoBuildUrl }'`, `Build finished with status: ${ steps.run_fastlane.status_text }`, `Build failed with error: ${ steps.run_gradle.error_text }`.
 
-```yaml send-slack-message.yml
-build:
-  name: Slack your team from custom build
-  steps:
-    # @info #
-    - eas/send_slack_message:
-        name: Send Slack message to a given webhook URL
-        inputs:
-          message: 'This is a message to plain input URL'
-          slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'
-    # @end #
-    - eas/send_slack_message:
-        name: Send Slack message to a default webhook URL from SLACK_HOOK_URL secret
-        inputs:
-          message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
-    - eas/send_slack_message:
-        name: Send Slack message to a webhook URL from specified secret
-        inputs:
-          message: 'This is a test message to a URL from specified secret'
-          slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
-
-    - eas/build
-    - eas/send_slack_message:
-        if: ${ always() }
-        name: Send Slack message when the build finishes (Android)
-        inputs:
-          message: |
-            This is a test message when Android build finishes
-            Status: `${ steps.run_gradle.status_text }`
-            Link: `${ eas.job.expoBuildUrl }`
-    - eas/send_slack_message:
-        if: ${ always() }
-        name: Send Slack message when the build finishes (iOS)
-        inputs:
-          message: |
-            This is a test message when iOS build finishes
-            Status: `${ steps.run_fastlane.status_text }`
-            Link: `${ eas.job.expoBuildUrl }`
-    - eas/send_slack_message:
-        if: ${ failure() }
-        name: Send Slack message when the build fails (Android)
-        inputs:
-          message: |
-            This is a test message when Android build fails
-            Error: `${ steps.run_gradle.error_text }`
-    - eas/send_slack_message:
-        if: ${ failure() }
-        name: Send Slack message when the build fails (iOS)
-        inputs:
-          message: |
-            This is a test message when iOS build fails
-            Error: `${ steps.run_fastlane.error_text }`
-    - eas/send_slack_message:
-        if: ${ success() }
-        name: Send Slack message when the build succeeds
-        inputs:
-          message: |
-            This is a test message when build succeeds
-    - eas/send_slack_message:
-        if: ${ always() }
-        name: Send Slack message with Slack Block Kit layout
-        inputs:
-          payload:
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: |-
-                    Hello, Sir Developer
-
-                     *Your build has finished!*
-              - type: divider
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: |-
-                    *${ eas.env.EAS_BUILD_ID }*
-                    *Status:* `${ steps.run_gradle.status_text }`
-                    *Link:* `${ eas.job.expoBuildUrl }`
-                accessory:
-                  type: image
-                  image_url: [your_image_url]
-                  alt_text: alt text for image
-              - type: divider
-              - type: actions
-                elements:
-                  - type: button
-                    text:
-                      type: plain_text
-                      text: 'Do a thing :rocket:'
-                      emoji: true
-                    value: a_thing
-                  - type: button
-                    text:
-                      type: plain_text
-                      text: 'Do another thing :x:'
-                      emoji: true
-                    value: another_thing
-```
-
-<EASFunctionDescription name="send_slack_message" />
+<EASFunctionDescription name="send_slack_message" exampleMode="Custom Build" />
 
 The following functions connect your build to [PostHog](/guides/using-posthog/). Run `eas integrations:posthog:connect` to link a PostHog project and set the environment variables these functions read. `eas/posthog_capture_event` uses your public project API key, while the other functions use a PostHog personal API key with the scopes noted for each one. For setup, see [Using PostHog](/guides/using-posthog/), and for complete workflows, see [PostHog recipes for EAS Workflows](/guides/using-posthog/recipes).
 
 #### `eas/posthog_capture_event`
 
-Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline.
-
-When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons).
-
-```yaml posthog-capture-event.yml
-build:
-  name: Build and mark the release in PostHog
-  steps:
-    - eas/build
-    - eas/posthog_capture_event:
-        name: Capture a PostHog event
-        inputs:
-          event: store_build_finished
-          properties:
-            platform: ios
-            profile: production
-```
-
-<EASFunctionDescription name="posthog_capture_event" />
+<EASFunctionDescription name="posthog_capture_event" exampleMode="Custom Build" />
 
 #### `eas/posthog_flag_rollout`
 
-Enables, disables, or rolls out a [PostHog feature flag](https://posthog.com/docs/feature-flags). The function looks up the flag by key and then updates it. Provide at least one of `active`, `rollout_percentage`, or `payload`.
-
-```yaml posthog-flag-rollout.yml
-build:
-  name: Roll out a PostHog feature flag
-  steps:
-    - eas/posthog_flag_rollout:
-        name: Roll out the flag to 25 percent
-        inputs:
-          flag: new-checkout
-          rollout_percentage: 25
-```
-
-<EASFunctionDescription name="posthog_flag_rollout" />
+<EASFunctionDescription name="posthog_flag_rollout" exampleMode="Custom Build" />
 
 #### `eas/posthog_wait_for_metric`
 
-Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate on a metric, such as holding until the error count over the last few minutes stays low. The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses.
-
-> **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
-
-```yaml posthog-wait-for-metric.yml
-build:
-  name: Gate on the error count
-  steps:
-    - eas/posthog_wait_for_metric:
-        name: Wait for the error count to stay low
-        inputs:
-          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
-          operator: lt
-          threshold: 10
-```
-
-<EASFunctionDescription name="posthog_wait_for_metric" />
+<EASFunctionDescription name="posthog_wait_for_metric" exampleMode="Custom Build" />
 
 #### `eas/posthog_wait_for_query`
 
-Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead. The step clears when the first column of the first row is `true` or a nonzero number.
-
-> **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
-
-```yaml posthog-wait-for-query.yml
-build:
-  name: Wait for a smoke test event
-  steps:
-    - eas/posthog_wait_for_query:
-        name: Wait for the smoke test to pass
-        inputs:
-          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
-```
-
-<EASFunctionDescription name="posthog_wait_for_query" />
+<EASFunctionDescription name="posthog_wait_for_query" exampleMode="Custom Build" />
 
 #### `eas/posthog_annotation`
 
-Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds, releases, and other milestones next to the metrics they affect.
-
-```yaml posthog-annotation.yml
-build:
-  name: Annotate the release in PostHog
-  steps:
-    - eas/posthog_annotation:
-        name: Create a PostHog annotation
-        inputs:
-          content: Published a production build
-```
-
-<EASFunctionDescription name="posthog_annotation" />
+<EASFunctionDescription name="posthog_annotation" exampleMode="Custom Build" />
 
 #### `eas/posthog_upload_sourcemaps`
 
-Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
-
-> **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
-
-```yaml posthog-upload-sourcemaps.yml
-build:
-  name: Export and upload source maps
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    - run:
-        name: Export the bundle and source maps
-        command: npx expo export --source-maps --platform ios
-    - eas/posthog_upload_sourcemaps:
-        name: Upload source maps to PostHog
-        inputs:
-          directory: dist
-```
-
-<EASFunctionDescription name="posthog_upload_sourcemaps" />
+<EASFunctionDescription name="posthog_upload_sourcemaps" exampleMode="Custom Build" />
 
 ### Using built-in EAS functions to build an app
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1777,169 +1777,33 @@ Below is a list of built-in functions you can use in your workflow steps.
 
 #### `eas/checkout`
 
-Checks out your project source files.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/checkout
-        # @end #
-```
-
-<EASFunctionDescription name="checkout" />
+<EASFunctionDescription name="checkout" exampleMode="Workflow" />
 
 #### `eas/install_node_modules`
 
-Installs node_modules using the package manager (bun, npm, pnpm, or Yarn) detected based on your project. Works with monorepos.
-
-```yaml example.yml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      # @info #
-      - uses: eas/install_node_modules
-      # @end #
-```
-
-<EASFunctionDescription name="install_node_modules" />
+<EASFunctionDescription name="install_node_modules" exampleMode="Workflow" />
 
 #### `eas/download_build`
 
 Downloads application archive of a given build. By default, the downloaded artifact can be an **.apk**, **.aab**, **.ipa**, or **.app** file, or a **.tar.gz** archive containing one or more of these files. If the artifact is a **.tar.gz** archive, it will be extracted and the first file matching the specified extensions will be returned. If the build produced no application archive, the step will fail.
 
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/download_build
-        with:
-          build_id: string # Required. ID of the build to download.
-          extensions: [apk, aab, ipa, app] # Optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
-```
-
-<EASFunctionDescription name="download_build" />
-
-Example usage:
-
-```yaml
-jobs:
-  build_ios:
-    type: build
-    params:
-      platform: ios
-      profile: production
-
-  my_job:
-    needs: [build_ios]
-    steps:
-      - uses: eas/download_build
-        id: download_build
-        with:
-          build_id: ${{ needs.build_ios.outputs.build_id }}
-      - name: Print artifact path
-        run: |
-          echo "Artifact path: ${{ steps.download_build.outputs.artifact_path }}"
-```
+<EASFunctionDescription name="download_build" exampleMode="Workflow" />
 
 #### `eas/prebuild`
 
-Runs the `expo prebuild` command using the package manager (bun, npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      # @info #
-      - uses: eas/prebuild
-      # @end #
-```
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/resolve_apple_team_id_from_credentials
-        id: resolve_apple_team_id_from_credentials
-      # @info #
-      - uses: eas/prebuild
-        with:
-          clean: false
-          apple_team_id: ${{ steps.resolve_apple_team_id_from_credentials.outputs.apple_team_id }}
-      # @end #
-```
-
-<EASFunctionDescription name="prebuild" />
+<EASFunctionDescription name="prebuild" exampleMode="Workflow" />
 
 #### `eas/restore_cache`
 
 Restores a previously saved cache from a specified key. This is useful for speeding up builds by reusing cached artifacts like compiled dependencies, build tools, or other intermediate build outputs.
 
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/prebuild
-      # @info #
-      - uses: eas/restore_cache
-        with:
-          key: cache-${{ hashFiles('package-lock.json') }}
-          restore_keys: cache
-          path: /path/to/cache
-      # @end #
-```
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/prebuild
-      # @info #
-      - uses: eas/restore_cache
-        with:
-          key: cache-${{ hashFiles('package-lock.json') }}
-          path: /path/to/cache
-      # @end #
-```
-
-<EASFunctionDescription name="restore_cache" />
+<EASFunctionDescription name="restore_cache" exampleMode="Workflow" />
 
 #### `eas/save_cache`
 
 Saves a cache to a specified key. This allows you to persist build artifacts, compiled dependencies, or other intermediate outputs that can be reused in subsequent builds to speed up the build process.
 
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/prebuild
-      - uses: eas/restore_cache
-        with:
-          key: cache-${{ hashFiles('package-lock.json') }}
-          path: /path/to/cache
-      - name: Build Android app
-        run: cd android && ./gradlew assembleRelease
-      # @info #
-      - uses: eas/save_cache
-        with:
-          key: cache-${{ hashFiles('package-lock.json') }}
-          path: /path/to/cache
-      # @end #
-```
-
-<EASFunctionDescription name="save_cache" />
+<EASFunctionDescription name="save_cache" exampleMode="Workflow" />
 
 #### `eas/send_slack_message`
 
@@ -1949,68 +1813,19 @@ You can reference build job properties and [use other steps outputs](#jobsjob_id
 
 Either `message` or `payload` has to be specified, but not both.
 
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/send_slack_message
-        # @end #
-        with:
-          message: 'This is a message sent to a Slack channel'
-          slack_hook_url: ${{ env.ANOTHER_SLACK_HOOK_URL }}
-```
-
-<EASFunctionDescription name="send_slack_message" />
+<EASFunctionDescription name="send_slack_message" exampleMode="Workflow" />
 
 #### `eas/use_npm_token`
 
-Configures Node package managers (bun, npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
-
-Set `NPM_TOKEN` in your project's secrets, and this function will configure the build environment by creating **.npmrc** with the token.
-
-```yaml example.yml
-jobs:
-  my_job:
-    name: Install private npm modules
-    steps:
-      - uses: eas/checkout
-      # @info #
-      - uses: eas/use_npm_token
-      # @end #
-      - name: Install dependencies
-        run: npm install # <---- Can now install private packages
-```
-
-<EASFunctionDescription name="use_npm_token" />
+<EASFunctionDescription name="use_npm_token" exampleMode="Workflow" />
 
 #### `eas/upload_artifact`
 
-Uploads files from the job's workspace as an artifact attached to the workflow run. Uploaded artifacts appear in the run's **Artifacts** section and can be retrieved in a later job with [`eas/download_artifact`](#easdownload_artifact).
+Uploads files from the job's workspace as an artifact attached to the run. Uploaded artifacts appear in the run's **Artifacts** section and can be retrieved in a later job with [`eas/download_artifact`](#easdownload_artifact).
 
 > **info** In a custom (non-build) job, set `type: other` to upload a generic artifact. The `application-archive` and `build-artifact` types are reserved for build jobs — using them in a custom job fails with an error like `Uploading application archives outside of builds is not supported`.
 
-```yaml
-jobs:
-  my_job:
-    steps:
-      - uses: eas/checkout
-      - name: Run tests
-        run: ./scripts/run-tests.sh # writes results into ./results
-      # @info Upload whatever the previous step produced. #
-      - uses: eas/upload_artifact
-        # @info `if: always()` uploads results even when a previous step failed. #
-        if: ${{ always() }}
-        with:
-          type: other
-          name: test-results
-          path: |
-            results/**/*
-```
-
-##### Properties
-
-<EASFunctionDescription name="upload_artifact" />
+<EASFunctionDescription name="upload_artifact" exampleMode="Workflow" />
 
 #### `eas/download_artifact`
 
@@ -2025,8 +1840,6 @@ jobs:
           name: string # Required if artifact_id is not provided. Name of the artifact to download.
           artifact_id: string # Required if artifact_name is not provided. ID of the artifact to download.
 ```
-
-##### Properties
 
 <EASFunctionDescription name="download_artifact" />
 
@@ -2054,137 +1867,27 @@ The following functions connect your workflow to [PostHog](/guides/using-posthog
 
 #### `eas/posthog_capture_event`
 
-Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline.
-
-When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons), which keeps workflow events out of your list of people.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/posthog_capture_event
-        # @end #
-        with:
-          event: ota_update_published
-          properties:
-            branch: main
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_capture_event" />
+<EASFunctionDescription name="posthog_capture_event" exampleMode="Workflow" />
 
 #### `eas/posthog_flag_rollout`
 
-Enables, disables, or rolls out a [PostHog feature flag](https://posthog.com/docs/feature-flags). The function looks up the flag by key and then updates it. Provide at least one of `active`, `rollout_percentage`, or `payload`.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/posthog_flag_rollout
-        # @end #
-        with:
-          flag: new-checkout
-          rollout_percentage: 25
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_flag_rollout" />
+<EASFunctionDescription name="posthog_flag_rollout" exampleMode="Workflow" />
 
 #### `eas/posthog_wait_for_metric`
 
-Pauses the workflow until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate a rollout on a metric, such as holding until the error count over the last few minutes stays low.
-
-The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses. A query that cannot be read, such as invalid HogQL, fails the step immediately, while transient errors are retried until the timeout.
-
-> **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/posthog_wait_for_metric
-        # @end #
-        with:
-          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
-          operator: lt
-          threshold: 10
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_wait_for_metric" />
+<EASFunctionDescription name="posthog_wait_for_metric" exampleMode="Workflow" />
 
 #### `eas/posthog_wait_for_query`
 
-Pauses the workflow until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead.
-
-The step clears when the first column of the first row is `true` or a nonzero number, so write the query to select a single boolean, such as `SELECT count() > 100 FROM events`.
-
-> **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/posthog_wait_for_query
-        # @end #
-        with:
-          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_wait_for_query" />
+<EASFunctionDescription name="posthog_wait_for_query" exampleMode="Workflow" />
 
 #### `eas/posthog_annotation`
 
-Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds, releases, and other milestones next to the metrics they affect.
-
-```yaml
-jobs:
-  my_job:
-    steps:
-      # @info #
-      - uses: eas/posthog_annotation
-        # @end #
-        with:
-          content: Published update to production
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_annotation" />
+<EASFunctionDescription name="posthog_annotation" exampleMode="Workflow" />
 
 #### `eas/posthog_upload_sourcemaps`
 
-Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
-
-> **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
-
-```yaml
-jobs:
-  publish_update:
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - run: npx expo export --source-maps
-      # @info #
-      - uses: eas/posthog_upload_sourcemaps
-        # @end #
-        with:
-          directory: dist
-```
-
-##### Properties
-
-<EASFunctionDescription name="posthog_upload_sourcemaps" />
+<EASFunctionDescription name="posthog_upload_sourcemaps" exampleMode="Workflow" />
 
 ## Built-in shell functions
 

--- a/docs/scenes/eas-functions/_checkout.mdx
+++ b/docs/scenes/eas-functions/_checkout.mdx
@@ -1,6 +1,43 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Checks out your project source files.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/checkout
+        # @end #
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml upload.yml
+build:
+  name: List files
+  steps:
+    - eas/checkout
+    - run:
+        name: List assets
+        run: ls assets
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
 
 <BoxLink
   title="eas/checkout source code"

--- a/docs/scenes/eas-functions/_downloadArtifact.mdx
+++ b/docs/scenes/eas-functions/_downloadArtifact.mdx
@@ -3,6 +3,8 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon } from '~/ui/components/DocIcons';
 
+##### Properties
+
 | Property      | Type   | Required   | Description                                                                      |
 | ------------- | ------ | ---------- | -------------------------------------------------------------------------------- |
 | `name`        | string | <NoIcon /> | The name of the artifact to download. Required if `artifact_id` is not provided. |

--- a/docs/scenes/eas-functions/_downloadBuild.mdx
+++ b/docs/scenes/eas-functions/_downloadBuild.mdx
@@ -3,6 +3,18 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/download_build
+        with:
+          build_id: string # Required. ID of the build to download.
+          extensions: [apk, aab, ipa, app] # Optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
+```
+
+##### Properties
+
 | Property     | Type     | Required    | Default                        | Description                                                                |
 | ------------ | -------- | ----------- | ------------------------------ | -------------------------------------------------------------------------- |
 | `build_id`   | string   | <YesIcon /> | –                              | The ID of the build to download. Must be a valid UUID.                     |
@@ -13,6 +25,28 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 | Property        | Type   | Description                                                                                                                                                       |
 | --------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `artifact_path` | string | The absolute path to the matching application archive. This output can be used as input into other steps. For example, to upload or process the artifact further. |
+
+Example usage:
+
+```yaml
+jobs:
+  build_ios:
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  my_job:
+    needs: [build_ios]
+    steps:
+      - uses: eas/download_build
+        id: download_build
+        with:
+          build_id: ${{ needs.build_ios.outputs.build_id }}
+      - name: Print artifact path
+        run: |
+          echo "Artifact path: ${{ steps.download_build.outputs.artifact_path }}"
+```
 
 <BoxLink
   title="eas/download_build source code"

--- a/docs/scenes/eas-functions/_installNodeModules.mdx
+++ b/docs/scenes/eas-functions/_installNodeModules.mdx
@@ -1,6 +1,44 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Installs node_modules using the package manager (bun, npm, pnpm, or Yarn) detected based on your project. Works with monorepos.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml example.yml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      # @info #
+      - uses: eas/install_node_modules
+      # @end #
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml example.yml
+build:
+  name: Install node modules
+  steps:
+    - eas/checkout
+    # @info #
+    - eas/install_node_modules
+    # @end #
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
 
 <BoxLink
   title="eas/install_node_modules source code"

--- a/docs/scenes/eas-functions/_posthogAnnotation.mdx
+++ b/docs/scenes/eas-functions/_posthogAnnotation.mdx
@@ -2,6 +2,47 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Creates a [PostHog annotation](https://posthog.com/docs/data/annotations) on the project timeline. Annotations show up on your PostHog charts, which makes them useful for marking builds, releases, and other milestones next to the metrics they affect.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_annotation
+        # @end #
+        with:
+          content: Published update to production
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-annotation.yml
+build:
+  name: Annotate the release in PostHog
+  steps:
+    - eas/posthog_annotation:
+        name: Create a PostHog annotation
+        inputs:
+          content: Published a production build
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property       | Type    | Required    | Description                                                                                                                                                  |
 | -------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/scenes/eas-functions/_posthogCaptureEvent.mdx
+++ b/docs/scenes/eas-functions/_posthogCaptureEvent.mdx
@@ -2,6 +2,55 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Sends an analytics event to [PostHog](https://posthog.com/). Use it to mark builds, releases, and other milestones on your PostHog timeline.
+
+When you do not provide a `distinct_id`, the event is sent anonymously and does not create a PostHog [person profile](https://posthog.com/docs/data/persons), which keeps these events out of your list of people.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_capture_event
+        # @end #
+        with:
+          event: ota_update_published
+          properties:
+            branch: main
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-capture-event.yml
+build:
+  name: Build and mark the release in PostHog
+  steps:
+    - eas/build
+    - eas/posthog_capture_event:
+        name: Capture a PostHog event
+        inputs:
+          event: store_build_finished
+          properties:
+            platform: ios
+            profile: production
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property       | Type    | Required    | Description                                                                                                                                                                                  |
 | -------------- | ------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_posthogFlagRollout.mdx
+++ b/docs/scenes/eas-functions/_posthogFlagRollout.mdx
@@ -2,6 +2,49 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Enables, disables, or rolls out a [PostHog feature flag](https://posthog.com/docs/feature-flags). The function looks up the flag by key and then updates it. Provide at least one of `active`, `rollout_percentage`, or `payload`.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_flag_rollout
+        # @end #
+        with:
+          flag: new-checkout
+          rollout_percentage: 25
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-flag-rollout.yml
+build:
+  name: Roll out a PostHog feature flag
+  steps:
+    - eas/posthog_flag_rollout:
+        name: Roll out the flag to 25 percent
+        inputs:
+          flag: new-checkout
+          rollout_percentage: 25
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property             | Type    | Required    | Description                                                                                                                                                                                                                                                             |
 | -------------------- | ------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_posthogUploadSourcemaps.mdx
+++ b/docs/scenes/eas-functions/_posthogUploadSourcemaps.mdx
@@ -2,6 +2,57 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Uploads JavaScript source maps to PostHog so that PostHog symbolicates stack traces in [error tracking](/guides/using-posthog/#error-tracking). Run it after the step that produces your bundle, in the same job, so the bundle and source maps are available on disk. Export with `npx expo export --source-maps`, and configure the PostHog Metro config from the [Source maps guide](/guides/using-posthog/#source-maps) so bundles carry the chunk IDs that match them to their source maps.
+
+> **warning** This step runs the PostHog CLI, which cannot tell a permissions error apart from any other failure. Unlike the other PostHog functions, setting `ignore_error: true` also hides authentication and scope errors.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  publish_update:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - run: npx expo export --source-maps
+      # @info #
+      - uses: eas/posthog_upload_sourcemaps
+        # @end #
+        with:
+          directory: dist
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-upload-sourcemaps.yml
+build:
+  name: Export and upload source maps
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - run:
+        name: Export the bundle and source maps
+        command: npx expo export --source-maps --platform ios
+    - eas/posthog_upload_sourcemaps:
+        name: Upload source maps to PostHog
+        inputs:
+          directory: dist
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property       | Type    | Required   | Description                                                                                                              |
 | -------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/scenes/eas-functions/_posthogWaitForMetric.mdx
+++ b/docs/scenes/eas-functions/_posthogWaitForMetric.mdx
@@ -2,6 +2,55 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns a number that satisfies a comparison. Use it to gate a rollout on a metric, such as holding until the error count over the last few minutes stays low.
+
+The function runs the query every `interval_seconds` until the comparison is true or `timeout_seconds` elapses. A query that cannot be read, such as invalid HogQL, fails the step immediately, while transient errors are retried until the timeout.
+
+> **info** This step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_wait_for_metric
+        # @end #
+        with:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-wait-for-metric.yml
+build:
+  name: Gate on the error count
+  steps:
+    - eas/posthog_wait_for_metric:
+        name: Wait for the error count to stay low
+        inputs:
+          query: SELECT count() FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 15 MINUTE
+          operator: lt
+          threshold: 10
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property           | Type   | Required    | Description                                                                                                             |
 | ------------------ | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_posthogWaitForQuery.mdx
+++ b/docs/scenes/eas-functions/_posthogWaitForQuery.mdx
@@ -2,6 +2,51 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Pauses until a [HogQL](https://posthog.com/docs/hogql) query returns true. Use it when the condition is easier to express in the query itself. For a numeric comparison with an explicit threshold, use [`eas/posthog_wait_for_metric`](#easposthog_wait_for_metric) instead.
+
+The step clears when the first column of the first row is `true` or a nonzero number, so write the query to select a single boolean, such as `SELECT count() > 100 FROM events`.
+
+> **info** Like `eas/posthog_wait_for_metric`, this step has no `ignore_error` input. A timeout or an unreadable query always fails the step.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/posthog_wait_for_query
+        # @end #
+        with:
+          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml posthog-wait-for-query.yml
+build:
+  name: Wait for a smoke test event
+  steps:
+    - eas/posthog_wait_for_query:
+        name: Wait for the smoke test to pass
+        inputs:
+          query: SELECT count() > 0 FROM events WHERE event = 'smoke_test_passed' AND timestamp > now() - INTERVAL 30 MINUTE
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property           | Type   | Required    | Description                                                                                                            |
 | ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_prebuild.mdx
+++ b/docs/scenes/eas-functions/_prebuild.mdx
@@ -1,6 +1,80 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Runs the `expo prebuild` command using the package manager (bun, npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      # @info #
+      - uses: eas/prebuild
+      # @end #
+```
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/resolve_apple_team_id_from_credentials
+        id: resolve_apple_team_id_from_credentials
+      # @info #
+      - uses: eas/prebuild
+        with:
+          clean: false
+          apple_team_id: ${{ steps.resolve_apple_team_id_from_credentials.outputs.apple_team_id }}
+      # @end #
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml example.yml
+build:
+  name: Run prebuild script
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/resolve_apple_team_id_from_credentials:
+        id: resolve_apple_team_id_from_credentials
+    # @info #
+    - eas/prebuild:
+        inputs:
+          clean: false
+          apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
+    # @end #
+```
+
+```yaml example.yml
+build:
+  name: Run prebuild script
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    # @info #
+    - eas/prebuild
+    # @end #
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property        | Type      | Description                                                                                                                                 |
 | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_restoreCache.mdx
+++ b/docs/scenes/eas-functions/_restoreCache.mdx
@@ -3,6 +3,39 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      # @info #
+      - uses: eas/restore_cache
+        with:
+          key: cache-${{ hashFiles('package-lock.json') }}
+          restore_keys: cache
+          path: /path/to/cache
+      # @end #
+```
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      # @info #
+      - uses: eas/restore_cache
+        with:
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
+      # @end #
+```
+
+##### Properties
+
 | Property       | Type     | Required    | Description                                                                                                                                              |
 | -------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |

--- a/docs/scenes/eas-functions/_saveCache.mdx
+++ b/docs/scenes/eas-functions/_saveCache.mdx
@@ -3,6 +3,29 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon } from '~/ui/components/DocIcons';
 
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      - uses: eas/restore_cache
+        with:
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
+      - name: Build Android app
+        run: cd android && ./gradlew assembleRelease
+      # @info #
+      - uses: eas/save_cache
+        with:
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
+      # @end #
+```
+
+##### Properties
+
 | Property | Type     | Required    | Description                                                                                                                                                                                                       |
 | -------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `key`    | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |

--- a/docs/scenes/eas-functions/_sendSlackMessage.mdx
+++ b/docs/scenes/eas-functions/_sendSlackMessage.mdx
@@ -1,6 +1,136 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/send_slack_message
+        # @end #
+        with:
+          message: 'This is a message sent to a Slack channel'
+          slack_hook_url: ${{ env.ANOTHER_SLACK_HOOK_URL }}
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml send-slack-message.yml
+build:
+  name: Slack your team from custom build
+  steps:
+    # @info #
+    - eas/send_slack_message:
+        name: Send Slack message to a given webhook URL
+        inputs:
+          message: 'This is a message to plain input URL'
+          slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'
+    # @end #
+    - eas/send_slack_message:
+        name: Send Slack message to a default webhook URL from SLACK_HOOK_URL secret
+        inputs:
+          message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
+    - eas/send_slack_message:
+        name: Send Slack message to a webhook URL from specified secret
+        inputs:
+          message: 'This is a test message to a URL from specified secret'
+          slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
+
+    - eas/build
+    - eas/send_slack_message:
+        if: ${ always() }
+        name: Send Slack message when the build finishes (Android)
+        inputs:
+          message: |
+            This is a test message when Android build finishes
+            Status: `${ steps.run_gradle.status_text }`
+            Link: `${ eas.job.expoBuildUrl }`
+    - eas/send_slack_message:
+        if: ${ always() }
+        name: Send Slack message when the build finishes (iOS)
+        inputs:
+          message: |
+            This is a test message when iOS build finishes
+            Status: `${ steps.run_fastlane.status_text }`
+            Link: `${ eas.job.expoBuildUrl }`
+    - eas/send_slack_message:
+        if: ${ failure() }
+        name: Send Slack message when the build fails (Android)
+        inputs:
+          message: |
+            This is a test message when Android build fails
+            Error: `${ steps.run_gradle.error_text }`
+    - eas/send_slack_message:
+        if: ${ failure() }
+        name: Send Slack message when the build fails (iOS)
+        inputs:
+          message: |
+            This is a test message when iOS build fails
+            Error: `${ steps.run_fastlane.error_text }`
+    - eas/send_slack_message:
+        if: ${ success() }
+        name: Send Slack message when the build succeeds
+        inputs:
+          message: |
+            This is a test message when build succeeds
+    - eas/send_slack_message:
+        if: ${ always() }
+        name: Send Slack message with Slack Block Kit layout
+        inputs:
+          payload:
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |-
+                    Hello, Sir Developer
+
+                     *Your build has finished!*
+              - type: divider
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |-
+                    *${ eas.env.EAS_BUILD_ID }*
+                    *Status:* `${ steps.run_gradle.status_text }`
+                    *Link:* `${ eas.job.expoBuildUrl }`
+                accessory:
+                  type: image
+                  image_url: [your_image_url]
+                  alt_text: alt text for image
+              - type: divider
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: 'Do a thing :rocket:'
+                      emoji: true
+                    value: a_thing
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: 'Do another thing :x:'
+                      emoji: true
+                    value: another_thing
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property         | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_uploadArtifact.mdx
+++ b/docs/scenes/eas-functions/_uploadArtifact.mdx
@@ -2,6 +2,61 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - name: Run tests
+        run: ./scripts/run-tests.sh # writes results into ./results
+      # @info Upload whatever the previous step produced. #
+      - uses: eas/upload_artifact
+        # @info `if: always()` uploads results even when a previous step failed. #
+        if: ${{ always() }}
+        with:
+          type: other
+          name: test-results
+          path: |
+            results/**/*
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml upload.yml
+build:
+  name: Upload artifacts
+  steps:
+    - eas/checkout
+    # - ...
+    - eas/upload_artifact:
+        name: Upload application archive
+        inputs:
+          path: fixtures/app-debug.apk
+    - eas/upload_artifact:
+        name: Upload artifacts
+        inputs:
+          type: build-artifact
+          path: |
+            assets/*.jpg
+            assets/*.png
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
+
+##### Properties
 
 | Property       | Type    | Required    | Description                                                                                                                                                                                                                                                     |
 | -------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/scenes/eas-functions/_useNpmToken.mdx
+++ b/docs/scenes/eas-functions/_useNpmToken.mdx
@@ -1,6 +1,52 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { EASFunctionExampleTabs } from '~/ui/components/EASFunctionDescription';
+import { Tab } from '~/ui/components/Tabs';
+
+export const modes = ['Workflow', 'Custom Build'];
+
+Configures Node package managers (bun, npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
+
+Set `NPM_TOKEN` in your project's secrets, and this function will configure the build environment by creating **.npmrc** with the token.
+
+<EASFunctionExampleTabs>
+
+<Tab label="Workflow">
+
+```yaml example.yml
+jobs:
+  my_job:
+    name: Install private npm modules
+    steps:
+      - uses: eas/checkout
+      # @info #
+      - uses: eas/use_npm_token
+      # @end #
+      - name: Install dependencies
+        run: npm install # <---- Can now install private packages
+```
+
+</Tab>
+
+<Tab label="Custom Build">
+
+```yaml example.yml
+build:
+  name: Install private npm modules
+  steps:
+    - eas/checkout
+    # @info #
+    - eas/use_npm_token
+    # @end #
+    - run:
+        name: Install dependencies
+        run: npm install # <---- Can now install private packages
+```
+
+</Tab>
+
+</EASFunctionExampleTabs>
 
 <BoxLink
   title="eas/use_npm_token source code"

--- a/docs/ui/components/EASFunctionDescription.tsx
+++ b/docs/ui/components/EASFunctionDescription.tsx
@@ -1,23 +1,40 @@
-import { ComponentType } from 'react';
+import {
+  Children,
+  ComponentType,
+  Fragment,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
+} from 'react';
 
-import Checkout from '~/scenes/eas-functions/_checkout.mdx';
-import DownloadArtifact from '~/scenes/eas-functions/_downloadArtifact.mdx';
-import DownloadBuild from '~/scenes/eas-functions/_downloadBuild.mdx';
-import InstallNodeModules from '~/scenes/eas-functions/_installNodeModules.mdx';
-import PosthogAnnotation from '~/scenes/eas-functions/_posthogAnnotation.mdx';
-import PosthogCaptureEvent from '~/scenes/eas-functions/_posthogCaptureEvent.mdx';
-import PosthogFlagRollout from '~/scenes/eas-functions/_posthogFlagRollout.mdx';
-import PosthogUploadSourcemaps from '~/scenes/eas-functions/_posthogUploadSourcemaps.mdx';
-import PosthogWaitForMetric from '~/scenes/eas-functions/_posthogWaitForMetric.mdx';
-import PosthogWaitForQuery from '~/scenes/eas-functions/_posthogWaitForQuery.mdx';
-import Prebuild from '~/scenes/eas-functions/_prebuild.mdx';
-import RestoreCache from '~/scenes/eas-functions/_restoreCache.mdx';
-import SaveCache from '~/scenes/eas-functions/_saveCache.mdx';
-import SendSlackMessage from '~/scenes/eas-functions/_sendSlackMessage.mdx';
-import UploadArtifact from '~/scenes/eas-functions/_uploadArtifact.mdx';
-import UseNpmToken from '~/scenes/eas-functions/_useNpmToken.mdx';
+import * as Checkout from '~/scenes/eas-functions/_checkout.mdx';
+import * as DownloadArtifact from '~/scenes/eas-functions/_downloadArtifact.mdx';
+import * as DownloadBuild from '~/scenes/eas-functions/_downloadBuild.mdx';
+import * as InstallNodeModules from '~/scenes/eas-functions/_installNodeModules.mdx';
+import * as PosthogAnnotation from '~/scenes/eas-functions/_posthogAnnotation.mdx';
+import * as PosthogCaptureEvent from '~/scenes/eas-functions/_posthogCaptureEvent.mdx';
+import * as PosthogFlagRollout from '~/scenes/eas-functions/_posthogFlagRollout.mdx';
+import * as PosthogUploadSourcemaps from '~/scenes/eas-functions/_posthogUploadSourcemaps.mdx';
+import * as PosthogWaitForMetric from '~/scenes/eas-functions/_posthogWaitForMetric.mdx';
+import * as PosthogWaitForQuery from '~/scenes/eas-functions/_posthogWaitForQuery.mdx';
+import * as Prebuild from '~/scenes/eas-functions/_prebuild.mdx';
+import * as RestoreCache from '~/scenes/eas-functions/_restoreCache.mdx';
+import * as SaveCache from '~/scenes/eas-functions/_saveCache.mdx';
+import * as SendSlackMessage from '~/scenes/eas-functions/_sendSlackMessage.mdx';
+import * as UploadArtifact from '~/scenes/eas-functions/_uploadArtifact.mdx';
+import * as UseNpmToken from '~/scenes/eas-functions/_useNpmToken.mdx';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
-const FUNCTIONS: Record<string, ComponentType> = {
+interface EASFunctionModule {
+  default: ComponentType;
+  modes?: readonly string[];
+}
+
+const FUNCTIONS: Record<string, EASFunctionModule> = {
   checkout: Checkout,
   download_artifact: DownloadArtifact,
   download_build: DownloadBuild,
@@ -38,12 +55,59 @@ const FUNCTIONS: Record<string, ComponentType> = {
 
 type EASFunctionName = keyof typeof FUNCTIONS;
 
-export function EASFunctionDescription({ name }: { name: EASFunctionName }) {
-  const Content = FUNCTIONS[name];
-  if (!Content) {
+const ExampleModeContext = createContext<string | undefined>(undefined);
+
+export function EASFunctionDescription({
+  name,
+  exampleMode,
+}: {
+  name: EASFunctionName;
+  exampleMode?: string;
+}) {
+  const fn = FUNCTIONS[name];
+  if (!fn) {
     throw new Error(
       `Unknown EAS function "${String(name)}". Valid names: ${Object.keys(FUNCTIONS).join(', ')}`
     );
   }
-  return <Content />;
+  const Content = fn.default;
+  return (
+    <ExampleModeContext.Provider value={exampleMode}>
+      <Content />
+    </ExampleModeContext.Provider>
+  );
+}
+
+type TabChild = ReactElement<{ label?: string; children?: ReactNode }>;
+
+const collectTabChildren = (nodes: ReactNode): TabChild[] => {
+  const panels: TabChild[] = [];
+  Children.forEach(nodes, child => {
+    if (!isValidElement<{ children?: ReactNode }>(child)) {
+      return;
+    }
+    if (child.type === Fragment) {
+      panels.push(...collectTabChildren(child.props.children));
+      return;
+    }
+    if (child.type === Tab) {
+      panels.push(child as TabChild);
+    }
+  });
+  return panels;
+};
+
+export function EASFunctionExampleTabs({ children }: PropsWithChildren) {
+  const exampleMode = useContext(ExampleModeContext);
+  const tabs = useMemo(() => collectTabChildren(children), [children]);
+
+  if (exampleMode) {
+    const match = tabs.find(tab => tab.props.label === exampleMode);
+    if (match) {
+      return <>{match.props.children}</>;
+    }
+    return null;
+  }
+
+  return <Tabs>{children}</Tabs>;
 }


### PR DESCRIPTION
# Why

Each eas/* function's code examples and property tables were duplicated inline in both `syntax.mdx` (Workflows) and `schema.mdx` (Custom Builds). Changes had to be made in two places.

# How

Move all remaining inline YAML examples, property tables, and BoxLinks into the shared MDX partials under `docs/scenes/eas-functions/`. The consuming pages now only call `<EASFunctionDescription name="..." exampleMode="..." />`.

# Test Plan

CI passes. Preview deploy visually verified against prod.

# Checklist

- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)