### PR TITLE
[expo-localization] Set android:supportsRtl in AndroidManifest.xml from supportsRTL prop

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Set `android:supportsRtl` in the `AndroidManifest.xml` from the `supportsRTL` config plugin prop.
+- Set `android:supportsRtl` in the `AndroidManifest.xml` from the `supportsRTL` config plugin prop. ([#48080](https://github.com/expo/expo/pull/48080) by [@zoontek](https://github.com/zoontek))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Set `android:supportsRtl` in the `AndroidManifest.xml` from the `supportsRTL` config plugin prop.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
+++ b/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
@@ -1,4 +1,38 @@
-import { convertBcp47ToResourceQualifier } from '../src/withExpoLocalization';
+import { AndroidConfig } from 'expo/config-plugins';
+
+import {
+  convertBcp47ToResourceQualifier,
+  setAndroidSupportsRtl,
+} from '../src/withExpoLocalization';
+
+function getManifest(): AndroidConfig.Manifest.AndroidManifest {
+  return {
+    manifest: {
+      $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+      application: [{ $: { 'android:name': '.MainApplication' } }],
+      queries: [],
+    },
+  };
+}
+
+describe('setAndroidSupportsRtl', () => {
+  it('sets android:supportsRtl to "true"', () => {
+    const manifest = setAndroidSupportsRtl(getManifest(), true);
+    expect(manifest.manifest.application?.[0].$['android:supportsRtl']).toBe('true');
+  });
+
+  it('sets android:supportsRtl to "false"', () => {
+    const manifest = setAndroidSupportsRtl(getManifest(), false);
+    expect(manifest.manifest.application?.[0].$['android:supportsRtl']).toBe('false');
+  });
+
+  it('overwrites an existing android:supportsRtl value', () => {
+    const manifest = getManifest();
+    manifest.manifest.application![0].$['android:supportsRtl'] = 'true';
+    setAndroidSupportsRtl(manifest, false);
+    expect(manifest.manifest.application?.[0].$['android:supportsRtl']).toBe('false');
+  });
+});
 
 describe('converts locales to BCP-47 format', () => {
   it('should convert simple language codes to BCP-47 format', () => {

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -181,6 +181,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
       return config;
     });
   }
+
   return withStringsXml(config, (config) => {
     if (supportsRTL != null) {
       config.modResults = AndroidConfig.Strings.setStringItem(

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -43,32 +43,49 @@ export function convertBcp47ToResourceQualifier(locale: string): string {
   return `b+${locale.replaceAll('-', '+')}`;
 }
 
+export function setAndroidSupportsRtl(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  supportsRTL: boolean
+): AndroidConfig.Manifest.AndroidManifest {
+  const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+  mainApplication.$['android:supportsRtl'] = String(supportsRTL);
+  return androidManifest;
+}
+
 function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
-  const mergedConfig = { ...config.extra, ...data };
+  const {
+    supportsRTL,
+    forcesRTL,
+    supportedLocales: supportedLocalesOption,
+  } = {
+    ...config.extra,
+    ...data,
+  };
 
   const supportedLocales =
-    typeof mergedConfig.supportedLocales === 'object' &&
-    !Array.isArray(mergedConfig.supportedLocales)
-      ? mergedConfig.supportedLocales.ios
-      : mergedConfig.supportedLocales;
+    typeof supportedLocalesOption === 'object' && !Array.isArray(supportedLocalesOption)
+      ? supportedLocalesOption.ios
+      : supportedLocalesOption;
 
-  if (
-    mergedConfig?.supportsRTL == null &&
-    mergedConfig?.forcesRTL == null &&
-    supportedLocales == null
-  )
+  if (supportsRTL == null && forcesRTL == null && supportedLocales == null) {
     return config;
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  if (mergedConfig?.supportsRTL != null) {
-    config.ios.infoPlist.ExpoLocalization_supportsRTL = mergedConfig?.supportsRTL;
   }
-  if (mergedConfig?.forcesRTL != null) {
-    config.ios.infoPlist.ExpoLocalization_forcesRTL = mergedConfig?.forcesRTL;
+  if (!config.ios) {
+    config.ios = {};
+  }
+  if (!config.ios.infoPlist) {
+    config.ios.infoPlist = {};
+  }
+  if (supportsRTL != null) {
+    config.ios.infoPlist.ExpoLocalization_supportsRTL = supportsRTL;
+  }
+  if (forcesRTL != null) {
+    config.ios.infoPlist.ExpoLocalization_forcesRTL = forcesRTL;
   }
   if (supportedLocales != null) {
     config.ios.infoPlist.CFBundleLocalizations = supportedLocales;
   }
+
   return config;
 }
 
@@ -76,25 +93,42 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
   if (data.allowDynamicLocaleChangesAndroid) {
     config = withAndroidManifest(config, (config) => {
       const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
+
       if (!mainActivity.$['android:configChanges']?.includes('locale')) {
         mainActivity.$['android:configChanges'] += '|locale';
       }
       if (!mainActivity.$['android:configChanges']?.includes('layoutDirection')) {
         mainActivity.$['android:configChanges'] += '|layoutDirection';
       }
+
       return config;
     });
   }
-  const mergedConfig = { ...config.extra, ...data };
+
+  const {
+    supportsRTL,
+    forcesRTL,
+    supportedLocales: supportedLocalesOption,
+  } = {
+    ...config.extra,
+    ...data,
+  };
 
   const supportedLocales =
-    typeof mergedConfig.supportedLocales === 'object' &&
-    !Array.isArray(mergedConfig.supportedLocales)
-      ? mergedConfig.supportedLocales.android
-      : mergedConfig.supportedLocales;
+    typeof supportedLocalesOption === 'object' && !Array.isArray(supportedLocalesOption)
+      ? supportedLocalesOption.android
+      : supportedLocalesOption;
 
-  if (supportedLocales) {
+  if (supportsRTL != null) {
+    config = withAndroidManifest(config, (config) => {
+      config.modResults = setAndroidSupportsRtl(config.modResults, supportsRTL);
+      return config;
+    });
+  }
+
+  if (supportedLocales != null) {
     supportedLocales.forEach(assertLocale);
+
     config = withDangerousMod(config, [
       'android',
       (config) => {
@@ -102,6 +136,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
         const folder = path.join(projectRootPath, 'app/src/main/res/xml');
 
         fs.mkdirSync(folder, { recursive: true });
+
         fs.writeFileSync(
           path.join(folder, 'locales_config.xml'),
           [
@@ -115,6 +150,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
         return config;
       },
     ]);
+
     config = withAndroidManifest(config, (config) => {
       const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
@@ -125,11 +161,13 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
 
       return config;
     });
+
     config = withAppBuildGradle(config, (config) => {
       if (config.modResults.language === 'groovy') {
         const resourceQualifiers = supportedLocales.map((locale) =>
           convertBcp47ToResourceQualifier(locale)
         );
+
         config.modResults.contents = AndroidConfig.CodeMod.appendContentsInsideDeclarationBlock(
           config.modResults.contents,
           'defaultConfig',
@@ -146,28 +184,29 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
     });
   }
   return withStringsXml(config, (config) => {
-    if (mergedConfig?.supportsRTL != null) {
+    if (supportsRTL != null) {
       config.modResults = AndroidConfig.Strings.setStringItem(
         [
           {
             $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
-            _: String(mergedConfig?.supportsRTL ?? 'unset'),
+            _: String(supportsRTL),
           },
         ],
         config.modResults
       );
     }
-    if (mergedConfig?.forcesRTL != null) {
+    if (forcesRTL != null) {
       config.modResults = AndroidConfig.Strings.setStringItem(
         [
           {
             $: { name: 'ExpoLocalization_forcesRTL', translatable: 'false' },
-            _: String(mergedConfig?.forcesRTL ?? 'unset'),
+            _: String(forcesRTL),
           },
         ],
         config.modResults
       );
     }
+
     return config;
   });
 }
@@ -178,6 +217,7 @@ function withExpoLocalization(config: ExpoConfig, data: ConfigPluginProps = {}) 
     ...data,
     allowDynamicLocaleChangesAndroid: data.allowDynamicLocaleChangesAndroid ?? true,
   };
+
   return withPlugins(config, [
     [withExpoLocalizationIos, normalizedData],
     [withExpoLocalizationAndroid, normalizedData],

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -70,12 +70,10 @@ function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
   if (supportsRTL == null && forcesRTL == null && supportedLocales == null) {
     return config;
   }
-  if (!config.ios) {
-    config.ios = {};
-  }
-  if (!config.ios.infoPlist) {
-    config.ios.infoPlist = {};
-  }
+
+  config.ios ??= {};
+  config.ios.infoPlist ??= {};
+
   if (supportsRTL != null) {
     config.ios.infoPlist.ExpoLocalization_supportsRTL = supportsRTL;
   }


### PR DESCRIPTION
# Why

The `supportsRTL` config plugin prop was only written to Android as an `ExpoLocalization_supportsRTL` string resource. It never set `android:supportsRtl` on the manifest's `<application>`, so the native flag stayed at its default.

# How

Added a `setAndroidSupportsRtl` helper that sets `android:supportsRtl` on the main application, and applied it via `withAndroidManifest` when `supportsRTL` is provided. Also cleaned up the plugin by destructuring the merged config / data up front instead of repeating `mergedConfig?.` access.

# Test Plan

Added unit tests for `setAndroidSupportsRtl` covering `true`, `false`, and overwriting an existing value. Run with `et check-packages expo-localization`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
