### PR TITLE
[ios][router]: sync native tabs group route title with the focused tab

### DIFF
--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import React, { use, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { use, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import { useRouteNode } from '../Route';
 import { router } from '../imperative-api';
-import type {
-  ParamListBase,
-  TabNavigationState,
-  TabRouterOptions,
+import {
+  type ParamListBase,
+  type TabNavigationState,
+  type TabRouterOptions,
+  useNavigation,
 } from '../react-navigation/native';
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
 import type {
@@ -33,6 +35,16 @@ import { convertIconColorPropToObject, convertLabelStylePropToObject } from './u
 const defaultBackBehavior = 'initialRoute';
 export const NativeTabsContext = React.createContext<boolean>(false);
 
+function useTabsGroupRouteTitle(title?: string, enabled?: boolean) {
+  const navigation = useNavigation();
+
+  useLayoutEffect(() => {
+    if (enabled && title !== undefined) {
+      navigation.setOptions({ title });
+    }
+  }, [enabled, navigation, title]);
+}
+
 function NativeTabsContent({
   state,
   descriptors,
@@ -52,6 +64,7 @@ function NativeTabsContent({
   disableIndicator,
   labelVisibilityMode,
   redirectToRouteName,
+  titleFromFocusedTab,
   ...rest
 }: StandardNavigatorContentProps<
   NativeTabOptions,
@@ -97,6 +110,11 @@ function NativeTabsContent({
   );
 
   const focusedIndex = visibleFocusedTabIndex >= 0 ? visibleFocusedTabIndex : 0;
+
+  const focusedTab = visibleTabs[focusedIndex];
+  const groupRouteTitle = focusedTab ? focusedTab.options.title || focusedTab.name : undefined;
+
+  useTabsGroupRouteTitle(groupRouteTitle, titleFromFocusedTab && Platform.OS === 'ios');
 
   // The focused route can be hidden or have no trigger at all — for example a path pointing at a
   // route without a tab, or a trigger hidden while focused. Redirect to the router's initial tab,

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -476,6 +476,23 @@ export interface NativeTabsProps extends PropsWithChildren {
    * @platform ios
    */
   unstable_nativeProps?: NativeTabsHostNativeProps;
+
+  /**
+   * When set to `true`, keeps the `title` option of the tabs group route in the
+   * parent stack in sync with the title of the currently focused tab.
+   *
+   * This is required for a correct back button title (and its long-press menu)
+   * on iOS: the native stack derives the back title from the `title` of the
+   * previous screen, which is the tabs layout route itself rather than the
+   * selected tab.
+   *
+   * > **Note**: This also affects the header title of the group route, if its
+   * > header is visible.
+   *
+   * @default false
+   * @platform iOS
+   */
+  titleFromFocusedTab?: boolean;
 }
 
 export interface InternalNativeTabsProps extends NativeTabsProps {
@@ -520,6 +537,7 @@ export interface NativeTabsViewProps extends Omit<
   | 'disableIndicator'
   | 'redirectToRouteName'
   | 'labelVisibilityMode'
+  | 'titleFromFocusedTab'
 > {
   focusedIndex: number;
   /**


### PR DESCRIPTION
# Why

On iOS the native stack takes the back button title (and its long-press menu) from the previous screen's `title`. For a tabs layout that screen is the group route, so it reads `(tabs)` instead of the tab you're returning to.

# How

Adds `titleFromFocusedTab` on `<NativeTabs>`. When enabled, writes the focused tab's title into the group route's `title` via `setOptions`, in a layout effect so it's set before a push. Falls back to the route name when the tab has no label. Off by default.

Also affects the group route's own header title if one is visible.

# Test Plan

`<NativeTabs titleFromFocusedTab>` in `app/(tabs)/_layout.tsx` under a root `<Stack>`, one tab labeled Settings. Select it, push a screen outside the group, long-press back: reads Settings instead of `(tabs)`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
