### PR TITLE
[ios][dev-launcher] Improve local network permission detection

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -27,6 +27,8 @@
 - [iOS] Fix Release build failure from an unguarded call to `RCTBundleURLProviderAllowPackagerServerAccess`. ([#47688](https://github.com/expo/expo/pull/47688) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Fix onUserLeaveHint NPE and lost EAS sign-in redirect. ([#47347](https://github.com/expo/expo/pull/47347) by [@vicprz](https://github.com/vicprz))
 - [iOS] Keep the dev-launcher local network Info.plist keys in custom debug build configurations instead of only a configuration literally named "Debug".
+- [iOS] Report a distinct "discovery isn't configured" message and stop mislabeling a missing Info.plist entry, no network, or a pending system prompt as a denied Local Network permission.
+- [iOS] Stop triggering the Local Network permission prompt at launch by suppressing the React Native packager check until a development server is selected.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
++ (void)disablePackagerServerAccess;
+
 - (void)start:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions;
 
 - (nullable NSURL *)sourceUrl;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -180,13 +180,18 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 #endif
 }
 
-- (void)start:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions
++ (void)disablePackagerServerAccess
 {
 #if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
-  // Matches the guard on the declaration in React/Base/RCTBundleURLProvider.h.
-  // The function isn't declared in builds without packager support.
+  // Guarded because the function isn't declared in builds without packager support
+  // (matches the guard in React/Base/RCTBundleURLProvider.h).
   RCTBundleURLProviderAllowPackagerServerAccess(NO);
 #endif
+}
+
+- (void)start:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions
+{
+  [EXDevLauncherController disablePackagerServerAccess];
 
   _delegate = delegate;
   _launchOptions = launchOptions;

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
@@ -4,10 +4,22 @@ import ExpoModulesCore
 
 public class ExpoDevLauncherAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   #if !os(macOS)
+  public func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    EXDevLauncherController.disablePackagerServerAccess()
+    return true
+  }
+
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     return EXDevLauncherController.sharedInstance().onDeepLink(url, options: options)
   }
   #else
