### PR TITLE
[docs] Add APK download link for Expo Go

### DIFF
--- a/docs/pages/get-started/set-up-your-environment.mdx
+++ b/docs/pages/get-started/set-up-your-environment.mdx
@@ -8,6 +8,7 @@ searchRank: 3
 import { DevelopmentEnvironmentInstructions } from '~/scenes/get-started/set-up-your-environment/DevelopmentEnvironmentInstructions';
 import { DevelopmentModeForm } from '~/scenes/get-started/set-up-your-environment/DevelopmentModeForm';
 import { PlatformAndDeviceForm } from '~/scenes/get-started/set-up-your-environment/PlatformAndDeviceForm';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 Let's set up a local development environment for running your project on Android and iOS.
 
@@ -27,7 +28,12 @@ Expo Go is a playground for students and learners to try Expo quickly. A develop
 
 <DevelopmentEnvironmentInstructions />
 
-If the latest version of Expo Go is not yet available on the Google Play Store, you can download the APK from the [Expo Go download page](https://expo.dev/go).
+<BoxLink
+  title="Download Expo Go"
+  description="You can also download any version of Expo Go, for from the Expo Go download page."
+  href="https://expo.dev/go"
+  Icon={Download03Icon}
+/>
 
 ## Next step
 

--- a/docs/pages/get-started/set-up-your-environment.mdx
+++ b/docs/pages/get-started/set-up-your-environment.mdx
@@ -27,6 +27,8 @@ Expo Go is a playground for students and learners to try Expo quickly. A develop
 
 <DevelopmentEnvironmentInstructions />
 
+If the latest version of Expo Go is not yet available on the Play Store, you can download the APK here: https://expo.dev/go
+
 ## Next step
 
 You have a project and a development environment. Now it's time to start developing.

--- a/docs/pages/get-started/set-up-your-environment.mdx
+++ b/docs/pages/get-started/set-up-your-environment.mdx
@@ -27,7 +27,7 @@ Expo Go is a playground for students and learners to try Expo quickly. A develop
 
 <DevelopmentEnvironmentInstructions />
 
-If the latest version of Expo Go is not yet available on the Play Store, you can download the APK here: https://expo.dev/go
+If the latest version of Expo Go is not yet available on the Google Play Store, you can download the APK from the [Expo Go download page](https://expo.dev/go).
 
 ## Next step
 

--- a/docs/pages/get-started/set-up-your-environment.mdx
+++ b/docs/pages/get-started/set-up-your-environment.mdx
@@ -5,6 +5,8 @@ hideTOC: true
 searchRank: 3
 ---
 
+import { Download03Icon } from '@expo/styleguide-icons/outline/Download03Icon';
+
 import { DevelopmentEnvironmentInstructions } from '~/scenes/get-started/set-up-your-environment/DevelopmentEnvironmentInstructions';
 import { DevelopmentModeForm } from '~/scenes/get-started/set-up-your-environment/DevelopmentModeForm';
 import { PlatformAndDeviceForm } from '~/scenes/get-started/set-up-your-environment/PlatformAndDeviceForm';
@@ -30,7 +32,7 @@ Expo Go is a playground for students and learners to try Expo quickly. A develop
 
 <BoxLink
   title="Download Expo Go"
-  description="You can also download any version of Expo Go, for from the Expo Go download page."
+  description="You can also download any version of Expo Go from the download page."
   href="https://expo.dev/go"
   Icon={Download03Icon}
 />


### PR DESCRIPTION
Added a note about downloading the Expo Go APK if the latest version is not yet available on the Google Play Store.

# Why

This change provides an alternative way to install Expo Go on Android when the latest version is not yet available on the Google Play Store.

# How

Added a note to the environment setup documentation with a link to the Expo Go download page, where users can download the APK.

# Test Plan

Reviewed the documentation change to ensure the wording follows the Expo Documentation Writing Style Guide and that the download link points to the official Expo Go download page.

# Checklist

* [ ] I added a `changelog.md` entry and rebuilt the package sources according to [[this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
* [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
* [x] Conforms with the [[Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)