### PR TITLE
[docs] Restore hideTOC and component table on SDK 57 drop-in replacements overview

### DIFF
--- a/docs/pages/versions/v57.0.0/sdk/ui/drop-in-replacements/index.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/drop-in-replacements/index.mdx
@@ -5,15 +5,18 @@ description: Components and APIs that serve as drop-in replacements for popular 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-57/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios', 'web', 'expo-go']
+hideTOC: true
 ---
 
 The following components provide API-compatible replacements for popular React Native community libraries, powered by `@expo/ui` native components (Jetpack Compose on Android and SwiftUI on iOS).
 
-- **[BottomSheet](bottomsheet)**: Compatible with `@gorhom/bottom-sheet`
-- **[DateTimePicker](datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
-- **[MaskedView](maskedview)**: Compatible with `@react-native-masked-view/masked-view`
-- **[Menu](menu)**: Compatible with `@react-native-menu/menu`
-- **[PagerView](pagerview)**: Compatible with `react-native-pager-view`
-- **[Picker](picker)**: Compatible with `@react-native-picker/picker`
-- **[SegmentedControl](segmentedcontrol)**: Compatible with `@react-native-segmented-control/segmented-control`
-- **[Slider](slider)**: Compatible with `@react-native-community/slider`
+| Component                              | Compatible with                                     |
+| -------------------------------------- | --------------------------------------------------- |
+| [`BottomSheet`](bottomsheet)           | `@gorhom/bottom-sheet`                              |
+| [`DateTimePicker`](datetimepicker)     | `@react-native-community/datetimepicker`            |
+| [`MaskedView`](maskedview)             | `@react-native-masked-view/masked-view`             |
+| [`Menu`](menu)                         | `@react-native-menu/menu`                           |
+| [`PagerView`](pagerview)               | `react-native-pager-view`                           |
+| [`Picker`](picker)                     | `@react-native-picker/picker`                       |
+| [`SegmentedControl`](segmentedcontrol) | `@react-native-segmented-control/segmented-control` |
+| [`Slider`](slider)                     | `@react-native-community/slider`                    |


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
<img width="3334" height="1348" alt="CleanShot 2026-07-22 at 23 16 36@2x" src="https://github.com/user-attachments/assets/584bb4fb-d5d7-443e-baae-63731e321a30" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Restore hideTOC and component table on SDK 57 drop-in replacements overview

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2504" height="1642" alt="CleanShot 2026-07-22 at 23 16 59@2x" src="https://github.com/user-attachments/assets/ff2e7fea-adba-4e17-a9ad-95815132b5ba" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
