### PR TITLE
Remove `uuid` dependency in tools/

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18124,9 +18124,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6547,9 +6547,6 @@ importers:
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@6.0.3)
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
     devDependencies:
       '@babel/core':
         specifier: ^7.26.0
@@ -6578,9 +6575,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.7.1
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)
@@ -9730,9 +9724,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -15117,11 +15108,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -18846,8 +18832,6 @@ snapshots:
       source-map: 0.6.1
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -25084,8 +25068,6 @@ snapshots:
   uuid@7.0.3: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/tools/package.json
+++ b/tools/package.json
@@ -61,8 +61,7 @@
     "strip-ansi": "^6.0.0",
     "tar": "^7.5.22",
     "terminal-link": "^2.1.1",
-    "typedoc": "^0.28.19",
-    "uuid": "^9.0.0"
+    "typedoc": "^0.28.19"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
@@ -74,7 +73,6 @@
     "@types/node": "^22.14.0",
     "@types/npm-registry-fetch": "^8.0.7",
     "@types/semver": "^7.5.8",
-    "@types/uuid": "^9.0.2",
     "eslint": "^9.39.4",
     "eslint-config-universe": "workspace:^15.2.0",
     "eslint-plugin-lodash": "^7.4.0",

--- a/tools/src/Unblocked.ts
+++ b/tools/src/Unblocked.ts
@@ -5,8 +5,8 @@
  * Unblocked knowledge base. Reads `UNBLOCKED_API_KEY` from the environment.
  */
 
+import { randomUUID } from 'crypto';
 import open from 'open';
-import { v4 as uuidv4 } from 'uuid';
 
 import { sleepAsync } from './Utils';
 
@@ -111,7 +111,7 @@ export function setApiKey(key: string): void {
  * that can be used to poll for the answer.
  */
 export async function submitQuestionAsync(question: string): Promise<string> {
-  const questionId = uuidv4();
+  const questionId = randomUUID();
   await requestAsync('PUT', `/answers/${questionId}`, { question });
   return questionId;
 }

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -2,6 +2,7 @@ import { Command } from '@expo/commander';
 import plist from '@expo/plist';
 import spawnAsync from '@expo/spawn-async';
 import assert from 'assert';
+import { randomUUID } from 'crypto';
 import fs, { mkdirp } from 'fs-extra';
 import { glob } from 'glob';
 import inquirer from 'inquirer';
@@ -9,7 +10,6 @@ import ora from 'ora';
 import path from 'path';
 import semver from 'semver';
 import * as tar from 'tar';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   EAS_EXPO_GO_PROJECT_DIR,
@@ -212,7 +212,7 @@ async function iosBuildAndSubmitAsync() {
 
     const certPEMPath = path.join(credentialsDir, 'cert.pem');
     const p12KeystorePath = path.join(credentialsDir, 'dist.p12');
-    const p12KeystorePassword = uuidv4();
+    const p12KeystorePassword = randomUUID();
 
     await spawnAsync(
       'openssl',


### PR DESCRIPTION
# Why

- Remove `uuid` dependency in tools/

# How

- Switch to node `randomUUID` from `crypto`

# Test Plan

- CI is running correctly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
