### PR TITLE
[expo-modules-autolinking][iOS] Gate swift-interface and use_frameworks post-install hooks on enabled?

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Gate the `disable_swift_interface_verification` and `configure_use_frameworks` post-install hooks on `enabled?` so they no longer mutate the Pods project (disabling swift interface emission, rewriting React modulemaps and linkage) when the prebuilt React framework is active but precompiled Expo modules are not enabled. ([#48042](https://github.com/expo/expo/pull/48042) by [@afonsojramos](https://github.com/afonsojramos))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Scan the whole Kotlin file for its `package` declaration when registering inline modules, so modules with long comments (for example, a license header) before the `package` declaration are no longer silently skipped. ([#47656](https://github.com/expo/expo/pull/47656) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -815,6 +815,7 @@ module Expo
       # Prevents swiftinterface verification failures when BUILD_LIBRARY_FOR_DISTRIBUTION=YES
       # is propagated from brownfield/framework user targets to pod targets by CocoaPods 1.16+.
       def disable_swift_interface_verification(installer)
+        return unless enabled?
         return unless prebuilt_react_active?
 
         Pod::UI.puts "[Expo] ".blue + "Disabling SWIFT_EMIT_MODULE_INTERFACE for pod targets (prebuilt React compatibility)"
@@ -846,6 +847,7 @@ module Expo
       # phase deletes and re-extracts the entire React-Core-prebuilt/ directory at
       # build time when switching Debug↔Release configurations.
       def configure_use_frameworks(installer)
+        return unless enabled?
         return unless prebuilt_react_active?
         return if linkage(installer).nil?
 


### PR DESCRIPTION
# Why

`PrecompiledModules#perform_post_install` runs six steps. Four of them (`ensure_artifacts`, `configure_header_search_paths`, `configure_codegen_for_prebuilt_modules`, `stub_bundled_pod_targets`) start with `return unless enabled?`. Two do not: `disable_swift_interface_verification` and `configure_use_frameworks` guard only on `prebuilt_react_active?`.

`enabled?` requires `EXPO_USE_PRECOMPILED_MODULES=1`, whereas `prebuilt_react_active?` only requires the prebuilt React.xcframework to be active — which is now the default (and, since #47329, `prebuilt_react_active?` returns `true` unless `RCT_USE_PREBUILT_RNCORE` is explicitly `0`).

As a result, a project that uses the **prebuilt React framework but has not opted into precompiled Expo modules** still has these two hooks mutate the Pods project on every `pod install`:

- `disable_swift_interface_verification` appends `SWIFT_EMIT_MODULE_INTERFACE = NO` to every pod target's xcconfig.
- `configure_use_frameworks` rewrites modulemaps and injects `-isystem` / `-fmodule-map-file` flags.

Both are precompiled-modules concerns and should not run when precompiled modules are disabled. This bites setups using `useFrameworks: 'static'` (e.g. alongside `react-native-firebase`), where the unexpected linkage/interface changes conflict with the app's own framework configuration.

# How

Add `return unless enabled?` to the two hooks so all six `perform_post_install` steps gate consistently on `enabled?`. `enabled?` already implies `prebuilt_react_active?` (it returns `false` and warns otherwise), so the existing `prebuilt_react_active?` guards are kept but are now effectively subsumed — no behavior change when precompiled modules are actually enabled.

# Test Plan

- With `EXPO_USE_PRECOMPILED_MODULES` unset and the prebuilt React framework active (SDK default), `pod install` no longer writes `SWIFT_EMIT_MODULE_INTERFACE = NO` into pod xcconfigs and no longer rewrites React modulemaps.
- With `EXPO_USE_PRECOMPILED_MODULES=1`, behavior is unchanged (both hooks still run).
