### PR TITLE
[file-system] Add File.digest() for calculating various hashes and deprecate old md5 usage

### DIFF
--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -292,7 +292,8 @@ function FileInfoSection({ withCurrentFile }: { withCurrentFile: WithCurrentFile
           exists: file.exists,
           size: file.size,
           type: file.type,
-          md5: file.md5,
+          md5: await file.digest('md5'),
+          sha256: await file.digest('sha-256'),
           modificationTime: file.modificationTime,
           creationTime: file.creationTime,
         }))}
@@ -306,10 +307,7 @@ function FileInfoSection({ withCurrentFile }: { withCurrentFile: WithCurrentFile
           }))}
         />
       )}
-      <SimpleActionDemo
-        title="Show info({ md5: true })"
-        action={withCurrentFile(async (file) => file.info({ md5: true }))}
-      />
+      <SimpleActionDemo title="Show info()" action={withCurrentFile(async (file) => file.info())} />
     </>
   );
 }

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -292,8 +292,8 @@ function FileInfoSection({ withCurrentFile }: { withCurrentFile: WithCurrentFile
           exists: file.exists,
           size: file.size,
           type: file.type,
-          md5: await file.digest('md5'),
-          sha256: await file.digest('sha-256'),
+          md5: await file.digest('MD5'),
+          sha256: await file.digest('SHA-256'),
           modificationTime: file.modificationTime,
           creationTime: file.creationTime,
         }))}

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -789,7 +789,7 @@ export async function test({ describe, expect, it, ...t }) {
         expect(src.exists).toBe(true);
       });
 
