### PR TITLE
Set v8 (^8.19.0) for @sentry/react-native in bundledNativeModules.json

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -120,6 +120,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "2.6.2",
   "@shopify/flash-list": "2.0.2",
-  "@sentry/react-native": "~7.11.0",
+  "@sentry/react-native": "^8.19.0",
   "react-native-bootsplash": "^6.3.10"
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Running `npx expo-doctor`/`npx expo install --check` pushes you towards downgrading Sentry to v7 when v8 works just fine.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Chore

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