+  public func applicationDidFinishLaunching(_ notification: Notification) {
+    EXDevLauncherController.disablePackagerServerAccess()
+  }
+
   public func application(_ app: NSApplication, open urls: [URL]) {
     EXDevLauncherController.sharedInstance().onDeepLink(urls[0], options: [:])
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -18,6 +18,7 @@ enum LocalNetworkPermissionStatus: Equatable, Sendable {
   case checking
   case granted
   case denied
+  case misconfigured
 }
 
 @MainActor
@@ -292,17 +293,38 @@ class DevLauncherViewModel: ObservableObject {
   func refreshPermissionStatus() {
     permissionStatus = .checking
     Task {
-      let hasAccess = await checkLocalNetworkAccess()
-      permissionStatus = hasAccess ? .granted : .denied
+      let verdict = await checkLocalNetworkAccess()
+      switch verdict {
+      case .granted:
+        markNetworkPermissionGranted()
+      case .denied:
+        permissionStatus = .denied
+      case .misconfigured:
+        permissionStatus = .misconfigured
+      case .undetermined:
+        permissionStatus = .unknown
+      }
     }
   }
 
-  func checkLocalNetworkAccess() async -> Bool {
+  func checkLocalNetworkAccess() async -> LocalNetworkVerdict {
+    if !LocalNetworkConfig.isConfigured(in: Bundle.main.infoDictionary) {
+      return .misconfigured
+    }
+
     let serviceType = BONJOUR_TYPE
     let queue = DispatchQueue(label: "expo.devlauncher.permissioncheck")
 
     return await withCheckedContinuation { continuation in
       var done = false
+
+      func finish(_ verdict: LocalNetworkVerdict, _ browser: NWBrowser, _ listener: NWListener?) {
+        guard !done else { return }
+        done = true
+        continuation.resume(returning: verdict)
+        browser.cancel()
+        listener?.cancel()
+      }
 
       let listener = try? NWListener(using: .tcp, on: .any)
       listener?.service = NWListener.Service(type: serviceType)
@@ -312,35 +334,51 @@ class DevLauncherViewModel: ObservableObject {
 
       let browser = NWBrowser(for: .bonjour(type: serviceType, domain: nil), using: .tcp)
       browser.browseResultsChangedHandler = { results, _ in
-        guard !done else { return }
         if !results.isEmpty {
-          done = true
-          continuation.resume(returning: true)
-          browser.cancel()
-          listener?.cancel()
+          finish(.granted, browser, listener)
         }
       }
 
       browser.stateUpdateHandler = { state in
-        guard !done else { return }
-        if case .waiting(let error) = state,
-           case .dns(let dnsError) = error,
-           dnsError == kDNSServiceErr_PolicyDenied {
-          done = true
-          continuation.resume(returning: false)
-          browser.cancel()
-          listener?.cancel()
+        switch state {
+        case .waiting(let error), .failed(let error):
+          if case .dns(let dnsError) = error {
+            let verdict = LocalNetworkClassifier.verdict(forDNSError: Int(dnsError))
+            // Leave `.undetermined` for the timeout: the system prompt may still be pending.
+            if verdict != .undetermined {
+              finish(verdict, browser, listener)
+            }
+          }
+        default:
+          break
         }
       }
 
       browser.start(queue: queue)
 
-      queue.asyncAfter(deadline: .now() + 2) {
-        guard !done else { return }
-        done = true
+      queue.asyncAfter(deadline: .now() + 4) {
+        finish(.undetermined, browser, listener)
+      }
+    }
+  }
+
+  func hasSatisfiedNetworkPath() async -> Bool {
+    return await withCheckedContinuation { continuation in
+      let monitor = NWPathMonitor()
+      let queue = DispatchQueue(label: "expo.devlauncher.pathcheck")
+      var resumed = false
+      monitor.pathUpdateHandler = { path in
+        guard !resumed else { return }
+        resumed = true
+        continuation.resume(returning: path.status == .satisfied)
+        monitor.cancel()
+      }
+      monitor.start(queue: queue)
+      queue.asyncAfter(deadline: .now() + 1) {
+        guard !resumed else { return }
+        resumed = true
         continuation.resume(returning: false)
-        browser.cancel()
-        listener?.cancel()
+        monitor.cancel()
       }
     }
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkConfig.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkConfig.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+enum LocalNetworkConfig {
+  static let bonjourServiceType = "_expo._tcp"
+
+  static func isConfigured(in infoDictionary: [String: Any]?) -> Bool {
+    guard let infoDictionary else {
+      return false
+    }
+    guard let description = infoDictionary["NSLocalNetworkUsageDescription"] as? String,
+      !description.isEmpty else {
+      return false
+    }
+    guard let services = infoDictionary["NSBonjourServices"] as? [String] else {
+      return false
+    }
+    return services.contains { normalized($0) == bonjourServiceType }
+  }
+
+  private static func normalized(_ service: String) -> String {
+    var value = service.lowercased()
+    if value.hasSuffix(".") {
+      value.removeLast()
+    }
+    return value
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -11,6 +11,9 @@ struct LocalNetworkPermissionView: View {
   @State private var showNoAccessMessage = false
   @State private var showTryAgainFailedAlert = false
   @State private var showAlreadyGrantedAlert = false
+  @State private var showMisconfiguredAlert = false
+  @State private var showCouldNotVerifyAlert = false
+  @State private var couldNotVerifyMessage = ""
 
   private var isDenied: Bool {
     viewModel.permissionStatus == .denied
@@ -73,6 +76,16 @@ struct LocalNetworkPermissionView: View {
       Text("Local network access is already enabled. You're all set!")
         .multilineTextAlignment(.center)
     }
+    .alert("Dev Server Discovery Isn't Set Up", isPresented: $showMisconfiguredAlert) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text("iOS is blocking discovery because this build's Info.plist is missing the \"_expo._tcp\" Bonjour entry. This is separate from the Local Network permission. Make sure the expo-dev-client config plugin is applied, then re-run \"npx expo prebuild --clean\" and rebuild.")
+    }
+    .alert("Couldn't Verify Access", isPresented: $showCouldNotVerifyAlert) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(couldNotVerifyMessage)
+    }
   }
 
   private var continueButton: some View {
@@ -112,13 +125,8 @@ struct LocalNetworkPermissionView: View {
       .foregroundColor(.white)
       .cornerRadius(12)
 
-      checkAccessButton(label: "I was not prompted") { hasAccess in
-        if hasAccess {
-          showAlreadyGrantedAlert = true
-        } else {
-          showNoAccessMessage = true
-          showTryAgainFailedAlert = true
-        }
+      checkAccessButton(label: "I was not prompted") { verdict in
+        handleCheckVerdict(verdict, onGranted: { showAlreadyGrantedAlert = true })
       }
     }
   }
@@ -147,13 +155,11 @@ struct LocalNetworkPermissionView: View {
       .foregroundColor(.primary)
       .cornerRadius(12)
 
-      checkAccessButton(label: "Try Again") { hasAccess in
-        if hasAccess {
+      checkAccessButton(label: "Try Again") { verdict in
+        handleCheckVerdict(verdict, onGranted: {
           viewModel.startServerDiscovery()
           onContinue()
-        } else {
-          showTryAgainFailedAlert = true
-        }
+        })
       }
 
       Button {
@@ -170,14 +176,34 @@ struct LocalNetworkPermissionView: View {
     }
   }
 
-  private func checkAccessButton(label: String, onResult: @escaping (Bool) -> Void) -> some View {
+  private func handleCheckVerdict(_ verdict: LocalNetworkVerdict, onGranted: @escaping () -> Void) {
+    switch verdict {
+    case .granted:
+      onGranted()
+    case .denied:
+      showNoAccessMessage = true
+      showTryAgainFailedAlert = true
+    case .misconfigured:
+      showMisconfiguredAlert = true
+    case .undetermined:
+      Task {
+        let hasNetwork = await viewModel.hasSatisfiedNetworkPath()
+        couldNotVerifyMessage = hasNetwork
+          ? "Couldn't verify local network access. If the system prompt didn't appear, make sure a dev server is running and try again. You can also check Settings \u{2192} Privacy & Security \u{2192} Local Network."
+          : "No network connection. Connect to Wi-Fi and try again to discover development servers running on your computer."
+        showCouldNotVerifyAlert = true
+      }
+    }
+  }
+
+  private func checkAccessButton(label: String, onResult: @escaping (LocalNetworkVerdict) -> Void) -> some View {
     Button {
       isCheckingAccess = true
       viewModel.stopServerDiscovery()
       Task {
-        let hasAccess = await viewModel.checkLocalNetworkAccess()
+        let verdict = await viewModel.checkLocalNetworkAccess()
         isCheckingAccess = false
-        onResult(hasAccess)
+        onResult(verdict)
       }
     } label: {
       if isCheckingAccess {

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkVerdict.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkVerdict.swift
@@ -1,0 +1,25 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import dnssd
+
+enum LocalNetworkVerdict: Equatable {
+  case granted
+  case denied
+  case misconfigured
+  case undetermined
+}
+
+enum LocalNetworkClassifier {
+  static func verdict(forDNSError code: Int) -> LocalNetworkVerdict {
+    switch code {
+    case Int(kDNSServiceErr_PolicyDenied):
+      return .denied
+    // Undocumented signal for a missing NSBonjourServices entry; best-effort only.
+    case Int(kDNSServiceErr_NoAuth):
+      return .misconfigured
+    default:
+      return .undetermined
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -81,7 +81,7 @@ struct SettingsTabView: View {
     .task {
       viewModel.refreshPermissionStatus()
     }
-    .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+    .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
       viewModel.refreshPermissionStatus()
     }
     #endif
@@ -323,6 +323,8 @@ struct SettingsTabView: View {
       return ("Allowed", "checkmark.circle.fill", .green)
     case .denied:
       return ("Not allowed", "xmark.circle.fill", .red)
+    case .misconfigured:
+      return ("Not configured", "exclamationmark.triangle.fill", .orange)
     case .checking, .unknown:
       return nil
     }

--- a/packages/expo-dev-launcher/ios/Tests/LocalNetworkConfigTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/LocalNetworkConfigTests.swift
@@ -1,0 +1,53 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import EXDevLauncher
+
+class LocalNetworkConfigTests: XCTestCase {
+  private func plist(services: Any?, description: Any?) -> [String: Any] {
+    var dict: [String: Any] = [:]
+    if let services { dict["NSBonjourServices"] = services }
+    if let description { dict["NSLocalNetworkUsageDescription"] = description }
+    return dict
+  }
+
+  func testConfiguredWhenServiceAndDescriptionPresent() {
+    let dict = plist(services: ["_expo._tcp"], description: "Discover dev servers")
+    XCTAssertTrue(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testServiceMatchIsCaseInsensitive() {
+    let dict = plist(services: ["_Expo._TCP"], description: "x")
+    XCTAssertTrue(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testServiceMatchToleratesTrailingDot() {
+    let dict = plist(services: ["_expo._tcp."], description: "x")
+    XCTAssertTrue(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testNotConfiguredWhenBonjourServiceMissing() {
+    let dict = plist(services: ["_other._tcp"], description: "x")
+    XCTAssertFalse(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testNotConfiguredWhenBonjourKeyAbsent() {
+    let dict = plist(services: nil, description: "x")
+    XCTAssertFalse(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testNotConfiguredWhenDescriptionMissing() {
+    let dict = plist(services: ["_expo._tcp"], description: nil)
+    XCTAssertFalse(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testNotConfiguredWhenDescriptionEmpty() {
+    let dict = plist(services: ["_expo._tcp"], description: "")
+    XCTAssertFalse(LocalNetworkConfig.isConfigured(in: dict))
+  }
+
+  func testNotConfiguredWhenNil() {
+    XCTAssertFalse(LocalNetworkConfig.isConfigured(in: nil))
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/LocalNetworkVerdictTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/LocalNetworkVerdictTests.swift
@@ -1,0 +1,24 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+import dnssd
+
+@testable import EXDevLauncher
+
+class LocalNetworkVerdictTests: XCTestCase {
+  func testPolicyDeniedMapsToDenied() {
+    XCTAssertEqual(LocalNetworkClassifier.verdict(forDNSError: Int(kDNSServiceErr_PolicyDenied)), .denied)
+  }
+
+  func testNoAuthMapsToMisconfigured() {
+    XCTAssertEqual(LocalNetworkClassifier.verdict(forDNSError: Int(kDNSServiceErr_NoAuth)), .misconfigured)
+  }
+
+  func testUnknownCodeMapsToUndetermined() {
+    XCTAssertEqual(LocalNetworkClassifier.verdict(forDNSError: Int(kDNSServiceErr_Timeout)), .undetermined)
+  }
+
+  func testZeroMapsToUndetermined() {
+    XCTAssertEqual(LocalNetworkClassifier.verdict(forDNSError: 0), .undetermined)
+  }
+}


### PR DESCRIPTION
# Why

The launcher reported "Permission Not Granted" even when Local Network access was enabled. The detection treated only one signal as denied and collapsed everything else (a missing Info.plist entry, no network, or a still-pending system prompt) into a denial, sending people to a Settings toggle that was already on. 

# How
Detection now returns a based on three checks. The app's own Info.plist and reports a distinct "discovery isn't configured" state for a missing plist entry, keeps denied only for the documented kDNSServiceErr_PolicyDenied signal, and treats a timeout as "couldn't verify" rather than a denial. The probe also handles the .failed browser state, only runs while the app is foreground-active, and persists the granted flag on any successful probe so people who grant without a running server stop re-seeing onboarding. To stop the launch-time prompt, packager access is now disabled from the app delegate subscriber before the scene starts React Native, and re-enabled once a dev server is selected.

# Test Plan
Granting works, an actually-denied permission shows the denial, Wi-Fi off shows the no-network message, and granting with no server running does not repeat onboarding.