-      it('Can copy from cache to documents', () => {
+      it('Can copy from cache to documents', async () => {
         const src = new File(Paths.cache, 'file.txt');
         const dst = new File(Paths.document, 'file.txt');
         // cleanup
@@ -803,7 +803,7 @@ export async function test({ describe, expect, it, ...t }) {
         src.copySync(dst);
         expect(dst.uri).toBe(FS.documentDirectory + 'file.txt');
         expect(dst.exists).toBe(true);
-        expect(dst.md5).toBe(src.md5);
+        expect(await dst.digest('md5')).toBe(await src.digest('md5'));
       });
 
       it('throws when destination file exists and overwrite is not set', () => {
@@ -1004,14 +1004,14 @@ export async function test({ describe, expect, it, ...t }) {
         expect(() => file.rename('shouldNotWork.txt')).toThrow();
       });
 
-      it('renames a file and preserves file metadata', () => {
+      it('renames a file and preserves file metadata', async () => {
         const file = new File(testDirectory, 'metadata.txt');
         file.writeSync('Content');
         const originalSize = file.size;
-        const originalMd5 = file.md5;
+        const originalMd5 = await file.digest('md5');
         file.rename('metadataRenamed.txt');
         expect(file.size).toBe(originalSize);
-        expect(file.md5).toBe(originalMd5);
+        expect(await file.digest('md5')).toBe(originalMd5);
       });
 
       it('throws an error when renaming to an empty string', () => {
@@ -1597,7 +1597,7 @@ export async function test({ describe, expect, it, ...t }) {
         const response = await fetch(url);
         const src = new File(testDirectory, 'file.pdf');
         src.writeSync(await response.bytes());
-        expect(src.md5).toEqual(md5);
+        expect(await src.digest('md5')).toEqual(md5);
       });
 
       it('reports download progress via onProgress callback', async () => {

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { Asset } from 'expo-asset';
 import Constants from 'expo-constants';
-import { File, Directory, Paths, FileMode } from 'expo-file-system';
+import { File, Directory, Paths, FileMode, type FileDigestAlgorithm } from 'expo-file-system';
 import * as FS from 'expo-file-system/legacy';
 import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
@@ -1809,6 +1809,49 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(testDirectory, 'file.txt');
         file.writeSync('Hello world');
         expect(file.md5).toBe('3e25960a79dbc69b674cd4ec67a72c62');
+      });
+
+      it('computes digest asynchronously', async () => {
+        const file = new File(testDirectory, 'digest.txt');
+        file.writeSync('Hello world');
+        const expectedDigests: [FileDigestAlgorithm, string][] = [
+          ['md5', '3e25960a79dbc69b674cd4ec67a72c62'],
+          ['sha-1', '7b502c3a1f48c8609ae212cdfb639dee39673f5e'],
+          ['sha-256', '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'],
+          [
+            'sha-384',
+            '9203b0c4439fd1e6ae5878866337b7c532acd6d9260150c80318e8ab8c27ce330189f8df94fb890df1d298ff360627e1',
+          ],
+          [
+            'sha-512',
+            'b7f783baed8297f0db917462184ff4f08e69c2d5e5f79a942600f9725f58ce1f29c18139bf80b06c0fff2bdd34738452ecf40c488c22a7e3d80cdf6f9c1c0d47',
+          ],
+        ];
+        for (const [algorithm, expected] of expectedDigests) {
+          expect(await file.digest(algorithm)).toBe(expected);
+        }
+      });
+
+      it('computes digest across multiple chunks', async () => {
+        const bufferSize = 65536; // Update this if the bufferSize in FileSystemFile.swift/.kt are changed
+        const file = new File(testDirectory, 'chunked-digest.txt');
+        file.writeSync('a'.repeat(bufferSize + 10));
+
+        expect(await file.digest('md5')).toBe('dddb00524349012a468de4f34fd7bad3');
+        expect(await file.digest('sha-256')).toBe(
+          '60a6f1743f9405aa728afbe26ac3b294914341e6aa867f4542c5c116cb816a4f'
+        );
+      });
+
+      it('rejects digest for a nonexistent file', async () => {
+        const file = new File(testDirectory, 'missing-digest.txt');
+        let error: Error | null = null;
+        try {
+          await file.digest('md5');
+        } catch (caughtError) {
+          error = caughtError as Error;
+        }
+        expect(error).not.toBeNull();
       });
 
       it('returns null size and md5 for nonexistent files', async () => {

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -1854,6 +1854,20 @@ export async function test({ describe, expect, it, ...t }) {
         expect(error).not.toBeNull();
       });
 
+      it('rejects digest when the path points to a directory', async () => {
+        const directoryUri = `${testDirectory}digest-directory`;
+        const directory = new Directory(directoryUri);
+        directory.create();
+        const file = new File(directoryUri);
+        let error: Error | null = null;
+        try {
+          await file.digest('md5');
+        } catch (caughtError) {
+          error = caughtError as Error;
+        }
+        expect(error).not.toBeNull();
+      });
+
       it('returns null size and md5 for nonexistent files', async () => {
         const file = new File(testDirectory, 'file2.txt');
         expect(file.size).toBe(null);

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -803,7 +803,7 @@ export async function test({ describe, expect, it, ...t }) {
         src.copySync(dst);
         expect(dst.uri).toBe(FS.documentDirectory + 'file.txt');
         expect(dst.exists).toBe(true);
-        expect(await dst.digest('md5')).toBe(await src.digest('md5'));
+        expect(await dst.digest('MD5')).toBe(await src.digest('MD5'));
       });
 
       it('throws when destination file exists and overwrite is not set', () => {
@@ -1008,10 +1008,10 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(testDirectory, 'metadata.txt');
         file.writeSync('Content');
         const originalSize = file.size;
-        const originalMd5 = await file.digest('md5');
+        const originalMd5 = await file.digest('MD5');
         file.rename('metadataRenamed.txt');
         expect(file.size).toBe(originalSize);
-        expect(await file.digest('md5')).toBe(originalMd5);
+        expect(await file.digest('MD5')).toBe(originalMd5);
       });
 
       it('throws an error when renaming to an empty string', () => {
@@ -1597,7 +1597,7 @@ export async function test({ describe, expect, it, ...t }) {
         const response = await fetch(url);
         const src = new File(testDirectory, 'file.pdf');
         src.writeSync(await response.bytes());
-        expect(await src.digest('md5')).toEqual(md5);
+        expect(await src.digest('MD5')).toEqual(md5);
       });
 
       it('reports download progress via onProgress callback', async () => {
@@ -1815,15 +1815,15 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(testDirectory, 'digest.txt');
         file.writeSync('Hello world');
         const expectedDigests: [FileDigestAlgorithm, string][] = [
-          ['md5', '3e25960a79dbc69b674cd4ec67a72c62'],
-          ['sha-1', '7b502c3a1f48c8609ae212cdfb639dee39673f5e'],
-          ['sha-256', '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'],
+          ['MD5', '3e25960a79dbc69b674cd4ec67a72c62'],
+          ['SHA-1', '7b502c3a1f48c8609ae212cdfb639dee39673f5e'],
+          ['SHA-256', '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'],
           [
-            'sha-384',
+            'SHA-384',
             '9203b0c4439fd1e6ae5878866337b7c532acd6d9260150c80318e8ab8c27ce330189f8df94fb890df1d298ff360627e1',
           ],
           [
-            'sha-512',
+            'SHA-512',
             'b7f783baed8297f0db917462184ff4f08e69c2d5e5f79a942600f9725f58ce1f29c18139bf80b06c0fff2bdd34738452ecf40c488c22a7e3d80cdf6f9c1c0d47',
           ],
         ];
@@ -1837,8 +1837,8 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(testDirectory, 'chunked-digest.txt');
         file.writeSync('a'.repeat(bufferSize + 10));
 
-        expect(await file.digest('md5')).toBe('dddb00524349012a468de4f34fd7bad3');
-        expect(await file.digest('sha-256')).toBe(
+        expect(await file.digest('MD5')).toBe('dddb00524349012a468de4f34fd7bad3');
+        expect(await file.digest('SHA-256')).toBe(
           '60a6f1743f9405aa728afbe26ac3b294914341e6aa867f4542c5c116cb816a4f'
         );
       });
@@ -1847,7 +1847,7 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(testDirectory, 'missing-digest.txt');
         let error: Error | null = null;
         try {
-          await file.digest('md5');
+          await file.digest('MD5');
         } catch (caughtError) {
           error = caughtError as Error;
         }
@@ -1861,7 +1861,7 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(directoryUri);
         let error: Error | null = null;
         try {
-          await file.digest('md5');
+          await file.digest('MD5');
         } catch (caughtError) {
           error = caughtError as Error;
         }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 - Add `File.preview()` and `File.canPreview()` methods for opening files with platform-native preview flows. (by [@eliotgevers](https://github.com/eliotgevers))
+- Added `File.digest()` for asynchronously calculating MD5, SHA-1, SHA-256, SHA-384 and SHA-512 file digests. ([#48089](https://github.com/expo/expo/pull/48089) by [@wh201906](https://github.com/wh201906))
 
 ### 🐛 Bug fixes
 
@@ -20,6 +21,7 @@
 
 ### 💡 Others
 
+- Marked `File.md5` and the MD5-related `File.info()` types (`InfoOptions`, `InfoOptions.md5` and `FileInfo.md5`) as deprecated. ([#48089](https://github.com/expo/expo/pull/48089) by [@wh201906](https://github.com/wh201906))
 - Improve read/write performance on Android by applying `withContext(Dispatchers.IO)` when possible. ([#46376](https://github.com/expo/expo/pull/46376), [#47945](https://github.com/expo/expo/pull/47945) by [@wh201906](https://github.com/wh201906))
 - Improved `FileHandle` docs. ([#46849](https://github.com/expo/expo/pull/46849) by [@barthap](https://github.com/barthap))
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
@@ -41,6 +41,9 @@ internal class UnsupportedContentUriReadWriteException :
       "Use READ or WRITE mode instead."
   )
 
+internal class UnsupportedDigestAlgorithmException(algorithm: String) :
+  CodedException("Unsupported digest algorithm: '$algorithm'.")
+
 internal class MissingAppContextException :
   CodedException("The app context is missing.")
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -174,12 +174,23 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
     return file.getContentUri(appContext ?: throw MissingAppContextException())
   }
 
-  @OptIn(ExperimentalStdlibApi::class)
   val md5: String get() {
+    return digest("md5")
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  fun digest(algorithm: String): String {
     val bufferSize = 65536
 
     validatePermission(FilePermissionService.Permission.READ)
-    val md = MessageDigest.getInstance("MD5")
+    val md = when (algorithm) {
+      "md5" -> MessageDigest.getInstance("MD5")
+      "sha-1" -> MessageDigest.getInstance("SHA-1")
+      "sha-256" -> MessageDigest.getInstance("SHA-256")
+      "sha-384" -> MessageDigest.getInstance("SHA-384")
+      "sha-512" -> MessageDigest.getInstance("SHA-512")
+      else -> throw IllegalArgumentException("Unsupported digest algorithm: $algorithm")
+    }
     file.inputStream().use { stream ->
       val buffer = ByteArray(bufferSize)
       var bytesRead: Int

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -175,7 +175,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   }
 
   val md5: String get() {
-    return digest("md5")
+    return digest("MD5")
   }
 
   @OptIn(ExperimentalStdlibApi::class)
@@ -184,11 +184,11 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
     validatePermission(FilePermissionService.Permission.READ)
     val md = when (algorithm) {
-      "md5" -> MessageDigest.getInstance("MD5")
-      "sha-1" -> MessageDigest.getInstance("SHA-1")
-      "sha-256" -> MessageDigest.getInstance("SHA-256")
-      "sha-384" -> MessageDigest.getInstance("SHA-384")
-      "sha-512" -> MessageDigest.getInstance("SHA-512")
+      "MD5" -> MessageDigest.getInstance("MD5")
+      "SHA-1" -> MessageDigest.getInstance("SHA-1")
+      "SHA-256" -> MessageDigest.getInstance("SHA-256")
+      "SHA-384" -> MessageDigest.getInstance("SHA-384")
+      "SHA-512" -> MessageDigest.getInstance("SHA-512")
       else -> throw IllegalArgumentException("Unsupported digest algorithm: $algorithm")
     }
     file.inputStream().use { stream ->

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -182,6 +182,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   fun digest(algorithm: String): String {
     val bufferSize = 65536
 
+    validateType()
     validatePermission(FilePermissionService.Permission.READ)
     val md = when (algorithm) {
       "MD5" -> MessageDigest.getInstance("MD5")
@@ -189,7 +190,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
       "SHA-256" -> MessageDigest.getInstance("SHA-256")
       "SHA-384" -> MessageDigest.getInstance("SHA-384")
       "SHA-512" -> MessageDigest.getInstance("SHA-512")
-      else -> throw IllegalArgumentException("Unsupported digest algorithm: $algorithm")
+      else -> throw UnsupportedDigestAlgorithmException(algorithm)
     }
     file.inputStream().use { stream ->
       val buffer = ByteArray(bufferSize)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -229,6 +229,12 @@ class FileSystemModule : Module() {
         file.info(options)
       }
 
+      AsyncFunction("digest") Coroutine { file: FileSystemFile, algorithm: String ->
+        withContext(Dispatchers.IO) {
+          file.digest(algorithm)
+        }
+      }
+
       Property("exists") { file: FileSystemFile ->
         file.exists
       }

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -107,6 +107,19 @@ class FileSystemFileTest {
   }
 
   @Test
+  fun digestRejectsUnsupportedAlgorithmWithCodedException() {
+    val source = temporaryFolder.newFile("digest.txt")
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.READ)))
+
+    val exception = assertThrows(UnsupportedDigestAlgorithmException::class.java) {
+      file.digest("unsupported")
+    }
+
+    assertTrue(exception.message?.contains("Unsupported digest algorithm: 'unsupported'") == true)
+  }
+
+  @Test
   fun createFileRejectsChildNameThatEscapesParentDirectory() {
     val parent = temporaryFolder.newFolder("parent")
     val escaped = File(parent.parentFile, "escaped.txt")

--- a/packages/expo-file-system/ios/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/FileSystemFile.swift
@@ -52,20 +52,45 @@ internal final class FileSystemFile: FileSystemPath {
 
   var md5: String {
     get throws {
-      return try withCorrectTypeAndScopedAccess(permission: .read) {
-        let bufferSize = 65536
+      return try digest(algorithm: "md5")
+    }
+  }
 
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
+  func digest(algorithm: String) throws -> String {
+    switch algorithm {
+    case "md5":
+      return try calculateDigest(using: Insecure.MD5())
+    case "sha-1":
+      return try calculateDigest(using: Insecure.SHA1())
+    case "sha-256":
+      return try calculateDigest(using: SHA256())
+    case "sha-384":
+      return try calculateDigest(using: SHA384())
+    case "sha-512":
+      return try calculateDigest(using: SHA512())
+    default:
+      throw Exception(
+        name: "UnsupportedDigestAlgorithm",
+        description: "Unsupported digest algorithm: \(algorithm)"
+      )
+    }
+  }
 
-        var hasher = Insecure.MD5()
-        while let chunk = try handle.read(upToCount: bufferSize), !chunk.isEmpty {
-          hasher.update(data: chunk)
-        }
+  // Keep the hasher generic so the streaming loop can be specialized for each hasher type
+  private func calculateDigest<H: HashFunction>(using hasher: H) throws -> String {
+    return try withCorrectTypeAndScopedAccess(permission: .read) {
+      let bufferSize = 65536
 
-        let hash = hasher.finalize()
-        return hash.map { String(format: "%02hhx", $0) }.joined()
+      let handle = try FileHandle(forReadingFrom: url)
+      defer { try? handle.close() }
+
+      var mutableHasher = hasher
+      while let chunk = try handle.read(upToCount: bufferSize), !chunk.isEmpty {
+        mutableHasher.update(data: chunk)
       }
+
+      let hash = mutableHasher.finalize()
+      return hash.map { String(format: "%02hhx", $0) }.joined()
     }
   }
 

--- a/packages/expo-file-system/ios/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/FileSystemFile.swift
@@ -52,21 +52,21 @@ internal final class FileSystemFile: FileSystemPath {
 
   var md5: String {
     get throws {
-      return try digest(algorithm: "md5")
+      return try digest(algorithm: "MD5")
     }
   }
 
   func digest(algorithm: String) throws -> String {
     switch algorithm {
-    case "md5":
+    case "MD5":
       return try calculateDigest(using: Insecure.MD5())
-    case "sha-1":
+    case "SHA-1":
       return try calculateDigest(using: Insecure.SHA1())
-    case "sha-256":
+    case "SHA-256":
       return try calculateDigest(using: SHA256())
-    case "sha-384":
+    case "SHA-384":
       return try calculateDigest(using: SHA384())
-    case "sha-512":
+    case "SHA-512":
       return try calculateDigest(using: SHA512())
     default:
       throw Exception(

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -323,6 +323,10 @@ public final class FileSystemModule: Module {
         return try file.info(options: options ?? InfoOptions())
       }
 
+      AsyncFunction("digest") { (file: FileSystemFile, algorithm: String) in
+        return try file.digest(algorithm: algorithm)
+      }
+
       AsyncFunction("write") { (file: FileSystemFile, content: Either<String, NativeArrayBuffer>, options: WriteOptions?) in
         try writeToFile(file, content: content, options: options)
       }

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -13,7 +13,7 @@
  * `packages/expo-crypto/mocks/ExpoCryptoAES.ts`.
  */
 
-import { FileMode } from '../src/File.types';
+import { type FileDigestAlgorithm, FileMode } from '../src/File.types';
 
 export type URL = string;
 export type FileSystemPath = any;
@@ -112,14 +112,26 @@ function base64Decode(str: string): Uint8Array {
   return new Uint8Array(Buffer.from(str, 'base64'));
 }
 
-function fakeMd5(uri: string, size: number): string {
+const digestHexLengths: Record<FileDigestAlgorithm, number> = {
+  md5: 32,
+  'sha-1': 40,
+  'sha-256': 64,
+  'sha-384': 96,
+  'sha-512': 128,
+};
+
+function fakeDigest(uri: string, size: number, hexLength: number): string {
   let h = 0x811c9dc5;
   const src = `${uri}:${size}`;
   for (let i = 0; i < src.length; i++) {
     h = Math.imul(h ^ src.charCodeAt(i), 0x01000193);
   }
   const hex = (h >>> 0).toString(16).padStart(8, '0');
-  return hex.repeat(4).slice(0, 32);
+  return hex.repeat(Math.ceil(hexLength / hex.length)).slice(0, hexLength);
+}
+
+function fakeMd5(uri: string, size: number): string {
+  return fakeDigest(uri, size, digestHexLengths.md5);
 }
 
 const listeners = new Map<string, Set<(event: any) => void>>();
@@ -207,6 +219,17 @@ export class FileSystemFile {
 
   get md5(): string | null {
     return this.exists ? fakeMd5(this.uri, this.size) : null;
+  }
+
+  async digest(algorithm: FileDigestAlgorithm): Promise<string> {
+    const hexLength = digestHexLengths[algorithm];
+    if (!hexLength) {
+      throw new Error(`Unsupported digest algorithm: ${algorithm}`);
+    }
+    if (!this.exists) {
+      throw new Error('File does not exist');
+    }
+    return fakeDigest(this.uri, this.size, hexLength);
   }
 
   get modificationTime(): number | null {

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -222,6 +222,10 @@ export class FileSystemFile {
   }
 
   async digest(algorithm: FileDigestAlgorithm): Promise<string> {
+    const entry = store.get(normalizeKey(this.uri));
+    if (entry?.exists && entry.kind === 'dir') {
+      throw new Error('A folder with the same name already exists in the file location');
+    }
     const hexLength = digestHexLengths[algorithm];
     if (!hexLength) {
       throw new Error(`Unsupported digest algorithm: ${algorithm}`);

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -113,11 +113,11 @@ function base64Decode(str: string): Uint8Array {
 }
 
 const digestHexLengths: Record<FileDigestAlgorithm, number> = {
-  md5: 32,
-  'sha-1': 40,
-  'sha-256': 64,
-  'sha-384': 96,
-  'sha-512': 128,
+  MD5: 32,
+  'SHA-1': 40,
+  'SHA-256': 64,
+  'SHA-384': 96,
+  'SHA-512': 128,
 };
 
 function fakeDigest(uri: string, size: number, hexLength: number): string {
@@ -131,7 +131,7 @@ function fakeDigest(uri: string, size: number, hexLength: number): string {
 }
 
 function fakeMd5(uri: string, size: number): string {
-  return fakeDigest(uri, size, digestHexLengths.md5);
+  return fakeDigest(uri, size, digestHexLengths.MD5);
 }
 
 const listeners = new Map<string, Set<(event: any) => void>>();

--- a/packages/expo-file-system/src/ExpoFileSystem.web.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.web.ts
@@ -10,10 +10,6 @@ class FileSystemFile {
     console.warn('expo-file-system is not supported on web');
     return Promise.reject(new Error('File preview is not supported on web'));
   }
-  digest(_algorithm: unknown): Promise<string> {
-    console.warn('expo-file-system is not supported on web');
-    return Promise.reject(new Error('File digest is not supported on web'));
-  }
 }
 
 class FileSystemDirectory {

--- a/packages/expo-file-system/src/ExpoFileSystem.web.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.web.ts
@@ -10,6 +10,10 @@ class FileSystemFile {
     console.warn('expo-file-system is not supported on web');
     return Promise.reject(new Error('File preview is not supported on web'));
   }
+  digest(_algorithm: unknown): Promise<string> {
+    console.warn('expo-file-system is not supported on web');
+    return Promise.reject(new Error('File digest is not supported on web'));
+  }
 }
 
 class FileSystemDirectory {

--- a/packages/expo-file-system/src/File.types.ts
+++ b/packages/expo-file-system/src/File.types.ts
@@ -226,15 +226,26 @@ export type FileInfo = {
   creationTime?: number;
   /**
    * Present if the `md5` option was truthy. Contains the MD5 hash of the file.
+   *
+   * @deprecated Use `await file.digest('md5')` instead.
    */
   md5?: string;
 };
 
+/**
+ * Algorithm used to calculate a file digest.
+ */
+export type FileDigestAlgorithm = 'md5' | 'sha-1' | 'sha-256' | 'sha-384' | 'sha-512';
+
+/**
+ * @deprecated Use `await file.digest('md5')` to calculate an MD5 digest.
+ */
 export type InfoOptions = {
   /**
    * Whether to return the MD5 hash of the file.
    *
    * @default false
+   * @deprecated Use `await file.digest('md5')` instead.
    */
   md5?: boolean;
 };

--- a/packages/expo-file-system/src/File.types.ts
+++ b/packages/expo-file-system/src/File.types.ts
@@ -227,7 +227,7 @@ export type FileInfo = {
   /**
    * Present if the `md5` option was truthy. Contains the MD5 hash of the file.
    *
-   * @deprecated Use `await file.digest('md5')` instead.
+   * @deprecated Use `await file.digest('MD5')` instead.
    */
   md5?: string;
 };
@@ -235,17 +235,17 @@ export type FileInfo = {
 /**
  * Algorithm used to calculate a file digest.
  */
-export type FileDigestAlgorithm = 'md5' | 'sha-1' | 'sha-256' | 'sha-384' | 'sha-512';
+export type FileDigestAlgorithm = 'MD5' | 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512';
 
 /**
- * @deprecated Use `await file.digest('md5')` to calculate an MD5 digest.
+ * @deprecated Use `await file.digest('MD5')` to calculate an MD5 digest.
  */
 export type InfoOptions = {
   /**
    * Whether to return the MD5 hash of the file.
    *
    * @default false
-   * @deprecated Use `await file.digest('md5')` instead.
+   * @deprecated Use `await file.digest('MD5')` instead.
    */
   md5?: boolean;
 };

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -67,6 +67,7 @@ describe('expo-file-system new API', () => {
     expect(typeof file.formData).toBe('function');
     expect(typeof file.canPreview).toBe('function');
     expect(typeof file.preview).toBe('function');
+    expect(typeof file.digest).toBe('function');
   });
 
   it('File.json parses file text', async () => {
@@ -326,6 +327,31 @@ describe('expo-file-system behavioral mock', () => {
     const resetFile = new File(Paths.cache, 'metadata.txt');
     resetFile.create();
     expect(resetFile.creationTime).toBe(creationTime);
+  });
+
+  it('File.digest supports the documented algorithms with lowercase hexadecimal output', async () => {
+    const file = new File(Paths.cache, 'digest.txt');
+    file.writeSync('hello');
+
+    await expect(file.digest('md5')).resolves.toBe(file.md5);
+    const algorithms = [
+      ['md5', 32],
+      ['sha-1', 40],
+      ['sha-256', 64],
+      ['sha-384', 96],
+      ['sha-512', 128],
+    ] as const;
+    for (const [algorithm, hexLength] of algorithms) {
+      await expect(file.digest(algorithm)).resolves.toMatch(
+        new RegExp(`^[0-9a-f]{${hexLength}}$`)
+      );
+    }
+  });
+
+  it('File.digest rejects when the file does not exist', async () => {
+    const file = new File(Paths.cache, 'missing-digest.txt');
+
+    await expect(file.digest('md5')).rejects.toThrow('File does not exist');
   });
 
   it('File.move updates this.uri and removes the source', async () => {

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -354,6 +354,14 @@ describe('expo-file-system behavioral mock', () => {
     await expect(file.digest('md5')).rejects.toThrow('File does not exist');
   });
 
+  it('File.digest rejects when the path points to a directory', async () => {
+    const directory = new Directory(Paths.cache, 'digest-directory');
+    directory.create();
+    const file = new File(directory.uri);
+
+    await expect(file.digest('md5')).rejects.toThrow();
+  });
+
   it('File.move updates this.uri and removes the source', async () => {
     const source = new File(Paths.cache, 'source.txt');
     source.writeSync('payload');

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -359,7 +359,9 @@ describe('expo-file-system behavioral mock', () => {
     directory.create();
     const file = new File(directory.uri);
 
-    await expect(file.digest('MD5')).rejects.toThrow();
+    await expect(file.digest('MD5')).rejects.toThrow(
+      'A folder with the same name already exists in the file location'
+    );
   });
 
   it('File.move updates this.uri and removes the source', async () => {

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -333,13 +333,13 @@ describe('expo-file-system behavioral mock', () => {
     const file = new File(Paths.cache, 'digest.txt');
     file.writeSync('hello');
 
-    await expect(file.digest('md5')).resolves.toBe(file.md5);
+    await expect(file.digest('MD5')).resolves.toBe(file.md5);
     const algorithms = [
-      ['md5', 32],
-      ['sha-1', 40],
-      ['sha-256', 64],
-      ['sha-384', 96],
-      ['sha-512', 128],
+      ['MD5', 32],
+      ['SHA-1', 40],
+      ['SHA-256', 64],
+      ['SHA-384', 96],
+      ['SHA-512', 128],
     ] as const;
     for (const [algorithm, hexLength] of algorithms) {
       await expect(file.digest(algorithm)).resolves.toMatch(
@@ -351,7 +351,7 @@ describe('expo-file-system behavioral mock', () => {
   it('File.digest rejects when the file does not exist', async () => {
     const file = new File(Paths.cache, 'missing-digest.txt');
 
-    await expect(file.digest('md5')).rejects.toThrow('File does not exist');
+    await expect(file.digest('MD5')).rejects.toThrow('File does not exist');
   });
 
   it('File.digest rejects when the path points to a directory', async () => {
@@ -359,7 +359,7 @@ describe('expo-file-system behavioral mock', () => {
     directory.create();
     const file = new File(directory.uri);
 
-    await expect(file.digest('md5')).rejects.toThrow();
+    await expect(file.digest('MD5')).rejects.toThrow();
   });
 
   it('File.move updates this.uri and removes the source', async () => {

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -342,9 +342,7 @@ describe('expo-file-system behavioral mock', () => {
       ['SHA-512', 128],
     ] as const;
     for (const [algorithm, hexLength] of algorithms) {
-      await expect(file.digest(algorithm)).resolves.toMatch(
-        new RegExp(`^[0-9a-f]{${hexLength}}$`)
-      );
+      await expect(file.digest(algorithm)).resolves.toMatch(new RegExp(`^[0-9a-f]{${hexLength}}$`));
     }
   });
 

--- a/packages/expo-file-system/src/index.ts
+++ b/packages/expo-file-system/src/index.ts
@@ -6,6 +6,7 @@ export { UploadTask, DownloadTask } from './NetworkTasks';
 export {
   DEFAULT_DEBOUNCE_MS,
   type FileCreateOptions,
+  type FileDigestAlgorithm,
   type DirectoryCreateOptions,
   type RelocationOptions,
   type FileHandle,

--- a/packages/expo-file-system/src/internal/NativeFileSystem.types.ts
+++ b/packages/expo-file-system/src/internal/NativeFileSystem.types.ts
@@ -7,6 +7,7 @@ import type {
   FileCreateOptions,
   FileCanPreviewOptions,
   FileHandle,
+  FileDigestAlgorithm,
   FileInfo,
   FileMode,
   FilePreviewOptions,
@@ -230,6 +231,14 @@ export declare class NativeFileSystemFile {
   info(options?: InfoOptions): FileInfo;
 
   /**
+   * Calculates the digest of the file's contents.
+   * @param algorithm The digest algorithm to use.
+   * @returns A promise that resolves to the lowercase hexadecimal digest.
+   * @throws Error if the file does not exist or cannot be read.
+   */
+  digest(algorithm: FileDigestAlgorithm): Promise<string>;
+
+  /**
    * A boolean representing if a file exists. `true` if the file exists, `false` otherwise.
    * Also, `false` if the application does not have read access to the file.
    */
@@ -314,6 +323,7 @@ export declare class NativeFileSystemFile {
   size: number;
   /**
    * A md5 hash of the file. Null if the file does not exist, or it cannot be read.
+   * @deprecated Use `await file.digest('md5')` instead.
    */
   md5: string | null;
   /**

--- a/packages/expo-file-system/src/internal/NativeFileSystem.types.ts
+++ b/packages/expo-file-system/src/internal/NativeFileSystem.types.ts
@@ -323,7 +323,7 @@ export declare class NativeFileSystemFile {
   size: number;
   /**
    * A md5 hash of the file. Null if the file does not exist, or it cannot be read.
-   * @deprecated Use `await file.digest('md5')` instead.
+   * @deprecated Use `await file.digest('MD5')` instead.
    */
   md5: string | null;
   /**


### PR DESCRIPTION
# Why

As suggested in https://github.com/expo/expo/pull/46403#pullrequestreview-4753352185, this PR adds an async `File.digest()` to calculate hashes like MD5/SHA-1/SHA-256/SHA-384/SHA-512, which exposes more digest algorithms supported by both Android and iOS. The async implementation also makes the UI more responsive.
This PR also adds `@deprecated` tag to the existing MD5 property/argument/results, as suggested in the same PR comment above.

# How

- Add `FileDigestAlgorithm` at TS side to limit the input to the supported digest algorithms
- Add native implementation of `FileSystemFile.digest()` on both Android and iOS, with chunk reading.
  - For iOS, Add `calculateDigest()` so the type of hasher can be determined during the loop.
- Add `@deprecated` for `FileInfo.md5`, `InfoOptions.md5`, `InfoOptions` itself and `NativeFileSystemFile.md5`
- Add tests
- Update downstream calls

# Test Plan

1. `pnpm et check expo-file-system` passed in a clean worktree
2. Filesystem related tests in `apps/bare-expo` passed on Android

<details><summary>Screenshot</summary>

<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/36f55230-7a9b-45f4-864d-4d8cd6fde50d" />

</details>

3. Filesystem related tests in `apps/bare-expo` passed on iOS

<details><summary>Screenshot</summary>

<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/d8721706-ecfb-4c17-9e9a-476d092f7377" />

</details>

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
