### PR TITLE
[expo-type-information] Fix generated methods, return types, unresolved types. Refactor parse context

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -130,23 +130,27 @@ public class TestModule: Module {
         TestClass(a)
       }
 
-      Property("TestIntProperty") { () -> Int in
+      Property("TestIntProperty") { (basicClass: TestBasicClass) -> Int in
         1
       }
 
-      Property("TestEitherProperty") { () -> Either<Int, String> in
+      Property("TestEitherProperty") { (basicClass: TestBasicClass) -> Either<Int, String> in
         1
       }
 
-      Property("TestEnumProperty") { () -> TestEnum in
+      Property("TestEnumProperty") { (basicClass: TestBasicClass) -> TestEnum in
         .simpleCase
       }
 
-      Property("TestRecordProperty") { () -> TestRecord2 in
+      Property("TestRecordProperty") { (basicClass: TestBasicClass) -> TestRecord2 in
         TestRecord2(1, "2")
       }
 
-      AsyncFunction("TestAsyncFunction") { (a: Int) async -> String in 
+      AsyncFunction("TestAsyncMethod") { (basicClass: TestBasicClass, a: Int) -> String in 
+        "string"
+      }
+
+      Function("TestSyncMethod") { (basicClass: TestBasicClass, a: Int) -> String in 
         "string"
       }
 

--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -39,7 +39,7 @@ public class TestModule: Module {
     Function("TestUnicodeCharacters") { () in
       let 🎉 = "Cheers"
 
-      return "\🎉! 🎉"
+      return "\(🎉)! 🎉"
     }
 
     Function("TestUntypedFunction2") { /* Comment 3 */ () in

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -62,8 +62,9 @@ export type TestBasicClassEvents = {
   EventName1: (payload?: any) => void;
 };
 export declare class TestBasicClass extends SharedObject<TestBasicClassEvents> {
+  TestSyncMethod(a: number): string;
   static TestStaticFunction(): string;
-  TestAsyncFunction(a: number): Promise<string>;
+  TestAsyncMethod(a: number): Promise<string>;
   static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
@@ -409,8 +410,9 @@ export type TestBasicClassEvents = {
   EventName1: (payload?: any) => void;
 };
 export declare class TestBasicClass extends SharedObject<TestBasicClassEvents> {
+  TestSyncMethod(a: number): string;
   static TestStaticFunction(): string;
-  TestAsyncFunction(a: number): Promise<string>;
+  TestAsyncMethod(a: number): Promise<string>;
   static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
@@ -589,8 +591,9 @@ export class TestClassWithConstructor {
     constructor(a: number) { }
 }
 export class TestBasicClass {
+    TestSyncMethod(a: number): string { return ""; }
     static TestStaticFunction(): string { return ""; }
-    async TestAsyncFunction(a: number): Promise<string> { return ""; }
+    async TestAsyncMethod(a: number): Promise<string> { return ""; }
     async static TestStaticAsyncFunction(a: string): Promise<void> { }
     constructor(a: number, b: string, c: string | TestRecord) { }
 }
@@ -670,8 +673,9 @@ export class TestClassWithConstructor {
     constructor(a) { }
 }
 export class TestBasicClass {
+    TestSyncMethod(a) { return ""; }
     static TestStaticFunction() { return ""; }
-    async TestAsyncFunction(a) { return ""; }
+    async TestAsyncMethod(a) { return ""; }
     async static TestStaticAsyncFunction(a) { }
     constructor(a, b, c) { }
 }
@@ -741,8 +745,9 @@ export type TestBasicClassEvents = {
   EventName1: (payload?: any) => void;
 };
 export declare class TestBasicClass extends SharedObject<TestBasicClassEvents> {
+  TestSyncMethod(a: number): string;
   static TestStaticFunction(): string;
-  TestAsyncFunction(a: number): Promise<string>;
+  TestAsyncMethod(a: number): Promise<string>;
   static TestStaticAsyncFunction(a: string): Promise<void>;
   readonly TestIntProperty: number;
   readonly TestEitherProperty: number | string;
@@ -1035,7 +1040,7 @@ exports[`Same type information 1`] = `
                 },
               ],
               "isStatic": false,
-              "name": "TestAsyncFunction",
+              "name": "TestAsyncMethod",
               "parameters": [],
               "returnType": {
                 "kind": 0,
@@ -1103,6 +1108,24 @@ exports[`Same type information 1`] = `
             "EventName1",
           ],
           "methods": [
+            {
+              "arguments": [
+                {
+                  "name": "a",
+                  "type": {
+                    "kind": 0,
+                    "type": 2,
+                  },
+                },
+              ],
+              "isStatic": false,
+              "name": "TestSyncMethod",
+              "parameters": [],
+              "returnType": {
+                "kind": 0,
+                "type": 1,
+              },
+            },
             {
               "arguments": [],
               "isStatic": true,

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -106,7 +106,7 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   readonly UntypedConstant: unknown /*The type couldn't be resolved automatically.*/;
   SimpleFunction(a: number, b: number): number;
   TestUntypedFunction(): string;
-  TestUnicodeCharacters(): unknown /*The type couldn't be resolved automatically.*/;
+  TestUnicodeCharacters(): string;
   TestUntypedFunction2(): TestEnum;
   TestObject(): object;
   TestAnyValue(): any;
@@ -140,7 +140,7 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
-  TestAsyncFunctionPromiseArgument3(): Promise<unknown /*The type couldn't be resolved automatically.*/>;
+  TestAsyncFunctionPromiseArgument3(): Promise<number>;
   TestUnderscore(
     url: string,
     _4: BarcodeType[]
@@ -347,7 +347,7 @@ export declare class TestModule extends NativeModule<TestModuleEvents> {
   readonly UntypedConstant: unknown /*The type couldn't be resolved automatically.*/;
   SimpleFunction(a: number, b: number): number;
   TestUntypedFunction(): string;
-  TestUnicodeCharacters(): unknown /*The type couldn't be resolved automatically.*/;
+  TestUnicodeCharacters(): string;
   TestUntypedFunction2(): TestEnum;
   TestObject(): object;
   TestAnyValue(): any;
@@ -381,7 +381,7 @@ export declare class TestModule extends NativeModule<TestModuleEvents> {
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
-  TestAsyncFunctionPromiseArgument3(): Promise<unknown /*The type couldn't be resolved automatically.*/>;
+  TestAsyncFunctionPromiseArgument3(): Promise<number>;
   TestUnderscore(
     url: string,
     _6: BarcodeType[]
@@ -555,7 +555,7 @@ export enum OuterNamespace {
 
 export function SimpleFunction(a: number, b: number): number { return 0; }
 export function TestUntypedFunction(): string { return ""; }
-export function TestUnicodeCharacters(): unknown /*The type couldn't be resolved automatically.*/ { return; }
+export function TestUnicodeCharacters(): string { return ""; }
 export function TestUntypedFunction2(): TestEnum { return TestEnum.simpleCase; }
 export function TestObject(): object { return {}; }
 export function TestAnyValue(): any { }
@@ -583,7 +583,7 @@ export function TestFunctionReturningEnum(): TestEnum { return TestEnum.simpleCa
 export async function TestSimpleAsyncFunction(a: string, b: string): Promise<string> { return ""; }
 export async function TestAsyncFunctionPromiseArgument1(): Promise<string> { return ""; }
 export async function TestAsyncFunctionPromiseArgument2(): Promise<void> { }
-export async function TestAsyncFunctionPromiseArgument3(): Promise<unknown /*The type couldn't be resolved automatically.*/> { return; }
+export async function TestAsyncFunctionPromiseArgument3(): Promise<number> { return 0; }
 export async function TestUnderscore(url: string, _2: BarcodeType[]): Promise<unknown /*The type couldn't be resolved automatically.*/> { return; }
 
 
@@ -649,7 +649,7 @@ export var OuterNamespace;
 })(OuterNamespace || (OuterNamespace = {}));
 export function SimpleFunction(a, b) { return 0; }
 export function TestUntypedFunction() { return ""; }
-export function TestUnicodeCharacters() { return; }
+export function TestUnicodeCharacters() { return ""; }
 export function TestUntypedFunction2() { return TestEnum.simpleCase; }
 export function TestObject() { return {}; }
 export function TestAnyValue() { }
@@ -667,7 +667,7 @@ export function TestFunctionReturningEnum() { return TestEnum.simpleCase; }
 export async function TestSimpleAsyncFunction(a, b) { return ""; }
 export async function TestAsyncFunctionPromiseArgument1() { return ""; }
 export async function TestAsyncFunctionPromiseArgument2() { }
-export async function TestAsyncFunctionPromiseArgument3() { return; }
+export async function TestAsyncFunctionPromiseArgument3() { return 0; }
 export async function TestUnderscore(url, _3) { return; }
 export class TestClassWithConstructor {
     constructor(a) { }
@@ -779,7 +779,7 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   readonly UntypedConstant: unknown /*The type couldn't be resolved automatically.*/;
   SimpleFunction(a: number, b: number): number;
   TestUntypedFunction(): string;
-  TestUnicodeCharacters(): unknown /*The type couldn't be resolved automatically.*/;
+  TestUnicodeCharacters(): string;
   TestUntypedFunction2(): TestEnum;
   TestObject(): object;
   TestAnyValue(): any;
@@ -813,7 +813,7 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
-  TestAsyncFunctionPromiseArgument3(): Promise<unknown /*The type couldn't be resolved automatically.*/>;
+  TestAsyncFunctionPromiseArgument3(): Promise<number>;
   TestUnderscore(
     url: string,
     _1: BarcodeType[]
@@ -976,7 +976,7 @@ exports[`Same type information 1`] = `
           "parameters": [],
           "returnType": {
             "kind": 0,
-            "type": 8,
+            "type": 2,
           },
         },
         {
@@ -1270,7 +1270,7 @@ exports[`Same type information 1`] = `
           "parameters": [],
           "returnType": {
             "kind": 0,
-            "type": 8,
+            "type": 1,
           },
         },
         {

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -372,12 +372,12 @@ function hasSubstructure(structure: Structure) {
 async function findReturnType(
   structure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<string | null> {
   if (
     structure['key.kind'] === swiftDeclarationKind.varLocal &&
     structure['key.name'].startsWith('returnValueDeclaration_') &&
-    options.typeInference
+    ctx.typeInference
   ) {
     // TODO(@HubertBer): this return type inference is really costly
     return getTypeOfByteOffsetVariable(structure['key.nameoffset'], file);
@@ -385,7 +385,7 @@ async function findReturnType(
 
   if (hasSubstructure(structure)) {
     for (const substructure of structure['key.substructure']) {
-      const returnType = findReturnType(substructure, file, options);
+      const returnType = findReturnType(substructure, file, ctx);
       if (returnType) {
         return returnType;
       }
@@ -416,14 +416,14 @@ function getUnresolvedType(): Type {
 async function extractDeclarationType(
   structure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<Type> {
   if (structure['key.typename']) {
     return mapSwiftTypeToTsType(structure['key.typename'] as string);
   }
 
   // TODO(@HubertBer): this type inference is really costly
-  if (options.typeInference) {
+  if (ctx.typeInference) {
     const inferReturn = await getTypeOfByteOffsetVariable(structure['key.nameoffset'], file);
     return inferReturn ? mapSwiftTypeToTsType(inferReturn) : getUnresolvedType();
   }
@@ -504,14 +504,14 @@ const parseModulePropertyStructure = parseModuleConstantStructure;
 async function parseClosureTypes(
   structure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<SourcekittenClosure> {
   const closure = structure['key.substructure']?.find(
     (s) => s['key.kind'] === swiftDeclarationKind.closure
   );
   if (!closure) {
     // Try finding the preprocessed return value, if not found we don't know the return type
-    const returnType = await findReturnType(structure, file, options);
+    const returnType = await findReturnType(structure, file, ctx);
     return { parameters: [], returnType };
   }
 
@@ -522,14 +522,14 @@ async function parseClosureTypes(
       typename: p['key.typename'],
     }));
 
-  const returnType = closure?.['key.typename'] ?? (await findReturnType(structure, file, options));
+  const returnType = closure?.['key.typename'] ?? (await findReturnType(structure, file, ctx));
   return { parameters, returnType };
 }
 
 async function parseModuleConstructorDeclaration(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<ConstructorDeclaration> {
   const definitionParams = substructure['key.substructure'];
   let types = null;
@@ -537,9 +537,9 @@ async function parseModuleConstructorDeclaration(
   // TODO(@HubertBer): rethink this maybe split based on what closure is expected
   // Maybe this should be the last substructure
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, options);
+    types = await parseClosureTypes(definitionParams[1], file, ctx);
   } else if (definitionParams[0] && hasSubstructure(definitionParams[0])) {
-    types = await parseClosureTypes(definitionParams[0], file, options);
+    types = await parseClosureTypes(definitionParams[0], file, ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -555,7 +555,7 @@ async function parseModuleConstructorDeclaration(
 async function parseModuleConstantStructure(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<ConstantDeclaration | null> {
   const definitionParams = substructure['key.substructure'];
   if (!definitionParams[0]) {
@@ -565,7 +565,7 @@ async function parseModuleConstantStructure(
   const name = getIdentifierFromOffsetObject(definitionParams[0], file);
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, options);
+    types = await parseClosureTypes(definitionParams[1], file, ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -627,7 +627,6 @@ function getClosureBodyStructure(structure: Structure): Structure | null {
 
 async function parseModuleClassStructure(
   structure: Structure,
-  options: SwiftFileTypeInformationOptions,
   ctx: ParseContext
 ): Promise<ClassDeclaration> {
   const { file } = ctx;
@@ -655,9 +654,23 @@ async function parseModuleClassStructure(
     nestedModuleSubstructure,
     'UNUSED_NAME',
     structure['key.offset'],
-    options,
     ctx
   );
+
+  const removeImplicitThis = (functionDeclaration: FunctionDeclaration) => {
+    const firstArg = functionDeclaration.arguments[0];
+    if (
+      firstArg === undefined ||
+      firstArg.type.kind !== TypeKind.IDENTIFIER ||
+      firstArg.type.type !== name
+    ) {
+      return;
+    }
+    functionDeclaration.arguments.shift();
+  };
+  classTypeInfo.functions.forEach(removeImplicitThis);
+  classTypeInfo.asyncFunctions.forEach(removeImplicitThis);
+
   return {
     name,
     events: classTypeInfo.events,
@@ -672,8 +685,8 @@ async function parseModuleClassStructure(
 async function parseModuleFunctionSubstructure(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions,
-  isStatic: boolean
+  isStatic: boolean,
+  ctx: ParseContext
 ): Promise<FunctionDeclaration> {
   const definitionParams = substructure['key.substructure'];
   const nameSubstrucutre = definitionParams[0];
@@ -682,7 +695,7 @@ async function parseModuleFunctionSubstructure(
     : 'UnnamedFunction';
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, options);
+    types = await parseClosureTypes(definitionParams[1], file, ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -702,14 +715,14 @@ async function parseModuleFunctionSubstructure(
 async function parseModuleAsyncFunctionSubstructure(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions,
-  isStatic: boolean
+  isStatic: boolean,
+  ctx: ParseContext
 ): Promise<FunctionDeclaration> {
   const functionDeclaration = await parseModuleFunctionSubstructure(
     substructure,
     file,
-    options,
-    isStatic
+    isStatic,
+    ctx
   );
   const lastArgument = functionDeclaration.arguments[functionDeclaration.arguments.length - 1];
   if (!lastArgument) {
@@ -728,7 +741,7 @@ async function parseModuleAsyncFunctionSubstructure(
 async function parseModulePropDeclaration(
   substructure: Structure,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<PropDeclaration> {
   const definitionParams = substructure['key.substructure'];
   const nameSubstrucutre = definitionParams[0];
@@ -737,7 +750,7 @@ async function parseModulePropDeclaration(
     : 'UnkownProp';
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, options);
+    types = await parseClosureTypes(definitionParams[1], file, ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -753,7 +766,6 @@ async function parseModulePropDeclaration(
 
 async function parseModuleViewDeclaration(
   substructure: Structure,
-  options: SwiftFileTypeInformationOptions,
   ctx: ParseContext
 ): Promise<ViewDeclaration | null> {
   const { file } = ctx;
@@ -771,13 +783,7 @@ async function parseModuleViewDeclaration(
     return null;
   }
 
-  return await parseModuleStructure(
-    viewSubstructure,
-    name,
-    viewStructure['key.offset'],
-    options,
-    ctx
-  );
+  return await parseModuleStructure(viewSubstructure, name, viewStructure['key.offset'], ctx);
 }
 
 function parseModuleEventDeclaration(structure: Structure, events: string[], ctx: ParseContext) {
@@ -809,7 +815,7 @@ async function parseRecordStructure(
   usedTypeIdentifiers: Set<string>,
   inferredTypeParametersCount: Map<string, number>,
   file: FileType,
-  options: SwiftFileTypeInformationOptions
+  ctx: ParseContext
 ): Promise<RecordType> {
   const recordSubstrucutres = recordStructure['key.substructure'].filter(
     (substructure) =>
@@ -818,7 +824,7 @@ async function parseRecordStructure(
   );
 
   const fields = await taskAll(recordSubstrucutres, async (substructure) => {
-    const type = await extractDeclarationType(substructure, file, options);
+    const type = await extractDeclarationType(substructure, file, ctx);
     return { type, name: substructure['key.name'] };
   });
 
@@ -889,13 +895,13 @@ type namespace = {
 type ParseContext = {
   file: FileType;
   namespaces: { [key: string]: namespace };
+  typeInference: boolean;
 };
 
 async function parseModuleStructure(
   moduleStructure: Structure[],
   name: string,
   definitionOffset: number,
-  options: SwiftFileTypeInformationOptions,
   ctx: ParseContext
 ): Promise<ModuleClassDeclaration> {
   const { file } = ctx;
@@ -936,24 +942,22 @@ async function parseModuleStructure(
       }
       case 'Function': {
         moduleClassDeclaration.functions.push(
-          await parseModuleFunctionSubstructure(structure, file, options, false)
+          await parseModuleFunctionSubstructure(structure, file, false, ctx)
         );
         break;
       }
       case 'Constant': {
-        const constantDeclaration = await parseModuleConstantStructure(structure, file, options);
+        const constantDeclaration = await parseModuleConstantStructure(structure, file, ctx);
         if (constantDeclaration) {
           moduleClassDeclaration.constants.push(constantDeclaration);
         }
         break;
       }
       case 'Class':
-        moduleClassDeclaration.classes.push(
-          await parseModuleClassStructure(structure, options, ctx)
-        );
+        moduleClassDeclaration.classes.push(await parseModuleClassStructure(structure, ctx));
         break;
       case 'Property': {
-        const propertyDeclaration = await parseModulePropertyStructure(structure, file, options);
+        const propertyDeclaration = await parseModulePropertyStructure(structure, file, ctx);
         if (propertyDeclaration) {
           moduleClassDeclaration.properties.push(propertyDeclaration);
         }
@@ -961,33 +965,31 @@ async function parseModuleStructure(
       }
       case 'AsyncFunction':
         moduleClassDeclaration.asyncFunctions.push(
-          await parseModuleAsyncFunctionSubstructure(structure, file, options, false)
+          await parseModuleAsyncFunctionSubstructure(structure, file, false, ctx)
         );
         break;
       case 'StaticAsyncFunction':
         moduleClassDeclaration.asyncFunctions.push(
-          await parseModuleAsyncFunctionSubstructure(structure, file, options, true)
+          await parseModuleAsyncFunctionSubstructure(structure, file, true, ctx)
         );
         break;
       case 'StaticFunction':
         moduleClassDeclaration.functions.push(
-          await parseModuleFunctionSubstructure(structure, file, options, true)
+          await parseModuleFunctionSubstructure(structure, file, true, ctx)
         );
         break;
       case 'Constructor':
         moduleClassDeclaration.constructor = await parseModuleConstructorDeclaration(
           structure,
           file,
-          options
+          ctx
         );
         break;
       case 'Prop':
-        moduleClassDeclaration.props.push(
-          await parseModulePropDeclaration(structure, file, options)
-        );
+        moduleClassDeclaration.props.push(await parseModulePropDeclaration(structure, file, ctx));
         break;
       case 'View': {
-        const viewDeclaration = await parseModuleViewDeclaration(structure, options, ctx);
+        const viewDeclaration = await parseModuleViewDeclaration(structure, ctx);
         if (viewDeclaration) {
           moduleClassDeclaration.views.push(viewDeclaration);
         }
@@ -1027,30 +1029,29 @@ type ParseStructureOptions = {
 function parseStructure(
   { file, structure, name }: ParseStructureOptions,
   // Note that instead of returning and merging the enum, record and module arrays, we're just collecting the items in the 3 arrays inside this object.
-  parsedStructuresOutput: ParseStructuresOutput
+  output: ParseStructuresOutput
 ) {
-  const { modulesStructures, recordsStructures, enumsStructures } = parsedStructuresOutput;
   // TODO(@HubertBer): Find out why sometimes the structure is undefined (for example when parsing expo-audio)
   const substructure = structure['key.substructure'];
-  if (!structure || !substructure) {
+  if (!substructure) {
     return;
   }
 
   if (isModuleStructure(structure)) {
-    modulesStructures.push({ structure, name });
+    output.modulesStructures.push({ structure, name });
   } else if (isRecordStructure(file, structure)) {
-    recordsStructures.push(structure);
+    output.recordsStructures.push(structure);
   } else if (isEnumStructure(structure)) {
-    enumsStructures.push(structure);
+    output.enumsStructures.push(structure);
   } else if (Array.isArray(substructure) && substructure.length > 0) {
-    for (const substructure of structure['key.substructure']) {
+    for (const child of substructure) {
       parseStructure(
         {
           file,
-          structure: substructure,
+          structure: child,
           name: structure['key.name'] ?? name,
         },
-        parsedStructuresOutput
+        output
       );
     }
   }
@@ -1209,7 +1210,7 @@ export async function getSwiftFileTypeInformation(
   parseStructure(
     {
       file,
-      structure: getStructureFromFile(file),
+      structure: fileStructure,
       name: '',
     },
     {
@@ -1229,14 +1230,9 @@ export async function getSwiftFileTypeInformation(
   const recordTypeIdentifiers = new Set<string>();
   const typeIdentifierDefinitionMap: TypeIdentifierDefinitionMap = new Map();
   const enums: EnumType[] = enumsStructures.map(parseEnumStructure);
+  const ctx = { namespaces, file, typeInference: options.typeInference };
   const recordMap = (rd: Structure) => {
-    return parseRecordStructure(
-      rd,
-      recordTypeIdentifiers,
-      inferredTypeParametersCount,
-      file,
-      options
-    );
+    return parseRecordStructure(rd, recordTypeIdentifiers, inferredTypeParametersCount, file, ctx);
   };
 
   const recordsPromise = taskAll(recordsStructures, recordMap);
@@ -1248,8 +1244,7 @@ export async function getSwiftFileTypeInformation(
         structure['key.substructure'],
         name,
         structure['key.offset'],
-        options,
-        { namespaces, file }
+        ctx
       );
     }
   );

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -204,6 +204,8 @@ const basicTypesConversions = new Map<string, BasicType>([
   ['Never', BasicType.NEVER],
 
   ['JavaScriptObject', BasicType.OBJECT],
+
+  ['_', BasicType.UNRESOLVED],
 ]);
 
 const convertibleTypesConversions = new Map<string, ConvertibleType>([
@@ -369,23 +371,19 @@ function hasSubstructure(structure: Structure) {
   return structure?.['key.substructure'] && structure['key.substructure'].length > 0;
 }
 
-async function findReturnType(
-  structure: Structure,
-  file: FileType,
-  ctx: ParseContext
-): Promise<string | null> {
+async function findReturnType(structure: Structure, ctx: ParseContext): Promise<string | null> {
   if (
     structure['key.kind'] === swiftDeclarationKind.varLocal &&
     structure['key.name'].startsWith('returnValueDeclaration_') &&
     ctx.typeInference
   ) {
     // TODO(@HubertBer): this return type inference is really costly
-    return getTypeOfByteOffsetVariable(structure['key.nameoffset'], file);
+    return getTypeOfByteOffsetVariable(structure['key.nameoffset'], ctx.file);
   }
 
   if (hasSubstructure(structure)) {
     for (const substructure of structure['key.substructure']) {
-      const returnType = findReturnType(substructure, file, ctx);
+      const returnType = await findReturnType(substructure, ctx);
       if (returnType) {
         return returnType;
       }
@@ -413,18 +411,14 @@ function getUnresolvedType(): Type {
   return { kind: TypeKind.BASIC, type: BasicType.UNRESOLVED };
 }
 
-async function extractDeclarationType(
-  structure: Structure,
-  file: FileType,
-  ctx: ParseContext
-): Promise<Type> {
+async function extractDeclarationType(structure: Structure, ctx: ParseContext): Promise<Type> {
   if (structure['key.typename']) {
     return mapSwiftTypeToTsType(structure['key.typename'] as string);
   }
 
   // TODO(@HubertBer): this type inference is really costly
   if (ctx.typeInference) {
-    const inferReturn = await getTypeOfByteOffsetVariable(structure['key.nameoffset'], file);
+    const inferReturn = await getTypeOfByteOffsetVariable(structure['key.nameoffset'], ctx.file);
     return inferReturn ? mapSwiftTypeToTsType(inferReturn) : getUnresolvedType();
   }
 
@@ -503,7 +497,6 @@ const parseModulePropertyStructure = parseModuleConstantStructure;
 
 async function parseClosureTypes(
   structure: Structure,
-  file: FileType,
   ctx: ParseContext
 ): Promise<SourcekittenClosure> {
   const closure = structure['key.substructure']?.find(
@@ -511,7 +504,7 @@ async function parseClosureTypes(
   );
   if (!closure) {
     // Try finding the preprocessed return value, if not found we don't know the return type
-    const returnType = await findReturnType(structure, file, ctx);
+    const returnType = await findReturnType(structure, ctx);
     return { parameters: [], returnType };
   }
 
@@ -522,13 +515,12 @@ async function parseClosureTypes(
       typename: p['key.typename'],
     }));
 
-  const returnType = closure?.['key.typename'] ?? (await findReturnType(structure, file, ctx));
+  const returnType = closure?.['key.typename'] ?? (await findReturnType(structure, ctx));
   return { parameters, returnType };
 }
 
 async function parseModuleConstructorDeclaration(
   substructure: Structure,
-  file: FileType,
   ctx: ParseContext
 ): Promise<ConstructorDeclaration> {
   const definitionParams = substructure['key.substructure'];
@@ -537,9 +529,9 @@ async function parseModuleConstructorDeclaration(
   // TODO(@HubertBer): rethink this maybe split based on what closure is expected
   // Maybe this should be the last substructure
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, ctx);
+    types = await parseClosureTypes(definitionParams[1], ctx);
   } else if (definitionParams[0] && hasSubstructure(definitionParams[0])) {
-    types = await parseClosureTypes(definitionParams[0], file, ctx);
+    types = await parseClosureTypes(definitionParams[0], ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -554,7 +546,6 @@ async function parseModuleConstructorDeclaration(
 
 async function parseModuleConstantStructure(
   substructure: Structure,
-  file: FileType,
   ctx: ParseContext
 ): Promise<ConstantDeclaration | null> {
   const definitionParams = substructure['key.substructure'];
@@ -562,10 +553,10 @@ async function parseModuleConstantStructure(
     return null;
   }
 
-  const name = getIdentifierFromOffsetObject(definitionParams[0], file);
+  const name = getIdentifierFromOffsetObject(definitionParams[0], ctx.file);
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, ctx);
+    types = await parseClosureTypes(definitionParams[1], ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -660,6 +651,7 @@ async function parseModuleClassStructure(
   const removeImplicitThis = (functionDeclaration: FunctionDeclaration) => {
     const firstArg = functionDeclaration.arguments[0];
     if (
+      functionDeclaration.isStatic ||
       firstArg === undefined ||
       firstArg.type.kind !== TypeKind.IDENTIFIER ||
       firstArg.type.type !== name
@@ -684,18 +676,17 @@ async function parseModuleClassStructure(
 
 async function parseModuleFunctionSubstructure(
   substructure: Structure,
-  file: FileType,
   isStatic: boolean,
   ctx: ParseContext
 ): Promise<FunctionDeclaration> {
   const definitionParams = substructure['key.substructure'];
   const nameSubstrucutre = definitionParams[0];
   const name = nameSubstrucutre
-    ? getIdentifierFromOffsetObject(nameSubstrucutre, file)
+    ? getIdentifierFromOffsetObject(nameSubstrucutre, ctx.file)
     : 'UnnamedFunction';
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, ctx);
+    types = await parseClosureTypes(definitionParams[1], ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -714,16 +705,10 @@ async function parseModuleFunctionSubstructure(
 
 async function parseModuleAsyncFunctionSubstructure(
   substructure: Structure,
-  file: FileType,
   isStatic: boolean,
   ctx: ParseContext
 ): Promise<FunctionDeclaration> {
-  const functionDeclaration = await parseModuleFunctionSubstructure(
-    substructure,
-    file,
-    isStatic,
-    ctx
-  );
+  const functionDeclaration = await parseModuleFunctionSubstructure(substructure, isStatic, ctx);
   const lastArgument = functionDeclaration.arguments[functionDeclaration.arguments.length - 1];
   if (!lastArgument) {
     return functionDeclaration;
@@ -740,17 +725,16 @@ async function parseModuleAsyncFunctionSubstructure(
 
 async function parseModulePropDeclaration(
   substructure: Structure,
-  file: FileType,
   ctx: ParseContext
 ): Promise<PropDeclaration> {
   const definitionParams = substructure['key.substructure'];
   const nameSubstrucutre = definitionParams[0];
   const name = nameSubstrucutre
-    ? getIdentifierFromOffsetObject(nameSubstrucutre, file)
+    ? getIdentifierFromOffsetObject(nameSubstrucutre, ctx.file)
     : 'UnkownProp';
   let types = null;
   if (definitionParams[1] && hasSubstructure(definitionParams[1])) {
-    types = await parseClosureTypes(definitionParams[1], file, ctx);
+    types = await parseClosureTypes(definitionParams[1], ctx);
   } else {
     // TODO(@HubertBer): There sometimes might be another case which needs to be handled.
     console.warn(`The type couldn't be resolved, this case is not yet implemented`);
@@ -814,17 +798,16 @@ async function parseRecordStructure(
   recordStructure: Structure,
   usedTypeIdentifiers: Set<string>,
   inferredTypeParametersCount: Map<string, number>,
-  file: FileType,
   ctx: ParseContext
 ): Promise<RecordType> {
   const recordSubstrucutres = recordStructure['key.substructure'].filter(
     (substructure) =>
       substructure['key.kind'] === swiftDeclarationKind.varInstance &&
-      hasFieldAttribute(substructure['key.attributes'], file)
+      hasFieldAttribute(substructure['key.attributes'], ctx.file)
   );
 
   const fields = await taskAll(recordSubstrucutres, async (substructure) => {
-    const type = await extractDeclarationType(substructure, file, ctx);
+    const type = await extractDeclarationType(substructure, ctx);
     return { type, name: substructure['key.name'] };
   });
 
@@ -942,12 +925,12 @@ async function parseModuleStructure(
       }
       case 'Function': {
         moduleClassDeclaration.functions.push(
-          await parseModuleFunctionSubstructure(structure, file, false, ctx)
+          await parseModuleFunctionSubstructure(structure, false, ctx)
         );
         break;
       }
       case 'Constant': {
-        const constantDeclaration = await parseModuleConstantStructure(structure, file, ctx);
+        const constantDeclaration = await parseModuleConstantStructure(structure, ctx);
         if (constantDeclaration) {
           moduleClassDeclaration.constants.push(constantDeclaration);
         }
@@ -957,7 +940,7 @@ async function parseModuleStructure(
         moduleClassDeclaration.classes.push(await parseModuleClassStructure(structure, ctx));
         break;
       case 'Property': {
-        const propertyDeclaration = await parseModulePropertyStructure(structure, file, ctx);
+        const propertyDeclaration = await parseModulePropertyStructure(structure, ctx);
         if (propertyDeclaration) {
           moduleClassDeclaration.properties.push(propertyDeclaration);
         }
@@ -965,28 +948,27 @@ async function parseModuleStructure(
       }
       case 'AsyncFunction':
         moduleClassDeclaration.asyncFunctions.push(
-          await parseModuleAsyncFunctionSubstructure(structure, file, false, ctx)
+          await parseModuleAsyncFunctionSubstructure(structure, false, ctx)
         );
         break;
       case 'StaticAsyncFunction':
         moduleClassDeclaration.asyncFunctions.push(
-          await parseModuleAsyncFunctionSubstructure(structure, file, true, ctx)
+          await parseModuleAsyncFunctionSubstructure(structure, true, ctx)
         );
         break;
       case 'StaticFunction':
         moduleClassDeclaration.functions.push(
-          await parseModuleFunctionSubstructure(structure, file, true, ctx)
+          await parseModuleFunctionSubstructure(structure, true, ctx)
         );
         break;
       case 'Constructor':
         moduleClassDeclaration.constructor = await parseModuleConstructorDeclaration(
           structure,
-          file,
           ctx
         );
         break;
       case 'Prop':
-        moduleClassDeclaration.props.push(await parseModulePropDeclaration(structure, file, ctx));
+        moduleClassDeclaration.props.push(await parseModulePropDeclaration(structure, ctx));
         break;
       case 'View': {
         const viewDeclaration = await parseModuleViewDeclaration(structure, ctx);
@@ -1175,7 +1157,7 @@ function parseNamespaces(
     namespaces[moduleName] = namespaces[moduleName] || {};
     const ns: namespace = namespaces[moduleName];
     currentNamespace[moduleName] = ns;
-    structure['key.substructure'].forEach((substructure) => {
+    structure['key.substructure']?.forEach((substructure) => {
       parseNamespaces(substructure, namespaces, file, ns);
     });
     return;
@@ -1232,7 +1214,7 @@ export async function getSwiftFileTypeInformation(
   const enums: EnumType[] = enumsStructures.map(parseEnumStructure);
   const ctx = { namespaces, file, typeInference: options.typeInference };
   const recordMap = (rd: Structure) => {
-    return parseRecordStructure(rd, recordTypeIdentifiers, inferredTypeParametersCount, file, ctx);
+    return parseRecordStructure(rd, recordTypeIdentifiers, inferredTypeParametersCount, ctx);
   };
 
   const recordsPromise = taskAll(recordsStructures, recordMap);


### PR DESCRIPTION
# Why
SourceKitten Swift parsing can be simplified a bit as some arguments are duplicated (`file`) and some can be merged. While doing the refactor I've also found some bugs, which I've fixed at the same time.

# How
- remove `file` argument from functions which already take `ctx` as argument
- move `typeInference` option to `ctx`
- partially fix return type inference (also fix emote test which started to fail after that)
- fix `_` type being generated
- fix generated methods having implicit `this` argument explicitly written in typescript 
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- [x] run `local-test`, update snapshots
- [x] check manually on pacakges `expo-contacts`, `expo-blob`

# Checklist
<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
