### PR TITLE
[docs] Cover both trailing-slash forms in redirects and add a check

### DIFF
--- a/docs/checks/check-redirects.test.ts
+++ b/docs/checks/check-redirects.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const REDIRECTS_FILE = fileURLToPath(new URL('../public/_redirects', import.meta.url));
+
+// Cloudflare Pages hard limit for static (non-splat) rules.
+const CLOUDFLARE_STATIC_RULE_LIMIT = 2000;
+
+interface Rule {
+  source: string;
+  destination: string;
+  status: string;
+  line: number;
+}
+
+function parseRules(): Rule[] {
+  return fs
+    .readFileSync(REDIRECTS_FILE, 'utf8')
+    .split('\n')
+    .map((raw, index) => ({ raw: raw.trim(), line: index + 1 }))
+    .filter(({ raw }) => raw.length > 0 && !raw.startsWith('#'))
+    .map(({ raw, line }) => {
+      const [source, destination, status = '301'] = raw.split(/\s+/);
+      return { source, destination, status, line };
+    });
+}
+
+// Exact page rules are the ones the site can receive in both trailing-slash
+// forms: no splats, no placeholders, no file extensions (like /index.md).
+const isExactPageRule = (rule: Rule) =>
+  !rule.source.includes('*') && !rule.source.includes(':') && !/\.[\da-z]+$/i.test(rule.source);
+
+// Sibling rules may legitimately target the slash and slashless form of the
+// same destination ("/mcp" and "/mcp/"); both resolve to the same page.
+const normalizeDestination = (destination: string) =>
+  destination.endsWith('/') ? destination.slice(0, -1) : destination;
+
+describe('public/_redirects', () => {
+  test('every exact page rule covers both trailing-slash forms', () => {
+    const rules = parseRules();
+    const bySource = new Map(rules.map(rule => [rule.source, rule]));
+    const problems: string[] = [];
+
+    for (const rule of rules.filter(isExactPageRule)) {
+      const sibling = rule.source.endsWith('/') ? rule.source.slice(0, -1) : `${rule.source}/`;
+      const match = bySource.get(sibling);
+      if (!match) {
+        problems.push(
+          `${rule.source} (line ${rule.line}) has no ${sibling} variant, so one URL form will 404 instead of redirecting`
+        );
+      } else if (
+        normalizeDestination(match.destination) !== normalizeDestination(rule.destination) ||
+        match.status !== rule.status
+      ) {
+        problems.push(
+          `${rule.source} (line ${rule.line}) and ${sibling} (line ${match.line}) disagree on destination or status`
+        );
+      }
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  test('stays within the Cloudflare Pages static rule limit', () => {
+    expect(parseRules().length).toBeLessThanOrEqual(CLOUDFLARE_STATIC_RULE_LIMIT);
+  });
+});

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,377 +1,624 @@
 # Old redirects
 /distribution/building-standalone-apps /build/setup 301
+/distribution/building-standalone-apps/ /build/setup 301
 
 # clients is now development
 /clients/installation /versions/latest/sdk/dev-client 301
+/clients/installation/ /versions/latest/sdk/dev-client 301
 
 # Expo Modules
 /modules /modules/overview 301
+/modules/ /modules/overview 301
 /module-api /modules/module-api 301
+/module-api/ /modules/module-api 301
 /module-config /modules/module-config 301
+/module-config/ /modules/module-config 301
 
 # Development builds
 /development/build /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/build/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 /development/getting-started /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/getting-started/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 /development/troubleshooting /develop/development-builds/introduction 301
+/development/troubleshooting/ /develop/development-builds/introduction 301
 /development/upgrading /develop/development-builds/introduction 301
+/development/upgrading/ /develop/development-builds/introduction 301
 /development/extensions /develop/development-builds/development-workflows 301
+/development/extensions/ /develop/development-builds/development-workflows 301
 /development/develop-your-project /develop/development-builds/use-development-builds 301
+/development/develop-your-project/ /develop/development-builds/use-development-builds 301
 /develop/development-builds/installation /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/develop/development-builds/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 
 # Guides that have been deleted
 /guides/web-performance /guides/analyzing-bundles 301
+/guides/web-performance/ /guides/analyzing-bundles 301
 /push-notifications/obtaining-a-device-token-for-fcm-or-apns /push-notifications/sending-notifications-custom 301
+/push-notifications/obtaining-a-device-token-for-fcm-or-apns/ /push-notifications/sending-notifications-custom 301
 
 # Redirects after adding Home to the docs
 /next-steps/additional-resources /additional-resources 301
+/next-steps/additional-resources/ /additional-resources 301
 /get-started/create-a-new-app /get-started/create-a-project 301
+/get-started/create-a-new-app/ /get-started/create-a-project 301
 /guides/config-plugins /config-plugins/introduction 301
+/guides/config-plugins/ /config-plugins/introduction 301
 /workflow/debugging /debugging/runtime-issues 301
+/workflow/debugging/ /debugging/runtime-issues 301
 /workflow/expo-go /get-started/set-up-your-environment 301
+/workflow/expo-go/ /get-started/set-up-your-environment 301
 /guides/splash-screens /develop/user-interface/splash-screen 301
+/guides/splash-screens/ /develop/user-interface/splash-screen 301
 /guides/app-icons /develop/user-interface/app-icons 301
+/guides/app-icons/ /develop/user-interface/app-icons 301
 /guides/color-schemes /develop/user-interface/color-themes 301
+/guides/color-schemes/ /develop/user-interface/color-themes 301
 /development/introduction /develop/development-builds/introduction 301
+/development/introduction/ /develop/development-builds/introduction 301
 /development/create-development-builds /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/create-development-builds/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 /development/use-development-builds /develop/development-builds/use-development-builds 301
+/development/use-development-builds/ /develop/development-builds/use-development-builds 301
 /development/development-workflows /develop/development-builds/development-workflows 301
+/development/development-workflows/ /develop/development-builds/development-workflows 301
 /debugging /debugging/runtime-issues 301
+/debugging/ /debugging/runtime-issues 301
 /debugging/runtime-issue /debugging/runtime-issues 301
+/debugging/runtime-issue/ /debugging/runtime-issues 301
 /develop/development-builds/parallel-installation /build-reference/variants 301
+/develop/development-builds/parallel-installation/ /build-reference/variants 301
 /guides/assets /develop/user-interface/assets 301
+/guides/assets/ /develop/user-interface/assets 301
 
 # Redirects after Guides organization
 /guides /guides/overview 301
+/guides/ /guides/overview 301
 /guides/routing-and-navigation /routing/introduction 301
+/guides/routing-and-navigation/ /routing/introduction 301
 /guides/errors /debugging/runtime-issues 301
+/guides/errors/ /debugging/runtime-issues 301
 /workflow/expo-cli /more/expo-cli 301
+/workflow/expo-cli/ /more/expo-cli 301
 /versions/latest/workflow/expo-cli /more/expo-cli 301
+/versions/latest/workflow/expo-cli/ /more/expo-cli 301
 /bare/hello-world /bare/overview 301
+/bare/hello-world/ /bare/overview 301
 /guides/using-graphql /guides/overview 301
+/guides/using-graphql/ /guides/overview 301
 /build/automating-submissions /build/automate-submissions 301
+/build/automating-submissions/ /build/automate-submissions 301
 /workflow/run-on-device /build/internal-distribution 301
+/workflow/run-on-device/ /build/internal-distribution 301
 /archive/workflow/customizing /workflow/customizing 301
+/archive/workflow/customizing/ /workflow/customizing 301
 /guides/building-standalone-apps /build/setup 301
+/guides/building-standalone-apps/ /build/setup 301
 /versions/latest/sdk/permissions /guides/permissions 301
+/versions/latest/sdk/permissions/ /guides/permissions 301
 /push-notifications/using-fcm /push-notifications/push-notifications-setup 301
+/push-notifications/using-fcm/ /push-notifications/push-notifications-setup 301
 
 # Redirects reported from SEO tools list (MOZ, SEMRush, GSC, etc.)
 /bare/installing-unimodules /bare/installing-expo-modules 301
+/bare/installing-unimodules/ /bare/installing-expo-modules 301
 /versions/latest/sdk/admob /versions/latest 301
+/versions/latest/sdk/admob/ /versions/latest 301
 /workflow/publishing /archive/classic-updates/publishing 301
+/workflow/publishing/ /archive/classic-updates/publishing 301
 /workflow/already-used-react-native /workflow/overview 301
+/workflow/already-used-react-native/ /workflow/overview 301
 /development/installation /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 /bare/updating-your-app /eas-update/getting-started 301
+/bare/updating-your-app/ /eas-update/getting-started 301
 /technical-specs/expo-updates-0 /technical-specs/expo-updates-1 301
+/technical-specs/expo-updates-0/ /technical-specs/expo-updates-1 301
 /archive/expokit/eject /archive/glossary 301
+/archive/expokit/eject/ /archive/glossary 301
 /archive/expokit/overview /archive/glossary 301
+/archive/expokit/overview/ /archive/glossary 301
 /expokit/overview /archive/glossary 301
+/expokit/overview/ /archive/glossary 301
 /bare/existing-apps /bare/installing-expo-modules 301
+/bare/existing-apps/ /bare/installing-expo-modules 301
 /bare/exploring-bare-workflow /bare/overview 301
+/bare/exploring-bare-workflow/ /bare/overview 301
 /build-reference/custom-build-config /custom-builds/get-started 301
+/build-reference/custom-build-config/ /custom-builds/get-started 301
 /build-reference/how-tos /build-reference/private-npm-packages 301
+/build-reference/how-tos/ /build-reference/private-npm-packages 301
 /eas-update/migrate-codepush-to-eas-update /eas-update/codepush 301
+/eas-update/migrate-codepush-to-eas-update/ /eas-update/codepush 301
 /guides/testing-on-devices /build/internal-distribution 301
+/guides/testing-on-devices/ /build/internal-distribution 301
 /technical-specs/latest /technical-specs/expo-updates-1 301
+/technical-specs/latest/ /technical-specs/expo-updates-1 301
 
 # We should change this redirect to a more general EAS guide later
 /guides/setting-up-continuous-integration /build/building-on-ci 301
+/guides/setting-up-continuous-integration/ /build/building-on-ci 301
 
 # Moved classic updates
 /distribution/release-channels /archive/classic-updates/release-channels 301
+/distribution/release-channels/ /archive/classic-updates/release-channels 301
 /distribution/advanced-release-channels /archive/classic-updates/advanced-release-channels 301
+/distribution/advanced-release-channels/ /archive/classic-updates/advanced-release-channels 301
 /distribution/optimizing-updates /archive/classic-updates/optimizing-updates 301
+/distribution/optimizing-updates/ /archive/classic-updates/optimizing-updates 301
 /distribution/runtime-versions /eas-update/runtime-versions 301
+/distribution/runtime-versions/ /eas-update/runtime-versions 301
 /guides/offline-support /archive/classic-updates/offline-support 301
+/guides/offline-support/ /archive/classic-updates/offline-support 301
 /guides/preloading-and-caching-assets /archive/classic-updates/preloading-and-caching-assets 301
+/guides/preloading-and-caching-assets/ /archive/classic-updates/preloading-and-caching-assets 301
 /guides/configuring-updates /archive/classic-updates/configuring-updates 301
+/guides/configuring-updates/ /archive/classic-updates/configuring-updates 301
 /eas-update/bare-react-native /eas-update/getting-started 301
+/eas-update/bare-react-native/ /eas-update/getting-started 301
 /worfkflow/publishing /archive/classic-updates/publishing 301
+/worfkflow/publishing/ /archive/classic-updates/publishing 301
 /classic/building-standalone-apps /build/setup 301
+/classic/building-standalone-apps/ /build/setup 301
 /classic/turtle-cli /build/setup 301
+/classic/turtle-cli/ /build/setup 301
 /archive/classic-updates/getting-started /eas-update/getting-started 301
+/archive/classic-updates/getting-started/ /eas-update/getting-started 301
 /archive/classic-updates/building-standalone-apps /build/setup 301
+/archive/classic-updates/building-standalone-apps/ /build/setup 301
 
 # EAS Update
 /eas-update/developing-with-eas-update /eas-update/develop-faster 301
+/eas-update/developing-with-eas-update/ /eas-update/develop-faster 301
 /eas-update/eas-update-with-local-build /eas-update/standalone-service 301
+/eas-update/eas-update-with-local-build/ /eas-update/standalone-service 301
 /eas-update/eas-update-and-eas-cli /eas-update/eas-cli 301
+/eas-update/eas-update-and-eas-cli/ /eas-update/eas-cli 301
 /eas-update/debug-updates /eas-update/debug 301
+/eas-update/debug-updates/ /eas-update/debug 301
 /eas-update/how-eas-update-works /eas-update/how-it-works 301
+/eas-update/how-eas-update-works/ /eas-update/how-it-works 301
 /eas-update/migrate-to-eas-update /eas-update/migrate-from-classic-updates 301
+/eas-update/migrate-to-eas-update/ /eas-update/migrate-from-classic-updates 301
 /eas-update/custom-updates-server /versions/latest/sdk/updates 301
+/eas-update/custom-updates-server/ /versions/latest/sdk/updates 301
 /distribution/custom-updates-server /versions/latest/sdk/updates 301
+/distribution/custom-updates-server/ /versions/latest/sdk/updates 301
 /bare/error-recovery /eas-update/error-recovery 301
+/bare/error-recovery/ /eas-update/error-recovery 301
 /deploy/instant-updates /eas-update/send-over-the-air-updates 301
+/deploy/instant-updates/ /eas-update/send-over-the-air-updates 301
 /eas-update/publish /eas-update/getting-started 301
+/eas-update/publish/ /eas-update/getting-started 301
 /eas-update/debug-advanced /eas-update/debug 301
+/eas-update/debug-advanced/ /eas-update/debug 301
 /eas-update/develop-faster /eas-update/preview 301
+/eas-update/develop-faster/ /eas-update/preview 301
 
 # Redirects for Expo Router docs
 /routing/next-steps /router/introduction 301
+/routing/next-steps/ /router/introduction 301
 /routing/introduction /router/introduction 301
+/routing/introduction/ /router/introduction 301
 /routing/installation /router/installation 301
+/routing/installation/ /router/installation 301
 /routing/create-pages /router/create-pages 301
+/routing/create-pages/ /router/create-pages 301
 /routing/navigating-pages /router/navigating-pages 301
+/routing/navigating-pages/ /router/navigating-pages 301
 /routing/layouts /router/basics/navigation-layouts 301
+/routing/layouts/ /router/basics/navigation-layouts 301
 /routing/appearance /router/introduction 301
+/routing/appearance/ /router/introduction 301
 /routing/error-handling /router/error-handling 301
+/routing/error-handling/ /router/error-handling 301
 /router/advance/root-layout /router/basics/navigation-layouts/#root-layout 301
+/router/advance/root-layout/ /router/basics/navigation-layouts/#root-layout 301
 /router/advance/stack /router/advanced/stack 301
+/router/advance/stack/ /router/advanced/stack 301
 /router/advance/tabs /router/advanced/tabs 301
+/router/advance/tabs/ /router/advanced/tabs 301
 /router/advance/drawer /router/advanced/drawer 301
+/router/advance/drawer/ /router/advanced/drawer 301
 /router/advanced/redirects /router/reference/redirects 301
+/router/advanced/redirects/ /router/reference/redirects 301
 /router/advance/nesting-navigators /router/advanced/nesting-navigators 301
+/router/advance/nesting-navigators/ /router/advanced/nesting-navigators 301
 /router/advance/modal /router/advanced/modals 301
+/router/advance/modal/ /router/advanced/modals 301
 /router/advance/platform-specific-modules /router/advanced/platform-specific-modules 301
+/router/advance/platform-specific-modules/ /router/advanced/platform-specific-modules 301
 /router/reference/platform-specific-modules /router/advanced/platform-specific-modules 301
+/router/reference/platform-specific-modules/ /router/advanced/platform-specific-modules 301
 /router/advance/shared-routes /router/advanced/shared-routes 301
+/router/advance/shared-routes/ /router/advanced/shared-routes 301
 /router/advance/router-setttings /router/advanced/router-settings 301
+/router/advance/router-setttings/ /router/advanced/router-settings 301
 /router/reference/search-parameters /router/reference/url-parameters 301
+/router/reference/search-parameters/ /router/reference/url-parameters 301
 /router/appearance /router/introduction 301
+/router/appearance/ /router/introduction 301
 
 # Removed API reference docs
 /versions/latest/sdk/facebook /guides/authentication 301
+/versions/latest/sdk/facebook/ /guides/authentication 301
 /versions/latest/sdk/taskmanager /versions/latest/sdk/task-manager 301
+/versions/latest/sdk/taskmanager/ /versions/latest/sdk/task-manager 301
 /versions/latest/sdk/videothumbnails /versions/latest/sdk/video-thumbnails 301
+/versions/latest/sdk/videothumbnails/ /versions/latest/sdk/video-thumbnails 301
 /versions/latest/sdk/appearance /versions/latest/react-native/appearance 301
+/versions/latest/sdk/appearance/ /versions/latest/react-native/appearance 301
 /versions/latest/sdk/app-loading /versions/latest/sdk/splash-screen 301
+/versions/latest/sdk/app-loading/ /versions/latest/sdk/splash-screen 301
 /versions/latest/sdk/app-auth /guides/authentication 301
+/versions/latest/sdk/app-auth/ /guides/authentication 301
 /versions/latest/sdk/firebase-core /guides/using-firebase 301
+/versions/latest/sdk/firebase-core/ /guides/using-firebase 301
 /versions/latest/sdk/firebase-analytics /guides/using-firebase 301
+/versions/latest/sdk/firebase-analytics/ /guides/using-firebase 301
 /versions/latest/sdk/firebase-recaptcha /guides/using-firebase 301
+/versions/latest/sdk/firebase-recaptcha/ /guides/using-firebase 301
 /versions/latest/sdk/google-sign-in /guides/authentication 301
+/versions/latest/sdk/google-sign-in/ /guides/authentication 301
 /versions/latest/sdk/google /guides/authentication 301
+/versions/latest/sdk/google/ /guides/authentication 301
 /versions/latest/sdk/amplitude /guides/using-analytics 301
+/versions/latest/sdk/amplitude/ /guides/using-analytics 301
 /versions/latest/sdk/util /versions/latest 301
+/versions/latest/sdk/util/ /versions/latest 301
 /versions/latest/introduction/faq /faq 301
+/versions/latest/introduction/faq/ /faq 301
 /versions/latest/sdk/in-app-purchases /guides/in-app-purchases/ 301
+/versions/latest/sdk/in-app-purchases/ /guides/in-app-purchases/ 301
 
 # Redirects based on Sentry reports
 /push-notifications /push-notifications/overview 301
+/push-notifications/ /push-notifications/overview 301
 /development/tools/expo-dev-client /develop/development-builds/introduction 301
+/development/tools/expo-dev-client/ /develop/development-builds/introduction 301
 /develop/user-interface/custom-fonts /develop/user-interface/fonts 301
+/develop/user-interface/custom-fonts/ /develop/user-interface/fonts 301
 /workflow/snack /more/glossary-of-terms 301
+/workflow/snack/ /more/glossary-of-terms 301
 /accounts/teams-and-accounts /accounts/account-types 301
+/accounts/teams-and-accounts/ /accounts/account-types 301
 /push-notifications/fcm /push-notifications/sending-notifications-custom 301
+/push-notifications/fcm/ /push-notifications/sending-notifications-custom 301
 /troubleshooting/clear-cache-mac /troubleshooting/clear-cache-macos-linux 301
+/troubleshooting/clear-cache-mac/ /troubleshooting/clear-cache-macos-linux 301
 /guides/using-preact /guides/overview 301
+/guides/using-preact/ /guides/overview 301
 /versions/latest/sdk/shared-element /versions/latest 301
+/versions/latest/sdk/shared-element/ /versions/latest 301
 /workflow/hermes /guides/using-hermes 301
+/workflow/hermes/ /guides/using-hermes 301
 
 # Redirects based on Algolia 404 report
 /workflow/build/building-on-ci /build/building-on-ci 301
+/workflow/build/building-on-ci/ /build/building-on-ci 301
 /task-manager /versions/latest/sdk/task-manager 301
+/task-manager/ /versions/latest/sdk/task-manager 301
 /versions/latest/sdk/filesystem.md /versions/latest/sdk/filesystem 301
 /guides/how-expo-works /faq 301
+/guides/how-expo-works/ /faq 301
 /config/app /workflow/configuration 301
+/config/app/ /workflow/configuration 301
 /guides/authentication.md /guides/authentication 301
 /versions/latest/workflow/linking /guides/linking 301
+/versions/latest/workflow/linking/ /guides/linking 301
 /versions/latest/sdk/overview /versions/latest 301
+/versions/latest/sdk/overview/ /versions/latest 301
 
 # Deprecated webpack
 /guides/customizing-webpack /archive/customizing-webpack 301
+/guides/customizing-webpack/ /archive/customizing-webpack 301
 
 # May 2024 home / get started section
 /overview /get-started/create-a-project 301
+/overview/ /get-started/create-a-project 301
 /get-started/installation /get-started/create-a-project 301
+/get-started/installation/ /get-started/create-a-project 301
 /get-started/expo-go /get-started/set-up-your-environment 301
+/get-started/expo-go/ /get-started/set-up-your-environment 301
 
 # Redirect for /learn URL
 /learn /tutorial/introduction 301
+/learn/ /tutorial/introduction 301
 
 # May 2024 home / develop section
 /develop/user-interface/app-icons /develop/user-interface/splash-screen-and-app-icon 301
+/develop/user-interface/app-icons/ /develop/user-interface/splash-screen-and-app-icon 301
 /develop/user-interface/splash-screen /develop/user-interface/splash-screen-and-app-icon 301
+/develop/user-interface/splash-screen/ /develop/user-interface/splash-screen-and-app-icon 301
 
 # Preview section
 /preview/support /preview/introduction 301
+/preview/support/ /preview/introduction 301
 /preview/react-compiler /guides/react-compiler 301
+/preview/react-compiler/ /guides/react-compiler 301
 
 # Archived
 /guides/using-flipper /debugging/tools 301
+/guides/using-flipper/ /debugging/tools 301
 
 # Troubleshooting section
 /guides/troubleshooting-proxies /troubleshooting/proxies 301
+/guides/troubleshooting-proxies/ /troubleshooting/proxies 301
 
 # After adding "Linking" (/linking/**) section
 /guides/linking /linking/overview 301
+/guides/linking/ /linking/overview 301
 /guides/deep-linking /linking/into-your-app 301
+/guides/deep-linking/ /linking/into-your-app 301
 
 # After adding /sdk/router/ API reference
 /router/reference/hooks /versions/latest/sdk/router 301
+/router/reference/hooks/ /versions/latest/sdk/router 301
 
 # After moving custom tabs under Expo Router > Navigation patterns
 /router/ui/tabs /router/advanced/custom-tabs 301
+/router/ui/tabs/ /router/advanced/custom-tabs 301
 
 # After new environment variables guide
 /build-reference/variables /eas/environment-variables 301
+/build-reference/variables/ /eas/environment-variables 301
 /eas-update/environment-variables /eas/environment-variables 301
+/eas-update/environment-variables/ /eas/environment-variables 301
 
 # After moving common questions from Expo Router FAQ to Introduction
 /router/reference/faq /router/introduction 301
+/router/reference/faq/ /router/introduction 301
 
 # After migrating Prebuild page info to CNG page
 /workflow/prebuild /workflow/continuous-native-generation 301
+/workflow/prebuild/ /workflow/continuous-native-generation 301
 
 # After removing UI programming section
 /ui-programming/image-background /tutorial/overview 301
+/ui-programming/image-background/ /tutorial/overview 301
 /ui-programming/implementing-a-checkbox /versions/latest/sdk/checkbox 301
+/ui-programming/implementing-a-checkbox/ /versions/latest/sdk/checkbox 301
 /ui-programming/z-index /tutorial/overview 301
+/ui-programming/z-index/ /tutorial/overview 301
 /ui-programming/using-svgs /versions/latest/sdk/svg 301
+/ui-programming/using-svgs/ /versions/latest/sdk/svg 301
 /ui-programming/react-native-toast /tutorial/overview 301
+/ui-programming/react-native-toast/ /tutorial/overview 301
 /ui-programming/react-native-styling-buttons /tutorial/overview 301
+/ui-programming/react-native-styling-buttons/ /tutorial/overview 301
 /ui-programming/user-interface-libraries /tutorial/overview 301
+/ui-programming/user-interface-libraries/ /tutorial/overview 301
 
 # After renaming "workflows" to "eas-workflows"
 /workflows/get-started /eas/workflows/get-started 301
+/workflows/get-started/ /eas/workflows/get-started 301
 /workflows/triggers /eas/workflows/syntax/#on 301
+/workflows/triggers/ /eas/workflows/syntax/#on 301
 /workflows/jobs /eas/workflows/syntax/#jobs 301
+/workflows/jobs/ /eas/workflows/syntax/#jobs 301
 /workflows/control-flow /eas/workflows/syntax/#control-flow 301
+/workflows/control-flow/ /eas/workflows/syntax/#control-flow 301
 /workflows/variables /eas/workflows/syntax/#jobsjob_idoutputs 301
+/workflows/variables/ /eas/workflows/syntax/#jobsjob_idoutputs 301
 
 # After moving eas-workflows to eas/workflows
 /eas-workflows/get-started /eas/workflows/get-started 301
+/eas-workflows/get-started/ /eas/workflows/get-started 301
 /eas-workflows/triggers /eas/workflows/syntax/#on 301
+/eas-workflows/triggers/ /eas/workflows/syntax/#on 301
 /eas-workflows/jobs /eas/workflows/syntax/#jobs 301
+/eas-workflows/jobs/ /eas/workflows/syntax/#jobs 301
 /eas-workflows/control-flow /eas/workflows/syntax/#control-flow 301
+/eas-workflows/control-flow/ /eas/workflows/syntax/#control-flow 301
 /eas-workflows/variables /eas/workflows/syntax/#jobsjob_idoutputs 301
+/eas-workflows/variables/ /eas/workflows/syntax/#jobsjob_idoutputs 301
 /eas-workflows/upgrade /eas/workflows/automating-eas-cli 301
+/eas-workflows/upgrade/ /eas/workflows/automating-eas-cli 301
 /eas/workflows/upgrade /eas/workflows/automating-eas-cli 301
+/eas/workflows/upgrade/ /eas/workflows/automating-eas-cli 301
 
 # After moving eas/workflows/examples to eas/workflows/examples/*
 /eas/workflows/examples /eas/workflows/examples/introduction 301
 /eas/workflows/reference/e2e-tests /eas/workflows/examples/e2e-tests 301
+/eas/workflows/reference/e2e-tests/ /eas/workflows/examples/e2e-tests 301
 
 # After moving e2e-tests to eas/workflows/reference
 /build-reference/e2e-tests /eas/workflows/examples/e2e-tests 301
+/build-reference/e2e-tests/ /eas/workflows/examples/e2e-tests 301
 
 # After adding distribution section under EAS
 /distribution/publishing-websites /guides/publishing-websites 301
+/distribution/publishing-websites/ /guides/publishing-websites 301
 
 # Based on Google Search Console not found report 2025-01-02
 /versions/latest/sdk/sqlite-next /versions/latest/sdk/sqlite 301
+/versions/latest/sdk/sqlite-next/ /versions/latest/sdk/sqlite 301
 /versions/latest/sdk/camera-next /versions/latest/sdk/camera 301
+/versions/latest/sdk/camera-next/ /versions/latest/sdk/camera 301
 /home/overview / 301
+/home/overview/ / 301
 /develop/project-structure /get-started/start-developing 301
+/develop/project-structure/ /get-started/start-developing 301
 /versions/latest/sdk/bar-code-scanner /versions/latest/sdk/camera 301
+/versions/latest/sdk/bar-code-scanner/ /versions/latest/sdk/camera 301
 /bare/using-expo-client /bare/install-dev-builds-in-bare 301
+/bare/using-expo-client/ /bare/install-dev-builds-in-bare 301
 /versions/latest/sdk/sqlite-legacy /versions/latest/sdk/sqlite 301
+/versions/latest/sdk/sqlite-legacy/ /versions/latest/sdk/sqlite 301
 /versions/latest/config/app/name /versions/latest/config/app/#name 301
+/versions/latest/config/app/name/ /versions/latest/config/app/#name 301
 /bare /bare/overview 301
+/bare/ /bare/overview 301
 /accounts/working-together /accounts/account-types 301
+/accounts/working-together/ /accounts/account-types 301
 /versions/latest/sdk/random /versions/latest/sdk/crypto 301
+/versions/latest/sdk/random/ /versions/latest/sdk/crypto 301
 /eas-update/known-issues /eas-update/introduction 301
+/eas-update/known-issues/ /eas-update/introduction 301
 
 # After consolidating the "Internal distribution" information
 /guides/sharing-preview-releases /build/internal-distribution 301
+/guides/sharing-preview-releases/ /build/internal-distribution 301
 
 # After merging EAS environment variables guides
 /eas/using-environment-variables /eas/environment-variables 301
 
 # After Expo Router Getting Started Guide
 /router/reference/authentication /router/advanced/authentication 301
+/router/reference/authentication/ /router/advanced/authentication 301
 /router/advanced/root-layout /router/basics/navigation-layouts/#root-layout 301
+/router/advanced/root-layout/ /router/basics/navigation-layouts/#root-layout 301
 /router/reference/not-found /router/error-handling 301
+/router/reference/not-found/ /router/error-handling 301
 /router/navigating-pages /router/basics/navigation 301
+/router/navigating-pages/ /router/basics/navigation 301
 /router/create-pages /router/basics/core-concepts 301
+/router/create-pages/ /router/basics/core-concepts 301
 /router/basics/layout /router/basics/navigation-layouts 301
+/router/basics/layout/ /router/basics/navigation-layouts 301
 
 # After updating config plugin section
 /config-plugins/plugins-and-mods /config-plugins/plugins 301
+/config-plugins/plugins-and-mods/ /config-plugins/plugins 301
 
 # After adding System bars
 /guides/configuring-statusbar /develop/user-interface/system-bars 301
 
 # After changing "Privacy Shield" to "Data Privacy Framework" and deleting Privacy Shield page
 /regulatory-compliance/privacy-shield /regulatory-compliance/data-and-privacy-protection 301
+/regulatory-compliance/privacy-shield/ /regulatory-compliance/data-and-privacy-protection 301
 
 # After changing brownfield docs
 /brownfield/installing-expo-modules /brownfield/overview 301
+/brownfield/installing-expo-modules/ /brownfield/overview 301
 /brownfield/get-started /brownfield/isolated-approach 301
+/brownfield/get-started/ /brownfield/isolated-approach 301
 
 # After removing Navigation section from Home and adding a Navigation page
 /develop/file-based-routing /develop/app-navigation 301
+/develop/file-based-routing/ /develop/app-navigation 301
 /develop/dynamic-routes /develop/app-navigation 301
+/develop/dynamic-routes/ /develop/app-navigation 301
 /develop/next-steps /develop/app-navigation 301
+/develop/next-steps/ /develop/app-navigation 301
 
 # After moving server-focused Expo Router docs under /router/web/**
 /router/reference/api-routes /router/web/api-routes 301
+/router/reference/api-routes/ /router/web/api-routes 301
 /router/reference/middleware /router/web/middleware 301
 /router/reference/static-rendering /router/web/static-rendering 301
+/router/reference/static-rendering/ /router/web/static-rendering 301
 /router/reference/async-routes /router/web/async-routes 301
+/router/reference/async-routes/ /router/web/async-routes 301
 
 # After moving FAQ to EAS Update page
 /eas-update/faq /eas-update/introduction 301
+/eas-update/faq/ /eas-update/introduction 301
 
 # After moving MetadataFAQ to EAS Metadata page
 /eas/metadata/faq /eas/metadata 301
+/eas/metadata/faq/ /eas/metadata 301
 
 # After creating EAS environment variables section
 /eas/hosting/environment-variables /eas/environment-variables/usage/#using-environment-variables-with-eas-hosting 301
 
 # After separating expo-router reference into multiple subsections
 /versions/unversioned/sdk/router-ui /versions/unversioned/sdk/router/ui 301
+/versions/unversioned/sdk/router-ui/ /versions/unversioned/sdk/router/ui 301
 /versions/unversioned/sdk/router-native-tabs /versions/unversioned/sdk/router/native-tabs 301
+/versions/unversioned/sdk/router-native-tabs/ /versions/unversioned/sdk/router/native-tabs 301
 /versions/unversioned/sdk/router-split-view /versions/unversioned/sdk/router/split-view 301
+/versions/unversioned/sdk/router-split-view/ /versions/unversioned/sdk/router/split-view 301
 /versions/v55.0.0/sdk/router-ui /versions/v55.0.0/sdk/router/ui 301
+/versions/v55.0.0/sdk/router-ui/ /versions/v55.0.0/sdk/router/ui 301
 /versions/v55.0.0/sdk/router-native-tabs /versions/v55.0.0/sdk/router/native-tabs 301
+/versions/v55.0.0/sdk/router-native-tabs/ /versions/v55.0.0/sdk/router/native-tabs 301
 /versions/v55.0.0/sdk/router-split-view /versions/v55.0.0/sdk/router/split-view 301
+/versions/v55.0.0/sdk/router-split-view/ /versions/v55.0.0/sdk/router/split-view 301
 /versions/latest/sdk/router-ui /versions/latest/sdk/router/ui 301
+/versions/latest/sdk/router-ui/ /versions/latest/sdk/router/ui 301
 /versions/latest/sdk/router-native-tabs /versions/latest/sdk/router/native-tabs 301
+/versions/latest/sdk/router-native-tabs/ /versions/latest/sdk/router/native-tabs 301
 /versions/latest/sdk/router-split-view /versions/latest/sdk/router/split-view 301
+/versions/latest/sdk/router-split-view/ /versions/latest/sdk/router/split-view 301
 
 # After merging get-started/introduction into get-started/create-a-project
 /get-started/introduction /get-started/create-a-project 301
 
 # After renaming ContextMenu to DropdownMenu in expo-ui (Android)
 /versions/unversioned/sdk/ui/jetpack-compose/contextmenu /versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu 301
+/versions/unversioned/sdk/ui/jetpack-compose/contextmenu/ /versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/contextmenu /versions/v55.0.0/sdk/ui/jetpack-compose/dropdownmenu 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/contextmenu/ /versions/v55.0.0/sdk/ui/jetpack-compose/dropdownmenu 301
 /versions/latest/sdk/ui/jetpack-compose/contextmenu /versions/latest/sdk/ui/jetpack-compose/dropdownmenu 301
+/versions/latest/sdk/ui/jetpack-compose/contextmenu/ /versions/latest/sdk/ui/jetpack-compose/dropdownmenu 301
 
 # After merging FilterChip into Chip in expo-ui (Android)
 /versions/unversioned/sdk/ui/jetpack-compose/filterchip /versions/unversioned/sdk/ui/jetpack-compose/chip 301
+/versions/unversioned/sdk/ui/jetpack-compose/filterchip/ /versions/unversioned/sdk/ui/jetpack-compose/chip 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/filterchip /versions/v55.0.0/sdk/ui/jetpack-compose/chip 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/filterchip/ /versions/v55.0.0/sdk/ui/jetpack-compose/chip 301
 /versions/latest/sdk/ui/jetpack-compose/filterchip /versions/latest/sdk/ui/jetpack-compose/chip 301
+/versions/latest/sdk/ui/jetpack-compose/filterchip/ /versions/latest/sdk/ui/jetpack-compose/chip 301
 
 # After removing TextButton and merging into Button in expo-ui (Android)
 /versions/unversioned/sdk/ui/jetpack-compose/textbutton /versions/unversioned/sdk/ui/jetpack-compose/button 301
+/versions/unversioned/sdk/ui/jetpack-compose/textbutton/ /versions/unversioned/sdk/ui/jetpack-compose/button 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/textbutton /versions/v55.0.0/sdk/ui/jetpack-compose/button 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/textbutton/ /versions/v55.0.0/sdk/ui/jetpack-compose/button 301
 /versions/latest/sdk/ui/jetpack-compose/textbutton /versions/latest/sdk/ui/jetpack-compose/button 301
+/versions/latest/sdk/ui/jetpack-compose/textbutton/ /versions/latest/sdk/ui/jetpack-compose/button 301
 
 # After merging LinearProgress and CircularProgress into Progress in expo-ui (Android)
 /versions/unversioned/sdk/ui/jetpack-compose/linearprogress /versions/unversioned/sdk/ui/jetpack-compose/progress 301
+/versions/unversioned/sdk/ui/jetpack-compose/linearprogress/ /versions/unversioned/sdk/ui/jetpack-compose/progress 301
 /versions/unversioned/sdk/ui/jetpack-compose/circularprogress /versions/unversioned/sdk/ui/jetpack-compose/progress 301
+/versions/unversioned/sdk/ui/jetpack-compose/circularprogress/ /versions/unversioned/sdk/ui/jetpack-compose/progress 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/linearprogress /versions/v55.0.0/sdk/ui/jetpack-compose/progress 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/linearprogress/ /versions/v55.0.0/sdk/ui/jetpack-compose/progress 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/circularprogress /versions/v55.0.0/sdk/ui/jetpack-compose/progress 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/circularprogress/ /versions/v55.0.0/sdk/ui/jetpack-compose/progress 301
 /versions/latest/sdk/ui/jetpack-compose/linearprogress /versions/latest/sdk/ui/jetpack-compose/progress 301
+/versions/latest/sdk/ui/jetpack-compose/linearprogress/ /versions/latest/sdk/ui/jetpack-compose/progress 301
 /versions/latest/sdk/ui/jetpack-compose/circularprogress /versions/latest/sdk/ui/jetpack-compose/progress 301
+/versions/latest/sdk/ui/jetpack-compose/circularprogress/ /versions/latest/sdk/ui/jetpack-compose/progress 301
 
 # Picker replaced by SegmentedButton
 /versions/latest/sdk/ui/jetpack-compose/picker /versions/latest/sdk/ui/jetpack-compose/segmentedbutton 301
+/versions/latest/sdk/ui/jetpack-compose/picker/ /versions/latest/sdk/ui/jetpack-compose/segmentedbutton 301
 /versions/unversioned/sdk/ui/jetpack-compose/picker /versions/unversioned/sdk/ui/jetpack-compose/segmentedbutton 301
+/versions/unversioned/sdk/ui/jetpack-compose/picker/ /versions/unversioned/sdk/ui/jetpack-compose/segmentedbutton 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/picker /versions/v55.0.0/sdk/ui/jetpack-compose/segmentedbutton 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/picker/ /versions/v55.0.0/sdk/ui/jetpack-compose/segmentedbutton 301
 
 # Based on Algolia 404 report 2026-04-01
 /versions/latest/sdk/secure-store /versions/latest/sdk/securestore 301
+/versions/latest/sdk/secure-store/ /versions/latest/sdk/securestore 301
 /versions/latest/sdk/av /versions/v54.0.0/sdk/av 301
+/versions/latest/sdk/av/ /versions/v54.0.0/sdk/av 301
 /versions/latest/sdk/ui/jetpack-compose/floatingactionbutton /versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton 301
+/versions/latest/sdk/ui/jetpack-compose/floatingactionbutton/ /versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton 301
 
 # TextInput renamed to TextField
 /versions/latest/sdk/ui/jetpack-compose/textinput /versions/latest/sdk/ui/jetpack-compose/textfield 301
+/versions/latest/sdk/ui/jetpack-compose/textinput/ /versions/latest/sdk/ui/jetpack-compose/textfield 301
 /versions/unversioned/sdk/ui/jetpack-compose/textinput /versions/unversioned/sdk/ui/jetpack-compose/textfield 301
+/versions/unversioned/sdk/ui/jetpack-compose/textinput/ /versions/unversioned/sdk/ui/jetpack-compose/textfield 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/textinput /versions/v55.0.0/sdk/ui/jetpack-compose/textfield 301
+/versions/v55.0.0/sdk/ui/jetpack-compose/textinput/ /versions/v55.0.0/sdk/ui/jetpack-compose/textfield 301
 
 # EAS Build, Submit, Update, and Insights predate the /eas/* URL convention;
 /eas/build/* /build/:splat 301
 /eas/build /build/introduction 301
+/eas/build/ /build/introduction 301
 /eas/submit/ /deploy/submit-to-app-stores 301
 /eas/submit/* /submit/:splat 301
 /eas/submit /deploy/submit-to-app-stores 301
 /eas/update/* /eas-update/:splat 301
 /eas/update /eas-update/introduction 301
+/eas/update/ /eas-update/introduction 301
 /eas/insights/* /eas-insights/:splat 301
 /eas/insights /eas-insights/introduction 301
+/eas/insights/ /eas-insights/introduction 301
 
 # EAS Submit introduction merged into the Submit to app stores overview
 /submit/introduction /deploy/submit-to-app-stores 301
@@ -383,11 +630,15 @@
 
 # After archiving Configure JS engines guide
 /guides/configuring-js-engines/ /archive/configuring-js-engines/ 301
+/guides/configuring-js-engines /archive/configuring-js-engines/ 301
 
 # After merging development build pages into the introduction (guided paths)
 /develop/development-builds/create-a-build /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/develop/development-builds/create-a-build/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
 /develop/development-builds/expo-go-to-dev-build /develop/development-builds/introduction/#build-locally 301
+/develop/development-builds/expo-go-to-dev-build/ /develop/development-builds/introduction/#build-locally 301
 /develop/development-builds/next-steps /develop/development-builds/faq/ 301
+/develop/development-builds/next-steps/ /develop/development-builds/faq/ 301
 
 
 # After Algolia 404 report on 2026-07-13


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25419

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add the trailing-slash sibling for every exact rule in `public/_redirects` (251 rules), since Cloudflare matches sources exactly while the site canonicalizes URLs with a trailing slash.
- Add `checks/check-redirects.test.ts` to enforce that every exact rule covers both URL forms with matching destinations, and that the file stays within Cloudflare's 2,000 static-rule limit.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `node --experimental-strip-types --experimental-vm-modules ./node_modules/jest/bin/jest.js checks/check-redirects.test.ts` and it should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
