### PR TITLE
[docs] Fix style order in GestureDetector example

### DIFF
--- a/docs/checks/ja/source-hashes.json
+++ b/docs/checks/ja/source-hashes.json
@@ -5,7 +5,7 @@
   "tutorial/create-a-modal.mdx": "a8ecfbea9889e193",
   "tutorial/create-your-first-app.mdx": "5477674e7291d57b",
   "tutorial/follow-up.mdx": "4271c3bae2bcbf0c",
-  "tutorial/gestures.mdx": "68574525bde18887",
+  "tutorial/gestures.mdx": "3eb01fe992b496fa",
   "tutorial/image-picker.mdx": "feb3dccc9daa27a7",
   "tutorial/introduction.mdx": "787b2c32b532fa9e",
   "tutorial/overview.mdx": "7556d50fbc3eb9ec",

--- a/docs/pages/ja/tutorial/gestures.mdx
+++ b/docs/pages/ja/tutorial/gestures.mdx
@@ -185,7 +185,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
-          style={/* @tutinfo `imageStyle` を渡すため、`Animated.Image` の `style` プロパティを変更します。 */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
+          style={/* @tutinfo `imageStyle` を渡すため、`Animated.Image` の `style` プロパティを変更します。 */[{ width: imageSize, height: imageSize }, imageStyle]/* @end */}
         />
       /* @tutinfo */
       </GestureDetector>
@@ -327,7 +327,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
           <Animated.Image
             source={stickerSource}
             resizeMode="contain"
-            style={[imageStyle, { width: imageSize, height: imageSize }]}
+            style={[{ width: imageSize, height: imageSize }, imageStyle]}
           />
         </GestureDetector>
       </Animated.View>

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -185,7 +185,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
-          style={/* @tutinfo Modify the `style` prop on the `Animated.Image` to pass the `imageStyle`. */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
+          style={/* @tutinfo Modify the `style` prop on the `Animated.Image` to pass the `imageStyle`. */[{ width: imageSize, height: imageSize }, imageStyle]/* @end */}
         />
       /* @tutinfo */
       </GestureDetector>
@@ -327,7 +327,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
           <Animated.Image
             source={stickerSource}
             resizeMode="contain"
-            style={[imageStyle, { width: imageSize, height: imageSize }]}
+            style={[{ width: imageSize, height: imageSize }, imageStyle]}
           />
         </GestureDetector>
       </Animated.View>


### PR DESCRIPTION
# Why

`imageStyle` includes animated `width` / `height`, but the static `{ width: imageSize, height: imageSize }` came after it in the style array, overriding the animation.

# How

Reordered the style array so `imageStyle` comes last.

# Test Plan

Ran the gestures tutorial example and confirmed the sticker resizes on pinch.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
