### PR TITLE
[expo-localization] Prevent supportedLocales plugin from duplicating resourceConfigurations on repeated prebuild

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent the `supportedLocales` config plugin from duplicating `resourceConfigurations` in `app/build.gradle` on repeated `expo prebuild --no-clean` runs.
+- Prevent the `supportedLocales` config plugin from duplicating `resourceConfigurations` in `app/build.gradle` on repeated `expo prebuild --no-clean` runs. ([#48092](https://github.com/expo/expo/pull/48092) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent the `supportedLocales` config plugin from duplicating `resourceConfigurations` in `app/build.gradle` on repeated `expo prebuild` runs without `--clean`.
+- Prevent the `supportedLocales` config plugin from duplicating `resourceConfigurations` in `app/build.gradle` on repeated `expo prebuild --no-clean` runs.
 
 ### 💡 Others
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent the `supportedLocales` config plugin from duplicating `resourceConfigurations` in `app/build.gradle` on repeated `expo prebuild` runs without `--clean`.
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-21

--- a/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
+++ b/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
@@ -3,6 +3,7 @@ import { AndroidConfig } from 'expo/config-plugins';
 import {
   convertBcp47ToResourceQualifier,
   setAndroidSupportsRtl,
+  setResourceConfigurations,
 } from '../src/withExpoLocalization';
 
 function getManifest(): AndroidConfig.Manifest.AndroidManifest {
@@ -51,5 +52,36 @@ describe('converts locales to BCP-47 format', () => {
     expect(convertBcp47ToResourceQualifier('zh-Hant')).toBe('b+zh+Hant');
     expect(convertBcp47ToResourceQualifier('es-419')).toBe('b+es+419');
     expect(convertBcp47ToResourceQualifier('zh-Hant-TW')).toBe('b+zh+Hant+TW');
+  });
+});
+
+const buildGradle = `android {
+    defaultConfig {
+        applicationId "com.example"
+        versionCode 1
+        versionName "1.0.0"
+    }
+}
+`;
+
+describe('setResourceConfigurations', () => {
+  it('inserts resourceConfigurations after versionName', () => {
+    const result = setResourceConfigurations(buildGradle, ['b+en', 'b+fr']);
+    expect(result).toContain('resourceConfigurations += ["b+en", "b+fr"]');
+  });
+
+  it('is idempotent across repeated prebuilds without --clean', () => {
+    const once = setResourceConfigurations(buildGradle, ['b+en', 'b+fr']);
+    const twice = setResourceConfigurations(once, ['b+en', 'b+fr']);
+    expect(twice).toEqual(once);
+    expect(twice.match(/resourceConfigurations \+=/g)).toHaveLength(1);
+  });
+
+  it('updates the resourceConfigurations when supportedLocales change', () => {
+    const before = setResourceConfigurations(buildGradle, ['b+en', 'b+fr']);
+    const after = setResourceConfigurations(before, ['b+en']);
+    expect(after).toContain('resourceConfigurations += ["b+en"]');
+    expect(after).not.toContain('"b+fr"');
+    expect(after.match(/resourceConfigurations \+=/g)).toHaveLength(1);
   });
 });

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from 'expo/config';
 import {
   AndroidConfig,
+  CodeGenerator,
   WarningAggregator,
   withAndroidManifest,
   withAppBuildGradle,
@@ -41,6 +42,22 @@ function assertLocale(value: unknown): asserts value is string {
 
 export function convertBcp47ToResourceQualifier(locale: string): string {
   return `b+${locale.replaceAll('-', '+')}`;
+}
+
+export function setResourceConfigurations(
+  appBuildGradle: string,
+  resourceQualifiers: string[]
+): string {
+  const list = resourceQualifiers.map((qualifier) => `"${qualifier}"`).join(', ');
+
+  return CodeGenerator.mergeContents({
+    src: appBuildGradle,
+    comment: '//',
+    tag: 'expo-localization-supported-locales',
+    offset: 1,
+    anchor: /versionName "[\d.]+"/,
+    newSrc: `        resourceConfigurations += [${list}]`,
+  }).contents;
 }
 
 export function setAndroidSupportsRtl(
@@ -160,10 +177,9 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
           convertBcp47ToResourceQualifier(locale)
         );
 
-        config.modResults.contents = AndroidConfig.CodeMod.appendContentsInsideDeclarationBlock(
+        config.modResults.contents = setResourceConfigurations(
           config.modResults.contents,
-          'defaultConfig',
-          `    resourceConfigurations += [${resourceQualifiers.map((qualifier) => `"${qualifier}"`).join(', ')}]\n    `
+          resourceQualifiers
         );
       } else {
         WarningAggregator.addWarningAndroid(


### PR DESCRIPTION
# Why

Running `npx expo prebuild` without `--clean` on a project using the `supportedLocales` option appended a new `resourceConfigurations` line to `app/build.gradle` every time, producing duplicated entries.

# How

Replaced `AndroidConfig.CodeMod.appendContentsInsideDeclarationBlock` with `CodeGenerator.mergeContents`, using a tagged block (`expo-localization-supported-locales`) anchored after `versionName`. The tag makes the edit idempotent: repeated prebuilds update the existing block instead of appending a new one, and changing `supportedLocales` rewrites it in place.

# Test Plan

Added unit tests for `setResourceConfigurations` covering insertion, idempotency across repeated prebuilds, and updates when `supportedLocales` change. Verified with `et check-packages expo-localization`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
