### PR TITLE
[docs] document workflow file size limit

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -19,7 +19,7 @@ To get started with workflows, see [Get Started with EAS Workflows](/eas/workflo
 
 ## Workflow files
 
-Workflow files use YAML syntax and must have either a `.yml` or `.yaml` file extension. If you're new to YAML and want to learn more, see [Learn YAML in Y minutes](https://learnxinyminutes.com/docs/yaml/).
+Workflow files use YAML syntax, must have either a `.yml` or `.yaml` file extension, and must be 16 KiB or smaller. If you're new to YAML and want to learn more, see [Learn YAML in Y minutes](https://learnxinyminutes.com/docs/yaml/).
 
 Workflow files are located in the **.eas/workflows** directory in your project. The **.eas** directory should be at the same level as your [**eas.json**](/build/eas-json/) file.
 


### PR DESCRIPTION
# Why

Workflow files over the size limit fail at run creation with a size error, but the limit was documented nowhere. Follow-up to the clearer error message in expo/universe#29253.

Triple-checked the docs and dont see that information being in any page; if I'm missing something, please let me know. 

# How

Note the 16 KiB per-file limit in the Workflow files section of the syntax reference, alongside the existing extension rule.

# Test Plan

Docs-only. Prose renders in the Workflow files section.