### PR TITLE
[brownfield][android] Fix fused strip-packages corrupting ExpoModulesPackageList.kt on broad prefixes

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix `build:ios` with precompiled modules: locate frameworks under `XCFrameworkIntermediates/`, bundle `ExpoModulesJSI`, copy SPM deps as real flavor-matched directories instead of symlinks, and fail fast on duplicate or colliding target names. ([#48065](https://github.com/expo/expo/pull/48065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Fix `brownfield.fused.strip-packages` corrupting the generated `ExpoModulesPackageList.kt` when given a broad prefix (e.g. `expo.modules`). ([@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix `build:ios` with precompiled modules: locate frameworks under `XCFrameworkIntermediates/`, bundle `ExpoModulesJSI`, copy SPM deps as real flavor-matched directories instead of symlinks, and fail fast on duplicate or colliding target names. ([#48065](https://github.com/expo/expo/pull/48065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [android] Fix `brownfield.fused.strip-packages` corrupting the generated `ExpoModulesPackageList.kt` when given a broad prefix (e.g. `expo.modules`). ([@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Fix `brownfield.fused.strip-packages` corrupting the generated `ExpoModulesPackageList.kt` when given a broad prefix (e.g. `expo.modules`). ([@gabrieldonadel](https://github.com/gabrieldonadel)) ([#48118](https://github.com/expo/expo/pull/48118) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/gradle-plugins/brownfield/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
   implementation("org.json:json:20250517")
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
+
+  testImplementation("junit:junit:4.13.2")
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -67,11 +67,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
         return@doLast
       }
       val original = outputFile.readText()
-      val stripped =
-        original
-          .lineSequence()
-          .filter { line -> stripPrefixes.none { prefix -> line.contains(prefix) } }
-          .joinToString("\n")
+      val stripped = stripFusedPackageListEntries(original, stripPrefixes)
       outputFile.writeText(stripped)
       expoProject.logger.lifecycle(
         "brownfield.fused: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/utils.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/utils.kt
@@ -113,6 +113,24 @@ private fun resolveResourceReference(raw: String, strings: Map<String, String>):
   return raw
 }
 
+/**
+ * Remove entries from a generated `ExpoModulesPackageList.kt` whose fully-qualified class name
+ * starts with any of the given package prefixes. Used by `--fused` brownfield builds to keep the
+ * package list consistent with a fat AAR that excludes some modules.
+ *
+ * Matching the start of the class name (not `contains`) preserves structural lines like the
+ * `package` declaration, imports, and the `getServices()` signature, which themselves contain
+ * `expo.modules`. This lets a broad prefix like `expo.modules` strip every entry without corrupting
+ * the file.
+ */
+fun stripFusedPackageListEntries(content: String, prefixes: Set<String>): String {
+  if (prefixes.isEmpty()) return content
+  return content
+    .lineSequence()
+    .filter { line -> prefixes.none { prefix -> line.trimStart().startsWith(prefix) } }
+    .joinToString("\n")
+}
+
 private fun escapeXmlAttribute(value: String): String =
   value.replace("&", "&amp;")
     .replace("<", "&lt;")

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/test/kotlin/expo/modules/plugin/StripFusedPackageListEntriesTest.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/test/kotlin/expo/modules/plugin/StripFusedPackageListEntriesTest.kt
@@ -1,0 +1,94 @@
+package expo.modules.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StripFusedPackageListEntriesTest {
+  // Mirrors the output of GeneratePackagesListTask: `package expo.modules;`, the imports, and the
+  // `getServices()` signature all legitimately contain `expo.modules`.
+  private val generated =
+    """
+    package expo.modules;
+
+    import expo.modules.core.interfaces.Package;
+    import expo.modules.kotlin.modules.Module;
+    import expo.modules.kotlin.ModulesProvider;
+
+    class ExpoModulesPackageList : ModulesProvider {
+      companion object {
+        val packagesList: List<Package> = listOf(
+          expo.modules.foo.FooPackage(),
+          expo.modules.bar.BarPackage()
+        )
+
+        val modulesMap: Map<Class<out Module>, String?> = mapOf(
+          expo.modules.foo.FooModule::class.java to "Foo",
+          expo.modules.bar.BarModule::class.java to "Bar"
+        )
+
+        @JvmStatic
+        fun getPackageList(): List<Package> {
+          return packagesList
+        }
+      }
+
+      override fun getModulesMap(): Map<Class<out Module>, String?> {
+        return modulesMap
+      }
+
+      override fun getServices(): List<Class<out expo.modules.kotlin.services.Service>> {
+        return listOf<Class<out expo.modules.kotlin.services.Service>>(
+          expo.modules.foo.FooService::class.java
+        )
+      }
+    }
+    """.trimIndent()
+
+  private fun assertBalanced(source: String) {
+    fun count(c: Char) = source.count { it == c }
+    assertEquals("unbalanced braces", count('{'), count('}'))
+    assertEquals("unbalanced parens", count('('), count(')'))
+  }
+
+  @Test
+  fun `broad prefix strips every module entry without corrupting structure`() {
+    val result = stripFusedPackageListEntries(generated, setOf("expo.modules"))
+
+    // Structural lines that legitimately contain the prefix must survive.
+    assertTrue(result.contains("package expo.modules;"))
+    assertTrue(result.contains("import expo.modules.core.interfaces.Package;"))
+    assertTrue(
+      result.contains("override fun getServices(): List<Class<out expo.modules.kotlin.services.Service>> {")
+    )
+    assertTrue(result.contains("return listOf<Class<out expo.modules.kotlin.services.Service>>("))
+
+    // The file must still be a valid, balanced Kotlin source (the reported crash was
+    // `Expecting member declaration` from stray `)`/`}` left behind).
+    assertBalanced(result)
+
+    // The actual module entries are gone.
+    assertFalse(result.contains("FooPackage()"))
+    assertFalse(result.contains("BarPackage()"))
+    assertFalse(result.contains("FooService::class.java"))
+  }
+
+  @Test
+  fun `specific prefix strips only the matching module`() {
+    val result = stripFusedPackageListEntries(generated, setOf("expo.modules.foo."))
+
+    assertFalse(result.contains("FooPackage()"))
+    assertFalse(result.contains("FooModule::class.java"))
+    assertFalse(result.contains("FooService::class.java"))
+
+    assertTrue(result.contains("BarPackage()"))
+    assertTrue(result.contains("BarModule::class.java"))
+    assertBalanced(result)
+  }
+
+  @Test
+  fun `empty prefix set leaves content untouched`() {
+    assertEquals(generated, stripFusedPackageListEntries(generated, emptySet()))
+  }
+}


### PR DESCRIPTION
# Why

While integrating expo/expo-brownfield-examples#45, we noticed an issue when using `-Pbrownfield.fused.strip-packages` with `--fused` and passing a broad or over-matching prefix (for example `expo.modules`), would create a corrupted `ExpoModulesPackageList.kt`. `:expo:compileReleaseKotlin` fails with `Syntax error: Expecting member declaration`. Any prefix broad enough to also appear in the file's structural lines broke the build, which is easy to hit since every entry lives under `expo.modules.*`.

# How

The stripping logic filtered out every line that `contains` the prefix. But `ExpoModulesPackageList.kt` legitimately contains `expo.modules` in lines that are not module entries: the `package` declaration, the `import`s, and the `getServices()` signature (`listOf<Class<out expo.modules.kotlin.services.Service>>(`). Deleting those left orphaned `)` / `}` tokens, hence the syntax error.

The fix matches at the start of the line's content (`trimStart().startsWith(prefix)`) rather than anywhere in it. Module entries begin with the fully-qualified class name being instantiated or referenced; structural lines begin with a Kotlin keyword. So a broad prefix like `expo.modules` now strips every module entry while leaving the file structurally valid.

The line-filtering was also extracted into a pure `stripFusedPackageListEntries()` helper so it can be unit tested in isolation.

# Test Plan

Added `StripFusedPackageListEntriesTest` covering a broad prefix (strips all entries, keeps structure and balanced braces), a specific prefix (strips only the matching module), and an empty prefix set (no-op). Verified red/green: the broad-prefix case fails against the old `contains` behavior and passes after the fix.

