### PR TITLE
feat(create-expo,package-manager): Add nub package manager support

### DIFF
--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add [nub](https://nubjs.com/) package manager support ([#48060](https://github.com/expo/expo/pull/48060) by [@colinhacks](https://github.com/colinhacks))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/package-manager/src/index.ts
+++ b/packages/@expo/package-manager/src/index.ts
@@ -6,6 +6,7 @@ export * from './node/NpmPackageManager';
 export * from './node/PnpmPackageManager';
 export * from './node/YarnPackageManager';
 export * from './node/BunPackageManager';
+export * from './node/NubPackageManager';
 
 export * from './utils/nodeManagers';
 export { isYarnOfflineAsync } from './utils/yarn';

--- a/packages/@expo/package-manager/src/node/NubPackageManager.ts
+++ b/packages/@expo/package-manager/src/node/NubPackageManager.ts
@@ -1,0 +1,63 @@
+import { resolveWorkspaceRoot, NUB_LOCK_FILE } from '../utils/nodeManagers';
+import { BasePackageManager } from './BasePackageManager';
+
+// nub mirrors pnpm's CLI grammar, so the flags below match PnpmPackageManager.
+export class NubPackageManager extends BasePackageManager {
+  readonly name = 'nub';
+  readonly bin = 'nub';
+  readonly lockFile = NUB_LOCK_FILE;
+
+  workspaceRoot() {
+    const root = resolveWorkspaceRoot(this.ensureCwdDefined('workspaceRoot'));
+    if (root) {
+      return new NubPackageManager({
+        ...this.options,
+        silent: this.silent,
+        log: this.log,
+        cwd: root,
+      });
+    }
+
+    return null;
+  }
+
+  installAsync(namesOrFlags: string[] = []) {
+    return this.runAsync(['install', ...namesOrFlags]);
+  }
+
+  addAsync(namesOrFlags: string[] = []) {
+    if (!namesOrFlags.length) {
+      return this.installAsync();
+    }
+
+    return this.runAsync(['add', ...namesOrFlags]);
+  }
+
+  addDevAsync(namesOrFlags: string[] = []) {
+    if (!namesOrFlags.length) {
+      return this.installAsync();
+    }
+
+    return this.runAsync(['add', '--save-dev', ...namesOrFlags]);
+  }
+
+  addGlobalAsync(namesOrFlags: string[] = []) {
+    if (!namesOrFlags.length) {
+      return this.installAsync();
+    }
+
+    return this.runAsync(['add', '--global', ...namesOrFlags]);
+  }
+
+  removeAsync(namesOrFlags: string[]) {
+    return this.runAsync(['remove', ...namesOrFlags]);
+  }
+
+  removeDevAsync(namesOrFlags: string[]) {
+    return this.runAsync(['remove', '--save-dev', ...namesOrFlags]);
+  }
+
+  removeGlobalAsync(namesOrFlags: string[]) {
+    return this.runAsync(['remove', '--global', ...namesOrFlags]);
+  }
+}

--- a/packages/@expo/package-manager/src/node/__tests__/NubPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/NubPackageManager-test.ts
@@ -1,0 +1,234 @@
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { mockSpawnPromise } from '../../__tests__/spawn-utils';
+import { NubPackageManager } from '../NubPackageManager';
+
+jest.mock('@expo/spawn-async');
+// Jest doesn't mock `node:fs` when mocking `fs`
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('node:fs', () => require('memfs').fs);
+
+beforeAll(() => {
+  // Disable logging to clean up test output
+  jest.spyOn(console, 'log').mockImplementation();
+});
+
+describe('NubPackageManager', () => {
+  const projectRoot = '/project/with-nub';
+
+  it('name is set to nub', () => {
+    const nub = new NubPackageManager({ cwd: projectRoot });
+    expect(nub.name).toBe('nub');
+  });
+
+  describe('getDefaultEnvironment', () => {
+    it('runs with ADBLOCK=1 and DISABLE_OPENCOLLECTIVE=1', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({ ADBLOCK: '1', DISABLE_OPENCOLLECTIVE: '1' }),
+        })
+      );
+    });
+
+    it('runs with overwritten default environment', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot, env: { ADBLOCK: '0' } });
+      await nub.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: { ADBLOCK: '0', DISABLE_OPENCOLLECTIVE: '1' },
+        })
+      );
+    });
+  });
+
+  describe('runAsync', () => {
+    it('logs executed command', async () => {
+      const log = jest.fn();
+      const nub = new NubPackageManager({ cwd: projectRoot, log });
+      await nub.runAsync(['install', '--some-flag']);
+      expect(log).toHaveBeenCalledWith('> nub install --some-flag');
+    });
+  });
+
+  describe('versionAsync', () => {
+    it('returns version from nub', async () => {
+      jest
+        .mocked(spawnAsync)
+        .mockImplementation(() => mockSpawnPromise(Promise.resolve({ stdout: '0.4.13\n' })));
+
+      const nub = new NubPackageManager({ cwd: projectRoot });
+
+      expect(await nub.versionAsync()).toBe('0.4.13');
+      expect(spawnAsync).toHaveBeenCalledWith('nub', ['--version'], expect.anything());
+    });
+  });
+
+  describe('installAsync', () => {
+    it('runs normal installation', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.installAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['install'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+
+    it('runs installation with flags', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.installAsync(['--ignore-scripts']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['install', '--ignore-scripts'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('addAsync', () => {
+    it('installs project without packages', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.addAsync();
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['install'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+
+    it('adds a single package to dependencies', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.addAsync(['@react-navigation/native']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['add', '@react-navigation/native'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+
+    it('adds multiple packages to dependencies', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.addAsync(['@react-navigation/native', '@react-navigation/drawer']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['add', '@react-navigation/native', '@react-navigation/drawer'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('addDevAsync', () => {
+    it('adds a single package to dev dependencies', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.addDevAsync(['eslint']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['add', '--save-dev', 'eslint'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('addGlobalAsync', () => {
+    it('adds a single package globally', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.addGlobalAsync(['expo-cli@^5']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['add', '--global', 'expo-cli@^5'],
+        expect.anything()
+      );
+    });
+  });
+
+  describe('removeAsync', () => {
+    it('removes multiple packages', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.removeAsync(['metro', 'jest-haste-map']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['remove', 'metro', 'jest-haste-map'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('removeDevAsync', () => {
+    it('removes a single dev package', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.removeDevAsync(['eslint']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['remove', '--save-dev', 'eslint'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('removeGlobalAsync', () => {
+    it('removes a single global package', async () => {
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      await nub.removeGlobalAsync(['expo-cli']);
+
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'nub',
+        ['remove', '--global', 'expo-cli'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+    });
+  });
+
+  describe('workspaceRoot', () => {
+    const workspaceRoot = '/monorepo';
+    const projectRoot = '/monorepo/packages/test';
+
+    it('returns null for non-monorepo project', () => {
+      vol.fromJSON(
+        {
+          'package.json': JSON.stringify({ name: 'project' }),
+        },
+        projectRoot
+      );
+
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      expect(nub.workspaceRoot()).toBeNull();
+    });
+
+    it('returns new instance for monorepo project', () => {
+      vol.fromJSON(
+        {
+          'packages/test/package.json': JSON.stringify({ name: 'project' }),
+          'package.json': JSON.stringify({
+            name: 'monorepo',
+            workspaces: ['packages/*'],
+          }),
+        },
+        workspaceRoot
+      );
+
+      const nub = new NubPackageManager({ cwd: projectRoot });
+      const root = nub.workspaceRoot();
+      expect(root).toBeInstanceOf(NubPackageManager);
+      expect(root).not.toBe(nub);
+    });
+  });
+});

--- a/packages/@expo/package-manager/src/node/__tests__/NubPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/node/__tests__/NubPackageManager-test.ts
@@ -1,6 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
 import { vol } from 'memfs';
-import path from 'path';
 
 import { mockSpawnPromise } from '../../__tests__/spawn-utils';
 import { NubPackageManager } from '../NubPackageManager';

--- a/packages/@expo/package-manager/src/utils/nodeManagers.ts
+++ b/packages/@expo/package-manager/src/utils/nodeManagers.ts
@@ -5,6 +5,7 @@ import { resolveWorkspaceRoot } from 'resolve-workspace-root';
 import type { PackageManagerOptions } from '../PackageManager';
 import { BunPackageManager } from '../node/BunPackageManager';
 import { NpmPackageManager } from '../node/NpmPackageManager';
+import { NubPackageManager } from '../node/NubPackageManager';
 import { PnpmPackageManager } from '../node/PnpmPackageManager';
 import { YarnPackageManager } from '../node/YarnPackageManager';
 
@@ -14,7 +15,8 @@ export type NodePackageManager =
   | NpmPackageManager
   | PnpmPackageManager
   | YarnPackageManager
-  | BunPackageManager;
+  | BunPackageManager
+  | NubPackageManager;
 
 export type NodePackageManagerForProject = PackageManagerOptions &
   Partial<Record<NodePackageManager['name'], boolean>>;
@@ -24,9 +26,10 @@ export const YARN_LOCK_FILE = 'yarn.lock';
 export const PNPM_LOCK_FILE = 'pnpm-lock.yaml';
 export const BUN_LOCK_FILE = 'bun.lockb';
 export const BUN_TEXT_LOCK_FILE = 'bun.lock';
+export const NUB_LOCK_FILE = 'nub.lock';
 
 /** The order of the package managers to use when resolving automatically */
-export const RESOLUTION_ORDER: NodePackageManager['name'][] = ['bun', 'yarn', 'npm', 'pnpm'];
+export const RESOLUTION_ORDER: NodePackageManager['name'][] = ['bun', 'nub', 'yarn', 'npm', 'pnpm'];
 
 /**
  * Resolve the used node package manager for a project by checking the lockfile.
@@ -43,6 +46,7 @@ export function resolvePackageManager(
     pnpm: [PNPM_LOCK_FILE],
     yarn: [YARN_LOCK_FILE],
     bun: [BUN_TEXT_LOCK_FILE, BUN_LOCK_FILE],
+    nub: [NUB_LOCK_FILE],
   };
 
   if (preferredManager) {
@@ -77,6 +81,8 @@ export function createForProject(
     return new PnpmPackageManager({ cwd: projectRoot, ...options });
   } else if (options.bun) {
     return new BunPackageManager({ cwd: projectRoot, ...options });
+  } else if (options.nub) {
+    return new NubPackageManager({ cwd: projectRoot, ...options });
   }
 
   switch (resolvePackageManager(projectRoot)) {
@@ -86,6 +92,8 @@ export function createForProject(
       return new YarnPackageManager({ cwd: projectRoot, ...options });
     case 'bun':
       return new BunPackageManager({ cwd: projectRoot, ...options });
+    case 'nub':
+      return new NubPackageManager({ cwd: projectRoot, ...options });
     case 'npm':
     default:
       return new NpmPackageManager({ cwd: projectRoot, ...options });

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Detect and support the nub package manager ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@colinhacks](https://github.com/colinhacks))
 - Reuse agent files from `@expo/llm-configs` ([#46968](https://github.com/expo/expo/pull/46968) by [@davidmokos](https://github.com/davidmokos))
 - Improved monorepo support ([#46434](https://github.com/expo/expo/pull/46434) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Detect and support the nub package manager ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@colinhacks](https://github.com/colinhacks))
+- Detect and support the nub package manager ([#48060](https://github.com/expo/expo/pull/48060) by [@colinhacks](https://github.com/colinhacks))
 - Reuse agent files from `@expo/llm-configs` ([#46968](https://github.com/expo/expo/pull/46968) by [@davidmokos](https://github.com/davidmokos))
 - Improved monorepo support ([#46434](https://github.com/expo/expo/pull/46434) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
+++ b/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
@@ -29,6 +29,10 @@ describe(resolvePackageManager, () => {
     process.env.npm_config_user_agent = 'bun';
     expect(resolvePackageManager()).toBe('bun');
   });
+  it('should use nub due to the user agent', () => {
+    process.env.npm_config_user_agent = 'nub/0.4.13 npm/? node/v22.13.0 darwin arm64';
+    expect(resolvePackageManager()).toBe('nub');
+  });
   it('should use npm due to the user agent', () => {
     process.env.npm_config_user_agent = 'npm/8.1.0 node/v16.13.0 darwin x64 workspaces/false';
     expect(resolvePackageManager()).toBe('npm');

--- a/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
+++ b/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
@@ -82,9 +82,12 @@ describe(resolvePackageManager, () => {
       })
       .mockImplementationOnce(() => {
         throw new Error('foobar');
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('foobar');
       });
 
     expect(resolvePackageManager()).toBe('npm');
-    expect(execSync).toHaveBeenCalledTimes(3);
+    expect(execSync).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/create-expo/src/resolvePackageManager.ts
+++ b/packages/create-expo/src/resolvePackageManager.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 
 import { CLI_NAME } from './cmd';
 
-export type PackageManagerName = 'npm' | 'pnpm' | 'yarn' | 'bun';
+export type PackageManagerName = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'nub';
 
 const debug = require('debug')('expo:init:resolvePackageManager') as typeof console.log;
 
@@ -18,6 +18,8 @@ export function resolvePackageManager(): PackageManagerName {
     return 'pnpm';
   } else if (userAgent?.startsWith('bun')) {
     return 'bun';
+  } else if (userAgent?.startsWith('nub')) {
+    return 'nub';
   } else if (userAgent?.startsWith('npm')) {
     return 'npm';
   }
@@ -29,6 +31,8 @@ export function resolvePackageManager(): PackageManagerName {
     return 'pnpm';
   } else if (isPackageManagerAvailable('bun')) {
     return 'bun';
+  } else if (isPackageManagerAvailable('nub')) {
+    return 'nub';
   }
 
   return 'npm';
@@ -50,6 +54,8 @@ export function formatRunCommand(packageManager: PackageManagerName, cmd: string
       return `yarn ${cmd}`;
     case 'bun':
       return `bun run ${cmd}`;
+    case 'nub':
+      return `nub run ${cmd}`;
     case 'npm':
     default:
       return `npm run ${cmd}`;
@@ -63,6 +69,8 @@ export function formatSelfCommand() {
       return `pnpx ${CLI_NAME}`;
     case 'bun':
       return `bunx ${CLI_NAME}`;
+    case 'nub':
+      return `nubx ${CLI_NAME}`;
     case 'yarn':
     case 'npm':
     default:
@@ -81,6 +89,8 @@ function createPackageManager(
       return new PackageManager.PnpmPackageManager(options);
     case 'bun':
       return new PackageManager.BunPackageManager(options);
+    case 'nub':
+      return new PackageManager.NubPackageManager(options);
     case 'npm':
     default:
       return new PackageManager.NpmPackageManager(options);


### PR DESCRIPTION
# Why

`create-expo` recognizes npm, pnpm, yarn, and bun, but not [nub](https://nubjs.com). When a project is scaffolded with `nubx create-expo`, `resolvePackageManager` falls through the `npm_config_user_agent` checks and installs dependencies with whichever other package manager happens to be available — not nub.

nub's CLI grammar is pnpm-compatible and it writes a `nub.lock` lockfile, so wiring it in is a direct mirror of the existing package managers.

# How

`@expo/package-manager`:

- Add `NubPackageManager` (mirrors `PnpmPackageManager`, since nub follows pnpm's CLI grammar): `bin` and `name` of `nub`, `lockFile` of `nub.lock`, `install`/`add`/`remove` and their dev/global variants.
- Add the `NUB_LOCK_FILE` constant and register nub in the lockfile-resolution map, `RESOLUTION_ORDER`, and `createForProject`.
- Export `NubPackageManager` from the package entry.

`create-expo`:

- Add `nub` to `PackageManagerName`, a `startsWith('nub')` user-agent branch, and a `nub --version` availability probe.
- `formatRunCommand` emits `nub run <cmd>`; `formatSelfCommand` emits `nubx create-expo`.
- Route `nub` to `NubPackageManager` in the factory.

`nub`'s user agent is `nub/<version> npm/? node/...`, so `startsWith('nub')` is unambiguous against the existing `npm` branch. `configureWorkspaces` already produces the correct output for nub (a pnpm-style `workspace:*` spec) once `nub` is a recognized value, so it is unchanged.

# Test Plan

- Added `NubPackageManager-test.ts`, mirroring the bun/pnpm suites (name, install, add/addDev/addGlobal, remove/removeDev/removeGlobal, workspace root).
- Added a nub user-agent case to `resolvePackageManager.test.ts`.

# Checklist

- [x] I added a `changelog.md` entry
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the Documentation Writing Style Guide
