### PR TITLE
[brownfield][ios] Fix build:ios packaging bugs with precompiled modules

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `build:ios` with precompiled modules: locate frameworks under `XCFrameworkIntermediates/`, bundle `ExpoModulesJSI`, copy SPM deps as real flavor-matched directories instead of symlinks, and fail fast on duplicate or colliding target names.
+- [iOS] Fix `build:ios` with precompiled modules: locate frameworks under `XCFrameworkIntermediates/`, bundle `ExpoModulesJSI`, copy SPM deps as real flavor-matched directories instead of symlinks, and fail fast on duplicate or colliding target names. ([#48065](https://github.com/expo/expo/pull/48065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `build:ios` with precompiled modules: locate frameworks under `XCFrameworkIntermediates/`, bundle `ExpoModulesJSI`, copy SPM deps as real flavor-matched directories instead of symlinks, and fail fast on duplicate or colliding target names.
+
 ### 💡 Others
 
 ## 56.0.15 — 2026-05-26

--- a/packages/expo-brownfield/cli/src/commands/build-ios.ts
+++ b/packages/expo-brownfield/cli/src/commands/build-ios.ts
@@ -6,6 +6,7 @@ import {
   resolveBuildConfigIos,
   validateHostProvided,
   validatePrebuild,
+  validateSchemeCollision,
   shipSwiftPackage,
   shipFrameworks,
 } from '../utils';
@@ -16,15 +17,16 @@ const buildIos = async (command: Command) => {
   const config = resolveBuildConfigIos(opts);
   printIosConfig(config);
   validateHostProvided(config);
+  validateSchemeCollision(config);
 
   await buildFramework(config);
 
   if (config.output !== 'frameworks') {
     // Ship frameworks as swift package
-    shipSwiftPackage(config);
+    await shipSwiftPackage(config);
   } else {
     // Ship frameworks as standalone XCFrameworks
-    shipFrameworks(config);
+    await shipFrameworks(config);
   }
 };
 

--- a/packages/expo-brownfield/cli/src/utils/__tests__/ios.test.ts
+++ b/packages/expo-brownfield/cli/src/utils/__tests__/ios.test.ts
@@ -1,0 +1,169 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as iosUtils from '../ios';
+import type { IosConfig } from '../types';
+
+jest.mock('@expo/spawn-async', () => jest.fn());
+
+const mockSpawn = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
+
+let tmpDir: string;
+
+const makeConfig = (overrides: Partial<IosConfig> = {}): IosConfig => ({
+  artifacts: path.join(tmpDir, 'artifacts'),
+  buildConfiguration: 'Release',
+  derivedDataPath: path.join(tmpDir, 'ios/build'),
+  device: path.join(tmpDir, 'ios/build/Build/Products/release-iphoneos'),
+  dryRun: false,
+  hostProvidedFrameworks: [],
+  output: 'frameworks',
+  scheme: 'MyKit',
+  simulator: path.join(tmpDir, 'ios/build/Build/Products/release-iphonesimulator'),
+  usePrebuilds: false,
+  verbose: false,
+  workspace: path.join(tmpDir, 'ios/App.xcworkspace'),
+  ...overrides,
+});
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brownfield-ios-'));
+  mockSpawn.mockReset();
+  mockSpawn.mockRejectedValue(new Error('spawnAsync not stubbed'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  jest.restoreAllMocks();
+});
+
+describe('createXCframework', () => {
+  it('resolves the scheme framework under XCFrameworkIntermediates/ when it is not at the slice root', async () => {
+    const config = makeConfig({ dryRun: true });
+    const deviceFramework = path.join(
+      config.device,
+      'XCFrameworkIntermediates',
+      'MyKit',
+      'MyKit.framework'
+    );
+    const simulatorFramework = path.join(
+      config.simulator,
+      'XCFrameworkIntermediates',
+      'MyKit',
+      'MyKit.framework'
+    );
+    fs.mkdirSync(deviceFramework, { recursive: true });
+    fs.mkdirSync(simulatorFramework, { recursive: true });
+
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await iosUtils.createXCframework(config, config.artifacts);
+
+    const command = log.mock.calls.map((args) => args.join(' ')).join('\n');
+    expect(command).toContain(deviceFramework);
+    expect(command).toContain(simulatorFramework);
+  });
+
+  it('uses the slice root when the framework is there', async () => {
+    const config = makeConfig({ dryRun: true });
+    const deviceFramework = path.join(config.device, 'MyKit.framework');
+    const simulatorFramework = path.join(config.simulator, 'MyKit.framework');
+    fs.mkdirSync(deviceFramework, { recursive: true });
+    fs.mkdirSync(simulatorFramework, { recursive: true });
+
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await iosUtils.createXCframework(config, config.artifacts);
+
+    const command = log.mock.calls.map((args) => args.join(' ')).join('\n');
+    expect(command).toContain(deviceFramework);
+    expect(command).toContain(simulatorFramework);
+  });
+
+  it('fails with a clear error when the built framework cannot be found', async () => {
+    const config = makeConfig();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    await expect(iosUtils.createXCframework(config, config.artifacts)).rejects.toThrow(
+      'process.exit'
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('enumerateSourceBuiltDeps', () => {
+  it('finds the scheme binary under XCFrameworkIntermediates/ and reads its linked frameworks', async () => {
+    const config = makeConfig();
+    const frameworkDir = path.join(
+      config.simulator,
+      'XCFrameworkIntermediates',
+      'MyKit',
+      'MyKit.framework'
+    );
+    fs.mkdirSync(frameworkDir, { recursive: true });
+    fs.writeFileSync(path.join(frameworkDir, 'MyKit'), 'binary');
+
+    mockSpawn.mockResolvedValue({
+      stdout: [
+        `${path.join(frameworkDir, 'MyKit')}:`,
+        '\t@rpath/MyKit.framework/MyKit (compatibility version 1.0.0, current version 1.0.0)',
+        '\t@rpath/ExpoModulesJSI.framework/ExpoModulesJSI (compatibility version 1.0.0, current version 1.0.0)',
+        '\t/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.101.0)',
+      ].join('\n'),
+    } as any);
+
+    const deps = await iosUtils.enumerateSourceBuiltDeps(config, new Set());
+    expect(deps).toEqual(['ExpoModulesJSI']);
+  });
+});
+
+describe('generatePackageMetadataFile', () => {
+  it('does not declare duplicate targets when the scheme name matches a bundled module', async () => {
+    // Fake project: a precompiled pod named exactly like the brownfield scheme.
+    const podDir = path.join(tmpDir, 'ios', 'Pods', 'TestKit');
+    fs.mkdirSync(path.join(podDir, 'TestKit.xcframework'), { recursive: true });
+    fs.mkdirSync(path.join(podDir, 'artifacts'), { recursive: true });
+    fs.writeFileSync(path.join(podDir, 'artifacts', 'TestKit-release.tar.gz'), '');
+    jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = makeConfig({
+      scheme: 'TestKit',
+      usePrebuilds: true,
+      output: { packageName: 'TestPackage-release' },
+    });
+    await iosUtils.generatePackageMetadataFile(config, tmpDir);
+
+    const manifest = fs.readFileSync(path.join(tmpDir, 'Package.swift'), 'utf8');
+    const targetDeclarations = manifest.match(/name: "TestKit"/g) ?? [];
+    expect(targetDeclarations).toHaveLength(1);
+  });
+});
+
+describe('validateSchemeCollision', () => {
+  it('fails when the scheme name collides with a bundled framework name', () => {
+    const podDir = path.join(tmpDir, 'ios', 'Pods', 'ExpoBrownfield');
+    fs.mkdirSync(path.join(podDir, 'ExpoBrownfield.xcframework'), { recursive: true });
+    fs.mkdirSync(path.join(podDir, 'artifacts'), { recursive: true });
+    fs.writeFileSync(path.join(podDir, 'artifacts', 'ExpoBrownfield-release.tar.gz'), '');
+    jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    const config = makeConfig({ scheme: 'ExpoBrownfield', usePrebuilds: true });
+    expect(() => (iosUtils as any).validateSchemeCollision(config)).toThrow('process.exit');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('passes for a unique scheme name', () => {
+    jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    const config = makeConfig({ scheme: 'MyKit' });
+    expect(() => (iosUtils as any).validateSchemeCollision(config)).not.toThrow();
+  });
+});

--- a/packages/expo-brownfield/cli/src/utils/__tests__/precompiled.test.ts
+++ b/packages/expo-brownfield/cli/src/utils/__tests__/precompiled.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { enumerateAllPrebuildModules, enumeratePrebuildModulesRaw } from '../precompiled';
+
+jest.mock('@expo/spawn-async', () =>
+  jest.fn(async () => {
+    throw new Error('spawnAsync should not be called in these tests');
+  })
+);
+
+let cwd: string;
+let podsDir: string;
+
+const makePrecompiledPod = (name: string): string => {
+  const podDir = path.join(podsDir, name);
+  fs.mkdirSync(path.join(podDir, `${name}.xcframework`), { recursive: true });
+  fs.mkdirSync(path.join(podDir, 'artifacts'), { recursive: true });
+  fs.writeFileSync(path.join(podDir, 'artifacts', `${name}-release.tar.gz`), '');
+  return podDir;
+};
+
+const makeSharedDepStore = (name: string, flavors: string[]): string => {
+  const storeDir = path.join(cwd, 'store', name);
+  for (const flavor of flavors) {
+    const xcframework = path.join(storeDir, flavor, `${name}.xcframework`);
+    fs.mkdirSync(xcframework, { recursive: true });
+    fs.writeFileSync(path.join(xcframework, 'Info.plist'), flavor);
+  }
+  return storeDir;
+};
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'brownfield-precompiled-'));
+  podsDir = path.join(cwd, 'ios', 'Pods');
+  fs.mkdirSync(podsDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+  jest.restoreAllMocks();
+});
+
+describe('pod-built vendored xcframeworks (e.g. ExpoModulesJSI)', () => {
+  it('includes Pods/<Pod>/Products/<Pod>.xcframework in the enumerated module set', () => {
+    makePrecompiledPod('ExpoModulesCore');
+    const jsiXcframework = path.join(
+      podsDir,
+      'ExpoModulesJSI',
+      'Products',
+      'ExpoModulesJSI.xcframework'
+    );
+    fs.mkdirSync(jsiXcframework, { recursive: true });
+
+    const { modules } = enumeratePrebuildModulesRaw(cwd, 'Release');
+    const jsi = modules.find((m) => m.name === 'ExpoModulesJSI');
+    expect(jsi).toBeDefined();
+    expect(jsi!.xcframeworkPath).toBe(jsiXcframework);
+  });
+
+  it('ignores pods without a matching Products/<Pod>.xcframework', () => {
+    makePrecompiledPod('ExpoModulesCore');
+    fs.mkdirSync(path.join(podsDir, 'SomePod', 'Products'), { recursive: true });
+
+    const { modules } = enumeratePrebuildModulesRaw(cwd, 'Release');
+    expect(modules.map((m) => m.name)).toEqual(['ExpoModulesCore']);
+  });
+});
+
+describe('symlinked shared SPM-dep xcframeworks', () => {
+  it('resolves symlinks to real paths and corrects the flavor to the requested configuration', () => {
+    const podDir = makePrecompiledPod('ExpoImage');
+    const storeDir = makeSharedDepStore('SDWebImage', ['debug', 'release']);
+    // Autolinking stages shared deps as symlinks into the flavor selected at pod-install time.
+    fs.symlinkSync(
+      path.join(storeDir, 'debug', 'SDWebImage.xcframework'),
+      path.join(podDir, 'SDWebImage.xcframework')
+    );
+
+    const { modules } = enumeratePrebuildModulesRaw(cwd, 'Release');
+    const dep = modules.find((m) => m.name === 'SDWebImage');
+    expect(dep).toBeDefined();
+    expect(dep!.xcframeworkPath).toBe(
+      fs.realpathSync(path.join(storeDir, 'release', 'SDWebImage.xcframework'))
+    );
+    expect(fs.lstatSync(dep!.xcframeworkPath).isSymbolicLink()).toBe(false);
+  });
+
+  it('reports a flavor mismatch when the requested flavor is not available', () => {
+    const podDir = makePrecompiledPod('ExpoImage');
+    const storeDir = makeSharedDepStore('SDWebImage', ['debug']);
+    fs.symlinkSync(
+      path.join(storeDir, 'debug', 'SDWebImage.xcframework'),
+      path.join(podDir, 'SDWebImage.xcframework')
+    );
+
+    const { flavorMismatches } = enumeratePrebuildModulesRaw(cwd, 'Release');
+    expect(flavorMismatches.map((m) => m.name)).toEqual(['SDWebImage']);
+  });
+
+  it('fails the strict enumeration on a flavor mismatch', () => {
+    const podDir = makePrecompiledPod('ExpoImage');
+    const storeDir = makeSharedDepStore('SDWebImage', ['debug']);
+    fs.symlinkSync(
+      path.join(storeDir, 'debug', 'SDWebImage.xcframework'),
+      path.join(podDir, 'SDWebImage.xcframework')
+    );
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    expect(() => enumerateAllPrebuildModules(cwd, 'Release')).toThrow('process.exit');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('does not fail on a flavor mismatch for host-provided frameworks', () => {
+    const podDir = makePrecompiledPod('ExpoImage');
+    const storeDir = makeSharedDepStore('SDWebImage', ['debug']);
+    fs.symlinkSync(
+      path.join(storeDir, 'debug', 'SDWebImage.xcframework'),
+      path.join(podDir, 'SDWebImage.xcframework')
+    );
+
+    const modules = enumerateAllPrebuildModules(cwd, 'Release', ['SDWebImage']);
+    expect(modules.map((m) => m.name)).toEqual(['ExpoImage']);
+  });
+});

--- a/packages/expo-brownfield/cli/src/utils/error.ts
+++ b/packages/expo-brownfield/cli/src/utils/error.ts
@@ -6,10 +6,13 @@ type ErrorType =
   | 'ios-artifacts-directory-unknown-error'
   | 'ios-directory-not-found'
   | 'ios-directory-unknown-error'
+  | 'ios-framework-not-found'
   | 'ios-hermes-framework-not-found'
   | 'ios-host-provided-without-prebuilds'
   | 'ios-pod-install-cancelled'
+  | 'ios-prebuilds-spm-dep-flavor-mismatch'
   | 'ios-prebuilds-spm-dep-missing'
+  | 'ios-scheme-name-collision'
   | 'ios-scheme-not-found'
   | 'ios-workspace-not-found'
   | 'ios-workspace-unknown-error'
@@ -29,13 +32,19 @@ class CLIError {
       'Unknown error occurred while creating artifacts directory',
     'ios-directory-not-found': 'Cannot find `ios` directory in the project',
     'ios-directory-unknown-error': 'Unknown error occurred while finding brownfield iOS scheme',
+    'ios-framework-not-found':
+      'Could not find the compiled brownfield framework in the Xcode build products directory (checked the products root and XCFrameworkIntermediates/). This usually means the xcodebuild step failed or built a different scheme than expected. Re-run with --verbose to inspect the build log, and confirm the scheme name matches `ios.targetName` in your expo-brownfield plugin config. Missing framework',
     'ios-hermes-framework-not-found': 'Could not find hermes framework in the project at path',
     'ios-host-provided-without-prebuilds':
       'ios.hostProvidedFrameworks is set but precompiled modules are not enabled. Without precompiled modules, third-party pods (like SDWebImage) are statically linked into the brownfield framework itself, so there is no separate xcframework to strip. Enable `ios.usePrecompiledModules: true` in expo-build-properties (run `pod install` afterwards), or remove ios.hostProvidedFrameworks from the expo-brownfield plugin config.',
     'ios-pod-install-cancelled':
       'Brownfield cannot be built without installing CocoaPods. Run `pod install` in the `ios/` and try again.',
+    'ios-prebuilds-spm-dep-flavor-mismatch':
+      'A shared SPM dependency xcframework is only available in a different build flavor than the requested one. Bundling it would mix debug and release binaries in the brownfield package. Re-run `pod install` with `EXPO_PRECOMPILED_FLAVOR` set to the requested flavor, run the precompile prebuild pipeline for that flavor, or ensure the consuming npm package ships `prebuilds/spm-deps/<dep>/<flavor>/<dep>.xcframework`. Mismatched dependency',
     'ios-prebuilds-spm-dep-missing':
       "Could not find a prebuilt xcframework for an SPM dependency declared by an Expo module. The brownfield Swift Package would ship without it, causing `Library not loaded: @rpath/...` at runtime in the host app. Either re-install the affected Expo module from a release published with bundled SPM deps (`bundleSharedDeps: true`), populate the monorepo's `packages/precompile/.build/.spm-deps/` cache, or set `EXPO_PRECOMPILED_MODULES_PATH` to a directory that contains `.spm-deps/<dep>/<flavor>/<dep>.xcframework`.",
+    'ios-scheme-name-collision':
+      'The brownfield target name collides with the name of a framework bundled into the package. The bundled module xcframework would overwrite the brownfield wrapper framework of the same name, producing a package that is missing the wrapper classes (e.g. `ReactNativeHostManager`). Rename `ios.targetName` in the expo-brownfield plugin config to a unique name (e.g. `MyAppKit`), run `npx expo prebuild --clean`, and build again. Colliding name',
     'ios-scheme-not-found': 'Could not find brownfield iOS scheme',
     'ios-workspace-not-found':
       'Could not find a brownfield iOS workspace (`.xcworkspace`) in the `ios/` directory. This usually means `pod install` has not been run yet. Run `pod install` and try again.',

--- a/packages/expo-brownfield/cli/src/utils/ios.ts
+++ b/packages/expo-brownfield/cli/src/utils/ios.ts
@@ -30,7 +30,11 @@ export const enumerateSourceBuiltDeps = async (
   config: IosConfig,
   alreadyCovered: Set<string>
 ): Promise<string[]> => {
-  const frameworkBinary = path.join(config.simulator, `${config.scheme}.framework`, config.scheme);
+  const frameworkDir = findSourceBuiltFramework(config.simulator, config.scheme);
+  if (!frameworkDir) {
+    return [];
+  }
+  const frameworkBinary = path.join(frameworkDir, config.scheme);
   if (!fs.existsSync(frameworkBinary)) {
     return [];
   }
@@ -332,10 +336,25 @@ export const createXCframework = async (config: IosConfig, at: string) => {
   const frameworkName = `${config.scheme}.xcframework`;
   const outputPath = path.join(at, frameworkName);
 
+  // Precompiled-module builds can place the scheme's framework under
+  // `XCFrameworkIntermediates/<scheme>/` instead of the products-dir root. In dry-run mode
+  // nothing has been built, so fall back to the root path to print the command.
+  const resolveSlice = (slicePath: string): string => {
+    const framework = findSourceBuiltFramework(slicePath, config.scheme);
+    if (framework) {
+      return framework;
+    }
+    const fallback = path.join(slicePath, `${config.scheme}.framework`);
+    if (!config.dryRun) {
+      CLIError.handle('ios-framework-not-found', fallback);
+    }
+    return fallback;
+  };
+
   const args = [
     '-create-xcframework',
-    ...xcframeworkSliceArgs(`${config.device}/${config.scheme}.framework`),
-    ...xcframeworkSliceArgs(`${config.simulator}/${config.scheme}.framework`),
+    ...xcframeworkSliceArgs(resolveSlice(config.device)),
+    ...xcframeworkSliceArgs(resolveSlice(config.simulator)),
     '-output',
     outputPath,
   ];
@@ -464,7 +483,16 @@ export const generatePackageMetadataFile = async (config: IosConfig, packagePath
   );
   const sourceBuiltDeps = sourceBuiltDepNames.map((name) => ({ name, targets: [name] }));
 
-  const xcframeworks = [...baseFrameworks, ...precompiledModules, ...sourceBuiltDeps];
+  const seenNames = new Set<string>();
+  const xcframeworks = [...baseFrameworks, ...precompiledModules, ...sourceBuiltDeps].filter(
+    ({ name }) => {
+      if (seenNames.has(name)) {
+        return false;
+      }
+      seenNames.add(name);
+      return true;
+    }
+  );
 
   // With prebuilds the module graph is large; expose a single aggregate library so consumers
   // `import <PackageName>` once and Xcode links every underlying binary target automatically.
@@ -564,6 +592,27 @@ export const printIosConfig = (config: IosConfig) => {
   }
 
   console.log();
+};
+
+/**
+ * Fails fast when the brownfield scheme shares its name with a bundled framework — the bundled
+ * xcframework would silently overwrite the wrapper framework in the output, and Package.swift
+ * would declare the same target twice.
+ */
+export const validateSchemeCollision = (config: IosConfig): void => {
+  const bundled = new Set(resolvedFixedXCFrameworks());
+  if (config.usePrebuilds) {
+    for (const module of enumerateAllPrebuildModules(
+      process.cwd(),
+      config.buildConfiguration,
+      config.hostProvidedFrameworks
+    )) {
+      bundled.add(module.name);
+    }
+  }
+  if (bundled.has(config.scheme)) {
+    CLIError.handle('ios-scheme-name-collision', config.scheme);
+  }
 };
 
 export const validateHostProvided = (config: IosConfig): void => {

--- a/packages/expo-brownfield/cli/src/utils/precompiled.ts
+++ b/packages/expo-brownfield/cli/src/utils/precompiled.ts
@@ -109,6 +109,105 @@ export const enumeratePrecompiledModules = (iosDir: string): ModuleXCFramework[]
 };
 
 /**
+ * Scans `ios/Pods/` for pods that build their vendored xcframework during the app build
+ * (`<Pod>/Products/<Pod>.xcframework`, e.g. ExpoModulesJSI). Prebuilt modules like
+ * ExpoModulesCore publicly depend on these, so without bundling them consumers fail with
+ * `unable to resolve module dependency: '<Name>'`.
+ */
+export const enumeratePodBuiltXcframeworks = (
+  iosDir: string,
+  existingNames: Set<string>
+): ModuleXCFramework[] => {
+  const podsDir = path.join(iosDir, 'Pods');
+  if (!fs.existsSync(podsDir)) {
+    return [];
+  }
+
+  const results: ModuleXCFramework[] = [];
+  for (const entry of fs.readdirSync(podsDir, { withFileTypes: true })) {
+    if (
+      !entry.isDirectory() ||
+      RESERVED_POD_DIRS.has(entry.name) ||
+      existingNames.has(entry.name)
+    ) {
+      continue;
+    }
+    const podDir = path.join(podsDir, entry.name);
+    const xcframeworkPath = path.join(podDir, 'Products', `${entry.name}.xcframework`);
+    if (!fs.existsSync(xcframeworkPath)) {
+      continue;
+    }
+    results.push({
+      name: entry.name,
+      podDir,
+      xcframeworkPath,
+      mainProduct: entry.name,
+    });
+  }
+
+  return results;
+};
+
+/**
+ * A shared SPM-dep xcframework staged as a symlink whose target only exists in a different
+ * build flavor than the requested one (e.g. only `.../SDWebImage/debug/` is on disk but a
+ * `--release` build was requested).
+ */
+export interface FlavorMismatch {
+  name: string;
+  /** The requested flavor that could not be found. */
+  flavor: string;
+  /** The wrong-flavor path the staged symlink resolves to. */
+  xcframeworkPath: string;
+}
+
+const FLAVOR_DIR_NAMES = new Set(['debug', 'release']);
+
+/**
+ * Autolinking stages shared SPM-dep xcframeworks as symlinks into a `<store>/<name>/<flavor>/`
+ * tree, using the flavor active at `pod install` time. Copying the symlink verbatim would make
+ * the package non-portable and could ship the wrong flavor, so resolve it to its real path and
+ * swap to the requested flavor's sibling directory — recording a `FlavorMismatch` when that
+ * sibling is missing.
+ */
+const resolveStagedXcframework = (
+  module: ModuleXCFramework,
+  flavor: string,
+  flavorMismatches: FlavorMismatch[]
+): ModuleXCFramework => {
+  let isSymlink = false;
+  try {
+    isSymlink = fs.lstatSync(module.xcframeworkPath).isSymbolicLink();
+  } catch {
+    return module;
+  }
+  if (!isSymlink) {
+    return module;
+  }
+
+  let real: string;
+  try {
+    real = fs.realpathSync(module.xcframeworkPath);
+  } catch {
+    // Dangling symlink — leave it; the copy step will surface the failure with context.
+    return module;
+  }
+
+  const flavorDir = path.dirname(real);
+  const stagedFlavor = path.basename(flavorDir).toLowerCase();
+  if (FLAVOR_DIR_NAMES.has(stagedFlavor) && stagedFlavor !== flavor) {
+    const candidate = path.join(path.dirname(flavorDir), flavor, path.basename(real));
+    if (fs.existsSync(candidate)) {
+      real = fs.realpathSync(candidate);
+    } else {
+      flavorMismatches.push({ name: module.name, flavor, xcframeworkPath: real });
+    }
+  }
+
+  return { ...module, xcframeworkPath: real };
+};
+
+/**
  * Reads `<podDir>/artifacts/.last_build_configuration` and, if it doesn't match the requested
  * build configuration, shells out to autolinking's `replace-xcframework.js` to extract the
  * correct flavor tarball in place. This protects against the user having run
@@ -608,9 +707,23 @@ export const enumerateAllPrebuildModules = (
     modules: allModules,
     podModules,
     podToNpm,
+    flavorMismatches,
   } = enumeratePrebuildModulesRaw(cwd, buildConfiguration);
 
   const modules = allModules.filter((m) => !hostProvided.has(m.name));
+
+  // Shipping a wrong-flavor SPM dep would silently mix debug and release binaries in the
+  // package, so fail fast unless the host app provides the framework itself.
+  const blockingMismatches = flavorMismatches.filter(({ name }) => !hostProvided.has(name));
+  if (blockingMismatches.length > 0) {
+    const detail = blockingMismatches
+      .map(
+        ({ name, flavor, xcframeworkPath }) =>
+          `${name} (requested ${flavor}, only found ${xcframeworkPath})`
+      )
+      .join(', ');
+    CLIError.handle('ios-prebuilds-spm-dep-flavor-mismatch', detail);
+  }
 
   // Drop host-provided names from the completeness check
   const declaredDeps = collectDeclaredSpmDeps(podModules, podToNpm).filter(
@@ -639,10 +752,18 @@ export const enumeratePrebuildModulesRaw = (
   modules: ModuleXCFramework[];
   podModules: ModuleXCFramework[];
   podToNpm: Map<string, NpmPackageInfo>;
+  flavorMismatches: FlavorMismatch[];
 } => {
-  const podModules = enumeratePrecompiledModules(path.join(cwd, 'ios'));
+  const flavor = buildConfiguration.toLowerCase();
+  const flavorMismatches: FlavorMismatch[] = [];
+  const podModules = enumeratePrecompiledModules(path.join(cwd, 'ios')).map((module) =>
+    resolveStagedXcframework(module, flavor, flavorMismatches)
+  );
   const podToNpm = buildPodToNpmPackageMap(cwd);
   const seenNames = new Set(podModules.map((m) => m.name));
+
+  const podBuiltModules = enumeratePodBuiltXcframeworks(path.join(cwd, 'ios'), seenNames);
+  podBuiltModules.forEach((m) => seenNames.add(m.name));
 
   const bundledModules = enumerateBundledSpmDepsXcframeworks(
     podModules,
@@ -655,8 +776,9 @@ export const enumeratePrebuildModulesRaw = (
   const spmDepModules = enumerateSpmDepsXcframeworks(cwd, buildConfiguration, seenNames);
 
   return {
-    modules: [...podModules, ...bundledModules, ...spmDepModules],
+    modules: [...podModules, ...podBuiltModules, ...bundledModules, ...spmDepModules],
     podModules,
     podToNpm,
+    flavorMismatches,
   };
 };

--- a/packages/expo-brownfield/jest.config.js
+++ b/packages/expo-brownfield/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, ['cli']);

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -79,8 +79,5 @@
   "peerDependencies": {
     "expo": "*",
     "react": "*"
-  },
-  "jest": {
-    "preset": "expo-module-scripts"
   }
 }


### PR DESCRIPTION
# Why

While integrating expo-brownfield in https://github.com/expo/expo-brownfield-examples a few bugs surfaced in the CLI that break iOS packaging when precompiled modules (`ios.usePrecompiledModules`) are enabled:
 

1. `build:ios` fails to locate the built brownfield framework because the pod build settings route it under `XCFrameworkIntermediates/<scheme>/` rather than the products-dir root.
2. The generated `Package.swift` can declare the same target twice (when the brownfield target shares its name with a bundled module), producing a manifest Xcode refuses to resolve. The bundled module's xcframework also silently overwrites the wrapper framework on disk, shipping a package without `ReactNativeHostManager`.
3. `ExpoModulesJSI.xcframework` is never bundled even though the prebuilt `ExpoModulesCore` publicly depends on it, so consumers fail to compile with `unable to resolve module dependency: 'ExpoModulesJSI'`.
4. Shared SPM-dep xcframeworks (e.g. `SDWebImage`) are copied as symlinks pointing into `node_modules/<pkg>/prebuilds/spm-deps/<flavor>/`, making the package non-portable and able to ship debug binaries in a release build when the flavor at `pod install` time differs from the requested one.

# How

- **Framework resolution:** `createXCframework` and `enumerateSourceBuiltDeps` now resolve the scheme framework through the existing `findSourceBuiltFramework` helper (products root first, then `XCFrameworkIntermediates/`). A missing framework now fails with an actionable error instead of a raw `xcodebuild` failure. This also revived the source-built dependency scan, which was silently returning empty in precompiled builds.
- **Duplicate targets:** `generatePackageMetadataFile` dedupes targets by name, and a new `validateSchemeCollision` check fails fast (before the long `xcodebuild` step) when the scheme name collides with a bundled framework, telling the user to rename `ios.targetName`.
- **Pod-built vendored xcframeworks:** a new enumeration layer picks up pods that build their vendored xcframework during the app build (`Pods/<Pod>/Products/<Pod>.xcframework`, the `ExpoModulesJSI` pattern) so they are bundled and declared as binary targets alongside the other layers.
- **Symlinked SPM deps:** enumeration resolves staged symlinks to their real paths and swaps to the requested flavor's sibling store directory. If that flavor is not on disk, the build fails with a flavor-mismatch error rather than silently mixing debug and release binaries. Host-provided frameworks are exempt from this check.

Also fixes `build:ios` not awaiting the ship step, and wires up unit testing for the CLI (previously untested) using the repo-standard composite jest preset.

# Test Plan

- Added 13 unit tests in `cli/src/utils/__tests__/` covering all four fixes: framework resolution at both locations plus the error path, `Package.swift` dedup, scheme collision validation, pod-built xcframework enumeration, and symlink flavor correction including the mismatch and host-provided cases. Tests were written red-first against the buggy behavior.
- `et check-packages expo-brownfield` passes (build, typecheck, lint, tests).
