### PR TITLE
[ios][dev-launcher] Improve dev server connection and discovery error reporting

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -29,6 +29,8 @@
 - [iOS] Keep the dev-launcher local network Info.plist keys in custom debug build configurations instead of only a configuration literally named "Debug".
 - [iOS] Report a distinct "discovery isn't configured" message and stop mislabeling a missing Info.plist entry, no network, or a pending system prompt as a denied Local Network permission.
 - [iOS] Stop triggering the Local Network permission prompt at launch by suppressing the React Native packager check until a development server is selected.
+- [iOS] Point at the Local Network setting when a local dev server URL can't be reached, and log instead of silently dropping discovered servers that fail to resolve. ([#48103](https://github.com/expo/expo/pull/48103) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Reload the recently opened apps list when the launcher appears so it no longer shows up empty or stale. ([#48103](https://github.com/expo/expo/pull/48103) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherLoadErrorMessage.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherLoadErrorMessage.swift
@@ -31,6 +31,9 @@ enum DevLauncherLoadErrorMessage {
       }
       return "The request to \(url) timed out. Check that the server is running and reachable from this device."
     case NSURLErrorNotConnectedToInternet:
+      if isLocalhost(host) || isPrivateNetworkHost(host) {
+        return "Could not reach \(url). Make sure this device is on the same Wi-Fi as the dev server and that Local Network access is enabled for this app in Settings > Privacy & Security > Local Network."
+      }
       return "Could not load the app because this device is offline. Connect to a network and try again."
     case NSURLErrorNetworkConnectionLost:
       return "The connection to \(url) was interrupted. Try again."

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -136,7 +136,7 @@ class DevLauncherViewModel: ObservableObject {
     loadMenuPreferences()
   }
 
-  private func loadRecentlyOpenedApps() {
+  func loadRecentlyOpenedApps() {
     let apps = EXDevLauncherController.sharedInstance().recentlyOpenedAppsRegistry.recentlyOpenedApps()
 
     let allApps = apps.compactMap { app -> RecentlyOpenedApp? in
@@ -485,7 +485,9 @@ class DevLauncherViewModel: ObservableObject {
           source: "local"
         )
       }
-    } catch {}
+    } catch {
+      NSLog("DevLauncher discovered a dev server but couldn't resolve its endpoint: %@", error.localizedDescription)
+    }
 
     return nil
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -64,6 +64,9 @@ struct HomeTabView: View {
     #if os(tvOS)
     .background()
     #endif
+    .onAppear {
+      viewModel.loadRecentlyOpenedApps()
+    }
     .sheet(isPresented: $showingInfoDialog) {
       DevServerInfoModal()
     }

--- a/packages/expo-dev-launcher/ios/Tests/DevLauncherLoadErrorMessageTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/DevLauncherLoadErrorMessageTests.swift
@@ -51,9 +51,14 @@ class DevLauncherLoadErrorMessageTests: XCTestCase {
     XCTAssertTrue(message.lowercased().contains("lan ip"))
   }
 
-  func testOffline() {
-    let message = DevLauncherLoadErrorMessage.message(for: urlError(NSURLErrorNotConnectedToInternet), url: "http://192.168.1.5:8081")
+  func testOfflineOnPublicHostMentionsOffline() {
+    let message = DevLauncherLoadErrorMessage.message(for: urlError(NSURLErrorNotConnectedToInternet), url: "https://u.expo.dev/abc")
     XCTAssertTrue(message.lowercased().contains("offline"))
+  }
+
+  func testNotConnectedOnLocalHostMentionsLocalNetwork() {
+    let message = DevLauncherLoadErrorMessage.message(for: urlError(NSURLErrorNotConnectedToInternet), url: "http://192.168.1.5:8081")
+    XCTAssertTrue(message.lowercased().contains("local network"))
   }
 
   func testDevelopmentClientErrorsPassThrough() {


### PR DESCRIPTION
# Why
Opening a local dev server while Local Network access was off showed a misleading "this device is offline" error, because a denied local network surfaces as NSURLErrorNotConnectedToInternet. Separately, a discovered server that failed endpoint resolution was dropped with no signal, so the list could show nothing while discovery had actually found something.

# How
For a NSURLErrorNotConnectedToInternet failure against a local or private host, the load error now points at the Local Network setting instead of reporting the device as offline. Public hosts keep the offline message. The silent catch in resolveDevServer now logs the failure so a discovered-but-unresolvable server is diagnosable.

# Test Plan
- Added unit tests for the error message covering the local-host and public-host branches.
- On device: with Local Network denied, opening a LAN server URL surfaces the Local Network guidance rather than "offline."

