### PR TITLE
[router] Refactor headless tabs, not to rely on routeNames

### DIFF
--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -10,8 +10,10 @@ import { router } from '../imperative-api';
 import { Stack } from '../layouts/Stack';
 import { Tabs as JSTabs } from '../layouts/Tabs';
 import { Link, Redirect } from '../link/Link';
+import { useIsFocused } from '../react-navigation/native';
 import { type RenderRouterOptions, renderRouter, waitFor } from '../testing-library';
 import { TabList, TabSlot, TabTrigger, Tabs } from '../ui';
+import { useNavigatorContext } from '../views/Navigator';
 import type { PressableProps } from '../views/Pressable';
 import { Pressable } from '../views/Pressable';
 
@@ -29,6 +31,7 @@ const renderFruitApp = (options: RenderRouterOptions = {}) =>
                 <TabTrigger name="apple" testID="goto-apple" href="/apple">
                   <Text>Apple</Text>
                 </TabTrigger>
+                {/* TODO(@ubax): Remove nested trigger href once headless tabs require direct-child hrefs (unify with NativeTabs). */}
                 <TabTrigger name="banana" testID="goto-banana" href="/banana/taste">
                   <Text>Banana</Text>
                 </TabTrigger>
@@ -241,6 +244,413 @@ it('can dynamically add tabs', () => {
   expect(screen).toHaveSegments(['orange']);
 });
 
