### PR TITLE
[android][audio] Pause playback when audio output disconnects

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48138](https://github.com/expo/expo/issues/48138) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48138](https://github.com/expo/expo/issues/48138) by [@vivekjm](https://github.com/vivekjm))
+- [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48151](https://github.com/expo/expo/pull/48151) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))
 - [Android] Fix recording crash in apps wrapped with Microsoft Intune. ([#47005](https://github.com/expo/expo/pull/47005) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -36,6 +36,7 @@ class AudioPlayer(
   player = ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
     .setAudioAttributes(AudioAttributes.DEFAULT, false)
+    .setHandleAudioBecomingNoisy(true)
     .setSeekForwardIncrementMs(SEEK_JUMP_INTERVAL_MS)
     .setSeekBackIncrementMs(SEEK_JUMP_INTERVAL_MS)
     .apply {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
@@ -28,6 +28,7 @@ class AudioPlaylist(
   player = ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
     .setAudioAttributes(AudioAttributes.DEFAULT, false)
+    .setHandleAudioBecomingNoisy(true)
     .setMediaSourceFactory(DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory))
     .build(),
   appContext = appContext,


### PR DESCRIPTION
# Why

On Android, expo-audio keeps playing through the device speaker when wired headphones or a Bluetooth audio route disconnects. This differs from iOS and from the documented behavior.

Closes #48138.

# How

Enable Media3's built-in audio-becoming-noisy handling on both `AudioPlayer` and `AudioPlaylist`. Media3 then pauses playback when Android reports that the current output route became noisy.

# Test Plan

- `pnpm run format --check` in `packages/expo-audio`
- `pnpm run lint` in `packages/expo-audio`
- `pnpm run typecheck` in `packages/expo-audio`
- `git diff --check`
- Attempted `./gradlew :expo-audio:compileDebugKotlin --no-daemon` from `apps/bare-expo/android`; Gradle stopped during settings evaluation because the local `node` subprocess exited before the expo-audio compile task ran.
- Not tested on a physical Android device; reproducing the route-disconnect event requires wired headphones or Bluetooth hardware.

A reviewer can verify manually by starting playback on a physical Android device through headphones, then disconnecting the wired or Bluetooth route. Playback should pause instead of moving to the speaker.

# Checklist

- [x] I added a `CHANGELOG.md` entry.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (not applicable; no config plugin changes).
- [ ] Conforms with the Documentation Writing Style Guide (not applicable; no documentation changes).