### PR TITLE
[router] Fix missing subpath warning from Metro when importing from `expo-router/server`

### DIFF
--- a/packages/expo-router/AGENTS.md
+++ b/packages/expo-router/AGENTS.md
@@ -113,8 +113,8 @@ File-based routing library for React Native and web applications. It provides au
 │   └── ExpoRouterModule.kt            # Material 3 dynamic and static color resolution
 ├── entry.js                   # Module entry point
 ├── head.js                    # Head/meta tags entrypoint - import Head from "expo-router/head"
-├── server.js                  # Deprecated server entrypoint. Use @expo/server instead.
-├── server.d.ts                # Re-exports types from `@expo/router-server`
+├── server.js                  # Legacy root shim for expo-router/server - delegates to build/server (source: src/server/index.ts, re-exports loader utilities from expo-server)
+├── server.d.ts                # Legacy root shim types - delegates to build/server
 ├── drawer.js                  # Drawer navigator - import { Drawer } from "expo-router/drawer"
 ├── stack.js                   # Stack navigator - import { Stack } from "expo-router/stack"
 ├── js-stack.js                # JS stack navigator - import { Stack } from "expo-router/js-stack"

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fix `renderRouter` ignoring `overrides` and listing duplicate routes when an override key matches a file in `appDir`. ([#47287](https://github.com/expo/expo/pull/47287) by [@wwdrew](https://github.com/wwdrew))
 - Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
 - [android][ios] Fix `expo-router/head` and `expo-router/stack` resolution on native platforms. ([#47870](https://github.com/expo/expo/pull/47870) by [@hassankhan](https://github.com/hassankhan))
-- Fix missing subpath warning from Metro when importing from `expo-router/server`
+- Fix missing subpath warning from Metro when importing from `expo-router/server` ([#48045](https://github.com/expo/expo/pull/48045) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix `renderRouter` ignoring `overrides` and listing duplicate routes when an override key matches a file in `appDir`. ([#47287](https://github.com/expo/expo/pull/47287) by [@wwdrew](https://github.com/wwdrew))
 - Guard the deep link decode in `extractExactPathFromURL` against malformed percent-encoding. ([#47526](https://github.com/expo/expo/pull/47526) by [@momomuchu](https://github.com/momomuchu))
 - [android][ios] Fix `expo-router/head` and `expo-router/stack` resolution on native platforms. ([#47870](https://github.com/expo/expo/pull/47870) by [@hassankhan](https://github.com/hassankhan))
+- Fix missing subpath warning from Metro when importing from `expo-router/server`
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -174,6 +174,14 @@
       "expo-source": "./src/layouts/TopTabs.tsx",
       "default": "./build/layouts/TopTabs.js"
     },
+    "./server": {
+      "types": {
+        "expo-source": "./src/server/index.ts",
+        "default": "./build/server/index.d.ts"
+      },
+      "expo-source": "./src/server/index.ts",
+      "default": "./build/server/index.js"
+    },
     "./stack": {
       "types": {
         "expo-source": "./src/stack.ts",

--- a/packages/expo-router/server.d.ts
+++ b/packages/expo-router/server.d.ts
@@ -1,14 +1,1 @@
-export type {
-  ImmutableRequest,
-  GenerateMetadataFunction,
-  LoaderFunction,
-  Metadata,
-  MiddlewareFunction,
-} from 'expo-server';
-
-export { createStaticLoader, createServerLoader } from 'expo-server';
-
-export type RequestHandler = (
-  request: Request,
-  params: Record<string, string>
-) => Response | Promise<Response>;
+export * from './build/server';

--- a/packages/expo-router/server.js
+++ b/packages/expo-router/server.js
@@ -1,1 +1,1 @@
-export { createStaticLoader, createServerLoader } from 'expo-server';
+module.exports = require('./build/server');

--- a/packages/expo-router/src/server/index.ts
+++ b/packages/expo-router/src/server/index.ts
@@ -1,0 +1,14 @@
+export type {
+  ImmutableRequest,
+  GenerateMetadataFunction,
+  LoaderFunction,
+  Metadata,
+  MiddlewareFunction,
+} from 'expo-server';
+
+export { createStaticLoader, createServerLoader } from 'expo-server';
+
+export type RequestHandler = (
+  request: Request,
+  params: Record<string, string>
+) => Response | Promise<Response>;


### PR DESCRIPTION
# Why

When importing from `expo-router/server`, the following warning would display during bundling:

```bash
 WARN  Attempted to import the module "~/expo/apps/router-e2e/node_modules/expo-router/server" which is not listed in the "exports" of "~/expo/packages/expo-router" under the requested subpath "./server". Falling back to file-based resolution. Consider updating the call site or asking the package maintainer(s) to expose this API.
```

# How

- Added a new barrel file for `expo-router/server` exports and exposed it in `expo-router/package.json`
- Updated the legacy root export files to use the new barrel file

The legacy root exports should all be removed as a group in a followup PR.

# Test Plan

- Ran `cd apps/router-e2e && pnpm start:static-loader` before and after this change.
- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
