### PR TITLE
[plugins] Add the dev server port to info.plist

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -402,6 +402,9 @@ PODS:
     - SDWebImageWebPCoder
   - ExpoImagePicker (56.0.14):
     - ExpoModulesCore
+  - ExpoImagePicker/Tests (56.0.14):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
   - ExpoInsights (56.0.14):
     - EASClient
     - ExpoModulesCore
@@ -3385,6 +3388,7 @@ DEPENDENCIES:
   - ExpoImage/Tests (from `../../../packages/expo-image/ios`)
   - ExpoImageManipulator (from `../../../packages/expo-image-manipulator/ios`)
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
+  - ExpoImagePicker/Tests (from `../../../packages/expo-image-picker/ios`)
   - ExpoInsights (from `../../../packages/expo-insights/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
@@ -4061,7 +4065,7 @@ SPEC CHECKSUMS:
   ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
   ExpoImageManipulator: 441ca8a28fe700c5948863772578bab2ffd79e77
-  ExpoImagePicker: 30a39958c3c92b3cf33534489db0b63d9ca13da3
+  ExpoImagePicker: 25027f16965fca672abf93c2a79d22e71527b53f
   ExpoInsights: 06e193356e22f9cf82e9e07d002b4cbf923a19fc
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
@@ -4108,7 +4112,7 @@ SPEC CHECKSUMS:
   EXUpdates: c6488f0bebe92d6decb5f9b685d33ee91feeccf0
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: e355eb94d3f8b7f4c08531a4d42af958d36c13de
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   JestMockSchema: 96b4cfec246644f6323d1c30693b6a02044be1e6
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -167,6 +167,9 @@ PODS:
     - SDWebImageWebPCoder
   - ExpoImagePicker (56.0.14):
     - ExpoModulesCore
+  - ExpoImagePicker/Tests (56.0.14):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
   - ExpoKeepAwake (56.0.3):
     - ExpoModulesCore
   - ExpoLinearGradient (56.0.4):
@@ -4183,6 +4186,7 @@ DEPENDENCIES:
   - ExpoImage/Tests (from `../../../packages/expo-image/ios`)
   - ExpoImageManipulator (from `../../../packages/expo-image-manipulator/ios`)
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
+  - ExpoImagePicker/Tests (from `../../../packages/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
   - ExpoLinking (from `../../../packages/expo-linking/ios`)
@@ -4766,7 +4770,7 @@ SPEC CHECKSUMS:
   ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
   ExpoImageManipulator: 441ca8a28fe700c5948863772578bab2ffd79e77
-  ExpoImagePicker: 30a39958c3c92b3cf33534489db0b63d9ca13da3
+  ExpoImagePicker: 25027f16965fca672abf93c2a79d22e71527b53f
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
   ExpoLinking: 82458b046854a5802092a37a5228a8a228f928a4
@@ -4820,7 +4824,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: d5c6d584ad5c5461ad9e34e0afb5d40d56e428f5
+  hermes-engine: 42f0ed2cf70592b35e2ca49a6b725d31c8ad4136
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add `IOSConfig.DevServer.withMetroPort` to write the `RCTMetroPort` Info.plist key from the `RCT_METRO_PORT` build setting. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 - Honor `ios.version` and `android.version` in `Updates.getAppVersion`, `Updates.getNativeVersion`, and the `appVersion` runtime version policy. Previously the platform-specific overrides were ignored, so projects that used only `ios.version`/`android.version` (with no top-level `version` in `app.json`) received the `package.json` fallback (or `"1.0.0"`) wherever these helpers were consumed. `Updates.getAppVersion` gains an optional `platform` argument; passing it prefers the platform-specific override, and calls without a platform keep the previous behavior. Also fixes `Updates.getNativeVersion` on Android, which previously used the iOS version for the `${version}` component. ([#47416](https://github.com/expo/expo/pull/47416) by [@tlenahan](https://github.com/tlenahan))

--- a/packages/@expo/config-plugins/src/ios/DevServer.ts
+++ b/packages/@expo/config-plugins/src/ios/DevServer.ts
@@ -1,0 +1,24 @@
+import type { ExpoConfig } from '@expo/config-types';
+
+import type { InfoPlist } from './IosConfig.types';
+import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+
+/**
+ * Info.plist key read by expo's native runtime (`ExpoReactNativeFactory`) to resolve the Metro
+ * dev server port at launch. It is set to the `RCT_METRO_PORT` build setting so that
+ * `expo run:ios --port <n>` flows through to the app.
+ *
+ * Prebuilt React freezes the compile-time `RCT_METRO_PORT` at `8081`, so without this a bare dev
+ * build (no `expo-dev-client`) always defaults to `:8081` and multiple running projects collide on
+ * a single dev server. This is the iOS analog of Android's `react_native_dev_server_port` resource.
+ */
+export const METRO_PORT_INFO_PLIST_KEY = 'RCTMetroPort';
+
+export const withMetroPort = createInfoPlistPlugin(setMetroPort, 'withMetroPort');
+
+export function setMetroPort(_config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist {
+  return {
+    ...infoPlist,
+    [METRO_PORT_INFO_PLIST_KEY]: '$(RCT_METRO_PORT)',
+  };
+}

--- a/packages/@expo/config-plugins/src/ios/index.ts
+++ b/packages/@expo/config-plugins/src/ios/index.ts
@@ -4,6 +4,7 @@ export * as BuildScheme from './BuildScheme';
 export * as BundleIdentifier from './BundleIdentifier';
 export * as DeploymentTarget from './DeploymentTarget';
 export * as DevelopmentTeam from './DevelopmentTeam';
+export * as DevServer from './DevServer';
 export * as DeviceFamily from './DeviceFamily';
 export * as Entitlements from './Entitlements';
 export * as Google from './Google';

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Generated iOS projects now include a `SceneDelegate` and `UIApplicationSceneManifest` for the scene-based life cycle. ([#46734](https://github.com/expo/expo/pull/46734) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Write the `RCTMetroPort` Info.plist key so bare dev builds resolve their own Metro port instead of defaulting to 8081. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -151,6 +151,7 @@ exports[`built-in plugins compiles mods 1`] = `
         "NSAllowsLocalNetworking": true,
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+      "RCTMetroPort": "$(RCT_METRO_PORT)",
       "UIApplicationSceneManifest": {
         "UIApplicationSupportsMultipleScenes": false,
         "UISceneConfigurations": {
@@ -882,6 +883,7 @@ exports[`built-in plugins introspects mods 1`] = `
             "NSAllowsLocalNetworking": true,
           },
           "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+          "RCTMetroPort": "$(RCT_METRO_PORT)",
           "UIApplicationSceneManifest": {
             "UIApplicationSupportsMultipleScenes": false,
             "UISceneConfigurations": {
@@ -1070,6 +1072,7 @@ exports[`built-in plugins introspects mods 1`] = `
         "NSAllowsLocalNetworking": true,
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+      "RCTMetroPort": "$(RCT_METRO_PORT)",
       "UIApplicationSceneManifest": {
         "UIApplicationSupportsMultipleScenes": false,
         "UISceneConfigurations": {
@@ -1533,6 +1536,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
             },
           },
           "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+          "RCTMetroPort": "$(RCT_METRO_PORT)",
           "UILaunchStoryboardName": "SplashScreen",
           "UIRequiredDeviceCapabilities": [
             "armv7",
@@ -1712,6 +1716,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
         },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+      "RCTMetroPort": "$(RCT_METRO_PORT)",
       "UILaunchStoryboardName": "SplashScreen",
       "UIRequiredDeviceCapabilities": [
         "armv7",

--- a/packages/@expo/prebuild-config/src/plugins/withDefaultPlugins.ts
+++ b/packages/@expo/prebuild-config/src/plugins/withDefaultPlugins.ts
@@ -40,6 +40,7 @@ export const withIosExpoPlugins: ConfigPlugin<{
     IOSConfig.Orientation.withOrientation,
     IOSConfig.RequiresFullScreen.withRequiresFullScreen,
     IOSConfig.Scheme.withScheme,
+    IOSConfig.DevServer.withMetroPort,
     IOSConfig.UsesNonExemptEncryption.withUsesNonExemptEncryption,
     IOSConfig.Version.withBuildNumber,
     IOSConfig.Version.withVersion,

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### 💡 Others
 
 - [iOS] Replace dev-menu swizzling and reflection into React Native internals with public APIs. ([#47638](https://github.com/expo/expo/pull/47638) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Remove the manual packager socket reconnect now that the bundle configuration resolves the dev server host. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 56.0.15 — 2026-05-26
 

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -37,14 +37,6 @@ class DevMenuPackagerConnectionHandler {
         queue: DispatchQueue.main,
         forMethod: "devMenu"
       )
-
-      // RCTDevSettings starts the packager WS before its bundleManager has a host,
-      // leaving the socket on localhost so it can't be reached from a physical device.
-      // Reconnect to the bundle URL once AppContext is ready.
-      if let bundleURL = manager.currentAppContext?.bundleURL, let host = bundleURL.host {
-        let port = bundleURL.port ?? 8081
-        packagerConnection?.reconnect("\(host):\(port)")
-      }
     }
 #endif
   }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix `import.meta.url` being `null` on web when read after the bundle's synchronous execution (from effects, async code, or dynamic imports). ([#47802](https://github.com/expo/expo/pull/47802) by [@zoontek](https://github.com/zoontek))
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets. ([#47894](https://github.com/expo/expo/pull/47894) by [@jakex7](https://github.com/jakex7))
 - [iOS] Add ExpoBundleConfiguration to derive RCTBundleConfiguration from the normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
+- [iOS] Resolve the dev server port from the `RCTMetroPort` Info.plist key at runtime so bare projects without expo-dev-client connect to their own Metro instance instead of defaulting to 8081. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -33,6 +33,7 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
         return _bundleConfiguration
       }
 #if os(iOS) || os(tvOS)
+      adoptInfoPlistMetroPort()
       return ExpoBundleConfiguration.configuration(bundleURL: self.delegate?.bundleURL())
 #else
       return super.bundleConfiguration
@@ -42,6 +43,31 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       _bundleConfiguration = newValue
     }
   }
+
+#if os(iOS) || os(tvOS)
+  private func adoptInfoPlistMetroPort() {
+#if DEBUG
+    if NSClassFromString("EXDevLauncherController") != nil {
+      return
+    }
+    guard let port = Bundle.main.object(forInfoDictionaryKey: "RCTMetroPort") as? String,
+      !port.isEmpty else {
+      return
+    }
+    var host = "localhost"
+    if let ipPath = Bundle.main.path(forResource: "ip", ofType: "txt"),
+      let ip = try? String(contentsOfFile: ipPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+      !ip.isEmpty {
+      host = ip
+    }
+    let settings = RCTBundleURLProvider.sharedSettings()
+    let target = "\(host):\(port)"
+    if settings.jsLocation != target {
+      settings.jsLocation = target
+    }
+#endif
+  }
+#endif
 
   @MainActor
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {
@@ -91,6 +117,10 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
         return bundleURL
       }
     }
+
+#if os(iOS) || os(tvOS)
+    adoptInfoPlistMetroPort()
+#endif
 
     let rootView: UIView
     if let factory = self.rootViewFactory as? ExpoReactRootViewFactory {


### PR DESCRIPTION
# Why

Follow up of #48010

Bare debug builds that don't use `expo-dev-client` always default the Metro port to `8081`. `RCT_METRO_PORT` is a compile-time macro that gets frozen at `8081` in prebuilt React, so the app has no runtime channel to learn the real port. Start two bare projects at once and their command sockets collide. The bundle loads from the correct server, but packager commands (reload, dev menu) from the first instance are acknowledged by both apps.

Android doesn't have this problem because it resolves the port at runtime from the `react_native_dev_server_port` resource.

# How

- **Config plugin.** A new `withMetroPort` plugin in  writes `RCTMetroPort = $(RCT_METRO_PORT)` into `Info.plist`, wired into prebuild through `withDefaultPlugins`. 

- **Runtime read.** `ExpoReactNativeFactory` reads `RCTMetroPort` from the plist at launch and seeds `RCTBundleURLProvider.jsLocation`, so both the bundle and the command socket resolve the right host and port. When `EXDevLauncherController` is present it bails, because dev-client owns server discovery and must not be overridden.

- **Cleanup.** With the socket host now seeded correctly at init through `EXBundleConfiguration`, the manual packager reconnect in `DevMenuPackagerConnectionHandler` is redundant and has been removed. It existed to work
around `RCTDevSettings` opening the socket on localhost before the host was known.

# Test Plan

- Two bare apps prebuilt and run on `8081` and `8082`. Before this change, commands from the first app were acknowledged by both. Now each app responds only to its own packager, and the behavior survives a reload.
- `bare-expo` on a physical device. Reload and dev menu commands work, confirming `EXBundleConfiguration` seeds the socket correctly without the manual reconnect.
- Expo Go is unaffected. It links no dev-launcher, has no `RCTMetroPort` key, and uses its own `setupWebSocketControls`. Its socket correctness comes from #48010.

