### PR TITLE
[cli] add feedback sessions and telemetry opt-out

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -75,7 +75,7 @@ describe('help output', () => {
       );
       expect(helpOutput).toContain('--resume <feedbackId>');
       expect(helpOutput).toContain(
-        'Set DO_NOT_TRACK=1 to omit automatically collected metadata and authentication.'
+        'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected'
       );
     } finally {
       process.argv = originalArgv;
@@ -300,6 +300,7 @@ describe('feedback submission', () => {
     delete env.EXPO_STAGING;
     delete env.EXPO_TOKEN;
     delete env.DO_NOT_TRACK;
+    delete env.EXPO_NO_TELEMETRY;
     process.env = env;
     writeJson(path.join(projectRoot, 'package.json'), {
       name: 'not-an-expo-app',
@@ -428,44 +429,47 @@ describe('feedback submission', () => {
     }
   });
 
-  it('omits telemetry data and authentication when DO_NOT_TRACK=1', async () => {
-    const originalArgv = process.argv;
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-    jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
-    process.env.DO_NOT_TRACK = '1';
-    process.env.EXPO_TOKEN = 'token';
-    process.argv = [
-      'node',
-      'submit-expo-feedback',
-      '--category',
-      'mcp',
-      '--subject',
-      'expo-mcp',
-      '--resume',
-      'session_ABC-123',
-      'private feedback',
-    ];
+  it.each(['DO_NOT_TRACK', 'EXPO_NO_TELEMETRY'] as const)(
+    'omits telemetry data and authentication when %s=1',
+    async (environmentVariable) => {
+      const originalArgv = process.argv;
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+      process.env[environmentVariable] = '1';
+      process.env.EXPO_TOKEN = 'token';
+      process.argv = [
+        'node',
+        'submit-expo-feedback',
+        '--category',
+        'mcp',
+        '--subject',
+        'expo-mcp',
+        '--resume',
+        'session_ABC-123',
+        'private feedback',
+      ];
 
-    try {
-      await runExpoFeedbackAsync();
+      try {
+        await runExpoFeedbackAsync();
 
-      const request = fetchMock.mock.calls[0][1];
-      expect(JSON.parse(request.body)).toEqual({
-        feedback: 'private feedback',
-        metadata: {
-          category: 'mcp',
-          feedbackId: 'session_ABC-123',
-          subject: 'expo-mcp',
-        },
-      });
-      expect(request.headers).toEqual({
-        'Content-Type': 'application/json',
-      });
-      expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-        'Submitting feedback without telemetry data because DO_NOT_TRACK=1.'
-      );
-    } finally {
-      process.argv = originalArgv;
+        const request = fetchMock.mock.calls[0][1];
+        expect(JSON.parse(request.body)).toEqual({
+          feedback: 'private feedback',
+          metadata: {
+            category: 'mcp',
+            feedbackId: 'session_ABC-123',
+            subject: 'expo-mcp',
+          },
+        });
+        expect(request.headers).toEqual({
+          'Content-Type': 'application/json',
+        });
+        expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+          'Submitting feedback without telemetry data because telemetry collection is disabled.'
+        );
+      } finally {
+        process.argv = originalArgv;
+      }
     }
-  });
+  );
 });

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -91,11 +91,9 @@ describe('feedback session ID', () => {
   });
 
   it.each(['short', 'contains spaces', 'contains/slash', 'a'.repeat(65)])(
-    'rejects invalid ID %p',
+    'generates a new ID for invalid ID %p',
     (feedbackId) => {
-      expect(() => resolveFeedbackId(feedbackId)).toThrow(
-        'Invalid feedback ID. Expected 6-64 letters, numbers, hyphens, or underscores.'
-      );
+      expect(resolveFeedbackId(feedbackId)).toMatch(/^[a-f0-9]{12}$/);
     }
   );
 });
