### PR TITLE
fix-doc: rename headerBackImageSource into its correct name headerBackIcon

### DIFF
--- a/docs/public/data/react-navigation-options.json
+++ b/docs/public/data/react-navigation-options.json
@@ -62,7 +62,7 @@
       "origin": "native-stack-navigator"
     },
     {
-      "name": "headerBackImageSource",
+      "name": "headerBackIcon",
       "description": "Image to display in the header as the icon in the back button. Defaults to back icon image for the platform\n\n- A chevron on iOS\n- An arrow on Android",
       "platform": "Both",
       "category": "header",


### PR DESCRIPTION
# Why

the correct naming of the react navigation option "header back icon" is `headerBackIcon` and not `headerBackImageSource`.
