### PR TITLE
[metro-config] Resolve polyfills via @react-native/js-polyfills when rn-get-polyfills subpath is gone

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Treat dynamic imports with rejection handlers as optional dependencies, ported from [react/metro#1697](https://github.com/react/metro/pull/1697) ([#47334](https://github.com/expo/expo/pull/47334) by [@kitten](https://github.com/kitten))
 - Fix `resolver.useWatchman: true` not re-enabling watchman as intended ([#47662](https://github.com/expo/expo/issues/47662) by [@isaka1022](https://github.com/isaka1022))
 - Fix `composeSourceMaps` crashing on Hermes source-map segments with a negative original position ([#47752](https://github.com/expo/expo/pull/47752) by [@kitten](https://github.com/kitten))
-- Resolve polyfills via `@react-native/js-polyfills` when the `react-native/rn-get-polyfills` subpath is unavailable, keeping compatibility with React Native 0.88 and 0.86.
+- Resolve polyfills via `@react-native/js-polyfills` when the `react-native/rn-get-polyfills` subpath is unavailable, keeping compatibility with React Native 0.88 and 0.86. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Treat dynamic imports with rejection handlers as optional dependencies, ported from [react/metro#1697](https://github.com/react/metro/pull/1697) ([#47334](https://github.com/expo/expo/pull/47334) by [@kitten](https://github.com/kitten))
 - Fix `resolver.useWatchman: true` not re-enabling watchman as intended ([#47662](https://github.com/expo/expo/issues/47662) by [@isaka1022](https://github.com/isaka1022))
 - Fix `composeSourceMaps` crashing on Hermes source-map segments with a negative original position ([#47752](https://github.com/expo/expo/pull/47752) by [@kitten](https://github.com/kitten))
-- Resolve polyfills via `@react-native/js-polyfills` when the `react-native/rn-get-polyfills` subpath is unavailable, keeping compatibility with React Native 0.88 and 0.86. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
+- Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Treat dynamic imports with rejection handlers as optional dependencies, ported from [react/metro#1697](https://github.com/react/metro/pull/1697) ([#47334](https://github.com/expo/expo/pull/47334) by [@kitten](https://github.com/kitten))
 - Fix `resolver.useWatchman: true` not re-enabling watchman as intended ([#47662](https://github.com/expo/expo/issues/47662) by [@isaka1022](https://github.com/isaka1022))
 - Fix `composeSourceMaps` crashing on Hermes source-map segments with a negative original position ([#47752](https://github.com/expo/expo/pull/47752) by [@kitten](https://github.com/kitten))
+- Resolve polyfills via `@react-native/js-polyfills` when the `react-native/rn-get-polyfills` subpath is unavailable, keeping compatibility with React Native 0.88 and 0.86.
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -84,6 +84,7 @@
     "@jridgewell/gen-mapping": "^0.3.13",
     "@jridgewell/remapping": "^2.3.5",
     "@jridgewell/sourcemap-codec": "^1.5.5",
+    "@react-native/js-polyfills": "0.86.0",
     "browserslist": "^4.25.0",
     "chalk": "^4.1.0",
     "debug": "^4.3.2",

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -386,9 +386,14 @@ export function getDefaultConfig(
           return [];
         }
 
-        return require(
-          path.join(getReactNativeHostPath(projectRoot, platform), 'rn-get-polyfills')
-        )();
+        const reactNativeHostPath = getReactNativeHostPath(projectRoot, platform);
+        const polyfillsModule =
+          resolveFrom.silent(reactNativeHostPath, './rn-get-polyfills') ??
+          resolveFrom.silent(reactNativeHostPath, '@react-native/js-polyfills');
+        if (!polyfillsModule) {
+          return [];
+        }
+        return require(polyfillsModule)();
       },
     },
     server: {

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -386,14 +386,7 @@ export function getDefaultConfig(
           return [];
         }
 
-        const reactNativeHostPath = getReactNativeHostPath(projectRoot, platform);
-        const polyfillsModule =
-          resolveFrom.silent(reactNativeHostPath, './rn-get-polyfills') ??
-          resolveFrom.silent(reactNativeHostPath, '@react-native/js-polyfills');
-        if (!polyfillsModule) {
-          return [];
-        }
-        return require(polyfillsModule)();
+        return require('@react-native/js-polyfills')();
       },
     },
     server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2630,6 +2630,9 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.5
         version: 1.5.5
+      '@react-native/js-polyfills':
+        specifier: 0.86.0
+        version: 0.86.0
       browserslist:
         specifier: ^4.25.0
         version: 4.28.2


### PR DESCRIPTION
# Why
React Native's nightly (0.88) removed the `react-native/rn-get-polyfills` subpath in [facebook/react-native#57482](https://github.com/facebook/react-native/pull/57482). metro-configs `getPolyfills `required that subpath directly, so bundling against RN 0.88 fails.

# How

getPolyfills now tries the legacy react-native/rn-get-polyfills subpath first, then falls back to resolving @react-native/js-polyfills from the same React Native host path. Behavior on RN 0.86 and earlier is unchanged, and RN 0.88 uses the fallback.

# Test Plan

- RN 0.86 resolves via the legacy rn-get-polyfills and returns [console.js, error-guard.js].
- A simulated 0.88 layout (subpath absent, @react-native/js-polyfills reachable) falls back and returns the identical set.

