### PR TITLE
[docs] Fix contrast of unselected package manager tab labels

### DIFF
--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -205,7 +205,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
             'rounded-md px-2 py-1 text-sm font-semibold transition-colors',
             isActive
               ? 'bg-palette-gray6 text-palette-white'
-              : 'text-palette-gray9 hocus:bg-palette-gray5'
+              : 'text-palette-gray11 hocus:bg-palette-gray5'
           )}
           onClick={() => {
             onSelect(manager);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25420

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix contrast of unselected package manager tab labels by using `gray11` color value from styleguide's design system.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2378" height="734" alt="CleanShot 2026-07-24 at 12 56 48@2x" src="https://github.com/user-attachments/assets/006f3258-661a-4353-8bbb-98cc7e26a3ec" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
