### PR TITLE
[sdk-57][brownfield] Fix check-packages failures

### DIFF
--- a/packages/expo-brownfield/cli/jest.config.js
+++ b/packages/expo-brownfield/cli/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-  ...require('../e2e/cli/jest.config.js'),
-  // When expo-module-test runs "pnpm test cli" it passes --rootDir cli, so Jest's
-  // rootDir is cli/. Point roots at e2e/cli so the same cli tests run.
-  roots: ['../e2e/cli'],
-};

--- a/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
+++ b/packages/expo-brownfield/e2e/maestro/__tests__/common/dev-menu.yml
@@ -26,7 +26,7 @@ appId: ${APP_ID}
 # Assert that information about the app
 # is correctly loaded
 - assertVisible: 'expo-app'
-- assertVisible: 'Runtime version: exposdk:56.0.0'
+- assertVisible: 'Runtime version: exposdk:57.0.0'
 
 - scrollUntilVisible:
     element:
@@ -36,7 +36,7 @@ appId: ${APP_ID}
 - assertVisible: '1.0.0'
 
 - assertVisible: 'Runtime version'
-- assertVisible: 'exposdk:56.0.0'
+- assertVisible: 'exposdk:57.0.0'
 
 - runFlow:
     when:

--- a/packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
+++ b/packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
@@ -6,7 +6,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Setup simulator
 source $DIR/setup-simulator.sh
-start_simulator
+if ! start_simulator || [[ -z "$DEVICE_ID" ]]; then
+  echo " ❌ Could not find or boot the target iOS simulator. Check that the runtime is installed (xcrun simctl list runtimes) and matches DEVICE/IOS_VERSION in setup-simulator.sh."
+  exit 1
+fi
 
 # Install app
 source $DIR/install-app-ios.sh $DEVICE_ID

