### PR TITLE
[ios][config-plugins] Update requireFullScreen for iOS 27

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- [iOS] Documented that `UIRequiresFullScreen` no longer opts an app out of resizing as of iOS 27, and noted it in the iPad multitasking warning. ([#48175](https://github.com/expo/expo/pull/48175) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 56.0.8 — 2026-05-23
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/config-plugins/src/ios/RequiresFullScreen.ts
+++ b/packages/@expo/config-plugins/src/ios/RequiresFullScreen.ts
@@ -32,6 +32,10 @@ function hasMinimumOrientations(masks: string[]): boolean {
  *
  * ERROR ITMS-90474: "Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bacon.app'."
  *
+ * As of iOS 27, `UIRequiresFullScreen` no longer opts an app out of resizing. It requests discrete
+ * resizing that honors the supported interface orientations, it applies to iPhone as well as iPad,
+ * and Apple has deprecated it.
+ *
  * @param interfaceOrientations
  * @returns
  */
@@ -47,7 +51,7 @@ function resolveExistingIpadInterfaceOrientations(interfaceOrientations: any): s
     const existingList = interfaceOrientations!.join(', ');
     addWarningIOS(
       'ios.requireFullScreen',
-      `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist. The Info.plist currently defines values that are incompatible with multitasking, these will be overwritten to prevent submission failure. Existing: ${existingList}`
+      `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist, and the values currently defined are incompatible with it, so they will be overwritten to prevent a submission failure. Existing: ${existingList}. Note that as of iOS 27 supported orientations are a preference that resizable windows ignore, so define these for App Store validation rather than as a way to control layout.`
     );
     return interfaceOrientations;
   }


### PR DESCRIPTION
# Why

Part of the iOS 27 resizability work started in #48168.

`UIRequiresFullScreen` was documented purely as iPad multitasking. As of iOS 27 it no longer opts an app out of resizing, it requests discrete resizing that honors the supported orientations, it applies to iPhone as well, and Apple has deprecated it.

# How

The plugin keeps writing the key, because it still does something. Only the doc comment and the multitasking warning change, so nobody reads `requireFullScreen: true` as an escape hatch from resizability.

Note that the app config reference itself still describes the old behavior. That text is generated, so it needs a separate schema change.

# Test Plan

The existing tests in `RequiresFullScreen-test.ts` pass unchanged, which is the point, since this changes no behavior.
