### PR TITLE
[ios][core] Add scene-aware geometry helpers

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -400,6 +400,10 @@ PODS:
   - ExpoImageManipulator (56.0.15):
     - ExpoModulesCore
     - SDWebImageWebPCoder
+  - ExpoImageManipulator/Tests (56.0.15):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+    - SDWebImageWebPCoder
   - ExpoImagePicker (56.0.14):
     - ExpoModulesCore
   - ExpoImagePicker/Tests (56.0.14):
@@ -3387,6 +3391,7 @@ DEPENDENCIES:
   - ExpoImage (from `../../../packages/expo-image/ios`)
   - ExpoImage/Tests (from `../../../packages/expo-image/ios`)
   - ExpoImageManipulator (from `../../../packages/expo-image-manipulator/ios`)
+  - ExpoImageManipulator/Tests (from `../../../packages/expo-image-manipulator/ios`)
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
   - ExpoImagePicker/Tests (from `../../../packages/expo-image-picker/ios`)
   - ExpoInsights (from `../../../packages/expo-insights/ios`)
@@ -4064,7 +4069,7 @@ SPEC CHECKSUMS:
   ExpoGlassEffect: 7d4233dc0727ee2b28dd757eda70e1b6abf662fd
   ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
-  ExpoImageManipulator: 441ca8a28fe700c5948863772578bab2ffd79e77
+  ExpoImageManipulator: 00e382cd32da78b9162cff710953f6e35bd6460c
   ExpoImagePicker: 25027f16965fca672abf93c2a79d22e71527b53f
   ExpoInsights: 06e193356e22f9cf82e9e07d002b4cbf923a19fc
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -74,6 +74,7 @@
 - [iOS] `SharedObject` is now paired with its JS counterpart through a `SharedObjectNativeState` attached to the JS object, so registry lookups in both directions go through the native state and fall back to the legacy id-based path. ([#46712](https://github.com/expo/expo/pull/46712) by [@tsapeta](https://github.com/tsapeta))
 - [iOS][android] Resolve the worklet UI runtime from its `react-native-worklets` holder instead of the reanimated `_WORKLET_RUNTIME` global; `installOnUIRuntime` now takes the holder from `getUIRuntimeHolder()`. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 - iOS Turn `getModule(implementing:)` into a public function ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
+- [iOS] Added `SceneGeometry` for reading bounds, safe area, display scale and interface orientation from the scene a view belongs to. ([#48168](https://github.com/expo/expo/pull/48168) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/ios/Tests/SceneGeometryTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SceneGeometryTests.swift
@@ -1,0 +1,74 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+#if os(iOS) || os(tvOS)
+
+import Testing
+import UIKit
+
+@testable import ExpoModulesCore
+
+@Suite("SceneGeometry")
+@MainActor
+struct SceneGeometryTests {
+  @Test
+  func `display scale prefers the first specified candidate`() {
+    #expect(SceneGeometry.resolveDisplayScale(candidates: [3, 2]) == 3)
+  }
+
+  @Test
+  func `display scale skips unspecified candidates`() {
+    // UITraitCollection documents an unspecified displayScale as 0.0, so a zero
+    // must not win over a real scale further down the chain.
+    #expect(SceneGeometry.resolveDisplayScale(candidates: [nil, 0, 2]) == 2)
+  }
+
+  @Test
+  func `display scale falls back to one when nothing is specified`() {
+    #expect(SceneGeometry.resolveDisplayScale(candidates: [nil, 0]) == 1)
+  }
+
+  @Test
+  func `bounds come from the view's own window when several exist`() {
+    let other = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    let host = UIWindow(frame: CGRect(x: 0, y: 0, width: 744, height: 1133))
+    let view = UIView()
+    host.addSubview(view)
+
+    #expect(SceneGeometry.bounds(for: view) == host.bounds)
+    #expect(SceneGeometry.bounds(for: view) != other.bounds)
+  }
+
+  @Test
+  func `bounds follow the view as it moves between windows`() {
+    let first = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    let second = UIWindow(frame: CGRect(x: 0, y: 0, width: 744, height: 1133))
+    let view = UIView()
+
+    first.addSubview(view)
+    #expect(SceneGeometry.bounds(for: view) == first.bounds)
+
+    second.addSubview(view)
+    #expect(SceneGeometry.bounds(for: view) == second.bounds)
+  }
+
+  @Test
+  func `safe area size comes from the view's own window when several exist`() {
+    let other = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    let host = UIWindow(frame: CGRect(x: 0, y: 0, width: 744, height: 1133))
+    let view = UIView()
+    host.addSubview(view)
+    host.layoutIfNeeded()
+
+    #expect(SceneGeometry.safeAreaSize(for: view) == host.safeAreaLayoutGuide.layoutFrame.size)
+    #expect(SceneGeometry.safeAreaSize(for: view) != other.safeAreaLayoutGuide.layoutFrame.size)
+  }
+
+  @Test
+  func `display scale is always positive`() {
+    // Callers divide by this value, so it must never be zero regardless of how much of the
+    // environment is available.
+    #expect(SceneGeometry.displayScale(for: UIView()) > 0)
+  }
+}
+
+#endif

--- a/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
+++ b/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
@@ -1,0 +1,92 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+#if os(iOS) || os(tvOS)
+
+import UIKit
+
+/**
+ Geometry lookups that start from the view asking the question, because iOS 27 makes iPhone apps
+ freely resizable. Neither `UIScreen.main` nor the first key window in any connected scene describes
+ the space a given view has, since either can belong to a differently sized scene.
+ */
+public enum SceneGeometry {
+  public static func windowScene(for view: UIView? = nil) -> UIWindowScene? {
+    if let scene = view?.window?.windowScene {
+      return scene
+    }
+    let scenes = windowScenes()
+    return scenes.first { $0.activationState == .foregroundActive }
+      ?? scenes.first { $0.activationState == .foregroundInactive }
+      ?? scenes.first
+  }
+
+  /// Deliberately strict, for callers deciding whether to attach a window to a scene at all.
+  public static func foregroundActiveScene() -> UIWindowScene? {
+    return windowScenes().first { $0.activationState == .foregroundActive }
+  }
+
+  private static func windowScenes() -> [UIWindowScene] {
+    return UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+  }
+
+  public static func keyWindow(for view: UIView? = nil) -> UIWindow? {
+    guard let scene = windowScene(for: view) else {
+      return nil
+    }
+    return scene.windows.first { $0.isKeyWindow } ?? scene.windows.first
+  }
+
+  public static func bounds(for view: UIView? = nil) -> CGRect {
+    return (view?.window ?? keyWindow(for: view))?.bounds ?? .zero
+  }
+
+  public static func safeAreaSize(for view: UIView? = nil) -> CGSize {
+    guard let window = view?.window ?? keyWindow(for: view) else {
+      return .zero
+    }
+    let safeArea = window.safeAreaLayoutGuide.layoutFrame.size
+    if safeArea.width > 0 && safeArea.height > 0 {
+      return safeArea
+    }
+    return window.bounds.size
+  }
+
+  /// Never cache the result. Scale can differ per scene.
+  public static func displayScale(for view: UIView? = nil) -> CGFloat {
+    return resolveDisplayScale(candidates: [
+      view?.traitCollection.displayScale,
+      windowScene(for: view)?.traitCollection.displayScale,
+      UITraitCollection.current.displayScale
+    ])
+  }
+
+  /// Returns the first positive candidate. `UITraitCollection` reports an unspecified scale as 0.
+  internal static func resolveDisplayScale(candidates: [CGFloat?]) -> CGFloat {
+    for case let candidate? in candidates where candidate > 0 {
+      return candidate
+    }
+    return 1
+  }
+}
+
+#if os(iOS)
+public extension SceneGeometry {
+  /// Reads `effectiveGeometry` because `UIWindowScene.interfaceOrientation` is deprecated as of iOS 26.
+  static func interfaceOrientation(for view: UIView? = nil) -> UIInterfaceOrientation {
+    return windowScene(for: view)?.effectiveGeometry.interfaceOrientation ?? .unknown
+  }
+
+  /// Returns `nil` when the system won't say. A requested lock is only a preference on iOS 27.
+  static func isInterfaceOrientationLocked(for view: UIView? = nil) -> Bool? {
+    guard let scene = windowScene(for: view) else {
+      return nil
+    }
+    if #available(iOS 26.0, *) {
+      return scene.effectiveGeometry.isInterfaceOrientationLocked
+    }
+    return nil
+  }
+}
+#endif
+
+#endif


### PR DESCRIPTION
# Why

iOS 27 makes iPhone apps freely resizable, both in iPhone Mirroring and when running on iPad, and rebuilding against the iOS 27 SDK opts an app in with no way back out. `UIScreen.main` and "the first key window in any connected scene" stop describing the space a view actually has, because either can belong to a differently sized scene.

Several of our packages read geometry that way. This is the base of a stack that moves them off it.

# How

Adds `SceneGeometry` to expo-modules-core. Every lookup starts from the view asking the question and degrades in one documented order, instead of each package reinventing that. Interface orientation comes from `effectiveGeometry`, which also clears the iOS 26 deprecation of `UIWindowScene.interfaceOrientation`.

Worth knowing for review: on iOS, `effectiveGeometry` carries no size below iOS 26, so available space comes from the view's own window rather than from scene geometry.

Nothing calls this yet. The rest of the stack does.

# Test Plan

Unit tests in `ios/Tests/SceneGeometryTests.swift`.

```
et native-unit-tests -p ios --packages expo-modules-core
```
