### PR TITLE
[ios] Optimize gradient rendering by switching to CAGradientLayer for  iOS and macOS

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS][macOS] Use `CAGradientLayer` instead of drawing bitmaps on the main thread, which could hitch large gradients.
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-07

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -1,29 +1,32 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 import QuartzCore
-import CoreGraphics
 import ExpoModulesCore
 
 var defaultStartPoint = CGPoint(x: 0.5, y: 0.0)
 var defaultEndPoint = CGPoint(x: 0.5, y: 1.0)
 var defaultLocations: [CGFloat] = []
 
-final class LinearGradientLayer: CALayer {
-  var colors = [UIColor]()
-  var startPoint = defaultStartPoint
-  var endPoint = defaultEndPoint
-  var locations = defaultLocations
+final class LinearGradientLayer: CAGradientLayer {
+  private var gradientColors = [UIColor]()
+  private var gradientLocations = defaultLocations
 
   override init() {
     super.init()
-    self.needsDisplayOnBoundsChange = true
-    self.masksToBounds = true
+    type = .axial
+    masksToBounds = true
+    needsDisplayOnBoundsChange = false
   }
-  
+
   override init(layer: Any) {
     super.init(layer: layer)
-    self.needsDisplayOnBoundsChange = true
-    self.masksToBounds = true
+    if let layer = layer as? LinearGradientLayer {
+      gradientColors = layer.gradientColors
+      gradientLocations = layer.gradientLocations
+    }
+    type = .axial
+    masksToBounds = true
+    needsDisplayOnBoundsChange = false
   }
 
   required init?(coder: NSCoder) {
@@ -31,117 +34,51 @@ final class LinearGradientLayer: CALayer {
   }
 
   func setColors(_ colors: [UIColor]) {
-    self.colors = colors
-    setNeedsDisplay()
+    gradientColors = colors
+    applyColors()
+    syncLocations()
   }
 
   func setStartPoint(_ startPoint: CGPoint?) {
     self.startPoint = startPoint ?? defaultStartPoint
-    setNeedsDisplay()
   }
 
   func setEndPoint(_ endPoint: CGPoint?) {
     self.endPoint = endPoint ?? defaultEndPoint
-    setNeedsDisplay()
   }
 
   func setLocations(_ locations: [CGFloat]?) {
-    self.locations = locations ?? defaultLocations
-    setNeedsDisplay()
+    gradientLocations = locations ?? defaultLocations
+    syncLocations()
   }
 
-  override func display() {
-    super.display()
-
-    if colors.isEmpty || bounds.size.width.isZero || bounds.size.height.isZero {
-      return
-    }
-    let hasAlpha = colors.reduce(false) { result, color in
-      return result || color.cgColor.alpha < 1.0
-    }
-
-    #if os(macOS)
-    setLayerContentsMacOS(hasAlpha: hasAlpha)
-    #else
-    setLayerContents(hasAlpha: hasAlpha)
-    #endif
+  /// Re-resolve dynamic colors after appearance / trait changes.
+  func refreshResolvedColors() {
+    applyColors()
   }
 
-  #if !os(macOS)
-  private func setLayerContents(hasAlpha: Bool) {
-    UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
-
-    guard let contextRef = UIGraphicsGetCurrentContext() else {
-      return
-    }
-
-    draw(in: contextRef)
-
-    guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
-      return
-    }
-
-    self.contents = image.cgImage
-    self.contentsScale = image.scale
-
-    UIGraphicsEndImageContext()
+  private func applyColors() {
+    colors = gradientColors.isEmpty ? nil : gradientColors.map(\.cgColor)
   }
-  #else
-  private func setLayerContentsMacOS(hasAlpha: Bool) {
-    let scale = contentsScale > 0 ? contentsScale : (NSScreen.main?.backingScaleFactor ?? 2.0)
-    let pixelWidth = Int(bounds.size.width * scale)
-    let pixelHeight = Int(bounds.size.height * scale)
-    if pixelWidth == 0 || pixelHeight == 0 {
+
+  private func syncLocations() {
+    let colorCount = gradientColors.count
+    guard colorCount >= 2 else {
+      locations = nil
       return
     }
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bitmapInfo: UInt32 = hasAlpha
-      ? CGImageAlphaInfo.premultipliedLast.rawValue
-      : CGImageAlphaInfo.noneSkipLast.rawValue
-    guard let ctx = CGContext(
-      data: nil,
-      width: pixelWidth,
-      height: pixelHeight,
-      bitsPerComponent: 8,
-      bytesPerRow: 0,
-      space: colorSpace,
-      bitmapInfo: bitmapInfo
-    ) else {
+
+    if gradientLocations.count == colorCount {
+      locations = gradientLocations.map { NSNumber(value: Double($0)) }
       return
     }
-    ctx.scaleBy(x: scale, y: scale)
-    draw(in: ctx)
-    self.contents = ctx.makeImage()
-    self.contentsScale = scale
-  }
-  #endif
 
-  override func draw(in ctx: CGContext) {
-    super.draw(in: ctx)
-
-    ctx.saveGState()
-
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let locations = colors.enumerated().map { (offset: Int, _: UIColor) -> CGFloat in
-      if self.locations.count > offset {
-        return self.locations[offset]
-      } else {
-        return CGFloat(offset) / CGFloat(colors.count - 1)
+    // Match previous behavior: use provided stops when available, otherwise evenly space.
+    locations = (0..<colorCount).map { offset in
+      if gradientLocations.count > offset {
+        return NSNumber(value: Double(gradientLocations[offset]))
       }
+      return NSNumber(value: Double(offset) / Double(colorCount - 1))
     }
-    let cgColors = colors.map { $0.cgColor } as CFArray
-
-    if let gradient = CGGradient(colorsSpace: colorSpace, colors: cgColors, locations: locations) {
-      let size = bounds.size
-
-      ctx.drawLinearGradient(
-        gradient,
-        start: CGPoint(x: startPoint.x * size.width, y: startPoint.y * size.height),
-        end: CGPoint(x: endPoint.x * size.width, y: endPoint.y * size.height),
-        options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
-      )
-    }
-
-    ctx.restoreGState()
   }
 }

--- a/packages/expo-linear-gradient/ios/LinearGradientView.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientView.swift
@@ -23,12 +23,12 @@ final class LinearGradientView: ExpoView {
   #if !os(macOS)
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    layer.setNeedsDisplay()
+    gradientLayer.refreshResolvedColors()
   }
   #else
   override func viewDidChangeEffectiveAppearance() {
     super.viewDidChangeEffectiveAppearance()
-    layer?.setNeedsDisplay()
+    gradientLayer.refreshResolvedColors()
   }
   #endif
 }


### PR DESCRIPTION
# Why

`expo-linear-gradient` on iOS/macOS previously subclassed `CALayer` and drew gradients into a bitmap on the main thread (`UIGraphicsBeginImageContext` / `CGContext` + `CGContextDrawLinearGradient`). For large views this allocates and fills a full-size image whenever colors, points, locations, or bounds change, which can cause noticeable UI hitches.

We hit this in production with large full-screen / near-full-screen gradients. Rendering should use the GPU via `CAGradientLayer` instead of CPU bitmap drawing.

# How

- Changed `LinearGradientLayer` to subclass `CAGradientLayer` (axial) and removed the custom `display()` / `draw(in:)` bitmap path.
- Keep `UIColor` instances and map them to `cgColor` when applying, so dynamic / appearance-aware colors still work.
- Sync `locations` to match the previous behavior: use provided stops when present, otherwise evenly space between colors.
- Keep `traitCollectionDidChange` (iOS) and `viewDidChangeEffectiveAppearance` (macOS), but call `refreshResolvedColors()` instead of `setNeedsDisplay()`, so dark/light mode updates without redoing expensive CPU drawing.
- Set `needsDisplayOnBoundsChange = false` because `CAGradientLayer` scales with bounds without a full redraw.

No JS/Android API changes.

# Test Plan

Manual verification on iOS (and macOS if available):

- [ ] Basic 2+ color linear gradient renders correctly
- [ ] Custom `start` / `end` points
- [ ] Custom `locations`
- [ ] Colors with alpha / transparency composite correctly over content
- [ ] Dynamic colors / appearance-aware colors update when switching light ↔ dark mode
- [ ] Large full-screen gradient no longer hitch the main thread when mounting or resizing
- [ ] (Optional) macOS BareExpo / Orbit-style screen still shows gradients correctly

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the Documentation Writing Style Guide