### PR TITLE
[docs] Fix lint job failing when all changed files match oxfmt `ignorePatterns`

### DIFF
--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -104,6 +104,15 @@ if (oxfmtChangedFiles !== null && oxfmtChangedFiles.length === 0) {
   oxfmtResult = { status: 0, output: 'No formattable files changed.' };
 } else if (oxfmtChangedFiles !== null) {
   oxfmtResult = await runAsync('oxfmt', ['--check', ...oxfmtChangedFiles]);
+  if (
+    oxfmtResult.status !== 0 &&
+    oxfmtResult.output.includes('Expected at least one target file')
+  ) {
+    oxfmtResult = {
+      status: 0,
+      output: 'No formattable files changed (all changed files are in ignorePatterns).',
+    };
+  }
 } else {
   const mdxFiles = globSync('**/*.mdx', { cwd: process.cwd() });
   oxfmtResult = await runAsync('oxfmt', ['--check', process.cwd(), ...mdxFiles]);


### PR DESCRIPTION
# Why

The Docs Website job on main fails when a push only touches files that oxfmt ignores. [Commit e84a707](https://github.com/expo/expo/commit/e84a707b28f347ac670c6a6370bc1767f7a01772) changed only `public/static/talks.ts`, and since `public` is in the oxfmt `ignorePatterns`, the CI-only changed-files path handed oxfmt a list that resolved to nothing:

> Expected at least one target file. All matched files may have been excluded by ignore rules.

This is the same hole #46150 already closed for oxlint, and it skipped the website build and deploy.

# How

- Treat oxfmt's `Expected at least one target file` error as a pass in `scripts/lint.js`, mirroring the existing oxlint `No files found to lint` guard.

# Test Plan

Real formatting violations still fail, `oxfmt --check` on a misformatted file exits 1 with `Format issues found`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).