### PR TITLE
[expo-contacts][iOS] Sanitize contact identifiers used as image cache filenames

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [iOS] Fix `ContactField.THUMBNAIL` crash in bulk `getAllDetails` by reading `thumbnailImageData` instead of `imageData`. ([#47779](https://github.com/expo/expo/pull/47779) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 - Fix `getDetails` throwing NPE on malformed label ([#46405](https://github.com/expo/expo/pull/46405) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] Fix contacts fetch failing for the whole batch when a contact identifier contains a slash, by sanitizing the identifier used as an image cache filename. ([#48201](https://github.com/expo/expo/pull/48201) by [@martintreurnicht](https://github.com/martintreurnicht))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -343,7 +343,9 @@ private func writeDataToUri(userId: String, data: Data?, imageKey: String, inclu
   let image = UIImage(data: data)
   let fileExtension = ".png"
 
-  var fileName = "\(userId)-\(imageKey)"
+  // Contact identifiers can contain "/" (e.g. "com.apple.introductions.accepted/494"), which
+  // `appendingPathComponent` would treat as a nested directory that doesn't exist.
+  var fileName = "\(userId.replacingOccurrences(of: "/", with: "_"))-\(imageKey)"
   fileName.append(fileExtension)
   guard let newPath = directory?.appendingPathComponent(fileName) else {
     return nil

--- a/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
+++ b/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
@@ -38,6 +38,8 @@ class ImageService {
     guard FileSystemUtilities.ensureDirExists(at: baseDirectoryURL) else {
       throw FailedToCacheContactImage("The contacts cache directory does not exist")
     }
-    return baseDirectoryURL.appendingPathComponent(filename)
+    // Contact identifiers can contain "/" (e.g. "com.apple.introductions.accepted/494"), which
+    // `appendingPathComponent` would treat as a nested directory that doesn't exist.
+    return baseDirectoryURL.appendingPathComponent(filename.replacingOccurrences(of: "/", with: "_"))
   }
 }


### PR DESCRIPTION
# Why

Fixes #48200.

`CNContact.identifier` is not always a UUID — Introductions / suggested contacts use identifiers like `com.apple.introductions.accepted/494`. Both contacts APIs interpolate that identifier straight into the image cache filename and pass it to `URL.appendingPathComponent`, which reads the slash as a path separator. The write then targets a nested directory that was never created and fails:

```
Error: The folder “com.apple.introductions.accepted/494-thumbnailImageData.png” doesn’t exist.
```

Since `getAllDetails` maps contacts with a throwing closure, one such contact rejects the whole batch and **no contacts load at all**. We're seeing this on ~1,700 users (16.7k events) in production, all on iOS 26.x.

# How

Replace `/` with `_` before the identifier-derived string is used as a path component, at the two sites that build these filenames:

- `ios/next/objects/contact/services/ImageService.swift` — `prepareCacheFileURL` is the single choke point for the OO API, so this covers `image`, `thumbnail`, and both mappers in `GetContactDetailsMapper`.
- `ios/Serialization.swift` — `writeDataToUri` for the legacy API (the path production is failing on today).

Deliberately left alone:

- `ios/ContactsModule.swift` `writeContactToFileAsync` builds a vCard filename from the contact's full name, so a contact named `A/B` fails the same way — separate, unreported, and I didn't want to widen this diff.
- The throwing `.map` in `Contact.swift:getAllDetails` that turns one bad contact into a failed batch. Worth hardening independently, but with the filename fixed there's no longer a known trigger.
- `ImageMapper` reading `imageData` where the thumbnail mapper wants `thumbnailImageData` — already covered by #47779.

# Test Plan

Reproducing on-device needs an Introductions/suggested contact **with a photo**, which can't be created programmatically. What is verifiable device-free is that the filename alone produces the exact reported error, and that the sanitized filename doesn't. Both templates, as built by the code before and after this change:

```swift
import Foundation

let cacheDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Contacts")
try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
let imageData = Data([0x89, 0x50, 0x4e, 0x47])
let identifier = "com.apple.introductions.accepted/494"   // from the production error

func attempt(_ label: String, _ filename: String) {
  do {
    try imageData.write(to: cacheDir.appendingPathComponent(filename), options: .atomic)
    print("PASS  \(label)")
  } catch {
    print("THROW \(label) -> \(error.localizedDescription)")
  }
}

// ImageService.prepareCacheFileURL (OO API)
attempt("before", "\(identifier)-image.png")
attempt("after ", "\(identifier)-image.png".replacingOccurrences(of: "/", with: "_"))

// Serialization.writeDataToUri (legacy API)
attempt("before", "\(identifier)-thumbnailImageData.png")
attempt("after ", "\(identifier.replacingOccurrences(of: "/", with: "_"))-thumbnailImageData.png")
```

```
$ swift repro.swift
THROW before -> The folder “494-image.png” doesn’t exist.
PASS  after
THROW before -> The folder “494-thumbnailImageData.png” doesn’t exist.
PASS  after
```

(iOS phrases the message with the full relative path, macOS with only the last component — same `NSFileNoSuchFileError`.)

Contacts whose identifiers contain no slash are unaffected: `replacingOccurrences` is a no-op, so cached filenames and the returned `uri` values are byte-identical to before for every UUID-style identifier.

**Would appreciate a cherry-pick onto `sdk-57`** so it reaches a 57.0.x patch — this is currently unfixable from app code.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
