### PR TITLE
[CI] Scope the bare-expo iOS pods cache by build configuration

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -14,6 +14,14 @@ inputs:
   bare-expo-pods:
     description: 'Restore /apps/bare-expo/ios pods cache'
     required: false
+  bare-expo-pods-configuration:
+    description: >
+      Build configuration the restored /apps/bare-expo/ios pods will be used with.
+      The Pods dir holds configuration-specific prebuilt artifacts (React-Core-prebuilt's
+      React.xcframework and its .last_build_configuration marker), so Debug and Release
+      consumers must not share a cache entry.
+    default: 'Release'
+    required: false
   bare-expo-macos-pods:
     description: 'Restore /apps/bare-expo/macos pods cache'
     required: false
@@ -105,7 +113,7 @@ runs:
       id: bare-expo-pods-cache
       with:
         path: apps/bare-expo/ios/Pods
-        key: ${{ runner.os }}-bare-expo-pods-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
+        key: ${{ runner.os }}-bare-expo-pods-${{ inputs.bare-expo-pods-configuration }}-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
 
     - name: ♻️ Restore apps/bare-expo/macos/Pods from cache
       if: inputs.bare-expo-macos-pods == 'true'

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -70,6 +70,11 @@ jobs:
         with:
           ccache: 'true'
           bare-expo-pods: 'true'
+          # Unit tests build Debug, while Test Suite e2e builds the same app Release. They'd
+          # otherwise share one cache entry, and whichever saved it first would decide which
+          # React.xcframework the other restored. A Release framework in a Debug build fails
+          # to link, since Debug ExpoModulesCore references debug-only Fabric symbols.
+          bare-expo-pods-configuration: 'Debug'
       - name: Reset ccache stats
         run: ccache -z
       - name: 📦 Install node modules


### PR DESCRIPTION
# Why

`iOS Unit Tests` is intermittently red on `main`: every bundle linking `ExpoModulesCore` fails on `REACT_NATIVE_DEBUG`-only Fabric symbols (`facebook::react::Sealable`, `ShadowNode::getDebugName`, `BaseViewProps::getDebugProps`).

Debug `ExpoModulesCore` references those (force-loaded via `-ObjC`); the **Release** `React.xcframework` doesn't export them (measured: debug tarball ~110, release 0).

`iOS Unit Tests` and `Test Suite e2e` both cache `apps/bare-expo/ios/Pods` under a key hashing only `Podfile.lock`, but unit tests build Debug and e2e builds Release. `Pods/React-Core-prebuilt` is configuration-specific state (the extracted framework plus a `.last_build_configuration` marker), and RN's `replace-rncore-version.js` swaps the framework only when that marker disagrees with the configuration being built, treating a missing marker as "already Debug". So restoring the other job's entry can hand a Debug build the Release framework with a marker that suppresses the swap. Hence the flip-flop between runs off one key: the swap took ~6s in the last green run (no extraction) vs ~14s in the red one.

`pod install` doesn't repair it: it runs unconditionally, but with `Pods/` restored and the lockfile unchanged, CocoaPods treats the `:http` pod as satisfied and leaves `React-Core-prebuilt` alone.

This regressed when the workflow moved from `apps/native-tests/ios` (private cache) to `apps/bare-expo/ios` (shared cache). The build logic was fine; cache isolation was lost.

# How

Put the configuration in the cache key so Debug and Release consumers can't share an entry:

```
key: ${{ runner.os }}-bare-expo-pods-${{ inputs.bare-expo-pods-configuration }}-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
```

`expo-caches` gains a `bare-expo-pods-configuration` input defaulting to `Release`, so `Test Suite e2e` needs no change; `ios-unit-tests.yml` passes `Debug`. Both jobs take a one-time cold miss, then repopulate their own entry.

Considered and rejected: forcing the swap by pre-writing the marker (works, but lies to upstream state and goes quiet when it drifts), and excluding `React-Core-prebuilt` from the cache (robust, but re-extracts every run and leaves the key collision in place).

# Test Plan

Verified locally on a fully clean build (wiped `/tmp/ExpoUnitTestsDerivedData` and `~/Library/Developer/Xcode/DerivedData/BareExpo-*`):

- Reproduced the failure with a Release framework and no marker; confirmed the symbol asymmetry with `nm -gU` on both extracted frameworks.
- Made the marker disagree (`printf 'Release' > Pods/React-Core-prebuilt/.last_build_configuration`) and `et native-unit-tests -p ios --packages expo-video` went green, no source changes.
- Confirmed it isn't package-specific: `et native-unit-tests --platform ios` failed all 25 packages, including ones already carrying `-lc++`; untouched `expo-clipboard` failed identically.

Ruled out: missing `-lc++` (green CI links these bundles with none anywhere), missing `ExpoModulesTestCore` (`expo-clipboard` declares it and still failed), stale DerivedData.

For this PR, `iOS Unit Tests` should go green with a `Debug`-suffixed key. Since the failure is a race off a shared key, the meaningful signal is the two workflows resolving different keys, ideally once an e2e run has saved its Release entry.

# Notes

- The upstream "no marker means Debug" assumption in `replace-rncore-version.js` only holds for a fresh `pod install`. This makes it unreachable for these jobs rather than fixing it, so it stays reportable upstream.
- Unrelated, left alone: `test-suite-macos.yml` gates its macOS pod install on `bare-expo-pods-hit` (the iOS output) instead of `bare-expo-macos-pods-hit`. Harmless today since that output is empty there, so pod install always runs.