### PR TITLE
[docs] Add Related Expo Skills placements across multiple docs

### DIFF
--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
 An existing native app that was built using another technology, whose main entry point is _not_ a React Native view, is commonly referred to as a "brownfield" app. For example, if your app was built using UIKit and Swift, and you want to use React Native for a single screen then that is considered an "existing native app" and "brownfield".
 
@@ -62,6 +63,12 @@ This separation simplifies the workflow for native developers, as they don't nee
 - You have separate teams for native and React Native development.
 - You want to minimize the impact of adding React Native on your existing native build process.
 - You prefer to treat the React Native part of your app as a self-contained module.
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it both brownfield integration approaches. The following skill is related to existing native apps:
+
+<RelatedSkills names={['expo-brownfield']} />
 
 ## Next steps
 

--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -66,7 +66,7 @@ This separation simplifies the workflow for native developers, as they don't nee
 
 ## Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it both brownfield integration approaches. The following skill is related to existing native apps:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it both brownfield integration approaches:
 
 <RelatedSkills names={['expo-brownfield']} />
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -10,6 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries (also called [standalone apps](/more/glossary-of-terms/#standalone-app)) for your Expo and React Native projects.
@@ -27,6 +28,12 @@ To build your app, run the following command:
 <Terminal cmd={['$ eas build --platform all']} />
 
 This command sends your project to EAS Build and produces installable binaries for Android and iOS. You can also build for one platform at a time by passing in `--platform android` or `--platform ios` as desired. For complete setup instructions, see [Create your first build](/build/setup/).
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to create production builds and ship them to the app stores. The following skill is related to EAS Build:
+
+<RelatedSkills names={['eas-app-stores']} />
 
 ## Key features
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -31,7 +31,7 @@ This command sends your project to EAS Build and produces installable binaries f
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to create production builds and ship them to the app stores. The following skill is related to EAS Build:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to create production builds and ship them to the app stores:
 
 <RelatedSkills names={['eas-app-stores']} />
 

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -78,7 +78,7 @@ EAS Submit uploads your **.ipa** to App Store Connect, where it becomes availabl
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to submit and release your app. The following skill is related to app store submissions:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to submit and release your app:
 
 <RelatedSkills names={['eas-app-stores']} />
 

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -11,6 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
@@ -74,6 +75,12 @@ EAS Submit uploads your **.ipa** to App Store Connect, where it becomes availabl
   href="/submit/ios-manual/"
   Icon={AppleAppStoreIcon}
 />
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to submit and release your app. The following skill is related to app store submissions:
+
+<RelatedSkills names={['eas-app-stores']} />
 
 ## Frequently asked questions
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -5,6 +5,7 @@ description: Learn how to deploy your web app using EAS Hosting.
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
@@ -80,6 +81,12 @@ The workflow above will create a web deployment on every commit to your project'
 <Terminal cmd={['$ eas workflow:run deploy-web.yml']} />
 
 Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app. The following skill is related to web deployments:
+
+<RelatedSkills names={['eas-hosting']} />
 
 ## Learn more
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -84,7 +84,7 @@ Learn more about common patterns with the [workflows examples guide](/eas/workfl
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app. The following skill is related to web deployments:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app:
 
 <RelatedSkills names={['eas-hosting']} />
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -39,7 +39,7 @@ All three methods produce the same development build. They differ in where the a
 
 Launch the development build from your device's Home screen and connect to a development server from the launcher screen to start working on your app. To learn how to use your new build, including the launcher screen, rebuilding, and debugging, see [Use a development build](/develop/development-builds/use-development-builds/). For common questions about development builds and Expo Go, including what you can't do in Expo Go and why, see the [FAQ](/develop/development-builds/faq/).
 
-### Related Expo Skills
+### Expo Skills for AI agents
 
 If you use an AI agent, install [Expo Skills](/skills/) to teach it the workflows on this page. The following skills are related to development builds:
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -41,6 +41,6 @@ Launch the development build from your device's Home screen and connect to a dev
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it the workflows on this page. The following skills are related to development builds:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it the workflows on this page:
 
 <RelatedSkills names={['expo-dev-client', 'eas-simulator']} />

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -46,7 +46,7 @@ For complete steps to start using EAS Update, see [Get started with EAS Update](
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to check the health of your published updates. The following skill is related to EAS Update:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to check the health of your published updates:
 
 <RelatedSkills names={['eas-update-insights']} />
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -14,6 +14,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Update** is a cloud service from EAS (Expo Application Services) that serves updates for projects using the [`expo-updates`](/versions/latest/sdk/updates/) library.
@@ -42,6 +43,12 @@ You need to create a new build for Android or iOS to include the `expo-updates` 
 This command publishes your JavaScript bundle and assets so users receive the new version on their next app launch.
 
 For complete steps to start using EAS Update, see [Get started with EAS Update](/eas-update/getting-started/).
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to check the health of your published updates. The following skill is related to EAS Update:
+
+<RelatedSkills names={['eas-update-insights']} />
 
 ## Key features
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -11,6 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Hosting** is a service from EAS (Expo Application Services) for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
@@ -37,6 +38,12 @@ To publish your web app, run the following command:
 <Terminal cmd={['$ eas deploy']} />
 
 Once your deployment is complete, the EAS CLI will output a preview URL to access your deployed web app.
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app and API routes. The following skill is related to EAS Hosting:
+
+<RelatedSkills names={['eas-hosting']} />
 
 ## Why EAS Hosting
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -41,7 +41,7 @@ Once your deployment is complete, the EAS CLI will output a preview URL to acces
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app and API routes. The following skill is related to EAS Hosting:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to deploy your web app and API routes:
 
 <RelatedSkills names={['eas-hosting']} />
 

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -52,7 +52,7 @@ Wrap your root layout with the `AppMetricsRoot` component (SDK 55) or the `Obser
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to set up `expo-observe` and query your app's performance metrics. The following skill is related to EAS Observe:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to set up `expo-observe` and query your app's performance metrics:
 
 <RelatedSkills
   names={['eas-observe']}

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -13,6 +13,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
@@ -48,6 +49,18 @@ Debugging performance in React Native has traditionally been limited to developm
 />
 
 Wrap your root layout with the `AppMetricsRoot` component (SDK 55) or the `ObserveRoot` component (SDK 56 and later) and call `markInteractive()` when your app is ready for user input. See [Get started](/eas/observe/get-started/) for the full setup guide.
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to set up `expo-observe` and query your app's performance metrics. The following skill is related to EAS Observe:
+
+<RelatedSkills
+  names={['eas-observe']}
+  descriptions={{
+    'eas-observe':
+      'Set up expo-observe, query metrics with the EAS CLI, and interpret startup and navigation performance data.',
+  }}
+/>
 
 ## Why EAS Observe
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -12,6 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { DownloadSlide } from '~/ui/components/DownloadSlide';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
@@ -45,6 +46,12 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
   href="/eas/workflows/get-started"
   Icon={Dataflow03Icon}
 />
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to write and debug workflow YAML files. The following skill is related to EAS Workflows:
+
+<RelatedSkills names={['eas-workflows']} />
 
 ## Key features
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -49,7 +49,7 @@ Workflows are defined as YAML files in the **.eas/workflows/** directory at the 
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to write and debug workflow YAML files. The following skill is related to EAS Workflows:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to write and debug workflow YAML files:
 
 <RelatedSkills names={['eas-workflows']} />
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -65,7 +65,7 @@ To create a known example directly, pass its name:
 
 ## Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it where files live in a new Expo project. The following skill is related to creating a project:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it where files live in a new Expo project:
 
 <RelatedSkills names={['expo-project-structure']} />
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -4,6 +4,7 @@ description: Learn how to create a new Expo project.
 hideTOC: true
 ---
 
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
 Expo is a React Native framework that makes developing Android and iOS apps easier. Our framework provides file-based routing, a standard library of native modules, and much more. Expo is open source with an active community on [GitHub](https://github.com/expo/expo) and [Discord](https://chat.expo.dev).
@@ -61,6 +62,12 @@ To create a known example directly, pass its name:
 />
 
 > **info** The rest of the guides in this **"Get started"** section follows the default project. An example app may be organized differently but the concepts are the same.
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it where files live in a new Expo project. The following skill is related to creating a project:
+
+<RelatedSkills names={['expo-project-structure']} />
 
 ## Next step
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -120,7 +120,7 @@ export default function App() {
 
 ## Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it when to reach for DOM components and how to migrate web code to native. The following skills are related to DOM components:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it when to reach for DOM components and how to migrate web code to native:
 
 <RelatedSkills names={['expo-dom', 'expo-web-to-native']} />
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -7,6 +7,7 @@ description: Learn about rendering React DOM components in Expo native apps usin
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -116,6 +117,12 @@ export default function App() {
   );
 }
 ```
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it when to reach for DOM components and how to migrate web code to native. The following skills are related to DOM components:
+
+<RelatedSkills names={['expo-dom', 'expo-web-to-native']} />
 
 ## Features
 

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -13,6 +13,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
@@ -41,6 +42,12 @@ This guide covers the basics of using Expo UI to integrate SwiftUI into your Exp
 You'll need to install the `@expo/ui` package in your Expo project. Run the following command to install it:
 
 <Terminal cmd={['$ npx expo install @expo/ui']} />
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to build native-feeling screens. The following skills are related to Expo UI:
+
+<RelatedSkills names={['expo-ui', 'expo-native-ui']} />
 
 ## Usage
 

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -45,7 +45,7 @@ You'll need to install the `@expo/ui` package in your Expo project. Run the foll
 
 ## Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it how to build native-feeling screens. The following skills are related to Expo UI:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it how to build native-feeling screens:
 
 <RelatedSkills names={['expo-ui', 'expo-native-ui']} />
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -6,6 +6,7 @@ description: Learn how to configure and use Tailwind CSS in your Expo project.
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { FileTree } from '~/ui/components/FileTree';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -289,6 +290,12 @@ export default function Index() {
 ## Tailwind for Android and iOS
 
 Tailwind does not support Android and iOS platforms. You can use a compatibility library such as [NativeWind](https://www.nativewind.dev/) or [Uniwind](https://uniwind.dev/) for universal support.
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it universal Tailwind CSS setup. The following skill is related to Tailwind CSS:
+
+<RelatedSkills names={['expo-tailwind-setup']} />
 
 ## Alternative for Android and iOS
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -293,7 +293,7 @@ Tailwind does not support Android and iOS platforms. You can use a compatibility
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it universal Tailwind CSS setup. The following skill is related to Tailwind CSS:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it universal Tailwind CSS setup:
 
 <RelatedSkills names={['expo-tailwind-setup']} />
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -20,7 +20,7 @@ We believe that using the Expo Modules API makes building and maintaining nearly
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it the module definition DSL and native view patterns. The following skill is related to the Expo Modules API:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it the module definition DSL and native view patterns:
 
 <RelatedSkills names={['expo-module']} />
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -10,12 +10,19 @@ import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
 ## What is the Expo Modules API
 
 The Expo Modules API allows you to write Swift and Kotlin to add new capabilities to your app with native modules and views. The API is designed to take advantage of modern language features, to be as consistent as possible on both platforms, to require minimal boilerplate, and provide comparable performance characteristics to React Native's Turbo Modules API. Expo Modules all support the New Architecture and are automatically backwards compatible with existing React Native apps using the old architecture.
 
 We believe that using the Expo Modules API makes building and maintaining nearly all kinds of React Native modules about as easy as it can be, and we think that the Expo Modules API is the best choice for the vast majority of developers building native modules for their apps.
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it the module definition DSL and native view patterns. The following skill is related to the Expo Modules API:
+
+<RelatedSkills names={['expo-module']} />
 
 ### Common questions
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -72,7 +72,7 @@ For example:
 
 #### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it the canonical patterns from the examples repository. The following skill is related to Expo examples:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it the canonical patterns from the examples repository:
 
 <RelatedSkills names={['expo-examples']} />
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -4,6 +4,7 @@ maxHeadingDepth: 4
 description: A command-line tool to create a new Expo and React Native project.
 ---
 
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
 `create-expo-app` is a command-line tool to create and set up a new Expo and React Native project. This tool simplifies the initialization process by providing various templates to get started quickly without the need for manual configuration.
@@ -68,6 +69,12 @@ For example:
 - Running `npx create-expo-app --example` shows an interactive list of available examples to choose from
 - Running `npx create-expo-app --example with-router` sets up a project with the Expo Router library
 - Running `npx create-expo-app --example with-react-navigation` sets up a project similar to the default template, but configured with plain React Navigation library
+
+#### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it the canonical patterns from the examples repository. The following skill is related to Expo examples:
+
+<RelatedSkills names={['expo-examples']} />
 
 ### `--version`
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -82,7 +82,7 @@ Now, you can start your project by running:
 
 ### Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it file-based navigation patterns. The following skill is related to Expo Router:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it file-based navigation patterns:
 
 <RelatedSkills names={['expo-router']} />
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -14,6 +14,7 @@ import { YoutubeIcon } from '@expo/styleguide-icons/outline/YoutubeIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -78,6 +79,12 @@ Now, you can start your project by running:
   description="A tutorial series from core concepts to more complex navigation flows."
   href="https://www.youtube.com/playlist?list=PLsXDmrmFV_AT17JDf-otXSNE_eH7s0uDD"
 />
+
+### Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it file-based navigation patterns. The following skill is related to Expo Router:
+
+<RelatedSkills names={['expo-router']} />
 
 ## Key features
 

--- a/docs/pages/router/web/data-loaders.mdx
+++ b/docs/pages/router/web/data-loaders.mdx
@@ -81,7 +81,7 @@ Start the development server:
 
 ## Expo Skills for AI agents
 
-If you use an AI agent, install [Expo Skills](/skills/) to teach it data fetching patterns, including data loaders. The following skill is related to data fetching:
+If you use an AI agent, install [Expo Skills](/skills/) to teach it data fetching patterns, including data loaders:
 
 <RelatedSkills names={['expo-data-fetching']} />
 

--- a/docs/pages/router/web/data-loaders.mdx
+++ b/docs/pages/router/web/data-loaders.mdx
@@ -6,6 +6,7 @@ isAlpha: true
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -77,6 +78,12 @@ Start the development server:
 />
 
 </Step>
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) to teach it data fetching patterns, including data loaders. The following skill is related to data fetching:
+
+<RelatedSkills names={['expo-data-fetching']} />
 
 ## Basic example
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -4,6 +4,7 @@ description: Learn how to incrementally upgrade the Expo SDK version in your pro
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -18,6 +19,8 @@ If you are looking to install a specific version of Expo Go, visit [expo.dev/go]
 ### Upgrade with an AI coding agent
 
 If you use an AI coding agent, install [Expo Skills](/skills/) and use the [`expo-upgrade` skill](/skills/#available-expo-skills). The skill provides guidelines for upgrading Expo SDK versions and fixing dependency issues. Review any proposed changes and check the SDK changelog for version-specific instructions.
+
+<RelatedSkills names={['expo-upgrade']} />
 
 ### Upgrade manually
 

--- a/docs/ui/components/RelatedSkills/RelatedSkills.test.tsx
+++ b/docs/ui/components/RelatedSkills/RelatedSkills.test.tsx
@@ -8,8 +8,16 @@ jest.unstable_mockModule('~/ui/components/ExpoSkillsTable/data/expo-skills.json'
       url: 'https://api.github.com/repos/expo/skills/contents/plugins/expo/skills',
       fetchedAt: '2026-01-01T00:00:00.000Z',
     },
-    totalSkills: 3,
+    totalSkills: 4,
     skills: [
+      {
+        name: 'skill-with-code',
+        category: 'framework',
+        description:
+          'Scaffold from the repo of ~70 `with-*` integrations (Stripe and more). Use when adapting canonical patterns.',
+        githubUrl:
+          'https://github.com/expo/skills/blob/main/plugins/expo/skills/skill-with-code/SKILL.md',
+      },
       {
         name: 'skill-multi-sentence',
         category: 'eas',
@@ -101,6 +109,27 @@ describe('RelatedSkills', () => {
 
     expect(screen.getByText('Custom short line.')).toBeInTheDocument();
     expect(screen.queryByText('Build things quickly.')).not.toBeInTheDocument();
+  });
+
+  it('renders backtick spans in a synced description as code', () => {
+    const { container } = render(<RelatedSkills names={['skill-with-code']} />);
+
+    const code = screen.getByText('with-*');
+    expect(code.tagName).toBe('CODE');
+    expect(container.textContent).not.toContain('`');
+  });
+
+  it('renders backtick spans in a custom description as code', () => {
+    const { container } = render(
+      <RelatedSkills
+        names={['skill-single-sentence']}
+        descriptions={{ 'skill-single-sentence': 'Configure `expo-observe` quickly.' }}
+      />
+    );
+
+    const code = screen.getByText('expo-observe');
+    expect(code.tagName).toBe('CODE');
+    expect(container.textContent).not.toContain('`');
   });
 
   it('falls back to the first sentence for skills without a custom description', () => {

--- a/docs/ui/components/RelatedSkills/RelatedSkills.test.tsx
+++ b/docs/ui/components/RelatedSkills/RelatedSkills.test.tsx
@@ -90,4 +90,28 @@ describe('RelatedSkills', () => {
 
     expect(screen.getByText('Trailing period is missing.')).toBeInTheDocument();
   });
+
+  it('uses a custom description from the descriptions prop', () => {
+    render(
+      <RelatedSkills
+        names={['skill-multi-sentence']}
+        descriptions={{ 'skill-multi-sentence': 'Custom short line.' }}
+      />
+    );
+
+    expect(screen.getByText('Custom short line.')).toBeInTheDocument();
+    expect(screen.queryByText('Build things quickly.')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the first sentence for skills without a custom description', () => {
+    render(
+      <RelatedSkills
+        names={['skill-multi-sentence', 'skill-single-sentence']}
+        descriptions={{ 'skill-multi-sentence': 'Custom short line.' }}
+      />
+    );
+
+    expect(screen.getByText('Custom short line.')).toBeInTheDocument();
+    expect(screen.getByText('Set up a single thing.')).toBeInTheDocument();
+  });
 });

--- a/docs/ui/components/RelatedSkills/index.tsx
+++ b/docs/ui/components/RelatedSkills/index.tsx
@@ -2,6 +2,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import expoSkillsData from '~/ui/components/ExpoSkillsTable/data/expo-skills.json';
+import { renderDescription } from '~/ui/components/utils/renderDescription';
 
 type Skill = {
   name: string;
@@ -31,7 +32,9 @@ export function RelatedSkills({ names, descriptions }: RelatedSkillsProps) {
         <BoxLink
           key={skill.name}
           title={skill.name}
-          description={descriptions?.[skill.name] ?? firstSentence(skill.description)}
+          description={renderDescription(
+            descriptions?.[skill.name] ?? firstSentence(skill.description)
+          )}
           href={skill.githubUrl}
           Icon={GithubIcon}
         />

--- a/docs/ui/components/RelatedSkills/index.tsx
+++ b/docs/ui/components/RelatedSkills/index.tsx
@@ -12,6 +12,7 @@ type Skill = {
 
 type RelatedSkillsProps = {
   names: string[];
+  descriptions?: Record<string, string>;
 };
 
 function firstSentence(description: string) {
@@ -19,7 +20,7 @@ function firstSentence(description: string) {
   return sentence.endsWith('.') ? sentence : `${sentence}.`;
 }
 
-export function RelatedSkills({ names }: RelatedSkillsProps) {
+export function RelatedSkills({ names, descriptions }: RelatedSkillsProps) {
   const skills = names
     .map(name => (expoSkillsData.skills as Skill[]).find(skill => skill.name === name))
     .filter((skill): skill is Skill => skill !== undefined);
@@ -30,7 +31,7 @@ export function RelatedSkills({ names }: RelatedSkillsProps) {
         <BoxLink
           key={skill.name}
           title={skill.name}
-          description={firstSentence(skill.description)}
+          description={descriptions?.[skill.name] ?? firstSentence(skill.description)}
           href={skill.githubUrl}
           Icon={GithubIcon}
         />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-24670

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add an `Expo Skills for AI agents` section with `<RelatedSkills />` cards to 17 landing pages, mapping all 6 `eas-*` and 11 `expo-*` skills to their product intros and guides, placed in the upper half of each page rather than after closing `Next steps` sections
- Add an optional `descriptions` prop to `RelatedSkills` for per-skill card text overrides with a first-sentence fallback, cover it with unit tests, and use it to shorten the `eas-observe` card
- Rename the existing `Related Expo Skills` heading on the development builds introduction to `Expo Skills for AI agents` for consistency

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
