### PR TITLE
[docs] Remove dangling redirects

### DIFF
--- a/docs/common/client-redirects.test.ts
+++ b/docs/common/client-redirects.test.ts
@@ -106,7 +106,7 @@ test('does not rewrite /eas/** paths that are canonical (workflows, hosting, met
 
 test('redirects deleted create-a-build page to the introduction EAS path', () => {
   expect(getRedirectPath('/develop/development-builds/create-a-build/')).toEqual(
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas'
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build'
   );
 });
 

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -217,7 +217,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/distribution/building-standalone-apps/': '/build/setup/',
   '/guides/genymotion/': '/workflow/android-studio-emulator/',
   '/workflow/create-react-native-app/': '/more/glossary-of-terms/#create-react-native-app',
-  '/expokit/': '/archive/glossary/#expokit/',
 
   // Development builds redirects
   '/development/build/':
@@ -234,7 +233,6 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Lots of old links pointing to guides when they have moved elsewhere
   '/guides/configuration/': '/workflow/configuration/',
-  '/guides/expokit/': '/archive/glossary/#expokit/',
   '/guides/publishing/': '/archive/classic-updates/publishing/',
   '/workflow/publishing/': '/archive/classic-updates/publishing/',
   '/guides/up-and-running/': '/get-started/create-a-project/',
@@ -276,7 +274,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/api/': '/versions/latest/',
 
   // Redirect to expand Expo Accounts and permissions
-  '/guides/account-permissions/': '/accounts/personal/',
+  '/guides/account-permissions/': '/accounts/account-types/',
 
   // Redirects based on Sentry reports
   '/next-steps/installation/': '/get-started/create-a-project/',
@@ -285,7 +283,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/push-notifications/': '/push-notifications/overview/',
   '/build-reference/how-tos/': '/build-reference/private-npm-packages/',
   '/get-started/': '/get-started/create-a-project/',
-  '/guides/detach/': '/archive/glossary/#detach',
   '/workflow/snack/': '/more/glossary-of-terms/#snack',
   '/eas/submit/': '/deploy/submit-to-app-stores/',
   '/submit/introduction/': '/deploy/submit-to-app-stores/',
@@ -305,7 +302,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/how-expo-works/': '/faq/#what-is-the-difference-between-expo-and-react-native',
 
   // Archive unused pages
-  '/guides/notification-channels/': '/archive/notification-channels/',
+  '/guides/notification-channels/': '/archive/push-notifications/notification-channels/',
 
   // Permissions API is moved to guide
   '/versions/latest/sdk/permissions/': '/guides/permissions/',
@@ -327,14 +324,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/distribution/security/': '/app-signing/security/',
 
   // Redirects for removed/archived pages or guides
-  '/versions/latest/expokit/eject/': '/archive/glossary/#eject',
-  '/expokit/eject/': '/archive/glossary/#eject',
-  '/expokit/expokit/': '/archive/glossary/#expokit',
   '/submit/classic-builds/': '/deploy/submit-to-app-stores/',
   '/technical-specs/expo-updates-0/': '/technical-specs/expo-updates-1/',
   '/technical-specs/latest/': '/technical-specs/expo-updates-1/',
-  '/archive/expokit/overview/': '/archive/glossary/',
-  '/expokit/overview/': '/archive/glossary/',
   '/push-notifications/using-fcm/': '/push-notifications/push-notifications-setup/',
   '/workflow/already-used-react-native/': '/workflow/overview/',
   '/development/installation/':
@@ -394,7 +386,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/workflow/hermes/': '/guides/using-hermes/',
   '/config/app/': '/workflow/configuration/',
   '/versions/latest/sdk/settings/': '/versions/latest/',
-  '/archive/expokit/eject/': '/archive/glossary/#eject',
   '/versions/latest/sdk/payments/': '/versions/latest/sdk/stripe/',
   '/distribution/app-icons/': '/develop/user-interface/splash-screen-and-app-icon/',
   '/guides/using-libraries/': '/workflow/using-libraries/',

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -166,7 +166,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/get-started/create-a-new-app/': '/get-started/create-a-project',
   '/guides/config-plugins/': '/config-plugins/introduction/',
   '/workflow/debugging/': '/debugging/runtime-issues/',
-  '/introduction/why-not-expo/': '/faq/#limitations',
+  '/introduction/why-not-expo/': '/faq/',
   '/next-steps/community/': '/',
   '/workflow/expo-go/': '/get-started/set-up-your-environment/',
   '/guides/splash-screens/': '/develop/user-interface/splash-screen/',
@@ -174,12 +174,12 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/color-schemes/': '/develop/user-interface/color-themes/',
   '/development/introduction/': '/develop/development-builds/introduction/',
   '/develop/development-builds/create-a-build/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/develop/development-builds/expo-go-to-dev-build/':
     '/develop/development-builds/introduction/#build-locally',
   '/develop/development-builds/next-steps/': '/develop/development-builds/faq/',
   '/development/create-development-builds/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/development/use-development-builds/': '/develop/development-builds/use-development-builds/',
   '/development/development-workflows/': '/develop/development-builds/development-workflows/',
   '/workflow/expo-cli/': '/more/expo-cli/',
@@ -188,7 +188,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/debugging/runtime-issue/': '/debugging/runtime-issues/',
   '/guides/testing-with-jest/': '/develop/unit-testing/',
   '/develop/development-builds/installation/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/develop/development-builds/parallel-installation': '/build-reference/variants/',
 
   // MCP server moved out of the EAS section to the top-level /mcp route
@@ -220,9 +220,9 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Development builds redirects
   '/development/build/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/development/getting-started/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/development/troubleshooting/': '/develop/development-builds/introduction/',
   '/development/upgrading/': '/develop/development-builds/introduction/',
   '/development/extensions/': '/develop/development-builds/development-workflows/',
@@ -286,8 +286,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/workflow/snack/': '/more/glossary-of-terms/#snack',
   '/eas/submit/': '/deploy/submit-to-app-stores/',
   '/submit/introduction/': '/deploy/submit-to-app-stores/',
-  '/development/tools/expo-dev-client/':
-    '/develop/development-builds/introduction/#what-is-expo-dev-client',
+  '/development/tools/expo-dev-client/': '/develop/development-builds/introduction/',
   '/develop/user-interface/custom-fonts/': '/develop/user-interface/fonts/#add-a-custom-font',
   '/accounts/teams-and-accounts/': '/accounts/account-types/',
   '/push-notifications/fcm/': '/push-notifications/sending-notifications-custom/',
@@ -330,7 +329,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/push-notifications/using-fcm/': '/push-notifications/push-notifications-setup/',
   '/workflow/already-used-react-native/': '/workflow/overview/',
   '/development/installation/':
-    '/develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas',
+    '/develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build',
   '/guides/routing-and-navigation/': '/routing/introduction/',
   '/build-reference/custom-build-config/': '/custom-builds/get-started/',
   '/eas-update/migrate-codepush-to-eas-update/': '/eas-update/codepush/',
@@ -473,7 +472,8 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // After new environment variables guide
   '/build-reference/variables/': '/eas/environment-variables/',
-  '/eas-update/environment-variables/': '/eas/environment-variables/#eas-update',
+  '/eas-update/environment-variables/':
+    '/eas/environment-variables/usage/#using-environment-variables-with-eas-update',
 
   // After moving common questions from Expo Router FAQ to Introduction
   '/router/reference/faq/': '/router/introduction/',
@@ -543,7 +543,7 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // After Expo Router Getting Started Guide
   '/router/reference/authentication/': '/router/advanced/authentication/',
-  '/router/advanced/root-layout/': '/router/basics/navigation-layouts/#root-layout/',
+  '/router/advanced/root-layout/': '/router/basics/navigation-layouts/#root-layout',
   '/router/reference/not-found/': '/router/error-handling/',
   '/router/navigating-pages/': '/router/basics/navigation/',
   '/router/create-pages/': '/router/basics/core-concepts/',

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -113,12 +113,6 @@
 /bare/updating-your-app/ /eas-update/getting-started 301
 /technical-specs/expo-updates-0 /technical-specs/expo-updates-1 301
 /technical-specs/expo-updates-0/ /technical-specs/expo-updates-1 301
-/archive/expokit/eject /archive/glossary 301
-/archive/expokit/eject/ /archive/glossary 301
-/archive/expokit/overview /archive/glossary 301
-/archive/expokit/overview/ /archive/glossary 301
-/expokit/overview /archive/glossary 301
-/expokit/overview/ /archive/glossary 301
 /bare/existing-apps /bare/installing-expo-modules 301
 /bare/existing-apps/ /bare/installing-expo-modules 301
 /bare/exploring-bare-workflow /bare/overview 301
@@ -185,8 +179,8 @@
 /distribution/custom-updates-server/ /versions/latest/sdk/updates 301
 /bare/error-recovery /eas-update/error-recovery 301
 /bare/error-recovery/ /eas-update/error-recovery 301
-/deploy/instant-updates /eas-update/send-over-the-air-updates 301
-/deploy/instant-updates/ /eas-update/send-over-the-air-updates 301
+/deploy/instant-updates /deploy/send-over-the-air-updates 301
+/deploy/instant-updates/ /deploy/send-over-the-air-updates 301
 /eas-update/publish /eas-update/getting-started 301
 /eas-update/publish/ /eas-update/getting-started 301
 /eas-update/debug-advanced /eas-update/debug 301
@@ -245,8 +239,6 @@
 /versions/latest/sdk/taskmanager/ /versions/latest/sdk/task-manager 301
 /versions/latest/sdk/videothumbnails /versions/latest/sdk/video-thumbnails 301
 /versions/latest/sdk/videothumbnails/ /versions/latest/sdk/video-thumbnails 301
-/versions/latest/sdk/appearance /versions/latest/react-native/appearance 301
-/versions/latest/sdk/appearance/ /versions/latest/react-native/appearance 301
 /versions/latest/sdk/app-loading /versions/latest/sdk/splash-screen 301
 /versions/latest/sdk/app-loading/ /versions/latest/sdk/splash-screen 301
 /versions/latest/sdk/app-auth /guides/authentication 301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -15,10 +15,10 @@
 /module-config/ /modules/module-config 301
 
 # Development builds
-/development/build /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/development/build/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/development/getting-started /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/development/getting-started/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/build /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/development/build/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/development/getting-started /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/development/getting-started/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
 /development/troubleshooting /develop/development-builds/introduction 301
 /development/troubleshooting/ /develop/development-builds/introduction 301
 /development/upgrading /develop/development-builds/introduction 301
@@ -27,8 +27,8 @@
 /development/extensions/ /develop/development-builds/development-workflows 301
 /development/develop-your-project /develop/development-builds/use-development-builds 301
 /development/develop-your-project/ /develop/development-builds/use-development-builds 301
-/develop/development-builds/installation /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/develop/development-builds/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/develop/development-builds/installation /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/develop/development-builds/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
 
 # Guides that have been deleted
 /guides/web-performance /guides/analyzing-bundles 301
@@ -55,8 +55,8 @@
 /guides/color-schemes/ /develop/user-interface/color-themes 301
 /development/introduction /develop/development-builds/introduction 301
 /development/introduction/ /develop/development-builds/introduction 301
-/development/create-development-builds /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/development/create-development-builds/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/create-development-builds /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/development/create-development-builds/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
 /development/use-development-builds /develop/development-builds/use-development-builds 301
 /development/use-development-builds/ /develop/development-builds/use-development-builds 301
 /development/development-workflows /develop/development-builds/development-workflows 301
@@ -107,8 +107,8 @@
 /workflow/publishing/ /archive/classic-updates/publishing 301
 /workflow/already-used-react-native /workflow/overview 301
 /workflow/already-used-react-native/ /workflow/overview 301
-/development/installation /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/development/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/development/installation /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/development/installation/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
 /bare/updating-your-app /eas-update/getting-started 301
 /bare/updating-your-app/ /eas-update/getting-started 301
 /technical-specs/expo-updates-0 /technical-specs/expo-updates-1 301
@@ -625,8 +625,8 @@
 /guides/configuring-js-engines /archive/configuring-js-engines/ 301
 
 # After merging development build pages into the introduction (guided paths)
-/develop/development-builds/create-a-build /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
-/develop/development-builds/create-a-build/ /develop/development-builds/introduction/?buildenv=build-with-eas#create-a-development-build-with-eas 301
+/develop/development-builds/create-a-build /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
+/develop/development-builds/create-a-build/ /develop/development-builds/introduction/?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build 301
 /develop/development-builds/expo-go-to-dev-build /develop/development-builds/introduction/#build-locally 301
 /develop/development-builds/expo-go-to-dev-build/ /develop/development-builds/introduction/#build-locally 301
 /develop/development-builds/next-steps /develop/development-builds/faq/ 301

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -307,7 +307,9 @@ async function testDeletedPageRedirectsAsync(): Promise<void> {
 
   if (
     easRedirect.status !== 301 ||
-    !easLocation.includes('?buildenv=build-with-eas#create-a-development-build-with-eas')
+    !easLocation.includes(
+      '?buildenv=build-with-eas#how-would-you-like-to-build-your-development-build'
+    )
   ) {
     throw new Error(
       `Expected 301 to the introduction EAS path, got: HTTP ${easRedirect.status} -> ${easLocation}`


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25484

# How

- Remove dangling `_redirects` rules whose destinations no longer exist: the three `expokit` sources pointing at `/archive/glossary` (deleted in #45220) and `/versions/latest/sdk/appearance` pointing at `/versions/latest/react-native/appearance` (removed with the React Native docs in #19287), both trailing-slash forms each.
- Fix `/deploy/instant-updates` to target `/deploy/send-over-the-air-updates` instead of the stale `/eas-update/` prefix.
- Remove nine `RENAMED_PAGES` entries in `common/client-redirects.ts` that also pointed at the deleted `/archive/glossary/`, including `/expokit/`, `/guides/expokit/`, `/guides/detach/`, and `/expokit/expokit/`.
- Fix `/guides/account-permissions/` to target `/accounts/account-types/` and `/guides/notification-channels/` to target `/archive/push-notifications/notification-channels/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
