### PR TITLE
[create-expo] Fix npm pack --json parsing for npm >= 12

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Invalid response from npm` error when resolving templates with npm >= 12 ([#48083](https://github.com/expo/expo/pull/48083) by [@lllincoln](https://github.com/lllincoln))
+
 ### 💡 Others
 
 ## 4.0.2 — 2026-05-20

--- a/packages/create-expo/src/utils/__tests__/npm.test.ts
+++ b/packages/create-expo/src/utils/__tests__/npm.test.ts
@@ -1,4 +1,9 @@
-import { applyBetaTag, getResolvedTemplateName, splitNpmNameAndTag } from '../npm';
+import {
+  applyBetaTag,
+  getResolvedTemplateName,
+  parseNpmPackOutput,
+  splitNpmNameAndTag,
+} from '../npm';
 
 describe(applyBetaTag, () => {
   const originalEnv = process.env;
@@ -33,6 +38,38 @@ describe(splitNpmNameAndTag, () => {
   });
   it(`splits an org with tag`, () => {
     expect(splitNpmNameAndTag('@expo/foobar@45.0.0')).toEqual(['@expo/foobar', '45.0.0']);
+  });
+});
+
+describe(parseNpmPackOutput, () => {
+  const packageInfo = {
+    id: 'expo-template-default@57.0.9',
+    name: 'expo-template-default',
+    version: '57.0.9',
+    size: 1408284,
+    unpackedSize: 1444997,
+    shasum: '8d13268805fc322ecb2fa588f32ff01264a30072',
+    integrity: 'sha512-pGOTwdKNxGx8MJHYcoqt0/hwUZ3gXke+OkG5hkRzLU5q2LefX5u+kwsWBi7fA+13zd4FtM/2EPeID50VDecZ1Q==',
+    filename: 'expo-template-default-57.0.9.tgz',
+    files: [{ path: 'package.json', size: 100, mode: 420 }],
+    entryCount: 1,
+    bundled: [],
+  };
+
+  it('parses the array shape returned by npm < 12', () => {
+    expect(parseNpmPackOutput(JSON.stringify([packageInfo]))).toEqual([packageInfo]);
+  });
+
+  it('parses the object-keyed-by-name shape returned by npm >= 12', () => {
+    expect(parseNpmPackOutput(JSON.stringify({ [packageInfo.name]: packageInfo }))).toEqual([
+      packageInfo,
+    ]);
+  });
+
+  it('throws on an invalid response', () => {
+    expect(() => parseNpmPackOutput(JSON.stringify({ foo: 'bar' }))).toThrow(
+      /Invalid response from npm/
+    );
   });
 });
 

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -161,17 +161,23 @@ async function npmPackAsync(
   }
 
   try {
-    const json = JSON.parse(results);
-    if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
-      return json.map(sanitizeNpmPackageFilename);
-    } else {
-      throw new Error(`Invalid response from npm: ${results}`);
-    }
+    return parseNpmPackOutput(results);
   } catch (error: any) {
     throw new Error(
       `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
     );
   }
+}
+
+export function parseNpmPackOutput(results: string): NpmPackageInfo[] {
+  const json = JSON.parse(results);
+  const infos = Array.isArray(json) ? json : Object.values(json);
+
+  if (!infos.every(isNpmPackageInfo)) {
+    throw new Error(`Invalid response from npm: ${results}`);
+  }
+
+  return infos.map(sanitizeNpmPackageFilename);
 }
 
 export type NpmPackageInfo = {

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -169,6 +169,14 @@ async function npmPackAsync(
   }
 }
 
+/**
+ * Parses the JSON emitted by `npm pack --json`.
+ *
+ * npm 12 changed this output from an array of package infos to an object
+ * keyed by package name, to match `npm publish --json`
+ * (see https://github.com/npm/cli/pull/9247). Supports both shapes so
+ * `create-expo` keeps working across npm versions.
+ */
 export function parseNpmPackOutput(results: string): NpmPackageInfo[] {
   const json = JSON.parse(results);
   const infos = Array.isArray(json) ? json : Object.values(json);


### PR DESCRIPTION
# Why

`create-expo-app` fails for any SDK version with `Error: Invalid response from npm: ...` when the user has npm >= 12 installed. This is because npm 12 made a breaking change to `npm pack --json` (https://github.com/npm/cli/pull/9247 and https://docs.npmjs.com/cli/v12/using-npm/changelog/).

# How

`parseNpmPackOutput` now works with both shapes by normalizing objects to arrays with `Object.values()` before running the same existing validation, so both npm <12 and npm >=12 output work without version detection.

# Test Plan

Added unit tests in `packages/create-expo/src/utils/__tests__/npm.test.ts` covering `parseNpmPackOutput` for npm < 12, npm >= 12, and an invalid response. All tests pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). **(not applicable?)**
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)