### PR TITLE
[docs] Use Expo Modules API sidebar icon in modules BoxLinks

### DIFF
--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -5,7 +5,7 @@ description: A tutorial on creating a native module with a config plugin using E
 searchRank: 3
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -510,12 +510,12 @@ If you want to challenge yourself and make the plugin more versatile, this exerc
   title="Expo Modules API Reference"
   description="A reference to create native modules using Kotlin and Swift."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Additional platform support"
   description="Learn how to add support for macOS and tvOS platforms."
   href="/modules/additional-platform-support/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -4,7 +4,7 @@ sidebar_title: Get started
 description: Learn about getting started with Expo modules API.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
@@ -220,12 +220,12 @@ Now that you have learned how to initialize a module and make simple changes to 
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Expo Modules API Reference"
   description="A reference to create native modules using Swift and Kotlin."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -4,7 +4,7 @@ sidebar_title: Create an inline module
 description: A tutorial on creating a native module and view directly in your Expo project using inline modules.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -295,12 +295,12 @@ Congratulations! You've created your first Expo inline module and view.
   title="Expo inline modules reference"
   description="A reference on how to create inline modules using Kotlin and Swift."
   href="/modules/inline-modules-reference"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/mocking.mdx
+++ b/docs/pages/modules/mocking.mdx
@@ -4,7 +4,7 @@ sidebar_title: Mocking native calls
 description: Learn about mocking native calls in Expo modules.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -162,5 +162,5 @@ describe('useMyHook', () => {
   title="Unit testing with Jest"
   description="Learn how to set up and configure the jest-expo package to write unit and snapshot tests for a project."
   href="/develop/unit-testing/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -5,7 +5,7 @@ description: A tutorial on creating a native module that persists settings with 
 hasVideoLink: true
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -600,12 +600,12 @@ Congratulations! You have created your first Expo Module for Android and iOS.
   title="Expo Modules API Reference"
   description="Create native modules using Kotlin and Swift."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Tutorial: Creating a native view"
   description="A tutorial on creating a native view with Expo Modules API."
   href="/modules/native-view-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -4,7 +4,7 @@ sidebar_title: Create a native view
 description: A tutorial on creating a native view that renders a WebView with Expo Modules API.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -660,12 +660,12 @@ Congratulations! You've created your first Expo module with a native view for An
   title="Expo Modules API Reference"
   description="Create native modules using Kotlin and Swift."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: An overview of the APIs and utilities provided by Expo to develop native modules.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -98,35 +98,35 @@ Learn more about this in the [Integrate an existing library](/modules/existing-l
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Tutorial: Creating a native view"
   description="A tutorial on creating a native view that renders a WebView with Expo Modules API."
   href="/modules/native-view-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Expo Modules API: Get started"
   description="Learn about getting started with Expo modules API."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Expo Modules API: Reference"
   description="A reference on creating native modules using Kotlin and Swfit."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Expo Modules API: Design considerations"
   description="An overview of the design considerations behind the Expo Modules API."
   href="/modules/design"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -4,7 +4,7 @@ description: Learn how to create a simple wrapper around two separate native lib
 hasVideoLink: true
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -518,5 +518,5 @@ Congratulations! You have created your first simple wrapper around two separate 
   title="Expo Modules API Reference"
   description="A reference to create native modules using Kotlin and Swift."
   href="/modules/module-api/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -3,7 +3,7 @@ title: How to use a standalone Expo module
 description: Learn how to use a standalone module created with create-expo-module in your project by using a monorepo or publishing the package to npm.
 ---
 
-import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -341,12 +341,12 @@ After this configuration, you see the text "Hello world! 👋" displayed in the 
   title="Wrap third-party native libraries"
   description="Learn how to wrap third-party native libraries in an Expo module."
   href="/modules/third-party-library/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />
 
 <BoxLink
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={Grid01Icon}
+  Icon={CpuChip01Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="3476" height="1316" alt="CleanShot 2026-07-24 at 17 29 49@2x" src="https://github.com/user-attachments/assets/1932feab-929e-424d-af80-fd00943582cd" />



# How

<!--
How did you build this feature or fix this bug and why?
-->

Use Expo Modules API sidebar icon in modules BoxLinks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
