### PR TITLE
[docs] Add vale repetition rule to docs and fix remaining doubled

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Repetition.yml
+++ b/docs/.vale/writing-styles/expo-docs/Repetition.yml
@@ -1,0 +1,6 @@
+extends: repetition
+message: "'%s' is repeated."
+level: error
+alpha: true
+tokens:
+  - '[^\s]+'

--- a/docs/pages/versions/v54.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/map-view.mdx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
 <Step label="4">
 #### Add the API key to your project
 
-- Copy your **API Key** into your your to either a **.env** file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` field like or copy it:
+- Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your **app.json** under the `android.config.googleMaps.apiKey` field like:
 
 ```json
     "android": {
@@ -150,7 +150,7 @@ const styles = StyleSheet.create({
 <Step label="3">
 #### Add the API key to your project
 
-- Copy your **API Key** into your your to either a **.env** file and then add it to your **app.json** under the `ios.config.googleMapsApiKey` field like or copy it:
+- Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your **app.json** under the `ios.config.googleMapsApiKey` field like:
 
 ```json
     "ios": {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25339

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `expo-docs.Repetition` Vale rule (`.vale/writing-styles/expo-docs/Repetition.yml`) to catch doubled words like "the the" in prose, including frontmatter descriptions and table cells. Validated against the full docs corpus with zero false positives.
- Fix two garbled "your your" sentences in `pages/versions/v54.0.0/sdk/map-view.mdx` by rewording them to match the phrasing used in v55 and later.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `pnpm lint-prose` and there should be 0 errors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
