### PR TITLE
[ios] Stop reading geometry from the main screen

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `renderToImageAsync` reporting the main screen's scale rather than the scale the image was rendered at. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 - Resolve package-style font paths. ([#46784](https://github.com/expo/expo/pull/46784) by [@maxlapides](https://github.com/maxlapides))

--- a/packages/expo-font/ios/FontUtilsModule.swift
+++ b/packages/expo-font/ios/FontUtilsModule.swift
@@ -52,7 +52,7 @@ public final class FontUtilsModule: Module {
           "uri": outputURL.absoluteString,
           "width": image.size.width,
           "height": image.size.height,
-          "scale": UIScreen.main.scale
+          "scale": image.scale
         ])
       } catch {
         promise.reject(SaveImageException(outputURL.absoluteString))

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Grant the camera app explicit access to the output URI, so image capture keeps working as Android removes the implicit URI grant for `ACTION_IMAGE_CAPTURE`. ([#46954](https://github.com/expo/expo/pull/46954) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`. ([#48005](https://github.com/expo/expo/pull/48005) by [@barthap](https://github.com/barthap))
+- [iOS] Fixed crop square detection using the main screen's scale instead of the scale of the view being measured. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
+++ b/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+import ExpoModulesCore
 import ObjectiveC.runtime
 
 private var cropFixDriverKey: UInt8 = 0
@@ -88,9 +89,10 @@ extension UIImagePickerController {
   }
 
   var cropView: UIView? {
+    let scale = SceneGeometry.displayScale(for: view)
     return findView(named: "PLCropOverlayCropView", from: view)?
       .subviews
-      .first(where: { $0.bounds.isSquare })
+      .first(where: { $0.bounds.isSquare(scale: scale) })
   }
 
   private func findView(named className: String, from view: UIView) -> UIView? {
@@ -162,8 +164,8 @@ private final class CropFixDriver: NSObject {
 }
 
 private extension CGRect {
-  var isSquare: Bool {
-    let tolerance = 2 / UIScreen.main.scale
+  func isSquare(scale: CGFloat) -> Bool {
+    let tolerance = 2 / scale
     return width >= 44 && abs(width - height) <= tolerance
   }
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Use `OkHttpClientProvider` instead of raw `OkHttpClient` in `FileDownloader` so React Native's shared client and its interceptors are applied. ([#46926](https://github.com/expo/expo/pull/46926) by [@cortinico](https://github.com/cortinico))
 - [Android] Log purge completion errors via `android.util.Log.e` directly instead of `logger.error`, so the failure path doesn't re-enter the `PersistentFileLog` dispatch queue from inside one of its own tasks. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
+- [iOS] Resolved the reload screen's window through the shared scene geometry helper. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 56.0.17 — 2026-05-26
 

--- a/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenManager.swift
@@ -1,4 +1,5 @@
 #if os(iOS) || os(tvOS)
+import ExpoModulesCore
 import UIKit
 
 public class ReloadScreenManager: Reloadable {
@@ -41,11 +42,10 @@ public class ReloadScreenManager: Reloadable {
   private func showReloadScreen() throws {
     let config = currentConfiguration ?? ReloadScreenConfiguration(options: nil)
 
-    if let windowScene = UIApplication.shared.connectedScenes
-      .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+    if let windowScene = SceneGeometry.foregroundActiveScene() {
       overlayWindow = UIWindow(windowScene: windowScene)
     } else {
-      overlayWindow = UIWindow(frame: UIScreen.main.bounds)
+      overlayWindow = UIWindow(frame: .zero)
     }
 
     guard let window = overlayWindow else {


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168. These are the three remaining call sites that derived a size or a scale from the main screen.

# How

expo-updates resolves the reload overlay's window through the shared helper rather than its own copy of the lookup.

expo-font reports the scale its `UIGraphicsImageRenderer` actually used, which the image already carries, so no scene lookup is needed at all.

expo-image-picker takes the crop tolerance from the view being measured, which meant turning `isSquare` into a function that receives the scale.

# Test Plan

```
et native-unit-tests -p ios --packages expo-updates
et native-unit-tests -p ios --packages expo-image-picker
```

Also ran the image picker with `allowsEditing` in native-component-list to exercise the crop overlay.
