### PR TITLE
[docs] Load API data per page instead of bundling every SDK version

### DIFF
--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { createRequire } from 'node:module';
 
 import { axe, renderWithHeadings } from '~/common/test-utilities';
+import { ApiDataProvider } from '~/providers/api-data';
 
 import APISection from './APISection';
 
@@ -101,6 +102,29 @@ describe('APISection', () => {
 
     expect(screen.queryAllByText('Props')).toHaveLength(0);
     expect(screen.queryAllByText('Enums')).toHaveLength(0);
+  });
+
+  test('renders from provider data without testRequire', () => {
+    const { children } = require('~/public/static/data/unversioned/expo-pedometer.json');
+
+    renderWithHeadings(
+      <ApiDataProvider data={{ 'unversioned/expo-pedometer': children }}>
+        <APISection packageName="expo-pedometer" forceVersion="unversioned" />
+      </ApiDataProvider>
+    );
+
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(4);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(12);
+    expect(screen.getAllByRole('table')).toHaveLength(5);
+  });
+
+  test('renders the fallback when provider data is missing', () => {
+    console.error = jest.fn();
+
+    render(<APISection packageName="expo-pedometer" forceVersion="unversioned" />);
+
+    expect(console.error).toHaveBeenCalled();
+    expect(screen.getAllByText('No API data file found, sorry!')).toHaveLength(1);
   });
 
   test('expo-router/native-tabs collapses huge mixed literal unions', () => {

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -26,6 +26,7 @@ import {
   getCommentContent,
   getPossibleComponentPropsNames,
 } from '~/components/plugins/api/APISectionUtils';
+import { type ApiSectionData, useApiSectionData } from '~/providers/api-data';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { WithTestRequire } from '~/types/common';
@@ -171,6 +172,7 @@ const groupByHeader = (entries: ApiDataEntry[]) => {
 
 const renderAPI = (
   sdkVersion: string,
+  apiSectionData: ApiSectionData | undefined,
   {
     packageName,
     apiName,
@@ -179,6 +181,23 @@ const renderAPI = (
   }: Omit<Props, 'forceVersion'>
 ) => {
   try {
+    const loadPackageData = (name?: string): GeneratedData[] => {
+      if (testRequire) {
+        const { children } = testRequire(`~/public/static/data/${sdkVersion}/${name}.json`);
+        return children;
+      }
+      const children = apiSectionData?.[`${sdkVersion}/${name}`];
+      if (!children) {
+        throw new Error(
+          `Missing API data for ${sdkVersion}/${name}: the page's getStaticProps did not provide it. ` +
+            'This usually means mdx-plugins/remark-api-section-data.js could not resolve this <APISection> ' +
+            'usage at build time. Keep packageName (and forceVersion) string or array-of-string literals ' +
+            'in the MDX source so the data can be loaded with the page.'
+        );
+      }
+      return children as GeneratedData[];
+    };
+
     let data: GeneratedData[] = [];
     // `deriveComponentsFromProps` synthesizes a derived component entry
     // for each static property typed as `React.FC<X>` or similar. It
@@ -196,19 +215,11 @@ const renderAPI = (
 
     if (Array.isArray(packageName)) {
       data = packageName
-        .map(name => {
-          const { children } = testRequire
-            ? testRequire(`~/public/static/data/${sdkVersion}/${name}.json`)
-            : require(`~/public/static/data/${sdkVersion}/${name}.json`);
-          return children;
-        })
+        .map(name => loadPackageData(name))
         .flat()
         .sort((a: GeneratedData, b: GeneratedData) => a.name.localeCompare(b.name));
     } else {
-      const { children } = testRequire
-        ? testRequire(`~/public/static/data/${sdkVersion}/${packageName}.json`)
-        : require(`~/public/static/data/${sdkVersion}/${packageName}.json`);
-      data = children;
+      data = loadPackageData(packageName);
     }
 
     const functionLikeEntries = data.filter(isFunctionLikeEntry);
@@ -451,6 +462,7 @@ const isDevMode = process.env.NODE_ENV === 'development';
 
 const APISection = ({ forceVersion, ...restProps }: Props) => {
   const { version } = usePageApiVersion();
+  const apiSectionData = useApiSectionData();
   const resolvedVersion =
     forceVersion ??
     (version === 'unversioned' ? version : version === 'latest' ? LATEST_VERSION : version);
@@ -461,7 +473,7 @@ const APISection = ({ forceVersion, ...restProps }: Props) => {
     }
   }, []);
 
-  return renderAPI(resolvedVersion, restProps);
+  return renderAPI(resolvedVersion, apiSectionData, restProps);
 };
 
 export default APISection;

--- a/docs/mdx-plugins/remark-api-section-data.js
+++ b/docs/mdx-plugins/remark-api-section-data.js
@@ -1,0 +1,94 @@
+import { parse } from 'acorn';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { visit } from 'unist-util-visit';
+
+const { LATEST_VERSION } = JSON.parse(
+  readFileSync(join(process.cwd(), 'public/static/constants/versions.json'), 'utf8')
+);
+
+// Collects every <APISection packageName=... /> usage so the page's generated
+// `getStaticProps` (see remark-create-static-props) loads the matching API data
+// JSON at build time instead of webpack bundling the whole data directory into
+// the client chunks. APISection reads the data back through providers/api-data.
+export default function remarkApiSectionData() {
+  return function transformer(tree, file) {
+    const entries = new Map();
+
+    visit(tree, ['mdxJsxFlowElement', 'mdxJsxTextElement'], node => {
+      if (node.name !== 'APISection') {
+        return;
+      }
+      const version = resolveVersion(node, file);
+      for (const name of readPackageNames(node, file)) {
+        const key = `${version}/${name}`;
+        // Data files can be absent for older SDK versions; APISection then renders
+        // its "No API data file found" fallback, same as the previous runtime require.
+        if (
+          !entries.has(key) &&
+          existsSync(join(process.cwd(), 'public/static/data', `${key}.json`))
+        ) {
+          entries.set(key, `__apiSectionData${entries.size}`);
+        }
+      }
+    });
+
+    if (entries.size === 0) {
+      return;
+    }
+
+    const imports = [...entries]
+      .map(([key, id]) => `import ${id} from '~/public/static/data/${key}.json';`)
+      .join('\n');
+    tree.children.unshift({
+      type: 'mdxjsEsm',
+      data: { estree: parse(imports, { sourceType: 'module', ecmaVersion: 2022 }) },
+    });
+    file.data.apiSectionDataExpression = `{ ${[...entries]
+      .map(([key, id]) => `'${key}': ${id}.children`)
+      .join(', ')} }`;
+  };
+}
+
+function readPackageNames(node, file) {
+  const attribute = node.attributes?.find(
+    entry => entry.type === 'mdxJsxAttribute' && entry.name === 'packageName'
+  );
+  if (!attribute) {
+    return [];
+  }
+  if (typeof attribute.value === 'string') {
+    return [attribute.value];
+  }
+  const expression = attribute.value?.data?.estree?.body?.[0]?.expression;
+  if (
+    expression?.type === 'ArrayExpression' &&
+    expression.elements.every(
+      element => element?.type === 'Literal' && typeof element.value === 'string'
+    )
+  ) {
+    return expression.elements.map(element => element.value);
+  }
+  throw new Error(
+    `<APISection> in ${file.path} uses a non-literal packageName (${attribute.value?.value ?? attribute.value}). ` +
+      'API data is resolved at build time, so packageName must be a string literal or an array of string literals.'
+  );
+}
+
+function resolveVersion(node, file) {
+  const attribute = node.attributes?.find(
+    entry => entry.type === 'mdxJsxAttribute' && entry.name === 'forceVersion'
+  );
+  if (attribute && typeof attribute.value !== 'string') {
+    throw new Error(
+      `<APISection> in ${file.path} uses a non-literal forceVersion. ` +
+        'API data is resolved at build time, so forceVersion must be a string literal.'
+    );
+  }
+  // Mirrors the runtime resolution in APISection: the version segment of the URL
+  // (via PageApiVersionProvider, which defaults to `latest` outside /versions/),
+  // with `latest` mapped to the newest released version.
+  const pathVersion = file.path?.match(/[/\\]pages[/\\]versions[/\\]([^/\\]+)[/\\]/)?.[1];
+  const version = attribute?.value ?? pathVersion ?? 'latest';
+  return version === 'latest' ? LATEST_VERSION : version;
+}

--- a/docs/mdx-plugins/remark-create-static-props.js
+++ b/docs/mdx-plugins/remark-create-static-props.js
@@ -1,12 +1,17 @@
 import { parse } from 'acorn';
 
-// AST transformer adds `getStaticProps` to the tree based on provided mapping
+// AST transformer adds `getStaticProps` to the tree based on provided mapping.
+// When remark-api-section-data collected API reference data for the page, it is
+// merged into the props so it reaches hydration through `__NEXT_DATA__` instead
+// of the client JS bundles.
 export default function createNextStaticProps(map) {
-  return function transformer(tree) {
+  return function transformer(tree, file) {
+    const apiSectionData = file.data?.apiSectionDataExpression;
+    const props = apiSectionData ? `{ ...(${map}), apiSectionData: ${apiSectionData} }` : map;
     tree.children.push({
       type: 'mdxjsEsm',
       data: {
-        estree: parse(`export const getStaticProps = () => ({ props: ${map} });`, {
+        estree: parse(`export const getStaticProps = () => ({ props: ${props} });`, {
           sourceType: 'module',
           ecmaVersion: 2022,
         }),

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -15,6 +15,7 @@ import semver from 'semver';
 
 import packageJson from '~/package.json';
 
+import remarkApiSectionData from './mdx-plugins/remark-api-section-data.js';
 import remarkCodeTitle from './mdx-plugins/remark-code-title.js';
 import remarkCreateStaticProps from './mdx-plugins/remark-create-static-props.js';
 import remarkExportHeadings from './mdx-plugins/remark-export-headings.js';
@@ -85,25 +86,6 @@ const nextConfig: NextConfig = {
           join(__dirname, 'empty-polyfill.js')
         )
       );
-
-      // APISection pulls versioned API reference data (public/static/data/<version>/*.json) through a
-      // dynamic `require.context`, so webpack otherwise bundles every SDK version into a single chunk.
-      // That chunk exceeds Cloudflare Pages' 25 MiB per-file limit once enough versions exist.
-      const splitChunks = config.optimization?.splitChunks;
-      if (splitChunks && typeof splitChunks === 'object') {
-        splitChunks.cacheGroups = {
-          ...splitChunks.cacheGroups,
-          apiData: {
-            test: /[/\\]public[/\\]static[/\\]data[/\\]/,
-            name(module: { identifier: () => string }) {
-              const match = module.identifier().match(/static[/\\]data[/\\]([^/\\]+)[/\\]/);
-              return `api-data-${match ? match[1] : 'misc'}`;
-            },
-            chunks: 'all',
-            enforce: true,
-          },
-        };
-      }
     }
 
     // Add support for MDX with our custom loader
@@ -127,6 +109,7 @@ const nextConfig: NextConfig = {
               remarkLinkRewrite,
               remarkImageSize,
               remarkSDKCompatibility,
+              remarkApiSectionData,
               [remarkCreateStaticProps, `{ meta: meta || {}, headings: headings || [] }`],
             ],
             rehypePlugins: [rehypeSlug],

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -16,6 +16,7 @@ import { websiteSchema } from '~/constants/structured-data';
 import { useAnalyticsPageTracking } from '~/providers/Analytics';
 import { CodeBlockSettingsProvider } from '~/providers/CodeBlockSettingsProvider';
 import { TutorialChapterCompletionProvider } from '~/providers/TutorialChapterCompletionProvider';
+import { ApiDataProvider } from '~/providers/api-data';
 import { HreflangAlternates } from '~/ui/components/HreflangAlternates';
 import { markdownComponents } from '~/ui/components/Markdown';
 import { CodeSelectionCopy } from '~/ui/components/Snippet/CodeSelectionCopy';
@@ -99,7 +100,9 @@ export default function App({ Component, pageProps }: AppProps) {
                 <CodeBlockSettingsProvider>
                   <MDXProvider components={rootMarkdownComponents}>
                     <Tooltip.Provider>
-                      <Component {...pageProps} />
+                      <ApiDataProvider data={pageProps.apiSectionData}>
+                        <Component {...pageProps} />
+                      </ApiDataProvider>
                       <CodeSelectionCopy />
                     </Tooltip.Provider>
                   </MDXProvider>

--- a/docs/providers/api-data.tsx
+++ b/docs/providers/api-data.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, type PropsWithChildren } from 'react';
+
+export type ApiSectionData = Record<string, unknown>;
+
+const ApiDataContext = createContext<ApiSectionData | undefined>(undefined);
+
+/**
+ * Serves the per-page API reference data loaded by the generated `getStaticProps`
+ * (see mdx-plugins/remark-api-section-data.js), keyed by `<sdkVersion>/<packageName>`.
+ */
+export function ApiDataProvider({ data, children }: PropsWithChildren<{ data?: ApiSectionData }>) {
+  return <ApiDataContext.Provider value={data}>{children}</ApiDataContext.Provider>;
+}
+
+export function useApiSectionData() {
+  return useContext(ApiDataContext);
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25340

Each SDK page loads all SDK `api-data-*` which is not required to serve one page.

<img width="4654" height="2326" alt="CleanShot 2026-07-21 at 17 18 47@2x" src="https://github.com/user-attachments/assets/9b1de460-f86b-4d0c-905e-e8ead67d9c2c" />


# How

- Add `mdx-plugins/remark-api-section-data.js`: scans each MDX page for `<APISection>` usages and emits literal JSON imports inside the generated `getStaticProps`, so a page carries only its own API data (version resolved from the file path, `forceVersion` respected, missing data files keep the existing fallback).
- Update `remark-create-static-props.js` to merge the collected data into page props as `apiSectionData`.
- Add `providers/api-data.tsx` and mount `ApiDataProvider` in `_app.tsx` so `APISection` reads its data from context instead of a template-string `require()`, which forced webpack to bundle all of `public/static/data/` (five `api-data-*` chunks, ~2.4 MB compressed) into every SDK page.
- Remove the now-dead `apiData` `splitChunks` cacheGroup from `next.config.ts`.
- Add tests for provider-served data and the missing-data fallback; the `testRequire` path is unchanged.

# Test Plan

- Build and serve with `pnpm build && pnpm export-server`, then open `/versions/latest/sdk/notifications/` with the Network tab (in your browser): no `api-data-*` chunks load, the API reference renders, and each sidebar navigation fetches one small per-page JSON instead. 

<img width="4662" height="2318" alt="CleanShot 2026-07-21 at 17 18 38@2x" src="https://github.com/user-attachments/assets/ac17ae17-c5fb-4b83-9eff-8407aee60535" />


- Rendered HTML and generated markdown verified byte-identical across all 1,312 exported pages against `main`; `pnpm test` and `pnpm lint` pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
