### PR TITLE
[expo-navigation-bar] Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown.
 - Polyfill `enforceContrast` on Android 8 and 9. ([#47382](https://github.com/expo/expo/pull/47382) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown.
+- Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown. ([#48097](https://github.com/expo/expo/pull/48097) by [@zoontek](https://github.com/zoontek))
 - Polyfill `enforceContrast` on Android 8 and 9. ([#47382](https://github.com/expo/expo/pull/47382) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others

--- a/packages/expo-navigation-bar/src/NavigationBar.android.ts
+++ b/packages/expo-navigation-bar/src/NavigationBar.android.ts
@@ -77,7 +77,7 @@ export function setStyle(style: NavigationBarStyle) {
 
   if (resolvedStyle !== currentValues.style) {
     currentValues.style = resolvedStyle;
-    ExpoNavigationBar.setStyle(resolvedStyle);
+    ExpoNavigationBar.setStyle(resolvedStyle).catch(() => {});
   }
 }
 
@@ -86,7 +86,7 @@ function setHidden(hidden: boolean) {
 
   if (hidden !== currentValues.hidden) {
     currentValues.hidden = hidden;
-    ExpoNavigationBar.setHidden(hidden);
+    ExpoNavigationBar.setHidden(hidden).catch(() => {});
   }
 }
 


### PR DESCRIPTION
# Why

Follow https://github.com/expo/expo/pull/48084

The declarative `NavigationBar` component updates Android through asynchronous native methods, but its internal `setStyle` and `setHidden` helpers do not return those promises to the caller.

If an update races with activity teardown, the native promise can reject after the component has already unmounted. Because this internal best-effort update has no consumer, the rejection becomes an unhandled promise rejection and can surface as a LogBox error.

# How

Consume rejections from the two declarative native updates. The public async visibility API remains unchanged and still propagates its rejection to callers.

# Test Plan

- `pnpm run lint`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
