### PR TITLE
[router] Don't set nativeContainerStyle for transparent navigators

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/modals/form-sheet-nested/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/modals/form-sheet-nested/_layout.tsx
@@ -4,7 +4,6 @@ export default function Layout() {
   return (
     <Stack
       screenOptions={{ headerShown: false, contentStyle: { backgroundColor: 'transparent' } }}
-      unstable_nativeProps={{ nativeContainerStyle: {} }}
     />
   );
 }

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- Unset `nativeContainerStyle` in transparent presentations ([#48154](https://github.com/expo/expo/pull/48154) by [@Ubax](https://github.com/Ubax))
 - [android] Disable safe area insets in Native Tabs on Android when tab bar is hidden. ([#47611](https://github.com/expo/expo/pull/47611) by [@debitan](https://github.com/debitan))
 - Sync config plugin `Props` type with the options schema, adding the missing `redirects`, `rewrites`, `platformRoutes`, and `disableSynchronousScreensUpdates` options. ([#46677](https://github.com/expo/expo/pull/46677) by [@zoontek](https://github.com/zoontek))
 - [android] fix renderingMode for toolbar icons ([#46149](https://github.com/expo/expo/pull/46149) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/native-stack/utils/ScreenPresentationContext.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/utils/ScreenPresentationContext.tsx
@@ -1,0 +1,10 @@
+'use client';
+import * as React from 'react';
+
+import type { NativeStackNavigationOptions } from '../types';
+
+// Effective `presentation` of the screen hosting the current subtree, so nested
+// navigators can skip opaque defaults inside transparent presentations.
+export const ScreenPresentationContext = React.createContext<
+  NativeStackNavigationOptions['presentation'] | undefined
+>(undefined);

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -34,6 +34,7 @@ import type {
   NativeStackNavigationConfig,
   NativeStackNavigationHelpers,
 } from '../types';
+import { ScreenPresentationContext } from '../utils/ScreenPresentationContext';
 import { debounce } from '../utils/debounce';
 import { getModalRouteKeys } from '../utils/getModalRoutesKeys';
 import { AnimatedHeaderHeightContext } from '../utils/useAnimatedHeaderHeight';
@@ -409,45 +410,49 @@ const SceneView = ({
         // So we keep any props that need it at the end
         // Otherwise invalid props may not be caught by TypeScript
         shouldFreeze={shouldFreeze}>
-        <AnimatedHeaderHeightContext.Provider value={animatedHeaderHeight}>
-          <HeaderHeightContext.Provider
-            value={headerShown !== false ? headerHeight : (parentHeaderHeight ?? 0)}>
-            {headerBackground != null ? (
-              /**
-               * To show a custom header background, we render it at the top of the screen below the header
-               * The header also needs to be positioned absolutely (with `translucent` style)
-               */
-              <View
-                style={[
-                  styles.background,
-                  headerTransparent ? styles.translucent : null,
-                  { height: headerHeight },
-                ]}>
-                {headerBackground()}
-              </View>
-            ) : null}
-            {header != null && headerShown !== false ? (
-              <View
-                onLayout={(e) => {
-                  const headerHeight = e.nativeEvent.layout.height;
+        <ScreenPresentationContext.Provider value={presentation}>
+          <AnimatedHeaderHeightContext.Provider value={animatedHeaderHeight}>
+            <HeaderHeightContext.Provider
+              value={headerShown !== false ? headerHeight : (parentHeaderHeight ?? 0)}>
+              {headerBackground != null ? (
+                /**
+                 * To show a custom header background, we render it at the top of the screen below the header
+                 * The header also needs to be positioned absolutely (with `translucent` style)
+                 */
+                <View
+                  style={[
+                    styles.background,
+                    headerTransparent ? styles.translucent : null,
+                    { height: headerHeight },
+                  ]}>
+                  {headerBackground()}
+                </View>
+              ) : null}
+              {header != null && headerShown !== false ? (
+                <View
+                  onLayout={(e) => {
+                    const headerHeight = e.nativeEvent.layout.height;
 
-                  setHeaderHeight(headerHeight);
-                  rawAnimatedHeaderHeight.setValue(headerHeight);
-                }}
-                style={[styles.header, headerTransparent ? styles.absolute : null]}>
-                {header({
-                  back: headerBack,
-                  options,
-                  route,
-                  navigation,
-                })}
-              </View>
-            ) : null}
-            <HeaderShownContext.Provider value={isParentHeaderShown || headerShown !== false}>
-              <HeaderBackContext.Provider value={headerBack}>{render()}</HeaderBackContext.Provider>
-            </HeaderShownContext.Provider>
-          </HeaderHeightContext.Provider>
-        </AnimatedHeaderHeightContext.Provider>
+                    setHeaderHeight(headerHeight);
+                    rawAnimatedHeaderHeight.setValue(headerHeight);
+                  }}
+                  style={[styles.header, headerTransparent ? styles.absolute : null]}>
+                  {header({
+                    back: headerBack,
+                    options,
+                    route,
+                    navigation,
+                  })}
+                </View>
+              ) : null}
+              <HeaderShownContext.Provider value={isParentHeaderShown || headerShown !== false}>
+                <HeaderBackContext.Provider value={headerBack}>
+                  {render()}
+                </HeaderBackContext.Provider>
+              </HeaderShownContext.Provider>
+            </HeaderHeightContext.Provider>
+          </AnimatedHeaderHeightContext.Provider>
+        </ScreenPresentationContext.Provider>
       </ScreenStackItem>
     </NavigationProvider>
   );
@@ -470,6 +475,12 @@ export function NativeStackView({
   const { colors } = useTheme();
   const { setNextDismissedKey } = useDismissedRouteError(state);
 
+  const parentPresentation = use(ScreenPresentationContext);
+  const isInTransparentPresentation =
+    parentPresentation === 'formSheet' ||
+    parentPresentation === 'transparentModal' ||
+    parentPresentation === 'containedTransparentModal';
+
   useInvalidPreventRemoveError(descriptors);
 
   const modalRouteKeys = getModalRouteKeys(state.routes, descriptors);
@@ -485,7 +496,9 @@ export function NativeStackView({
   return (
     <SafeAreaProviderCompat>
       <ScreenStack
-        nativeContainerStyle={{ backgroundColor: colors.background }}
+        nativeContainerStyle={
+          isInTransparentPresentation ? undefined : { backgroundColor: colors.background }
+        }
         style={styles.container}
         {...unstable_nativeProps}>
         {state.routes.concat(state.preloadedRoutes).map((route, index) => {

--- a/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.nested-presentation.test.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.nested-presentation.test.native.tsx
@@ -1,0 +1,119 @@
+import { act, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { ScreenStack as _ScreenStack } from 'react-native-screens';
+
+import { router } from '../../../../imperative-api';
+import Stack from '../../../../layouts/StackClient';
+import { renderRouter } from '../../../../testing-library';
+import type { NativeStackHostNativeProps, NativeStackNavigationOptions } from '../../types';
+
+jest.mock('react-native-screens', () => {
+  const actualScreens = jest.requireActual(
+    'react-native-screens'
+  ) as typeof import('react-native-screens');
+  return {
+    ...actualScreens,
+    ScreenStack: jest.fn((props) => <actualScreens.ScreenStack {...props} />),
+  };
+});
+
+const ScreenStack = _ScreenStack as jest.MockedFunction<typeof _ScreenStack>;
+
+/** Stacks are tagged with a `testID` so they can be told apart in the render calls. */
+function nativeContainerStyleOf(testID: string) {
+  const call = ScreenStack.mock.calls.findLast((call) => call[0].testID === testID);
+  expect(call).toBeDefined();
+  return call![0].nativeContainerStyle;
+}
+
+/** Renders a root stack with a `sheet` screen using `presentation`, containing a nested stack. */
+function renderNestedStack(
+  presentation: NativeStackNavigationOptions['presentation'],
+  nestedNativeProps?: NativeStackHostNativeProps
+) {
+  renderRouter({
+    _layout: () => (
+      <Stack unstable_nativeProps={{ testID: 'root' }}>
+        <Stack.Screen name="sheet" options={{ presentation }} />
+      </Stack>
+    ),
+    index: () => <Text testID="index">Index</Text>,
+    'sheet/_layout': () => (
+      <Stack unstable_nativeProps={{ testID: 'nested', ...nestedNativeProps }} />
+    ),
+    'sheet/index': () => <Text testID="sheet">Sheet</Text>,
+  });
+
+  expect(screen.getByTestId('index')).toBeVisible();
+
+  // Index 0 is always forced to `card`, so the sheet has to be pushed.
+  act(() => router.push('/sheet'));
+
+  expect(screen.getByTestId('sheet')).toBeVisible();
+}
+
+describe('nested stack inside a transparent presentation', () => {
+  beforeEach(() => {
+    ScreenStack.mockClear();
+  });
+
+  it.each(['formSheet', 'transparentModal', 'containedTransparentModal'] as const)(
+    'does not set a native container background inside %s',
+    (presentation) => {
+      renderNestedStack(presentation);
+
+      expect(nativeContainerStyleOf('root')).toEqual({
+        backgroundColor: expect.any(String),
+      });
+      expect(nativeContainerStyleOf('nested')).toBeUndefined();
+    }
+  );
+
+  it.each(['modal', 'pageSheet', 'card'] as const)(
+    'keeps the native container background inside %s',
+    (presentation) => {
+      renderNestedStack(presentation);
+
+      expect(nativeContainerStyleOf('nested')).toEqual(nativeContainerStyleOf('root'));
+      expect(nativeContainerStyleOf('nested')).toEqual({
+        backgroundColor: expect.any(String),
+      });
+    }
+  );
+
+  it('resets the default background for a stack nested deeper under a card screen', () => {
+    renderRouter({
+      _layout: () => (
+        <Stack unstable_nativeProps={{ testID: 'root' }}>
+          <Stack.Screen name="sheet" options={{ presentation: 'formSheet' }} />
+        </Stack>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      'sheet/_layout': () => <Stack unstable_nativeProps={{ testID: 'nested' }} />,
+      'sheet/index': () => <Text testID="sheet">Sheet</Text>,
+      'sheet/card/_layout': () => <Stack unstable_nativeProps={{ testID: 'deep' }} />,
+      'sheet/card/index': () => <Text testID="card">Card</Text>,
+    });
+
+    act(() => router.push('/sheet'));
+    act(() => router.push('/sheet/card'));
+
+    expect(screen.getByTestId('card')).toBeVisible();
+
+    // The sheet's own stack stays transparent, the one nested under its card screen does not.
+    expect(nativeContainerStyleOf('nested')).toBeUndefined();
+    expect(nativeContainerStyleOf('deep')).toEqual({
+      backgroundColor: expect.any(String),
+    });
+  });
+
+  it('lets unstable_nativeProps override the skipped background', () => {
+    renderNestedStack('formSheet', {
+      nativeContainerStyle: { backgroundColor: 'red' },
+    });
+
+    expect(nativeContainerStyleOf('nested')).toEqual({
+      backgroundColor: 'red',
+    });
+  });
+});

--- a/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.nested-presentation.test.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.nested-presentation.test.native.tsx
@@ -5,7 +5,7 @@ import { ScreenStack as _ScreenStack } from 'react-native-screens';
 import { router } from '../../../../imperative-api';
 import Stack from '../../../../layouts/StackClient';
 import { renderRouter } from '../../../../testing-library';
-import type { NativeStackHostNativeProps, NativeStackNavigationOptions } from '../../types';
+import type { NativeStackNavigationConfig, NativeStackNavigationOptions } from '../../types';
 
 jest.mock('react-native-screens', () => {
   const actualScreens = jest.requireActual(
@@ -29,7 +29,7 @@ function nativeContainerStyleOf(testID: string) {
 /** Renders a root stack with a `sheet` screen using `presentation`, containing a nested stack. */
 function renderNestedStack(
   presentation: NativeStackNavigationOptions['presentation'],
-  nestedNativeProps?: NativeStackHostNativeProps
+  nestedNativeProps?: NativeStackNavigationConfig['unstable_nativeProps']
 ) {
   renderRouter({
     _layout: () => (


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/47831

# How

When the presentation of the whole navigator is one of - `formSheet`, `transparentModal` or `containedTransparentModal` - don't set the `nativeContainerStyle`. The navigator will most likely render over a content

# Test Plan

1. Router e2e
2. CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
