### PR TITLE
feat(cli): Preserve explicit `watchFolders` outside of `serverRoot`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Bump to `dnssd-advertise@^1.1.6` ([#47183](https://github.com/expo/expo/pull/47183) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate structured event logging to the `2g` package ([#46667](https://github.com/expo/expo/pull/46667) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
+- Preserve `watchFolders` external to `serverRoot` explicitly, when they've been manually added ([#48177](https://github.com/expo/expo/pull/48177) by [@kitten](https://github.com/kitten))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -21,6 +21,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { Log } from '../../../log';
+import { isPathInside } from '../../../utils/dir';
 import { env } from '../../../utils/env';
 import { isServerEnvironment } from '../middleware/metroOptions';
 import type { PlatformBundlers } from '../platformBundlers';
@@ -983,6 +984,7 @@ export async function withMetroMultiPlatformAsync(
     config,
     exp,
     platformBundlers,
+    serverRoot,
 
     isTsconfigPathsEnabled,
     isAutolinkingResolverEnabled,
@@ -1011,8 +1013,12 @@ export async function withMetroMultiPlatformAsync(
   // NOTE(@kitten): If the on-demand filesystem is enabled, we can aggressively cut down the `watchFolders`
   // to a minimum, since the files will be read lazily. This almost always speeds up exports
   if (isExporting && !!config.resolver.unstable_onDemandFilesystem) {
+    // Preserve additional watchFolders the user added outside of serverRoot explicitly
+    // TODO(@kitten): In the future we can instead use the `onDemandFilesystem: 'UNSTABLE_ALLOW_ALL'` mode while issuing a warning
+    const internalRoot = serverRoot ?? projectRoot;
+    const externalWatchFolders = watchFolders.filter((dir) => !isPathInside(dir, internalRoot));
     watchFolders.length = 0;
-    watchFolders.push(projectRoot);
+    watchFolders.push(projectRoot, ...externalWatchFolders);
   }
 
   // Change the default metro-runtime to a custom one that supports bundle splitting.


### PR DESCRIPTION
# Why

When the `watchFolders` are modified to point at folders outside of the `serverRoot`, they shouldn't be erased during an `expo export` run, which limits `watchFolders` to `projectRoot` due to the on-demand filesystem, improving the single-export run performance.

However, while this is rare, when a `watchFolders` entry is outside of `serverRoot ?? projectRoot`, it needs to be preserved, since the "strict" default mode of the on-demand filesystem won't allow access. This usually doesn't affect many projects since a monorepo (or project) will sit at the root with no parent or sibling directories, by convention.

# How

- Instead of setting `watchFolders = [projectRoot]` filter by non-server-root folders and then add `projectRoot`

# Test Plan

- Manually verified

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
