### PR TITLE
[ios][gl] Set the GL surface scale from the view's trait collection

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the GL surface using a cached main-screen scale instead of the scale of the scene the view is in. ([#48169](https://github.com/expo/expo/pull/48169) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 - Update docs to `createContextAsync` and `destroyContextAsync` methods which purpose wasn't documented and [was confusing](https://github.com/expo/expo/issues/40037). ([#47200](https://github.com/expo/expo/pull/47200) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-gl/ios/GLView.swift
+++ b/packages/expo-gl/ios/GLView.swift
@@ -44,8 +44,6 @@ internal final class GLView: ExpoView, EXGLContextDelegate {
     displayLink = CADisplayLink(target: self, selector: #selector(drawGL))
     displayLink?.add(to: RunLoop.main, forMode: .common)
 
-    contentScaleFactor = EXUtilities.screenScale()
-
     // Initialize properties of our backing CAEAGLLayer
     if let eaglLayer = layer as? CAEAGLLayer {
       eaglLayer.isOpaque = false
@@ -63,6 +61,24 @@ internal final class GLView: ExpoView, EXGLContextDelegate {
   }
 
   // MARK: - UIView
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    updateContentScaleFactor()
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    updateContentScaleFactor()
+  }
+
+  private func updateContentScaleFactor() {
+    let scale = SceneGeometry.displayScale(for: self)
+    if contentScaleFactor != scale {
+      contentScaleFactor = scale
+      setNeedsLayout()
+    }
+  }
 
   override func layoutSubviews() {
     resizeViewBuffersToWidth(width: contentScaleFactor * frame.size.width, height: contentScaleFactor * frame.size.height)


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

`GLView` took its scale from `EXUtilities.screenScale()`, which caches the main screen's scale in a `dispatch_once` and so can never be corrected. It also read it in `init`, before the view has a window and therefore before its real scale is known.

# How

Reads the scale from the view's own trait collection when it gains a window and on trait changes, and requests layout so the GL buffers follow it.

`EXGLContext` still uses the old static. That is a snapshot path where the device scale is defensible.

# Test Plan

expo-gl has no native test target. Ran the GL screens in native-component-list and confirmed they still render at full resolution.
