### PR TITLE
Bump `tar` to `^7.5.22`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5114,7 +5114,7 @@ importers:
         version: 1.6.11
       yaml:
         specifier: ^2.8.3
-        version: 2.8.3
+        version: 2.9.0
     devDependencies:
       '@types/jest':
         specifier: ^29.2.1
@@ -5865,7 +5865,7 @@ importers:
         version: 6.0.3
       yaml:
         specifier: ^2.3.2
-        version: 2.8.3
+        version: 2.9.0
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -6539,8 +6539,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.1
       tar:
-        specifier: ^7.5.12
-        version: 7.5.12
+        specifier: ^7.5.22
+        version: 7.5.22
       terminal-link:
         specifier: ^2.1.1
         version: 2.1.1
@@ -7746,7 +7746,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
@@ -14730,8 +14730,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.12:
-    resolution: {integrity: sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   taskr@1.1.0:
@@ -15553,11 +15553,6 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
-
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -22719,7 +22714,7 @@ snapshots:
       metro-cache: 0.84.4
       metro-core: 0.84.4
       metro-runtime: 0.84.4
-      yaml: 2.8.3
+      yaml: 2.9.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -24698,7 +24693,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.12:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -24936,7 +24931,7 @@ snapshots:
       markdown-it: 14.1.1
       minimatch: 10.2.5
       typescript: 6.0.3
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   typescript@6.0.3: {}
 
@@ -25624,10 +25619,7 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  yaml@2.8.3: {}
-
-  yaml@2.9.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/tools/package.json
+++ b/tools/package.json
@@ -2,17 +2,19 @@
   "name": "expotools",
   "version": "1.0.0",
   "description": "A set of commands and libraries for working within the Expo repository",
-  "main": "build/expotools.js",
+  "license": "MIT",
+  "author": "support@expo.dev",
+  "bin": {
+    "et": "bin/expotools.js",
+    "expotools": "bin/expotools.js"
+  },
   "files": [
     "bin",
     "build",
     "scripts",
     "templates"
   ],
-  "bin": {
-    "et": "bin/expotools.js",
-    "expotools": "bin/expotools.js"
-  },
+  "main": "build/expotools.js",
   "scripts": {
     "build": "expo-build cjs:src=build",
     "clean": "rm -rf build cache",
@@ -20,17 +22,15 @@
     "lint": "eslint .",
     "test": "pnpm build && node --test 'build/**/*.test.js'"
   },
-  "author": "support@expo.dev",
-  "license": "MIT",
   "dependencies": {
     "@expo/commander": "2.21.1",
     "@expo/json-file": "workspace:*",
     "@expo/multipart-body-parser": "^1.1.0",
     "@expo/osascript": "workspace:*",
     "@expo/plist": "workspace:*",
-    "@expo/xcpretty": "^4.4.4",
     "@expo/spawn-async": "^1.8.0",
     "@expo/swiftlint": "^0.57.1",
+    "@expo/xcpretty": "^4.4.4",
     "@linear/sdk": "^2.6.0",
     "@octokit/rest": "^19.0.7",
     "chalk": "^4.1.2",
@@ -59,7 +59,7 @@
     "recursive-omit-by": "^2.0.0",
     "semver": "^7.6.3",
     "strip-ansi": "^6.0.0",
-    "tar": "^7.5.12",
+    "tar": "^7.5.22",
     "terminal-link": "^2.1.1",
     "typedoc": "^0.28.19",
     "uuid": "^9.0.0"


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/pull/48135

# How

Bump `tar` to `^7.5.22`

# Test Plan

- CI is running correctly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
