### PR TITLE
[android][dev-launcher] Reload an existing React context

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Reload an existing React context instead of crashing when launching a selected app.
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Reload an existing React context instead of crashing when launching a selected app.
+- [Android] Reload an existing React context instead of crashing when launching a selected app. ([#48085](https://github.com/expo/expo/pull/48085) by [@magnesae](https://github.com/magnesae))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -46,7 +46,7 @@ abstract class DevLauncherAppLoader(
     return { activity ->
       onDelegateWillBeCreated(activity)
 
-      require(appHost.currentReactContext == null) { "App react context shouldn't be created before." }
+      val existingReactContext = appHost.currentReactContext
       appHost.addReactInstanceEventListener(object : ReactInstanceEventListener {
         override fun onReactContextInitialized(context: ReactContext) {
           if (reactContextWasInitialized) {
@@ -60,6 +60,10 @@ abstract class DevLauncherAppLoader(
           continuation!!.resume(true)
         }
       })
+
+      if (existingReactContext != null) {
+        appHost.reload("DevLauncher replacing existing React context")
+      }
 
       activity.lifecycle.addObserver(object : DefaultLifecycleObserver {
         override fun onCreate(owner: LifecycleOwner) {

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderTest.kt
@@ -1,0 +1,37 @@
+package expo.modules.devlauncher.launcher.loaders
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactHost
+import com.facebook.react.bridge.ReactContext
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherAppLoaderTest {
+  private val context: Context = ApplicationProvider.getApplicationContext()
+  private val controller = mockk<DevLauncherControllerInterface>(relaxed = true)
+
+  @Test
+  fun `reloads an existing React context before loading the selected app`() {
+    val existingReactContext = mockk<ReactContext>()
+    val appHost = mockk<ReactHost>(relaxed = true)
+    every { appHost.currentReactContext } returns existingReactContext
+    val activity = mockk<ReactActivity>(relaxed = true)
+    val appLoader = object : DevLauncherAppLoader(appHost, context, controller) {
+      override fun injectBundleLoader() = true
+    }
+
+    appLoader.createOnDelegateWillBeCreatedListener()(activity)
+
+    verify(exactly = 1) {
+      appHost.reload("DevLauncher replacing existing React context")
+    }
+  }
+}


### PR DESCRIPTION
# Why

`DevLauncherAppLoader` currently requires the shared `ReactHost` to have no React context before the selected app's activity delegate is created.

That invariant does not always hold. A background/headless React task can initialize the process first—for example, an Android home-screen widget update—or a development build can be reopened while a context from the previous launch still exists. The development activity then crashes at startup with:

```text
IllegalArgumentException: App react context shouldn't be created before.
```

The same stack was previously reported in #35385, but that issue was auto-closed for lacking a minimal reproduction; the assertion remains on `main`.

# How

Capture an existing context, install Dev Launcher's React instance listener, then ask the public `ReactHost.reload` API to replace that context with the bundle loader already selected by Dev Launcher.

Registering the listener before reloading ensures the replacement context still follows the normal `onAppLoaded` / `onReactContext` path.

A focused Robolectric/MockK regression test covers the pre-existing-context case and verifies the reload request.

# Test Plan

- Added `DevLauncherAppLoaderTest` under the package's existing `src/testDebug` Robolectric suite.
- Verified the production call against React Native 0.86's public `ReactHost.reload(reason)` API.
- `git diff --check`

I did not run the Android Gradle suite locally because this contribution was prepared from a sparse package checkout; Expo CI has the full native workspace and will run the added test.

# Checklist

- [x] I added a changelog entry.
- [x] This is debug-only Android code and does not affect release builds or prebuild output.
- [x] The fix uses a public React Native API.
