### PR TITLE
[router] fix stripInvisibleSegmentsFromPath

### DIFF
--- a/packages/expo-router/src/__tests__/matchers.test.ios.ts
+++ b/packages/expo-router/src/__tests__/matchers.test.ios.ts
@@ -3,6 +3,7 @@ import {
   getNameFromFilePath,
   matchGroupName,
   stripGroupSegmentsFromPath,
+  stripInvisibleSegmentsFromPath,
   matchArrayGroupName,
   matchLastGroupName,
 } from '../matchers';
@@ -13,6 +14,18 @@ describe(stripGroupSegmentsFromPath, () => {
       '/[[...foobar]]/bar/[bax]'
     );
     expect(stripGroupSegmentsFromPath('(foo)/(bar)')).toBe('');
+  });
+});
+
+describe(stripInvisibleSegmentsFromPath, () => {
+  it('strips index route segments', () => {
+    expect(stripInvisibleSegmentsFromPath('index')).toBe('');
+    expect(stripInvisibleSegmentsFromPath('/index')).toBe('');
+    expect(stripInvisibleSegmentsFromPath('nested/index')).toBe('nested');
+  });
+
+  it.each(['/reindex', 'someindex'])('preserves the route name %s', (path) => {
+    expect(stripInvisibleSegmentsFromPath(path)).toBe(path);
   });
 });
 

--- a/packages/expo-router/src/matchers.tsx
+++ b/packages/expo-router/src/matchers.tsx
@@ -80,7 +80,7 @@ export function stripGroupSegmentsFromPath(path: string): string {
 }
 
 export function stripInvisibleSegmentsFromPath(path: string): string {
-  return stripGroupSegmentsFromPath(path).replace(/\/?index$/, '');
+  return stripGroupSegmentsFromPath(path).replace(/(^|\/)index$/, '');
 }
 
 /**


### PR DESCRIPTION
# Why

Pre-requisit for follow-up PRs.

Fixes `stripInvisibleSegmentsFromPath` for paths like `reindex`. Before it produced `re` and now it correctly produces `reindex`

# How

Fix regex: `/\/?index$/` -> `/(^|\/)index$/`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>