### PR TITLE
[updates][ios] Allow overriding the dev client package name

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`.
+- [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`. ([#48020](https://github.com/expo/expo/pull/48020) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Skip reading and hashing embedded assets on first launch by default, serving them from the app binary instead of copying them into the updates cache. ([#47284](https://github.com/expo/expo/pull/47284) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Allow overriding the package used to detect the installed dev client via the `expo.updates.devClientPackage`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -18,7 +18,8 @@ begin
   # No dev client if we are using native debug
   if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
     project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
-    use_dev_client = File.dirname(`node --print "require.resolve('expo-dev-client/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`).length > 0
+    dev_client_package = podfile_properties['expo.updates.devClientPackage'] || 'expo-dev-client'
+    use_dev_client = File.dirname(`node --print "require.resolve('#{dev_client_package}/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`).length > 0
   end
 rescue
   use_dev_client = false


### PR DESCRIPTION
# Why
The podspec hardcodes `expo-dev-client` when detecting whether a dev client is installed to enable the `USE_DEV_CLIENT` build flag. Projects that ship a dev client under a different package name can't opt into that path.

# How

Read an optional `expo.updates.devClientPackage` Podfile property and use it as the package to resolve, defaulting to expo-dev-client. When the property is unset, the require.resolve call is identical to before, no behavior change for existing projects.

# Test Plan

- Default (property unset): pod install in an app with expo-dev-client installed  EXUpdates still builds with -DUSE_DEV_CLIENT in an app without it → flag absent.
- Property set: set expo.updates.devClientPackage to a custom package present in the project → EXUpdates builds with -DUSE_DEV_CLIENT.
- Property set to a missing package: build succeeds with -DUSE_DEV_CLIENT absent, safe fallback.

