### PR TITLE
[observe] fix OTel date conversion

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix OTel date conversion ([#48161](https://github.com/expo/expo/pull/48161) by [@Ubax](https://github.com/Ubax))
 - [Android] Fix `logEvent` not being forwarded to the AppMetrics module through the native module proxy. ([@Ubax](https://github.com/Ubax)) ([#47766](https://github.com/expo/expo/pull/47766) by [@Ubax](https://github.com/Ubax))
 - Fix non-serializable route params issue ([#47497](https://github.com/expo/expo/pull/47497) by [@Ubax](https://github.com/Ubax))
 - [iOS] Adjust dispatch code to comply with OTLP retry spec. ([#47159](https://github.com/expo/expo/pull/47159) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
@@ -199,6 +199,14 @@ class OpenTelemetryTest {
   }
 
   @Test
+  fun `toOTMetric converts ISO8601 timestamp with fractional seconds to nanoseconds`() {
+    val metric = makeMetric("loadTime", 1.0, "2026-01-09T12:08:09.123Z")
+    val otMetric = metric.toOTMetric()
+
+    assertEquals(1_767_960_489_123_000_000L, otMetric.gauge.dataPoints[0].timeUnixNano)
+  }
+
+  @Test
   fun `toOTMetric uses sessionId for session id attribute`() {
     val customSessionId = "custom-session-123"
     val metric = EASMetric(
@@ -520,10 +528,13 @@ internal val OTAnyValue.stringValue: String?
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [28])
 class LogEventToOTLogRecordTest {
-  private fun makeLog(severity: String): LogEvent =
+  private fun makeLog(
+    severity: String,
+    timestamp: String = "2025-01-01T00:00:00.000Z"
+  ): LogEvent =
     LogEvent(
       sessionId = "session-1",
-      timestamp = "2025-01-01T00:00:00.000Z",
+      timestamp = timestamp,
       name = "auth.login_failed",
       body = "invalid_credentials",
       severity = severity,
@@ -550,5 +561,16 @@ class LogEventToOTLogRecordTest {
     val ot = makeLog(severity = "frobnicate").toOTLogRecord()
     assertEquals("INFO", ot.severityText)
     assertEquals(9, ot.severityNumber)
+  }
+
+  @Test
+  fun `converts ISO8601 timestamp with fractional seconds to nanoseconds`() {
+    val ot = makeLog(
+      severity = "info",
+      timestamp = "2026-01-09T12:08:09.123Z"
+    ).toOTLogRecord()
+
+    assertEquals(1_767_960_489_123_000_000L, ot.timeUnixNano)
+    assertEquals(1_767_960_489_123_000_000L, ot.observedTimeUnixNano)
   }
 }

--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -193,13 +193,11 @@ let metricNameMap = [
   "navigation/tti": "expo.navigation.tti",
 ]
 
-nonisolated(unsafe) let formatter = ISO8601DateFormatter()
-
 private func nsFromISOString(_ dateString: String?) -> UInt64 {
   if let dateString,
-    let date = formatter.date(from: dateString)
+    let date = try? Date.ISO8601FormatStyle().parse(dateString)
   {
-    return UInt64(date.timeIntervalSince1970 * 1_000_000_000)
+    return UInt64((date.timeIntervalSince1970 * 1_000).rounded()) * 1_000_000
   }
   return UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
 }

--- a/packages/expo-observe/ios/Tests/OpenTelemetryTests.swift
+++ b/packages/expo-observe/ios/Tests/OpenTelemetryTests.swift
@@ -148,6 +148,31 @@ struct OpenTelemetryTests {
     #expect(otMetric.gauge.dataPoints[0].timeUnixNano == expectedNanos)
   }
 
+  @Test
+  func `toOTMetric converts ISO8601 timestamp with fractional seconds to nanoseconds`() {
+    let metric = makeMetric(name: "loadTime", value: 1.0, timestamp: "2026-01-09T12:08:09.123Z")
+    let otMetric = metric.toOTMetric()
+
+    #expect(otMetric.gauge.dataPoints[0].timeUnixNano == 1_767_960_489_123_000_000)
+  }
+
+  @Test
+  func `toOTLogRecord converts ISO8601 timestamp with fractional seconds to nanoseconds`() {
+    let log = Event.Log(
+      name: "auth.login_failed",
+      body: nil,
+      timestamp: "2026-01-09T12:08:09.123Z",
+      severity: .info,
+      attributes: nil,
+      droppedAttributesCount: 0,
+      sessionId: testSessionId
+    )
+    let otLog = log.toOTLogRecord()
+
+    #expect(otLog.timeUnixNano == 1_767_960_489_123_000_000)
+    #expect(otLog.observedTimeUnixNano == 1_767_960_489_123_000_000)
+  }
+
   // MARK: - Event metadata
 
   @Test


### PR DESCRIPTION
# Why

When a date included fractional seconds, such as 2026-01-09T12:08:09.123Z, the iOS conversion to OpenTelemetry failed to parse the timestamp correctly. As a fallback, it used the current date and time instead of the original timestamp.

# How

1.  Add tests
2. Replace `ISO8601DateFormatter` with `Date.ISO8601FormatStyle()`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
