### PR TITLE
[ios][screen-capture] Detach recording overlay when allowing screen capture

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@bluespore](https://github.com/bluespore))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@bluespore](https://github.com/bluespore))
+- [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -48,6 +48,7 @@ public final class ScreenCaptureModule: Module {
 
     AsyncFunction("allowScreenCapture") {
       self.allowScreenshots()
+      self.blockView?.removeFromSuperview()
 
       NotificationCenter.default.removeObserver(
         self,


### PR DESCRIPTION
# Why

On iOS, `preventScreenCapture` adds a black `blockView` overlay over the key window while a screen recording is active (via `preventScreenRecording`). However, `allowScreenCapture` only calls `allowScreenshots()` and removes the `UIScreen.capturedDidChangeNotification` observer — it never detaches that `blockView`.

As a result, if an app releases capture protection (e.g. on screen blur) while a recording is still in progress, the black overlay stays attached and the observer that would normally tear it down when recording stops has already been removed. The app is left on a permanently black, unrecoverable screen. This reproduces reliably after a biometric/PIN unlock flow while screen recording.

The defect is present in `expo-screen-capture` 57.0.0, 57.0.1, and `main`.

# How

In the `allowScreenCapture` async function, detach the overlay right after restoring screenshots and before removing the observer:

```swift
AsyncFunction("allowScreenCapture") {
  self.allowScreenshots()
  self.blockView?.removeFromSuperview()

  NotificationCenter.default.removeObserver(
    self,
    name: UIScreen.capturedDidChangeNotification,
    object: nil
  )
}.runOnQueue(.main)
```

`blockView` is optional and lazily created, so this is a no-op when no overlay was ever shown.

# Test Plan

Verified on a physical iOS device:

- Start a screen recording, navigate into a protected screen (`preventScreenCaptureAsync`) via a biometric/PIN unlock flow, then leave the screen so protection is released (`allowScreenCaptureAsync`). Before this change the app stayed black; after it, the overlay is removed and the app remains visible and interactive.
- Stop the recording mid-session and confirm the app remains visible and responsive.
- Confirmed the overlay still appears correctly while recording when protection remains active (no regression to `preventScreenRecording`).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)