### PR TITLE
[docs] document build and update job hooks and defaults.hooks

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -38,6 +38,9 @@ jobs:
       profile: string # optional - default: production
       message: string # optional
       refresh_ad_hoc_provisioning_profile: boolean # optional
+    hooks:
+      before_install_node_modules: step[] # optional - steps to run before dependencies are installed.
+      after_install_node_modules: step[] # optional - steps to run after dependencies are installed.
 ```
 
 #### Parameters
@@ -74,6 +77,15 @@ You can reference the following outputs in subsequent jobs:
 | runtime_version   | string | The runtime version used.                                          |
 | sdk_version       | string | The SDK version used.                                              |
 | simulator         | string | Whether the build is for simulator.                                |
+
+#### Hooks
+
+The following hooks are supported for the Build job:
+
+- `before_install_node_modules`: steps to run before the build installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the build installs your project's dependencies.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
 ### Examples
 
@@ -905,6 +917,9 @@ jobs:
       rollout_percentage: number # optional - 0 to 100, defaults to 100
       private_key_path: string # optional
       upload_sentry_sourcemaps: boolean # optional - defaults to "try uploading, but don't fail the job if it fails"
+    hooks:
+      before_update: step[] # optional - steps to run before the update is published.
+      after_update: step[] # optional - steps to run after the update is published.
 ```
 
 #### Environment variables
@@ -933,6 +948,15 @@ You can reference the following outputs in subsequent jobs:
 | --------------------- | ------ | ------------------------------------------------------------- |
 | first_update_group_id | string | The ID of the first update group.                             |
 | updates_json          | string | A JSON string containing information about all update groups. |
+
+#### Hooks
+
+The following hooks are supported for the Update job:
+
+- `before_update`: steps to run before the update is published.
+- `after_update`: steps to run after the update is published. Files produced during publishing (for example, sourcemaps in the **dist** directory) are available to the hook steps.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
 ### Examples
 
@@ -1006,6 +1030,31 @@ jobs:
     params:
       branch: ${{ github.ref_name }}
       message: 'Update for branch: ${{ github.ref_name }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Upload sourcemaps after publishing an update">
+
+This workflow publishes an update and then uploads the generated sourcemaps to an error tracking service (PostHog in this example). Sourcemaps are produced in the **dist** directory during publishing and are only available on the worker that ran the job, so uploading them must happen in an `after_update` hook rather than in a separate job. Hook steps inherit the job's environment, so credentials such as `POSTHOG_CLI_API_KEY` can be provided as [EAS environment variables](/eas/environment-variables/).
+
+```yaml .eas/workflows/update-with-sourcemaps.yml
+name: Update with sourcemaps
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  update:
+    name: Publish update
+    type: update
+    params:
+      channel: production
+    hooks:
+      after_update:
+        - name: Upload sourcemaps to PostHog
+          run: npx -y @posthog/cli hermes upload --directory dist
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -39,8 +39,8 @@ jobs:
       message: string # optional
       refresh_ad_hoc_provisioning_profile: boolean # optional
     hooks:
-      before_install_node_modules: step[] # optional - steps to run before dependencies are installed.
-      after_install_node_modules: step[] # optional - steps to run after dependencies are installed.
+      before_install_node_modules: step[] # optional - steps to run before the build installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the build installs dependencies.
 ```
 
 #### Parameters
@@ -240,6 +240,10 @@ jobs:
       alias: string # optional
       prod: boolean # optional
       source_maps: boolean # optional
+    hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
 ```
 
 #### Parameters
@@ -264,6 +268,16 @@ You can reference the following outputs in subsequent jobs:
 | deploy_deployment_url | string | Unique URL to the deployment (for example, `https://account-project--uniqueid.expo.app`).                                                        |
 | deploy_identifier     | string | Identifier of the deployment.                                                                                                                    |
 | deploy_dashboard_url  | string | URL to the deployment dashboard (for example, `https://expo.dev/projects/[project]/hosting/deployments`).                                        |
+
+#### Hooks
+
+The following hooks are supported for the Deploy job:
+
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
 ### Examples
 
@@ -342,6 +356,10 @@ jobs:
     environment: production | preview | development # optional, defaults to production
     env: # optional list of environment variables
       ENV_VAR_NAME: value
