### PR TITLE
[web][notifications] Fix crash when browser storage is blocked

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [web] Fixed crash when browser storage is blocked (e.g. Safari's "Block All Cookies"), where reading `localStorage` throws a `SecurityError` instead of returning `null`. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@Ignigena](https://github.com/Ignigena))
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-26

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [web] Fixed crash when browser storage is blocked (e.g. Safari's "Block All Cookies"), where reading `localStorage` throws a `SecurityError` instead of returning `null`. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@Ignigena](https://github.com/Ignigena))
+- [web] Fixed crash when browser storage is blocked (e.g. Safari's "Block All Cookies"), where reading `localStorage` throws a `SecurityError` instead of returning `null`. ([#48033](https://github.com/expo/expo/pull/48033) by [@Ignigena](https://github.com/Ignigena))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/src/ServerRegistrationModule.web.ts
+++ b/packages/expo-notifications/src/ServerRegistrationModule.web.ts
@@ -31,7 +31,11 @@ export default {
     if (typeof localStorage === 'undefined') {
       return null;
     }
-    return localStorage.getItem(REGISTRATION_INFO_KEY);
+    try {
+      return localStorage.getItem(REGISTRATION_INFO_KEY);
+    } catch {
+      return null;
+    }
   },
   setRegistrationInfoAsync: async (registrationInfo: string | null) => {
     if (typeof localStorage === 'undefined') {


### PR DESCRIPTION
# Why

`expo-notifications` blanks the page on web when the browser blocks storage — specifically Safari's **"Block All Cookies"** setting, or a partitioned / blocked third-party storage context. In those environments reading `window.localStorage` throws `SecurityError: The operation is insecure.` rather than returning `null`.

The web `ServerRegistrationModule` reads registration state directly from `localStorage`. Its `getRegistrationInfoAsync` only guards `typeof localStorage === 'undefined'`, which is insufficient: under blocked storage `localStorage` *is* defined — it is the **access** that throws.

Crucially this fires as an import-time side effect: `DevicePushTokenAutoRegistration.fx.ts` calls `ServerRegistrationModule.getRegistrationInfoAsync().then(...)` at module scope, so simply importing `expo-notifications` anywhere in a web bundle runs the read. The `.then` attaches only a rejection handler, which cannot catch a **synchronous** throw, so the error escapes to React's `reportError` and crashes the app — even for apps that never use web push.

This is the web counterpart of the iOS fix in #43829, which added the same guard to the native variant of this function.

# How

Wrapped the `localStorage.getItem(REGISTRATION_INFO_KEY)` read in `getRegistrationInfoAsync` with `try/catch`, returning `null` on failure. This matches the existing behavior of the sibling methods (`setRegistrationInfoAsync` / `deleteRegistrationInfoAsync`) and treats blocked storage as "no persisted registration", which is the correct semantic — an app with no readable storage simply has nothing registered.

# Test Plan

- Open a web app that imports `expo-notifications` in Safari with **Settings → Privacy → Block All Cookies** enabled.
- **Before:** the page renders blank; the console shows an uncaught `SecurityError: The operation is insecure.` originating from `getRegistrationInfoAsync` → `DevicePushTokenAutoRegistration.fx`.
- **After:** the page renders normally; the blocked read is swallowed and registration info resolves to `null`.
- Verified normal (storage-allowed) web behavior is unchanged — a previously persisted registration value is still returned.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)