### PR TITLE
[docs] Load image lightbox on demand to remove render-blocking stylesheet

### DIFF
--- a/docs/ui/components/ContentSpotlight/LightboxImage.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxImage.tsx
@@ -1,7 +1,9 @@
+import dynamic from 'next/dynamic';
 import { ImgHTMLAttributes, useState } from 'react';
-import { Lightbox } from 'yet-another-react-lightbox';
-import 'yet-another-react-lightbox/styles.css';
-import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+
+// Loaded on first click so the lightbox JS and its stylesheet stay out of the
+// render-blocking path; the inline image below is independent of it.
+const LightboxModal = dynamic(() => import('./LightboxModal'), { ssr: false });
 
 type Props = ImgHTMLAttributes<HTMLImageElement> & {
   src: string;
@@ -9,34 +11,27 @@ type Props = ImgHTMLAttributes<HTMLImageElement> & {
 
 export function LightboxImage({ src, alt, ...rest }: Props) {
   const [open, setOpen] = useState(false);
+  const [lightboxRequested, setLightboxRequested] = useState(false);
 
   return (
     <>
       <button
         type="button"
         onClick={() => {
+          setLightboxRequested(true);
           setOpen(true);
         }}>
         <img src={src} alt={alt} {...rest} />
       </button>
-      <Lightbox
-        open={open}
-        close={() => {
-          setOpen(false);
-        }}
-        slides={[{ src }]}
-        styles={{ container: { backgroundColor: 'rgba(0, 0, 0, .8)' } }}
-        controller={{
-          aria: true,
-          closeOnBackdropClick: true,
-        }}
-        carousel={{ finite: true }}
-        render={{
-          buttonPrev: () => null,
-          buttonNext: () => null,
-        }}
-        plugins={[Zoom]}
-      />
+      {lightboxRequested && (
+        <LightboxModal
+          src={src}
+          open={open}
+          close={() => {
+            setOpen(false);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/docs/ui/components/ContentSpotlight/LightboxModal.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxModal.tsx
@@ -1,0 +1,30 @@
+import { Lightbox } from 'yet-another-react-lightbox';
+import 'yet-another-react-lightbox/styles.css';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+
+type Props = {
+  src: string;
+  open: boolean;
+  close: () => void;
+};
+
+export default function LightboxModal({ src, open, close }: Props) {
+  return (
+    <Lightbox
+      open={open}
+      close={close}
+      slides={[{ src }]}
+      styles={{ container: { backgroundColor: 'rgba(0, 0, 0, .8)' } }}
+      controller={{
+        aria: true,
+        closeOnBackdropClick: true,
+      }}
+      carousel={{ finite: true }}
+      render={{
+        buttonPrev: () => null,
+        buttonNext: () => null,
+      }}
+      plugins={[Zoom]}
+    />
+  );
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25359

# How

- Move the YARL `Lightbox` and its `styles.css` import out of `LightboxImage` into a new `LightboxModal.tsx`, loaded via `next/dynamic` on first image click, the same pattern `ContentSpotlight` already uses for `ReactPlayer`.
- Keep the inline `<button><img></button>` markup untouched, and keep the modal mounted after first open so close animations still play.

# Test Plan

- Locally: `pnpm build && pnpm export-server`
- Open `localhost:8000/versions/latest/sdk/notifications/` with DevTools Network (Disable cache) and reload
  - Only one render-blocking stylesheet loads with the page. Click the notification categories screenshot: a small JS chunk and the lightbox CSS load at that moment, and the lightbox opens with zoom and close working as before.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
