### PR TITLE
[image-picker][Android] Fix crop failing for large images

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`. ([#48005](https://github.com/expo/expo/pull/48005) by [@barthap](https://github.com/barthap))
+- [Android] Fix crop failing for large images ([#48019](https://github.com/expo/expo/pull/48019) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -1,6 +1,5 @@
 package expo.modules.imagepicker
 
-import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.PorterDuff
@@ -333,7 +332,7 @@ class ExpoCropImageActivity :
 
   override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception?) {
     if (error != null) {
-      setResult(null, error, 1)
+      setResultError()
       return
     }
     if (cropImageOptions.initialCropWindowRectangle != null) {
@@ -350,7 +349,11 @@ class ExpoCropImageActivity :
   }
 
   override fun onCropImageComplete(view: CropImageView, result: CropImageView.CropResult) {
-    setResult(result.uriContent, result.error, result.sampleSize)
+    if (result.error != null) {
+      setResultError()
+      return
+    }
+    setResultOK()
   }
   // endregion
 
@@ -411,7 +414,7 @@ class ExpoCropImageActivity :
   // region Crop Result
   private fun cropImage() {
     if (cropImageOptions.noOutputImage) {
-      setResult(null, null, 1)
+      setResultOK()
     } else {
       cropImageView?.croppedImageAsync(
         saveCompressFormat = cropImageOptions.outputCompressFormat,
@@ -429,26 +432,14 @@ class ExpoCropImageActivity :
     finish()
   }
 
-  private fun setResult(uri: Uri?, error: Exception?, sampleSize: Int) {
-    setResult(
-      error?.let { CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE } ?: RESULT_OK,
-      getResultIntent(uri, error, sampleSize)
-    )
+  private fun setResultError() {
+    setResult(CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE)
     finish()
   }
 
-  private fun getResultIntent(uri: Uri?, error: Exception?, sampleSize: Int): Intent {
-    val result = CropImage.ActivityResult(
-      originalUri = cropImageView?.imageUri,
-      uriContent = uri,
-      error = error,
-      cropPoints = cropImageView?.cropPoints,
-      cropRect = cropImageView?.cropRect,
-      rotation = cropImageView?.rotatedDegrees ?: 0,
-      wholeImageRect = cropImageView?.wholeImageRect,
-      sampleSize = sampleSize
-    )
-    return Intent().putExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, result)
+  private fun setResultOK() {
+    setResult(RESULT_OK)
+    finish()
   }
   // endregion
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.os.Build
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.canhub.cropper.CropImage
@@ -55,18 +54,18 @@ internal class CropImageContract(
   }
 
   override fun parseResult(input: CropImageContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult {
-    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, CropImage.ActivityResult::class.java)
-    } else {
-      @Suppress("DEPRECATION")
-      intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT)
-    }
-    if (resultCode == Activity.RESULT_CANCELED || result == null) {
+    if (resultCode == Activity.RESULT_CANCELED) {
       return ImagePickerContractResult.Cancelled
     }
-    val targetUri = requireNotNull(result.uriContent)
-    val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
-    runBlocking { copyExifData(input.sourceUri.toUri(), input.outputFile, contentResolver) }
+    if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+      return ImagePickerContractResult.Error
+    }
+    if (resultCode != Activity.RESULT_OK) {
+      return ImagePickerContractResult.Error
+    }
+    val reactContext = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }
+    val targetUri = input.outputFile.getContentUri(reactContext)
+    runBlocking { copyExifData(input.sourceUri.toUri(), input.outputFile, reactContext.contentResolver) }
     return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
   }
 }


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/48011

Cropping large images (for example 28000x28000px) couldn't be handled by the image cropper, which returned a null URI to `parseResult` which wasn't able to handle it and crashed the app with `IllegalArgumentException`

# How

- added a new result function with error code `CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE`
- handled the error code in `parseResult`, which now branches solely on the result code
- dropped the unnecessary result intent and replaced it with `input.outputFile`

# Test Plan

BareExpo ✅ 