@@ -397,6 +395,29 @@ describe('feedback submission', () => {
       });
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
         'To continue the feedback session use:\nnpx submit-expo-feedback --resume session_ABC-123'
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it('replaces an invalid feedback ID and reports the generated ID', async () => {
+    const originalArgv = process.argv;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    process.argv = ['node', 'submit-expo-feedback', '--resume', 'invalid/id', 'one more detail'];
+
+    try {
+      await runExpoFeedbackAsync();
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const feedbackId = requestBody.metadata.feedbackId;
+      expect(feedbackId).toMatch(/^[a-f0-9]{12}$/);
+      expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+        `The provided feedback ID is invalid, so a new one was generated: ${feedbackId}`
+      );
+      expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+        `npx submit-expo-feedback --resume ${feedbackId}`
       );
     } finally {
       process.argv = originalArgv;

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -74,6 +74,9 @@ describe('help output', () => {
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
       expect(helpOutput).toContain('--resume <feedbackId>');
+      expect(helpOutput).toContain(
+        'Set DO_NOT_TRACK=1 to omit automatically collected metadata and authentication.'
+      );
     } finally {
       process.argv = originalArgv;
       consoleLogSpy.mockRestore();
@@ -296,6 +299,7 @@ describe('feedback submission', () => {
     };
     delete env.EXPO_STAGING;
     delete env.EXPO_TOKEN;
+    delete env.DO_NOT_TRACK;
     process.env = env;
     writeJson(path.join(projectRoot, 'package.json'), {
       name: 'not-an-expo-app',
@@ -418,6 +422,47 @@ describe('feedback submission', () => {
       );
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
         `npx submit-expo-feedback --resume ${feedbackId}`
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it('omits telemetry data and authentication when DO_NOT_TRACK=1', async () => {
+    const originalArgv = process.argv;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    process.env.DO_NOT_TRACK = '1';
+    process.env.EXPO_TOKEN = 'token';
+    process.argv = [
+      'node',
+      'submit-expo-feedback',
+      '--category',
+      'mcp',
+      '--subject',
+      'expo-mcp',
+      '--resume',
+      'session_ABC-123',
+      'private feedback',
+    ];
+
+    try {
+      await runExpoFeedbackAsync();
+
+      const request = fetchMock.mock.calls[0][1];
+      expect(JSON.parse(request.body)).toEqual({
+        feedback: 'private feedback',
+        metadata: {
+          category: 'mcp',
+          feedbackId: 'session_ABC-123',
+          subject: 'expo-mcp',
+        },
+      });
+      expect(request.headers).toEqual({
+        'Content-Type': 'application/json',
+      });
+      expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+        'Submitting feedback without telemetry data because DO_NOT_TRACK=1.'
       );
     } finally {
       process.argv = originalArgv;

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -399,7 +399,7 @@ describe('feedback submission', () => {
         },
       });
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-        'To continue the feedback session use:\nnpx submit-expo-feedback --resume session_ABC-123'
+        'To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume session_ABC-123'
       );
     } finally {
       process.argv = originalArgv;
@@ -422,7 +422,7 @@ describe('feedback submission', () => {
         `The provided feedback ID is invalid, so a new one was generated: ${feedbackId}`
       );
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-        `npx submit-expo-feedback --resume ${feedbackId}`
+        `npx submit-expo-feedback@latest --resume ${feedbackId}`
       );
     } finally {
       process.argv = originalArgv;

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -8,6 +8,7 @@ import {
   getProjectMetadata,
   getUserMetadataAsync,
   resolveFeedbackAsync,
+  resolveFeedbackId,
   runExpoFeedbackAsync,
   sendFeedbackAsync,
 } from '../cli';
@@ -72,11 +73,31 @@ describe('help output', () => {
       expect(helpOutput).toContain(
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
+      expect(helpOutput).toContain('--resume <feedbackId>');
     } finally {
       process.argv = originalArgv;
       consoleLogSpy.mockRestore();
     }
   });
+});
+
+describe('feedback session ID', () => {
+  it('generates a short hexadecimal ID when one is not provided', () => {
+    expect(resolveFeedbackId()).toMatch(/^[a-f0-9]{12}$/);
+  });
+
+  it('uses a valid provided ID', () => {
+    expect(resolveFeedbackId('session_ABC-123')).toBe('session_ABC-123');
+  });
+
+  it.each(['short', 'contains spaces', 'contains/slash', 'a'.repeat(65)])(
+    'rejects invalid ID %p',
+    (feedbackId) => {
+      expect(() => resolveFeedbackId(feedbackId)).toThrow(
+        'Invalid feedback ID. Expected 6-64 letters, numbers, hyphens, or underscores.'
+      );
+    }
+  );
 });
 
 describe('feedback message resolution', () => {
@@ -324,6 +345,7 @@ describe('feedback submission', () => {
     expect(AbortSignal.timeout).toHaveBeenCalledWith(15_000);
     expect(metadata).toMatchObject({
       category: 'mcp',
+      feedbackId: expect.stringMatching(/^[a-f0-9]{12}$/),
       subject: 'expo-mcp',
       agentEnvironment: {
         detected: true,
@@ -349,5 +371,35 @@ describe('feedback submission', () => {
         username: 'expo-user',
       },
     });
+  });
+
+  it('resumes a feedback session and prints instructions using the provided ID', async () => {
+    const originalArgv = process.argv;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    process.argv = [
+      'node',
+      'submit-expo-feedback',
+      '--resume',
+      'session_ABC-123',
+      'one more detail',
+    ];
+
+    try {
+      await runExpoFeedbackAsync();
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody).toMatchObject({
+        feedback: 'one more detail',
+        metadata: {
+          feedbackId: 'session_ABC-123',
+        },
+      });
+      expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+        'To continue the feedback session use:\nnpx submit-expo-feedback --resume session_ABC-123'
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
   });
 });

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -38,10 +38,13 @@ type ConfigFilePaths = {
   dynamicConfigPath: string | null;
 };
 
-type FeedbackMetadata = {
+type FeedbackContextMetadata = {
   category: FeedbackCategory;
   feedbackId: string;
   subject?: string;
+};
+
+type FeedbackTelemetryMetadata = {
   cli: {
     name: typeof CLI_NAME;
     version: string;
@@ -76,6 +79,9 @@ type FeedbackMetadata = {
     authType: 'token' | 'session';
   };
 };
+
+type FeedbackMetadata = FeedbackContextMetadata & FeedbackTelemetryMetadata;
+type FeedbackPayloadMetadata = FeedbackContextMetadata | FeedbackMetadata;
 
 export async function runExpoFeedbackAsync(): Promise<void> {
   await runAsync();
@@ -123,7 +129,8 @@ async function runAsync(): Promise<void> {
   }
 
   const { category, feedback } = await resolveFeedbackAsync(args._, args['--category']);
-  const session = getSession();
+  const telemetryDisabled = isTelemetryDisabled();
+  const session = telemetryDisabled ? null : getSession();
   const metadata = await createFeedbackMetadataAsync(
     process.cwd(),
     session,
@@ -141,7 +148,9 @@ async function runAsync(): Promise<void> {
 
   console.log(
     chalk.dim(
-      'Submitting feedback with available agent, sandbox, environment, project, and Expo account metadata.'
+      telemetryDisabled
+        ? 'Submitting feedback without telemetry data because DO_NOT_TRACK=1.'
+        : 'Submitting feedback with available agent, sandbox, environment, project, and Expo account metadata.'
     )
   );
   await sendFeedbackAsync({
@@ -207,18 +216,26 @@ export async function resolveFeedbackAsync(
 
 export async function createFeedbackMetadataAsync(
   projectRoot: string,
-  session = getSession(),
+  session?: UserSession | null,
   category: FeedbackCategory = 'unknown',
   subjectValue?: string,
   feedbackIdValue?: string
-): Promise<FeedbackMetadata> {
+): Promise<FeedbackPayloadMetadata> {
   const subject = normalizeSubject(subjectValue);
   const feedbackId = resolveFeedbackId(feedbackIdValue);
-
-  return {
+  const context: FeedbackContextMetadata = {
     category,
     feedbackId,
     ...(subject ? { subject } : {}),
+  };
+
+  if (isTelemetryDisabled()) {
+    return context;
+  }
+  const resolvedSession = session === undefined ? getSession() : session;
+
+  return {
+    ...context,
     cli: {
       name: CLI_NAME,
       version: getPackageVersion(),
@@ -240,7 +257,7 @@ export async function createFeedbackMetadataAsync(
     },
     packageManager: resolvePackageManager(projectRoot),
     project: getProjectMetadata(projectRoot),
-    user: await getUserMetadataAsync(session),
+    user: await getUserMetadataAsync(resolvedSession),
   };
 }
 
@@ -264,7 +281,7 @@ function getSandboxEnvironment() {
 
 export async function getUserMetadataAsync(
   session: UserSession | null
-): Promise<FeedbackMetadata['user']> {
+): Promise<FeedbackTelemetryMetadata['user']> {
   const authType = process.env.EXPO_TOKEN ? 'token' : session?.sessionSecret ? 'session' : null;
   if (!authType) {
     return undefined;
@@ -285,7 +302,7 @@ export async function getUserMetadataAsync(
   };
 }
 
-export function getProjectMetadata(projectRoot: string): FeedbackMetadata['project'] {
+export function getProjectMetadata(projectRoot: string): FeedbackTelemetryMetadata['project'] {
   const pkg = getPackageJson(projectRoot);
   const paths = getConfigFilePaths(projectRoot);
 
@@ -384,16 +401,21 @@ export async function sendFeedbackAsync({
   session,
 }: {
   feedback: string;
-  metadata: FeedbackMetadata;
+  metadata: FeedbackPayloadMetadata;
   session?: UserSession | null;
 }): Promise<void> {
+  const telemetryDisabled = isTelemetryDisabled();
   const response = await fetch(new URL('/v2/feedback/cli-send', getExpoApiBaseUrl()).toString(), {
     method: 'POST',
     signal: AbortSignal.timeout(FEEDBACK_TIMEOUT_MS),
     headers: {
-      ...getAuthHeaders(session),
       'Content-Type': 'application/json',
-      'User-Agent': `${CLI_NAME}/${getPackageVersion()}`,
+      ...(telemetryDisabled
+        ? {}
+        : {
+            ...getAuthHeaders(session),
+            'User-Agent': `${CLI_NAME}/${getPackageVersion()}`,
+          }),
     },
     body: JSON.stringify({
       feedback,
@@ -481,6 +503,7 @@ function printHelp(): void {
   {bold Data collection}
     Feedback includes available agent/session identifiers, sandbox and environment
     details, Expo project metadata, and Expo account identifiers.
+    Set DO_NOT_TRACK=1 to omit automatically collected metadata and authentication.
 
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
@@ -514,6 +537,10 @@ function resolveFeedbackCategory(value?: string): FeedbackCategory {
 function normalizeSubject(value?: string): string | undefined {
   const subject = value?.trim();
   return subject || undefined;
+}
+
+function isTelemetryDisabled(): boolean {
+  return process.env.DO_NOT_TRACK === '1';
 }
 
 export function resolveFeedbackId(value?: string): string {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -149,7 +149,7 @@ async function runAsync(): Promise<void> {
   console.log(
     chalk.dim(
       telemetryDisabled
-        ? 'Submitting feedback without telemetry data because DO_NOT_TRACK=1.'
+        ? 'Submitting feedback without telemetry data because telemetry collection is disabled.'
         : 'Submitting feedback with available agent, sandbox, environment, project, and Expo account metadata.'
     )
   );
@@ -503,7 +503,8 @@ function printHelp(): void {
   {bold Data collection}
     Feedback includes available agent/session identifiers, sandbox and environment
     details, Expo project metadata, and Expo account identifiers.
-    Set DO_NOT_TRACK=1 to omit automatically collected metadata and authentication.
+    Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected
+    metadata and authentication.
 
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
@@ -540,7 +541,7 @@ function normalizeSubject(value?: string): string | undefined {
 }
 
 function isTelemetryDisabled(): boolean {
-  return process.env.DO_NOT_TRACK === '1';
+  return process.env.DO_NOT_TRACK === '1' || process.env.EXPO_NO_TELEMETRY === '1';
 }
 
 export function resolveFeedbackId(value?: string): string {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -161,7 +161,7 @@ async function runAsync(): Promise<void> {
 
   console.log(chalk.green('Thanks for the feedback!'));
   console.log(
-    `To continue the feedback session use:\nnpx submit-expo-feedback --resume ${metadata.feedbackId}`
+    `To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume ${metadata.feedbackId}`
   );
 }
 

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -131,6 +131,13 @@ async function runAsync(): Promise<void> {
     args['--subject'],
     args['--resume']
   );
+  if (args['--resume'] !== undefined && metadata.feedbackId !== args['--resume']) {
+    console.log(
+      chalk.yellow(
+        `The provided feedback ID is invalid, so a new one was generated: ${metadata.feedbackId}`
+      )
+    );
+  }
 
   console.log(
     chalk.dim(
@@ -510,18 +517,13 @@ function normalizeSubject(value?: string): string | undefined {
 }
 
 export function resolveFeedbackId(value?: string): string {
-  if (value === undefined) {
-    return randomBytes(GENERATED_FEEDBACK_ID_BYTES).toString('hex');
-  }
-
   if (
+    value === undefined ||
     value.length < MIN_FEEDBACK_ID_LENGTH ||
     value.length > MAX_FEEDBACK_ID_LENGTH ||
     !FEEDBACK_ID_PATTERN.test(value)
   ) {
-    throw new CommandError(
-      `Invalid feedback ID. Expected ${MIN_FEEDBACK_ID_LENGTH}-${MAX_FEEDBACK_ID_LENGTH} letters, numbers, hyphens, or underscores.`
-    );
+    return randomBytes(GENERATED_FEEDBACK_ID_BYTES).toString('hex');
   }
 
   return value;

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -4,6 +4,7 @@ import { detectAgent } from 'agent-cli-detector';
 import arg from 'arg';
 import chalk from 'chalk';
 import * as ciInfo from 'ci-info';
+import { randomBytes } from 'crypto';
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import path from 'path';
@@ -12,6 +13,10 @@ import { detectSandbox } from 'sandbox-cli-detector';
 
 const CLI_NAME = 'submit-expo-feedback';
 const FEEDBACK_TIMEOUT_MS = 15_000;
+const GENERATED_FEEDBACK_ID_BYTES = 6;
+const MIN_FEEDBACK_ID_LENGTH = 6;
+const MAX_FEEDBACK_ID_LENGTH = 64;
+const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'unknown'] as const;
 
 type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
@@ -35,6 +40,7 @@ type ConfigFilePaths = {
 
 type FeedbackMetadata = {
   category: FeedbackCategory;
+  feedbackId: string;
   subject?: string;
   cli: {
     name: typeof CLI_NAME;
@@ -94,6 +100,7 @@ async function runAsync(): Promise<void> {
       '--version': Boolean,
       '--category': String,
       '--subject': String,
+      '--resume': String,
       '-h': '--help',
       '-v': '--version',
       '-c': '--category',
@@ -121,7 +128,8 @@ async function runAsync(): Promise<void> {
     process.cwd(),
     session,
     category,
-    args['--subject']
+    args['--subject'],
+    args['--resume']
   );
 
   console.log(
@@ -136,6 +144,9 @@ async function runAsync(): Promise<void> {
   });
 
   console.log(chalk.green('Thanks for the feedback!'));
+  console.log(
+    `To continue the feedback session use:\nnpx submit-expo-feedback --resume ${metadata.feedbackId}`
+  );
 }
 
 export async function resolveFeedbackAsync(
@@ -191,12 +202,15 @@ export async function createFeedbackMetadataAsync(
   projectRoot: string,
   session = getSession(),
   category: FeedbackCategory = 'unknown',
-  subjectValue?: string
+  subjectValue?: string,
+  feedbackIdValue?: string
 ): Promise<FeedbackMetadata> {
   const subject = normalizeSubject(subjectValue);
+  const feedbackId = resolveFeedbackId(feedbackIdValue);
 
   return {
     category,
+    feedbackId,
     ...(subject ? { subject } : {}),
     cli: {
       name: CLI_NAME,
@@ -464,6 +478,7 @@ function printHelp(): void {
   {bold Options}
     --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
     --subject, -s <subject>    Exact item the feedback is about, based on the category
+    --resume <feedbackId>      Continue a feedback session using its ID
     --version, -v              Version number
     --help, -h                 Usage info
 
@@ -492,6 +507,24 @@ function resolveFeedbackCategory(value?: string): FeedbackCategory {
 function normalizeSubject(value?: string): string | undefined {
   const subject = value?.trim();
   return subject || undefined;
+}
+
+export function resolveFeedbackId(value?: string): string {
+  if (value === undefined) {
+    return randomBytes(GENERATED_FEEDBACK_ID_BYTES).toString('hex');
+  }
+
+  if (
+    value.length < MIN_FEEDBACK_ID_LENGTH ||
+    value.length > MAX_FEEDBACK_ID_LENGTH ||
+    !FEEDBACK_ID_PATTERN.test(value)
+  ) {
+    throw new CommandError(
+      `Invalid feedback ID. Expected ${MIN_FEEDBACK_ID_LENGTH}-${MAX_FEEDBACK_ID_LENGTH} letters, numbers, hyphens, or underscores.`
+    );
+  }
+
+  return value;
 }
 
 function getPackageVersion(): string {


### PR DESCRIPTION
Adds an optional --resume <feedbackId> argument to group consecutive submit-expo-feedback submissions, generating a short hexadecimal ID when omitted and replacing invalid IDs with a reported replacement. Honors both the cross-tool DO_NOT_TRACK=1 convention and Expo’s EXPO_NO_TELEMETRY=1 setting by retaining only user-directed category, subject, and session ID context while omitting detected telemetry, authentication, and explicit CLI user-agent headers. Sends the resolved feedback ID in metadata and prints an npx submit-expo-feedback@latest command for continuing the session after success. Adds coverage for session IDs, replacement behavior, both privacy variables, payload metadata, and terminal output.

Tested with pnpm --filter submit-expo-feedback test, typecheck, lint, and build.