### PR TITLE
[ios][ui] Size HostView from its own scene

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -80,6 +80,7 @@
 - [iOS] Fix the `font` modifier dropping Dynamic Type scaling (`relativeTo`) and `weight` on concatenated `Text` runs. The Text-concatenation path now resolves the same `Font` as the view path. ([#46509](https://github.com/expo/expo/pull/46509) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [android] Fix universal `TextInput` ignoring `style` `backgroundColor` / `borderWidth` and not applying `textAlign` to the placeholder. ([#46441](https://github.com/expo/expo/pull/46441) by [@duyanhv](https://github.com/duyanhv))
 - [android] Fix `Switch` alignment when `label` is provided ([#47088](https://github.com/expo/expo/pull/47088) by [@rklomp](https://github.com/rklomp))
+- [iOS] Fixed viewport size measurement reading the main screen instead of the scene the view is in. ([#48170](https://github.com/expo/expo/pull/48170) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/HostView.swift
+++ b/packages/expo-ui/ios/HostView.swift
@@ -89,22 +89,6 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
     }
   }
 
-  private func safeAreaSize() -> CGSize {
-    let safeSize = UIApplication
-      .shared
-      .connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .flatMap { $0.windows }
-      .first { $0.isKeyWindow }?
-      .safeAreaLayoutGuide
-      .layoutFrame
-      .size
-      ?? UIScreen.main.bounds.size
-
-    let width = safeSize.width > 0 ? safeSize.width : UIScreen.main.bounds.width
-    let height = safeSize.height > 0 ? safeSize.height : UIScreen.main.bounds.height
-    return CGSize(width: width, height: height)
-  }
 }
 
 /**
@@ -150,21 +134,7 @@ private struct ViewportSizeMeasurementLayout: Layout {
   }
 
   private func safeAreaSize() -> CGSize {
-    let screenSize = UIScreen.main.bounds.size
-    let safeSize = UIApplication
-      .shared
-      .connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .flatMap { $0.windows }
-      .first { $0.isKeyWindow }?
-      .safeAreaLayoutGuide
-      .layoutFrame
-      .size
-      ?? screenSize
-
-    let width = safeSize.width > 0 ? safeSize.width : screenSize.width
-    let height = safeSize.height > 0 ? safeSize.height : screenSize.height
-    return CGSize(width: width, height: height)
+    return SceneGeometry.safeAreaSize()
   }
 }
 


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

Both copies of `safeAreaSize()` in `HostView` searched every connected scene for any key window, then fell back to the main screen.

# How

`HostView`'s own copy turned out to be dead, because the only call site resolves to the identical implementation inside `ViewportSizeMeasurementLayout`. Deleted it and pointed the live one at `SceneGeometry`.

`useViewportSizeMeasurement` is the only prop that uses this path, so that is the only layout that can move.

# Test Plan

Ran the Expo UI screens in native-component-list, the `useViewportSizeMeasurement` cases in particular.
