### PR TITLE
[expo-blur][Android] Proxy startViewTransition/endViewTransition to the blur target

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix `BlurView` not applying border radius styles to the native blur layer. ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong)) and [@behenate](https://github.com/behenate)
 - [Android] Fix gesture handlers treating views under a `BlurTargetView` as detached and cancelling their gestures. ([#47404](https://github.com/expo/expo/pull/47404) by [@efstathiosntonas](https://github.com/efstathiosntonas))
+- [Android] Fix content inside a `BlurTargetView` disappearing during screen exit animations. ([#48141](https://github.com/expo/expo/pull/48141) by [@alok-debnath](https://github.com/alok-debnath))
 
 ### 💡 Others
 

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
@@ -109,6 +109,30 @@ class ExpoBlurTargetView(context: Context, appContext: AppContext) : ExpoView(co
     return blurTargetView.indexOfChild(child)
   }
 
+  // `ViewGroup.startViewTransition` records the view in the *receiver's* `mTransitioningViews`,
+  // guarded by `if (view.mParent == this)`. Every proxied child's real parent is
+  // `blurTargetView`, so calling it on this host silently does nothing and the child is detached
+  // for real as soon as its React element unmounts — even mid-animation.
+  // `react-native-screens` relies on this call (`Screen.startRemovalTransition`, which walks the
+  // tree with the public `getChildCount`/`getChildAt` overridden above) to keep an outgoing
+  // screen painted while it animates out, so without the proxy a blur target's contents vanish
+  // on pop while its siblings animate normally. Mirror the add/remove overrides above.
+  override fun startViewTransition(view: View?) {
+    if (view === blurTargetView) {
+      super.startViewTransition(view)
+      return
+    }
+    blurTargetView.startViewTransition(view)
+  }
+
+  override fun endViewTransition(view: View?) {
+    if (view === blurTargetView) {
+      super.endViewTransition(view)
+      return
+    }
+    blurTargetView.endViewTransition(view)
+  }
+
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     val width = MeasureSpec.getSize(widthMeasureSpec)
     val height = MeasureSpec.getSize(heightMeasureSpec)


### PR DESCRIPTION
# Why

Fixes #48139.

On Android, content rendered inside a `<BlurTargetView>` disappears instantly when a `react-native-screens` native-stack screen is popped, instead of staying painted for the exit animation. Siblings of the target animate out correctly, so the screen visibly tears in half mid-transition. iOS is unaffected.

`ExpoBlurTargetView` adds a `UIManagerCompatibleBlurTarget` as its only real child and proxies the child operations onto it, so for every React-managed child `child.getParent() === blurTargetView`, not the host. `startViewTransition` / `endViewTransition` were not among the proxied operations, and `ViewGroup.startViewTransition` is guarded on exactly that:

```java
public void startViewTransition(View view) {
    if (view.mParent == this) {
        ...
        mTransitioningViews.add(view);
    }
}
```

`react-native-screens` calls it on every node of an outgoing screen's subtree — `Screen.startRemovalTransition()` → `startTransitionRecursive()`, which walks the tree with the public `getChildCount()` / `getChildAt(i)`. At an `ExpoBlurTargetView` those return views whose real parent is `blurTargetView`, so `host.startViewTransition(child)` hits the guard and no-ops. Nothing lands in `mTransitioningViews`.

When Fabric then unmounts the popped screen — while the animation is still running — the removal is proxied to `blurTargetView.removeView(child)`. Since the child was never registered as transitioning, `removeViewInternal` does not move it into `mDisappearingChildren`; it is detached for real and stops being drawn immediately.

`endTransitionRecursive` / `endRemovalTransition` had the mirrored problem.

Same class of bug as #43595 (removal ops) and #47404 (`indexOfChild`) — another `ViewGroup` method the reparenting proxy did not cover.

# How

Mirror the existing `addView` / `removeView` / `indexOfChild` overrides: route both calls to `blurTargetView`, with the usual guard for the real child.

# Test Plan

Verified on a physical Android device against Expo SDK 57 (`expo-blur` 57.0.2, `react-native` 0.86.0 new architecture, `react-native-screens` 4.26.2), on a screen shaped like the documented Android blur pattern — a per-screen `BlurTargetView` wrapping the page content, with a floating header rendered as its sibling holding a `BlurView` with `blurMethod="dimezisBlurViewSdk31Plus"` pointed at the target.

A/B with the same compile path both times (`buildFromSource` for `expo-blur` left on, the patch as the only variable):

- **Without the fix:** pressing back makes the page content vanish at the first frame of the pop; the header slides out normally.
- **With the fix:** the whole screen animates out together.

Also checked the case where the semantics change — removed children now enter `mDisappearingChildren` where previously they entered nothing — by starting a back-swipe and cancelling it. No lingering ghost content.
