### PR TITLE
[ui][android] Fix presses dropping on RN content hosted in RNHostView

### DIFF
--- a/apps/native-component-list/src/screens/UI/HostingRNViewsScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/HostingRNViewsScreen.android.tsx
@@ -6,14 +6,18 @@ import {
   RNHostView,
   Card,
   LazyColumn,
+  LazyRow,
 } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers';
 import { useState } from 'react';
 import { Text as RNText, View, Pressable, FlatList } from 'react-native';
 
+const LAZY_ROW_BUTTONS = ['Button One', 'Button Two', 'Button Three', 'Button Four'];
+
 export default function HostingRNViewsScreen() {
   const [counter, setCounter] = useState(0);
   const [boxSize, setBoxSize] = useState(200);
+  const [lastPress, setLastPress] = useState<{ label: string; count: number } | null>(null);
 
   return (
     <Host style={{ flex: 1 }}>
@@ -52,6 +56,37 @@ export default function HostingRNViewsScreen() {
                 </Pressable>
               </RNHostView>
             </Row>
+          </Column>
+        </Card>
+        <Card modifiers={[fillMaxWidth()]}>
+          <Column verticalArrangement={{ spacedBy: 12 }} modifiers={[padding(16, 16, 16, 16)]}>
+            <ComposeText>Pressables inside a Compose LazyRow</ComposeText>
+            <ComposeText>
+              {`Regression test for presses on hosted RN content (#48131): taps, presses with slight finger movement, and presses on items scrolled into view must all fire, and must hit the button under the finger. Last press: ${lastPress ? `${lastPress.label} (${lastPress.count})` : 'none'}`}
+            </ComposeText>
+            <LazyRow horizontalArrangement={{ spacedBy: 12 }}>
+              {LAZY_ROW_BUTTONS.map((label) => (
+                <RNHostView key={label} matchContents>
+                  <Pressable
+                    onPress={() =>
+                      setLastPress((prev) => ({
+                        label,
+                        count: prev?.label === label ? prev.count + 1 : 1,
+                      }))
+                    }
+                    style={{
+                      width: 144,
+                      height: 56,
+                      borderRadius: 999,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      backgroundColor: '#9B59B6',
+                    }}>
+                    <RNText style={{ color: 'white', fontWeight: '600' }}>{label}</RNText>
+                  </Pressable>
+                </RNHostView>
+              ))}
+            </LazyRow>
           </Column>
         </Card>
         <Card modifiers={[fillMaxWidth()]}>

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [iOS] Added module lifecycle hooks that replace the `OnCreate`, `OnDestroy`, `OnStartObserving` and `OnStopObserving` DSL components: `didCreate`, `willDestroy`, `didStartListening` and `didStopListening`. ([#47542](https://github.com/expo/expo/pull/47542) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Support `PlatformColor` as Color. ([#47632](https://github.com/expo/expo/pull/47632) by [@jakex7](https://github.com/jakex7))
 - [Android] Added `ArrayBuffer.withJSBytes` for safe scoped access to underlying bytes from any thread. ([#47261](https://github.com/expo/expo/pull/47261) by [@barthap](https://github.com/barthap))
+- Added a `layoutRoot` prop to Expo views that marks the shadow node with the `RootNodeKind` trait, so `measure()` reports coordinates relative to that node — for views that dispatch touch events from their own root view, like `RNHostView` in `@expo/ui`. ([#48208](https://github.com/expo/expo/pull/48208) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
@@ -69,6 +69,21 @@ private:
         this->traits_.unset(react::ShadowNodeTraits::Trait::ForceFlattenView);
       }
     }
+
+    {
+      // Views that dispatch touch events from their own root view (e.g. RNHostView) set
+      // `layoutRoot` so that `measure()` reports coordinates relative to this node instead of
+      // the surface root, matching the coordinate space of the dispatched touches. The same
+      // reason React Native's <Modal> shadow node sets this trait.
+      auto it = viewProps.propsMap.find("layoutRoot");
+      bool layoutRoot = (it != viewProps.propsMap.end()) && it->second.getBool();
+
+      if (layoutRoot) {
+        this->traits_.set(react::ShadowNodeTraits::Trait::RootNodeKind);
+      } else {
+        this->traits_.unset(react::ShadowNodeTraits::Trait::RootNodeKind);
+      }
+    }
   }
 };
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `Pressable` (and other responder-based touchables) hosted in `RNHostView` dropping presses on any finger movement. ([#48131](https://github.com/expo/expo/issues/48131) by [@BrianUribe6](https://github.com/BrianUribe6)) ([#48208](https://github.com/expo/expo/pull/48208) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix unexpected resize when opening the calendar from spinner mode on Android. ([#47273](https://github.com/expo/expo/issues/47273) by [@TomCorvus](https://github.com/TomCorvus)) ([#48125](https://github.com/expo/expo/pull/48125) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [iOS] Fix `tvOS` build failure in the SwiftUI `menuOrder` modifier — `MenuOrder.priority` is unavailable on tvOS, so it now falls back to `.automatic` there. ([#48111](https://github.com/expo/expo/pull/48111) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `community/menu` `MenuView` not tinting a leaf action `Button`'s leading SF Symbol from `imageColor` — it applied `.foregroundColor` (which the iOS system menu ignores for a button's content) where checkable `Toggle` items applied `.tint`; leaf buttons now use `.tint` too. ([#47908](https://github.com/expo/expo/issues/47908) by [@cvburgess](https://github.com/cvburgess)) ([#47909](https://github.com/expo/expo/pull/47909) by [@cvburgess](https://github.com/cvburgess))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -155,7 +155,11 @@ class ExpoUIModule : Module() {
       colorScheme.toTokenMap()
     }
 
-    View(RNHostView::class)
+    View(RNHostView::class) {
+      // Consumed by `ExpoViewShadowNode` in C++, which marks the shadow node with the
+      // `RootNodeKind` trait. Declared here only so React Native forwards the prop to native
+      Prop("layoutRoot") { _, _: Boolean -> }
+    }
 
     View(SlotView::class) {
       Events("onSlotEvent")

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -6,14 +6,13 @@ import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -55,8 +54,19 @@ internal class RNHostView(context: Context, appContext: AppContext) :
   private val childViewState = mutableStateOf<View?>(null)
   private val wrapperState = mutableStateOf<TouchDispatchingRootViewGroup?>(null)
 
+  private val childSizeState = mutableStateOf(IntSize.Zero)
+  private val childLayoutListener = View.OnLayoutChangeListener { _, l, t, r, b, _, _, _, _ ->
+    childSizeState.value = IntSize(r - l, b - t)
+  }
+
   override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams) {
     childViewState.value = child
+    childSizeState.value = if (child.width > 0 && child.height > 0) {
+      IntSize(child.width, child.height)
+    } else {
+      IntSize.Zero
+    }
+    child.addOnLayoutChangeListener(childLayoutListener)
     val wrapper = TouchDispatchingRootViewGroup(child.context).apply {
       val reactContext = child.context as? ReactContext
       if (reactContext != null) {
@@ -71,6 +81,7 @@ internal class RNHostView(context: Context, appContext: AppContext) :
 
   override fun removeView(view: View) {
     if (view == childViewState.value) {
+      view.removeOnLayoutChangeListener(childLayoutListener)
       wrapperState.value?.removeView(view)
       childViewState.value = null
       wrapperState.value = null
@@ -81,6 +92,7 @@ internal class RNHostView(context: Context, appContext: AppContext) :
 
   override fun removeViewAt(index: Int) {
     childViewState.value?.let { child ->
+      child.removeOnLayoutChangeListener(childLayoutListener)
       wrapperState.value?.removeView(child)
     }
     childViewState.value = null
@@ -93,9 +105,9 @@ internal class RNHostView(context: Context, appContext: AppContext) :
     val scope: ComposableScope = this
 
     wrapperState.value?.let { wrapper ->
-      val childView = childViewState.value ?: return@let
+      childViewState.value ?: return@let
       val sizingModifier = if (matchContents) {
-        applySizeFromYogaNodeModifier(childView)
+        applySizeFromYogaNodeModifier()
       } else {
         Modifier
           .fillMaxSize()
@@ -114,35 +126,17 @@ internal class RNHostView(context: Context, appContext: AppContext) :
     }
   }
 
-  // Sets Compose view size from Yoga node size
-  // Listens to yoga node size changes and updates the Compose view size
+  // Sets Compose view size from Yoga node size, tracked by the view-owned layout listener above.
   @Composable
-  private fun applySizeFromYogaNodeModifier(childView: View): Modifier {
+  private fun applySizeFromYogaNodeModifier(): Modifier {
     val density = LocalDensity.current
-
-    val childSize = remember {
-      mutableStateOf(
-        if (childView.width > 0 && childView.height > 0) {
-          IntSize(childView.width, childView.height)
-        } else {
-          IntSize.Zero
-        }
-      )
-    }
-
-    DisposableEffect(childView) {
-      val listener = View.OnLayoutChangeListener { _, l, t, r, b, _, _, _, _ ->
-        childSize.value = IntSize(r - l, b - t)
-      }
-      childView.addOnLayoutChangeListener(listener)
-      onDispose { childView.removeOnLayoutChangeListener(listener) }
-    }
+    val childSize = childSizeState.value
 
     return with(density) {
-      if (childSize.value.width > 0 && childSize.value.height > 0) {
+      if (childSize.width > 0 && childSize.height > 0) {
         Modifier.requiredSize(
-          childSize.value.width.toDp(),
-          childSize.value.height.toDp()
+          childSize.width.toDp(),
+          childSize.height.toDp()
         )
       } else {
         Modifier
@@ -222,6 +216,11 @@ private class TouchDispatchingRootViewGroup(
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
     if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+      // Ancestor React roots (the surface root, outer hosts) also see this gesture and dispatch a
+      // duplicate JS touch stream in their own coordinate space. Their moves land outside the
+      // host-relative responder region and break `Pressable`. Tell them a native child owns the
+      // gesture, before dispatching our own start, so their stream ends ahead of it.
+      notifyAncestorRootViews { it.onChildStartedNativeGesture(this, ev) }
       // dispatchTouchEvent is the true start of every gesture, so reset all per-gesture state here.
       getLocationInWindow(gestureStartLocation)
       trackingGestureOffset = true
@@ -248,8 +247,17 @@ private class TouchDispatchingRootViewGroup(
 
     if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) {
       trackingGestureOffset = false
+      notifyAncestorRootViews { it.onChildEndedNativeGesture(this, ev) }
     }
     return handled
+  }
+
+  private inline fun notifyAncestorRootViews(block: (RootView) -> Unit) {
+    var current: ViewParent? = parent
+    while (current != null) {
+      (current as? RootView)?.let(block)
+      current = current.parent
+    }
   }
 
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {

--- a/packages/expo-ui/src/jetpack-compose/RNHostView/index.tsx
+++ b/packages/expo-ui/src/jetpack-compose/RNHostView/index.tsx
@@ -24,14 +24,14 @@ export interface RNHostProps extends PrimitiveBaseProps {
   modifiers?: ModifierConfig[];
   /**
    * Style applied to the host view's React Native shadow node. Useful for
-   * controlling its layout position (e.g. `position: 'absolute'`) so the shadow
-   * layout matches where the hosting Compose component draws the content —
-   * important for `measure()`-based hit-testing such as `Pressable`.
+   * controlling its layout position (e.g. `position: 'absolute'`).
    */
   style?: StyleProp<ViewStyle>;
 }
 
-type NativeRNHostProps = RNHostProps;
+type NativeRNHostProps = RNHostProps & {
+  layoutRoot: boolean;
+};
 const NativeRNHostView: ComponentType<NativeRNHostProps> = requireNativeView(
   'ExpoUI',
   'RNHostView'
@@ -43,6 +43,9 @@ function transformProps(props: RNHostProps): NativeRNHostProps {
     modifiers,
     ...(modifiers ? createViewModifierEventListener(modifiers) : undefined),
     ...restProps,
+    // Touches on hosted content are dispatched relative to the host, so `measure()` must report
+    // the same coordinate space; otherwise `Pressable` cancels the press on any finger movement.
+    layoutRoot: true,
   };
 }
 


### PR DESCRIPTION
# Why

`Pressable` (and other responder-based touchables) hosted in `RNHostView` drops presses on any finger movement, and presses inside a `LazyRow` can fire the wrong item after scrolling.

Fixes - https://github.com/expo/expo/issues/48131

# How

- Mark the host's shadow node with RN's `RootNodeKind` trait via a new internal `layoutRoot` prop (read in `ExpoViewShadowNode`), so `measure()` reports coordinates in the same host-relative space as the touches dispatched by the host's wrapper. Same mechanism RN's `<Modal>` uses for the same reason.
- Own the hosted child's size on the view instead of the disposable item composition, so lazy containers can't measure a re-entering item with a stale/absent size (this corrupted item placements after recycling).
- Evict the touch wrapper from its interop holder when the item's composition deactivates — lazy containers keep deactivated holders attached at stale frames, where a wrapper left inside keeps stealing touches.

# Test Plan

Tested in the user shared repro. Added an example for testing in NCL.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
