### PR TITLE
[docs] Fix broken anchor links in versioned SDK pages part 2

### DIFF
--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -61,7 +61,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time-with-expo-asset-config-plugin).
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 `expo-dev-client` adds various useful development tools to your debug builds:
 
 - A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests-expo-only))
 - [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -371,7 +371,7 @@ When your Expo project doesn't benefit from having particular permission include
 
 Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
 
-To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#android).
 
 ### iOS
 

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -163,7 +163,7 @@ export default function App() {
 
 ### Custom marker icons
 
-You can use the [`useImage`](/versions/latest/sdk/image/#useimage) hook from `expo-image` to load custom marker and annotation icons.
+You can use the [`useImage`](/versions/latest/sdk/image/#useimagesource-options-dependencies) hook from `expo-image` to load custom marker and annotation icons.
 
 <Tabs>
 <Tab label="Google Maps">

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -66,7 +66,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
 ## Learn more
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -14,7 +14,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-debugger).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -356,7 +356,7 @@ const styles = StyleSheet.create({
 
 ### `useSQLiteContext()` hook with `React.Suspense`
 
-As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
+As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqlitesqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
 
 ```tsx useSQLiteContext() hook with React.Suspense
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
@@ -430,7 +430,7 @@ await db.execAsync('PRAGMA foreign_keys = ON');
 
 ### Import an existing database
 
-To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqliteprovider) with [`assetSource`](#assetsource).
+To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqlitesqliteprovider) with [`assetSource`](#assetsource).
 
 ```tsx useSQLiteContext() with existing database
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -340,7 +340,7 @@ const styles = StyleSheet.create({
 
 ### Using the VideoPlayer directly
 
-In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
+In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup-playerbuilderoptions) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
 In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
 ```tsx Creating player instance

--- a/docs/pages/versions/v54.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/asset.mdx
@@ -60,7 +60,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time-with-expo-asset-config-plugin).
 
 ## API
 

--- a/docs/pages/versions/v54.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/dev-client.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 `expo-dev-client` adds various useful development tools to your debug builds:
 
 - A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests-expo-only))
 - [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v54.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/location.mdx
@@ -365,7 +365,7 @@ When your Expo project doesn't benefit from having particular permission include
 
 Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
 
-To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#android).
 
 ### iOS
 

--- a/docs/pages/versions/v54.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/netinfo.mdx
@@ -66,7 +66,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
 ## Learn more
 

--- a/docs/pages/versions/v54.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/reanimated.mdx
@@ -14,7 +14,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-debugger).
 
 ## Installation
 

--- a/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
@@ -288,7 +288,7 @@ const styles = StyleSheet.create({
 
 ### `useSQLiteContext()` hook with `React.Suspense`
 
-As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
+As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqlitesqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
 
 ```tsx useSQLiteContext() hook with React.Suspense
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
@@ -362,7 +362,7 @@ await db.execAsync('PRAGMA foreign_keys = ON');
 
 ### Import an existing database
 
-To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqliteprovider) with [`assetSource`](#assetsource).
+To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqlitesqliteprovider) with [`assetSource`](#assetsource).
 
 ```tsx useSQLiteContext() with existing database
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';

--- a/docs/pages/versions/v55.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/asset.mdx
@@ -60,7 +60,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time-with-expo-asset-config-plugin).
 
 ## API
 

--- a/docs/pages/versions/v55.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/dev-client.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 `expo-dev-client` adds various useful development tools to your debug builds:
 
 - A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests-expo-only))
 - [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v55.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/location.mdx
@@ -371,7 +371,7 @@ When your Expo project doesn't benefit from having particular permission include
 
 Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
 
-To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#android).
 
 ### iOS
 

--- a/docs/pages/versions/v55.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/netinfo.mdx
@@ -66,7 +66,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
 ## Learn more
 

--- a/docs/pages/versions/v55.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/reanimated.mdx
@@ -14,7 +14,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-debugger).
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/sqlite.mdx
@@ -355,7 +355,7 @@ const styles = StyleSheet.create({
 
 ### `useSQLiteContext()` hook with `React.Suspense`
 
-As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
+As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqlitesqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
 
 ```tsx useSQLiteContext() hook with React.Suspense
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
@@ -429,7 +429,7 @@ await db.execAsync('PRAGMA foreign_keys = ON');
 
 ### Import an existing database
 
-To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqliteprovider) with [`assetSource`](#assetsource).
+To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqlitesqliteprovider) with [`assetSource`](#assetsource).
 
 ```tsx useSQLiteContext() with existing database
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/label.mdx
@@ -49,7 +49,7 @@ export default function LabelCustomIconExample() {
 
 ### Icon only
 
-Use the [`labelStyle`](/versions/latest/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
+Use the [`labelStyle`](modifiers/#labelstylestyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
 
 ```tsx LabelIconOnlyExample.tsx
 import { Host, Label } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/v55.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/video.mdx
@@ -338,7 +338,7 @@ const styles = StyleSheet.create({
 
 ### Using the VideoPlayer directly
 
-In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
+In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup-playerbuilderoptions) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
 In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
 ```tsx Creating player instance

--- a/docs/pages/versions/v56.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/asset.mdx
@@ -61,7 +61,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time-with-expo-asset-config-plugin).
 
 ## API
 

--- a/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/dev-client.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 `expo-dev-client` adds various useful development tools to your debug builds:
 
 - A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests-expo-only))
 - [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v56.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/location.mdx
@@ -371,7 +371,7 @@ When your Expo project doesn't benefit from having particular permission include
 
 Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
 
-To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#android).
 
 ### iOS
 

--- a/docs/pages/versions/v56.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/maps.mdx
@@ -162,7 +162,7 @@ export default function App() {
 
 ### Custom marker icons
 
-You can use the [`useImage`](/versions/v56.0.0/sdk/image/#useimage) hook from `expo-image` to load custom marker and annotation icons.
+You can use the [`useImage`](/versions/v56.0.0/sdk/image/#useimagesource-options-dependencies) hook from `expo-image` to load custom marker and annotation icons.
 
 <Tabs>
 <Tab label="Google Maps">

--- a/docs/pages/versions/v56.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/netinfo.mdx
@@ -66,7 +66,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
 ## Learn more
 

--- a/docs/pages/versions/v56.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/reanimated.mdx
@@ -14,7 +14,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-debugger).
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
@@ -355,7 +355,7 @@ const styles = StyleSheet.create({
 
 ### `useSQLiteContext()` hook with `React.Suspense`
 
-As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
+As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqlitesqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
 
 ```tsx useSQLiteContext() hook with React.Suspense
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
@@ -429,7 +429,7 @@ await db.execAsync('PRAGMA foreign_keys = ON');
 
 ### Import an existing database
 
-To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqliteprovider) with [`assetSource`](#assetsource).
+To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqlitesqliteprovider) with [`assetSource`](#assetsource).
 
 ```tsx useSQLiteContext() with existing database
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/video.mdx
@@ -340,7 +340,7 @@ const styles = StyleSheet.create({
 
 ### Using the VideoPlayer directly
 
-In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
+In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup-playerbuilderoptions) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
 In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
 ```tsx Creating player instance

--- a/docs/pages/versions/v57.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/asset.mdx
@@ -61,7 +61,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time-with-expo-asset-config-plugin).
 
 ## API
 

--- a/docs/pages/versions/v57.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/dev-client.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 `expo-dev-client` adds various useful development tools to your debug builds:
 
 - A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests-expo-only))
 - [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v57.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/location.mdx
@@ -371,7 +371,7 @@ When your Expo project doesn't benefit from having particular permission include
 
 Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
 
-To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#android).
 
 ### iOS
 

--- a/docs/pages/versions/v57.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/maps.mdx
@@ -163,7 +163,7 @@ export default function App() {
 
 ### Custom marker icons
 
-You can use the [`useImage`](/versions/v57.0.0/sdk/image/#useimage) hook from `expo-image` to load custom marker and annotation icons.
+You can use the [`useImage`](/versions/v57.0.0/sdk/image/#useimagesource-options-dependencies) hook from `expo-image` to load custom marker and annotation icons.
 
 <Tabs>
 <Tab label="Google Maps">

--- a/docs/pages/versions/v57.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/netinfo.mdx
@@ -66,7 +66,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
 ## Learn more
 

--- a/docs/pages/versions/v57.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/reanimated.mdx
@@ -14,7 +14,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-debugger).
 
 ## Installation
 

--- a/docs/pages/versions/v57.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/sqlite.mdx
@@ -356,7 +356,7 @@ const styles = StyleSheet.create({
 
 ### `useSQLiteContext()` hook with `React.Suspense`
 
-As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
+As with the [`useSQLiteContext()`](#usesqlitecontext-hook) hook, you can also integrate the [`SQLiteProvider`](#sqlitesqliteprovider) with [`React.Suspense`](https://react.dev/reference/react/Suspense) to show a fallback component until the database is ready. To enable the integration, pass the `useSuspense` prop to the `SQLiteProvider` component.
 
 ```tsx useSQLiteContext() hook with React.Suspense
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
@@ -430,7 +430,7 @@ await db.execAsync('PRAGMA foreign_keys = ON');
 
 ### Import an existing database
 
-To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqliteprovider) with [`assetSource`](#assetsource).
+To open a new SQLite database using an existing **.db** file you already have, you can use the [`SQLiteProvider`](#sqlitesqliteprovider) with [`assetSource`](#assetsource).
 
 ```tsx useSQLiteContext() with existing database
 import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';

--- a/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a Compose [`MutableState`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/MutableState) on the native side, so reads and writes to `.value` are tracked directly by Compose without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/usenativestate.mdx
@@ -9,9 +9,9 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`useNativeState` returns an [`ObservableState`](#observablestate) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
+`useNativeState` returns an [`ObservableState`](#observablestatet) that maps to a SwiftUI [`ObservableObject`](https://developer.apple.com/documentation/combine/observableobject) on the native side, so reads and writes to `.value` are observed directly by SwiftUI without going through the React render cycle. This lets you update the native view synchronously from a worklet on the UI thread.
 
-> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestate) and [`set`](#observablestate) methods, which are compliant with the React Compiler standards.
+> **Note:** When working with the [React Compiler](https://react.dev/learn/react-compiler), you should refrain from accessing and modifying the `value` property directly. Instead, use the [`get`](#observablestatet) and [`set`](#observablestatet) methods, which are compliant with the React Compiler standards.
 
 ## Installation
 

--- a/docs/pages/versions/v57.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/video.mdx
@@ -340,7 +340,7 @@ const styles = StyleSheet.create({
 
 ### Using the VideoPlayer directly
 
-In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
+In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup-playerbuilderoptions) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
 In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
 ```tsx Creating player instance


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/48196

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix broken anchor links in versioned SDK pages (mdx files source).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
