### PR TITLE
[audio][ios] Create a fresh recording file when prepareToRecordAsync is called without options

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Deactivate the audio session off the main thread to avoid app hangs. ([#47066](https://github.com/expo/expo/pull/47066) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix playlist `currentIndex` freezing after the first auto-advance. ([#47257](https://github.com/expo/expo/pull/47257) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Create a fresh recording file each time `prepareToRecordAsync` is called, matching Android — repeated takes no longer overwrite the previous recording at the same URL. ([#48002](https://github.com/expo/expo/pull/48002) by [@idoyana](https://github.com/idoyana))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -92,7 +92,10 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       throw AudioRecordingException("Failed to configure audio session: \(error.localizedDescription)")
     }
 
-    if let options {
+    // Fall back to the stored options so an argless prepare also creates a fresh
+    // recorder — and a fresh file URL — matching Android, where every prepare
+    // records to a new file.
+    if let options = options ?? currentOptions {
       let newRecorder: AVAudioRecorder
       do {
         newRecorder = try AudioUtils.createRecorder(directory: recordingDirectory(for: options), with: options)

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -92,9 +92,6 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       throw AudioRecordingException("Failed to configure audio session: \(error.localizedDescription)")
     }
 
-    // Fall back to the stored options so an argless prepare also creates a fresh
-    // recorder — and a fresh file URL — matching Android, where every prepare
-    // records to a new file.
     if let options = options ?? currentOptions {
       let newRecorder: AVAudioRecorder
       do {


### PR DESCRIPTION
# Why

On iOS, calling `prepareToRecordAsync()` **without options** re-prepares the existing `AVAudioRecorder`, so every take in a recorder's lifetime records to the **same** `recording-<UUID>` file URL — each new recording overwrites the previous one in place, and `recorder.uri` never changes across takes.

Android behaves differently: `prepareRecording` falls back to the construction options (`options ?: this.options`) and always runs `createRecordingFilePath`, so **every prepare gets a fresh file**. The same JS code therefore has different file-identity semantics per platform, and nothing in the docs signals the divergence.

This is a real foot-gun for any app that treats `recorder.uri` as identifying a recording (upload dedupe, caches, optimistic UI). In our production app (a voice-message chat), an upload registry keyed by the local URI made **every voice note after the first silently send the first note's audio** — users received answers to their previous message, with zero errors thrown anywhere. The same shared URL also means a long-running upload of take N can be reading the file while take N+1's recorder truncates it, and playback UIs holding the "old" URI actually play the newest take.

# How

One-line fix in `AudioRecorder.prepare` (plus a comment): fall back to the stored `currentOptions` when no options are passed, so an argless prepare also goes through `AudioUtils.createRecorder` and mints a fresh recording URL — matching Android.

```swift
if let options = options ?? currentOptions {
```

- `currentOptions` is always set (the constructor stores it, and every prepare-with-options refreshes it), so in practice each prepare now creates a fresh recorder + file, exactly like Android.
- Behavior with explicit options is unchanged.
- `handleMediaServicesReset` already re-prepares with `currentOptions`; unchanged.
- Recording settings for the argless path are identical to before (same stored options — only the output URL changes).

# Test Plan

Manual, on an iOS device (bare workflow, SDK 57):

```tsx
const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);

// take 1
await recorder.prepareToRecordAsync();
recorder.record();
// ...speak...
await recorder.stop();
console.log("take 1:", recorder.uri);

// take 2
await recorder.prepareToRecordAsync();
recorder.record();
// ...speak differently...
await recorder.stop();
console.log("take 2:", recorder.uri);
```

- **Before**: both logs print the same `.../ExpoAudio/recording-<UUID>.m4a`; the file contains only take 2's audio.
- **After**: two distinct URLs; each file plays back its own take.
- Android (unchanged): two distinct URLs before and after this PR.

Also verified: explicit-options prepare (`prepareToRecordAsync(options)`) behaves identically before/after, and recording after `stop()` still transitions `idle → prepared → recording` correctly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (Swift-only change — no TS/build output affected)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no config-plugin changes)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
