### PR TITLE
[notifications][iOS] Lock NotificationCenterManager delegate state

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a data race on `NotificationCenterManager` delegate state that could corrupt the heap. ([#48147](https://github.com/expo/expo/pull/48147) by [@zcharef](https://github.com/zcharef))
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-26

--- a/packages/expo-notifications/ios/ExpoNotifications/Notifications/NotificationCenterManager.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Notifications/NotificationCenterManager.swift
@@ -42,8 +42,28 @@ public class NotificationCenterManager: NSObject,
   @objc
   public static let shared = NotificationCenterManager()
 
-  var delegates: [NotificationDelegate] = []
-  var pendingResponses: [UNNotificationResponse] = []
+  // Delegates are added and removed on whichever thread registers a module or adds a JS
+  // listener, while the UNUserNotificationCenter callbacks read them on another thread.
+  // Arrays are value types with copy-on-write storage, so unsynchronized access here tears
+  // the buffer apart. Every read and write goes through `stateLock`, and the getters hand
+  // back a copy: callers iterate a snapshot instead of holding the lock across a delegate
+  // call, which is free to call back into `addDelegate` or `removeDelegate`.
+  private let stateLock = NSLock()
+  private var _delegates: [NotificationDelegate] = []
+  private var _pendingResponses: [UNNotificationResponse] = []
+
+  var delegates: [NotificationDelegate] {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return _delegates
+  }
+
+  var pendingResponses: [UNNotificationResponse] {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return _pendingResponses
+  }
+
   let userNotificationCenter: UNUserNotificationCenter = UNUserNotificationCenter.current()
 
   private override init() {
@@ -62,19 +82,26 @@ public class NotificationCenterManager: NSObject,
   }
 
   public func addDelegate(_ delegate: NotificationDelegate) {
-    delegates.append(delegate)
+    stateLock.lock()
+    _delegates.append(delegate)
+    stateLock.unlock()
+
     var handled = false
     for pendingResponse in pendingResponses {
       handled = delegate.didReceive(pendingResponse, completionHandler: {}) || handled
     }
     if handled {
-      pendingResponses.removeAll()
+      stateLock.lock()
+      _pendingResponses.removeAll()
+      stateLock.unlock()
     }
   }
 
   public func removeDelegate(_ delegate: AnyObject) {
-    if let index = delegates.firstIndex(where: { $0 === delegate }) {
-      delegates.remove(at: index)
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    if let index = _delegates.firstIndex(where: { $0 === delegate }) {
+      _delegates.remove(at: index)
     }
   }
 
@@ -118,7 +145,9 @@ public class NotificationCenterManager: NSObject,
       handled = delegate.didReceive(response, completionHandler: completionHandler) || handled
     }
     if !handled {
-      pendingResponses.append(response)
+      stateLock.lock()
+      _pendingResponses.append(response)
+      stateLock.unlock()
     }
     completionHandler()
   }


### PR DESCRIPTION
# Why

`NotificationCenterManager` keeps `delegates` and `pendingResponses` as plain Swift arrays with no synchronization. They are written from whichever thread registers a module or adds a JS listener, and read from the `UNUserNotificationCenter` callbacks on another thread. Swift arrays are value types over copy-on-write storage, so two threads touching one at the same time can release an element out of a buffer that is being reallocated underneath them.

Three modules add and remove themselves on module lifecycle, all on the JS thread:

- `EmitterModule` (`OnCreate` / `OnDestroy`)
- `HandlerModule` (`OnCreate` / `OnDestroy`)
- `PushTokenModule` (`OnCreate` / `OnDestroy`)

`OnCreate` fires inside `ModuleHolder.init` → `ModuleRegistry.register(fromProvider:)` → `AppContext.registerNativeModules()`, which runs on the React instance's JS thread. One RN instance plus a notification arriving on the main thread during startup is already enough to race. Anything that keeps several RN instances alive at once makes it much easier to hit.

A crash from a debug simulator build on SDK 55 (`expo-notifications@55.0.23`), where seven `com.facebook.react.runtime.JavaScript` threads were inside `AppContext.registerNativeModules()` at the same time and an eighth was running `-[RCTInstance invalidate]`:

```
Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000beaddcc8d610

Thread 41 Crashed:: com.facebook.react.runtime.JavaScript
0   libswiftCore.dylib   _swift_release_dealloc + 16
1   libswiftCore.dylib   RefCounts<...>::doDecrementSlow<...> + 156
2   libswiftCore.dylib   _ArrayBuffer._copyContents(subRange:initializing:) + 160
3   libswiftCore.dylib   _ArrayBuffer._consumeAndCreateNew(...) + 468
4   libswiftCore.dylib   Array._reserveCapacityAssumingUniqueBuffer(oldCount:) + 108
5   libswiftCore.dylib   Array.append(_:) + 76
6   ExpoNotifications    NotificationCenterManager.addDelegate(_:) + 192   (NotificationCenterManager.swift:65)
7   ExpoNotifications    closure #1 in EmitterModule.definition() + 104    (EmitterModule.swift:19)
...
13  ExpoNotifications    ModuleHolder.post(event:) + 132
14  ExpoNotifications    ModuleHolder.init(appContext:module:name:) + 384
16  ExpoNotifications    ModuleRegistry.register(module:name:...) + 260
22  ExpoNotifications    ModuleRegistry.register(fromProvider:) + 188
26  ExpoNotifications    AppContext.registerNativeModules() + 84
```

The faulting address sits in no mapped region. It was read out of a buffer another thread had already reallocated.

#47702 hit the same race on 57.0.3 with a different symptom, `_xzm_free_abort` inside `Array.append`. It was closed automatically for a missing reproduction. A race between a module registration and a system callback has no small deterministic repro, so I am sending the patch instead.

# How

Both arrays move behind an `NSLock`. The two properties become computed getters that copy under the lock and hand back the copy, so callers iterate a snapshot instead of holding the lock while calling into a delegate. That part matters: a delegate can call `addDelegate` or `removeDelegate` from inside `didReceive`, and `NSLock` is not recursive, so holding it across a callback would deadlock.

Behaviour is otherwise unchanged. `delegates` and `pendingResponses` stay internal, keep their types, and every existing `for delegate in delegates` site works as before.

# Test Plan

- `swiftc -parse` on the modified file passes.
- Checked every reader and writer of `delegates` and `pendingResponses` under `packages/expo-notifications/ios`. They all live in this file, so no caller depends on the properties being stored or settable.
- I have not built this against the monorepo iOS setup, so CI is the first real compile. Happy to adjust if you would rather see a `DispatchQueue` or an actor here than an `NSLock`.
