### PR TITLE
[iOS][location] Remove stale top-level scope and accuracy from permission response

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [iOS] Remove the stale top-level `scope` and `accuracy` properties from the permission response returned by `getForegroundPermissionsAsync` and `requestForegroundPermissionsAsync`. Use the values under `ios` instead. ([#48009](https://github.com/expo/expo/pull/48009) by [@Wenszel](https://github.com/Wenszel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-location/ios/Requesters/EXForegroundPermissionRequester.m
+++ b/packages/expo-location/ios/Requesters/EXForegroundPermissionRequester.m
@@ -61,8 +61,6 @@ static SEL whenInUseAuthorizationSelector;
               @"scope": scope,
               @"accuracy": accuracy
             },
-            @"scope": scope, // Incorrect according to https://docs.expo.dev/versions/latest/sdk/location/#locationpermissionresponse but long-present. TODO remove for SDK 56 or later
-            @"accuracy": accuracy
          };
 }
 


### PR DESCRIPTION
# Why

follow-up to: https://github.com/expo/expo/pull/41328

removes stale top-level `LocationPermissionResponse` properties that should be inside the `ios` object, per the [docs](https://docs.expo.dev/versions/latest/sdk/location/#locationpermissionresponse)

# How
removes `scope` and `accuracy` returned by `parsePermissions` in `EXForegroundPermissionRequester.m`

# Test Plan
Tested on BareExpo ✅ 