### PR TITLE
[docs] Fix sidebar contrast failures flagged by Lighthouse

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -3,6 +3,15 @@
 
 @import './tailwind-compat.css';
 
+:root {
+  /* AA contrast on palette blue3/blue4 backgrounds, where text-link falls short */
+  --expo-theme-text-link-on-blue: #0c6bbf;
+}
+
+.dark-theme {
+  --expo-theme-text-link-on-blue: var(--blue-11);
+}
+
 @layer base {
   html {
     @apply bg-default;

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -32,6 +32,9 @@ module.exports = {
     borderColor: {
       'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
     },
+    textColor: {
+      'link-on-blue': 'var(--expo-theme-text-link-on-blue)',
+    },
     backgroundImage: {
       'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
       'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",

--- a/docs/ui/components/Sidebar/ApiVersionSelect.tsx
+++ b/docs/ui/components/Sidebar/ApiVersionSelect.tsx
@@ -22,7 +22,7 @@ export function ApiVersionSelect() {
         'flex flex-col gap-1 border-b border-b-default bg-default px-4 pt-3 pb-4',
         'max-lg:sticky max-lg:top-0 max-lg:z-10'
       )}>
-      <FOOTNOTE theme="tertiary">Reference version</FOOTNOTE>
+      <FOOTNOTE theme="secondary">Reference version</FOOTNOTE>
       <Select
         id="api-version-select"
         className="min-w-full"

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -39,7 +39,7 @@ export const SidebarSingleEntry = ({
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-sm',
             isActive &&
-              'bg-palette-blue3! font-medium text-link hocus:bg-palette-blue4! hocus:text-link'
+              'bg-palette-blue3! text-[#0c6ec4] font-medium dark:text-link dark:hocus:text-link hocus:bg-palette-blue4! hocus:text-[#0c6ec4]'
           )}
           {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
           {...(isActive && mainSection && { 'data-main-section': mainSection })}>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -39,7 +39,7 @@ export const SidebarSingleEntry = ({
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-sm',
             isActive &&
-              'bg-palette-blue3! text-[#0c6ec4] font-medium dark:text-link dark:hocus:text-link hocus:bg-palette-blue4! hocus:text-[#0c6ec4]'
+              'bg-palette-blue3! font-medium text-link-on-blue hocus:bg-palette-blue4! hocus:text-link-on-blue'
           )}
           {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
           {...(isActive && mainSection && { 'data-main-section': mainSection })}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25344

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix sidebar contrast failures flagged by Lighthouse.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit any SDK page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
