### PR TITLE
[ios][dev-menu] Create dev menu window from the active scene

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Re-enable the Fast Refresh toggle in the dev menu's Tools section. ([#47136](https://github.com/expo/expo/pull/47136) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 - [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have. ([#47693](https://github.com/expo/expo/pull/47693) by [@ramonclaudio](https://github.com/ramonclaudio))
+- [iOS] Fixed the dev menu sizing itself from the main screen instead of the app's own window, and the FAB choosing its slide-in edge from the screen rather than its window. ([#48171](https://github.com/expo/expo/pull/48171) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 #if !os(macOS)
 
+import ExpoModulesCore
 import React
 
 #if os(tvOS)
@@ -21,7 +22,11 @@ class DevMenuWindow: UIWindow, PresentationControllerDelegate {
     self.manager = manager
     self.devMenuViewController = DevMenuViewController(manager: manager)
 
-    super.init(frame: UIScreen.main.bounds)
+    if let windowScene = SceneGeometry.foregroundActiveScene() {
+      super.init(windowScene: windowScene)
+    } else {
+      super.init(frame: .zero)
+    }
 
     self.rootViewController = UIViewController()
     self.backgroundColor = UIColor(white: 0, alpha: 0.4)

--- a/packages/expo-dev-menu/ios/FAB/DevMenuFABWindow.swift
+++ b/packages/expo-dev-menu/ios/FAB/DevMenuFABWindow.swift
@@ -2,6 +2,7 @@
 
 #if !os(macOS) && !os(tvOS)
 
+import ExpoModulesCore
 import UIKit
 import SwiftUI
 
@@ -46,8 +47,8 @@ class DevMenuFABWindow: UIWindow {
   }
 
   private var edgeTranslation: CGAffineTransform {
-    let screenWidth = windowScene?.screen.bounds.width ?? UIScreen.main.bounds.width
-    let isOnRight = fabFrame == .zero || fabFrame.midX > (screenWidth / 2)
+    let availableWidth = SceneGeometry.bounds(for: self).width
+    let isOnRight = fabFrame == .zero || fabFrame.midX > (availableWidth / 2)
     let dx: CGFloat = isOnRight ? 60 : -60
     return CGAffineTransform(translationX: dx, y: 0)
   }


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

The dev menu window was created with the main screen's bounds, so it sizes itself to the display rather than to the app's own window.

# How

Attaches the window to the active scene instead. The FAB now picks its slide-in edge from its own window width, and its main screen fallback was already unreachable, since the FAB window is constructed with a scene.

# Test Plan

Opened the dev menu and confirmed its size and that the FAB sits on the correct edge.

```
et native-unit-tests -p ios --packages expo-dev-menu
```
