### PR TITLE
[cli,router-server] feat: support SVG favicons via `web.favicon` and `public/favicon.svg`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- Support SVG favicons via `web.favicon` and `public/favicon.svg` ([#48026](https://github.com/expo/expo/pull/48026) by [@danfitz36](https://github.com/danfitz36))
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
 - Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/src/export/__tests__/favicon.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/favicon.test.ts
@@ -33,6 +33,24 @@ describe(generateFaviconAssetAsync, () => {
     expect(result).toBeNull();
   });
 
+  it('returns the SVG href when the user supplied a `public/favicon.svg`', async () => {
+    // Browsers don't auto-discover SVG favicons the way they do
+    // `/favicon.ico`, so a `<link>` tag must still be emitted. The SVG file
+    // itself is copied to the output by `copyPublicFolderAsync`, not here.
+    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+
+    const files: ExportAssetMap = new Map();
+    const result = await generateFaviconAssetAsync('/project', {
+      baseUrl: '/app',
+      outputDir: '/out',
+      files,
+      exp: { name: '', slug: '' } as any,
+    });
+
+    expect(result).toEqual({ href: '/app/favicon.svg' });
+    expect(files.size).toBe(0);
+  });
+
   it('returns `null` when `web.favicon` is not set', async () => {
     const result = await generateFaviconAssetAsync('/project', {
       baseUrl: '',
@@ -57,6 +75,37 @@ describe(generateFaviconAssetAsync, () => {
       contents: Buffer.from([1, 2, 3]),
       targetDomain: 'client',
     });
+  });
+
+  it('copies an SVG `web.favicon` raw (no rasterization) and returns the SVG href', async () => {
+    // Rasterizing would defeat the point of an SVG favicon — features like
+    // `prefers-color-scheme` media queries need the original markup to
+    // survive into the served asset.
+    const svgSource = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+    const readFileMock = jest
+      .spyOn(require('fs').promises, 'readFile')
+      .mockResolvedValue(Buffer.from(svgSource));
+
+    try {
+      const files: ExportAssetMap = new Map();
+      const result = await generateFaviconAssetAsync('/project', {
+        baseUrl: '/app',
+        outputDir: '/out',
+        files,
+        exp: { name: '', slug: '', web: { favicon: './icon.svg' } } as any,
+      });
+
+      expect(result).toEqual({ href: '/app/favicon.svg' });
+      expect(files.get('favicon.svg')).toEqual({
+        contents: Buffer.from(svgSource),
+        targetDomain: 'client',
+      });
+      // The raster pipeline must not have been invoked for the SVG input.
+      const { generateImageAsync } = jest.requireMock('@expo/image-utils');
+      expect(generateImageAsync).not.toHaveBeenCalled();
+    } finally {
+      readFileMock.mockRestore();
+    }
   });
 
   it('writes to disk when no asset map is provided', async () => {

--- a/packages/@expo/cli/src/export/__tests__/favicon.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/favicon.test.ts
@@ -54,6 +54,50 @@ describe(generateFaviconAssetAsync, () => {
     expect(generateImageAsync).not.toHaveBeenCalled();
   });
 
+  it('still generates favicon.ico when a public SVG is paired with a raster web.favicon', async () => {
+    // A project that has both used to get a generated `favicon.ico`. The public SVG takes the
+    // `<link>`, but dropping the ICO would silently remove the fallback older browsers
+    // auto-discover at `/favicon.ico`.
+    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+
+    const files: ExportAssetMap = new Map();
+    const result = await generateFaviconAssetAsync('/project', {
+      baseUrl: '',
+      outputDir: '/out',
+      files,
+      exp: { name: '', slug: '', web: { favicon: './icon.png' } } as any,
+    });
+
+    expect(result).toEqual({ href: '/favicon.svg' });
+    expect(files.get('favicon.ico')).toEqual({
+      contents: Buffer.from([1, 2, 3]),
+      targetDomain: 'client',
+    });
+  });
+
+  it('does not double-write favicon.svg when a public SVG is paired with an SVG web.favicon', async () => {
+    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    const readFileMock = jest
+      .spyOn(require('fs').promises, 'readFile')
+      .mockResolvedValue(Buffer.from('<svg/>'));
+
+    try {
+      const files: ExportAssetMap = new Map();
+      const result = await generateFaviconAssetAsync('/project', {
+        baseUrl: '',
+        outputDir: '/out',
+        files,
+        exp: { name: '', slug: '', web: { favicon: './icon.svg' } } as any,
+      });
+
+      // The public file already occupies `favicon.svg` in the output.
+      expect(result).toEqual({ href: '/favicon.svg' });
+      expect(files.size).toBe(0);
+    } finally {
+      readFileMock.mockRestore();
+    }
+  });
+
   it('returns `null` when `web.favicon` is not set', async () => {
     const result = await generateFaviconAssetAsync('/project', {
       baseUrl: '',

--- a/packages/@expo/cli/src/export/__tests__/favicon.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/favicon.test.ts
@@ -49,6 +49,9 @@ describe(generateFaviconAssetAsync, () => {
 
     expect(result).toEqual({ href: '/app/favicon.svg' });
     expect(files.size).toBe(0);
+    // The raster pipeline is the pre-patch crash path for SVG input; assert it stays skipped.
+    const { generateImageAsync } = jest.requireMock('@expo/image-utils');
+    expect(generateImageAsync).not.toHaveBeenCalled();
   });
 
   it('returns `null` when `web.favicon` is not set', async () => {

--- a/packages/@expo/cli/src/export/__tests__/favicon.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/favicon.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateFaviconAssetAsync } from '../favicon';
+import { generateFaviconAssetAsync, getSvgFaviconHref } from '../favicon';
 import type { ExportAssetMap } from '../saveAssets';
 
 jest.mock('../publicFolder', () => ({
@@ -167,5 +167,41 @@ describe(generateFaviconAssetAsync, () => {
     } finally {
       fsMock.mockRestore();
     }
+  });
+});
+
+describe(getSvgFaviconHref, () => {
+  beforeEach(() => {
+    getUserDefinedFile.mockReturnValue(null);
+  });
+
+  it('returns the SVG href for an SVG `web.favicon`', () => {
+    expect(
+      getSvgFaviconHref('/project', { name: '', slug: '', web: { favicon: './icon.svg' } } as any)
+    ).toBe('/favicon.svg');
+  });
+
+  it('returns the SVG href for a `public/favicon.svg`', () => {
+    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    expect(getSvgFaviconHref('/project', { name: '', slug: '' } as any)).toBe('/favicon.svg');
+  });
+
+  // `.ico` needs no tag: browsers auto-discover `/favicon.ico`, which is why the dev server
+  // never had to inject one before SVG support.
+  it('returns `null` for a raster `web.favicon`', () => {
+    expect(
+      getSvgFaviconHref('/project', { name: '', slug: '', web: { favicon: './icon.png' } } as any)
+    ).toBeNull();
+  });
+
+  it('returns `null` for a `public/favicon.ico`', () => {
+    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.ico');
+    expect(
+      getSvgFaviconHref('/project', { name: '', slug: '', web: { favicon: './icon.svg' } } as any)
+    ).toBeNull();
+  });
+
+  it('returns `null` when no favicon is configured', () => {
+    expect(getSvgFaviconHref('/project', { name: '', slug: '' } as any)).toBeNull();
   });
 });

--- a/packages/@expo/cli/src/export/__tests__/favicon.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/favicon.test.ts
@@ -16,6 +16,14 @@ const { getUserDefinedFile } = jest.requireMock('../publicFolder') as {
   getUserDefinedFile: jest.Mock;
 };
 
+/** Make the `getUserDefinedFile` mock resolve against a given set of public folder files. */
+function mockPublicFolder(publicFiles: string[]) {
+  getUserDefinedFile.mockImplementation((_projectRoot: string, possiblePaths: string[]) => {
+    const match = possiblePaths.find((possiblePath) => publicFiles.includes(possiblePath));
+    return match ? `/project/public/${match.replace(/^\.\//, '')}` : null;
+  });
+}
+
 describe(generateFaviconAssetAsync, () => {
   beforeEach(() => {
     getUserDefinedFile.mockReturnValue(null);
@@ -37,7 +45,7 @@ describe(generateFaviconAssetAsync, () => {
     // Browsers don't auto-discover SVG favicons the way they do
     // `/favicon.ico`, so a `<link>` tag must still be emitted. The SVG file
     // itself is copied to the output by `copyPublicFolderAsync`, not here.
-    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    mockPublicFolder(['./favicon.svg']);
 
     const files: ExportAssetMap = new Map();
     const result = await generateFaviconAssetAsync('/project', {
@@ -58,7 +66,7 @@ describe(generateFaviconAssetAsync, () => {
     // A project that has both used to get a generated `favicon.ico`. The public SVG takes the
     // `<link>`, but dropping the ICO would silently remove the fallback older browsers
     // auto-discover at `/favicon.ico`.
-    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    mockPublicFolder(['./favicon.svg']);
 
     const files: ExportAssetMap = new Map();
     const result = await generateFaviconAssetAsync('/project', {
@@ -75,8 +83,27 @@ describe(generateFaviconAssetAsync, () => {
     });
   });
 
+  it('does not overwrite a public favicon.ico when the public folder also holds an SVG', async () => {
+    // `getUserDefinedFaviconFile` reports the SVG (it wins the `<link>`) and never mentions the
+    // sibling ICO, so generation has to re-check the output path: `copyPublicFolderAsync` has
+    // already copied the user's own `favicon.ico` there, and writing over it would replace a
+    // hand-crafted multi-size icon with a rasterized `web.favicon`.
+    mockPublicFolder(['./favicon.svg', './favicon.ico']);
+
+    const files: ExportAssetMap = new Map();
+    const result = await generateFaviconAssetAsync('/project', {
+      baseUrl: '',
+      outputDir: '/out',
+      files,
+      exp: { name: '', slug: '', web: { favicon: './icon.png' } } as any,
+    });
+
+    expect(result).toEqual({ href: '/favicon.svg' });
+    expect(files.size).toBe(0);
+  });
+
   it('does not double-write favicon.svg when a public SVG is paired with an SVG web.favicon', async () => {
-    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    mockPublicFolder(['./favicon.svg']);
     const readFileMock = jest
       .spyOn(require('fs').promises, 'readFile')
       .mockResolvedValue(Buffer.from('<svg/>'));
@@ -182,7 +209,7 @@ describe(getSvgFaviconHref, () => {
   });
 
   it('returns the SVG href for a `public/favicon.svg`', () => {
-    getUserDefinedFile.mockReturnValueOnce('/project/public/favicon.svg');
+    mockPublicFolder(['./favicon.svg']);
     expect(getSvgFaviconHref('/project', { name: '', slug: '' } as any)).toBe('/favicon.svg');
   });
 

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -9,18 +9,28 @@ import { debugEvent } from './events';
 import { getUserDefinedFile } from './publicFolder';
 import type { ExportAssetMap } from './saveAssets';
 
-/** @returns the file system path for a user-defined favicon.ico file in the public folder. */
+/** @returns whether the given path looks like an SVG (by file extension). */
+function isSvgPath(p: string): boolean {
+  return path.extname(p).toLowerCase() === '.svg';
+}
+
+/** @returns the file system path for a user-defined favicon file in the public folder. */
 export function getUserDefinedFaviconFile(projectRoot: string): string | null {
-  return getUserDefinedFile(projectRoot, ['./favicon.ico']);
+  // SVG first: when a user drops both files, they almost certainly want the
+  // SVG to win in modern browsers. Older browsers ignore the SVG `<link>` and
+  // auto-discover `/favicon.ico`, so the ICO still functions as a fallback.
+  return getUserDefinedFile(projectRoot, ['./favicon.svg', './favicon.ico']);
 }
 
 /**
- * Generate a favicon.ico from `web.favicon` in the Expo config and write it into the asset map
- * (or to disk if no asset map is provided).
+ * Generate a favicon from `web.favicon` in the Expo config and write it into the asset map
+ * (or to disk if no asset map is provided). Accepts either a raster image (rasterized to a
+ * multi-size `favicon.ico`) or an SVG (copied byte-for-byte to `favicon.svg`, preserving
+ * features like `prefers-color-scheme` media queries inside the SVG).
  *
- * @returns the public href for the generated favicon, or `null` when a user-supplied
- *   `favicon.ico` already exists in the public folder (browsers resolve it at `/favicon.ico`
- *   automatically) or when no `web.favicon` is configured.
+ * @returns the public href for the generated favicon (`.ico` or `.svg`), or `null` when a
+ *   user-supplied `favicon.ico` already exists in the public folder (browsers resolve it at
+ *   `/favicon.ico` automatically), or when no `web.favicon` is configured.
  */
 export async function generateFaviconAssetAsync(
   projectRoot: string,
@@ -33,6 +43,13 @@ export async function generateFaviconAssetAsync(
 ): Promise<{ href: string } | null> {
   const existing = getUserDefinedFaviconFile(projectRoot);
   if (existing) {
+    if (isSvgPath(existing)) {
+      // A user-supplied `public/favicon.svg` is copied to the output by
+      // `copyPublicFolderAsync`; we still need to inject the `<link>` tag,
+      // because browsers don't auto-discover SVG favicons the way they do
+      // `/favicon.ico`.
+      return { href: `${baseUrl}/favicon.svg` };
+    }
     return null;
   }
 
@@ -66,6 +83,26 @@ export async function getFaviconFromExpoConfigAsync(
   const src = exp.web?.favicon ?? null;
   if (!src) {
     return null;
+  }
+
+  // SVG: copy the file raw. Rasterizing it would defeat the point of an SVG
+  // favicon — features like `prefers-color-scheme` media queries inside the
+  // SVG need the original markup to survive into the served asset. It would
+  // also crash the export today, since `@expo/image-utils` rejects SVG in
+  // `ensureImageOptionsAsync` (unsupported MIME) and this function's
+  // `try/catch` only handles `ENOENT`.
+  if (isSvgPath(src)) {
+    try {
+      const absSrc = path.resolve(projectRoot, src);
+      const source = await fs.promises.readFile(absSrc);
+      return { source, path: 'favicon.svg' };
+    } catch (error: any) {
+      if (!force && error.code === 'ENOENT') {
+        Log.warn(`Favicon source file in Expo config (web.favicon) does not exist: ${src}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   const dims = [16, 32, 48];

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -28,6 +28,23 @@ export function getUserDefinedFaviconFile(projectRoot: string): string | null {
 }
 
 /**
+ * Resolve the favicon href that needs an explicit `<link>` tag, without generating anything.
+ * Used by the dev server, where the bytes are served on demand by `FaviconMiddleware` (or by
+ * the static middleware for public-folder files) rather than written to an output directory.
+ *
+ * @returns `/favicon.svg` when the resolved favicon is an SVG, or `null` otherwise — `.ico`
+ *   favicons need no tag, since browsers auto-discover `/favicon.ico`.
+ */
+export function getSvgFaviconHref(projectRoot: string, exp?: ExpoConfig): string | null {
+  const existing = getUserDefinedFaviconFile(projectRoot);
+  if (existing) {
+    return isSvgPath(existing) ? '/favicon.svg' : null;
+  }
+  const src = exp?.web?.favicon;
+  return src && isSvgPath(src) ? '/favicon.svg' : null;
+}
+
+/**
  * Generate a favicon from `web.favicon` in the Expo config and write it into the asset map
  * (or to disk if no asset map is provided). Accepts either a raster image (rasterized to a
  * multi-size `favicon.ico`) or an SVG (copied byte-for-byte to `favicon.svg`, preserving

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -9,8 +9,13 @@ import { debugEvent } from './events';
 import { getUserDefinedFile } from './publicFolder';
 import type { ExportAssetMap } from './saveAssets';
 
-/** @returns whether the given path looks like an SVG (by file extension). */
-function isSvgPath(p: string): boolean {
+/**
+ * @returns whether the given path looks like an SVG (by file extension).
+ *
+ * Works for both filesystem paths and query-stripped URL pathnames, so the export pipeline
+ * and the dev-server middleware classify a favicon the same way.
+ */
+export function isSvgPath(p: string): boolean {
   return path.extname(p).toLowerCase() === '.svg';
 }
 
@@ -27,6 +32,11 @@ export function getUserDefinedFaviconFile(projectRoot: string): string | null {
  * (or to disk if no asset map is provided). Accepts either a raster image (rasterized to a
  * multi-size `favicon.ico`) or an SVG (copied byte-for-byte to `favicon.svg`, preserving
  * features like `prefers-color-scheme` media queries inside the SVG).
+ *
+ * A favicon in the public folder wins over `web.favicon`, matching the pre-existing behavior
+ * for `public/favicon.ico`. So `public/favicon.svg` suppresses generation from `web.favicon`
+ * too — a user who wants an `.ico` fallback for older browsers alongside it should add their
+ * own `public/favicon.ico`, which browsers auto-discover.
  *
  * @returns the public href for the generated favicon (`.ico` or `.svg`), or `null` when a
  *   user-supplied `favicon.ico` already exists in the public folder (browsers resolve it at

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -53,8 +53,9 @@ export function getSvgFaviconHref(projectRoot: string, exp?: ExpoConfig): string
  * A favicon in the public folder wins the `<link>`, matching the pre-existing behavior for
  * `public/favicon.ico`. A `public/favicon.svg` does *not* suppress `favicon.ico` generation,
  * though: a raster `web.favicon` is still rasterized so that browsers without SVG favicon
- * support keep auto-discovering `/favicon.ico`. (An SVG `web.favicon` is skipped in that case,
- * since it would write to the same `favicon.svg` path the public file already occupies.)
+ * support keep auto-discovering `/favicon.ico`. Generation is skipped only when the public
+ * folder already ships a file at the same output path, since `copyPublicFolderAsync` has
+ * copied it there and writing over it would replace the user's own icon.
  *
  * @returns the public href for the favicon to link (`.ico` or `.svg`), or `null` when a
  *   user-supplied `favicon.ico` already exists in the public folder (browsers resolve it at
@@ -85,10 +86,13 @@ export async function generateFaviconAssetAsync(
 
   // Generate the configured favicon even when a public SVG takes the `<link>`, so that a
   // raster `web.favicon` keeps producing the `/favicon.ico` older browsers auto-discover.
-  // Skip it only when it would collide with the public file's own output path.
-  const isCollidingWithPublicSvg = !!publicSvgHref && !!data && isSvgPath(data.path);
+  // Skip it only when the public folder already owns that output path — `getUserDefinedFaviconFile`
+  // reports just the winning file, so a project holding both `favicon.svg` and `favicon.ico`
+  // would otherwise rasterize `web.favicon` over the user's own ICO.
+  const isOutputPathOwnedByPublicFolder =
+    !!data && !!getUserDefinedFile(projectRoot, [`./${data.path}`]);
 
-  if (data && !isCollidingWithPublicSvg) {
+  if (data && !isOutputPathOwnedByPublicFolder) {
     const assetPath = path.join(outputDir, data.path);
     if (files) {
       debugEvent('favicon:storing_asset', { assetPath });

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -33,12 +33,13 @@ export function getUserDefinedFaviconFile(projectRoot: string): string | null {
  * multi-size `favicon.ico`) or an SVG (copied byte-for-byte to `favicon.svg`, preserving
  * features like `prefers-color-scheme` media queries inside the SVG).
  *
- * A favicon in the public folder wins over `web.favicon`, matching the pre-existing behavior
- * for `public/favicon.ico`. So `public/favicon.svg` suppresses generation from `web.favicon`
- * too — a user who wants an `.ico` fallback for older browsers alongside it should add their
- * own `public/favicon.ico`, which browsers auto-discover.
+ * A favicon in the public folder wins the `<link>`, matching the pre-existing behavior for
+ * `public/favicon.ico`. A `public/favicon.svg` does *not* suppress `favicon.ico` generation,
+ * though: a raster `web.favicon` is still rasterized so that browsers without SVG favicon
+ * support keep auto-discovering `/favicon.ico`. (An SVG `web.favicon` is skipped in that case,
+ * since it would write to the same `favicon.svg` path the public file already occupies.)
  *
- * @returns the public href for the generated favicon (`.ico` or `.svg`), or `null` when a
+ * @returns the public href for the favicon to link (`.ico` or `.svg`), or `null` when a
  *   user-supplied `favicon.ico` already exists in the public folder (browsers resolve it at
  *   `/favicon.ico` automatically), or when no `web.favicon` is configured.
  */
@@ -52,35 +53,44 @@ export async function generateFaviconAssetAsync(
   }: { outputDir: string; baseUrl: string; files?: ExportAssetMap; exp?: ExpoConfig }
 ): Promise<{ href: string } | null> {
   const existing = getUserDefinedFaviconFile(projectRoot);
-  if (existing) {
-    if (isSvgPath(existing)) {
-      // A user-supplied `public/favicon.svg` is copied to the output by
-      // `copyPublicFolderAsync`; we still need to inject the `<link>` tag,
-      // because browsers don't auto-discover SVG favicons the way they do
-      // `/favicon.ico`.
-      return { href: `${baseUrl}/favicon.svg` };
-    }
+  if (existing && !isSvgPath(existing)) {
     return null;
   }
+
+  // A user-supplied `public/favicon.svg` is copied to the output by `copyPublicFolderAsync`,
+  // but still needs a `<link>` tag: browsers don't auto-discover SVG favicons the way they do
+  // `/favicon.ico`.
+  const publicSvgHref = existing ? `${baseUrl}/favicon.svg` : null;
 
   const data = await getFaviconFromExpoConfigAsync(projectRoot, {
     exp,
   });
 
-  if (!data) {
-    return null;
+  // Generate the configured favicon even when a public SVG takes the `<link>`, so that a
+  // raster `web.favicon` keeps producing the `/favicon.ico` older browsers auto-discover.
+  // Skip it only when it would collide with the public file's own output path.
+  const isCollidingWithPublicSvg = !!publicSvgHref && !!data && isSvgPath(data.path);
+
+  if (data && !isCollidingWithPublicSvg) {
+    const assetPath = path.join(outputDir, data.path);
+    if (files) {
+      debugEvent('favicon:storing_asset', { assetPath });
+      files.set(data.path, {
+        contents: data.source,
+        targetDomain: 'client',
+      });
+    } else {
+      debugEvent('favicon:writing_asset', { assetPath });
+      await fs.promises.writeFile(assetPath, data.source);
+    }
   }
 
-  const assetPath = path.join(outputDir, data.path);
-  if (files) {
-    debugEvent('favicon:storing_asset', { assetPath });
-    files.set(data.path, {
-      contents: data.source,
-      targetDomain: 'client',
-    });
-  } else {
-    debugEvent('favicon:writing_asset', { assetPath });
-    await fs.promises.writeFile(assetPath, data.source);
+  if (publicSvgHref) {
+    return { href: publicSvgHref };
+  }
+
+  if (!data) {
+    return null;
   }
 
   return { href: `${baseUrl}/${data.path}` };

--- a/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
@@ -4,14 +4,24 @@ import { event } from './events';
 import type { ServerNext, ServerRequest, ServerResponse } from './server.types';
 
 /**
- * Middleware for generating a favicon.ico file for the current project if one doesn't exist.
+ * Middleware for generating a favicon for the current project if one doesn't already exist.
+ * Handles both `/favicon.ico` (the historic default) and `/favicon.svg`, picking the response
+ * format based on the configured source in `web.favicon`:
  *
- * Test by making a get request with:
- * curl -v http://localhost:8081/favicon.ico
+ *  - `web.favicon: './path/to/icon.png'` (or other raster) → serves `/favicon.ico` rasterized.
+ *  - `web.favicon: './path/to/icon.svg'`                    → serves `/favicon.svg` raw.
+ *
+ * Requests for a format that doesn't match the configured source fall through to the static
+ * middleware, so a user with `web.favicon` set to a PNG can still ship a hand-crafted
+ * `favicon.svg` in their public folder (and vice versa).
+ *
+ * Test with:
+ *   curl -v http://localhost:8081/favicon.ico
+ *   curl -v http://localhost:8081/favicon.svg
  */
 export class FaviconMiddleware extends ExpoMiddleware {
   constructor(protected projectRoot: string) {
-    super(projectRoot, ['/favicon.ico']);
+    super(projectRoot, ['/favicon.ico', '/favicon.svg']);
   }
 
   async handleRequestAsync(
@@ -23,13 +33,22 @@ export class FaviconMiddleware extends ExpoMiddleware {
       return next();
     }
 
-    let faviconImageData: Buffer | null;
+    const requestedKind: 'svg' | 'ico' = req.url?.endsWith('.svg') ? 'svg' : 'ico';
+
     try {
       const data = await getFaviconFromExpoConfigAsync(this.projectRoot, { force: true });
       if (!data) {
         return next();
       }
-      faviconImageData = data.source;
+      const configuredKind: 'svg' | 'ico' = data.path.endsWith('.svg') ? 'svg' : 'ico';
+      if (configuredKind !== requestedKind) {
+        return next();
+      }
+      res.setHeader(
+        'Content-Type',
+        configuredKind === 'svg' ? 'image/svg+xml' : 'image/x-icon'
+      );
+      res.end(data.source);
     } catch (error: any) {
       // Pass through on ENOENT errors
       event('favicon:generate_failed', { error: event.error(error as Error) });
@@ -38,8 +57,5 @@ export class FaviconMiddleware extends ExpoMiddleware {
       }
       return next(error);
     }
-    // Respond with the generated favicon file
-    res.setHeader('Content-Type', 'image/x-icon');
-    res.end(faviconImageData);
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
@@ -1,4 +1,6 @@
-import { getFaviconFromExpoConfigAsync } from '../../../export/favicon';
+import { parse } from 'url';
+
+import { getFaviconFromExpoConfigAsync, isSvgPath } from '../../../export/favicon';
 import { ExpoMiddleware } from './ExpoMiddleware';
 import { event } from './events';
 import type { ServerNext, ServerRequest, ServerResponse } from './server.types';
@@ -33,21 +35,22 @@ export class FaviconMiddleware extends ExpoMiddleware {
       return next();
     }
 
-    const requestedKind: 'svg' | 'ico' = req.url?.endsWith('.svg') ? 'svg' : 'ico';
+    // Match on the pathname, not the raw URL: `shouldHandleRequest` dispatches on the
+    // query-stripped pathname, so `/favicon.svg?v=2` reaches this handler and would
+    // otherwise be misread as a `.ico` request.
+    const pathname = parse(req.url ?? '').pathname ?? '';
+    const requestedKind: 'svg' | 'ico' = isSvgPath(pathname) ? 'svg' : 'ico';
 
     try {
       const data = await getFaviconFromExpoConfigAsync(this.projectRoot, { force: true });
       if (!data) {
         return next();
       }
-      const configuredKind: 'svg' | 'ico' = data.path.endsWith('.svg') ? 'svg' : 'ico';
+      const configuredKind: 'svg' | 'ico' = isSvgPath(data.path) ? 'svg' : 'ico';
       if (configuredKind !== requestedKind) {
         return next();
       }
-      res.setHeader(
-        'Content-Type',
-        configuredKind === 'svg' ? 'image/svg+xml' : 'image/x-icon'
-      );
+      res.setHeader('Content-Type', configuredKind === 'svg' ? 'image/svg+xml' : 'image/x-icon');
       res.end(data.source);
     } catch (error: any) {
       // Pass through on ENOENT errors

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -1,12 +1,14 @@
 import type { ExpoConfig, ExpoGoConfig, PackageJSONConfig, ProjectConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { createFaviconAsString } from '@expo/router-server/build/utils/html';
 import { respond } from 'expo-server/adapter/http';
 import { posix } from 'node:path';
 import { resolve } from 'url';
 
 import { getActorDisplayName, getUserAsync } from '../../../api/user/user';
 import { isEnableHermesManaged } from '../../../export/exportHermes';
+import { getSvgFaviconHref } from '../../../export/favicon';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { toPosixPath } from '../../../utils/filePath';
@@ -356,9 +358,15 @@ export abstract class ManifestMiddleware<
     // Read from headers
     const bundleUrl = this.getWebBundleUrl();
 
+    // SVG favicons need an explicit `<link>` — unlike `/favicon.ico`, browsers don't
+    // auto-discover them, so without this the dev server would render no favicon at all
+    // for a project configured with one.
+    const faviconHref = getSvgFaviconHref(this.projectRoot, this.initialProjectConfig.exp);
+
     return createTemplateHtmlFromExpoConfigAsync(this.projectRoot, {
       exp: this.initialProjectConfig.exp,
       scripts: [bundleUrl],
+      extraHead: faviconHref ? createFaviconAsString(faviconHref) : undefined,
     });
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
@@ -102,6 +102,97 @@ it(`generates a favicon from Expo config`, async () => {
   expect(next).toHaveBeenCalledTimes(0);
   expect(res.end).toHaveBeenCalledTimes(1);
   expect(res.end).toHaveBeenCalledWith(Buffer.from('...'));
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/x-icon');
+});
+
+it(`serves an SVG favicon with the SVG MIME type`, async () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+  vol.fromJSON(
+    {
+      'assets/favicon.svg': svg,
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        sdkVersion: '49.0.0',
+        web: { favicon: './assets/favicon.svg' },
+      }),
+    },
+    '/'
+  );
+
+  const middleware = new FaviconMiddleware('/').getHandler();
+
+  const res = getMockRes();
+  const next = jest.fn();
+  await middleware(
+    asRequest({ url: '/favicon.svg', method: 'GET' }),
+    res,
+    next
+  );
+
+  expect(next).toHaveBeenCalledTimes(0);
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/svg+xml');
+  expect(res.end).toHaveBeenCalledTimes(1);
+  expect((res.end as jest.Mock).mock.calls[0][0].toString()).toBe(svg);
+});
+
+it(`falls through /favicon.svg when web.favicon is a raster image`, async () => {
+  vol.fromJSON(
+    {
+      'assets/favicon.png': '...',
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        sdkVersion: '49.0.0',
+        web: { favicon: './assets/favicon.png' },
+      }),
+    },
+    '/'
+  );
+
+  const middleware = new FaviconMiddleware('/').getHandler();
+
+  const res = getMockRes();
+  const next = jest.fn();
+  await middleware(
+    asRequest({ url: '/favicon.svg', method: 'GET' }),
+    res,
+    next
+  );
+
+  // Configured format is ICO; request was for SVG — pass through so the
+  // static middleware can serve a hand-crafted SVG if the user provides one.
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenCalledWith();
+  expect(res.end).toHaveBeenCalledTimes(0);
+});
+
+it(`falls through /favicon.ico when web.favicon is an SVG`, async () => {
+  vol.fromJSON(
+    {
+      'assets/favicon.svg': '<svg/>',
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        sdkVersion: '49.0.0',
+        web: { favicon: './assets/favicon.svg' },
+      }),
+    },
+    '/'
+  );
+
+  const middleware = new FaviconMiddleware('/').getHandler();
+
+  const res = getMockRes();
+  const next = jest.fn();
+  await middleware(
+    asRequest({ url: '/favicon.ico', method: 'GET' }),
+    res,
+    next
+  );
+
+  // Configured format is SVG; old browsers asking for /favicon.ico fall
+  // through so a hand-crafted `public/favicon.ico` can serve as fallback.
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenCalledWith();
+  expect(res.end).toHaveBeenCalledTimes(0);
 });
 
 it(`fails when favicon from Expo config is invalid`, async () => {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
@@ -135,6 +135,33 @@ it(`serves an SVG favicon with the SVG MIME type`, async () => {
   expect((res.end as jest.Mock).mock.calls[0][0].toString()).toBe(svg);
 });
 
+it(`serves an SVG favicon when the request carries a query string`, async () => {
+  // `shouldHandleRequest` dispatches on the query-stripped pathname, so a cache-busted
+  // `/favicon.svg?v=2` reaches the handler and must still be classified as SVG.
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+  vol.fromJSON(
+    {
+      'assets/favicon.svg': svg,
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        sdkVersion: '49.0.0',
+        web: { favicon: './assets/favicon.svg' },
+      }),
+    },
+    '/'
+  );
+
+  const middleware = new FaviconMiddleware('/').getHandler();
+
+  const res = getMockRes();
+  const next = jest.fn();
+  await middleware(asRequest({ url: '/favicon.svg?v=2', method: 'GET' }), res, next);
+
+  expect(next).toHaveBeenCalledTimes(0);
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/svg+xml');
+  expect((res.end as jest.Mock).mock.calls[0][0].toString()).toBe(svg);
+});
+
 it(`falls through /favicon.svg when web.favicon is a raster image`, async () => {
   vol.fromJSON(
     {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
@@ -123,11 +123,7 @@ it(`serves an SVG favicon with the SVG MIME type`, async () => {
 
   const res = getMockRes();
   const next = jest.fn();
-  await middleware(
-    asRequest({ url: '/favicon.svg', method: 'GET' }),
-    res,
-    next
-  );
+  await middleware(asRequest({ url: '/favicon.svg', method: 'GET' }), res, next);
 
   expect(next).toHaveBeenCalledTimes(0);
   expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/svg+xml');
@@ -179,11 +175,7 @@ it(`falls through /favicon.svg when web.favicon is a raster image`, async () => 
 
   const res = getMockRes();
   const next = jest.fn();
-  await middleware(
-    asRequest({ url: '/favicon.svg', method: 'GET' }),
-    res,
-    next
-  );
+  await middleware(asRequest({ url: '/favicon.svg', method: 'GET' }), res, next);
 
   // Configured format is ICO; request was for SVG — pass through so the
   // static middleware can serve a hand-crafted SVG if the user provides one.
@@ -209,11 +201,7 @@ it(`falls through /favicon.ico when web.favicon is an SVG`, async () => {
 
   const res = getMockRes();
   const next = jest.fn();
-  await middleware(
-    asRequest({ url: '/favicon.ico', method: 'GET' }),
-    res,
-    next
-  );
+  await middleware(asRequest({ url: '/favicon.ico', method: 'GET' }), res, next);
 
   // Configured format is SVG; old browsers asking for /favicon.ico fall
   // through so a hand-crafted `public/favicon.ico` can serve as fallback.

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -70,6 +70,46 @@ describe('checkBrowserRequestAsync', () => {
   const createConstructUrl = () =>
     jest.fn(({ scheme, hostname }) => `${scheme}://${hostname ?? 'localhost'}:8080`);
 
+  it('injects an SVG favicon link into the dev HTML when `web.favicon` is an SVG', async () => {
+    // Browsers auto-discover `/favicon.ico` but not `/favicon.svg`, so without this tag the
+    // dev server renders no favicon at all for an SVG-configured project.
+    jest.mocked(getPlatformBundlers).mockReturnValueOnce({
+      web: 'metro',
+      ios: 'metro',
+      android: 'metro',
+      tvos: 'metro',
+      macos: 'metro',
+    });
+
+    jest.mocked(getConfig).mockReturnValueOnce({
+      pkg: {},
+      exp: {
+        sdkVersion: '45.0.0',
+        name: 'my-app',
+        slug: 'my-app',
+        platforms: ['ios', 'android', 'web'],
+        web: { favicon: './assets/favicon.svg' },
+      },
+    } as any);
+
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: createConstructUrl(),
+      mode: 'development',
+    });
+
+    const req = asReq({ url: 'http://localhost:8080/', headers: {} });
+    const res = new MockServerResponse();
+
+    expect(await middleware.checkBrowserRequestAsync(req, asRes(res), () => {})).toBe(true);
+
+    expect(createTemplateHtmlFromExpoConfigAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({
+        extraHead: '<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>',
+      })
+    );
+  });
+
   it('handles browser requests when the web bundler is "metro" and no platform is specified', async () => {
     jest.mocked(getPlatformBundlers).mockReturnValueOnce({
       web: 'metro',

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Emit `type="image/svg+xml"` on the favicon `<link>` when the href points to an SVG ([#48026](https://github.com/expo/expo/pull/48026) by [@danfitz36](https://github.com/danfitz36))
 - Compile `pageHeaders` rules into the routes manifest ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes

--- a/packages/@expo/router-server/src/utils/__tests__/html.test.ts
+++ b/packages/@expo/router-server/src/utils/__tests__/html.test.ts
@@ -91,6 +91,18 @@ describe(createFaviconAsString, () => {
     expect(createFaviconAsString('/favicon.ico')).toBe('<link rel="icon" href="/favicon.ico"/>');
   });
 
+  it('adds `type="image/svg+xml"` when the href points to an SVG', () => {
+    expect(createFaviconAsString('/favicon.svg')).toBe(
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>'
+    );
+  });
+
+  it('adds the SVG type for a baseUrl-prefixed SVG href', () => {
+    expect(createFaviconAsString('/app/favicon.svg')).toBe(
+      '<link rel="icon" type="image/svg+xml" href="/app/favicon.svg"/>'
+    );
+  });
+
   it('escapes attribute-unsafe characters in the href', () => {
     expect(createFaviconAsString('/icons?size=32&q="x"')).toBe(
       '<link rel="icon" href="/icons?size=32&amp;q=&quot;x&quot;"/>'

--- a/packages/@expo/router-server/src/utils/__tests__/html.test.ts
+++ b/packages/@expo/router-server/src/utils/__tests__/html.test.ts
@@ -1,5 +1,6 @@
 import {
   createFaviconAsString,
+  isSvgFaviconHref,
   createInjectedCssAsString,
   createInjectedScriptsAsString,
   createLoaderDataScriptAsString,
@@ -84,6 +85,22 @@ describe(createInjectedScriptsAsString, () => {
     const result = createInjectedScriptsAsString(['/a.js', '/b.js']);
     expect(result).toBe('<script src="/a.js" defer></script>\n<script src="/b.js" defer></script>');
   });
+});
+
+describe(isSvgFaviconHref, () => {
+  it.each(['/favicon.svg', '/app/favicon.svg', '/favicon.SVG', '/f.svg?v=2', '/f.svg#x'])(
+    'treats %s as an SVG',
+    (href) => {
+      expect(isSvgFaviconHref(href)).toBe(true);
+    }
+  );
+
+  it.each(['/favicon.ico', '/favicon.png', '/svg', '/not-svg.ico', '/favicon.svgz'])(
+    'does not treat %s as an SVG',
+    (href) => {
+      expect(isSvgFaviconHref(href)).toBe(false);
+    }
+  );
 });
 
 describe(createFaviconAsString, () => {

--- a/packages/@expo/router-server/src/utils/__tests__/react.test.node.tsx
+++ b/packages/@expo/router-server/src/utils/__tests__/react.test.node.tsx
@@ -18,10 +18,26 @@ describe(createFaviconAsNode, () => {
     expect(node.key).toBe('favicon');
   });
 
+  it('includes `type="image/svg+xml"` when the href points to an SVG', () => {
+    const node = createFaviconAsNode('/favicon.svg') as ReactElement<{
+      rel: string;
+      type?: string;
+      href: string;
+    }>;
+    expect(node.props.type).toBe('image/svg+xml');
+    expect(node.props.href).toBe('/favicon.svg');
+  });
+
   it('renders to the expected static markup', () => {
     expect(
       ReactDOMServer.renderToStaticMarkup(createFaviconAsNode('/favicon.ico') as ReactElement)
     ).toBe('<link rel="icon" href="/favicon.ico"/>');
+  });
+
+  it('renders SVG hrefs with the SVG MIME type — byte-equivalent to createFaviconAsString', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(createFaviconAsNode('/favicon.svg') as ReactElement)
+    ).toBe('<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>');
   });
 });
 

--- a/packages/@expo/router-server/src/utils/__tests__/react.test.node.tsx
+++ b/packages/@expo/router-server/src/utils/__tests__/react.test.node.tsx
@@ -1,6 +1,7 @@
 import { isValidElement, type ReactElement } from 'react';
 import ReactDOMServer from 'react-dom/server';
 
+import { createFaviconAsString } from '../html';
 import { createFaviconAsNode, createInjectedExternalCssAsNodes } from '../react';
 
 describe(createFaviconAsNode, () => {
@@ -34,10 +35,25 @@ describe(createFaviconAsNode, () => {
     ).toBe('<link rel="icon" href="/favicon.ico"/>');
   });
 
-  it('renders SVG hrefs with the SVG MIME type — byte-equivalent to createFaviconAsString', () => {
+  it('renders SVG hrefs with the SVG MIME type', () => {
     expect(
       ReactDOMServer.renderToStaticMarkup(createFaviconAsNode('/favicon.svg') as ReactElement)
     ).toBe('<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>');
+  });
+
+  // The two builders feed the SSR and SPA paths respectively; `createFaviconAsString`'s doc
+  // comment requires them to agree byte-for-byte. Compare them against each other rather than
+  // against hardcoded markup, so a change to either one has to break this test to land.
+  it.each([
+    '/favicon.ico',
+    '/favicon.svg',
+    '/app/favicon.svg',
+    '/favicon.svg?v=2',
+    '/icons?size=32&q="x"',
+  ])('renders identically to createFaviconAsString for %s', (href) => {
+    expect(ReactDOMServer.renderToStaticMarkup(createFaviconAsNode(href) as ReactElement)).toBe(
+      createFaviconAsString(href)
+    );
   });
 });
 

--- a/packages/@expo/router-server/src/utils/html.ts
+++ b/packages/@expo/router-server/src/utils/html.ts
@@ -62,14 +62,20 @@ export function createInjectedScriptsAsString(srcs: string[]): string {
 }
 
 /**
- * Returns a `<link rel="icon" />` HTML string for the given favicon href.
+ * Returns a `<link rel="icon" />` HTML string for the given favicon href. When the href
+ * points to an SVG (extension `.svg`), the tag also carries `type="image/svg+xml"` so
+ * browsers know to use the vector asset in preference to any auto-discovered `/favicon.ico`.
  *
  * Used by the SPA export path, which splices into a pre-rendered template instead of a React
  * tree. Output must stay byte-equivalent to `createFaviconAsNode` (rendered to static markup)
  * so both rendering paths agree on the tag shape.
  */
 export function createFaviconAsString(href: string): string {
-  return `<link rel="icon" href="${escapeHtmlAttribute(href)}"/>`;
+  const safeHref = escapeHtmlAttribute(href);
+  if (href.endsWith('.svg')) {
+    return `<link rel="icon" type="image/svg+xml" href="${safeHref}"/>`;
+  }
+  return `<link rel="icon" href="${safeHref}"/>`;
 }
 
 /**

--- a/packages/@expo/router-server/src/utils/html.ts
+++ b/packages/@expo/router-server/src/utils/html.ts
@@ -62,6 +62,16 @@ export function createInjectedScriptsAsString(srcs: string[]): string {
 }
 
 /**
+ * Returns whether a favicon href points to an SVG, ignoring any query string or fragment.
+ *
+ * Shared by `createFaviconAsString` and `createFaviconAsNode` so the SPA and SSR paths can
+ * never disagree about whether a given href needs the `image/svg+xml` type hint.
+ */
+export function isSvgFaviconHref(href: string): boolean {
+  return /\.svg([?#]|$)/i.test(href);
+}
+
+/**
  * Returns a `<link rel="icon" />` HTML string for the given favicon href. When the href
  * points to an SVG (extension `.svg`), the tag also carries `type="image/svg+xml"` so
  * browsers know to use the vector asset in preference to any auto-discovered `/favicon.ico`.
@@ -72,7 +82,7 @@ export function createInjectedScriptsAsString(srcs: string[]): string {
  */
 export function createFaviconAsString(href: string): string {
   const safeHref = escapeHtmlAttribute(href);
-  if (href.endsWith('.svg')) {
+  if (isSvgFaviconHref(href)) {
     return `<link rel="icon" type="image/svg+xml" href="${safeHref}"/>`;
   }
   return `<link rel="icon" href="${safeHref}"/>`;

--- a/packages/@expo/router-server/src/utils/react.tsx
+++ b/packages/@expo/router-server/src/utils/react.tsx
@@ -76,6 +76,9 @@ export function getBootstrapContents({
 }
 
 export function createFaviconAsNode(href: string): ReactNode {
+  if (href.endsWith('.svg')) {
+    return <link key="favicon" rel="icon" type="image/svg+xml" href={href} />;
+  }
   return <link key="favicon" rel="icon" href={href} />;
 }
 

--- a/packages/@expo/router-server/src/utils/react.tsx
+++ b/packages/@expo/router-server/src/utils/react.tsx
@@ -1,7 +1,11 @@
 import type { ServerFontResourceDescriptor } from 'expo-font';
 import { type ReactNode } from 'react';
 
-import { getHydrationFlagScriptContents, getLoaderDataScriptContents } from './html';
+import {
+  getHydrationFlagScriptContents,
+  getLoaderDataScriptContents,
+  isSvgFaviconHref,
+} from './html';
 
 type CreateNodeResult = {
   headNodes?: ReactNode[];
@@ -76,7 +80,7 @@ export function getBootstrapContents({
 }
 
 export function createFaviconAsNode(href: string): ReactNode {
-  if (href.endsWith('.svg')) {
+  if (isSvgFaviconHref(href)) {
     return <link key="favicon" rel="icon" type="image/svg+xml" href={href} />;
   }
   return <link key="favicon" rel="icon" href={href} />;


### PR DESCRIPTION
Fixes #48024.

## Summary

Adds SVG support to the `web.favicon` pipeline. Setting `web.favicon` to an SVG previously crashed `expo export -p web` outright with `Invalid mimeType` from `@expo/image-utils`, because `getFaviconFromExpoConfigAsync` unconditionally rasterizes and that package's MIME table doesn't include SVG. The favicon `try/catch` only handles `ENOENT`, so the error propagated and killed the export, leaving `dist/` empty. This PR branches on the `.svg` extension in `@expo/cli` and copies the file raw — preserving features like `prefers-color-scheme` media queries inside the SVG.

`web.favicon` stays typed as `string`; format is inferred from the extension. PNG/ICO inputs are byte-identical to today.

Two things beyond the crash fix, both needed for SVG favicons to actually work end to end:

- **`expo start` rendered no favicon at all** for an SVG-configured project. The dev HTML carries no icon tag, and browsers auto-discover `/favicon.ico` but never `/favicon.svg` — so a `<link>` has to be emitted. This covers the default SPA dev HTML (`web.output: 'single'`) and the RSC dev path, which share the same template. Non-RSC `web.output: 'static' | 'server'` renders through a different dev SSR path that has never been passed a favicon href; I left that alone rather than widen the diff, happy to wire it up here if you'd prefer.
- **`favicon.ico` generation is preserved alongside a `public/favicon.svg`.** The public SVG takes the `<link>`, but a raster `web.favicon` still rasterizes, so the fallback older browsers auto-discover isn't silently dropped. Generation is skipped only when the public folder already ships a file at that same output path — otherwise a project holding both `public/favicon.svg` and `public/favicon.ico` would have its hand-crafted ICO overwritten by a generated one.

## Changes

Since #46586 split favicon rendering across two packages, the SVG-aware pieces live in both.

**`@expo/cli`**

- `src/export/favicon.ts` — detect `.svg` earlier in `getFaviconFromExpoConfigAsync` and copy the file raw (skip `generateImageAsync`, which rejects SVG). Extend `getUserDefinedFaviconFile` to also detect `public/favicon.svg`, and inject a `<link>` tag for it. New `getSvgFaviconHref` resolves the href the dev server needs without generating anything.
- `src/start/server/middleware/FaviconMiddleware.ts` — intercept both `/favicon.ico` and `/favicon.svg` in dev; pick the response based on the configured source; fall through on format mismatch. Classify on the query-stripped pathname, since `shouldHandleRequest` already dispatches on it and `/favicon.svg?v=2` reaches the handler with the raw URL.
- `src/start/server/middleware/ManifestMiddleware.ts` — emit the SVG favicon `<link>` in the dev server HTML.

**`@expo/router-server`**

- `src/utils/html.ts` — `createFaviconAsString` emits `type="image/svg+xml"` when the href points to an SVG, via a shared `isSvgFaviconHref` that ignores any query string or fragment.
- `src/utils/react.tsx` — `createFaviconAsNode` does the same via a React attribute, staying byte-equivalent to the string form (per the existing doc comment invariant).

## Design notes

- **API stays `string`.** Format-by-extension is the least invasive path — no `ExpoConfig` type change, no caller updates, no docs churn beyond mentioning that SVG is accepted. If a `{ svg, ico }` object shape is preferred, happy to add it — I chose the additive path first.
- **No auto-generated ICO fallback for SVG inputs.** Rasterizing the SVG would freeze its `prefers-color-scheme` media query at build time (defeating the point), and it would require bypassing the `@expo/image-utils` MIME check (touching a shared package). Modern browser support for SVG favicons is high enough that users needing an ICO fallback can drop a hand-crafted `public/favicon.ico` — which the auto-detect already picks up.
- **No `@expo/image-utils` changes.** The MIME-table gate stays intact; SVG bypasses the raster pipeline entirely in `@expo/cli`.

## Tests

- `favicon.test.ts` — the SVG config path, the `public/favicon.svg` auto-detect path, a check that `generateImageAsync` is *not* called on SVG input, and each public-folder/config combination that decides whether generation runs (including the both-public-files case that would otherwise clobber the user's ICO).
- `FaviconMiddleware.test.ts` — SVG serving with the right MIME, a cache-busted `/favicon.svg?v=2`, and format-mismatch fall-through in both directions.
- `ManifestMiddleware-test.ts` — the dev HTML carries the SVG `<link>`.
- `html.test.ts` / `react.test.node.tsx` — the SVG `type` attribute, plus a case comparing `createFaviconAsNode`'s static markup against `createFaviconAsString` across a range of hrefs, so the byte-equivalence invariant can't drift silently.

## Verification

Run locally on this branch:

- `packages/@expo/cli` — jest: 243 suites, 1940 passed / 7 skipped; `tsc --noEmit`: clean.
- `packages/@expo/router-server` — jest: 21 suites, 317 passed.
- `turbo lint format depscheck` for both packages — 0 warnings, 0 errors, no files rewritten.
- **Live end-to-end** (SDK 56 architecture, before this PR's TS-level changes): repro at [danfitz36/expo-svg-favicon-repro](https://github.com/danfitz36/expo-svg-favicon-repro) confirmed the pre-fix crash. Hand-patched the built favicon.js in `node_modules` to mirror the fix; `dist/favicon.svg` byte-identical to source, correct `<link rel="icon" type="image/svg+xml">` in HTML head, PNG path byte-identical to pre-fix output. The dev-server and public-folder behavior above is covered by unit tests, not by that manual run.

## Notes

This branch and issue were drafted with Claude Code assistance and reviewed by me — flagging so you know what you're looking at. The diff has also been reviewed by [@jhhayashi](https://github.com/jhhayashi), a senior engineer on my team.
