### PR TITLE
[cli] add missing --clean option to expo prebuild --help

### DIFF
--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -35,6 +35,7 @@ export const expoPrebuild: Command = async (argv) => {
         chalk`<dir>                                    Directory of the Expo project. {dim Default: Current working directory}`,
         `--no-install                             Skip installing npm packages and CocoaPods`,
         `--no-clean                               Apply changes to the existing native folders instead of recreating them`,
+        `--clean                                  Delete the native directories before generating`,
         chalk`--npm                                    Use npm to install dependencies. {dim Default when package-lock.json exists}`,
         chalk`--yarn                                   Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
         chalk`--bun                                    Use bun to install dependencies. {dim Default when bun.lock or bun.lockb exists}`,


### PR DESCRIPTION
# Why

The `expo prebuild` command supports the `--clean` option, but it is missing from the `expo prebuild --help` output. This makes the CLI help inconsistent with the documented behavior in the Expo documentation.

This PR adds the missing help entry for `--clean` without changing any existing behavior.

References:
- https://docs.expo.dev/workflow/continuous-native-generation/#clean
- https://docs.expo.dev/workflow/continuous-native-generation/#using---clean-option

Fixes #48203

# How

Added the missing `--clean` help entry to the `expo prebuild` help output alongside the existing `--no-clean` option. No functionality was changed—this update only improves the CLI help text to accurately reflect the supported options.

# Test Plan

- Run `npx expo prebuild --help`.
- Verify that the help output now includes:

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