+it('can dynamically remove the active tab', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showAll, setShowAll] = useState(true);
+
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showAll && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowAll(false)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+    },
+    {
+      initialUrl: '/orange',
+    }
+  );
+
+  expect(screen).toHaveSegments(['orange']);
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+
+  expect(screen).toHaveSegments(['apple']);
+});
+
+it('preserves surviving tab content when the trigger set changes', () => {
+  let appleMounts = 0;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showOrange && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(appleMounts).toBe(1);
+});
+
+it('does not reset tab content when only a trigger href changes', () => {
+  let appleMounts = 0;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [withQuery, setWithQuery] = useState(false);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href={withQuery ? '/apple?updated=true' : '/apple'} />
+            </TabList>
+            <TabSlot />
+            <Button testID="change-href" title="Change href" onPress={() => setWithQuery(true)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('change-href'));
+  expect(appleMounts).toBe(1);
+});
+
+it('does not reset tab content when triggers are reordered', () => {
+  let appleMounts = 0;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reversed, setReversed] = useState(false);
+        const triggers = [
+          <TabTrigger key="apple" name="apple" href="/apple" />,
+          <TabTrigger key="orange" name="orange" href="/orange" />,
+        ];
+        return (
+          <Tabs>
+            <TabList>{reversed ? triggers.reverse() : triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder" title="Reorder" onPress={() => setReversed(true)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('reorder'));
+  expect(appleMounts).toBe(1);
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('uses the new trigger order for order back behavior', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = reordered
+          ? [
+              <TabTrigger key="orange" name="orange" href="/orange" />,
+              <TabTrigger key="apple" name="apple" href="/apple" />,
+              <TabTrigger key="pear" name="pear" href="/pear" />,
+            ]
+          : [
+              <TabTrigger key="apple" name="apple" href="/apple" />,
+              <TabTrigger key="orange" name="orange" href="/orange" />,
+              <TabTrigger key="pear" name="pear" href="/pear" />,
+            ];
+
+        return (
+          <Tabs options={{ backBehavior: 'order' }}>
+            <TabList>{triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/pear' }
+  );
+
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['apple']);
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('returns to the initial route after triggers are reordered', () => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName: 'orange' },
+        default: function TabLayout() {
+          const [reordered, setReordered] = useState(false);
+          const triggers = [
+            <TabTrigger key="apple" name="apple" href="/apple" />,
+            <TabTrigger key="orange" name="orange" href="/orange" />,
+            <TabTrigger key="pear" name="pear" href="/pear" />,
+          ];
+
+          return (
+            <Tabs>
+              <TabList>{reordered ? triggers.reverse() : triggers}</TabList>
+              <TabSlot />
+              <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+            </Tabs>
+          );
+        },
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/pear' }
+  );
+
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('preserves visit history when triggers are reordered', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = [
+          <TabTrigger key="apple" name="apple" href="/apple" />,
+          <TabTrigger key="orange" name="orange" testID="goto-orange" href="/orange" />,
+          <TabTrigger key="pear" name="pear" testID="goto-pear" href="/pear" />,
+        ];
+
+        return (
+          <Tabs options={{ backBehavior: 'history' }}>
+            <TabList>{reordered ? triggers.reverse() : triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  fireEvent.press(screen.getByTestId('goto-orange'));
+  fireEvent.press(screen.getByTestId('goto-pear'));
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('scopes trigger reordering to a nested tab navigator', () => {
+  let parentState: string | undefined;
+
+  function ParentStateProbe() {
+    const { state } = useNavigatorContext();
+    parentState = JSON.stringify({
+      routeNames: state.routeNames,
+      routeKeys: state.routes.map((route) => route.key),
+      index: state.index,
+      history: state.history,
+    });
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs options={{ backBehavior: 'history' }}>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+          <ParentStateProbe />
+        </Tabs>
+      ),
+      index: () => null,
+      'fruit/_layout': function FruitTabs() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = reordered
+          ? [
+              <TabTrigger key="orange" name="orange" href="/fruit/orange" />,
+              <TabTrigger key="apple" name="apple" href="/fruit/apple" />,
+              <TabTrigger key="pear" name="pear" href="/fruit/pear" />,
+            ]
+          : [
+              <TabTrigger key="apple" name="apple" href="/fruit/apple" />,
+              <TabTrigger key="orange" name="orange" href="/fruit/orange" />,
+              <TabTrigger key="pear" name="pear" href="/fruit/pear" />,
+            ];
+
+        return (
+          <Tabs options={{ backBehavior: 'order' }}>
+            <TabList>{triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder-child" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+      'fruit/pear': () => null,
+    },
+    { initialUrl: '/fruit/pear' }
+  );
+
+  const stateBeforeReorder = parentState;
+  fireEvent.press(screen.getByTestId('reorder-child'));
+  expect(parentState).toBe(stateBeforeReorder);
+  act(() => router.back());
+  expect(screen).toHaveSegments(['fruit', 'apple']);
+});
+
+it('keeps focus hooks correct after removing the active trigger', () => {
+  function Apple() {
+    return <Text testID="apple-focus">{useIsFocused() ? 'focused' : 'not focused'}</Text>;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showOrange && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(screen.getByTestId('apple-focus')).toHaveTextContent('focused');
+});
+
+it('removes the active trigger from a nested dynamic tab navigator', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/_layout': function FruitTabs() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/fruit/apple" />
+              {showOrange && <TabTrigger name="orange" href="/fruit/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+    },
+    { initialUrl: '/fruit/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(screen).toHaveSegments(['fruit', 'apple']);
+});
+
+it('does not redirect from an inactive nested tab navigator', () => {
+  let hideOrange!: () => void;
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" testID="goto-index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => null,
+      'fruit/_layout': function FruitTabs() {
+        const [showOrange, setShowOrange] = useState(true);
+        hideOrange = () => setShowOrange(false);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/fruit/apple" />
+              {showOrange && <TabTrigger name="orange" href="/fruit/orange" />}
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+    },
+    { initialUrl: '/fruit/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('goto-index'));
+  act(hideOrange);
+  expect(screen).toHavePathname('/');
+});
+
 it('does works with shared groups', () => {
   renderRouter(
     {
@@ -306,6 +716,176 @@ it('works with nested layouts', () => {
   fireEvent.press(screen.getByTestId('goto-page'));
   expect(screen.getByTestId('page')).toBeVisible();
   expect(screen).toHaveSegments(['page']);
+});
+
+it('registers declared routes in trigger order', () => {
+  function StateProbe() {
+    const { state } = useNavigatorContext();
+    return (
+      <Text testID="tab-state">
+        {state.routes.map((route) => route.name).join(',')}:{state.routes[state.index]!.name}
+      </Text>
+    );
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="orange" href="/orange" />
+            <TabTrigger name="apple" href="/apple" />
+          </TabList>
+          <TabSlot />
+          <StateProbe />
+        </Tabs>
+      ),
+      apple: () => null,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(screen.getByTestId('tab-state')).toHaveTextContent('orange,apple:apple');
+});
+
+it('redirects router.push from a filesystem route without a trigger', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" testID="goto-index" href="/" />
+          <TabTrigger name="visible" testID="goto-visible" href="/visible" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => <Text testID="index">Index</Text>,
+    visible: () => <Text testID="visible">Visible</Text>,
+    hidden: () => <Text testID="hidden">Hidden</Text>,
+  });
+
+  act(() => router.push('/hidden'));
+  expect(screen).toHavePathname('/');
+  expect(screen.queryByTestId('hidden')).toBeNull();
+  expect(screen.getByTestId('goto-index')).toHaveProp('isFocused', true);
+});
+
+it('removes a redirected filesystem route from tab history', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs options={{ backBehavior: 'history' }}>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="visible" testID="goto-visible" href="/visible" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    visible: () => null,
+    hidden: () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-visible'));
+  act(() => router.push('/hidden'));
+  expect(screen).toHavePathname('/');
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/visible');
+});
+
+it('redirects a Link from a filesystem route without a trigger', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => <Link testID="hidden-link" href="/hidden" />,
+    hidden: () => <Text testID="hidden">Hidden</Text>,
+  });
+
+  fireEvent.press(screen.getByTestId('hidden-link'));
+  expect(screen).toHavePathname('/');
+  expect(screen.queryByTestId('hidden')).toBeNull();
+});
+
+it('redirects a deep link from a filesystem route without a trigger', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('hidden')).toBeNull();
+});
+
+it.each(['second', 'second/index'])('redirects to initial route %s', (initialRouteName) => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName },
+        default: () => (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="index" href="/" />
+              <TabTrigger name="second" href="/second" />
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        ),
+      },
+      index: () => <Text testID="index">Index</Text>,
+      [initialRouteName]: () => <Text testID="second">Second</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/second');
+  expect(screen.getByTestId('second')).toBeVisible();
+});
+
+it('falls back to the first trigger when the initial route has no trigger', () => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName: 'hidden' },
+        default: () => (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="index" href="/" />
+              <TabTrigger name="visible" href="/visible" />
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        ),
+      },
+      index: () => <Text testID="index">Index</Text>,
+      visible: () => <Text testID="visible">Visible</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
 });
 
 describe('warnings/errors', () => {
@@ -383,9 +963,33 @@ describe('warnings/errors', () => {
       'Trigger {"name":"duplicate","href":"http://expo.dev"} has the same name as parent trigger {"name":"duplicate","href":"/two"}. Triggers must have unique names.'
     );
   });
+
+  it('does not allow trigger hrefs outside a nested tabs layout', () => {
+    expect(() =>
+      renderRouter(
+        {
+          _layout: () => <Stack />,
+          'fruit/_layout': () => (
+            <Tabs>
+              <TabList>
+                <TabTrigger name="apple" href="/other/apple" />
+              </TabList>
+              <TabSlot />
+            </Tabs>
+          ),
+          'fruit/apple': () => null,
+          'other/_layout': () => <Stack />,
+          'other/apple': () => null,
+        },
+        { initialUrl: '/fruit/apple' }
+      )
+    ).toThrow(
+      `Tab trigger 'apple' with href '/other/apple' must point to a route within the tabs layout.`
+    );
+  });
 });
 
