### PR TITLE
[ios][dev-launcher] Strip permissions keys only in release builds

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [Android] Forward the launching intent's extras when cold-launching the most recently opened bundle, so launch arguments (e.g. from Maestro/Detox or `adb am start -e`) reach the app and `react-native-launch-arguments` can read them. ([#47352](https://github.com/expo/expo/pull/47352) by [@kanzelm3](https://github.com/kanzelm3))
 - [iOS] Fix Release build failure from an unguarded call to `RCTBundleURLProviderAllowPackagerServerAccess`. ([#47688](https://github.com/expo/expo/pull/47688) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Fix onUserLeaveHint NPE and lost EAS sign-in redirect. ([#47347](https://github.com/expo/expo/pull/47347) by [@vicprz](https://github.com/vicprz))
+- [iOS] Keep the dev-launcher local network Info.plist keys in custom debug build configurations instead of only a configuration literally named "Debug".
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -13,12 +13,13 @@ const pkg = require('../../package.json');
 
 /**
  * Adds a build phase script that strips dev-launcher-specific local network permission keys
- * from non-Debug builds. This keeps the keys in Debug builds (where dev-launcher is active)
- * but removes only the dev-launcher entries from production builds.
+ * from release builds. It keeps the keys in any debug build, detected via the DEBUG compile
+ * condition rather than the configuration name, so custom debug configurations (e.g. "Dev",
+ * "Staging") keep working. Only the dev-launcher entries are removed from release builds.
  *
  * IMPORTANT: This script only removes _expo._tcp Bonjour services and the dev-launcher
  * usage description. Any other Bonjour services or custom local network descriptions
- * added by the app will be preserved in production builds.
+ * added by the app will be preserved in release builds.
  */
 const withStripLocalNetworkKeysForRelease: ConfigPlugin = (config) => {
   return withXcodeProject(config, (config) => {
@@ -44,13 +45,25 @@ const withStripLocalNetworkKeysForRelease: ConfigPlugin = (config) => {
       return config;
     }
 
-    project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
-      shellPath: '/bin/sh',
-      shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
+    project.addBuildPhase(
+      [],
+      'PBXShellScriptBuildPhase',
+      buildPhaseName,
+      nativeTargetId,
+      {
+        shellPath: '/bin/sh',
+        shellScript: `# Strip dev-launcher-specific local network permission keys from release builds.
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.
+#
+# Detect debug builds via the DEBUG compile condition rather than the configuration name,
+# so custom debug configurations (e.g. "Dev", "Staging") that define DEBUG keep the keys.
+case " $SWIFT_ACTIVE_COMPILATION_CONDITIONS " in
+  *" DEBUG "*) IS_DEBUG_BUILD=1 ;;
+  *) IS_DEBUG_BUILD=0 ;;
+esac
 
-if [ "$CONFIGURATION" != "Debug" ]; then
+if [ "$IS_DEBUG_BUILD" != "1" ]; then
   PLIST_PATH="\${TARGET_BUILD_DIR}/\${INFOPLIST_PATH}"
   if [ -f "$PLIST_PATH" ]; then
     # Check if NSBonjourServices exists
@@ -81,7 +94,9 @@ if [ "$CONFIGURATION" != "Debug" ]; then
   fi
 fi
 `,
-    }, undefined);
+      },
+      undefined
+    );
 
     const targetPhases: { value: string; comment?: string }[] =
       project.pbxNativeTargetSection()[nativeTargetId]?.buildPhases ?? [];


### PR DESCRIPTION
# Why

Dev clients built under a custom debug-like configuration (for example Dev or Staging) silently lost dev server discovery. The config plugin's release-strip build phase keyed off the configuration being literally named Debug, so any other name had _expo._tcp and the usage description stripped from its Info.plist.

# How
The strip build phase now decides whether a build is a debug build from the DEBUG compile condition (SWIFT_ACTIVE_COMPILATION_CONDITIONS) rather than the configuration name. Configurations cloned from Debug keep DEBUG defined and so keep the keys, while real release builds still get only the dev-launcher entries removed. The app's own Bonjour services and custom descriptions are untouched.

# Test Plan
Ran prebuild --clean on the sandbox app and verified the plist state
- Debug and a custom Dev . _expo._tcp and the usage description are kept.
- Release: only the dev-launcher entries are removed, an app-provided entries are preserved.

