### PR TITLE
[iOS] fix(expo,expo-go): Provide `bundleConfiguration` based on final bundle URL

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -25,8 +25,10 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDevSettings.h>
+#import <React/RCTDevMenu.h>
 #import <React/RCTPackagerConnection.h>
 #import <React/RCTRootView.h>
+#import <Expo/EXBundleConfiguration.h>
 
 #if __has_include(<ExpoModulesCore-Swift.h>)
 #import <ExpoModulesCore-Swift.h>
@@ -134,7 +136,11 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
     [self _startObservingNotificationsForHost];
     
     if (!_isHeadless) {
-      _reactRootView = [self.expoAppInstance.reactNativeFactory.rootViewFactory viewWithModuleName:[self applicationKeyForRootView] initialProperties:[self initialPropertiesForRootView]];
+      _reactRootView = [self.expoAppInstance.reactNativeFactory.rootViewFactory viewWithModuleName:[self applicationKeyForRootView]
+                                                                                 initialProperties:[self initialPropertiesForRootView]
+                                                                                     launchOptions:nil
+                                                                               bundleConfiguration:[EXBundleConfiguration configurationWithBundleURL:[self bundleUrl]]
+                                                                              devMenuConfiguration:[RCTDevMenuConfiguration defaultConfiguration]];
     }
 
     [self setupWebSocketControls];

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
 - Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets. ([#47894](https://github.com/expo/expo/pull/47894) by [@jakex7](https://github.com/jakex7))
-- [iOS] Add `ExpoBundleConfiguration` derive `RCTBundleConfiguration` from normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
+- [iOS] Add ExpoBundleConfiguration to derive RCTBundleConfiguration from the normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
 - Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets. ([#47894](https://github.com/expo/expo/pull/47894) by [@jakex7](https://github.com/jakex7))
+- [iOS] Add `ExpoBundleConfiguration` derive `RCTBundleConfiguration` from normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo/ios/AppDelegates/EXBundleConfiguration.h
+++ b/packages/expo/ios/AppDelegates/EXBundleConfiguration.h
@@ -1,0 +1,23 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#import <ExpoModulesCore/Platform.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+NS_SWIFT_NAME(ExpoBundleConfiguration)
+@interface EXBundleConfiguration : RCTBundleConfiguration
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL NS_DESIGNATED_INITIALIZER;
+
++ (RCTBundleConfiguration *)configurationWithBundleURL:(nullable NSURL *)bundleURL NS_SWIFT_NAME(configuration(bundleURL:));
+
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo/ios/AppDelegates/EXBundleConfiguration.mm
+++ b/packages/expo/ios/AppDelegates/EXBundleConfiguration.mm
@@ -1,0 +1,77 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+#import <Expo/EXBundleConfiguration.h>
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+@implementation EXBundleConfiguration {
+  NSURL *_bundleURL;
+}
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+{
+  if (bundleURL.fileURL) {
+    self = [super initWithBundleFilePath:bundleURL];
+  } else {
+    self = [super init];
+  }
+  if (self) {
+    _bundleURL = bundleURL;
+  }
+  return self;
+}
+
+- (NSURL *)getBundleURL
+{
+  return _bundleURL;
+}
+
+- (NSString *)getPackagerServerScheme
+{
+  if (_bundleURL.fileURL) {
+    return [super getPackagerServerScheme];
+  }
+
+  NSString *scheme = _bundleURL.scheme;
+  if ([scheme isEqualToString:@"https"] || [scheme isEqualToString:@"exps"]) {
+    return @"https";
+  } else if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"exp"]) {
+    return @"http";
+  } else {
+    return [super getPackagerServerScheme];
+  }
+}
+
+- (NSString *)getPackagerServerHost
+{
+  if (_bundleURL.fileURL) {
+    return [super getPackagerServerHost];
+  }
+
+  NSString *host = _bundleURL.host;
+  if (host == nil) {
+    return [super getPackagerServerHost];
+  }
+
+  NSNumber *port = _bundleURL.port;
+  if (port == nil) {
+    return host;
+  } else if ([host containsString:@":"] && ![host hasPrefix:@"["]) {
+    return [NSString stringWithFormat:@"[%@]:%@", host, port];
+  } else {
+    return [NSString stringWithFormat:@"%@:%@", host, port];
+  }
+}
+
++ (RCTBundleConfiguration *)configurationWithBundleURL:(nullable NSURL *)bundleURL
+{
+  if (bundleURL == nil) {
+    return [RCTBundleConfiguration defaultConfiguration];
+  } else {
+    return [[EXBundleConfiguration alloc] initWithBundleURL:bundleURL];
+  }
+}
+
+@end
+
+#endif

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -78,14 +78,18 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     let rootView: UIView
     if let factory = self.rootViewFactory as? ExpoReactRootViewFactory {
       // RCTDevMenuConfiguration is only available in react-native 0.83+
+      // bundleConfiguration is only accepted in react-native 0.84+
 #if os(iOS) || os(tvOS)
+      let bundleConfiguration = ExpoBundleConfiguration.configuration(
+        bundleURL: withBundleURL ?? configuration?.bundleURLBlock()
+      )
       // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
       // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
       rootView = factory.superView(
         withModuleName: moduleName ?? defaultModuleName,
         initialProperties: initialProps,
         launchOptions: launchOptions ?? [:],
-        bundleConfiguration: RCTBundleConfiguration.default(),
+        bundleConfiguration: bundleConfiguration,
         devMenuConfiguration: self.devMenuConfiguration
       )
 #else
@@ -97,11 +101,14 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
 #endif
     } else {
 #if os(iOS) || os(tvOS)
+      let bundleConfiguration = ExpoBundleConfiguration.configuration(
+        bundleURL: withBundleURL ?? configuration?.bundleURLBlock()
+      )
       rootView = rootViewFactory.view(
         withModuleName: moduleName ?? defaultModuleName,
         initialProperties: initialProps,
         launchOptions: launchOptions,
-        bundleConfiguration: RCTBundleConfiguration.default(),
+        bundleConfiguration: bundleConfiguration,
         devMenuConfiguration: self.devMenuConfiguration ?? RCTDevMenuConfiguration.default()
       )
 #else

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -4,6 +4,7 @@ import React
 
 public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNativeFactoryProtocol {
   private let defaultModuleName = "main"
+  private var _bundleConfiguration: RCTBundleConfiguration?
 
   @MainActor
   private lazy var reactDelegate: ExpoReactDelegate = {
@@ -24,6 +25,22 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     ?? RCTReleaseLevel.Stable
 
     super.init(delegate: delegate, releaseLevel: releaseLevel)
+  }
+
+  public override var bundleConfiguration: RCTBundleConfiguration {
+    get {
+      if let _bundleConfiguration {
+        return _bundleConfiguration
+      }
+#if os(iOS) || os(tvOS)
+      return ExpoBundleConfiguration.configuration(bundleURL: self.delegate?.bundleURL())
+#else
+      return super.bundleConfiguration
+#endif
+    }
+    set {
+      _bundleConfiguration = newValue
+    }
   }
 
   @MainActor

--- a/packages/expo/ios/Expo.h
+++ b/packages/expo/ios/Expo.h
@@ -1,4 +1,5 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <Expo/EXAppDefinesLoader.h>
 #import <Expo/ExpoReactNativeFactory.h>
+#import <Expo/EXBundleConfiguration.h>
 #import <Expo/RCTAppDelegateUmbrella.h>


### PR DESCRIPTION
Related to #43018
Related to https://github.com/react/react-native/pull/54258
Follow-up to #47424

# Why

React Native 0.84 added `RCTBundleConfiguration` as a new root view (host creation?) argument as `bundleConfiguration`, while `RCTDevSettings` now uses this input to start the `RCTPackagerConnection`.

Internally, `RCTPackagerConnection` is now instance-owned by `RCTDevSettings` and initialized from `RCTBundleManager.bundleConfig`.

Expo was passing the real resolved bundle URL through `bundleURLBlock`, however, hooked up `RCTBundleConfiguration.default()` to the `bundleConfiguration` argument. As a result, the bundle was loading correctly (from the manifest-provided URL), however, the command websocket on `/message` used `RCTBundleURLProvider`'s default shared settings, which is `localhost:8081`.

Previously, this wasn't as noticeable since Expo Go and `expo-dev-client` would reconnect immediately via `devSettings.packagerConnection`. But, this reconnection was removed on Expo Go and this made the issue more obvious. Either way, the `reconnect` path doesn't seem to be desired fix here.

# How

This PR adds `EXBundleConfiguration` / `ExpoBundleConfiguration`, which implements/sub-classes `RCTBundleConfiguration` so it can be derived from an already normalised and resolved bundle URL.

This:
- returns the original bundle URL on `getBundleURL`
- derives the host and scheme from the bundle URL
- preserves file URL behaviour as is on `initWithBundleFilePath`
- falls back to the default configuration as well otherwise

This is then used in `ExpoReactNativeFactory` and in Expo Go's root view.

# Test Plan

- Compiled and ran `apps/expo-go` and connected to `expo start --port 1337 --clear`
  - NOTE: No connections to `8081` are observed and the reload command works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