--- a/packages/expo-brownfield/e2e/scripts/setup-simulator.sh
+++ b/packages/expo-brownfield/e2e/scripts/setup-simulator.sh
@@ -33,7 +33,7 @@ function start_simulator() {
 
   echo " 🔍 Looking for device: $DEVICE with iOS version: $IOS_VERSION..."
 
-  DEVICE_ID=$(xcrun simctl list devices iPhone available --json | jq -r --arg device "$DEVICE" --arg ios_version "$IOS_VERSION" '.devices | to_entries[] | select(.key | contains("com.apple.CoreSimulator.SimRuntime.iOS-" + $ios_version + "-2")) | .value[] | select(.name == $device) | .udid' | head -n1)
+  DEVICE_ID=$(xcrun simctl list devices iPhone available --json | jq -r --arg device "$DEVICE" --arg ios_version "$IOS_VERSION" '.devices | to_entries[] | select(.key | contains("com.apple.CoreSimulator.SimRuntime.iOS-" + $ios_version + "-")) | .value[] | select(.name == $device) | .udid' | head -n1)
   if [[ -z "$DEVICE_ID" ]]; then
       echo " ⚠️  No device found for $DEVICE with iOS $IOS_VERSION"
       return 1

--- a/packages/expo-brownfield/e2e/utils/process.ts
+++ b/packages/expo-brownfield/e2e/utils/process.ts
@@ -1,4 +1,4 @@
-import spawnAsync from '@expo/spawn-async';
+import spawnAsync, { SpawnResult } from '@expo/spawn-async';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,58 +8,29 @@ export const CREATE_EXPO_BIN = require.resolve('create-expo/bin/create-expo.js')
 
 export interface ExecuteCLIOptions {
   ignoreErrors?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 /**
  * Execute the CLI
  */
-export const executeCLIASync = async (
+export const executeCLIASync = (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  try {
-    const { stdout, stderr, status } = await spawnAsync(CLI_PATH, args, {
-      cwd,
-      stdio: 'pipe',
-    });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
-  }
+  return executeCommandAsync(cwd, CLI_PATH, args, options);
 };
 
 /**
  * Execute Expo CLI
  */
-export const executeExpoCLIAsync = async (
+export const executeExpoCLIAsync = (
   cwd: string,
   args: string[],
   options: ExecuteCLIOptions = { ignoreErrors: false }
 ) => {
-  try {
-    const { stdout, stderr, status } = await spawnAsync('pnpm', ['expo', ...args], {
-      cwd,
-      stdio: 'pipe',
-    });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
-  }
+  return executeCommandAsync(cwd, 'pnpm', ['expo', ...args], options);
 };
 
 /**
@@ -73,21 +44,10 @@ export const executeCreateExpoCLIAsync = async (
   // Isolate create-expo's tmpdir template cache because `create-expo --template` doesn't support parallel work
   const cacheDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'create-expo-cache-'));
   try {
-    const { stdout, stderr, status } = await spawnAsync(CREATE_EXPO_BIN, args, {
-      cwd,
-      stdio: 'pipe',
+    return await executeCommandAsync(cwd, CREATE_EXPO_BIN, args, {
+      ...options,
       env: { ...process.env, TMPDIR: cacheDir, TMP: cacheDir, TEMP: cacheDir },
     });
-
-    return processOutput({ stdout, stderr, status });
-  } catch (error) {
-    if (!options.ignoreErrors) {
-      console.error(error);
-      throw error;
-    }
-
-    const { stdout, stderr, status } = error;
-    return processOutput({ stdout, stderr, status });
   } finally {
     await fs.promises.rm(cacheDir, { recursive: true, force: true });
   }
@@ -106,16 +66,24 @@ export const executeCommandAsync = async (
     const { stdout, stderr, status } = await spawnAsync(command, args, {
       cwd,
       stdio: 'pipe',
+      env: options.env,
     });
 
     return processOutput({ stdout, stderr, status });
   } catch (error) {
+    const { stdout, stderr, status } = error as SpawnResult;
+
     if (!options.ignoreErrors) {
-      console.error(error);
+      console.error(`Command "${[command, ...args].join(' ')}" exited with code ${status ?? 1}`);
+      if (stdout) {
+        console.error(`stdout:\n${stripAnsi(stdout)}`);
+      }
+      if (stderr) {
+        console.error(`stderr:\n${stripAnsi(stderr)}`);
+      }
       throw error;
     }
 
-    const { stdout, stderr, status } = error;
     return processOutput({ stdout, stderr, status });
   }
 };

--- a/packages/expo-brownfield/e2e/utils/project.ts
+++ b/packages/expo-brownfield/e2e/utils/project.ts
@@ -129,11 +129,11 @@ const listWorkspaces = async (): Promise<Record<string, string>> => {
   const { stdout } = await spawnAsync('pnpm', ['list', '--depth=-1', '-r', '--json'], {
     cwd: path.join(__dirname, '../../'),
   });
-  const workspaces: { name: string; path: string; }[] = JSON.parse(stdout);
-  return workspaces.reduce((acc, entry) => {
+  const workspaces: { name: string; path: string }[] = JSON.parse(stdout);
+  return workspaces.reduce<Record<string, string>>((acc, entry) => {
     acc[entry.name] = entry.path;
     return acc;
-  }, {} as Record<string, string>);
+  }, {});
 };
 
 /**

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -48,9 +48,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/unversioned/sdk/brownfield/",
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/env": "workspace:~2.4.2",
     "@expo/spawn-async": "^1.8.0",

--- a/packages/expo-brownfield/plugin/build/android/plugins/withGradlePropertiesPlugin.js
+++ b/packages/expo-brownfield/plugin/build/android/plugins/withGradlePropertiesPlugin.js
@@ -31,7 +31,7 @@ const getFusedLibrarySupportConfiguration = (hasFusedOptIn, hasFusedPubFlag) => 
     if (!hasFusedOptIn) {
         items.push({
             type: 'comment',
-            value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+            value: 'Acknowledge AGP Fused Library Preview status (required to apply the plugin)',
         }, {
             type: 'property',
             key: 'android.experimental.fusedLibrarySupport',

--- a/packages/expo-brownfield/plugin/jest.config.js
+++ b/packages/expo-brownfield/plugin/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-  ...require('../e2e/plugin/jest.config.js'),
-  // When expo-module-test runs "pnpm test plugin" it passes --rootDir plugin, so Jest's
-  // rootDir is plugin/. Point roots at e2e/plugin so the same plugin tests run.
-  roots: ['../e2e/plugin'],
-};

--- a/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
@@ -18,8 +18,7 @@ const withGradlePropertiesPlugin: ConfigPlugin = (config) => {
     // `include(project(...))` resolve sibling subprojects directly (no mavenLocal
     // round-trip). No-op in non-fused mode.
     const hasFusedOptIn = config.modResults.some(
-      (item) =>
-        item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
+      (item) => item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
     );
     const hasFusedPubFlag = config.modResults.some(
       (item) =>
@@ -46,7 +45,7 @@ const getFusedLibrarySupportConfiguration = (
     items.push(
       {
         type: 'comment',
-        value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+        value: 'Acknowledge AGP Fused Library Preview status (required to apply the plugin)',
       },
       {
         type: 'property',

--- a/packages/expo-module-scripts/createCompositeJestPreset.cjs
+++ b/packages/expo-module-scripts/createCompositeJestPreset.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const basePreset = require('./jest-preset.cjs');
+
+// Builds a single multi-project Jest config for a package that has build sub-targets
+// (e.g. `plugin`, `cli`, `utils`) with their own tests. The package's `src` tests run via
+// the multi-platform module preset, and each sub-folder runs as its own project rooted at
+// that folder — so a single `jest` invocation runs the whole package.
+//
+// Notes:
+// - Jest forbids nesting `projects`, so the module preset's per-platform projects are
+//   flattened in rather than added as one entry.
+// - `watchPlugins`/`prettierPath` are root-only in multi-project mode, so they're kept at the
+//   root (from the module preset) and stripped from each sub-project config.
+// - `rootDir` is forced to the sub-folder so the sub-configs don't need to be invoked with an
+//   external `--rootDir` (as `expo-module test <target>` does).
+// `opts.srcProjects` overrides the default `src` projects — used by packages whose `src`
+// tests are platform-specific (e.g. iOS-only) rather than the full multi-platform set.
+// `opts.rsc` appends the React Server Component per-platform projects (from
+// `jest-expo/rsc/jest-preset`) so a package's `__rsc_tests__` run as part of the single `jest`
+// invocation instead of a separate `test:rsc` script.
+module.exports = function createCompositeJestPreset(
+  rootDir,
+  subdirs = [],
+  { srcProjects, rsc = false } = {}
+) {
+  return {
+    ...basePreset,
+    projects: [
+      // `src` — flattened per-platform projects from the module preset (or a custom set).
+      ...(srcProjects ?? basePreset.projects),
+      // Each build sub-target as its own project, rooted at its folder. Mirrors
+      // `expo-module test <target>`: use the sub-folder's own `jest.config.js` if present,
+      // otherwise fall back to the default preset for that target (`jest-preset-<target>`).
+      ...subdirs.map((dir) => {
+        const localConfig = path.join(rootDir, dir, 'jest.config.js');
+        const { watchPlugins, prettierPath, ...config } = fs.existsSync(localConfig)
+          ? require(localConfig)
+          : require(`./jest-preset-${dir}.cjs`);
+        // Name the project after its folder so failures are attributable in multi-project output.
+        return { displayName: dir, ...config, rootDir: path.join(rootDir, dir) };
+      }),
+      // RSC `__rsc_tests__` as their own per-platform projects (named `rsc/<platform>`). These
+      // only match `**/__rsc_tests__/**`, so they're inert for packages without such tests.
+      ...(rsc ? require('jest-expo/rsc/jest-preset').projects : []),
+    ],
+  };
+};

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -21,6 +21,10 @@
     "./eslint.config.base": {
       "require": "./eslint.config.base.cjs"
     },
+    "./createCompositeJestPreset": {
+      "import": "./createCompositeJestPreset.cjs",
+      "require": "./createCompositeJestPreset.cjs"
+    },
     "./jest-preset-*": {
       "import": "./jest-preset-*.cjs",
       "require": "./jest-preset-*.cjs"


### PR DESCRIPTION
# Why

The cherry-picks of the Fused Library support (#47921) and the iOS packaging fixes (#48065) to `sdk-57` broke the `check-packages` CI job for `expo-brownfield`

# How

Aligned the branch's Jest wiring with main:

- Removed the top-level `jest` key from `expo-brownfield/package.json`. The cherry-pick brought main's root `jest.config.js`, and Jest refuses to run when both a config file and a `package.json` config exist. This was the direct cause of the CI failure.
- Backported `createCompositeJestPreset.cjs` (and its `exports` entry) to `expo-module-scripts`. The cherry-picked root `jest.config.js` requires it, and it did not exist on this branch.
- Deleted the `sdk-57`-only `cli/jest.config.js` and `plugin/jest.config.js` shims (added in #43391 to run the e2e suites inside check-packages). With the composite preset in place, the cli shim gets pulled into the plain `pnpm test` run as a sub-project, where the e2e config's `testTimeout: 600000` is silently ignored (it is a global-only option inside project configs), so the slower e2e tests fail at the default 5s timeout. Without the shims, `pnpm test cli` and `pnpm test plugin` fall back to the unit-test presets exactly like on main, and e2e coverage remains with the dedicated isolated E2E workflow, which already runs against `sdk-57`.
- Fixed two prettier warnings in `withGradlePropertiesPlugin.ts` introduced by the #47921 cherry-pick and rebuilt its committed `plugin/build` output, since this branch still tracks build artifacts in git.

# Test Plan

- CI should be green
