### PR TITLE
[location] Add `altitudeAboveMeanSeaLevel` property to `LocationObjectCoords`

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,10 +8,14 @@
 
 ### 🎉 New features
 
+- Add `altitudeAboveMeanSeaLevel` property to `LocationObjectCoords`. ([#48220](https://github.com/expo/expo/pull/48220) by [@Wenszel](https://github.com/Wenszel))
+
 ### 🐛 Bug fixes
 
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))
+- [iOS] Fix foreground location updates to return the WGS 84 ellipsoid `altitude`. ([#48220](https://github.com/expo/expo/pull/48220) by [@Wenszel](https://github.com/Wenszel))
+- [Android] Fix `altitudeAccuracy` being `undefined` instead of `null` on Android API < 26. ([#48220](https://github.com/expo/expo/pull/48220) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
@@ -138,6 +138,7 @@ internal class LocationObjectCoords(
   @Field var latitude: Double? = null,
   @Field var longitude: Double? = null,
   @Field var altitude: Double? = null,
+  @Field var altitudeAboveMeanSeaLevel: Double? = null,
   @Field var accuracy: Double? = null,
   @Field var altitudeAccuracy: Double? = null,
   @Field var heading: Double? = null,
@@ -147,8 +148,13 @@ internal class LocationObjectCoords(
     latitude = location.latitude,
     longitude = location.longitude,
     altitude = location.altitude,
+    altitudeAboveMeanSeaLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && location.hasMslAltitude()) {
+      location.mslAltitudeMeters
+    } else {
+      null
+    },
     accuracy = location.accuracy.toDouble(),
-    altitudeAccuracy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    altitudeAccuracy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasVerticalAccuracy()) {
       location.verticalAccuracyMeters.toDouble()
     } else {
       null
@@ -169,8 +175,11 @@ internal class LocationObjectCoords(
     latitude?.let { putDouble("latitude", it) }
     longitude?.let { putDouble("longitude", it) }
     altitude?.let { putDouble("altitude", it) }
+    altitudeAboveMeanSeaLevel?.let { putDouble("altitudeAboveMeanSeaLevel", it) }
+      ?: putString("altitudeAboveMeanSeaLevel", null)
     accuracy?.let { putDouble("accuracy", it) }
     altitudeAccuracy?.let { putDouble("altitudeAccuracy", it) }
+      ?: putString("altitudeAccuracy", null)
     heading?.let { putDouble("heading", it) }
     speed?.let { putDouble("speed", it) }
   }

--- a/packages/expo-location/ios/EXLocation.m
+++ b/packages/expo-location/ios/EXLocation.m
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
         @"latitude": @(location.coordinate.latitude),
         @"longitude": @(location.coordinate.longitude),
         @"altitude": @(location.ellipsoidalAltitude),
+        @"altitudeAboveMeanSeaLevel": @(location.altitude),
         @"accuracy": @(location.horizontalAccuracy),
         @"altitudeAccuracy": @(location.verticalAccuracy),
         @"heading": @(location.course),

--- a/packages/expo-location/ios/LocationUtils.swift
+++ b/packages/expo-location/ios/LocationUtils.swift
@@ -24,7 +24,8 @@ internal func exportLocation(_ location: CLLocation) -> [String: Any] {
     "coords": [
       "latitude": location.coordinate.latitude,
       "longitude": location.coordinate.longitude,
-      "altitude": location.altitude,
+      "altitude": location.ellipsoidalAltitude,
+      "altitudeAboveMeanSeaLevel": location.altitude,
       "accuracy": location.horizontalAccuracy,
       "altitudeAccuracy": location.verticalAccuracy,
       "heading": location.course,

--- a/packages/expo-location/src/ExpoLocation.web.ts
+++ b/packages/expo-location/src/ExpoLocation.web.ts
@@ -16,13 +16,14 @@ class GeocoderError extends Error {
 /**
  * Converts `GeolocationPosition` to JavaScript object.
  */
-function geolocationPositionToJSON(position: LocationObject): LocationObject {
+function geolocationPositionToJSON(position: GeolocationPosition): LocationObject {
   const { coords, timestamp } = position;
   return {
     coords: {
       latitude: coords.latitude,
       longitude: coords.longitude,
       altitude: coords.altitude,
+      altitudeAboveMeanSeaLevel: null,
       accuracy: coords.accuracy,
       altitudeAccuracy: coords.altitudeAccuracy,
       heading: coords.heading,

--- a/packages/expo-location/src/Location.types.ts
+++ b/packages/expo-location/src/Location.types.ts
@@ -285,15 +285,27 @@ export type LocationObjectCoords = {
    */
   longitude: number;
   /**
-   * The altitude in meters above the WGS 84 reference ellipsoid. Can be `null` on Web if it's not available.
+   * The altitude in meters above the WGS 84 reference ellipsoid.
+   * On Web, it is `null` when unavailable.
+   * On iOS, it is never `null` — when the altitude is invalid, the value is `0` and `altitudeAccuracy` is negative.
    */
   altitude: number | null;
+  /**
+   * The altitude in meters above mean sea level.
+   * On Android, it is `null` when unavailable — on devices running Android 13 or lower, or when the location fix doesn't include an MSL altitude.
+   * On iOS, it is never `null` — when the altitude is invalid, the value is `0` and `altitudeAccuracy` is negative.
+   * @platform android 14+
+   * @platform ios
+   */
+  altitudeAboveMeanSeaLevel: number | null;
   /**
    * The radius of uncertainty for the location, measured in meters. Can be `null` on Web if it's not available.
    */
   accuracy: number | null;
   /**
-   * The accuracy of the altitude value, in meters. Can be `null` on Web if it's not available.
+   * The accuracy of the altitude value, in meters.
+   * On Android and Web, it is `null` when unavailable.
+   * On iOS, it is never `null` — a negative value indicates that the altitude values are invalid.
    */
   altitudeAccuracy: number | null;
   /**


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/48100, follow-up to https://github.com/expo/expo/pull/41318

On some devices only `CLLocation.altitude` or only `CLLocation.ellipsoidalAltitude` is available. Therefore, we should expose both of them.


# Design decisions
There are two types of altitude available on Android and iOS: the mean sea level altitude and the WGS 84 - ellipsoidal altitude. On Android these are `Location.mslAltitudeMeters` and `Location.altitude` respectively, and on iOS `CLLocation.altitude` and `CLLocation.ellipsoidalAltitude`.

1) Expose one `altitude` property with a fallback vs two separate properties

We could simply expose a single `altitude` property which returns WGS 84 and falls back to MSL, but these two values might differ significantly (in my location it was a 50 m difference).

2) There should be one main altitude - which is more common, WGS 84 or MSL altitude?

Unfortunately, on Android the mean sea level altitude has only been available since API 34, so making it the main one would result in returning `null` on devices with earlier Android versions. That's why the default `altitude` should be the WGS 84 one, since it covers more API versions.

# How

- Expose the `altitudeAboveMeanSeaLevel` property, which is `mslAltitudeMeters` on Android and `CLLocation.altitude` on iOS
- Return `CLLocation.ellipsoidalAltitude` instead of `CLLocation.altitude` as `altitude` in the `exportLocation` function
- Fix `altitudeAccuracy` being `undefined` instead of `null` on Android API < 26
- Fix `geolocationPositionToJSON` parameter type from `LocationObject` to `GeolocationPosition`
# Test Plan

Tested in NCL on a physical device