### PR TITLE
[docs][screen-orientation] Document iOS 27 resizability

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
@@ -15,6 +15,7 @@ import {
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](devicemotion.mdx).
 
@@ -27,13 +28,24 @@ On both Android and iOS platforms, changes to the screen orientation will overri
 
 > Web has [limited support](https://caniuse.com/#feat=deviceorientation).
 
+## Orientation locks on iOS 27 and later&ensp;<PlatformTags platforms={['ios']} />
+
+Starting in iOS 27, iPhone apps can be resized, for example in iPhone Mirroring on macOS or when running on an iPad. While an app is resizable, the system treats a supported orientation as a preference rather than a requirement. This has two consequences:
+
+- `lockAsync` may have no effect. The system can refuse the request, and your app stays resizable.
+- `getOrientationAsync` may not describe the shape of the window your app is drawing into. iPhone Mirroring always reports a portrait orientation regardless of the window's aspect ratio.
+
+Design your screens to adapt to the space available to them instead of relying on a fixed orientation. In debug builds, this library logs a warning when the system refuses an orientation lock. Use those warnings to find the screens that still depend on a lock the platform no longer guarantees.
+
 ## Installation
 
 <APIInstallSection />
 
 ### Warning
 
-Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
+Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature by setting [`ios.requireFullScreen`](/versions/latest/config/app/#requirefullscreen) to `true` in your [app config](/workflow/configuration/).
+
+On iOS 27 and later, `requireFullScreen` no longer opts your app out of being resized, so it cannot reliably lock the screen orientation. See [Orientation locks on iOS 27 and later](#orientation-locks-on-ios-27-and-later). For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
 ## Configuration in app config
 


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

The page told you to disable iPad split view in order to lock orientation, which is exactly the mechanism iOS 27 stops honoring.

# How

Adds a section on what changes for orientation locks on iOS 27, and corrects the split view warning so it no longer reads as a way to control layout.

# Test Plan

Read the rendered page.
