### PR TITLE
[image-picker][ios] Fix base64 JPEG data for all paths

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
-- [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`.
+- [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`. ([#48005](https://github.com/expo/expo/pull/48005) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`.
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ExpoImagePicker.podspec
+++ b/packages/expo-image-picker/ios/ExpoImagePicker.podspec
@@ -20,8 +20,15 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = "Tests/"
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.dependency 'ExpoModulesTestCore'
+
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
+  end
 end

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -194,23 +194,31 @@ internal struct ImageUtils {
     orFileUrl fileUrl: URL,
     tryReadingFile: Bool
   ) throws -> String? {
-    let sourceImage: UIImage
     if tryReadingFile {
-      do {
-        let data = try Data(contentsOf: fileUrl)
-        guard let loaded = UIImage(data: data) else {
-          throw FailedToReadImageDataException()
-        }
-        sourceImage = loaded
-      } catch {
-        throw FailedToReadImageDataException()
-          .causedBy(error)
-      }
-    } else {
-      sourceImage = image
+      return try readJpegBase64From(fileUrl: fileUrl, compressionQuality: compressionQuality)
     }
+    return try readJpegBase64From(image: image, compressionQuality: compressionQuality)
+  }
 
-    guard let jpegData = sourceImage.jpegData(compressionQuality: compressionQuality) else {
+  // Decodes the file at `fileUrl` and re-encodes it as JPEG, so base64 output is always JPEG
+  // regardless of the source file's original format (e.g. HEIC, PNG).
+  static func readJpegBase64From(fileUrl: URL, compressionQuality: Double) throws -> String? {
+    let sourceImage: UIImage
+    do {
+      let data = try Data(contentsOf: fileUrl)
+      guard let loaded = UIImage(data: data) else {
+        throw FailedToReadImageDataException()
+      }
+      sourceImage = loaded
+    } catch {
+      throw FailedToReadImageDataException()
+        .causedBy(error)
+    }
+    return try readJpegBase64From(image: sourceImage, compressionQuality: compressionQuality)
+  }
+
+  static func readJpegBase64From(image: UIImage, compressionQuality: Double) throws -> String? {
+    guard let jpegData = image.jpegData(compressionQuality: compressionQuality) else {
       throw FailedToReadImageDataForBase64Exception()
     }
     return jpegData.base64EncodedString()

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -156,11 +156,15 @@ internal struct MediaHandler {
 
         // Conditionally read raw data only if needed to avoid unnecessary I/O
         var rawData: Data?
-        if options.base64 || options.exif {
+        if options.exif {
           rawData = try? Data(contentsOf: cachedUrl)
         }
 
-        let base64 = options.base64 ? rawData?.base64EncodedString() : nil
+        // Always export base64 as JPEG, matching the `allowsEditing` path, so callers get a
+        // consistent format regardless of the source file (e.g. HEIC).
+        let base64 = options.base64
+          ? try? ImageUtils.readJpegBase64From(fileUrl: cachedUrl, compressionQuality: options.quality)
+          : nil
         let exif = options.exif ? (rawData.flatMap { ImageUtils.readExifFrom(data: $0) }) : nil
 
         return AssetInfo(
@@ -200,7 +204,11 @@ internal struct MediaHandler {
 
     // We need to get EXIF from original image data, as it is being lost in UIImage
     let exif = options.exif ? ImageUtils.readExifFrom(data: rawData) : nil
-    let base64 = options.base64 ? imageData?.base64EncodedString() : nil
+    // Always export base64 as JPEG, matching the `allowsEditing` path, so callers get a
+    // consistent format regardless of the source file (e.g. HEIC).
+    let base64 = options.base64
+      ? try ImageUtils.readJpegBase64From(image: image, compressionQuality: options.quality)
+      : nil
 
     let size = CGSize(width: image.size.width, height: image.size.height)
 

--- a/packages/expo-image-picker/ios/Tests/ImageUtilsBase64Tests.swift
+++ b/packages/expo-image-picker/ios/Tests/ImageUtilsBase64Tests.swift
@@ -14,9 +14,6 @@ private func isJpeg(_ data: Data) -> Bool {
   return data.count >= 2 && data[0] == 0xFF && data[1] == 0xD8
 }
 
-// Regression test for https://github.com/expo/expo/issues/47988: base64 export must always be
-// JPEG regardless of the source image's original format. This guards the helper used by every
-// export path, including the PHPicker path taken when `allowsEditing` is false.
 @Suite("ImageUtils base64")
 struct ImageUtilsBase64Tests {
   @Test

--- a/packages/expo-image-picker/ios/Tests/ImageUtilsBase64Tests.swift
+++ b/packages/expo-image-picker/ios/Tests/ImageUtilsBase64Tests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import ExpoImagePicker
+
+// A 1x1 red PNG - a non-JPEG source we can decode and re-encode.
+private let pngData = Data(
+  base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)!
+
+// JPEG files always start with the SOI marker 0xFF 0xD8.
+private func isJpeg(_ data: Data) -> Bool {
+  return data.count >= 2 && data[0] == 0xFF && data[1] == 0xD8
+}
+
+// Regression test for https://github.com/expo/expo/issues/47988: base64 export must always be
+// JPEG regardless of the source image's original format. This guards the helper used by every
+// export path, including the PHPicker path taken when `allowsEditing` is false.
+@Suite("ImageUtils base64")
+struct ImageUtilsBase64Tests {
+  @Test
+  func `encodes an in-memory image as JPEG`() throws {
+    let image = try #require(UIImage(data: pngData))
+
+    let base64 = try #require(try ImageUtils.readJpegBase64From(image: image, compressionQuality: 1.0))
+    let decoded = try #require(Data(base64Encoded: base64))
+
+    #expect(isJpeg(decoded))
+  }
+
+  @Test
+  func `re-encodes a non-JPEG file as JPEG`() throws {
+    let fileUrl = FileManager.default.temporaryDirectory
+      .appendingPathComponent("expo-image-picker-test-\(UUID().uuidString).png")
+    try pngData.write(to: fileUrl)
+    defer { try? FileManager.default.removeItem(at: fileUrl) }
+
+    let base64 = try #require(try ImageUtils.readJpegBase64From(fileUrl: fileUrl, compressionQuality: 1.0))
+    let decoded = try #require(Data(base64Encoded: base64))
+
+    // The source file is PNG; the output must not preserve that format.
+    #expect(isJpeg(decoded))
+  }
+}

--- a/packages/expo-image-picker/spm.config.json
+++ b/packages/expo-image-picker/spm.config.json
@@ -17,6 +17,7 @@
           "name": "ExpoImagePicker",
           "path": "ios",
           "pattern": "**/*.swift",
+          "exclude": ["Tests/**"],
           "dependencies": [
             "Hermes",
             "React",


### PR DESCRIPTION
# Why

Fixes #47988.

On iOS, `launchImageLibraryAsync` with `base64: true` returned the original file data (e.g. HEIC) instead of JPEG when `allowsEditing` was `false`. #43806 was meant to fix this, but it only patched the `UIImagePickerController` path, which is used when `allowsEditing: true`. The `PHPickerViewController` path, used when `allowsEditing: false`, was missed and still base64-encoded the raw file bytes. With the default `quality: 1` and `preferredAssetRepresentationMode: current`, that path hits the zero-copy fast copy, so a picked HEIC came back as HEIC base64.

# How

`handleImage(from:)` now always re-encodes base64 as JPEG, matching the `allowsEditing` path, on both branches: the fast copy path re-encodes from the cached file, and the slow path re-encodes from the decoded `UIImage`. `ImageUtils.readJpegBase64From` was split into small `image:` and `fileUrl:` helpers so both paths can reuse it. The file on disk, its `uri` and `mimeType` are unchanged, only base64 is normalized to JPEG.

# Test Plan

- NCL
- Added native unit tests. They can't exercise the picker experience directly, but they're good for testing utils like base64 encoding or video transcoding.

# Checklist

- [x] I added a `CHANGELOG.md` entry.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
