### PR TITLE
chore(expo-modules-test-core): Fix invalid app.plugin.js deps

### DIFF
--- a/packages/expo-modules-test-core/app.plugin.js
+++ b/packages/expo-modules-test-core/app.plugin.js
@@ -1,4 +1,4 @@
-const { withProjectBuildGradle } = require('@expo/config-plugins');
+const { withProjectBuildGradle } = require('expo/config-plugins');
 const kotlinClassPath = 'org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion';
 
 const withKotlinGradle = (config, version) => {

--- a/packages/expo-modules-test-core/package.json
+++ b/packages/expo-modules-test-core/package.json
@@ -39,6 +39,9 @@
     "xml-js": "^1.6.11",
     "yaml": "^2.8.3"
   },
+  "peerDependencies": {
+    "expo": "*"
+  },
   "devDependencies": {
     "@types/jest": "^29.2.1",
     "expo-module-scripts": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5097,6 +5097,9 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.15
+      expo:
+        specifier: '*'
+        version: link:../expo
       expo-type-information:
         specifier: workspace:^0.0.5
         version: link:../expo-type-information
@@ -7578,7 +7581,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
@@ -17767,9 +17770,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
# Why

The `app.plugin.js` in `expo-modules-test-core` requires `@expo/config-plugins`, instead of `expo/config-plugins`. However, it also doesn't declare a dependency on `expo` and hence has an invalid deps chain.

# How

- Add `expo` peer dep
- Replace `@expo/config-plugins` with `expo/config-plugins`

# Test Plan

- `node app.plugin.js` (also reproduces in other flows, running `native-component-list`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
