### PR TITLE
[ios][screen-orientation] Report refused geometry updates

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-21

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -23,13 +23,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   public var currentTraitCollection: UITraitCollection?
   var lastOrientationMask: UIInterfaceOrientationMask
   var rootViewController: UIViewController? {
-    let keyWindow = UIApplication
-      .shared
-      .connectedScenes
-      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-      .last { $0.isKeyWindow }
-
-    return keyWindow?.rootViewController
+    return SceneGeometry.keyWindow()?.rootViewController
   }
 
   public var currentOrientationMask: UIInterfaceOrientationMask {
@@ -58,7 +52,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
    Called by ScreenOrientationAppDelegate in order to set initial interface orientation.
    */
   public func updateCurrentScreenOrientation() {
-      self.currentScreenOrientation = rootViewController?.view.window?.windowScene?.interfaceOrientation ?? .unknown
+    self.currentScreenOrientation = SceneGeometry.interfaceOrientation(for: rootViewController?.view)
   }
 
   deinit {
@@ -89,11 +83,20 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
         return
       }
 
-      if #available(iOS 16.0, *) {
-        let windowScene = self.rootViewController?.view.window?.windowScene
-        windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientationMask))
-        self.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+      let windowScene = SceneGeometry.windowScene(for: self.rootViewController?.view)
+      windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientationMask)) { error in
+        #if DEBUG
+        log.warn(
+          "Couldn't lock the screen orientation because the system refused the request. This happens "
+          + "when your app is resizable, such as iPad multitasking, iPhone Mirroring, or any app on "
+          + "iOS 27 and later, where a supported orientation is only a preference. Design your screens "
+          + "to adapt to the available space, or on iPad set `ios.requireFullScreen` to `true` in your "
+          + "app config. See https://docs.expo.dev/versions/latest/sdk/screen-orientation/ "
+          + "Underlying error: \(error.localizedDescription)"
+        )
+        #endif
       }
+      self.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
       UIDevice.current.setValue(newOrientation.rawValue, forKey: "orientation")
       UIViewController.attemptRotationToDeviceOrientation()
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -9,21 +9,17 @@ class ScreenOrientationViewController: UIViewController {
   private var defaultOrientationMask: UIInterfaceOrientationMask
   private var previousInterfaceOrientation: UIInterfaceOrientation = .unknown
   private var windowInterfaceOrientation: UIInterfaceOrientation? {
-    let keyWindow = UIApplication
-      .shared
-      .connectedScenes
-      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-      .last { $0.isKeyWindow }
-
-    return keyWindow?.windowScene?.interfaceOrientation
+    let orientation = SceneGeometry.interfaceOrientation(for: view)
+    return orientation == .unknown ? nil : orientation
   }
 
   init(defaultOrientationMask: UIInterfaceOrientationMask = doesDeviceHaveNotch ? .allButUpsideDown : .all) {
     self.defaultOrientationMask = defaultOrientationMask
     super.init(nibName: nil, bundle: nil)
 
-    // For iPads traitCollectionDidChange will not be called (it's always in the same size class). It is necessary
-    // to init it in here, so it's possible to return it in the didUpdateDimensionsEvent of the module
+    // traitCollectionDidChange doesn't fire for every geometry change, such as a window resized
+    // within one size class, so seed the registry here to have a value ready for the module's
+    // didUpdateDimensionsEvent.
     if self.screenOrientationRegistry.currentTraitCollection == nil {
       self.screenOrientationRegistry.traitCollectionDidChange(to: self.traitCollection)
     }


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

iOS 27 treats a supported orientation as a preference and ignores it while the app is resizable, so `lockAsync` can silently do nothing. The `requestGeometryUpdate` call passed no error handler, so the refusal was discarded and neither the app nor the developer ever found out.

# How

Passes an error handler and warns in debug builds.

The lock deliberately does not throw. Apps reasonably call it unconditionally, so rejecting would break them. If we ever want that, it belongs in a major.

Also reads interface orientation from `effectiveGeometry` and resolves the root view controller through the scene instead of scanning every connected scene.

# Test Plan

This package has no native test target. Confirmed `lockAsync` still behaves normally on a phone, since the refactor touches the path every lock goes through.

The refusal path needs a resizable environment, so it cannot be exercised until Xcode 27 is available.