+    hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
 ```
 
 #### Environment variables
@@ -364,6 +382,16 @@ You can reference the following outputs in subsequent jobs:
 | ------------------------ | ------ | --------------------------------- |
 | android_fingerprint_hash | string | The fingerprint hash for Android. |
 | ios_fingerprint_hash     | string | The fingerprint hash for iOS.     |
+
+#### Hooks
+
+The following hooks are supported for the Fingerprint job:
+
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
 ### Examples
 
@@ -563,6 +591,9 @@ jobs:
       profile: string # optional - default: production
       groups: string[] # optional
     hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
       before_submit: step[] # optional - steps to run before the submission starts.
       after_submit: step[] # optional - steps to run after the submission completes.
 ```
@@ -591,6 +622,9 @@ You can reference the following outputs in subsequent jobs:
 
 The following hooks are supported for the Submit job:
 
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
 - `before_submit`: steps to run before the submission starts.
 - `after_submit`: steps to run after the submission completes.
 
@@ -705,6 +739,10 @@ jobs:
       changelog: string # optional
       submit_beta_review: boolean # optional
       wait_processing_timeout_seconds: number # optional - default: 1800 (30 minutes)
+    hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
 ```
 
 #### Parameters
@@ -727,6 +765,16 @@ You can reference the following outputs in subsequent jobs:
 | --------------------- | ------ | ------------------------------------------------- |
 | apple_app_id          | string | The Apple App ID of the submitted build.          |
 | ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
+
+#### Hooks
+
+The following hooks are supported for the TestFlight job:
+
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax. Hooks are not supported when [submitting an already uploaded build](#submit-an-already-uploaded-build) because that job variant does not run on a worker.
 
 #### Examples
 
@@ -918,8 +966,11 @@ jobs:
       private_key_path: string # optional
       upload_sentry_sourcemaps: boolean # optional - defaults to "try uploading, but don't fail the job if it fails"
     hooks:
-      before_update: step[] # optional - steps to run before the update is published.
-      after_update: step[] # optional - steps to run after the update is published.
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
+      before_update: step[] # optional - steps to run before publishing the update.
+      after_update: step[] # optional - steps to run after publishing the update.
 ```
 
 #### Environment variables
@@ -953,8 +1004,11 @@ You can reference the following outputs in subsequent jobs:
 
 The following hooks are supported for the Update job:
 
-- `before_update`: steps to run before the update is published.
-- `after_update`: steps to run after the update is published. Files produced during publishing (for example, sourcemaps in the **dist** directory) are available to the hook steps.
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
+- `before_update`: steps to run before publishing the update.
+- `after_update`: steps to run after publishing the update. Hook steps can access files produced during publishing (for example, sourcemaps in the **dist** directory).
 
 See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
@@ -1036,7 +1090,7 @@ jobs:
 
 <Collapsible summary="Upload sourcemaps after publishing an update">
 
