### PR TITLE
test(cli): Drop the router-e2e `customizeFrame` override

### DIFF
--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -42,13 +42,4 @@ const config = getDefaultConfig(
 // Disable Babel's RC lookup, reducing the config loading in Babel - resulting in faster bootup for transformations
 config.transformer.enableBabelRCLookup = false;
 
-const originalCustomizeFrame = config.symbolicator.customizeFrame;
-config.symbolicator.customizeFrame = (frame) => {
-  const newFrame = originalCustomizeFrame(frame);
-  // This will make frames collapsed the same as in use apps, where expo/packages are in node_modules
-  // and thus collapsed by default.
-  newFrame.collapse ||= new RegExp('expo/packages/.+').test(frame.file);
-  return newFrame;
-};
-
 module.exports = config;

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Bump to `dnssd-advertise@^1.1.6` ([#47183](https://github.com/expo/expo/pull/47183) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate structured event logging to the `2g` package ([#46667](https://github.com/expo/expo/pull/46667) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
+- [Internal] Remove the `router-e2e` `customizeFrame` override that was hiding stack frames in the dev console tests ([#48053](https://github.com/expo/expo/pull/48053) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -48,7 +48,6 @@
 - Bump to `dnssd-advertise@^1.1.6` ([#47183](https://github.com/expo/expo/pull/47183) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate structured event logging to the `2g` package ([#46667](https://github.com/expo/expo/pull/46667) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
-- [Internal] Remove the `router-e2e` `customizeFrame` override that was hiding stack frames in the dev console tests ([#48053](https://github.com/expo/expo/pull/48053) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -294,45 +294,28 @@ Call Stack
     await openPageAndEagerlyLoadJS(expoStart, page);
     await page.getByText('console.error(string)').click();
 
-    if (isWindows) {
-      // NOTE: On Windows the call stack additionally leads with internal
-      // `packages/expo` and `packages/@expo/log-box` frames, because in this monorepo
-      // those workspace packages resolve to real `packages/...` paths instead of
-      // `node_modules/...` (so the node_modules collapse patterns miss them). A real app
-      // installs them under node_modules and they collapse. We assert the component stack here.
-      await expectOutput(
-        output,
-        `
-Code: index.tsx
-  139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
-  140 |   return (
-> 141 |     <Text
-      |     ^
-  142 |       style={{ fontSize: 24, backgroundColor: 'darkcyan', color: 'white', padding: 16 }}
-  143 |       onPress={onPress}>
-  144 |       {title}
-Call Stack
-  BigButton (apps\\router-e2e\\__e2e__\\06-errors\\app\\index.tsx:141:5)
-  App (apps\\router-e2e\\__e2e__\\06-errors\\app\\index.tsx:95:7)
-        `.trim()
-      );
-    } else {
-      await expectOutput(
-        output,
-        `
-Web  ERROR  console-error-string
+    // `expo` and `@expo/log-box` are in `packages/` here, not `node_modules/`, so the collapse
+    // patterns miss them and those frames show up. In a real app both are installed under
+    // `node_modules` and get collapsed.
+    await expectOutputAnySeparator(output, 'Web  ERROR  console-error-string');
+    await expectOutputAnySeparator(output, 'Code: setupHMR.js');
+    // These line numbers come from built output, so don't match on them.
+    await expectOutputAnySeparator(
+      output,
+      'captureCurrentStack (packages/expo/build/async-require/setupHMR.js'
+    );
+    await expectOutputAnySeparator(
+      output,
+      'consoleErrorMiddleware (packages/@expo/log-box/build/LogBox.js'
+    );
+    await expectOutputAnySeparator(
+      output,
+      'BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:98:19)'
+    );
 
-Code: index.tsx
-   96 |         title="console.error(string)"
-   97 |         onPress={() => {
->  98 |           console.error('console-error-string');
-      |                   ^
-   99 |         }}
-  100 |       />
-  101 |       <BigButton
-Call Stack
-  BigButton.props.onPress (apps/router-e2e/__e2e__/06-errors/app/index.tsx:98:19)
-
+    await expectOutputAnySeparator(
+      output,
+      `
 Code: index.tsx
   139 | function BigButton({ title, onPress }: { title: string; onPress: () => void }) {
   140 |   return (
@@ -344,9 +327,8 @@ Code: index.tsx
 Call Stack
   BigButton (apps/router-e2e/__e2e__/06-errors/app/index.tsx:141:5)
   App (apps/router-e2e/__e2e__/06-errors/app/index.tsx:95:7)
-        `.trim()
-      );
-    }
+      `.trim()
+    );
   });
 
   test('prints console.warn strings without stack traces', async ({ page }) => {
@@ -364,6 +346,17 @@ async function expectOutput(output: { all: string }, expectedConsoleOutput: stri
   await expect
     .poll(() => normalizeConsoleOutput(output.all), { timeout: 30_000 })
     .toContain(normalizeConsoleOutput(expectedConsoleOutput));
+}
+
+/** Same as `expectOutput`, but ignores the path separator so Windows matches too. */
+async function expectOutputAnySeparator(output: { all: string }, expectedConsoleOutput: string) {
+  await expect
+    .poll(() => toPosixOutput(output.all), { timeout: 30_000 })
+    .toContain(toPosixOutput(expectedConsoleOutput));
+}
+
+function toPosixOutput(output: string) {
+  return normalizeConsoleOutput(output).replace(/\\/g, '/');
 }
 
 function expectNoStackTrace(output: { all: string }) {

--- a/packages/@expo/cli/src/start/server/__tests__/serverLogLikeMetro.test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/serverLogLikeMetro.test.ts
@@ -96,6 +96,26 @@ describe(formatStackLikeMetro, () => {
   });
 });
 
+describe('internal frame filtering', () => {
+  // These two fixtures are the same stack. One has `packages/expo-router`, the other has
+  // `node_modules/expo-router`, so the only difference is which one INTERNAL_CALLSITES_REGEX
+  // matches.
+  it('drops the expo-router initialisation path once it resolves under node_modules', () => {
+    const workspace = stripAnsi(
+      formatStackLikeMetro(PROJECT_ROOT, ERROR_IN_ROUTER_GLOBAL_SCOPE)
+    )!.split('\n');
+    const installed = stripAnsi(
+      formatStackLikeMetro(PROJECT_ROOT, ERROR_IN_ROUTER_GLOBAL_SCOPE_PRODUCTION)
+    )!.split('\n');
+
+    expect(installed[0]).toContain('app/index.tsx');
+    expect(workspace[0]).toBe(installed[0]);
+    // These numbers are what it does today, not what it should do.
+    expect(workspace).toHaveLength(8);
+    expect(installed).toHaveLength(1);
+  });
+});
+
 describe(logLikeMetro, () => {
   it(`logs a basic server log`, () => {
     const log = jest.fn();


### PR DESCRIPTION
# Why

`apps/router-e2e/metro.config.js` adds a second collapse rule on top of `customizeFrame` that matches `expo/packages/.+`. It matches on the path, so it only works when the repo folder is named `expo`. In a fork, in a worktree, or on Windows it doesn't match and the internal frames show up.

So the test was only passing because of the override.

# How

Removed the override and updated the test to match what actually prints.

`expo` and `@expo/log-box` live in `packages/` here, not `node_modules/`, so the collapse patterns miss them and those frames show up. The code frame ends up on `setupHMR.js`. In a real app both are under `node_modules` and get collapsed. Nothing in `@expo/metro-config` changed.

One thing worth flagging: the test now names frames from `packages/expo` and `@expo/log-box`, so if someone renames `captureCurrentStack` or moves it, this test breaks. I left the line numbers out so it only matches the file and function names.

The test had a separate Windows branch because Windows never matched the override anyway. Both platforms print the same thing now, so that branch is gone.

I also added a test for the two `ERROR_IN_ROUTER_GLOBAL_SCOPE` fixtures in `serverLogLikeMetro.test.ts`. They're the same stack, one with `packages/expo-router` and one with `node_modules/expo-router`, and the snapshots keep 8 frames for the first and 1 for the second. Right now you'd only catch that by comparing the two snapshot files. Happy to drop it if it's noise.

# Test Plan

- `et check-packages @expo/cli`
- `pnpm test:playwright dev-console-errors`, 7 passed

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
