### PR TITLE
fix(cli): process DOM components sequentially in expo export to avoid metadata race

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix a race condition in `expo export` where concurrently-processed DOM components could overwrite each other's entries in `domComponentAssetsMetadata`, causing some DOM components to be missing from `metadata.json` (and 404 in their WebView after an EAS Update) on apps with multiple `"use dom"` components. ([#37269](https://github.com/expo/expo/issues/37269))
 - Avoid writing a 500 response when a DevTools plugin server request has already started or aborted. ([#47192](https://github.com/expo/expo/pull/47192) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Pass a fetch API `Request` to DevTools plugin WebSocket handlers instead of `IncomingMessage`. ([#47410](https://github.com/expo/expo/pull/47410) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Use `loadModule` for MCP and DevTools plugin server module loading. ([#47139](https://github.com/expo/expo/pull/47139) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
@@ -439,3 +439,158 @@ describe('Multiple DOM components metadata accumulation', () => {
     expect(allPaths).not.toContain('www.bundle/_expo/static/js/web/entry-dom2.js');
   });
 });
+
+describe('Concurrent DOM component metadata accumulation (race condition)', () => {
+  // The spread-accumulation fix (`domComponentAssetsMetadata[platform] =
+  // [...(domComponentAssetsMetadata[platform] || []), ...newEntries]`) is a
+  // non-atomic read-modify-write. `exportApp.ts` processes DOM components via
+  // `Promise.all(expoDomComponentReferences.map(async (filePath) => { ... }))`,
+  // so multiple callbacks can be in flight at once. If callback A reads the
+  // array (to spread it) before callback B has written its own update back,
+  // A's write clobbers B's — even though the accumulation *logic* is correct
+  // in isolation, it is not safe under concurrent execution.
+  //
+  // This suite exercises that scenario directly by staggering resolution
+  // order (the component processed *first* finishes *last*, as commonly
+  // happens when component export cost varies), which the previous
+  // sequential-only tests (see suite above) do not cover.
+  // See: https://github.com/expo/expo/issues/37269
+
+  const makeBundle = (n: number): BundleOutput => ({
+    artifacts: [
+      {
+        filename: `_expo/static/js/web/entry-dom${n}.js`,
+        originFilename: `components/Editor${n}.js`,
+        type: 'js',
+        metadata: {},
+        source: `console.log("dom${n}")`,
+      },
+    ],
+    assets: [],
+  });
+
+  // A delayed variant of `addDomBundleToMetadataAsync` — standing in for
+  // real-world variance in how long each DOM component's own bundling takes.
+  const addDomBundleToMetadataAfterDelay = async (bundle: BundleOutput, delayMs: number) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return addDomBundleToMetadataAsync(bundle);
+  };
+
+  // Mirrors the exact shape of the accumulation statement in `exportApp.ts`:
+  // the existing array is READ as the first spread element (synchronously),
+  // then the function SUSPENDS mid-expression on
+  // `...(await addDomBundleToMetadataAsync(...))`, and only WRITES the
+  // result back once that resolves. Critically, the `await` sits *inside*
+  // the array literal, between the read and the write — putting the delay
+  // before this statement (as if awaiting a slow `exportDomComponentAsync`
+  // call first) would NOT reproduce the bug, because by the time the
+  // statement itself runs, it executes as a single synchronous read+write
+  // with no interleaving opportunity. The race exists only because
+  // `exportApp.ts` awaits *while already inside* the assignment expression.
+  const accumulate = async (
+    domComponentAssetsMetadata: Record<string, any[]>,
+    platform: string,
+    bundle: BundleOutput,
+    htmlOutputName: string,
+    files: ExportAssetMap,
+    delayMs: number
+  ) => {
+    domComponentAssetsMetadata[platform] = [
+      ...(domComponentAssetsMetadata[platform] || []),
+      ...(await addDomBundleToMetadataAfterDelay(bundle, delayMs)),
+      ...transformDomEntryForMd5Filename({ files, htmlOutputName }),
+    ];
+  };
+
+  it('drops entries when processed concurrently via Promise.all (demonstrates the race)', async () => {
+    const domComponentAssetsMetadata: Record<string, any[]> = {};
+    const platform = 'ios';
+
+    const files1: ExportAssetMap = new Map([
+      ['www.bundle/dom1.html', { contents: '<html>DOM1</html>' }],
+    ]);
+    const files2: ExportAssetMap = new Map([
+      ['www.bundle/dom2.html', { contents: '<html>DOM2</html>' }],
+    ]);
+    const files3: ExportAssetMap = new Map([
+      ['www.bundle/dom3.html', { contents: '<html>DOM3</html>' }],
+    ]);
+
+    // Component 1 starts first but is the slowest to resolve — component 3
+    // starts last but resolves first. This out-of-order resolution is what
+    // triggers the lost-update race, even though every callback runs the
+    // "fixed" spread-accumulation logic from the suite above.
+    await Promise.all([
+      accumulate(
+        domComponentAssetsMetadata,
+        platform,
+        makeBundle(1),
+        'www.bundle/dom1.html',
+        files1,
+        30
+      ),
+      accumulate(
+        domComponentAssetsMetadata,
+        platform,
+        makeBundle(2),
+        'www.bundle/dom2.html',
+        files2,
+        20
+      ),
+      accumulate(
+        domComponentAssetsMetadata,
+        platform,
+        makeBundle(3),
+        'www.bundle/dom3.html',
+        files3,
+        10
+      ),
+    ]);
+
+    // With `Promise.all(map(...))`, this is fewer than the 6 entries (3 JS +
+    // 3 HTML) all three components should have contributed — some were lost
+    // to the race, reproducing the "missing DOM component after EAS Update"
+    // bug even with the accumulation-logic fix from #38290 in place.
+    expect(domComponentAssetsMetadata[platform].length).toBeLessThan(6);
+  });
+
+  it('accumulates every entry when processed sequentially (the fix)', async () => {
+    const domComponentAssetsMetadata: Record<string, any[]> = {};
+    const platform = 'ios';
+
+    const filesByIndex: ExportAssetMap[] = [
+      new Map([['www.bundle/dom1.html', { contents: '<html>DOM1</html>' }]]),
+      new Map([['www.bundle/dom2.html', { contents: '<html>DOM2</html>' }]]),
+      new Map([['www.bundle/dom3.html', { contents: '<html>DOM3</html>' }]]),
+    ];
+    const delays = [30, 20, 10];
+
+    // Same staggered latencies as the failing test above, but processed with
+    // a sequential `for...of` + `await` (the actual fix applied to
+    // `exportApp.ts`) instead of `Promise.all(map(...))`. Because each
+    // component's read-modify-write completes fully before the next one
+    // starts, there is no window for a lost update regardless of how long
+    // any individual component's export takes.
+    for (let i = 0; i < 3; i++) {
+      await accumulate(
+        domComponentAssetsMetadata,
+        platform,
+        makeBundle(i + 1),
+        `www.bundle/dom${i + 1}.html`,
+        filesByIndex[i],
+        delays[i]
+      );
+    }
+
+    // All 3 components contribute 1 JS + 1 HTML entry each = 6 total, with
+    // none lost, regardless of per-component export latency.
+    expect(domComponentAssetsMetadata[platform]).toHaveLength(6);
+
+    const jsEntries = domComponentAssetsMetadata[platform].filter((entry) => entry.ext === 'js');
+    expect(jsEntries.map((e) => e.path)).toEqual([
+      'www.bundle/_expo/static/js/web/entry-dom1.js',
+      'www.bundle/_expo/static/js/web/entry-dom2.js',
+      'www.bundle/_expo/static/js/web/entry-dom3.js',
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -237,44 +237,52 @@ export async function exportAppAsync(
                 .flat()
             ),
           ];
-          await Promise.all(
-            // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.
-            expoDomComponentReferences.map(async (filePath) => {
-              const { bundle: platformDomComponentsBundle, htmlOutputName } =
-                await exportDomComponentAsync({
-                  filePath,
-                  projectRoot,
-                  dev,
-                  devServer,
-                  isHermes,
-                  includeSourceMaps: sourceMaps,
-                  exp,
-                  files,
-                  useMd5Filename: true,
-                });
+          // NOTE: This must run sequentially, not via `Promise.all(map(...))`.
+          // `domComponentAssetsMetadata[platform]` is accumulated with a
+          // read-modify-write (`[...(domComponentAssetsMetadata[platform] ||
+          // []), ...newEntries]`), which is not atomic. When multiple DOM
+          // components are exported concurrently, callbacks can read the
+          // array before earlier callbacks have written their update back,
+          // silently dropping entries — apps with 2+ DOM components can end
+          // up with some of their HTML bundles missing from metadata.json,
+          // which 404s in the corresponding WebView after an EAS Update.
+          // See: https://github.com/expo/expo/issues/37269
+          // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.
+          for (const filePath of expoDomComponentReferences) {
+            const { bundle: platformDomComponentsBundle, htmlOutputName } =
+              await exportDomComponentAsync({
+                filePath,
+                projectRoot,
+                dev,
+                devServer,
+                isHermes,
+                includeSourceMaps: sourceMaps,
+                exp,
+                files,
+                useMd5Filename: true,
+              });
 
-              // Merge the assets from the DOM component into the output assets, deduplicating by hash.
-              const existingHashes = new Set(bundle.assets.map((a) => a.hash));
-              (bundle.assets as (typeof bundle.assets)[0][]).push(
-                ...platformDomComponentsBundle.assets.filter((a) => !existingHashes.has(a.hash))
-              );
+            // Merge the assets from the DOM component into the output assets, deduplicating by hash.
+            const existingHashes = new Set(bundle.assets.map((a) => a.hash));
+            (bundle.assets as (typeof bundle.assets)[0][]).push(
+              ...platformDomComponentsBundle.assets.filter((a) => !existingHashes.has(a.hash))
+            );
 
-              transformNativeBundleForMd5Filename({
-                domComponentReference: filePath,
-                nativeBundle: bundle,
+            transformNativeBundleForMd5Filename({
+              domComponentReference: filePath,
+              nativeBundle: bundle,
+              files,
+              htmlOutputName,
+            });
+            domComponentAssetsMetadata[platform] = [
+              ...(domComponentAssetsMetadata[platform] || []),
+              ...(await addDomBundleToMetadataAsync(platformDomComponentsBundle)),
+              ...transformDomEntryForMd5Filename({
                 files,
                 htmlOutputName,
-              });
-              domComponentAssetsMetadata[platform] = [
-                ...(domComponentAssetsMetadata[platform] || []),
-                ...(await addDomBundleToMetadataAsync(platformDomComponentsBundle)),
-                ...transformDomEntryForMd5Filename({
-                  files,
-                  htmlOutputName,
-                }),
-              ];
-            })
-          );
+              }),
+            ];
+          }
 
           if (platform === 'web') {
             const faviconAsset = await generateFaviconAssetAsync(projectRoot, {


### PR DESCRIPTION
# Why

#38290 fixed `domComponentAssetsMetadata` being **overwritten** instead of accumulated across DOM components, but the surrounding loop in `exportApp.ts` still processes every DOM component **concurrently** via:

```ts
await Promise.all(
  expoDomComponentReferences.map(async (filePath) => {
    ...
    domComponentAssetsMetadata[platform] = [
      ...(domComponentAssetsMetadata[platform] || []),
      ...(await addDomBundleToMetadataAsync(platformDomComponentsBundle)),
      ...transformDomEntryForMd5Filename({ files, htmlOutputName }),
    ];
  })
);
```

The `await addDomBundleToMetadataAsync(...)` sits **inside the array literal**, between the read of the existing array (the first spread element, evaluated synchronously) and the write (the assignment, which only happens once that `await` resolves). When multiple DOM components are in flight and resolve out of order — e.g. the component that starts first happens to finish last — a later callback's write can be silently clobbered by an earlier-started callback resuming with a stale read of the array. That component's metadata is dropped entirely.

In practice, apps with 2+ `"use dom"` components can end up with some of them missing from the exported `metadata.json` — the corresponding WebView then 404s after loading an EAS Update, even on `@expo/cli` versions that already include the #38290 fix. This reproduced consistently for us in a production app with 2 DOM components: the manifest would non-deterministically ship with 1 or 2 HTML bundles depending on export timing.

Fixes #37269 (the underlying issue is the same one #38290 targeted — that fix was necessary but not sufficient under concurrent execution).

# How

Switched the loop from `Promise.all(expoDomComponentReferences.map(async ...))` to a sequential `for...of` + `await`, so each component's full read-await-write completes before the next one starts. No behavior change other than removing the race — component export order is now deterministic (declaration order) rather than unspecified, and total export time is unaffected in the common case (`Promise.all` didn't meaningfully parallelize this work anyway, since each iteration bundles a whole separate DOM component via Metro).

```diff
-await Promise.all(
-  expoDomComponentReferences.map(async (filePath) => {
-    ...
-  })
-);
+for (const filePath of expoDomComponentReferences) {
+  ...
+}
```

# Test Plan

Added a regression test (`Concurrent DOM component metadata accumulation (race condition)` in `exportDomComponents-test.ts`) that:
1. Reproduces the race by staggering resolution timing so the component that starts first resolves last (mirroring real-world variance in per-component bundling cost) — asserts the concurrent `Promise.all` shape drops entries.
2. Verifies the sequential fix accumulates every entry regardless of per-component latency.

I verified the exact async-ordering mechanics (that the race requires the `await` to sit *inside* the array literal, not merely somewhere before the read-modify-write statement) against a minimal standalone reproduction before writing the test, since a naive "await-then-build-array" version of the test does **not** reproduce the bug — only the "await-inside-the-literal" shape that matches the actual code does.

**Manual verification:** applied the equivalent fix locally (via `pnpm patch`) against a production app with 2 DOM components and confirmed `expo export` now consistently produces the full expected HTML bundle count for both DOM components on both iOS and Android, where it previously non-deterministically dropped one.

# Checklist

- [x] Added a `changelog.md` entry
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no native/config-plugin changes — export-time only)
- [x] Conforms with the Documentation Writing Style Guide