### PR TITLE
[docs] document Broadcast option in iOS capability syncing

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -96,6 +96,24 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 
 The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value. Here is a list of all of the [official Apple capabilities](https://developer.apple.com/help/account/reference/supported-capabilities-ios).
 
+### Broadcast push notifications
+
+Apple's Broadcast option lives inside the Push Notifications capability and has no entitlement of its own. To turn it on, set [`ios.usesBroadcastPushNotifications`](/versions/latest/config/app/#usesbroadcastpushnotifications) to `true` in your [app config](/workflow/configuration/):
+
+```json app.json
+{
+  "expo": {
+    "ios": {
+      "usesBroadcastPushNotifications": true
+    }
+  }
+}
+```
+
+EAS Build sets the Broadcast option only when it enables the Push Notifications capability, so your entitlements also need `aps-environment`. Apple limits [broadcast push notifications](https://developer.apple.com/documentation/usernotifications/setting-up-broadcast-push-notifications) to Live Activities on iOS 18 and later.
+
+If you enable Broadcast only in [Apple Developer Console][apple-dev-console], the next `eas build` resets the Push Notifications capability to its default options and turns Broadcast off. APNs then rejects your channel management requests with a `FeatureNotEnabled` error.
+
 ## Capability identifiers
 
 Merchant IDs, App Groups, and CloudKit Containers can all be automatically registered and assigned to your app. These assignments require Apple cookies authentication (running locally) as the official App Store Connect API does not support these operations.

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -112,7 +112,7 @@ Apple's Broadcast option lives inside the Push Notifications capability and has 
 
 EAS Build sets the Broadcast option only when it enables the Push Notifications capability, so your entitlements also need `aps-environment`. Apple limits [broadcast push notifications](https://developer.apple.com/documentation/usernotifications/setting-up-broadcast-push-notifications) to Live Activities on iOS 18 and later.
 
-If you enable Broadcast only in [Apple Developer Console][apple-dev-console], the next `eas build` resets the Push Notifications capability to its default options and turns Broadcast off. APNs then rejects your channel management requests with a `FeatureNotEnabled` error.
+If you enable Broadcast only in [Apple Developer Console][apple-dev-console], the next `eas build` resets the Push Notifications capability to its default options and turns Broadcast off. Apple Push Notification service (APNs) then rejects your channel management requests with a `FeatureNotEnabled` error.
 
 ## Capability identifiers
 


### PR DESCRIPTION
# Why

Capability sync resets Push Notifications to its defaults on every build, which turns off the Broadcast option people enabled in the portal. `ios.usesBroadcastPushNotifications` prevents that, but it only shows up in the generated config reference, so people find `EXPO_NO_CAPABILITY_SYNC=1` first and turn sync off entirely.

expo/eas-cli#3815

# How

Broadcast has no entitlement of its own, so it can't go in the table. It gets a short subsection under it.

# Test Plan

Vale passes. Checked the sync behavior against the capability tests in eas-cli, and the Broadcast and APNs error details against Apple's docs.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
