### PR TITLE
[router] Integrate native stack with standard navigation

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### 💡 Others
 
+- Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))
 - Refactor native-stack for compliance with standard-navigation integration ([#46592](https://github.com/expo/expo/pull/46592) by [@Ubax](https://github.com/Ubax))
 - Remove the deprecated static-navigation API from `expo-router/react-navigation`. ([#48071](https://github.com/expo/expo/pull/48071) by [@Ubax](https://github.com/Ubax))
 - Remove `UNSTABLE_routeNamesChangeBehavior` and unhandled-state replay from `useNavigationBuilder`. ([#47985](https://github.com/expo/expo/pull/47985) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/fork/native-stack/createNativeStackNavigator.tsx
@@ -1,5 +1,6 @@
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import * as React from 'react';
+import { createStandardNavigator } from 'standard-navigation';
 
 import { useClearGuardedRoutes } from '../../layouts/useClearGuardedRoutes';
 import {
@@ -7,26 +8,13 @@ import {
   type InternalNavigationOptions,
 } from '../../navigationParams';
 import {
-  createNavigatorFactory,
-  type EventArg,
-  type NavigatorTypeBagBase,
-  type ParamListBase,
-  type StackActionHelpers,
-  StackActions,
-  type StackNavigationState,
-  StackRouter,
-  type StackRouterOptions,
-  type TypedNavigator,
-  useNavigationBuilder,
-} from '../../react-navigation/native';
-import {
+  NativeStackView,
+  type NativeStackDescriptorMap,
   type NativeStackNavigationEventMap,
   type NativeStackNavigationOptions,
-  type NativeStackNavigationProp,
-  NativeStackView,
-  type NativeStackNavigatorProps,
-  makePopAction,
 } from '../../react-navigation/native-stack';
+import type { NativeStackNavigationConfig } from '../../react-navigation/native-stack/types';
+import type { NavigatorContentProps } from '../../standard-navigation';
 import { CompositionContext, mergeOptions, useCompositionRegistry } from './composition-options';
 import { DescriptorsContext } from './descriptors-context';
 import { usePreviewTransition } from './usePreviewTransition';
@@ -36,84 +24,49 @@ const GLASS = isLiquidGlassAvailable();
 type NativeStackNavigationOptionsWithInternal = NativeStackNavigationOptions &
   InternalNavigationOptions;
 
-function NativeStackNavigator({
-  id,
-  initialRouteName,
-  children,
-  layout,
-  screenListeners,
-  screenOptions,
-  screenLayout,
-  UNSTABLE_router,
-  ...rest
-}: NativeStackNavigatorProps) {
-  const { state, descriptors, navigation, NavigationContent } = useNavigationBuilder<
-    StackNavigationState<ParamListBase>,
-    StackRouterOptions,
-    StackActionHelpers<ParamListBase>,
-    NativeStackNavigationOptionsWithInternal,
-    NativeStackNavigationEventMap
-  >(StackRouter, {
-    id,
-    initialRouteName,
-    children,
-    layout,
-    screenListeners,
-    screenOptions,
-    screenLayout,
-    UNSTABLE_router,
-  });
+export interface NativeStackNavigatorCreateProps {
+  pop: (count: number, sourceRouteKey: string) => void;
+  removeRoutes: (routeNames: string[]) => void;
+  /** Registers pop-to-top on parent tab press, or returns undefined without a tab parent. */
+  subscribePopToTopOnParentTabPress: () => (() => void) | undefined;
+}
 
-  const removeRoutesFromState = React.useCallback(
-    (routeNames: string[]) =>
-      navigation.dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
-    [navigation]
-  );
-  useClearGuardedRoutes(removeRoutesFromState);
+export type StandardNativeStackEventMap = {
+  [Event in keyof NativeStackNavigationEventMap]: NativeStackNavigationEventMap[Event] & {
+    canPreventDefault: false;
+  };
+};
 
-  React.useEffect(
-    () =>
-      // @ts-expect-error: there may not be a tab navigator in parent
-      navigation?.addListener?.('tabPress', (e: any) => {
-        const isFocused = navigation.isFocused();
+type ContentArgs = NavigatorContentProps<
+  NativeStackNavigationOptions,
+  StandardNativeStackEventMap,
+  NativeStackNavigationConfig,
+  NativeStackNavigatorCreateProps
+>;
 
-        // Run the operation in the next frame so we're sure all listeners have been run
-        // This is necessary to know if preventDefault() has been called
-        requestAnimationFrame(() => {
-          if (state.index > 0 && isFocused && !(e as EventArg<'tabPress', true>).defaultPrevented) {
-            // When user taps on already focused tab and we're inside the tab,
-            // reset the stack to replicate native behaviour
-            // START FORK
-            // navigation.dispatch({
-            //   ...StackActions.popToTop(),
-            //   target: state.key,
-            // });
-            // The popToTop will be automatically triggered on native side for native tabs
-            if (e.data?.__internalTabsType !== 'native') {
-              navigation.dispatch({
-                ...StackActions.popToTop(),
-                target: state.key,
-              });
-            }
-            // END FORK
-          }
-        });
-      }),
-    [navigation, state.index, state.key]
-  );
+function NativeStackNavigatorContent({
+  state,
+  descriptors,
+  emitter,
+  pop,
+  removeRoutes,
+  subscribePopToTopOnParentTabPress,
+  unstable_nativeProps,
+}: ContentArgs) {
+  const fullDescriptors = descriptors as unknown as NativeStackDescriptorMap;
 
-  // START FORK
-  const { computedState, emit } = usePreviewTransition(state, navigation.emit);
+  const { computedState, emit } = usePreviewTransition(state, emitter.emit);
 
-  const pop = makePopAction(navigation.dispatch, state.key);
+  useClearGuardedRoutes(removeRoutes);
+  React.useEffect(() => subscribePopToTopOnParentTabPress(), [subscribePopToTopOnParentTabPress]);
 
   // Map internal gesture option to React Navigation's gestureEnabled option
   // This allows Expo Router to override gesture behavior without affecting user settings
   const finalDescriptors = React.useMemo(() => {
     let needsNewMap = false;
-    const result: typeof descriptors = {};
-    for (const key of Object.keys(descriptors)) {
-      const descriptor = descriptors[key]!;
+    const result: NativeStackDescriptorMap = {};
+    for (const key of Object.keys(fullDescriptors)) {
+      const descriptor = fullDescriptors[key]!;
       const options = descriptor.options as NativeStackNavigationOptionsWithInternal;
       const internalGestureEnabled = options?.[INTERNAL_EXPO_ROUTER_GESTURE_ENABLED_OPTION_NAME];
       const needsGestureFix = internalGestureEnabled !== undefined;
@@ -136,56 +89,32 @@ function NativeStackNavigator({
         result[key] = descriptor;
       }
     }
-    return needsNewMap ? result : descriptors;
-  }, [descriptors]);
+    return needsNewMap ? result : fullDescriptors;
+  }, [fullDescriptors]);
   const { registry, contextValue } = useCompositionRegistry();
 
   const mergedDescriptors = React.useMemo(
     () => mergeOptions(finalDescriptors, registry, computedState),
     [finalDescriptors, computedState, registry]
   );
-  // END FORK
 
   return (
-    // START FORK
-    <DescriptorsContext value={descriptors}>
-      {/* END FORK */}
-      <NavigationContent>
-        <CompositionContext value={contextValue}>
-          <NativeStackView
-            {...rest}
-            // START FORK
-            state={computedState}
-            descriptors={mergedDescriptors}
-            emit={emit}
-            pop={pop}
-            // state={state}
-            // navigation={navigation}
-            // descriptors={descriptors}
-            // END FORK
-          />
-        </CompositionContext>
-      </NavigationContent>
-      {/* START FORK */}
+    <DescriptorsContext value={fullDescriptors}>
+      <CompositionContext value={contextValue}>
+        <NativeStackView
+          state={computedState}
+          descriptors={mergedDescriptors}
+          emit={emit}
+          pop={pop}
+          unstable_nativeProps={unstable_nativeProps}
+        />
+      </CompositionContext>
     </DescriptorsContext>
-    // END FORK
   );
 }
 
-export function createNativeStackNavigator<
-  const ParamList extends ParamListBase,
-  const NavigatorID extends string | undefined = undefined,
-  const TypeBag extends NavigatorTypeBagBase = {
-    ParamList: ParamList;
-    NavigatorID: NavigatorID;
-    State: StackNavigationState<ParamList>;
-    ScreenOptions: NativeStackNavigationOptions;
-    EventMap: NativeStackNavigationEventMap;
-    NavigationList: {
-      [RouteName in keyof ParamList]: NativeStackNavigationProp<ParamList, RouteName, NavigatorID>;
-    };
-    Navigator: typeof NativeStackNavigator;
-  },
->(): TypedNavigator<TypeBag> {
-  return createNavigatorFactory(NativeStackNavigator)();
-}
+export const createStandardNativeStackNavigator = createStandardNavigator<
+  NativeStackNavigationOptions,
+  StandardNativeStackEventMap,
+  NativeStackNavigatorCreateProps
+>(NativeStackNavigatorContent);

--- a/packages/expo-router/src/layouts/StackClient.tsx
+++ b/packages/expo-router/src/layouts/StackClient.tsx
@@ -1,39 +1,30 @@
 'use client';
-import { nanoid } from 'nanoid/non-secure';
 import type { ComponentProps } from 'react';
 import { Children, useMemo } from 'react';
 
-import { createNativeStackNavigator } from '../fork/native-stack/createNativeStackNavigator';
+import {
+  createStandardNativeStackNavigator,
+  type NativeStackNavigatorCreateProps,
+  type StandardNativeStackEventMap,
+} from '../fork/native-stack/createNativeStackNavigator';
 import { useLinkPreviewContext } from '../link/preview/LinkPreviewContext';
 import {
   getInternalExpoRouterParams,
-  INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME,
   INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME,
-  INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME,
-  INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME,
-  type InternalExpoRouterParams,
 } from '../navigationParams';
 import {
-  type CommonNavigationAction,
-  type NavigationAction,
   type ParamListBase,
-  type PartialRoute,
-  type PartialState,
-  type Route,
-  type RouterConfigOptions,
-  type StackActionType,
-  type StackNavigationState,
-  StackRouter as RNStackRouter,
   type RouteProp,
+  StackActions,
+  type StackNavigationState,
+  type StackRouterOptions,
 } from '../react-navigation/native';
-import type {
-  NativeStackNavigationEventMap,
-  NativeStackNavigationOptions,
-} from '../react-navigation/native-stack';
-import type { SingularOptions } from '../useScreens';
-import { getSingularId } from '../useScreens';
+import { makePopAction, type NativeStackNavigationOptions } from '../react-navigation/native-stack';
+import type { NativeStackNavigationConfig } from '../react-navigation/native-stack/types';
+import { unstable_integrateWithRouter } from '../standard-navigation';
 import { isChildOfType } from '../utils/children';
 import { Protected } from '../views/Protected';
+import { StackRouter } from './stack-router';
 import {
   type StackScreenProps,
   StackHeader,
@@ -45,11 +36,6 @@ import {
   mapProtectedScreen,
   validateStackPresentation,
 } from './stack-utils';
-import { withLayoutContext } from './withLayoutContext';
-
-type GetId = NonNullable<RouterConfigOptions['routeGetIdList'][string]>;
-
-const NativeStackNavigator = createNativeStackNavigator().Navigator;
 
 /**
  * We extend NativeStackNavigationOptions with our custom props
@@ -95,490 +81,34 @@ export type ExtendedStackNavigationOptions = NativeStackNavigationOptions & {
   };
 };
 
-const RNStack = withLayoutContext<
+const RNStack = unstable_integrateWithRouter<
   ExtendedStackNavigationOptions,
-  typeof NativeStackNavigator,
   StackNavigationState<ParamListBase>,
-  NativeStackNavigationEventMap
->(NativeStackNavigator);
-
-type RNNavigationAction = Extract<CommonNavigationAction, { type: 'NAVIGATE' }>;
-type RNPreloadAction = Extract<CommonNavigationAction, { type: 'PRELOAD' }>;
-type ExpoNavigationAction = Omit<RNNavigationAction, 'payload'> & {
-  payload: Omit<RNNavigationAction['payload'], 'params'> & {
-    params: RNNavigationAction['payload']['params'] & InternalExpoRouterParams;
-  };
-};
-
-function isStackAction(
-  action: NavigationAction
-): action is StackActionType | RNPreloadAction | ExpoNavigationAction {
-  return (
-    action.type === 'PUSH' ||
-    action.type === 'NAVIGATE' ||
-    action.type === 'POP' ||
-    action.type === 'POP_TO_TOP' ||
-    action.type === 'REPLACE' ||
-    action.type === 'PRELOAD'
-  );
-}
-
-const isPreviewAction = (action: NavigationAction): action is ExpoNavigationAction =>
-  !!action.payload &&
-  'params' in action.payload &&
-  typeof action.payload.params === 'object' &&
-  !!getInternalExpoRouterParams(action.payload?.params ?? undefined)[
-    INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME
-  ];
-
-const getZoomTransitionIdFromAction = (action: NavigationAction): string | undefined => {
-  const allParams =
-    !!action.payload && 'params' in action.payload && typeof action.payload.params === 'object'
-      ? action.payload.params
-      : undefined;
-  const internalParams = getInternalExpoRouterParams(allParams ?? undefined);
-  const val = internalParams[INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME];
-  if (val && typeof val === 'string') {
-    return val;
-  }
-  return undefined;
-};
-
-/**
- * React Navigation matches a screen by its name or a 'getID' function that uniquely identifies a screen.
- * When a screen has been uniquely identified, the Stack can only have one instance of that screen.
- *
- * Expo Router allows for a screen to be matched by name and path params, a 'getID' function or a singular id.
- *
- * Instead of reimplementing the entire StackRouter, we can override the getStateForAction method to handle the singular screen logic.
- *
- */
-export const stackRouterOverride: NonNullable<ComponentProps<typeof RNStack>['UNSTABLE_router']> = (
-  original
-) => {
-  return {
-    getStateForAction: (state, action, options) => {
-      if (action.target && action.target !== state.key) {
-        return null;
-      }
-
-      if (!isStackAction(action)) {
-        return original.getStateForAction(state, action, options);
-      }
-
-      // The dynamic getId added to an action, `router.push('screen', { singular: true })`
-      const actionSingularOptions =
-        action.payload && 'singular' in action.payload
-          ? (action.payload.singular as SingularOptions)
-          : undefined;
-
-      // Handle if 'getID' or 'singular' is set.
-      function getIdFunction(): GetId | undefined {
-        // Actions can be fired by the user, so we do need to validate their structure.
-        if (
-          !('payload' in action) ||
-          !action.payload ||
-          !('name' in action.payload) ||
-          typeof action.payload.name !== 'string'
-        ) {
-          return;
-        }
-
-        const actionName = action.payload.name;
-
-        return (
-          // The dynamic singular added to an action, `router.push('screen', { singular: () => 'id' })`
-          getActionSingularIdFn(actionSingularOptions, actionName) ||
-          // The static getId added as a prop to `<Screen singular />` or `<Screen getId={} />`
-          options.routeGetIdList[actionName]
-        );
-      }
-
-      const { routeParamList } = options;
-
-      switch (action.type) {
-        case 'PUSH':
-        case 'NAVIGATE': {
-          if (!state.routeNames.includes(action.payload.name)) {
-            return null;
+  StandardNativeStackEventMap,
+  NativeStackNavigationConfig,
+  StackRouterOptions,
+  NativeStackNavigatorCreateProps
+>(createStandardNativeStackNavigator, StackRouter, {
+  createProps: ({ state, dispatch, navigation }) => ({
+    pop: makePopAction(dispatch, state.key),
+    removeRoutes: (routeNames) => dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
+    subscribePopToTopOnParentTabPress: () =>
+      // @ts-expect-error: there may not be a tab navigator in parent
+      navigation.addListener?.('tabPress', (e) => {
+        const isFocused = navigation.isFocused();
+        requestAnimationFrame(() => {
+          if (
+            state.index > 0 &&
+            isFocused &&
+            !e.defaultPrevented &&
+            e.data?.__internalTabsType !== 'native'
+          ) {
+            dispatch({ ...StackActions.popToTop(), target: state.key });
           }
-
-          // START FORK
-          const getId = getIdFunction();
-          // const getId = options.routeGetIdList[action.payload.name];
-          // END FORK
-          const id = getId?.({ params: action.payload.params });
-          const activeRoutes = state.routes.slice(0, state.index + 1);
-          const preloadedRoutes = state.routes.slice(state.index + 1);
-
-          let route: Route<string> | undefined;
-
-          if (id !== undefined) {
-            route = activeRoutes.findLast(
-              (route) =>
-                route.name === action.payload.name && id === getId?.({ params: route.params })
-            );
-          } else if (action.type === 'NAVIGATE') {
-            const currentRoute = activeRoutes[state.index]!;
-
-            // If the route matches the current one, then navigate to it
-            if (action.payload.name === currentRoute.name && !isPreviewAction(action)) {
-              route = currentRoute;
-            } else if (action.payload.pop) {
-              route = activeRoutes.findLast((route) => route.name === action.payload.name);
-            }
-          }
-
-          // START FORK
-          let isPreloadedRoute = false;
-          if (isPreviewAction(action) && !route) {
-            route = preloadedRoutes.find(
-              (route) => route.name === action.payload.name && id === route.key
-            );
-            isPreloadedRoute = !!route;
-          }
-          // END FORK
-
-          if (!route) {
-            route = preloadedRoutes.find(
-              (route) =>
-                route.name === action.payload.name && id === getId?.({ params: route.params })
-            );
-            // START FORK
-            isPreloadedRoute = !!route;
-            // END FORK
-          }
-
-          let params;
-
-          if (action.type === 'NAVIGATE' && action.payload.merge && route) {
-            params =
-              action.payload.params !== undefined ||
-              routeParamList[action.payload.name] !== undefined
-                ? {
-                    ...routeParamList[action.payload.name],
-                    ...route.params,
-                    ...action.payload.params,
-                  }
-                : route.params;
-          } else {
-            params =
-              routeParamList[action.payload.name] !== undefined
-                ? {
-                    ...routeParamList[action.payload.name],
-                    ...action.payload.params,
-                  }
-                : action.payload.params;
-          }
-
-          let routes: Route<string>[];
-
-          if (route) {
-            if (action.type === 'NAVIGATE' && action.payload.pop) {
-              routes = [];
-
-              // Get all routes until the matching one
-              for (const r of activeRoutes) {
-                if (r.key === route.key) {
-                  routes.push({
-                    ...route,
-                    path: action.payload.path !== undefined ? action.payload.path : route.path,
-                    params,
-                  });
-                  break;
-                }
-
-                routes.push(r);
-              }
-
-              // Promote the route when it is preloaded and therefore absent from the active routes.
-              if (!routes.some((r) => r.key === route.key)) {
-                routes.push({
-                  ...route,
-                  path: action.payload.path !== undefined ? action.payload.path : route.path,
-                  params,
-                });
-              }
-            } else {
-              // START FORK
-              // If there is an id, then filter out the existing route with the same id.
-              // THIS ACTION IS DANGEROUS. This can cause React Native Screens to freeze
-              if (id !== undefined) {
-                routes = activeRoutes.filter((r) => r.key !== route.key);
-              } else if (action.type === 'NAVIGATE' && activeRoutes.length > 0) {
-                // The navigation action should only replace the last route if it has the same name and path params.
-                const lastRoute = activeRoutes[activeRoutes.length - 1]!;
-                if (
-                  getSingularId(lastRoute.name, { params: lastRoute.params }) ===
-                  getSingularId(route.name, { params })
-                ) {
-                  routes = activeRoutes.slice(0, -1);
-                } else {
-                  routes = [...activeRoutes];
-                }
-              } else {
-                routes = [...activeRoutes];
-              }
-
-              // If the routes length is the same as the state routes length, then we are navigating to a new route.
-              // Otherwise we are replacing an existing route.
-              // For preloaded route, we want to use the same key, so that preloaded screen is used.
-              const key =
-                routes.length === activeRoutes.length && !isPreloadedRoute
-                  ? `${action.payload.name}-${nanoid()}`
-                  : route.key;
-
-              routes.push({
-                ...route,
-                key,
-                path:
-                  action.type === 'NAVIGATE' && action.payload.path !== undefined
-                    ? action.payload.path
-                    : route.path,
-                params,
-              });
-
-              // routes = state.routes.filter((r) => r.key !== route.key);
-              // routes.push({
-              //   ...route,
-              //   path:
-              //     action.type === 'NAVIGATE' && action.payload.path !== undefined
-              //       ? action.payload.path
-              //       : route.path,
-              //   params,
-              // });
-              // END FORK
-            }
-          } else {
-            routes = [
-              ...activeRoutes,
-              {
-                key: `${action.payload.name}-${nanoid()}`,
-                name: action.payload.name,
-                path: action.type === 'NAVIGATE' ? action.payload.path : undefined,
-                params,
-              },
-            ];
-          }
-
-          // START FORK
-          // return filterSingular(
-          const result = {
-            ...state,
-            index: routes.length - 1,
-            routes: routes.concat(
-              preloadedRoutes.filter((route) => routes[routes.length - 1]!.key !== route.key)
-            ),
-          };
-          if (actionSingularOptions) {
-            return filterSingular(result, getId);
-          }
-
-          const zoomTransitionId = getZoomTransitionIdFromAction(action);
-          if (zoomTransitionId) {
-            const lastRoute = result.routes[result.index]!;
-            const key = lastRoute.key;
-            const modifiedLastRoute: typeof lastRoute = {
-              ...lastRoute,
-              params: {
-                ...lastRoute.params,
-                [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: key,
-              },
-            };
-            return {
-              ...result,
-              routes: result.routes.map((route, index) =>
-                index === result.index ? modifiedLastRoute : route
-              ),
-            };
-          }
-
-          return result;
-          // return {
-          //   ...state,
-          //   index: routes.length - 1,
-          //   preloadedRoutes: state.preloadedRoutes.filter(
-          //     (route) => routes[routes.length - 1].key !== route.key
-          //   ),
-          //   routes,
-          // };
-          // END FORK
-        }
-        case 'PRELOAD': {
-          // START FORK
-          // This will be the case for example for protected route
-          if (!state.routeNames.includes(action.payload.name)) {
-            return null;
-          }
-          // END FORK
-          const getId = options.routeGetIdList[action.payload.name];
-          const id = getId?.({ params: action.payload.params });
-          const activeRoutes = state.routes.slice(0, state.index + 1);
-          const preloadedRoutes = state.routes.slice(state.index + 1);
-
-          let route: Route<string> | undefined;
-
-          if (id !== undefined) {
-            route = activeRoutes.find(
-              (route) =>
-                route.name === action.payload.name && id === getId?.({ params: route.params })
-            );
-          }
-
-          const preloadZoomTransitionId = getZoomTransitionIdFromAction(action);
-
-          if (route) {
-            return {
-              ...state,
-              routes: state.routes.map((r) => {
-                if (r.key !== route?.key) {
-                  return r;
-                }
-                const mergedParams =
-                  routeParamList[action.payload.name] !== undefined
-                    ? {
-                        ...routeParamList[action.payload.name],
-                        ...action.payload.params,
-                      }
-                    : action.payload.params;
-                return {
-                  ...r,
-                  params: preloadZoomTransitionId
-                    ? {
-                        ...mergedParams,
-                        [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: r.key,
-                      }
-                    : mergedParams,
-                };
-              }),
-            };
-          } else {
-            // START FORK
-            const preloadedRouteKey = `${action.payload.name}-${nanoid()}`;
-            const preloadedRouteParams =
-              routeParamList[action.payload.name] !== undefined
-                ? {
-                    ...routeParamList[action.payload.name],
-                    ...action.payload.params,
-                  }
-                : action.payload.params;
-            const currentPreloadedRoute: (typeof state)['routes'][number] = {
-              key: preloadedRouteKey,
-              name: action.payload.name,
-              params: preloadZoomTransitionId
-                ? {
-                    ...preloadedRouteParams,
-                    [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: preloadedRouteKey,
-                  }
-                : preloadedRouteParams,
-            };
-            // END FORK
-            return {
-              ...state,
-              // START FORK
-              // Adding the current preloaded route to the beginning of the preloadedRoutes array
-              // This ensures that the preloaded route will be the next one after the visible route
-              // and when navigation will happen, there will be no reshuffling
-              // This is a workaround for the link preview navigation issue, when screen would freeze after navigation from native side
-              // and reshuffling from react-navigation
-              routes: activeRoutes.concat(
-                currentPreloadedRoute,
-                preloadedRoutes.filter(
-                  (r) => r.name !== action.payload.name || id !== getId?.({ params: r.params })
-                )
-              ),
-              // preloadedRoutes: state.preloadedRoutes
-              //   .filter(
-              //     (r) =>
-              //       r.name !== action.payload.name ||
-              //       id !== getId?.({ params: r.params })
-              //   )
-              //   .concat({
-              //     key: `${action.payload.name}-${nanoid()}`,
-              //     name: action.payload.name,
-              //     params:
-              //       routeParamList[action.payload.name] !== undefined
-              //         ? {
-              //             ...routeParamList[action.payload.name],
-              //             ...action.payload.params,
-              //           }
-              //         : action.payload.params,
-              //   }),
-              // END FORK
-            };
-          }
-        }
-        default: {
-          return original.getStateForAction(state, action, options);
-        }
-      }
-    },
-  };
-};
-
-function getActionSingularIdFn(
-  actionGetId: SingularOptions | undefined,
-  name: string
-): GetId | undefined {
-  if (typeof actionGetId === 'function') {
-    return (options) => actionGetId(name, options.params ?? {});
-  } else if (actionGetId === true) {
-    return (options) => getSingularId(name, options);
-  }
-
-  return undefined;
-}
-
-/**
- * If there is a dynamic singular on an action, then we need to filter the state to only have singular screens.
- * As multiples may have been added before we did the singular navigation.
- */
-function filterSingular<
-  T extends
-    | StackNavigationState<ParamListBase>
-    | PartialState<StackNavigationState<ParamListBase>>
-    | null,
->(state: T, getId?: GetId): T {
-  if (!state) {
-    return state;
-  }
-
-  if (!state.routes) {
-    return state;
-  }
-
-  // TODO(@kitten): This looks wrong as it's defaulting `index === 0`
-  const currentIndex = state.index ?? state.routes.length - 1;
-  const activeRoutes = state.routes.slice(0, currentIndex + 1);
-  const preloadedRoutes = state.routes.slice(currentIndex + 1);
-  const current = activeRoutes[currentIndex]!;
-  const name = current.name;
-
-  const id = getId?.({ params: current.params });
-
-  if (!id) {
-    return state;
-  }
-
-  // TypeScript needs a type assertion here for the filter to work.
-  let routes = activeRoutes as PartialRoute<Route<string, object | undefined>>[];
-  routes = routes.filter((route, index) => {
-    // If the route is the current route, keep it.
-    if (index === currentIndex) {
-      return true;
-    }
-
-    // Remove all other routes with the same name and id.
-    return name !== route.name || id !== getId?.({ params: route.params });
-  });
-
-  return {
-    ...state,
-    index: routes.length - 1,
-    // Filtering preserves the input state's route type even though TypeScript widens it to partial routes.
-    routes: [...routes, ...preloadedRoutes] as T extends null ? never : NonNullable<T>['routes'],
-  };
-}
+        });
+      }),
+  }),
+});
 
 /**
  * Renders a native stack navigator.
@@ -628,14 +158,7 @@ const Stack = Object.assign(
       [props.children]
     );
 
-    return (
-      <RNStack
-        {...props}
-        children={rnChildren}
-        screenOptions={screenOptions}
-        UNSTABLE_router={stackRouterOverride}
-      />
-    );
+    return <RNStack {...props} children={rnChildren} screenOptions={screenOptions} />;
   },
   {
     Screen: StackScreen,
@@ -681,12 +204,5 @@ function shouldDisableAnimationBasedOnParams(route: RouteProp<ParamListBase, str
   return !!expoParams[INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME];
 }
 
+export { StackRouter, stackRouterOverride } from './stack-router';
 export default Stack;
-
-export const StackRouter: typeof RNStackRouter = (options) => {
-  const router = RNStackRouter(options);
-  return {
-    ...router,
-    ...stackRouterOverride(router),
-  };
-};

--- a/packages/expo-router/src/layouts/stack-router.ts
+++ b/packages/expo-router/src/layouts/stack-router.ts
@@ -1,0 +1,512 @@
+import { nanoid } from 'nanoid/non-secure';
+
+import {
+  getInternalExpoRouterParams,
+  INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME,
+  INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME,
+  INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME,
+  type InternalExpoRouterParams,
+} from '../navigationParams';
+import {
+  type CommonNavigationAction,
+  type NavigationAction,
+  type ParamListBase,
+  type PartialRoute,
+  type PartialState,
+  type Route,
+  type RouterConfigOptions,
+  type StackActionType,
+  type StackNavigationState,
+  StackRouter as RNStackRouter,
+} from '../react-navigation/native';
+import type { NativeStackNavigatorProps } from '../react-navigation/native-stack';
+import type { SingularOptions } from '../useScreens';
+import { getSingularId } from '../useScreens';
+
+type GetId = NonNullable<RouterConfigOptions['routeGetIdList'][string]>;
+
+type RNNavigationAction = Extract<CommonNavigationAction, { type: 'NAVIGATE' }>;
+type RNPreloadAction = Extract<CommonNavigationAction, { type: 'PRELOAD' }>;
+type ExpoNavigationAction = Omit<RNNavigationAction, 'payload'> & {
+  payload: Omit<RNNavigationAction['payload'], 'params'> & {
+    params: RNNavigationAction['payload']['params'] & InternalExpoRouterParams;
+  };
+};
+
+function isStackAction(
+  action: NavigationAction
+): action is StackActionType | RNPreloadAction | ExpoNavigationAction {
+  return (
+    action.type === 'PUSH' ||
+    action.type === 'NAVIGATE' ||
+    action.type === 'POP' ||
+    action.type === 'POP_TO_TOP' ||
+    action.type === 'REPLACE' ||
+    action.type === 'PRELOAD'
+  );
+}
+
+const isPreviewAction = (action: NavigationAction): action is ExpoNavigationAction =>
+  !!action.payload &&
+  'params' in action.payload &&
+  typeof action.payload.params === 'object' &&
+  !!getInternalExpoRouterParams(action.payload?.params ?? undefined)[
+    INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME
+  ];
+
+const getZoomTransitionIdFromAction = (action: NavigationAction): string | undefined => {
+  const allParams =
+    !!action.payload && 'params' in action.payload && typeof action.payload.params === 'object'
+      ? action.payload.params
+      : undefined;
+  const internalParams = getInternalExpoRouterParams(allParams ?? undefined);
+  const val = internalParams[INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME];
+  if (val && typeof val === 'string') {
+    return val;
+  }
+  return undefined;
+};
+
+/**
+ * React Navigation matches a screen by its name or a 'getID' function that uniquely identifies a screen.
+ * When a screen has been uniquely identified, the Stack can only have one instance of that screen.
+ *
+ * Expo Router allows for a screen to be matched by name and path params, a 'getID' function or a singular id.
+ *
+ * Instead of reimplementing the entire StackRouter, we can override the getStateForAction method to handle the singular screen logic.
+ *
+ */
+export const stackRouterOverride: NonNullable<NativeStackNavigatorProps['UNSTABLE_router']> = (
+  original
+) => {
+  return {
+    getStateForAction: (state, action, options) => {
+      if (action.target && action.target !== state.key) {
+        return null;
+      }
+
+      if (!isStackAction(action)) {
+        return original.getStateForAction(state, action, options);
+      }
+
+      // The dynamic getId added to an action, `router.push('screen', { singular: true })`
+      const actionSingularOptions =
+        action.payload && 'singular' in action.payload
+          ? (action.payload.singular as SingularOptions)
+          : undefined;
+
+      // Handle if 'getID' or 'singular' is set.
+      function getIdFunction(): GetId | undefined {
+        // Actions can be fired by the user, so we do need to validate their structure.
+        if (
+          !('payload' in action) ||
+          !action.payload ||
+          !('name' in action.payload) ||
+          typeof action.payload.name !== 'string'
+        ) {
+          return;
+        }
+
+        const actionName = action.payload.name;
+
+        return (
+          // The dynamic singular added to an action, `router.push('screen', { singular: () => 'id' })`
+          getActionSingularIdFn(actionSingularOptions, actionName) ||
+          // The static getId added as a prop to `<Screen singular />` or `<Screen getId={} />`
+          options.routeGetIdList[actionName]
+        );
+      }
+
+      const { routeParamList } = options;
+
+      switch (action.type) {
+        case 'PUSH':
+        case 'NAVIGATE': {
+          if (!state.routeNames.includes(action.payload.name)) {
+            return null;
+          }
+
+          // START FORK
+          const getId = getIdFunction();
+          // const getId = options.routeGetIdList[action.payload.name];
+          // END FORK
+          const id = getId?.({ params: action.payload.params });
+          const activeRoutes = state.routes.slice(0, state.index + 1);
+          const preloadedRoutes = state.routes.slice(state.index + 1);
+
+          let route: Route<string> | undefined;
+
+          if (id !== undefined) {
+            route = activeRoutes.findLast(
+              (route) =>
+                route.name === action.payload.name && id === getId?.({ params: route.params })
+            );
+          } else if (action.type === 'NAVIGATE') {
+            const currentRoute = activeRoutes[state.index]!;
+
+            // If the route matches the current one, then navigate to it
+            if (action.payload.name === currentRoute.name && !isPreviewAction(action)) {
+              route = currentRoute;
+            } else if (action.payload.pop) {
+              route = activeRoutes.findLast((route) => route.name === action.payload.name);
+            }
+          }
+
+          // START FORK
+          let isPreloadedRoute = false;
+          if (isPreviewAction(action) && !route) {
+            route = preloadedRoutes.find(
+              (route) => route.name === action.payload.name && id === route.key
+            );
+            isPreloadedRoute = !!route;
+          }
+          // END FORK
+
+          if (!route) {
+            route = preloadedRoutes.find(
+              (route) =>
+                route.name === action.payload.name && id === getId?.({ params: route.params })
+            );
+            // START FORK
+            isPreloadedRoute = !!route;
+            // END FORK
+          }
+
+          let params;
+
+          if (action.type === 'NAVIGATE' && action.payload.merge && route) {
+            params =
+              action.payload.params !== undefined ||
+              routeParamList[action.payload.name] !== undefined
+                ? {
+                    ...routeParamList[action.payload.name],
+                    ...route.params,
+                    ...action.payload.params,
+                  }
+                : route.params;
+          } else {
+            params =
+              routeParamList[action.payload.name] !== undefined
+                ? {
+                    ...routeParamList[action.payload.name],
+                    ...action.payload.params,
+                  }
+                : action.payload.params;
+          }
+
+          let routes: Route<string>[];
+
+          if (route) {
+            if (action.type === 'NAVIGATE' && action.payload.pop) {
+              routes = [];
+
+              // Get all routes until the matching one
+              for (const r of activeRoutes) {
+                if (r.key === route.key) {
+                  routes.push({
+                    ...route,
+                    path: action.payload.path !== undefined ? action.payload.path : route.path,
+                    params,
+                  });
+                  break;
+                }
+
+                routes.push(r);
+              }
+
+              // Promote the route when it is preloaded and therefore absent from the active routes.
+              if (!routes.some((r) => r.key === route.key)) {
+                routes.push({
+                  ...route,
+                  path: action.payload.path !== undefined ? action.payload.path : route.path,
+                  params,
+                });
+              }
+            } else {
+              // START FORK
+              // If there is an id, then filter out the existing route with the same id.
+              // THIS ACTION IS DANGEROUS. This can cause React Native Screens to freeze
+              if (id !== undefined) {
+                routes = activeRoutes.filter((r) => r.key !== route.key);
+              } else if (action.type === 'NAVIGATE' && activeRoutes.length > 0) {
+                // The navigation action should only replace the last route if it has the same name and path params.
+                const lastRoute = activeRoutes[activeRoutes.length - 1]!;
+                if (
+                  getSingularId(lastRoute.name, { params: lastRoute.params }) ===
+                  getSingularId(route.name, { params })
+                ) {
+                  routes = activeRoutes.slice(0, -1);
+                } else {
+                  routes = [...activeRoutes];
+                }
+              } else {
+                routes = [...activeRoutes];
+              }
+
+              // If the routes length is the same as the state routes length, then we are navigating to a new route.
+              // Otherwise we are replacing an existing route.
+              // For preloaded route, we want to use the same key, so that preloaded screen is used.
+              const key =
+                routes.length === activeRoutes.length && !isPreloadedRoute
+                  ? `${action.payload.name}-${nanoid()}`
+                  : route.key;
+
+              routes.push({
+                ...route,
+                key,
+                path:
+                  action.type === 'NAVIGATE' && action.payload.path !== undefined
+                    ? action.payload.path
+                    : route.path,
+                params,
+              });
+
+              // routes = state.routes.filter((r) => r.key !== route.key);
+              // routes.push({
+              //   ...route,
+              //   path:
+              //     action.type === 'NAVIGATE' && action.payload.path !== undefined
+              //       ? action.payload.path
+              //       : route.path,
+              //   params,
+              // });
+              // END FORK
+            }
+          } else {
+            routes = [
+              ...activeRoutes,
+              {
+                key: `${action.payload.name}-${nanoid()}`,
+                name: action.payload.name,
+                path: action.type === 'NAVIGATE' ? action.payload.path : undefined,
+                params,
+              },
+            ];
+          }
+
+          // START FORK
+          // return filterSingular(
+          const result = {
+            ...state,
+            index: routes.length - 1,
+            routes: routes.concat(
+              preloadedRoutes.filter((route) => routes[routes.length - 1]!.key !== route.key)
+            ),
+          };
+          if (actionSingularOptions) {
+            return filterSingular(result, getId);
+          }
+
+          const zoomTransitionId = getZoomTransitionIdFromAction(action);
+          if (zoomTransitionId) {
+            const lastRoute = result.routes[result.index]!;
+            const key = lastRoute.key;
+            const modifiedLastRoute: typeof lastRoute = {
+              ...lastRoute,
+              params: {
+                ...lastRoute.params,
+                [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: key,
+              },
+            };
+            return {
+              ...result,
+              routes: result.routes.map((route, index) =>
+                index === result.index ? modifiedLastRoute : route
+              ),
+            };
+          }
+
+          return result;
+          // return {
+          //   ...state,
+          //   index: routes.length - 1,
+          //   preloadedRoutes: state.preloadedRoutes.filter(
+          //     (route) => routes[routes.length - 1].key !== route.key
+          //   ),
+          //   routes,
+          // };
+          // END FORK
+        }
+        case 'PRELOAD': {
+          // START FORK
+          // This will be the case for example for protected route
+          if (!state.routeNames.includes(action.payload.name)) {
+            return null;
+          }
+          // END FORK
+          const getId = options.routeGetIdList[action.payload.name];
+          const id = getId?.({ params: action.payload.params });
+          const activeRoutes = state.routes.slice(0, state.index + 1);
+          const preloadedRoutes = state.routes.slice(state.index + 1);
+
+          let route: Route<string> | undefined;
+
+          if (id !== undefined) {
+            route = activeRoutes.find(
+              (route) =>
+                route.name === action.payload.name && id === getId?.({ params: route.params })
+            );
+          }
+
+          const preloadZoomTransitionId = getZoomTransitionIdFromAction(action);
+
+          if (route) {
+            return {
+              ...state,
+              routes: state.routes.map((r) => {
+                if (r.key !== route?.key) {
+                  return r;
+                }
+                const mergedParams =
+                  routeParamList[action.payload.name] !== undefined
+                    ? {
+                        ...routeParamList[action.payload.name],
+                        ...action.payload.params,
+                      }
+                    : action.payload.params;
+                return {
+                  ...r,
+                  params: preloadZoomTransitionId
+                    ? {
+                        ...mergedParams,
+                        [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: r.key,
+                      }
+                    : mergedParams,
+                };
+              }),
+            };
+          } else {
+            // START FORK
+            const preloadedRouteKey = `${action.payload.name}-${nanoid()}`;
+            const preloadedRouteParams =
+              routeParamList[action.payload.name] !== undefined
+                ? {
+                    ...routeParamList[action.payload.name],
+                    ...action.payload.params,
+                  }
+                : action.payload.params;
+            const currentPreloadedRoute: (typeof state)['routes'][number] = {
+              key: preloadedRouteKey,
+              name: action.payload.name,
+              params: preloadZoomTransitionId
+                ? {
+                    ...preloadedRouteParams,
+                    [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME]: preloadedRouteKey,
+                  }
+                : preloadedRouteParams,
+            };
+            // END FORK
+            return {
+              ...state,
+              // START FORK
+              // Adding the current preloaded route to the beginning of the preloadedRoutes array
+              // This ensures that the preloaded route will be the next one after the visible route
+              // and when navigation will happen, there will be no reshuffling
+              // This is a workaround for the link preview navigation issue, when screen would freeze after navigation from native side
+              // and reshuffling from react-navigation
+              routes: activeRoutes.concat(
+                currentPreloadedRoute,
+                preloadedRoutes.filter(
+                  (r) => r.name !== action.payload.name || id !== getId?.({ params: r.params })
+                )
+              ),
+              // preloadedRoutes: state.preloadedRoutes
+              //   .filter(
+              //     (r) =>
+              //       r.name !== action.payload.name ||
+              //       id !== getId?.({ params: r.params })
+              //   )
+              //   .concat({
+              //     key: `${action.payload.name}-${nanoid()}`,
+              //     name: action.payload.name,
+              //     params:
+              //       routeParamList[action.payload.name] !== undefined
+              //         ? {
+              //             ...routeParamList[action.payload.name],
+              //             ...action.payload.params,
+              //           }
+              //         : action.payload.params,
+              //   }),
+              // END FORK
+            };
+          }
+        }
+        default: {
+          return original.getStateForAction(state, action, options);
+        }
+      }
+    },
+  };
+};
+
+function getActionSingularIdFn(
+  actionGetId: SingularOptions | undefined,
+  name: string
+): GetId | undefined {
+  if (typeof actionGetId === 'function') {
+    return (options) => actionGetId(name, options.params ?? {});
+  } else if (actionGetId === true) {
+    return (options) => getSingularId(name, options);
+  }
+
+  return undefined;
+}
+
+/**
+ * If there is a dynamic singular on an action, then we need to filter the state to only have singular screens.
+ * As multiples may have been added before we did the singular navigation.
+ */
+function filterSingular<
+  T extends
+    | StackNavigationState<ParamListBase>
+    | PartialState<StackNavigationState<ParamListBase>>
+    | null,
+>(state: T, getId?: GetId): T {
+  if (!state) {
+    return state;
+  }
+
+  if (!state.routes) {
+    return state;
+  }
+
+  // TODO(@kitten): This looks wrong as it's defaulting `index === 0`
+  const currentIndex = state.index ?? state.routes.length - 1;
+  const activeRoutes = state.routes.slice(0, currentIndex + 1);
+  const preloadedRoutes = state.routes.slice(currentIndex + 1);
+  const current = activeRoutes[currentIndex]!;
+  const name = current.name;
+
+  const id = getId?.({ params: current.params });
+
+  if (!id) {
+    return state;
+  }
+
+  // TypeScript needs a type assertion here for the filter to work.
+  let routes = activeRoutes as PartialRoute<Route<string, object | undefined>>[];
+  routes = routes.filter((route, index) => {
+    // If the route is the current route, keep it.
+    if (index === currentIndex) {
+      return true;
+    }
+
+    // Remove all other routes with the same name and id.
+    return name !== route.name || id !== getId?.({ params: route.params });
+  });
+
+  return {
+    ...state,
+    index: routes.length - 1,
+    // Filtering preserves the input state's route type even though TypeScript widens it to partial routes.
+    routes: [...routes, ...preloadedRoutes] as T extends null ? never : NonNullable<T>['routes'],
+  };
+}
+
+export const StackRouter: typeof RNStackRouter = (options) => {
+  const router = RNStackRouter(options);
+  return {
+    ...router,
+    ...stackRouterOverride(router),
+  };
+};


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

1. use `createStandardNavigator` to create the navigator:
   - remove `useNavigationBuilder`
   - Moves the js pop to top logic (`navigation?.addListener?.('tabPress'`) to StackClient.tsx (`subscribePopToTopOnParentTabPress`)
2. Split StackClient into two files - one for router and one for integration 

# Test Plan

- CI
- Router-e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
