### PR TITLE
[expo-updates][iOS] Fix SIGABRT in UpdatesLogReader on truncated log lines

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - Fix `isUpdatePending` incorrectly becoming `true` after a fetch or check that finds no new update to download. ([#47830](https://github.com/expo/expo/pull/47830) by [@kudo](https://github.com/kudo))
+- [iOS] Fix SIGABRT during log purge when the persistent log contains a truncated line: `UpdatesLogReader` guarded on UTF-8 byte length but advanced the string index by Characters, so a line holding only the multi-byte emoji log prefix trapped with "String index is out of bounds". ([#48222](https://github.com/expo/expo/pull/48222) by [@valinagacevschi](https://github.com/valinagacevschi))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogReader.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogReader.swift
@@ -71,11 +71,14 @@ public final class UpdatesLogReader {
   }
 
   private func logStringToFilteredLogEntry(entryString: String, epoch: UInt) -> UpdatesLogEntry? {
-    if entryString.lengthOfBytes(using: .utf8) < 2 {
+    // NOTE: the guard must count Characters, not UTF-8 bytes. Every log line is prefixed
+    // with a multi-byte emoji (see ExpoModulesCore.LogType.prefix), so a truncated line
+    // containing only the prefix passes a byte-length guard and then traps in
+    // index(_:offsetBy:) with "String index is out of bounds" -> SIGABRT.
+    if entryString.count < 2 {
       return nil
     }
-    let suffixFrom = entryString.index(entryString.startIndex, offsetBy: 2)
-    let entryStringSuffix = String(entryString.suffix(from: suffixFrom))
+    let entryStringSuffix = String(entryString.dropFirst(2))
     let entry = UpdatesLogEntry.create(from: entryStringSuffix)
     return entry?.timestamp ?? 0 >= epoch ? entry : nil
   }

--- a/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
@@ -135,12 +135,58 @@ struct UpdatesLogReaderTests {
     #expect((logEntry?.duration)! >= 300)
   }
 
+  /// Regression test for a SIGABRT during log purge.
+  ///
+  /// `logStringToFilteredLogEntry` used to guard on `lengthOfBytes(using: .utf8) < 2` and then
+  /// advance the index by two *Characters*. Every persisted line begins with `LogType.prefix` —
+  /// a colored-circle emoji that is 4–6 UTF-8 bytes but a single Character — so a line consisting
+  /// of only that prefix passed the byte guard and trapped in `index(_:offsetBy:)` with
+  /// "String index is out of bounds". Such a line is what a torn append leaves behind, since
+  /// `PersistentFileLog.appendTextToFile` writes non-atomically. The trap fired before the purge
+  /// could rewrite the file, so the bad line survived and the app aborted on every launch.
+  ///
+  /// Note: on the unfixed reader this aborts the test process (a Swift runtime trap is not a
+  /// recoverable `#expect` failure).
+  @Test
+  @MainActor
+  func `PurgeSurvivesTruncatedSingleCharacterEntry`() async throws {
+    let date1 = Date()
+
+    // U+1F7E2 LARGE GREEN CIRCLE — the value of `LogType.info.prefix`, written as an escape
+    // because `prefix` is internal to ExpoModulesCore. 4 UTF-8 bytes, 1 Character.
+    let truncatedEntry = "\u{1F7E2}"
+    await appendRawEntryAsync(entry: truncatedEntry)
+    await logErrorAsync(message: "Test message", code: .noUpdatesAvailable)
+
+    // Reading must skip the malformed entry rather than trapping.
+    let entries: [String] = logReader.getLogEntries(newerThan: date1)
+    #expect(entries.count == 1)
+
+    // The purge must run to completion and drop the malformed entry, so the next launch is clean.
+    await purgeEntriesAsync(olderThan: date1)
+
+    let remaining = PersistentFileLog(category: category).readEntries()
+    #expect(remaining.count == 1)
+    #expect(!remaining.contains(truncatedEntry))
+  }
+
   // MARK: - Private methods
 
   func clearLogAsync() async {
     await withCheckedContinuation { continuation in
       let persistentLog = PersistentFileLog(category: category)
       persistentLog.clearEntries { _ in
+        continuation.resume()
+      }
+    }
+  }
+
+  /// Appends a raw string as a log line, bypassing `UpdatesLogger`'s formatting. Used to simulate
+  /// a torn write.
+  func appendRawEntryAsync(entry: String) async {
+    await withCheckedContinuation { continuation in
+      let persistentLog = PersistentFileLog(category: category)
+      persistentLog.appendEntry(entry: entry) { _ in
         continuation.resume()
       }
     }


### PR DESCRIPTION
# Why

Fixes #48221 — a SIGABRT on iOS during `expo-updates` startup, seen in production on SDK 57 (iOS 26, mostly iPads). Once it happens, the app aborts on **every** launch until it is reinstalled.

`UpdatesLogReader.logStringToFilteredLogEntry` guards on **UTF-8 byte length** and then advances the string index by two **Characters**:

```swift
if entryString.lengthOfBytes(using: .utf8) < 2 {   // counts BYTES
  return nil
}
let suffixFrom = entryString.index(entryString.startIndex, offsetBy: 2)  // advances CHARACTERS
let entryStringSuffix = String(entryString.suffix(from: suffixFrom))
```

Every persisted line is written as `"\(type.prefix) \($0)"`, and `ExpoModulesCore.LogType.prefix` is a colored-circle emoji — 4–6 UTF-8 bytes but a **single Character**:

| prefix | UTF-8 bytes | Characters |
|---|---|---|
| `U+1F7E2` (green) | 4 | 1 |
| `U+26AA U+FE0F` (white) | 6 | 1 |

So a line consisting of only the prefix passes the byte guard, and `index(startIndex, offsetBy: 2)` then runs past `endIndex`:

```
Fatal error: String index is out of bounds
Exception Type:  SIGABRT
Crash Thread/Queue: dev.expo.modules.core.logging
Blame frame: ExpoModulesCore.PersistentFileLog.purgeEntriesNotMatchingFilter(
               filter: (String) -> Bool, completion: (Error?) -> Void) -> ()
```

**Where a 1-Character line comes from.** By elimination: a well-formed line is always ≥ 2 Characters (emoji + space + payload), and `PersistentFileLog.stringToList` filters only `!entryString.isEmpty`, so a 1-Character line reaches the filter untouched. `PersistentFileLog.appendTextToFile` appends via a **non-atomic** `FileHandle.seekToEndOfFile()` + `write(...)`, so a process kill mid-write (backgrounding, jetsam) leaves a partial trailing line. That the tear must land byte-aligned immediately after the emoji is why this is rare — a tear *inside* the UTF-8 sequence yields invalid UTF-8, which `String(contentsOfFile:encoding:)` reports as a **thrown** error that the existing `do`/`catch` already handles.

**Why it is unrecoverable.** `UpdatesUtils.purgeUpdatesLogsOlderThanOneDay` runs on every app start. The trap fires inside the filter closure, *before* `writeFileSync`, so the poison line is never removed and the next launch aborts identically. The `do`/`catch` around that block cannot intercept it — a Swift runtime trap is not a thrown `Error`. The log file lives in Application Support and survives App Store updates, so users cannot wait it out. Shipping this fix *does* heal already-affected devices: the corrected guard rejects the line and the purge then rewrites the file clean.

Android is unaffected — `UpdatesLogReader.kt` does no prefix stripping and parses via `runCatching`.

# How

Two lines. Count Characters instead of bytes, and use `dropFirst(2)` so the offset can never overrun a short string:

```diff
-    if entryString.lengthOfBytes(using: .utf8) < 2 {
+    if entryString.count < 2 {
       return nil
     }
-    let suffixFrom = entryString.index(entryString.startIndex, offsetBy: 2)
-    let entryStringSuffix = String(entryString.suffix(from: suffixFrom))
+    let entryStringSuffix = String(entryString.dropFirst(2))
```

Behaviour on well-formed input is identical: every valid line has ≥ 2 Characters, and dropping the first 2 Characters removes exactly the emoji + space that `Logger` prepended. Deliberately **not** included: making `appendTextToFile` atomic. It would be a larger change to `expo-modules-core`, and with this fix the purge already cleans up after a torn write.

# Test Plan

Added `PurgeSurvivesTruncatedSingleCharacterEntry` to `packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift`. It appends a raw `"\u{1F7E2}"` entry (what a torn append leaves behind), then asserts that reading skips it and that the purge completes and removes it. It uses the per-test `category` isolation added in #47082, so it does not race other suites.

⚠️ Worth knowing for review: on the **unfixed** reader this test does not fail — it **aborts the test process**, because a Swift runtime trap is not a recoverable `#expect` failure. A reviewer who checks out the parent commit to watch it go red will see a crashed test runner, not a red assertion. That is the bug.

I did not run the iOS test suite locally (no expo-updates test host set up here); CI will exercise it. The discriminating fact was verified directly with a standalone Swift snippet:

```swift
import Foundation

for s in ["\u{1F7E2}", "\u{26AA}\u{FE0F}", "\u{1F7E2} {\"a\":1}"] {
  print("bytes:", s.lengthOfBytes(using: .utf8),
        "chars:", s.count,
        "oldGuardPasses:", s.lengthOfBytes(using: .utf8) >= 2,
        "newGuardPasses:", s.count >= 2)
}
```

```
bytes: 4  chars: 1  oldGuardPasses: true  newGuardPasses: false
bytes: 6  chars: 1  oldGuardPasses: true  newGuardPasses: false
bytes: 12 chars: 9  oldGuardPasses: true  newGuardPasses: true
```

Manual reproduction on a device, from the issue: kill the app, overwrite `<App Container>/Library/Application Support/dev.expo.modules.core.logging.expo-updates.txt` with `printf '\xf0\x9f\x9f\xa2\n'`, then relaunch. Before this change the app aborts during `expo-updates` startup on every launch; after it, the line is dropped and the file is rewritten clean.

Present in `expo-updates@57.0.10` and on `main`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — N/A, Swift source only; no module plugin or config changes.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — N/A, no docs changed.