-it('can update href dynamically', () => {
+it('can update a tab trigger href', () => {
   const MockContext = React.createContext({ href: '/a', setHref: (href: string) => {} });
   renderRouter({
     _layout: function TabLayout() {
@@ -395,11 +999,11 @@ it('can update href dynamically', () => {
           <Tabs>
             <TabSlot />
             <TabList>
-              <TabTrigger name="index" href="/">
-                <Text>Index</Text>
-              </TabTrigger>
               <TabTrigger name="[p]" href={href}>
                 <Text>{href}</Text>
+              </TabTrigger>
+              <TabTrigger name="index" href="/">
+                <Text>Index</Text>
               </TabTrigger>
             </TabList>
           </Tabs>
@@ -413,38 +1017,85 @@ it('can update href dynamically', () => {
           <Button
             testID="toggle"
             title="Toggle"
-            onPress={() => setHref(href === '/a' ? '/b' : '/a')}
+            onPress={() => setHref(href === '/a' ? '/b?updated=true' : '/a')}
           />
         </View>
       );
     },
     '[p]': function P() {
-      const { p } = useLocalSearchParams();
-      return <Text testID="page">{p}</Text>;
+      const { p, updated } = useLocalSearchParams();
+      return <Text testID="page">{`${p}:${updated}`}</Text>;
     },
   });
   expect(screen.getByTestId('index')).toBeVisible();
-  expect(screen.queryByTestId('page')).toBeNull();
-  expect(screen.getByText('/a')).toBeVisible();
-  expect(screen.getByText('Index')).toBeVisible();
-
   fireEvent.press(screen.getByText('/a'));
-  expect(screen.queryByTestId('index')).toBeNull();
-  expect(screen.getByTestId('page')).toBeVisible();
-  expect(screen.getByTestId('page')).toHaveTextContent('a');
-  expect(screen.getByText('Index')).toBeVisible();
-
+  expect(screen.getByTestId('page')).toHaveTextContent('a:undefined');
   fireEvent.press(screen.getByText('Index'));
-  expect(screen.getByTestId('index')).toBeVisible();
-  expect(screen.queryByTestId('page')).toBeNull();
-
   fireEvent.press(screen.getByTestId('toggle'));
-  expect(screen.getByText('/b')).toBeVisible();
-  expect(screen.queryByText('/a')).toBeNull();
+  fireEvent.press(screen.getByText('/b?updated=true'));
+  expect(screen.getByTestId('page')).toHaveTextContent('b:true');
+});
 
-  fireEvent.press(screen.getByText('/b'));
-  expect(screen.getByTestId('page')).toBeVisible();
-  expect(screen.getByTestId('page')).toHaveTextContent('b');
+it('passes query params to a direct child navigator', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" testID="goto-index" href="/" />
+          <TabTrigger name="movies" testID="goto-movies" href="/movies?filter=recent" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    'movies/_layout': function MoviesLayout() {
+      const { filter } = useLocalSearchParams();
+      return (
+        <>
+          <Text testID="filter">{filter}</Text>
+          <Stack />
+        </>
+      );
+    },
+    'movies/index': () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-movies'));
+  expect(screen.getByTestId('filter')).toHaveTextContent('recent');
+});
+
+it('can reference a parent trigger from nested tabs', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      'fruit/_layout': () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="apple" href="/fruit/apple" />
+          </TabList>
+          <TabTrigger name="fruit" testID="current-parent" />
+          <TabTrigger name="index" testID="goto-parent" />
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/apple': () => <Text testID="apple">Apple</Text>,
+    },
+    { initialUrl: '/fruit/apple' }
+  );
+
+  expect(screen.getByTestId('current-parent')).toHaveProp('isFocused', true);
+  expect(screen.getByTestId('goto-parent')).toHaveProp('isFocused', false);
+  fireEvent.press(screen.getByTestId('goto-parent'));
+  expect(screen.getByTestId('index')).toBeVisible();
 });
 
 it('does not reset on focus when resetOnFocus is false', () => {
@@ -778,6 +1429,33 @@ it('router.replace works in headless tabs', async () => {
 
   expect(screen.getByTestId('second')).toBeVisible();
   expect(router.canGoBack()).toBe(false);
+});
+
+it('router.replace only removes the latest visit with full history', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs options={{ backBehavior: 'fullHistory' }}>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="second" testID="goto-second" href="/second" />
+          <TabTrigger name="third" href="/third" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-second'));
+  act(() => router.push('/'));
+  act(() => router.replace('/third'));
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+  act(() => router.back());
+  expect(screen).toHavePathname('/');
 });
 
 it('Link with replace works in headless tabs', async () => {

--- a/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
@@ -1,0 +1,21 @@
+import { act, screen } from '@testing-library/react-native';
+
+import { router } from '../imperative-api';
+import { Tabs } from '../layouts/Tabs';
+import { renderRouter } from '../testing-library';
+
+it('removes the replaced tab from history', () => {
+  renderRouter({
+    _layout: () => <Tabs backBehavior="history" />,
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  act(() => router.push('/second'));
+  act(() => router.push('/third'));
+  act(() => router.replace('/'));
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+});

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -1,20 +1,17 @@
 'use client';
 
-import React, { use, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { use, useCallback, useMemo, useRef } from 'react';
 
 import { useRouteNode } from '../Route';
-import { router } from '../imperative-api';
 import type {
   ParamListBase,
   TabNavigationState,
   TabRouterOptions,
 } from '../react-navigation/native';
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
-import type {
-  StandardNavigatorContentProps,
-  StandardNavigatorDescriptor,
-} from '../standard-navigation/types';
+import type { StandardNavigatorContentProps } from '../standard-navigation/types';
 import { getAllChildrenNotOfType, getAllChildrenOfType } from '../utils/children';
+import { useHiddenTabRedirect } from '../utils/useHiddenTabRedirect';
 import { NativeBottomTabsRouter } from './NativeBottomTabsRouter';
 import { NativeTabTrigger } from './NativeTabTrigger';
 import { NativeTabsView } from './NativeTabsView';
@@ -66,57 +63,35 @@ function NativeTabsContent({
 
   const { routes } = state;
 
+  const { visibleRoutes, visibleFocusedIndex } = useHiddenTabRedirect({
+    routes,
+    focusedRouteKey: routes[state.index]!.key,
+    descriptors,
+    redirectToRouteName,
+  });
   const visibleTabs = useMemo(
     () =>
-      routes
-        // Every filesystem route is registered in state; only routes declared by a
-        // non-hidden <NativeTabs.Trigger> become tab items.
-        .filter((route) => {
-          const descriptor = descriptors[
-            route.key
-          ]! as StandardNavigatorDescriptor<NativeTabOptions>;
-          return descriptor.routeSource === 'layout' && descriptor.options?.hidden !== true;
+      visibleRoutes.map(
+        (route): NativeTabsViewTabItem => ({
+          options: descriptors[route.key]!.options,
+          routeKey: route.key,
+          name: route.name,
+          contentRenderer: () => descriptors[route.key]!.render(),
         })
-        .map(
-          (route): NativeTabsViewTabItem => ({
-            options: descriptors[route.key]!.options,
-            routeKey: route.key,
-            name: route.name,
-            contentRenderer: () => descriptors[route.key]!.render(),
-          })
-        ),
-    [routes, descriptors]
-  );
-  const visibleFocusedTabIndex = useMemo(
-    () => visibleTabs.findIndex((tab) => tab.routeKey === routes[state.index]!.key),
-    [visibleTabs, routes, state.index]
+      ),
+    [descriptors, visibleRoutes]
   );
   const visibleTabsKeys = useMemo(
     () => visibleTabs.map((tab) => tab.routeKey).join(';'),
     [visibleTabs]
   );
 
-  const focusedIndex = visibleFocusedTabIndex >= 0 ? visibleFocusedTabIndex : 0;
+  const focusedIndex = visibleFocusedIndex >= 0 ? visibleFocusedIndex : 0;
 
   // The focused route can be hidden or have no trigger at all — for example a path pointing at a
   // route without a tab, or a trigger hidden while focused. Redirect to the router's initial tab,
   // falling back to the first visible tab. `replace` keeps the unreachable route out of history.
   // TODO(@ubax): Show a formsheet for hidden tabs which are focused (Tabs + Stack in one).
-  const redirectTabHref = useMemo(() => {
-    const redirectTab =
-      visibleTabs.find(
-        (tab) =>
-          tab.name === redirectToRouteName ||
-          tab.name.replace(/\/index$/, '') === redirectToRouteName
-      ) ?? visibleTabs[0];
-    return routes.find((route) => route.key === redirectTab?.routeKey)?.href;
-  }, [redirectToRouteName, routes, visibleTabs]);
-  useEffect(() => {
-    if (visibleFocusedTabIndex < 0 && redirectTabHref != null) {
-      router.replace(redirectTabHref);
-    }
-  }, [visibleFocusedTabIndex, redirectTabHref]);
-
   const provenanceRef = useRef(0);
 
   const onTabChange = useCallback(

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -242,6 +242,27 @@ describe('Native Bottom Tabs trigger changes', () => {
     expect(screen).toHavePathname('/');
   });
 
+  it('removes a replaced route from tab history', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs backBehavior="history">
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+      notSpecified: () => <View testID="not-specified" />,
+    });
+
+    act(() => router.push('/second'));
+    act(() => router.push('/notSpecified'));
+    expect(screen).toHavePathname('/');
+
+    act(() => router.back());
+    expect(screen).toHavePathname('/second');
+  });
+
   it('respects initialRouteName when redirecting from a route without a visible tab', () => {
     renderRouter(
       {

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -209,6 +209,7 @@ export function DrawerRouter({
 
           return addDrawerToHistory(state);
 
+        case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':
         case 'NAVIGATE_DEPRECATED': {

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -112,7 +112,7 @@ export const TabActions = {
   },
 };
 
-const getRouteHistory = (
+export const getRouteHistory = (
   routes: Route<string>[],
   index: number,
   backBehavior: BackBehavior,

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -1,6 +1,5 @@
 import { nanoid } from 'nanoid/non-secure';
 
-import type { StackActionType } from '../core';
 import { BaseRouter } from './BaseRouter';
 import { createParamsFromAction } from './createParamsFromAction';
 import type {
@@ -13,12 +12,19 @@ import type {
   Router,
 } from './types';
 
-export type TabActionType = {
-  type: 'JUMP_TO';
-  payload: { name: string; params?: object };
-  source?: string;
-  target?: string;
-};
+export type TabActionType =
+  | {
+      type: 'JUMP_TO';
+      payload: { name: string; params?: object };
+      source?: string;
+      target?: string;
+    }
+  | {
+      type: 'REPLACE';
+      payload: { name: string; params?: object };
+      source?: string;
+      target?: string;
+    };
 
 export type BackBehavior =
   | 'firstRoute'
@@ -61,6 +67,20 @@ export type TabNavigationState<ParamList extends ParamListBase> = Omit<
 
 export type TabActionHelpers<ParamList extends ParamListBase> = {
   /**
+   * Replaces the current tab with another tab.
+   *
+   * @param screen Name of the tab that will replace the current one.
+   * @param [params] Params object for the new tab.
+   */
+  replace<RouteName extends keyof ParamList>(
+    ...args: RouteName extends unknown
+      ? undefined extends ParamList[RouteName]
+        ? [screen: RouteName, params?: ParamList[RouteName]]
+        : [screen: RouteName, params: ParamList[RouteName]]
+      : never
+  ): void;
+
+  /**
    * Jump to an existing tab.
    *
    * @param screen Name of the route to jump to.
@@ -81,6 +101,12 @@ export const TabActions = {
   jumpTo(name: string, params?: object) {
     return {
       type: 'JUMP_TO',
+      payload: { name, params },
+    } as const satisfies TabActionType;
+  },
+  replace(name: string, params?: object) {
+    return {
+      type: 'REPLACE',
       payload: { name, params },
     } as const satisfies TabActionType;
   },
@@ -182,9 +208,17 @@ const changeIndex = (
   };
 };
 
-// TODO(@ubax): unify the logic into single router instead of BaseTabRouter and override
 // TODO(@ubax): add REPLACE action to CommonAction type and handle it in all routers
-function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRouterOptions) {
+/**
+ * TabRouter is considered an internal implementation and its behavior may change without a notice between expo-router's version
+ */
+export function TabRouter({
+  initialRouteName,
+  backBehavior = 'firstRoute',
+}: TabRouterOptions): Router<
+  TabNavigationState<ParamListBase>,
+  TabActionType | CommonNavigationAction
+> {
   const router: Router<
     TabNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
@@ -315,7 +349,12 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
     },
 
     getStateForAction(state, action, { routeParamList, routeGetIdList }) {
+      if (action.target && action.target !== state.key) {
+        return null;
+      }
+
       switch (action.type) {
+        case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':
         case 'NAVIGATE_DEPRECATED': {
@@ -374,12 +413,14 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
             initialRouteName
           );
 
-          return {
+          const result = {
             ...updatedState,
             preloadedRouteKeys: updatedState.preloadedRouteKeys.filter(
               (key) => key !== state.routes[updatedState.index]!.key
             ),
           };
+
+          return action.type === 'REPLACE' ? removeReplacedRouteFromHistory(state, result) : result;
         }
 
         case 'SET_PARAMS':
@@ -495,56 +536,23 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
   return router;
 }
 
-/**
- * TabRouter is considered an internal implementation and its behavior may change without a notice between expo-router's version
- */
-export function TabRouter(
-  args: TabRouterOptions
-): Router<TabNavigationState<ParamListBase>, TabActionType | CommonNavigationAction> {
-  const base = BaseTabRouter(args);
-  return {
-    ...base,
-    getStateForAction: (state, action, options) => {
-      if (action.target && action.target !== state.key) {
-        return null;
-      }
+function removeReplacedRouteFromHistory(
+  previousState: TabNavigationState<ParamListBase>,
+  nextState: TabNavigationState<ParamListBase>
+) {
+  const replacedRouteKey = previousState.routes[previousState.index]?.key;
+  const focusedRouteKey = nextState.routes[nextState.index]?.key;
+  if (!replacedRouteKey || replacedRouteKey === focusedRouteKey) {
+    return nextState;
+  }
 
-      if ((action.type as string) === 'REPLACE') {
-        const replaceAction = action as unknown as Extract<StackActionType, { type: 'REPLACE' }>;
-        // Generate the state as if we were using JUMP_TO
-        let nextState = base.getStateForAction(
-          state,
-          {
-            ...replaceAction,
-            type: 'JUMP_TO',
-          },
-          options
-        );
+  const history = [...nextState.history];
+  for (let index = history.length - 1; index >= 0; index--) {
+    if (history[index]!.key === replacedRouteKey) {
+      history.splice(index, 1);
+      break;
+    }
+  }
 
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
-          return null;
-        }
-
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (nextState.index !== 0) {
-          const previousIndex = nextState.index - 1;
-
-          nextState = {
-            ...nextState,
-            key: `${nextState.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...nextState.history.slice(0, previousIndex),
-              ...nextState.history.splice(nextState.index),
-            ],
-          };
-        }
-
-        return nextState;
-      }
-
-      return base.getStateForAction(state, action, options);
-    },
-  };
+  return { ...nextState, history };
 }

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -294,7 +294,7 @@ test('handles navigate action', () => {
       { key: 'baz', name: 'baz', params: { answer: 42 } },
       { key: 'bar', name: 'bar' },
     ],
-    history: [{ type: 'route', key: 'baz' }],
+    history: [{ type: 'route', key: 'baz', params: undefined }],
     default: 'closed',
   });
 });
@@ -338,6 +338,52 @@ test('handles navigate action with open drawer', () => {
     preloadedRouteKeys: [],
     routes: [
       { key: 'baz', name: 'baz', params: { answer: 42 } },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [{ type: 'route', key: 'baz' }],
+    default: 'closed',
+  });
+});
+
+test('closes open drawer on replace with backBehavior: fullHistory', () => {
+  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'drawer',
+        preloadedRouteKeys: [],
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+        history: [
+          { type: 'route', key: 'bar' },
+          { type: 'drawer', status: 'open' },
+        ],
+        default: 'closed',
+      },
+      DrawerActions.replace('baz'),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'drawer',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    preloadedRouteKeys: [],
+    routes: [
+      { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'baz' }],

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,15 +1,37 @@
 import { expect, jest, test } from '@jest/globals';
+import { expectTypeOf } from 'expect-type';
 
 import {
   CommonActions,
   type ParamListBase,
   type RouterConfigOptions,
   TabActions,
+  type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
 } from '../index';
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
+
+test('types replace action helper params', () => {
+  type Params = {
+    optional: undefined;
+    required: { id: string };
+  };
+
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('optional');
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: '1' });
+
+  if (false) {
+    const helpers = {} as TabActionHelpers<Params>;
+    // @ts-expect-error: Required route params cannot be omitted.
+    helpers.replace('required');
+    // @ts-expect-error: Route params must match the route's param type.
+    helpers.replace('required', { id: 1 });
+    // @ts-expect-error: The route must exist in the param list.
+    helpers.replace('missing');
+  }
+});
 
 test('gets initial state from route names and params with initialRouteName', () => {
   const router = TabRouter({ initialRouteName: 'baz' });
@@ -1053,6 +1075,135 @@ test('ensures unique ID for jump to', () => {
       { type: 'route', key: 'bar-test' },
     ],
   });
+});
+
+test('replaces the focused route when the destination is the first tab', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('bar'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'baz-test' },
+    { type: 'route', key: 'bar-test' },
+  ]);
+});
+
+test('replaces the focused route based on visit history instead of route order', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux', 'foo'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('foo'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'foo-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+});
+
+test('only removes the latest visit when replacing with backBehavior: fullHistory', () => {
+  const router = TabRouter({ backBehavior: 'fullHistory' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('bar'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'baz-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+});
+
+test('preserves history when replacing a tab with itself', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('baz'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'baz-test' },
+  ]);
+});
+
+test('preserves the navigator key across repeated replaces', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const initialState = router.getInitialState(options);
+
+  const replacedState = router.getStateForAction(
+    initialState,
+    TabActions.replace('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  const replacedAgainState = router.getStateForAction(
+    replacedState,
+    TabActions.replace('qux'),
+    options
+  );
+
+  expect(replacedState.key).toBe(initialState.key);
+  expect(replacedAgainState?.key).toBe(initialState.key);
 });
 
 test('handles back action with backBehavior: history', () => {

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -5,6 +5,8 @@ import {
   type TabActionType as RNTabActionType,
   type TabNavigationState,
   type TabRouterOptions as RNTabRouterOptions,
+  type StackActionType,
+  type NavigationAction,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
 import type { TriggerMap } from './common';
@@ -13,9 +15,12 @@ export type ExpoTabRouterOptions = RNTabRouterOptions & {
   triggerMap: TriggerMap;
 };
 
+type ReplaceAction = Extract<StackActionType, { type: 'REPLACE' }>;
+
 export type ExpoTabActionType =
   | RNTabActionType
   | CommonNavigationAction
+  | ReplaceAction
   | {
       type: 'JUMP_TO';
       source?: string;
@@ -36,7 +41,37 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   > = {
     ...rnTabRouter,
     getStateForAction(state, action, options) {
-      if (action.type !== 'JUMP_TO') {
+      if (isReplaceAction(action)) {
+        action = {
+          ...action,
+          type: 'JUMP_TO',
+        };
+        // Generate the state as if we were using JUMP_TO
+        const nextState = rnTabRouter.getStateForAction(state, action, options);
+
+        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
+          return null;
+        }
+
+        // We can assert that nextState is TabNavigationState here, because we checked for index and history above
+        state = nextState as TabNavigationState<ParamListBase>;
+
+        // If the state is valid and we didn't JUMP_TO a single history state,
+        // then remove the previous state.
+        if (state.index !== 0) {
+          const previousIndex = state.index - 1;
+
+          state = {
+            ...state,
+            key: `${state.key}-replace`,
+            // Omit the previous history entry that we are replacing
+            history: [
+              ...state.history.slice(0, previousIndex),
+              ...state.history.splice(state.index),
+            ],
+          };
+        }
+      } else if (action.type !== 'JUMP_TO') {
         return rnTabRouter.getStateForAction(state, action, options);
       }
 
@@ -75,4 +110,8 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   };
 
   return router;
+}
+
+function isReplaceAction(action: NavigationAction): action is ReplaceAction {
+  return action.type === 'REPLACE';
 }

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -5,22 +5,19 @@ import {
   type TabActionType as RNTabActionType,
   type TabNavigationState,
   type TabRouterOptions as RNTabRouterOptions,
-  type StackActionType,
-  type NavigationAction,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
+import { getRouteHistory } from '../react-navigation/routers/TabRouter';
 import type { TriggerMap } from './common';
 
 export type ExpoTabRouterOptions = RNTabRouterOptions & {
   triggerMap: TriggerMap;
 };
 
-type ReplaceAction = Extract<StackActionType, { type: 'REPLACE' }>;
-
 export type ExpoTabActionType =
   | RNTabActionType
   | CommonNavigationAction
-  | ReplaceAction
+  | { type: 'EXPO_ROUTER_TAB_ORDER_CHANGED'; source?: string; target?: string }
   | {
       type: 'JUMP_TO';
       source?: string;
@@ -40,39 +37,35 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
     ExpoTabActionType | CommonNavigationAction
   > = {
     ...rnTabRouter,
-    getStateForAction(state, action, options) {
-      if (isReplaceAction(action)) {
-        action = {
-          ...action,
-          type: 'JUMP_TO',
-        };
-        // Generate the state as if we were using JUMP_TO
-        const nextState = rnTabRouter.getStateForAction(state, action, options);
+    getStateForAction(state, action, routerConfigOptions) {
+      if (action.type === 'EXPO_ROUTER_TAB_ORDER_CHANGED') {
+        const backBehavior = options.backBehavior ?? 'firstRoute';
 
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
-          return null;
+        if (
+          backBehavior !== 'firstRoute' &&
+          backBehavior !== 'initialRoute' &&
+          backBehavior !== 'order'
+        ) {
+          return state;
         }
 
-        // We can assert that nextState is TabNavigationState here, because we checked for index and history above
-        state = nextState as TabNavigationState<ParamListBase>;
+        const history = getRouteHistory(
+          state.routes,
+          state.index,
+          backBehavior,
+          options.initialRouteName
+        );
 
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (state.index !== 0) {
-          const previousIndex = state.index - 1;
-
-          state = {
-            ...state,
-            key: `${state.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...state.history.slice(0, previousIndex),
-              ...state.history.splice(state.index),
-            ],
-          };
+        if (
+          history.length === state.history.length &&
+          history.every((item, index) => item.key === state.history[index]!.key)
+        ) {
+          return state;
         }
+
+        return { ...state, history };
       } else if (action.type !== 'JUMP_TO') {
-        return rnTabRouter.getStateForAction(state, action, options);
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
       }
 
       const route = state.routes.find((route) => route.name === action.payload.name);
@@ -90,8 +83,8 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
       }
 
       if (shouldReset) {
-        options.routeParamList[route.name] = {
-          ...options.routeParamList[route.name],
+        routerConfigOptions.routeParamList[route.name] = {
+          ...routerConfigOptions.routeParamList[route.name],
         };
         state = {
           ...state,
@@ -102,16 +95,17 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
             return { ...r, state: undefined };
           }),
         };
-        return rnTabRouter.getStateForAction(state, action, options);
-      } else {
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
+      } else if (route.state !== undefined) {
+        // TODO(@ubax): Remove this branch together with nested trigger href support. Refocusing
+        // a tab that hosts a navigator must not re-apply the trigger's nested payload
+        // (`params.screen`), which would reset the preserved child state.
         return rnTabRouter.getStateForRouteFocus(state, route.key);
+      } else {
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
       }
     },
   };
 
   return router;
-}
-
-function isReplaceAction(action: NavigationAction): action is ReplaceAction {
-  return action.type === 'REPLACE';
 }

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -5,8 +5,6 @@ import {
   type TabActionType as RNTabActionType,
   type TabNavigationState,
   type TabRouterOptions as RNTabRouterOptions,
-  type StackActionType,
-  type NavigationAction,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
 import type { TriggerMap } from './common';
@@ -15,12 +13,9 @@ export type ExpoTabRouterOptions = RNTabRouterOptions & {
   triggerMap: TriggerMap;
 };
 
-type ReplaceAction = Extract<StackActionType, { type: 'REPLACE' }>;
-
 export type ExpoTabActionType =
   | RNTabActionType
   | CommonNavigationAction
-  | ReplaceAction
   | {
       type: 'JUMP_TO';
       source?: string;
@@ -41,37 +36,7 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   > = {
     ...rnTabRouter,
     getStateForAction(state, action, options) {
-      if (isReplaceAction(action)) {
-        action = {
-          ...action,
-          type: 'JUMP_TO',
-        };
-        // Generate the state as if we were using JUMP_TO
-        const nextState = rnTabRouter.getStateForAction(state, action, options);
-
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
-          return null;
-        }
-
-        // We can assert that nextState is TabNavigationState here, because we checked for index and history above
-        state = nextState as TabNavigationState<ParamListBase>;
-
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (state.index !== 0) {
-          const previousIndex = state.index - 1;
-
-          state = {
-            ...state,
-            key: `${state.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...state.history.slice(0, previousIndex),
-              ...state.history.splice(state.index),
-            ],
-          };
-        }
-      } else if (action.type !== 'JUMP_TO') {
+      if (action.type !== 'JUMP_TO') {
         return rnTabRouter.getStateForAction(state, action, options);
       }
 
@@ -110,8 +75,4 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   };
 
   return router;
-}
-
-function isReplaceAction(action: NavigationAction): action is ReplaceAction {
-  return action.type === 'REPLACE';
 }

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -120,7 +120,7 @@ export type SwitchToOptions = {
 export type Trigger = TriggerMap[string] & {
   isFocused: boolean;
   resolvedHref: string;
-  route: TabNavigationState<any>['routes'][number];
+  route?: TabNavigationState<any>['routes'][number];
 };
 
 export type UseTabTriggerResult = {
@@ -140,7 +140,7 @@ export type TriggerProps = {
  * Utility hook creating custom `TabTrigger`.
  */
 export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
-  const { state, navigation } = useNavigatorContext();
+  const { state, navigation, contextKey } = useNavigatorContext();
   const { name, resetOnFocus, onPress, onLongPress } = options;
   const triggerMap = use(TabTriggerMapContext);
 
@@ -152,14 +152,24 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         return;
       }
 
+      // Parent triggers are inherited, so read the state of the navigator that registered them.
+      const owningState =
+        config.type === 'internal' && config.contextKey !== contextKey
+          ? navigation?.getParent(config.contextKey || undefined)?.getState()
+          : state;
+      const routeIndex =
+        config.type === 'internal'
+          ? (owningState?.routes.findIndex((route) => route.name === config.routeNode.route) ?? -1)
+          : -1;
+
       return {
-        isFocused: state.index === config.index,
-        route: state.routes[config.index]!,
+        isFocused: owningState?.index === routeIndex,
+        route: owningState?.routes[routeIndex],
         resolvedHref: stripGroupSegmentsFromPath(appendBaseUrl(config.href)),
         ...config,
       };
     },
-    [triggerMap]
+    [contextKey, navigation, state, triggerMap]
   );
 
   const trigger = name !== undefined ? getTrigger(name) : undefined;
@@ -201,7 +211,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
 
       navigation?.emit({
         type: 'tabPress',
-        target: trigger.type === 'internal' ? trigger.route.key : trigger?.href,
+        target: trigger.route?.key ?? trigger.href,
         canPreventDefault: true,
       });
 
@@ -222,7 +232,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
 
       navigation?.emit({
         type: 'tabLongPress',
-        target: trigger.type === 'internal' ? trigger.route.key : trigger?.href,
+        target: trigger.route?.key ?? trigger.href,
       });
 
       if (!shouldHandleMouseEvent(event)) return;

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement, ReactNode, PropsWithChildren } from 'react';
-import { Children, Fragment, isValidElement, use, useMemo } from 'react';
+import { Children, Fragment, isValidElement, use, useEffect, useMemo, useRef } from 'react';
 import type { ViewProps } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 
@@ -15,6 +15,7 @@ import type {
 } from '../react-navigation/native';
 import { LinkingContext, useNavigationBuilder } from '../react-navigation/native';
 import { shouldLinkExternally } from '../utils/url';
+import { useHiddenTabRedirect } from '../utils/useHiddenTabRedirect';
 import type { NavigatorContextValue } from '../views/Navigator';
 import { NavigatorContext } from '../views/Navigator';
 import type { ExpoTabsScreenOptions, TabNavigationEventMap, TabsContextValue } from './TabContext';
@@ -25,7 +26,7 @@ import { ExpoTabRouter } from './TabRouter';
 import { isTabSlot } from './TabSlot';
 import { isTabTrigger } from './TabTrigger';
 import type { ScreenTrigger } from './common';
-import { ViewSlot, triggersToScreens } from './common';
+import { ViewSlot, useTriggersToScreens } from './common';
 import { useComponent } from './useComponent';
 
 export * from './TabContext';
@@ -153,11 +154,10 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
 
   const initialRouteName = routeNode.initialRouteName;
 
-  const { children, triggerMap } = triggersToScreens(
+  const { children, triggerMap } = useTriggersToScreens(
     triggers,
     routeNode,
     linking,
-    initialRouteName,
     parentTriggerMap,
     routeInfo,
     contextKey
@@ -175,6 +175,7 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     triggerMap,
     id: contextKey,
     initialRouteName,
+    backBehavior: rest.backBehavior ?? (initialRouteName ? 'initialRoute' : undefined),
   });
 
   const {
@@ -184,6 +185,28 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     describe,
     NavigationContent: RNNavigationContent,
   } = navigatorContext;
+
+  const routeNamesKey = JSON.stringify(state.routeNames);
+  const previousRouteNamesKeyRef = useRef(routeNamesKey);
+  useEffect(() => {
+    if (previousRouteNamesKeyRef.current === routeNamesKey) {
+      return;
+    }
+    previousRouteNamesKeyRef.current = routeNamesKey;
+    navigation.dispatch((state) => ({
+      type: 'EXPO_ROUTER_TAB_ORDER_CHANGED',
+      target: state.key,
+    }));
+  }, [routeNamesKey, navigation]);
+
+  useHiddenTabRedirect({
+    routes: state.routes,
+    focusedRouteKey: state.routes[state.index]!.key,
+    descriptors,
+    redirectToRouteName: initialRouteName,
+  });
+
+  // TODO(@ubax): Show a formsheet for focused routes without a trigger (Tabs + Stack in one).
 
   const navigatorContextValue = useMemo<NavigatorContextValue>(
     () => ({

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -8,9 +8,8 @@ import type {
   PartialRoute,
   Route,
 } from '../react-navigation/native';
-import { sortRoutesWithInitial } from '../sortRoutes';
 import type { Href } from '../types';
-import { routeToScreen } from '../useScreens';
+import { type ScreenProps, useSortedScreens } from '../useScreens';
 import { Slot } from './Slot';
 import type { ExpoTabActionType } from './TabRouter';
 
@@ -35,17 +34,18 @@ type TriggerConfig =
       name: string;
       href: string;
       routeNode: RouteNode;
+      contextKey: string;
+      initialParams?: Record<string, any>;
       action: JumpToNavigationAction;
     }
   | { type: 'external'; name: string; href: string };
 
-export type TriggerMap = Record<string, TriggerConfig & { index: number }>;
+export type TriggerMap = Record<string, TriggerConfig>;
 
-export function triggersToScreens(
+export function useTriggersToScreens(
   triggers: ScreenTrigger[],
   layoutRouteNode: RouteNode,
   linking: LinkingOptions<ParamListBase>,
-  initialRouteName: undefined | string,
   parentTriggerMap: TriggerMap,
   routeInfo: UrlObject,
   contextKey: string
@@ -119,10 +119,17 @@ export function triggersToScreens(
       if (state.name === targetStateName) break;
       state = state.state.routes[state.state.index ?? state.state.routes.length - 1]!;
     }
+    const isWithinLayout = state?.name === targetStateName;
     routeState =
       state!.state?.routes[state!.state.index ?? state!.state.routes.length - 1] || state;
 
     const routeNode = layoutRouteNode.children.find((child) => child.route === routeState?.name);
+
+    if (!isWithinLayout) {
+      throw new Error(
+        `Tab trigger '${trigger.name}' with href '${resolvedHref}' must point to a route within the tabs layout.`
+      );
+    }
 
     if (!routeNode) {
       console.warn(
@@ -144,51 +151,56 @@ export function triggersToScreens(
     if (duplicateTrigger) {
       const duplicateTriggerText = `${JSON.stringify({ name: duplicateTrigger.name, href: duplicateTrigger.href })} and ${JSON.stringify({ name: trigger.name, href: trigger.href })}`;
 
+      // TODO(@ubax): Support multiple triggers for one dynamic route with different params.
       throw new Error(
         `A navigator cannot contain multiple trigger components that map to the same sub-segment. Consider adding a shared group and assigning a group to each trigger. Conflicting triggers:\n\t${duplicateTriggerText}.\nBoth triggers map to route ${routeNode.route}.`
       );
     }
 
+    const params = { ...routeState.params };
+    let nestedState = routeState.state;
+    while (nestedState) {
+      const nestedRoute = nestedState.routes[nestedState.index ?? nestedState.routes.length - 1]!;
+      Object.assign(params, nestedRoute.params);
+      nestedState = nestedRoute.state;
+    }
+
+    // TODO(@ubax): Remove nested trigger href support to unify with other tab navigators.
+    const action = stateToAction(state, layoutRouteNode.route);
+    action.payload.params = { ...params, ...action.payload.params };
     configs.push({
       ...trigger,
       href: resolvedHref,
       routeNode,
-      action: stateToAction(state, layoutRouteNode.route),
+      contextKey,
+      initialParams: params,
+      action,
     });
   }
 
-  const sortFn = sortRoutesWithInitial(initialRouteName);
-
-  const sortedConfigs = configs.sort((a, b) => {
-    // External routes should be last. They will eventually be dropped
-    if (a.type === 'external' && b.type === 'external') {
-      return 0;
-    } else if (a.type === 'external') {
-      return 1;
-    } else if (b.type === 'external') {
-      return -1;
-    }
-
-    return sortFn(a.routeNode, b.routeNode);
-  });
-
-  const children: React.JSX.Element[] = [];
+  const screenProps: ScreenProps[] = [];
   const triggerMap: TriggerMap = { ...parentTriggerMap };
 
-  for (const [index, config] of sortedConfigs.entries()) {
-    triggerMap[config.name] = { ...config, index };
+  for (const config of configs) {
+    triggerMap[config.name] = config;
 
     if (config.type === 'internal') {
-      // Trigger-declared screens are layout-declared, same as `<Screen>` children.
-      children.push(routeToScreen(config.routeNode, undefined, undefined, 'layout'));
+      screenProps.push({
+        name: config.routeNode.route,
+        initialParams: config.initialParams,
+      });
     }
   }
+
+  const children = useSortedScreens(screenProps);
+
   return {
     children,
     triggerMap,
   };
 }
 
+// TODO(@ubax): Remove stateToAction together with nested trigger href support.
 export function stateToAction(
   state: PartialRoute<Route<string, object | undefined>> | undefined,
   startAtRoute?: string

--- a/packages/expo-router/src/utils/useHiddenTabRedirect.ts
+++ b/packages/expo-router/src/utils/useHiddenTabRedirect.ts
@@ -1,0 +1,65 @@
+import { useEffect, useMemo } from 'react';
+
+import { router } from '../imperative-api';
+import {
+  type NavigationRoute,
+  type ParamListBase,
+  type RouteSource,
+  useIsFocused,
+} from '../react-navigation/native';
+import { useBuildHref } from '../standard-navigation/useBuildHref';
+
+type TabRoute = NavigationRoute<ParamListBase, string> & { href?: string };
+
+type TabDescriptor = {
+  routeSource?: RouteSource;
+  options?: object;
+};
+
+export function useHiddenTabRedirect<Route extends TabRoute>({
+  routes,
+  focusedRouteKey,
+  descriptors,
+  redirectToRouteName,
+}: {
+  routes: Route[];
+  focusedRouteKey: string;
+  descriptors: Record<string, TabDescriptor>;
+  redirectToRouteName?: string;
+}) {
+  const buildHref = useBuildHref();
+  const isFocused = useIsFocused();
+  const visibleRoutes = useMemo(
+    () =>
+      routes.filter((route) => {
+        const descriptor = descriptors[route.key];
+        const isHidden =
+          descriptor?.options &&
+          'hidden' in descriptor.options &&
+          descriptor.options.hidden === true;
+        return descriptor?.routeSource === 'layout' && !isHidden;
+      }),
+    [routes, descriptors]
+  );
+  const visibleFocusedIndex = useMemo(
+    () => visibleRoutes.findIndex((route) => route.key === focusedRouteKey),
+    [focusedRouteKey, visibleRoutes]
+  );
+  const redirectHref = useMemo(() => {
+    const redirectRoute =
+      visibleRoutes.find(
+        (route) =>
+          route.name === redirectToRouteName ||
+          route.name.replace(/\/index$/, '') === redirectToRouteName
+      ) ?? visibleRoutes[0];
+    return redirectRoute && (redirectRoute.href ?? buildHref(redirectRoute));
+  }, [buildHref, redirectToRouteName, visibleRoutes]);
+
+  useEffect(() => {
+    if (isFocused && visibleFocusedIndex < 0 && redirectHref != null) {
+      router.replace(redirectHref);
+    }
+  }, [isFocused, redirectHref, visibleFocusedIndex]);
+
+  return { visibleRoutes, visibleFocusedIndex };
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>