### PR TITLE
fix(autolinking,precompiled) change buildFromSource to update graph

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Propagate `buildFromSource` across the precompiled dependency graph, so building a prebuilt dependency from source (e.g. `react-native-worklets`) also forces its dependents (e.g. `react-native-reanimated`) to build from source, instead of linking a prebuilt XCFramework against a source-built dependency.
+- [iOS] Propagate `buildFromSource` across the precompiled dependency graph, so building a prebuilt dependency from source (e.g. `react-native-worklets`) also forces its dependents (e.g. `react-native-reanimated`) to build from source, instead of linking a prebuilt XCFramework against a source-built dependency. ([#48041](https://github.com/expo/expo/pull/48041) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Propagate `buildFromSource` across the precompiled dependency graph, so building a prebuilt dependency from source (e.g. `react-native-worklets`) also forces its dependents (e.g. `react-native-reanimated`) to build from source, instead of linking a prebuilt XCFramework against a source-built dependency.
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -1651,19 +1651,26 @@ module Expo
         }
       end
 
-      # Returns local Expo product dependencies whose prebuilt availability must
-      # match this product's availability. Runtime deps like React/Hermes are not
-      # encoded as package/product strings and are ignored here.
+      # Returns the product names of dependencies whose prebuilt availability must
+      # match this product's availability. Both slash-form package/product strings
+      # (e.g. "expo-modules-core/ExpoModulesCore") and bare product names (e.g.
+      # "RNWorklets") are surfaced. Which of them are actually precompiled-managed
+      # pods is decided later by @pod_lookup_map membership in the resolver, so
+      # runtime deps like React/Hermes are surfaced here but ignored there.
       def prebuilt_dependency_pods(external_dependencies)
         (external_dependencies || []).filter_map do |dep|
-          next unless dep.is_a?(String) && dep.include?('/')
+          next unless dep.is_a?(String)
 
           parts = dep.split('/')
-          is_scoped = parts[0].start_with?('@')
-          package_name = is_scoped ? "#{parts[0]}/#{parts[1]}" : parts[0]
-          product_name = is_scoped ? parts[2] : parts[1]
+          product_name =
+            if parts.length == 1
+              parts[0]                          # bare, e.g. "RNWorklets"
+            elsif parts[0].start_with?('@')
+              parts[2]                          # @scope/package/Product
+            else
+              parts[1]                          # package/Product
+            end
 
-          next unless package_name&.start_with?('expo-', '@expo/')
           next if CUSTOM_XCFRAMEWORK_DEPENDENCIES.include?(product_name)
 
           product_name
@@ -1975,6 +1982,11 @@ module Expo
         next_visiting = visiting.dup.add(pod_name)
 
         (pod_info[:prebuilt_dependency_pods] || []).each do |dep_name|
+          # Only precompiled-managed pods participate in availability propagation.
+          # Runtime deps like React/Hermes are surfaced by prebuilt_dependency_pods
+          # but are not in the map, so they are ignored here.
+          next unless pod_lookup_map.key?(dep_name)
+
           dep_resolution = resolve_prebuilt_status(dep_name, next_visiting)
           next if dep_resolution[:available]
 


### PR DESCRIPTION
## Why

When setting the `buildFromSource` field in the package.json file, the precompiled ruby pipeline only filters on the actual names - it doesn't look at the graph to detect dependencies upstream (this is done for Expo modules where we use a slash-based naming model).

This will cause `react-native-reanimated` to be linked against the none-existing `react-native-worklets` if we add `react-native-worklets` to the `buildFromSource` setting in package.json

## How

This PR fixes this by:

1. prebuilt_dependency_pods now surfaces all dependency product names (bare like "RNWorklets" + slash-form), instead of only expo-scoped slash-form ones.
2. _resolve_prebuilt_status_uncached gates the dependency walk on pod_lookup_map.key?(dep_name) — so only real precompiled-managed pods (worklets) propagate, while non-managed deps (React/Hermes) are ignored.

Result: worklets in buildFromSource now correctly forces reanimated to source too.

## Test-plan

Tested by adding react-native-worklets to BareExpo's package.json `buildFromSource` property:

1. Mark worklets as build from source in apps/bare-expo/package.json → expo.autolinking: "ios": { "buildFromSource": ["react-native-worklets"] }
2. Install pods, pulling prebuilt XCFrameworks from the EAS bucket: cd apps/bare-expo/ios
EXPO_USE_PRECOMPILED_MODULES=1 \
EXPO_PRECOMPILED_MODULES_BASE_URL=https://storage.googleapis.com/eas-build-precompiled-modules \ pod install

Observe — the [Expo-precompiled] Precompiled modules: summary:
- RNWorklets → built from source ✅ (expected)
- RNReanimated → 📦 RNReanimated (consumed as prebuilt) ❌ — the bug. It downloads and links its prebuilt XCFramework even though its worklets dependency is source-built.

Expected (with the fix): RNReanimated is absent from the used-list — built from source, following worklets.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
