### PR TITLE
[android][navigation-bar] Handle rejected declarative updates

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown.
 - Polyfill `enforceContrast` on Android 8 and 9. ([#47382](https://github.com/expo/expo/pull/47382) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown.
+- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown. ([#48084](https://github.com/expo/expo/pull/48084) by [@magnesae](https://github.com/magnesae))
 - Polyfill `enforceContrast` on Android 8 and 9. ([#47382](https://github.com/expo/expo/pull/47382) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others

--- a/packages/expo-navigation-bar/src/NavigationBar.android.ts
+++ b/packages/expo-navigation-bar/src/NavigationBar.android.ts
@@ -77,7 +77,7 @@ export function setStyle(style: NavigationBarStyle) {
 
   if (resolvedStyle !== currentValues.style) {
     currentValues.style = resolvedStyle;
-    ExpoNavigationBar.setStyle(resolvedStyle);
+    ExpoNavigationBar.setStyle(resolvedStyle).catch(() => {});
   }
 }
 
@@ -86,7 +86,7 @@ function setHidden(hidden: boolean) {
 
   if (hidden !== currentValues.hidden) {
     currentValues.hidden = hidden;
-    ExpoNavigationBar.setHidden(hidden);
+    ExpoNavigationBar.setHidden(hidden).catch(() => {});
   }
 }
 

--- a/packages/expo-navigation-bar/src/__tests__/NavigationBar-test.android.ts
+++ b/packages/expo-navigation-bar/src/__tests__/NavigationBar-test.android.ts
@@ -1,0 +1,41 @@
+import ExpoNavigationBar from '../ExpoNavigationBar';
+import { NavigationBar, setStyle } from '../NavigationBar.android';
+
+jest.mock('../ExpoNavigationBar', () => ({
+  __esModule: true,
+  default: {
+    setStyle: jest.fn(),
+    setHidden: jest.fn(),
+  },
+}));
+
+jest.mock('react-native', () => ({
+  Appearance: {
+    getColorScheme: () => 'light',
+  },
+  useColorScheme: () => 'light',
+}));
+
+const mockExpoNavigationBar = jest.mocked(ExpoNavigationBar);
+
+describe('NavigationBar', () => {
+  it('handles rejected native style updates', () => {
+    const catchError = jest.fn();
+    mockExpoNavigationBar.setStyle.mockReturnValue({ catch: catchError } as never);
+
+    setStyle('dark');
+
+    expect(mockExpoNavigationBar.setStyle).toHaveBeenCalledWith('dark');
+    expect(catchError).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('handles rejected native visibility updates', () => {
+    const catchError = jest.fn();
+    mockExpoNavigationBar.setHidden.mockReturnValue({ catch: catchError } as never);
+
+    NavigationBar.setHidden(true);
+
+    expect(mockExpoNavigationBar.setHidden).toHaveBeenCalledWith(true);
+    expect(catchError).toHaveBeenCalledWith(expect.any(Function));
+  });
+});


### PR DESCRIPTION
# Why

The declarative `NavigationBar` component updates Android through asynchronous native methods, but its internal `setStyle` and `setHidden` helpers do not return those promises to the caller.

If an update races with activity teardown, the native promise can reject after the component has already unmounted. Because this internal best-effort update has no consumer, the rejection becomes an unhandled promise rejection and can surface as a LogBox error.

# How

Consume rejections from the two declarative native updates. The public async visibility API remains unchanged and still propagates its rejection to callers.

Added focused Android unit coverage that verifies both internal update paths attach rejection handlers.

# Test Plan

- `pnpm run lint`
- Targeted Expo formatter check for both changed TypeScript files
- Focused Android Jest suite: 2 tests passed
- `git diff --check`

The focused Jest suite was run with the repository's installed `@swc/jest` transformer to isolate it from unrelated sparse-checkout workspace packages.

# Checklist

- [x] I added a changelog entry.
- [x] This diff does not change a config plugin or prebuild output.
- [x] Conforms with the Expo JavaScript style.
