### PR TITLE
[docs] Simplify Expo MCP authentication instructions

### DIFF
--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -144,18 +144,9 @@ The above command adds the MCP server to your Codex configuration file and promp
 
 ### Authenticate with Expo
 
-After installing the MCP server, you'll need to authenticate using one of two methods:
+After installing the MCP server, you'll need to authenticate.
 
-#### Access token (recommended)
-
-Generate a **Personal access token** from your Expo account and use it during the OAuth flow.
-
-- To generate an access token, open [Access tokens](https://expo.dev/accounts/[account]/settings/access-tokens) settings page in EAS dashboard.
-- Under **Personal access tokens**, click **Create token**. Copy the token and use it during the OAuth flow.
-
-#### Credentials
-
-Use your Expo account username and password. In this case, the server will generate an access token automatically.
+Sign in with your Expo account in the browser when prompted. The server will generate an access token automatically.
 
 </Step>
 


### PR DESCRIPTION
# Why

The Expo MCP server authentication docs described two methods (a personal access token and account credentials) during the OAuth flow. The PAT path is no longer accurate, so removed it from the docs. A user wrote in about it: https://app.usepylon.com/support/issues/views/e37c600c-1895-44b4-9a45-db4118109bfe?issueNumber=20745&view=fs

# How

Replaced the two-method breakdown with a single, concise instruction to sign in with the Expo account in the browser when prompted, noting the server generates an access token automatically.

# Test Plan

Documentation-only change. Verified the rendered wording reads correctly in `docs/pages/mcp.mdx`.

# Checklist

- [x] This change is documentation-only and follows the documentation style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)