### PR TITLE
[media-library][Android] Fix transposed width/height for rotated assets in new API

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
+import expo.modules.medialibrary.assets.maybeRotateAssetSize
 import expo.modules.medialibrary.next.exceptions.AssetCouldNotBeCreated
 import expo.modules.medialibrary.next.extensions.getNullableInt
 import expo.modules.medialibrary.next.extensions.getNullableLong
@@ -39,6 +40,34 @@ suspend fun ContentResolver.queryAssetWidth(contentUri: Uri): Int? =
 
 suspend fun ContentResolver.queryAssetHeight(contentUri: Uri): Int? =
   queryOne(contentUri, MediaStore.MediaColumns.HEIGHT, Cursor::getNullableInt)
+
+/**
+ * Queries WIDTH, HEIGHT, and ORIENTATION in a single cursor pass and applies
+ * [maybeRotateAssetSize] so that portrait photos stored as rotated landscape buffers
+ * report correct display dimensions (matching the legacy API behaviour).
+ */
+suspend fun ContentResolver.queryAssetOrientedDimensions(contentUri: Uri): Pair<Int?, Int?> =
+  withContext(Dispatchers.IO) {
+    val projection = arrayOf(
+      MediaStore.MediaColumns.WIDTH,
+      MediaStore.MediaColumns.HEIGHT,
+      MediaStore.MediaColumns.ORIENTATION
+    )
+    val cursor = safeQuery(contentUri, projection, null, null)
+      ?: return@withContext Pair(null, null)
+    cursor.use {
+      if (!it.moveToFirst()) return@withContext Pair(null, null)
+      val rawWidth = it.getNullableInt(it.getColumnIndexOrThrow(MediaStore.MediaColumns.WIDTH))
+      val rawHeight = it.getNullableInt(it.getColumnIndexOrThrow(MediaStore.MediaColumns.HEIGHT))
+      val orientation = it.getNullableInt(it.getColumnIndexOrThrow(MediaStore.MediaColumns.ORIENTATION)) ?: 0
+      if (rawWidth != null && rawHeight != null) {
+        val (w, h) = maybeRotateAssetSize(rawWidth, rawHeight, orientation)
+        Pair(w, h)
+      } else {
+        Pair(rawWidth, rawHeight)
+      }
+    }
+  }
 
 suspend fun ContentResolver.queryAssetData(contentUri: Uri): String? =
   queryOne(contentUri, MediaStore.MediaColumns.DATA, Cursor::getNullableString)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/AssetMapper.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/AssetMapper.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+import expo.modules.medialibrary.assets.maybeRotateAssetSize
 
 class AssetMapper(private val contentResolver: ContentResolver) {
   suspend fun toDto(mediaStoreItem: AssetMediaStoreItem): AssetInfo =
@@ -36,14 +37,20 @@ class AssetMapper(private val contentResolver: ContentResolver) {
       MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE
     )
 
+    val (rawWidth, rawHeight) = maybeRotateAssetSize(
+      imageAsset.width ?: 0,
+      imageAsset.height ?: 0,
+      imageAsset.orientation ?: 0
+    )
+
     return AssetInfo(
       id = contentUri,
       uri = mapUri(imageAsset.data)
         ?: throw AssetPropertyNotFoundException("Uri"),
       mediaType = MediaType.IMAGE,
-      width = mapWidth(imageAsset.width, contentUri)
+      width = mapWidth(rawWidth.takeIf { it > 0 }, contentUri)
         ?: throw AssetPropertyNotFoundException("Width"),
-      height = mapHeight(imageAsset.height, contentUri)
+      height = mapHeight(rawHeight.takeIf { it > 0 }, contentUri)
         ?: throw AssetPropertyNotFoundException("Height"),
       creationTime = mapCreationTime(imageAsset.dateTaken),
       modificationTime = mapModificationTime(imageAsset.dateModified),
@@ -60,14 +67,20 @@ class AssetMapper(private val contentResolver: ContentResolver) {
       MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO
     )
 
+    val (rawWidth, rawHeight) = maybeRotateAssetSize(
+      videoAsset.width ?: 0,
+      videoAsset.height ?: 0,
+      videoAsset.orientation ?: 0
+    )
+
     return AssetInfo(
       id = contentUri,
       uri = mapUri(videoAsset.data)
         ?: throw AssetPropertyNotFoundException("Uri"),
       mediaType = MediaType.VIDEO,
-      width = mapWidth(videoAsset.width, contentUri)
+      width = mapWidth(rawWidth.takeIf { it > 0 }, contentUri)
         ?: throw AssetPropertyNotFoundException("Width"),
-      height = mapHeight(videoAsset.height, contentUri)
+      height = mapHeight(rawHeight.takeIf { it > 0 }, contentUri)
         ?: throw AssetPropertyNotFoundException("Height"),
       creationTime = mapCreationTime(videoAsset.dateTaken),
       modificationTime = mapModificationTime(videoAsset.dateModified),
@@ -101,12 +114,17 @@ class AssetMapper(private val contentResolver: ContentResolver) {
   }
 
   fun toMetadata(fileAsset: MediaStoreFile): AssetMetadata {
+    val (rotatedWidth, rotatedHeight) = maybeRotateAssetSize(
+      fileAsset.width ?: 0,
+      fileAsset.height ?: 0,
+      fileAsset.orientation ?: 0
+    )
     return AssetMetadata(
       id = extractAssetContentUri(fileAsset.id, fileAsset.mediaType),
       mediaType = fileAsset.mediaType?.let { MediaType.fromMediaStoreValue(it) }
         ?: MediaType.UNKNOWN,
-      width = fileAsset.width,
-      height = fileAsset.height,
+      width = rotatedWidth.takeIf { it > 0 } ?: fileAsset.width,
+      height = rotatedHeight.takeIf { it > 0 } ?: fileAsset.height,
       creationTime = mapCreationTime(fileAsset.dateTaken),
       modificationTime = mapModificationTime(fileAsset.dateModified),
       duration = mapDuration(fileAsset.duration),

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetModernDelegate.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetModernDelegate.kt
@@ -16,8 +16,7 @@ import expo.modules.medialibrary.next.extensions.resolver.insertPendingAsset
 import expo.modules.medialibrary.next.extensions.resolver.publishPendingAsset
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetDisplayName
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetDuration
-import expo.modules.medialibrary.next.extensions.resolver.queryAssetHeight
-import expo.modules.medialibrary.next.extensions.resolver.queryAssetWidth
+import expo.modules.medialibrary.next.extensions.resolver.queryAssetOrientedDimensions
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetData
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetDateModified
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetDateTaken
@@ -86,15 +85,21 @@ class AssetModernDelegate(
       ?: throw AssetPropertyNotFoundException("Filename")
 
   override suspend fun getHeight(): Int {
-    val mediaStoreHeight = contentResolver.queryAssetHeight(contentUri)
-    return assetMapper.mapHeight(mediaStoreHeight, contentUri)
+    val (_, orientedHeight) = contentResolver.queryAssetOrientedDimensions(contentUri)
+    val height = orientedHeight
+      ?: assetMapper.mapHeight(null, contentUri)
       ?: throw AssetPropertyNotFoundException("Height")
+    return if (height > 0) height else
+      assetMapper.mapHeight(null, contentUri) ?: throw AssetPropertyNotFoundException("Height")
   }
 
   override suspend fun getWidth(): Int {
-    val mediaStoreWidth = contentResolver.queryAssetWidth(contentUri)
-    return assetMapper.mapWidth(mediaStoreWidth, contentUri)
+    val (orientedWidth, _) = contentResolver.queryAssetOrientedDimensions(contentUri)
+    val width = orientedWidth
+      ?: assetMapper.mapWidth(null, contentUri)
       ?: throw AssetPropertyNotFoundException("Width")
+    return if (width > 0) width else
+      assetMapper.mapWidth(null, contentUri) ?: throw AssetPropertyNotFoundException("Width")
   }
 
   override suspend fun getShape(): Shape? {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreFile.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreFile.kt
@@ -14,6 +14,7 @@ data class MediaStoreFile(
   val dateModified: Long?,
   val width: Int?,
   val height: Int?,
+  val orientation: Int?,
   val duration: Long?,
   val mediaType: Int?,
   val isFavorite: Int?
@@ -30,6 +31,7 @@ data class MediaStoreFile(
         dateModified = getNullableLong(columnIndexes.dateModified),
         width = getNullableInt(columnIndexes.width),
         height = getNullableInt(columnIndexes.height),
+        orientation = getNullableInt(columnIndexes.orientation),
         duration = columnIndexes.duration?.let { getNullableLong(it) },
         mediaType = getNullableInt(columnIndexes.mediaType),
         isFavorite = columnIndexes.isFavorite?.let { getNullableInt(it) }
@@ -44,6 +46,7 @@ data class MediaStoreFile(
       add(MediaStore.Files.FileColumns.DATE_MODIFIED)
       add(MediaStore.Files.FileColumns.WIDTH)
       add(MediaStore.Files.FileColumns.HEIGHT)
+      add(MediaStore.Files.FileColumns.ORIENTATION)
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         add(MediaStore.Files.FileColumns.DURATION)
       }
@@ -62,6 +65,7 @@ data class MediaStoreFileColumnIndexes(
   val dateModified: Int,
   val width: Int,
   val height: Int,
+  val orientation: Int,
   val duration: Int?,
   val isFavorite: Int?
 ) {
@@ -75,6 +79,7 @@ data class MediaStoreFileColumnIndexes(
         dateModified = getColumnIndexOrThrow(MediaStore.Files.FileColumns.DATE_MODIFIED),
         width = getColumnIndexOrThrow(MediaStore.Files.FileColumns.WIDTH),
         height = getColumnIndexOrThrow(MediaStore.Files.FileColumns.HEIGHT),
+        orientation = getColumnIndexOrThrow(MediaStore.Files.FileColumns.ORIENTATION),
         duration = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
           getColumnIndexOrThrow(MediaStore.Files.FileColumns.DURATION)
         } else {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreImage.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreImage.kt
@@ -14,6 +14,7 @@ data class MediaStoreImage(
   val dateModified: Long?,
   val width: Int?,
   val height: Int?,
+  val orientation: Int?,
   val data: String?,
   val isFavorite: Int?
 ) {
@@ -29,6 +30,7 @@ data class MediaStoreImage(
         dateModified = getNullableLong(columnIndexes.dateModified),
         width = getNullableInt(columnIndexes.width),
         height = getNullableInt(columnIndexes.height),
+        orientation = getNullableInt(columnIndexes.orientation),
         data = getNullableString(columnIndexes.data),
         isFavorite = columnIndexes.isFavorite?.let { getNullableInt(it) }
       )
@@ -41,6 +43,7 @@ data class MediaStoreImage(
       add(DATE_MODIFIED)
       add(WIDTH)
       add(HEIGHT)
+      add(ORIENTATION)
       add(DATA)
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         add(IS_FAVORITE)
@@ -56,6 +59,7 @@ data class MediaStoreImageColumnIndexes(
   val dateModified: Int,
   val width: Int,
   val height: Int,
+  val orientation: Int,
   val data: Int,
   val isFavorite: Int?
 ) {
@@ -68,6 +72,7 @@ data class MediaStoreImageColumnIndexes(
         dateModified = getColumnIndexOrThrow(DATE_MODIFIED),
         width = getColumnIndexOrThrow(WIDTH),
         height = getColumnIndexOrThrow(HEIGHT),
+        orientation = getColumnIndexOrThrow(ORIENTATION),
         data = getColumnIndexOrThrow(DATA),
         isFavorite = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
           getColumnIndexOrThrow(IS_FAVORITE)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreVideo.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/domain/MediaStoreVideo.kt
@@ -14,6 +14,7 @@ data class MediaStoreVideo(
   val dateModified: Long?,
   val width: Int?,
   val height: Int?,
+  val orientation: Int?,
   val duration: Long?,
   val data: String?,
   val isFavorite: Int?
@@ -30,6 +31,7 @@ data class MediaStoreVideo(
         dateModified = getNullableLong(columnIndexes.dateModified),
         width = getNullableInt(columnIndexes.width),
         height = getNullableInt(columnIndexes.height),
+        orientation = columnIndexes.orientation?.let { getNullableInt(it) },
         duration = getNullableLong(columnIndexes.duration),
         data = getNullableString(columnIndexes.data),
         isFavorite = columnIndexes.isFavorite?.let { getNullableInt(it) }
@@ -45,6 +47,9 @@ data class MediaStoreVideo(
       add(HEIGHT)
       add(DATA)
       add(DURATION)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        add(ORIENTATION)
+      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         add(IS_FAVORITE)
       }
@@ -59,6 +64,7 @@ data class MediaStoreVideoColumnIndexes(
   val dateModified: Int,
   val width: Int,
   val height: Int,
+  val orientation: Int?,
   val duration: Int,
   val data: Int,
   val isFavorite: Int?
@@ -72,6 +78,11 @@ data class MediaStoreVideoColumnIndexes(
         dateModified = getColumnIndexOrThrow(DATE_MODIFIED),
         width = getColumnIndexOrThrow(WIDTH),
         height = getColumnIndexOrThrow(HEIGHT),
+        orientation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          getColumnIndexOrThrow(ORIENTATION)
+        } else {
+          null
+        },
         duration = getColumnIndexOrThrow(DURATION),
         data = getColumnIndexOrThrow(DATA),
         isFavorite = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {


### PR DESCRIPTION
## Summary

Fixes #48149

The new class-based API never read `MediaStore.MediaColumns.ORIENTATION`, so
portrait photos (stored as landscape pixel buffers + a rotation flag) reported
transposed width/height (e.g. 800×600 instead of the correct 600×800).
The legacy API compensated via `maybeRotateAssetSize()` — this PR brings the
new API to parity.

## Changes

- **`MediaStoreImage`** — add `orientation` field + `ORIENTATION` to projection (API 1+)
- **`MediaStoreVideo`** — add `orientation` field + `ORIENTATION` gated behind API 29
- **`MediaStoreFile`** — add `orientation` field + `ORIENTATION` to Files-table projection
- **`AssetMapper.toDto`** (image/video) — apply `maybeRotateAssetSize` before `mapWidth`/`mapHeight`
- **`AssetMapper.toMetadata`** — apply rotation for `Query.exeForMetadata()` path
- **`AssetExtensions`** — add `queryAssetOrientedDimensions()` (single cursor pass, no extra I/O)
- **`AssetModernDelegate.getWidth/getHeight`** — use `queryAssetOrientedDimensions` so `getShape()` also reports correct display dimensions

## Test Plan

Ran the repro app from https://github.com/oeddyo/expo-media-library-orientation-repro on
API 35 emulator and physical Samsung Galaxy S23 (Android 16):

| API | Before | After |
|-----|--------|-------|
| `Asset.getInfo().width/height` | 800×600 ❌ | 600×800 ✅ |
| `asset.getWidth()` / `.getHeight()` | 800×600 ❌ | 600×800 ✅ |
| `Query.exeForMetadata()` | 800×600 ❌ | 600×800 ✅ |
| Legacy `getAssetInfoAsync()` | 600×800 ✅ | 600×800 ✅ (unchanged) |
