### PR TITLE
[calendar][iOS] Fix `getDefaultCalendarSync` and `getCalendars` requiring full access

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Throw `UnavailabilityError` when iOS-only Reminders and Sources APIs (`listReminders()`, `createReminder()`, `ExpoCalendarReminder.get/update/delete`, `requestRemindersPermissions()`, `getRemindersPermissions()`, and `getSourcesSync()`) are called on non-iOS platforms. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - Return a denied permission response from `useRemindersPermissions()` on non-iOS platforms instead of throwing. ([#46416](https://github.com/expo/expo/pull/46416) by [@kota113](https://github.com/kota113))
 - [ios] Fix typo in the internal permissions exception name (`MissionPermissionsException` -> `MissingPermissionsException`), which corrects the error code surfaced to JS from `ERR_MISSION_PERMISSIONS` to `ERR_MISSING_PERMISSIONS`. ([#47804](https://github.com/expo/expo/pull/47804) by [@conanm](https://github.com/conanm))
+- [iOS] Allow `getDefaultCalendarSync`, `getCalendars` and `ExpoCalendar.get` to work with write-only calendar access. ([#48186](https://github.com/expo/expo/pull/48186) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/Next/CalendarAccessGuard.swift
+++ b/packages/expo-calendar/ios/Next/CalendarAccessGuard.swift
@@ -30,31 +30,31 @@ public class CalendarAccessGuard {
     self.permittedEntities = permittedEntities
   }
 
-  public func checkCalendarPermissions() throws {
-    try self.checkPermissions(
+  public func ensureCalendarFullAccess() throws {
+    try self.ensurePermissions(
       entity: .event,
       requester: CalendarNextPermissionsRequester.self,
       permissionName: "CALENDAR"
     )
   }
 
-  public func checkCalendarWritePermissions() throws {
-    try self.checkPermissions(
+  public func ensureCalendarWriteOnlyOrFullAccess() throws {
+    try self.ensurePermissions(
       entity: .event,
       requester: CalendarWriteOnlyNextPermissionsRequester.self,
       permissionName: "CALENDARWRITEONLY"
     )
   }
 
-  public func checkRemindersPermissions() throws {
-    try self.checkPermissions(
+  public func ensureRemindersAccess() throws {
+    try self.ensurePermissions(
       entity: .reminder,
       requester: RemindersNextPermissionRequester.self,
       permissionName: "REMINDERS"
     )
   }
 
-  private func checkPermissions(
+  private func ensurePermissions(
     entity: EKEntityType,
     requester: EXPermissionsRequester.Type,
     permissionName: String

--- a/packages/expo-calendar/ios/Next/CalendarNextModule.swift
+++ b/packages/expo-calendar/ios/Next/CalendarNextModule.swift
@@ -29,7 +29,9 @@ public final class CalendarNextModule: Module {
     }
 
     Function("getDefaultCalendarSync") { () -> ExpoCalendar in
-      try calendarAccessGuard?.checkCalendarPermissions()
+      // With write-only permissions granted, `eventStore.defaultCalendarForNewEvents` is a virtual calendar:
+      // https://developer.apple.com/documentation/EventKit/accessing-the-event-store#Use-EventKit-with-write-only-calendar-access
+      try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
       guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
         throw DefaultCalendarNotFoundException()
       }
@@ -40,21 +42,24 @@ public final class CalendarNextModule: Module {
       let calendars: [EKCalendar]
       switch type {
       case nil:
-        try calendarAccessGuard?.checkCalendarPermissions()
-        try calendarAccessGuard?.checkRemindersPermissions()
+        // With write-only permissions granted, `eventStore.calendars` returns a single virtual calendar:
+        // https://developer.apple.com/documentation/EventKit/accessing-the-event-store#Use-EventKit-with-write-only-calendar-access
+        try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
+        try calendarAccessGuard?.ensureRemindersAccess()
         calendars = eventStore.calendars(for: .event) + eventStore.calendars(for: .reminder)
       case .event:
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
         calendars = eventStore.calendars(for: .event)
       case .reminder:
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
         calendars = eventStore.calendars(for: .reminder)
       }
       return calendars.map { ExpoCalendar(calendar: $0) }
     }
 
     AsyncFunction("getCalendarById") { (calendarId: String) -> ExpoCalendar in
-      try calendarAccessGuard?.checkCalendarPermissions()
+      // With write-only access, this can resolve the virtual calendar's identifier.
+      try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
       guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
         throw CalendarIdNotFoundException(calendarId)
       }
@@ -62,6 +67,7 @@ public final class CalendarNextModule: Module {
     }
 
     AsyncFunction("presentPicker") { (promise: Promise) in
+      // No access guard here on purpose. The system picker itself shows a message when permissions aren't granted.
       guard let currentVc = appContext?.utilities?.currentViewController() else {
         throw MissingCurrentViewControllerException()
       }
@@ -88,10 +94,10 @@ public final class CalendarNextModule: Module {
       let calendar: EKCalendar
       switch calendarRecord.entityType {
       case .event:
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         calendar = EKCalendar(for: .event, eventStore: eventStore)
       case .reminder:
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
         calendar = EKCalendar(for: .reminder, eventStore: eventStore)
       case .none:
         throw EntityNotSupportedException(calendarRecord.entityType?.rawValue)
@@ -122,7 +128,9 @@ public final class CalendarNextModule: Module {
       startDateStr: Either<String, Double>,
       endDateStr: Either<String, Double>,
       promise: Promise) throws in
-      try calendarAccessGuard?.checkCalendarPermissions()
+      // The default EventKit behavior is to return an empty array if write-only permissions are granted.
+      // Ensuring full access makes the function throw instead of returning an ambiguous empty array.
+      try calendarAccessGuard?.ensureCalendarFullAccess()
 
       let startDate = try requireDate(from: startDateStr)
       let endDate = try requireDate(from: endDateStr)
@@ -147,7 +155,7 @@ public final class CalendarNextModule: Module {
 
     AsyncFunction("getEventById") {
       (eventId: String) -> ExpoCalendarEvent in
-      try calendarAccessGuard?.checkCalendarPermissions()
+      try calendarAccessGuard?.ensureCalendarFullAccess()
       guard let event = eventStore.event(withIdentifier: eventId) else {
         throw EventNotFoundException(eventId)
       }
@@ -156,7 +164,7 @@ public final class CalendarNextModule: Module {
 
     AsyncFunction("getReminderById") {
       (reminderId: String) -> ExpoCalendarReminder in
-      try calendarAccessGuard?.checkRemindersPermissions()
+      try calendarAccessGuard?.ensureRemindersAccess()
       guard let reminder = eventStore.calendarItem(withIdentifier: reminderId) as? EKReminder else {
         throw ReminderNotFoundException(reminderId)
       }
@@ -260,7 +268,9 @@ public final class CalendarNextModule: Module {
         startDateStr: Either<String, Double>,
         endDateStr: Either<String, Double>,
         promise: Promise) throws in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        // The default EventKit behavior is to return an empty array if write-only permissions are granted.
+        // Ensuring full access makes the function throw instead of returning an ambiguous empty array.
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         let startDate = try requireDate(from: startDateStr)
         let endDate = try requireDate(from: endDateStr)
         promise.resolve(try expoCalendar.listEvents(startDate: startDate, endDate: endDate))
@@ -272,7 +282,7 @@ public final class CalendarNextModule: Module {
         endDateStr: String?,
         status: String?,
         promise: Promise) throws in
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
 
         var startDate: Date?
         var endDate: Date?
@@ -290,7 +300,7 @@ public final class CalendarNextModule: Module {
 
       // swiftlint:enable closure_parameter_position
       AsyncFunction("createEvent") { (expoCalendar: ExpoCalendar, eventRecord: EventNext, options: RecurringEventOptions?) -> ExpoCalendarEvent in
-        try calendarAccessGuard?.checkCalendarWritePermissions()
+        try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
 
         guard let calendar = expoCalendar.calendar else {
           throw CalendarNoLongerExistsException()
@@ -312,7 +322,7 @@ public final class CalendarNextModule: Module {
       }
 
       AsyncFunction("createReminder") { (expoCalendar: ExpoCalendar, reminderRecord: Reminder, _: RecurringEventOptions?) -> ExpoCalendarReminder in
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
 
         guard let calendarInstance = expoCalendar.calendar else {
           throw CalendarNoLongerExistsException()
@@ -334,7 +344,7 @@ public final class CalendarNextModule: Module {
       }
 
       AsyncFunction("addEventWithForm") { (expoCalendar: ExpoCalendar, options: AddEventWithFormOptions?, promise: Promise) in
-        try calendarAccessGuard?.checkCalendarWritePermissions()
+        try calendarAccessGuard?.ensureCalendarWriteOnlyOrFullAccess()
 
         let event = EKEvent(eventStore: eventStore)
         event.calendar = expoCalendar.calendar
@@ -364,12 +374,12 @@ public final class CalendarNextModule: Module {
       }.runOnQueue(.main)
 
       AsyncFunction("update") { (expoCalendar: ExpoCalendar, calendarRecord: CalendarRecordNext) throws in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         try expoCalendar.update(calendarRecord: calendarRecord)
       }
 
       AsyncFunction("delete") { (expoCalendar: ExpoCalendar) in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         try expoCalendar.delete()
       }
     }
@@ -468,7 +478,7 @@ public final class CalendarNextModule: Module {
       }
 
       AsyncFunction("openInCalendar") { (expoEvent: ExpoCalendarEvent, options: OpenInCalendarOptions?, promise: Promise) in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
 
         let startDate = parse(date: options?.instanceStartDate)
         guard let calendarEvent = expoEvent.getOccurrence(startDate: startDate) else {
@@ -503,7 +513,7 @@ public final class CalendarNextModule: Module {
       }.runOnQueue(.main)
 
       AsyncFunction("editInCalendar") { (expoEvent: ExpoCalendarEvent, _: OpenInCalendarOptions?, promise: Promise) in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
 
         guard let event = expoEvent.event else {
           throw ItemNoLongerExistsException()
@@ -513,7 +523,7 @@ public final class CalendarNextModule: Module {
       }.runOnQueue(.main)
 
       Function("getOccurrenceSync") { (expoEvent: ExpoCalendarEvent, options: RecurringEventOptions?) throws in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         guard let ekEvent = try expoEvent.getOccurrence(options: options) else {
           throw EventNotFoundException(options?.instanceStartDate ?? "")
         }
@@ -522,17 +532,17 @@ public final class CalendarNextModule: Module {
       }
 
       AsyncFunction("getAttendees") { (expoEvent: ExpoCalendarEvent) throws in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         return try expoEvent.getAttendees()
       }
 
       AsyncFunction("update") { (expoEvent: ExpoCalendarEvent, eventRecord: EventNext, nullableFields: [String]?) throws in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         try expoEvent.update(eventRecord: eventRecord, nullableFields: nullableFields)
       }
 
       AsyncFunction("delete") { (expoEvent: ExpoCalendarEvent) in
-        try calendarAccessGuard?.checkCalendarPermissions()
+        try calendarAccessGuard?.ensureCalendarFullAccess()
         try expoEvent.delete()
       }
     }
@@ -633,12 +643,12 @@ public final class CalendarNextModule: Module {
       }
 
       AsyncFunction("update") { (expoReminder: ExpoCalendarReminder, reminderRecord: Reminder, nullableFields: [String]?) in
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
         try expoReminder.update(reminderRecord: reminderRecord, nullableFields: nullableFields)
       }
 
       AsyncFunction("delete") { (expoReminder: ExpoCalendarReminder) in
-        try calendarAccessGuard?.checkRemindersPermissions()
+        try calendarAccessGuard?.ensureRemindersAccess()
         try expoReminder.delete()
       }
     }

--- a/packages/expo-calendar/src/Calendar.ts
+++ b/packages/expo-calendar/src/Calendar.ts
@@ -210,6 +210,10 @@ export class ExpoCalendar extends InternalExpoCalendar.ExpoCalendar {
 
 /**
  * Gets an instance of the default calendar object.
+ *
+ * > **iOS 17+:** With write-only calendar access, this returns EventKit's virtual calendar,
+ * > which can be used to create events but does not expose existing calendar data.
+ *
  * > **Android:** This function is not available on Android. Android does not expose a single
  * > system-managed default calendar. Use `getCalendars()` and choose an appropriate writable
  * > calendar for your app; `isPrimary` can help identify per-account primary calendars.
@@ -226,12 +230,16 @@ export function getDefaultCalendarSync(): ExpoCalendar {
 }
 
 /**
- * Gets an array of [`ExpoCalendar`](#expocalendar) shared objects with details about the different calendars stored on the device.
- * @param entityType __iOS Only.__ Not required, but if defined, filters the returned calendars to
- * a specific [entity type](#entitytypes). Possible values are `Calendar.EntityTypes.EVENT` (for calendars shown in
- * the Calendar app) and `Calendar.EntityTypes.REMINDER` (for the Reminders app).
- * > **Note:** If not defined, you will need both permissions: **CALENDAR** and **REMINDERS**.
- * @return An array of [`ExpoCalendar`](#expocalendar) shared objects matching the provided entity type (if provided).
+ * Gets an array of [`ExpoCalendar`](#expocalendar) shared objects with details about the
+ * calendars available to the app.
+ *
+ * > **iOS 17+:** With write-only calendar access, requesting `EntityTypes.EVENT` returns a
+ * > single virtual calendar, which can be used to create events but does not expose the user's
+ * > real calendars.
+ *
+ * @param entityType __iOS Only.__ Not required, but if defined, filters the returned calendars to a specific [entity type](#entitytypes).
+ * > **Note:** If not defined, both calendar (write-only is enough) and reminders permissions are required.
+ * @return An array of [`ExpoCalendar`](#expocalendar) shared objects matching the provided entity type, if provided.
  */
 export async function getCalendars(entityType?: EntityTypes): Promise<ExpoCalendar[]> {
   if (!InternalExpoCalendar.getCalendars) {

--- a/packages/expo-calendar/src/ExpoCalendar.types.ts
+++ b/packages/expo-calendar/src/ExpoCalendar.types.ts
@@ -229,6 +229,10 @@ export declare class ExpoCalendar {
 
   /**
    * Gets a calendar by its ID. Throws an error if the calendar with the given ID does not exist.
+   *
+   * > **iOS 17+:** With write-only calendar access, only the virtual calendar's ID can be
+   * > resolved - real calendars require full calendar access.
+   *
    * @param calendarId The ID of the calendar to get.
    * @returns An [`ExpoCalendar`](#expocalendar) object representing the calendar.
    */


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/48143

On iOS, if write-only permissions are granted, `eventStore.defaultCalendarForNewEvents` and `eventStore.calendars(for:)` return a single virtual calendar, so `getDefaultCalendarSync` and `getCalendars` don't have to require full access permissions. This lets apps create new events directly, without the entire UI creation flow via `presentPicker` and `addEventWithForm`. 

docs ref: https://developer.apple.com/documentation/EventKit/accessing-the-event-store#Use-EventKit-with-write-only-calendar-access

### Design decision for `listEvents`:
We could loosen the permissions for listEvents as well. Per docs, `eventStore.events` returns an empty array if write-only permissions are granted. However, if write-only permissions are granted, returning an empty array instead of throwing is ambiguous.

# How

* Replace full access check in `getDefaultCalendarSync`, `getCalendars` and `getCalendarById` with write-only or full access check
* Rename the `CalendarAccessGuard` methods to be more precise 


# Test Plan

Tested on WriteOnlyPermissionsScreen in NCL