-This workflow publishes an update and then uploads the generated sourcemaps to an error tracking service (PostHog in this example). Sourcemaps are produced in the **dist** directory during publishing and are only available on the worker that ran the job, so uploading them must happen in an `after_update` hook rather than in a separate job. Hook steps inherit the job's environment, so credentials such as `POSTHOG_CLI_API_KEY` can be provided as [EAS environment variables](/eas/environment-variables/).
+This workflow publishes an update and then uploads the generated sourcemaps to PostHog with the built-in [`eas/posthog_upload_sourcemaps`](/eas/workflows/syntax/#easposthog_upload_sourcemaps) function. Publishing an update creates sourcemaps in the **dist** directory, the function's default upload directory. These files only exist on the worker that runs the job, so the upload must happen in an `after_update` hook rather than in a separate job. Hook steps inherit the job's environment, so you can provide the `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` credentials as [EAS environment variables](/eas/environment-variables/). To upload to a different service, run its upload command in a `run` step instead.
 
 ```yaml .eas/workflows/update-with-sourcemaps.yml
 name: Update with sourcemaps
@@ -1053,8 +1107,7 @@ jobs:
       channel: production
     hooks:
       after_update:
-        - name: Upload sourcemaps to PostHog
-          run: npx -y @posthog/cli hermes upload --directory dist
+        - uses: eas/posthog_upload_sourcemaps
 ```
 
 </Collapsible>
@@ -1199,6 +1252,7 @@ jobs:
       output_format: string # optional - defaults to junit
       skip_build_check: boolean # optional - defaults to false
     hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
       before_maestro_tests: step[] # optional - steps to run before the tests start.
       after_maestro_tests: step[] # optional - steps to run after the tests complete.
 ```
@@ -1227,6 +1281,7 @@ You can pass the following parameters into the `params` list:
 
 The following hooks are supported for the Maestro job:
 
+- `after_checkout`: steps to run after the job checks out your project.
 - `before_maestro_tests`: steps to run before the tests start.
 - `after_maestro_tests`: steps to run after the tests complete.
 
@@ -1418,6 +1473,7 @@ jobs:
       branch: string # optional - override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional - run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
     hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
       before_maestro_cloud: step[] # optional - steps to run before the Maestro Cloud upload.
       after_maestro_cloud: step[] # optional - steps to run after the Maestro Cloud upload.
 ```
@@ -1450,6 +1506,7 @@ You can pass the following parameters into the `params` list:
 
 The following hooks are supported for the Maestro Cloud job:
 
+- `after_checkout`: steps to run after the job checks out your project.
 - `before_maestro_cloud`: steps to run before the Maestro Cloud upload.
 - `after_maestro_cloud`: steps to run after the Maestro Cloud upload.
 
@@ -2201,6 +2258,10 @@ jobs:
       message: string # optional
       repack_version: string # optional
       repack_package: string # optional
+    hooks:
+      after_checkout: step[] # optional - steps to run after the job checks out your project.
+      before_install_node_modules: step[] # optional - steps to run before the job installs dependencies.
+      after_install_node_modules: step[] # optional - steps to run after the job installs dependencies.
 ```
 
 > **Note:** If the build might still be in progress, use [`get-build`](#get-build) with `wait_for_in_progress: true`, then pass its `build_id` to `repack`.
@@ -2240,6 +2301,16 @@ You can pass the following parameters into the `params` list:
 | repack_package                          | string  | Optional. The repack npm package to use. Defaults to `@expo/repack-app`.                                                                                                                                        |
 | ios_signing_use_source_app_entitlements | boolean | Optional. Whether to use fastlane resign `use_app_entitlements` behavior: extract app bundle code signing entitlements and combine them with entitlements from the new provisioning profile. Defaults to false. |
 | ios_signing_app_entitlements_path       | string  | Optional. Path to the entitlements file to use, for example, `myApp/MyApp.entitlements`. This is exclusive with `ios_signing_use_source_app_entitlements`                                                       |
+
+#### Hooks
+
+The following hooks are supported for the Repack job:
+
+- `after_checkout`: steps to run after the job checks out your project.
+- `before_install_node_modules`: steps to run before the job installs your project's dependencies.
+- `after_install_node_modules`: steps to run after the job installs your project's dependencies.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
 
 ### Examples
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1136,6 +1136,9 @@ jobs:
       profile: string # optional, default: production
       message: string # optional
       refresh_ad_hoc_provisioning_profile: boolean # optional
+    hooks:
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
 ```
 
 This job outputs the following properties:
@@ -1342,6 +1345,9 @@ jobs:
       rollout_percentage: number # optional - 0 to 100, defaults to 100
       private_key_path: string # optional
       upload_sentry_sourcemaps: boolean # optional - defaults to "try uploading, but don't fail the job if it fails"
+    hooks:
+      before_update: step[] # optional
+      after_update: step[] # optional
 ```
 
 This job outputs the following properties:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -480,7 +480,7 @@ jobs:
 
 ### `jobs.<job_id>.hooks`
 
-Some pre-packaged jobs support hooks to run additional steps before or after the main job action (for example, `maestro-cloud`, `maestro`, and `submit`). Hook names are job-specific. See the job's documentation for the available hook keys.
+The following pre-packaged jobs support hooks to run additional steps before or after the main job action: `build`, `deploy`, `fingerprint`, `maestro`, `maestro-cloud`, `repack`, `submit`, `testflight`, and `update`. Hook names are job-specific. See the job's documentation for the available hook keys. To set default hooks for all jobs in the workflow, use [`defaults.hooks`](#defaultshooks).
 
 ```yaml
 jobs:
@@ -517,6 +517,28 @@ jobs:
 ## `defaults`
 
 Parameters to use as defaults for all jobs defined in the workflow configuration.
+
+### `defaults.hooks`
+
+Default [hooks](#jobsjob_idhooks) for all jobs in the workflow. Each job runs the hook keys that apply to it and ignores the rest. A job-level hook key overrides the same key from `defaults.hooks`. To opt a single job out of a default hook, set the key to an empty array.
+
+```yaml
+defaults:
+  hooks:
+    before_install_node_modules:
+      - name: Configure private registry
+        run: echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc
+
+jobs:
+  build_app:
+    type: build
+    params:
+      platform: ios
+  publish_update:
+    type: update
+    hooks:
+      before_install_node_modules: [] # opt this job out of the default hook
+```
 
 ### `defaults.image`
 
@@ -1175,6 +1197,10 @@ jobs:
       alias: string # optional
       prod: boolean # optional
       source_maps: boolean # optional
+    hooks:
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
 ```
 
 This job outputs the following properties:
@@ -1201,6 +1227,10 @@ jobs:
     type: fingerprint
     # @end #
     environment: production # Should match your build profile
+    hooks:
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
 ```
 
 This job outputs the following properties:
@@ -1275,6 +1305,9 @@ jobs:
       profile: string # optional, default: production
       groups: string[] # optional
     hooks:
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
       before_submit: step[] # optional
       after_submit: step[] # optional
 ```
@@ -1308,6 +1341,10 @@ jobs:
       external_groups: string[] # optional
       changelog: string # optional
       submit_beta_review: boolean # optional
+    hooks: # only when uploading and submitting with build_id
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
 ```
 
 When uploading and submitting with `build_id`, this job outputs the following properties:
@@ -1346,6 +1383,9 @@ jobs:
       private_key_path: string # optional
       upload_sentry_sourcemaps: boolean # optional - defaults to "try uploading, but don't fail the job if it fails"
     hooks:
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
       before_update: step[] # optional
       after_update: step[] # optional
 ```
@@ -1438,6 +1478,7 @@ jobs:
       output_format: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
       skip_build_check: boolean # optional, defaults to false. Skip validation of the build (whether an iOS build is a simulator build).
     hooks:
+      after_checkout: step[] # optional
       before_maestro_tests: step[] # optional
       after_maestro_tests: step[] # optional
 ```
@@ -1473,6 +1514,7 @@ jobs:
       branch: string # optional. Override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, *not* whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
     hooks:
+      after_checkout: step[] # optional. Steps to run after the job checks out your project.
       before_maestro_cloud: step[] # optional. Steps to run before the Maestro Cloud upload.
       after_maestro_cloud: step[] # optional. Steps to run after the Maestro Cloud upload.
 ```
@@ -1583,6 +1625,10 @@ jobs:
       message: string # optional
       repack_version: string # optional
       repack_package: string # optional
+    hooks:
+      after_checkout: step[] # optional
+      before_install_node_modules: step[] # optional
+      after_install_node_modules: step[] # optional
     # @end #
 ```
 


### PR DESCRIPTION
# Why

EAS Workflows hooks got several additions that the public docs don't cover yet: `before_update` / `after_update` on the update job, install hooks now running on build jobs, and the long-undocumented `defaults.hooks`. ENG-22616

# How

Listing the changes separately since each one can be dropped independently:

1. **Update job hooks** (`before_update` / `after_update`), with an example that uploads sourcemaps after publishing using the built-in `eas/posthog_upload_sourcemaps` function. Sourcemaps only exist on the worker that published the update, which is what the hook is for.
2. **Build job hooks** (`before_install_node_modules` / `after_install_node_modules`) — managed builds now run these.
3. **`defaults.hooks`**, first-time docs: broadcasts to every job (each job runs the keys that apply to it and ignores the rest), a job-level key overrides the default, `[]` opts a job out.
4. **Complete per-job hook lists for all nine hook-capable jobs** (from review feedback): new Hooks sections for deploy, fingerprint, repack, and testflight (checkout and install hooks; the testflight `asc_build_id` variant doesn't support hooks and says so); checkout and install hooks added to submit and update; `after_checkout` added to maestro and maestro-cloud. All of these keys already fire today, the docs just never listed them. The build job intentionally lists only the install pair: managed native builds don't wrap the checkout phase, so `after_checkout` wouldn't fire there.
5. **The hooks overview sentence in the syntax reference now names all nine supported jobs** instead of a three-job example list.

# Test Plan

Docs lint (including Vale prose lint) passes.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
