### PR TITLE
[expo-audio] Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix playlist `currentIndex` freezing after the first auto-advance. ([#47257](https://github.com/expo/expo/pull/47257) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Create a fresh recording file each time `prepareToRecordAsync` is called, matching Android — repeated takes no longer overwrite the previous recording at the same URL. ([#48002](https://github.com/expo/expo/pull/48002) by [@idoyana](https://github.com/idoyana))
+- Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix playlist `currentIndex` freezing after the first auto-advance. ([#47257](https://github.com/expo/expo/pull/47257) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Create a fresh recording file each time `prepareToRecordAsync` is called, matching Android — repeated takes no longer overwrite the previous recording at the same URL. ([#48002](https://github.com/expo/expo/pull/48002) by [@idoyana](https://github.com/idoyana))
-- Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types.
+- Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types. ([#48219](https://github.com/expo/expo/pull/48219) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -509,9 +509,13 @@ class AudioModule : Module() {
         }
       }
 
-      Function("replace") { player: AudioPlayer, source: AudioSource ->
+      Function("replace") { player: AudioPlayer, source: AudioSource? ->
         runOnMain {
           if (player.ref.availableCommands.contains(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
+            if (source == null) {
+              player.clearMediaSource()
+              return@runOnMain
+            }
             val mediaSource = createMediaItem(source)
             val wasPlaying = player.ref.isPlaying
             mediaSource?.let {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -98,6 +98,12 @@ class AudioPlayer(
     startUpdating()
   }
 
+  fun clearMediaSource() {
+    previousPlaybackState = Player.STATE_IDLE
+    ref.pause()
+    ref.clearMediaItems()
+  }
+
   override fun onPlaybackStateUpdated(playbackState: Int, justFinished: Boolean) {
     val updateMap = mutableMapOf<String, Any?>(
       "playbackState" to playbackStateToString(playbackState)

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -231,8 +231,8 @@ public class AudioModule: Module {
         }
       }
 
-      Function("replace") { (player, source: AudioSource) in
-        if let uri = source.uri?.absoluteString, let cachedPlayer = self.registry.removePreloadedPlayer(forKey: uri) {
+      Function("replace") { (player, source: AudioSource?) in
+        if let uri = source?.uri?.absoluteString, let cachedPlayer = self.registry.removePreloadedPlayer(forKey: uri) {
           let cachedItem = cachedPlayer.currentItem
           cachedPlayer.replaceCurrentItem(with: nil)
           player.replaceWithPreloadedItem(cachedItem)

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -266,7 +266,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
     }
   }
 
-  func replaceCurrentSource(source: AudioSource) {
+  func replaceCurrentSource(source: AudioSource?) {
     self.source = source
     let wasPlaying = ref.timeControlStatus == .playing
     let wasSamplingEnabled = samplingEnabled


### PR DESCRIPTION
# Why

Fixes #48093.

`player.replace(null)` throws on both platforms, because the native `replace` functions declared `source` as non-optional even though `AudioSource` includes `null`. Regression from #33708, which reverted the nullable support #33854 added.

# How

- iOS: `Function("replace")` and `AudioPlayer.replaceCurrentSource` now take `AudioSource?`. `AudioUtils.createAVPlayerItem(from:)` already handles `nil`, returning `nil` to clear the item.
- Android: `Function("replace")` now takes `AudioSource?`. On `null`, it calls a new `AudioPlayer.clearMediaSource()` (pause + `ExoPlayer.clearMediaItems()`), matching `AudioPlaylist.clear()`.

# Test Plan

- Run `et check-packages expo-audio`: lint and build pass.
- Verify `player.replace(null)` on both platforms using https://github.com/felipe-software/expo-audio-replace-null-repro.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
