### PR TITLE
docs: add EAS Simulator preview documentation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -742,6 +742,17 @@ export const learn = [
 const preview = [
   makeSection('Preview', [
     makePage('preview/introduction.mdx'),
+    makeGroup(
+      'EAS Simulator',
+      [
+        makePage('preview/eas-simulator/introduction.mdx'),
+        makePage('preview/eas-simulator/get-started.mdx'),
+        makePage('preview/eas-simulator/run-and-control.mdx'),
+        makePage('preview/eas-simulator/cli-reference.mdx'),
+        makePage('preview/eas-simulator/troubleshooting.mdx'),
+      ],
+      { expanded: true }
+    ),
     makeGroup('Expo Router', [makePage('preview/singular.mdx'), { expanded: true }]),
   ]),
 ];

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -7,7 +7,7 @@ description: Reference for the experimental EAS CLI commands that create, inspec
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-The `simulator:*` commands are experimental and hidden. Use a current [EAS CLI](/eas/cli/) to run them:
+The `simulator:*` commands are experimental and hidden. Install or update [EAS CLI](/eas/cli/) before running them:
 
 <Terminal cmd={['$ eas simulator:start --help']} />
 
@@ -15,21 +15,21 @@ The `--help` flag displays the available options for `simulator:start`.
 
 ## Commands
 
-| Command                  | Purpose                                                                  |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `simulator:availability` | Check whether the current project's account can use EAS Simulator        |
-| `simulator:start`        | Create a session and wait for its controller configuration               |
-| `simulator`              | Alias for `simulator:start`                                              |
-| `simulator:exec`         | Run another command with **.env.eas-simulator** loaded                   |
-| `simulator:get`          | Get status, connection details, dashboard URL, timestamps, and artifacts |
-| `simulator:list`         | List and filter sessions for the current project                         |
-| `simulator:stop`         | Stop a session                                                           |
+| Command                                            | Purpose                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`simulator:availability`](#simulatoravailability) | Check whether the current project's account can use EAS Simulator        |
+| [`simulator:start`](#simulatorstart)               | Create a session and wait for its controller configuration               |
+| [`simulator`](#simulatorstart)                     | Alias for `simulator:start`                                              |
+| [`simulator:exec`](#simulatorexec)                 | Run another command with **.env.eas-simulator** loaded                   |
+| [`simulator:get`](#simulatorget)                   | Get status, connection details, dashboard URL, timestamps, and artifacts |
+| [`simulator:list`](#simulatorlist)                 | List and filter sessions for the current project                         |
+| [`simulator:stop`](#simulatorstop)                 | Stop a session                                                           |
 
 ## `simulator:availability`
 
 <Terminal cmd={['$ eas simulator:availability --json']} />
 
-The JSON output contains `available` and `accountName`. This command does not create a session or consume simulator usage.
+The `--json` flag is optional. It prints a stable, machine-readable result for agents and automation; omit it for human-readable output. The JSON object contains `available` and `accountName`. This command does not create a session or consume simulator usage.
 
 ## `simulator:start`
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -7,9 +7,11 @@ description: Reference for the experimental EAS CLI commands that create, inspec
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-The `simulator:*` commands are experimental and hidden. Run them through a current EAS CLI:
+The `simulator:*` commands are experimental and hidden. Use a current [EAS CLI](/eas/cli/) to run them:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --help']} />
+<Terminal cmd={['$ eas simulator:start --help']} />
+
+The `--help` flag displays the available options for `simulator:start`.
 
 ## Commands
 
@@ -25,33 +27,29 @@ The `simulator:*` commands are experimental and hidden. Run them through a curre
 
 ## `simulator:availability`
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+<Terminal cmd={['$ eas simulator:availability --json']} />
 
 The JSON output contains `available` and `accountName`. This command does not create a session or consume simulator usage.
 
 ## `simulator:start`
 
-Choose a controller type when starting a session:
+A controller is the tool provisioned with the remote device to install, inspect, and interact with apps. Choose a controller type when starting a session:
 
 <Tabs>
 
 <Tab label="agent-device">
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-  ]}
-/>
+Use [agent-device](/agents/agent-device/) for accessibility-driven device actions and app installation.
+
+<Terminal cmd={['$ eas simulator:start --platform ios --type agent-device --non-interactive']} />
 
 </Tab>
 
 <Tab label="Argent">
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
-  ]}
-/>
+Use [Argent](/agents/argent/) to run its remote device tools through the session.
+
+<Terminal cmd={['$ eas simulator:start --platform ios --type argent --non-interactive']} />
 
 </Tab>
 
@@ -61,7 +59,7 @@ Important flags:
 
 | Flag                | Description                                                                                                                                |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `-p, --platform`    | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal                                              |
+| `-p, --platform`    | `android` or `ios`. Required in non-interactive mode; prompted for in an interactive terminal                                              |
 | `--type`            | Controller provisioned for the session. Use `agent-device` or `argent` for programmatic control, or `serve-sim` for a browser-only preview |
 | `--package-version` | Controller package version. Defaults to the service's latest version                                                                       |
 | `--out-config-type` | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                                                                  |
@@ -92,12 +90,6 @@ Without `--non-interactive`, the start command stays attached and polls the sess
 
 With `--non-interactive` or `--json`, the command returns after the controller is ready. You must stop the session separately.
 
-### Existing session behavior
-
-The default `--force` behavior creates a new session even when `EAS_SIMULATOR_SESSION_ID` is already loaded. EAS CLI overwrites the dotenv file but does not stop the previous remote session. Use `simulator:list --status in-progress` to find and stop orphaned sessions.
-
-Pass `--no-force` when you want EAS CLI to fail instead of replacing the local session configuration.
-
 ## `simulator:exec`
 
 `simulator:exec` is controller-agnostic. It loads the connection variables for the active session from **.env.eas-simulator**, then spawns the command and arguments that follow.
@@ -108,15 +100,13 @@ Use the command pattern for the controller selected when the session started:
 
 <Tab label="agent-device">
 
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
-/>
+<Terminal cmd={['$ eas simulator:exec npx agent-device@latest <command> [args...]']} />
 
 </Tab>
 
 <Tab label="Argent">
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
+<Terminal cmd={['$ eas simulator:exec argent run <tool> [args...]']} />
 
 </Tab>
 
@@ -128,13 +118,11 @@ Use the command pattern for the controller selected when the session started:
 
 Get the session referenced by **.env.eas-simulator**:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
+<Terminal cmd={['$ eas simulator:get --json --non-interactive']} />
 
 Get another session explicitly:
 
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:get --id <session-id> --json --non-interactive']}
-/>
+<Terminal cmd={['$ eas simulator:get --id <session-id> --json --non-interactive']} />
 
 The response includes:
 
@@ -147,9 +135,7 @@ The response includes:
 ## `simulator:list`
 
 <Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:list --platform ios --status in-progress --json --non-interactive',
-  ]}
+  cmd={['$ eas simulator:list --platform ios --status in-progress --json --non-interactive']}
 />
 
 Filters can be repeated:
@@ -166,11 +152,11 @@ Use `--limit` to control page size and `--after` with the previous response's `e
 
 Stop the session referenced by **.env.eas-simulator**:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+<Terminal cmd={['$ eas simulator:stop']} />
 
 Stop a specific session:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
+<Terminal cmd={['$ eas simulator:stop --id <session-id>']} />
 
 The stop mutation is idempotent.
 
@@ -178,7 +164,7 @@ The stop mutation is idempotent.
 
 The managed file always contains the session ID:
 
-```bash .env.eas-simulator
+```sh .env.eas-simulator
 EAS_SIMULATOR_SESSION_ID="<session-id>"
 ```
 
@@ -191,7 +177,7 @@ Controller connection variables depend on the selected type:
 
 Add the file to **.gitignore**:
 
-```bash .gitignore
+```sh .gitignore
 .env.eas-simulator
 ```
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -143,7 +143,7 @@ The stop mutation is idempotent. After a non-interactive run, remove or reset **
 
 The managed file contains:
 
-```dotenv
+```bash .env.eas-simulator
 AGENT_DEVICE_DAEMON_BASE_URL="<controller-url>"
 AGENT_DEVICE_DAEMON_AUTH_TOKEN="<secret>"
 EAS_SIMULATOR_SESSION_ID="<session-id>"
@@ -153,7 +153,7 @@ Argent sessions use `ARGENT_TOOLS_URL` and, when required, `ARGENT_AUTH_TOKEN` i
 
 Add the file to **.gitignore**:
 
-```gitignore
+```bash .gitignore
 .env.eas-simulator
 ```
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -141,7 +141,7 @@ Stop a specific session:
 
 <Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
 
-The stop mutation is idempotent. After a non-interactive run, remove or reset **.env.eas-simulator** so later commands do not target the stopped session.
+The stop mutation is idempotent.
 
 ## **.env.eas-simulator**
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -79,11 +79,19 @@ Pass `--no-force` when you want EAS CLI to fail instead of replacing the local s
 
 ## `simulator:exec`
 
-`simulator:exec` loads **.env.eas-simulator**, then spawns the command and arguments that follow:
+`simulator:exec` is controller-agnostic. It loads the connection variables for the active session from **.env.eas-simulator**, then spawns the command and arguments that follow.
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i']} />
+For the default agent-device controller:
 
-It is a connection wrapper, not a device controller. Commands such as `press` and `screenshot` come from agent-device or another controller.
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
+/>
+
+For an Argent session:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
+
+It is a connection wrapper, not a device controller. Commands such as `press` come from agent-device, while tools such as `reinstall-app` come from Argent.
 
 ## `simulator:get`
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -5,6 +5,7 @@ description: Reference for the experimental EAS CLI commands that create, inspec
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 The `simulator:*` commands are experimental and hidden. Run them through a current EAS CLI:
 
@@ -30,39 +31,60 @@ The JSON output contains `available` and `accountName`. This command does not cr
 
 ## `simulator:start`
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive']} />
+Choose a controller type when starting a session:
+
+<Tabs>
+
+<Tab label="agent-device">
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Argent">
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 Important flags:
 
-| Flag                | Description                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `-p, --platform`    | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal           |
-| `--type`            | `agent-device`, `argent`, or `serve-sim`. Defaults to `agent-device`                                    |
-| `--package-version` | Controller package version. Defaults to the service's latest version                                    |
-| `--out-config-type` | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                               |
-| `--[no-]force`      | Whether to create a new session when a session ID already exists in the environment. Defaults to `true` |
-| `--non-interactive` | Return after the controller is ready instead of staying attached                                        |
-| `--json`            | Print machine-readable output and imply non-interactive mode                                            |
+| Flag                | Description                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-p, --platform`    | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal                                              |
+| `--type`            | Controller provisioned for the session. Use `agent-device` or `argent` for programmatic control, or `serve-sim` for a browser-only preview |
+| `--package-version` | Controller package version. Defaults to the service's latest version                                                                       |
+| `--out-config-type` | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                                                                  |
+| `--[no-]force`      | Whether to create a new session when a session ID already exists in the environment. Defaults to `true`                                    |
+| `--non-interactive` | Return after the controller is ready instead of staying attached                                                                           |
+| `--json`            | Print machine-readable output and imply non-interactive mode                                                                               |
 
 The default `dotenv` output writes configuration even when `--json` is used. Use `--out-config-type env` when you explicitly do not want the file.
 
-JSON output has this shape:
+Common JSON output fields have this shape. The fields inside `remoteConfig` depend on the selected controller:
 
 ```json
 {
   "id": "<session-id>",
-  "type": "agent-device",
+  "type": "<controller-type>",
   "deviceRunSessionUrl": "https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions/<session-id>",
   "remoteConfig": {
-    "__typename": "AgentDeviceRunSessionRemoteConfig",
-    "agentDeviceRemoteSessionUrl": "https://<controller-url>",
-    "agentDeviceRemoteSessionToken": "<secret>",
-    "webPreviewUrl": "https://<preview-url>"
+    "<controller-specific-key>": "<value>"
   }
 }
 ```
 
-Treat `remoteConfig` as secret because it includes the controller token.
+Treat `remoteConfig` as secret because it includes controller credentials.
 
 ### Interactive and non-interactive behavior
 
@@ -80,17 +102,27 @@ Pass `--no-force` when you want EAS CLI to fail instead of replacing the local s
 
 `simulator:exec` is controller-agnostic. It loads the connection variables for the active session from **.env.eas-simulator**, then spawns the command and arguments that follow.
 
-For the default agent-device controller:
+Use the command pattern for the controller selected when the session started:
+
+<Tabs>
+
+<Tab label="agent-device">
 
 <Terminal
   cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
 />
 
-For an Argent session:
+</Tab>
+
+<Tab label="Argent">
 
 <Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
 
-It is a connection wrapper, not a device controller. Commands such as `press` come from agent-device, while tools such as `reinstall-app` come from Argent.
+</Tab>
+
+</Tabs>
+
+`simulator:exec` does not implement device actions. It only supplies the active session's connection environment and runs the command that follows. The available actions and argument syntax come from [agent-device](/agents/agent-device/) or [Argent](/agents/argent/).
 
 ## `simulator:get`
 
@@ -144,15 +176,18 @@ The stop mutation is idempotent.
 
 ## **.env.eas-simulator**
 
-The managed file contains:
+The managed file always contains the session ID:
 
 ```bash .env.eas-simulator
-AGENT_DEVICE_DAEMON_BASE_URL="<controller-url>"
-AGENT_DEVICE_DAEMON_AUTH_TOKEN="<secret>"
 EAS_SIMULATOR_SESSION_ID="<session-id>"
 ```
 
-Argent sessions use `ARGENT_TOOLS_URL` and, when required, `ARGENT_AUTH_TOKEN` instead.
+Controller connection variables depend on the selected type:
+
+| Controller   | Connection variables                                             |
+| ------------ | ---------------------------------------------------------------- |
+| agent-device | `AGENT_DEVICE_DAEMON_BASE_URL`, `AGENT_DEVICE_DAEMON_AUTH_TOKEN` |
+| Argent       | `ARGENT_TOOLS_URL` and, when required, `ARGENT_AUTH_TOKEN`       |
 
 Add the file to **.gitignore**:
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -1,0 +1,160 @@
+---
+title: EAS Simulator CLI reference
+sidebar_title: CLI reference
+description: Reference for the experimental EAS CLI commands that create, inspect, control, list, and stop remote simulator sessions.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+The `simulator:*` commands are experimental and hidden. Run them through a current EAS CLI:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --help']} />
+
+## Commands
+
+| Command                  | Purpose                                                                  |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `simulator:availability` | Check whether the current project's account can use EAS Simulator        |
+| `simulator:start`        | Create a session and wait for its controller configuration               |
+| `simulator`              | Alias for `simulator:start`                                              |
+| `simulator:exec`         | Run another command with **.env.eas-simulator** loaded                   |
+| `simulator:get`          | Get status, connection details, dashboard URL, timestamps, and artifacts |
+| `simulator:list`         | List and filter sessions for the current project                         |
+| `simulator:stop`         | Stop a session                                                           |
+
+## `simulator:availability`
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+
+The JSON output contains `available` and `accountName`. This command does not create a session or consume simulator usage.
+
+## `simulator:start`
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+  ]}
+/>
+
+Important flags:
+
+| Flag                     | Description                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `-p, --platform`         | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal           |
+| `--type`                 | `agent-device`, `argent`, or `serve-sim`. Defaults to `agent-device`                                    |
+| `--package-version`      | Controller package version. Defaults to the service's latest version                                    |
+| `--max-duration-minutes` | Requested automatic stop time. Custom values are available only on paid plans                           |
+| `--out-config-type`      | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                               |
+| `--[no-]force`           | Whether to create a new session when a session ID already exists in the environment. Defaults to `true` |
+| `--non-interactive`      | Return after the controller is ready instead of staying attached                                        |
+| `--json`                 | Print machine-readable output and imply non-interactive mode                                            |
+
+The default `dotenv` output writes configuration even when `--json` is used. Use `--out-config-type env` when you explicitly do not want the file.
+
+JSON output has this shape:
+
+```json
+{
+  "id": "<session-id>",
+  "type": "agent-device",
+  "deviceRunSessionUrl": "https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions/<session-id>",
+  "remoteConfig": {
+    "__typename": "AgentDeviceRunSessionRemoteConfig",
+    "agentDeviceRemoteSessionUrl": "https://<controller-url>",
+    "agentDeviceRemoteSessionToken": "<secret>",
+    "webPreviewUrl": "https://<preview-url>"
+  }
+}
+```
+
+Treat `remoteConfig` as secret because it includes the controller token.
+
+### Interactive and non-interactive behavior
+
+Without `--non-interactive`, the start command stays attached and polls the session. Press Ctrl+C once to stop it. EAS CLI resets **.env.eas-simulator** after it confirms the session ended.
+
+With `--non-interactive` or `--json`, the command returns after the controller is ready. You must stop the session separately.
+
+### Existing session behavior
+
+The default `--force` behavior creates a new session even when `EAS_SIMULATOR_SESSION_ID` is already loaded. EAS CLI overwrites the dotenv file but does not stop the previous remote session. Use `simulator:list --status in-progress` to find and stop orphaned sessions.
+
+Pass `--no-force` when you want EAS CLI to fail instead of replacing the local session configuration.
+
+## `simulator:exec`
+
+`simulator:exec` loads **.env.eas-simulator**, then spawns the command and arguments that follow:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i']} />
+
+It is a connection wrapper, not a device controller. Commands such as `press` and `screenshot` come from agent-device or another controller.
+
+## `simulator:get`
+
+Get the session referenced by **.env.eas-simulator**:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
+
+Get another session explicitly:
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:get --id <session-id> --json --non-interactive']}
+/>
+
+The response includes:
+
+- ID, type, status, and platform
+- Created, started, finished, and updated timestamps
+- The expo.dev simulator session URL
+- Controller connection configuration
+- Session artifacts, when present
+
+## `simulator:list`
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:list --platform ios --status in-progress --json --non-interactive',
+  ]}
+/>
+
+Filters can be repeated:
+
+| Filter       | Values                                     |
+| ------------ | ------------------------------------------ |
+| `--platform` | `ios`, `android`                           |
+| `--type`     | `agent-device`, `argent`, `serve-sim`      |
+| `--status`   | `new`, `in-progress`, `stopped`, `errored` |
+
+Use `--limit` to control page size and `--after` with the previous response's `endCursor` for pagination.
+
+## `simulator:stop`
+
+Stop the session referenced by **.env.eas-simulator**:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+
+Stop a specific session:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
+
+The stop mutation is idempotent. After a non-interactive run, remove or reset **.env.eas-simulator** so later commands do not target the stopped session.
+
+## **.env.eas-simulator**
+
+The managed file contains:
+
+```dotenv
+AGENT_DEVICE_DAEMON_BASE_URL="<controller-url>"
+AGENT_DEVICE_DAEMON_AUTH_TOKEN="<secret>"
+EAS_SIMULATOR_SESSION_ID="<session-id>"
+```
+
+Argent sessions use `ARGENT_TOOLS_URL` and, when required, `ARGENT_AUTH_TOKEN` instead.
+
+Add the file to **.gitignore**:
+
+```gitignore
+.env.eas-simulator
+```
+
+Do not modify its values while the session is running.

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -30,11 +30,7 @@ The JSON output contains `available` and `accountName`. This command does not cr
 
 ## `simulator:start`
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive']} />
 
 Important flags:
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -34,16 +34,15 @@ The JSON output contains `available` and `accountName`. This command does not cr
 
 Important flags:
 
-| Flag                     | Description                                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `-p, --platform`         | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal           |
-| `--type`                 | `agent-device`, `argent`, or `serve-sim`. Defaults to `agent-device`                                    |
-| `--package-version`      | Controller package version. Defaults to the service's latest version                                    |
-| `--max-duration-minutes` | Requested automatic stop time. Custom values are available only on paid plans                           |
-| `--out-config-type`      | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                               |
-| `--[no-]force`           | Whether to create a new session when a session ID already exists in the environment. Defaults to `true` |
-| `--non-interactive`      | Return after the controller is ready instead of staying attached                                        |
-| `--json`                 | Print machine-readable output and imply non-interactive mode                                            |
+| Flag                | Description                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `-p, --platform`    | `ios` or `android`. Required in non-interactive mode; prompted for in an interactive terminal           |
+| `--type`            | `agent-device`, `argent`, or `serve-sim`. Defaults to `agent-device`                                    |
+| `--package-version` | Controller package version. Defaults to the service's latest version                                    |
+| `--out-config-type` | `dotenv` to write **.env.eas-simulator**, or `env` to print shell exports                               |
+| `--[no-]force`      | Whether to create a new session when a session ID already exists in the environment. Defaults to `true` |
+| `--non-interactive` | Return after the controller is ready instead of staying attached                                        |
+| `--json`            | Print machine-readable output and imply non-interactive mode                                            |
 
 The default `dotenv` output writes configuration even when `--json` is used. Use `--out-config-type env` when you explicitly do not want the file.
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -10,7 +10,7 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access preview.** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
 
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -10,12 +10,12 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** [Contact us](https://expo.dev/contact) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">
-    EAS Simulator is not enabled on every account. Check the current project's account before
-    starting a session.
+    EAS Simulator access is granted directly to select partners. Check the current project's account
+    before starting a session.
   </Requirement>
   <Requirement title="A linked Expo project">
     Run these commands from the project directory. If the project does not have an EAS project ID,

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -5,28 +5,33 @@ description: Check whether EAS Simulator is available, start a remote device ses
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
-
-> **info** For an agentic workflow, install [Expo Skills](/skills/) and ask your coding agent to use the EAS Simulator skill. The agent can perform the session workflow below and drive the app for you. Use this page when you want to understand or run the commands manually.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">
-    EAS Simulator is not enabled on every account. You will check the current project's account
-    before starting a session.
+    EAS Simulator is not enabled on every account. Check the current project's account before
+    starting a session.
   </Requirement>
   <Requirement title="A linked Expo project">
     Run these commands from the project directory. If the project does not have an EAS project ID,
-    run `npx --yes eas-cli@latest init` first.
+    run `eas init` first.
   </Requirement>
   <Requirement title="A recent EAS CLI">
-    The `simulator:*` commands are experimental and hidden. Use `npx --yes eas-cli@latest` so an
-    older global installation does not mask them.
+    The `simulator:*` commands are experimental and hidden. [Install or update EAS CLI](/eas/cli/)
+    before using them.
   </Requirement>
 </Prerequisites>
+
+## Expo Skills for AI agents
+
+If you use an AI agent, install [Expo Skills](/skills/) and ask it to use the EAS Simulator skill. The skill can perform the session workflow below, drive the app, and collect evidence for you. Use this page when you want to understand or run the commands manually.
+
+<RelatedSkills names={['eas-simulator']} />
 
 ## Start a session manually
 
@@ -36,13 +41,13 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 On an interactive machine, log in and confirm the current user:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest login', '$ npx --yes eas-cli@latest whoami']} />
+<Terminal cmd={['$ eas login', '$ eas whoami']} />
 
 In CI or a headless agent environment, provide an [Expo access token](/accounts/programmatic-access/) in `EXPO_TOKEN` instead of starting an interactive login.
 
 If the project is not linked to EAS, initialize it:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest init']} />
+<Terminal cmd={['$ eas init']} />
 
 </Step>
 
@@ -52,7 +57,7 @@ If the project is not linked to EAS, initialize it:
 
 The availability check is read-only. It does not start a device or consume simulator usage:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+<Terminal cmd={['$ eas simulator:availability --json']} />
 
 An enabled account returns:
 
@@ -63,7 +68,7 @@ An enabled account returns:
 }
 ```
 
-If `available` is `false`, do not call `simulator:start`. Use a local Simulator or Emulator, or wait until the feature is enabled for the account.
+If `available` is `false`, do not call `simulator:start`. Use a local simulator or emulator, or wait until the feature is enabled for the account.
 
 </Step>
 
@@ -73,7 +78,7 @@ If `available` is `false`, do not call `simulator:start`. Use a local Simulator 
 
 EAS CLI writes the current session ID and controller credentials to **.env.eas-simulator**. Add the file to **.gitignore** before starting:
 
-```bash .gitignore
+```sh .gitignore
 .env.eas-simulator
 ```
 
@@ -93,11 +98,7 @@ Choose the controller you plan to use for installation and device actions. Pass 
 
 See [agent-device and Expo](/agents/agent-device/) for controller setup and commands.
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ eas simulator:start --platform ios --type agent-device --non-interactive']} />
 
 </Tab>
 
@@ -105,11 +106,7 @@ See [agent-device and Expo](/agents/agent-device/) for controller setup and comm
 
 See [Argent and Expo](/agents/argent/) for controller setup and commands.
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ eas simulator:start --platform ios --type argent --non-interactive']} />
 
 </Tab>
 
@@ -117,7 +114,7 @@ See [Argent and Expo](/agents/argent/) for controller setup and commands.
 
 With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`. Keep the explicit `--type` when you use the alias.
 
-Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
+Use `--platform android` for an Android emulator. Android sessions do not currently include a live browser preview.
 
 When `--platform` is omitted in an interactive terminal, EAS CLI asks which platform to use. Non-interactive runs require the flag.
 
@@ -137,7 +134,7 @@ The start command waits for the selected controller to become ready, then writes
 
 Use the session ID from **.env.eas-simulator**:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
+<Terminal cmd={['$ eas simulator:get --json --non-interactive']} />
 
 Continue when `status` is `IN_PROGRESS` and `remoteConfig` is present. A stopped session can still have old connection configuration, so the dotenv file alone is not proof that the device is live.
 
@@ -169,7 +166,7 @@ For supported iOS sessions, open `webPreviewUrl` in a desktop browser to view an
 
 When you finish, stop the current session:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+<Terminal cmd={['$ eas simulator:stop']} />
 
 If you started EAS CLI without `--non-interactive`, it remains attached. Press Ctrl+C once to stop the session and let EAS CLI reset **.env.eas-simulator**.
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -10,7 +10,7 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Contact us](https://expo.dev/contact) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
 
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">
@@ -55,7 +55,7 @@ If the project is not linked to EAS, initialize it:
 
 ### Check account availability
 
-The availability check is read-only. It does not start a device or consume simulator usage:
+The availability check is read-only. It does not start a device or consume simulator usage. The `--json` flag is optional, but it makes the result easy for an agent or script to inspect:
 
 <Terminal cmd={['$ eas simulator:availability --json']} />
 
@@ -68,7 +68,7 @@ An enabled account returns:
 }
 ```
 
-If `available` is `false`, do not call `simulator:start`. Use a local simulator or emulator, or wait until the feature is enabled for the account.
+If `available` is `false`, do not call `simulator:start`. Use a local simulator or emulator, or [join the waitlist](https://expo.dev/services/simulator) for access.
 
 </Step>
 
@@ -111,8 +111,6 @@ See [Argent and Expo](/agents/argent/) for controller setup and commands.
 </Tab>
 
 </Tabs>
-
-With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`. Keep the explicit `--type` when you use the alias.
 
 Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -114,7 +114,7 @@ See [Argent and Expo](/agents/argent/) for controller setup and commands.
 
 With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`. Keep the explicit `--type` when you use the alias.
 
-Use `--platform android` for an Android emulator. Android sessions do not currently include a live browser preview.
+Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
 
 When `--platform` is omitted in an interactive terminal, EAS CLI asks which platform to use. Non-interactive runs require the flag.
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -84,19 +84,11 @@ Do not commit or share this file. It includes the token that lets a controller r
 
 Start an iOS session with agent-device:
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive']} />
 
 With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`:
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator --platform ios --type agent-device --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator --platform ios --non-interactive']} />
 
 Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -11,6 +11,8 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 > **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
+> **info** For an agentic workflow, install [Expo Skills](/skills/) and ask your coding agent to use the EAS Simulator skill. The agent can perform the session workflow below and drive the app for you. Use this page when you want to understand or run the commands manually.
+
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">
     EAS Simulator is not enabled on every account. You will check the current project's account
@@ -26,7 +28,7 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
   </Requirement>
 </Prerequisites>
 
-## Start your first session
+## Start a session manually
 
 <Step label="1">
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -147,15 +147,3 @@ When you finish, stop the current session:
 If you started EAS CLI without `--non-interactive`, it remains attached. Press Ctrl+C once to stop the session and let EAS CLI reset **.env.eas-simulator**.
 
 </Step>
-
-## Avoid orphaned sessions
-
-Starting another session overwrites **.env.eas-simulator** by default but does not stop the earlier remote session. Before starting again, list active sessions:
-
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
-/>
-
-Stop each unwanted session by ID:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -1,0 +1,185 @@
+---
+title: Get started with EAS Simulator
+sidebar_title: Get started
+description: Check whether EAS Simulator is available, start a remote device session, and connect to it.
+---
+
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+import { Step } from '~/ui/components/Step';
+import { Terminal } from '~/ui/components/Snippet';
+
+> **important** EAS Simulator is a limited-access, experimental service. Sessions use your plan's compute allowance. Check availability before doing work such as creating an EAS Build for the session.
+
+<Prerequisites>
+  <Requirement title="An Expo account with EAS Simulator access">
+    EAS Simulator is not enabled on every account. You will check the current project's account
+    before starting a session.
+  </Requirement>
+  <Requirement title="A linked Expo project">
+    Run these commands from the project directory. If the project does not have an EAS project ID,
+    run `npx --yes eas-cli@latest init` first.
+  </Requirement>
+  <Requirement title="A recent EAS CLI">
+    The `simulator:*` commands are experimental and hidden. Use `npx --yes eas-cli@latest` so an
+    older global installation does not mask them.
+  </Requirement>
+</Prerequisites>
+
+## Start your first session
+
+<Step label="1">
+
+### Authenticate and verify the project
+
+On an interactive machine, log in and confirm the current user:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest login', '$ npx --yes eas-cli@latest whoami']} />
+
+In CI or a headless agent environment, provide an [Expo access token](/accounts/programmatic-access/) in `EXPO_TOKEN` instead of starting an interactive login.
+
+If the project is not linked to EAS, initialize it:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest init']} />
+
+</Step>
+
+<Step label="2">
+
+### Check account availability
+
+The availability check is read-only. It does not start a device or consume simulator usage:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+
+An enabled account returns:
+
+```json
+{
+  "available": true,
+  "accountName": "my-account"
+}
+```
+
+If `available` is `false`, do not call `simulator:start`. Use a local Simulator or Emulator, or wait until the feature is enabled for the account.
+
+</Step>
+
+<Step label="3">
+
+### Protect the session configuration
+
+EAS CLI writes the current session ID and controller credentials to **.env.eas-simulator**. Add the file to **.gitignore** before starting:
+
+```gitignore
+.env.eas-simulator
+```
+
+Do not commit or share this file. It includes the token that lets a controller reach the remote device.
+
+</Step>
+
+<Step label="4">
+
+### Start a remote device
+
+Start an iOS session with agent-device:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+  ]}
+/>
+
+With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator --platform ios --type agent-device --non-interactive',
+  ]}
+/>
+
+Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
+
+When `--platform` is omitted in an interactive terminal, EAS CLI asks which platform to use. Non-interactive runs require the flag.
+
+The start command waits for the selected controller to become ready, then writes **.env.eas-simulator**. It also prints:
+
+- A direct simulator session page on expo.dev
+- A temporary `webPreviewUrl` for supported iOS sessions
+- The command pattern for controlling the device
+
+> **warning** `--non-interactive` does not automatically stop the session. The command returns when the session is ready, and the remote device remains active.
+
+</Step>
+
+<Step label="5">
+
+### Confirm that the session is active
+
+Use the session ID from **.env.eas-simulator**:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
+
+Continue when `status` is `IN_PROGRESS` and `remoteConfig` is present. A stopped session can still have old connection configuration, so the dotenv file alone is not proof that the device is live.
+
+</Step>
+
+<Step label="6">
+
+### Open the web surfaces
+
+The start command links to a session page with this shape:
+
+```text
+https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions/<session-id>
+```
+
+The project-level session list is:
+
+```text
+https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions
+```
+
+For iOS, open `webPreviewUrl` in a desktop browser to view and interact with the live simulator. The preview URL is not an application deep link. Do not pass it to `agent-device open`.
+
+</Step>
+
+<Step label="7">
+
+### Stop the session
+
+When you finish, stop the current session:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+
+If you started EAS CLI without `--non-interactive`, it remains attached. Press Ctrl+C once to stop the session and let EAS CLI reset **.env.eas-simulator**.
+
+After a non-interactive run, remove the stale local session configuration after the stop succeeds:
+
+<Terminal cmd={['$ rm -f .env.eas-simulator']} />
+
+</Step>
+
+## Bound the session duration
+
+Paid plans can request an automatic stop time:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive --max-duration-minutes 30',
+  ]}
+/>
+
+If `--max-duration-minutes` is not available for the account, omit it to use the plan-derived default.
+
+## Avoid orphaned sessions
+
+Starting another session overwrites **.env.eas-simulator** by default but does not stop the earlier remote session. Before starting again, list active sessions:
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
+/>
+
+Stop each unwanted session by ID:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -148,18 +148,6 @@ If you started EAS CLI without `--non-interactive`, it remains attached. Press C
 
 </Step>
 
-## Bound the session duration
-
-Paid plans can request an automatic stop time:
-
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive --max-duration-minutes 30',
-  ]}
-/>
-
-If `--max-duration-minutes` is not available for the account, omit it to use the plan-derived default.
-
 ## Avoid orphaned sessions
 
 Starting another session overwrites **.env.eas-simulator** by default but does not stop the earlier remote session. Before starting again, list active sessions:

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -8,7 +8,7 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** EAS Simulator is a limited-access, experimental service. Sessions use your plan's compute allowance. Check availability before doing work such as creating an EAS Build for the session.
+> **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
 <Prerequisites>
   <Requirement title="An Expo account with EAS Simulator access">

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -146,10 +146,6 @@ When you finish, stop the current session:
 
 If you started EAS CLI without `--non-interactive`, it remains attached. Press Ctrl+C once to stop the session and let EAS CLI reset **.env.eas-simulator**.
 
-After a non-interactive run, remove the stale local session configuration after the stop succeeds:
-
-<Terminal cmd={['$ rm -f .env.eas-simulator']} />
-
 </Step>
 
 ## Bound the session duration

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -70,7 +70,7 @@ If `available` is `false`, do not call `simulator:start`. Use a local Simulator 
 
 EAS CLI writes the current session ID and controller credentials to **.env.eas-simulator**. Add the file to **.gitignore** before starting:
 
-```gitignore
+```bash .gitignore
 .env.eas-simulator
 ```
 

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -7,6 +7,7 @@ description: Check whether EAS Simulator is available, start a remote device ses
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 > **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
@@ -80,15 +81,39 @@ Do not commit or share this file. It includes the token that lets a controller r
 
 <Step label="4">
 
-### Start a remote device
+### Choose a controller and start a remote device
 
-Start an iOS session with agent-device:
+Choose the controller you plan to use for installation and device actions. Pass its type explicitly when you start the session.
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive']} />
+<Tabs>
 
-With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`:
+<Tab label="agent-device">
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator --platform ios --non-interactive']} />
+See [agent-device and Expo](/agents/agent-device/) for controller setup and commands.
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Argent">
+
+See [Argent and Expo](/agents/argent/) for controller setup and commands.
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
+
+With a current EAS CLI, `eas simulator` is an alias for `eas simulator:start`. Keep the explicit `--type` when you use the alias.
 
 Use `--platform android` for an Android Emulator. Android sessions do not currently include a live browser preview.
 
@@ -132,7 +157,7 @@ The project-level session list is:
 https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions
 ```
 
-For iOS, open `webPreviewUrl` in a desktop browser to view and interact with the live simulator. The preview URL is not an application deep link. Do not pass it to `agent-device open`.
+For supported iOS sessions, open `webPreviewUrl` in a desktop browser to view and interact with the live simulator. The preview URL is not an application deep link. Do not pass it to a controller command that opens apps or URLs.
 
 </Step>
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access preview.** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
 
 **EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** [Contact us](https://expo.dev/contact) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
 **EAS Simulator** runs a remote iOS simulator or Android emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction to EAS Simulator
 sidebar_title: Introduction
-description: Run and control remote iOS Simulators and Android Emulators on EAS infrastructure from the CLI, an AI agent, or a browser.
+description: Run and control remote iOS simulators and Android emulators on EAS infrastructure from the CLI, an AI agent, or a browser.
 ---
 
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
@@ -9,14 +9,12 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
-import { Terminal } from '~/ui/components/Snippet';
-import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
-**EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, interact with it, collect screenshots and recordings, and hand an iOS browser preview to another person without running the device locally.
+**EAS Simulator** runs a remote iOS simulator or Android emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
 
-EAS Simulator is built for agentic development. It gives coding agents a real device runtime so they can verify agent-written code, fix issues they observe, and return evidence from the running app instead of stopping after a source-code change.
+EAS Simulator is built for agentic development. It gives coding agents a real device runtime for verifying agent-written code. Agents can fix issues they observe and return evidence from the running app.
 
 EAS Simulator is especially useful when:
 
@@ -25,11 +23,11 @@ EAS Simulator is especially useful when:
 - You want a temporary, shareable iOS browser preview
 - You need to offload simulator compute or test on a remote platform
 
-EAS Simulator does not replace local Xcode or Android Studio workflows when you already have the required local simulator and do not need remote or shareable access.
+EAS Simulator does not replace local Xcode or Android Studio workflows when you already have the required local device runtime. Use it when you need remote or shareable access.
 
-## Close the loop on agent-written code
+## Use EAS Simulator with a coding agent
 
-For agentic development, the recommended starting point is the official EAS Simulator skill. Ask your coding agent to use the skill instead of manually giving it individual EAS CLI and controller commands. The skill teaches the agent how to check access, prepare the appropriate build, start a remote device, drive the app with your selected controller, collect evidence, and stop the session.
+For agentic development, start with the official EAS Simulator skill. Ask your coding agent to use the skill instead of giving it individual EAS CLI and controller commands. The skill covers the access check, build preparation, remote session, controller workflow, evidence collection, and cleanup.
 
 <RelatedSkills names={['eas-simulator']} />
 
@@ -43,7 +41,7 @@ The agent can then complete the runtime loop:
 
 ### Typical setup: a Cursor cloud agent
 
-A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another background coding agent working in a cloud project checkout. The environment can edit and build the project but cannot launch a local iOS Simulator. With the EAS Simulator skill, the agent starts a remote device on EAS, controls it through agent-device or Argent, and returns the result to the task or pull request. Your computer does not need to host the simulator.
+A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another background coding agent working in a cloud project checkout. The environment can edit and build the project, but it cannot launch a local iOS simulator. With the EAS Simulator skill, the agent starts a remote device on EAS and controls it through agent-device or Argent. It then returns the result to the task or pull request, while your computer does not need to host the simulator.
 
 ## How it works
 
@@ -60,8 +58,8 @@ EAS CLI manages the session lifecycle and connection configuration. The controll
 
 | Capability                                      | Availability |
 | ----------------------------------------------- | ------------ |
-| Remote iOS Simulator                            | <YesIcon />  |
-| Remote Android Emulator                         | <YesIcon />  |
+| Remote iOS simulator                            | <YesIcon />  |
+| Remote Android emulator                         | <YesIcon />  |
 | Programmatic control with agent-device          | <YesIcon />  |
 | Programmatic control with Argent                | <YesIcon />  |
 | Live browser preview for iOS                    | <YesIcon />  |
@@ -69,96 +67,34 @@ EAS CLI manages the session lifecycle and connection configuration. The controll
 | Physical device access                          | <NoIcon />   |
 | Fast Refresh with a development build and Metro | <YesIcon />  |
 
-Use [EAS Build](/build/introduction/) for build and signing workflows, and use local device tooling for physical devices.
-
-## Quick start
-
-The EAS Simulator skill can perform this sequence for your agent. Use the commands below when you want to operate a session manually or integrate it into custom automation.
-
-Run the availability check from a linked Expo project:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
-
-Choose the controller you want to use, then start the session with its type explicitly:
-
-<Tabs>
-
-<Tab label="agent-device">
-
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Argent">
-
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
-  ]}
-/>
-
-</Tab>
-
-</Tabs>
-
-Confirm that the session is active:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
-
-The start command writes **.env.eas-simulator** with the session ID and controller credentials. `simulator:exec` loads that configuration and runs the command for the controller you selected:
-
-<Tabs>
-
-<Tab label="agent-device">
-
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
-/>
-
-</Tab>
-
-<Tab label="Argent">
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
-
-</Tab>
-
-</Tabs>
-
-Always stop the session when you finish:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+Use [EAS Build](/build/introduction/) to create installable builds, and use local device tooling for physical devices.
 
 ## Next steps
 
 <BoxLink
   title="Get started"
   description="Check access, start your first session, and open the dashboard and browser preview."
-  href="/preview/eas-simulator/get-started"
+  href="/preview/eas-simulator/get-started/"
   Icon={Cloud01Icon}
 />
 
 <BoxLink
   title="Run and control your app"
   description="Install a local or EAS build, interact with the app, and capture evidence."
-  href="/preview/eas-simulator/run-and-control"
+  href="/preview/eas-simulator/run-and-control/"
   Icon={Cloud01Icon}
 />
 
 <BoxLink
   title="CLI reference"
   description="Review the experimental simulator commands, flags, output, and managed environment file."
-  href="/preview/eas-simulator/cli-reference"
+  href="/preview/eas-simulator/cli-reference/"
   Icon={Cloud01Icon}
 />
 
 <BoxLink
   title="Troubleshooting"
   description="Recover from unavailable accounts, stale sessions, dropped tunnels, and incorrect builds."
-  href="/preview/eas-simulator/troubleshooting"
+  href="/preview/eas-simulator/troubleshooting/"
   Icon={Cloud01Icon}
 />

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
-> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Contact us](https://expo.dev/contact) if you are interested in trying it.
+> **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulator) if you are interested in trying it.
 
 **EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction to EAS Simulator
 sidebar_title: Introduction
-description: Run and control remote iOS simulators and Android emulators on EAS infrastructure from the CLI, an AI agent, or a browser.
+description: Run and control remote iOS Simulators and Android Emulators on EAS infrastructure from the CLI, an AI agent, or a browser.
 ---
 
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
@@ -12,7 +12,7 @@ import { RelatedSkills } from '~/ui/components/RelatedSkills';
 
 > **important** **EAS Simulator is a limited-access [preview](/more/release-statuses/#preview).** It is not included with paid or free plans and is currently available only to select partners. [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
-**EAS Simulator** runs a remote iOS simulator or Android emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
+**EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, and interact with it. You can also collect screenshots and recordings or share an iOS browser preview without running the device locally.
 
 EAS Simulator is built for agentic development. It gives coding agents a real device runtime for verifying agent-written code. Agents can fix issues they observe and return evidence from the running app.
 
@@ -41,7 +41,7 @@ The agent can then complete the runtime loop:
 
 ### Typical setup: a Cursor cloud agent
 
-A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another background coding agent working in a cloud project checkout. The environment can edit and build the project, but it cannot launch a local iOS simulator. With the EAS Simulator skill, the agent starts a remote device on EAS and controls it through agent-device or Argent. It then returns the result to the task or pull request, while your computer does not need to host the simulator.
+A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another background coding agent working in a cloud project checkout. The environment can edit and build the project, but it cannot launch a local iOS Simulator. With the EAS Simulator skill, the agent starts a remote device on EAS and controls it through agent-device or Argent. It then returns the result to the task or pull request, while your computer does not need to host the simulator.
 
 ## How it works
 
@@ -58,8 +58,8 @@ EAS CLI manages the session lifecycle and connection configuration. The controll
 
 | Capability                                      | Availability |
 | ----------------------------------------------- | ------------ |
-| Remote iOS simulator                            | <YesIcon />  |
-| Remote Android emulator                         | <YesIcon />  |
+| Remote iOS Simulator                            | <YesIcon />  |
+| Remote Android Emulator                         | <YesIcon />  |
 | Programmatic control with agent-device          | <YesIcon />  |
 | Programmatic control with Argent                | <YesIcon />  |
 | Live browser preview for iOS                    | <YesIcon />  |

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -23,6 +23,8 @@ EAS Simulator is especially useful when:
 - You want a temporary, shareable iOS browser preview
 - You need to offload simulator compute or test on a remote platform
 
+> **Note** EAS Simulator is also useful for developers on Linux or Windows who need access to an iOS Simulator, or when local resources are constrained and you want to offload the device runtime to EAS for a simpler setup.
+
 EAS Simulator does not replace local Xcode or Android Studio workflows when you already have the required local device runtime. Use it when you need remote or shareable access.
 
 ## Use EAS Simulator with a coding agent

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -1,0 +1,114 @@
+---
+title: Introduction to EAS Simulator
+sidebar_title: Introduction
+description: Run and control remote iOS Simulators and Android Emulators on EAS infrastructure from the CLI, an AI agent, or a browser.
+---
+
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { RelatedSkills } from '~/ui/components/RelatedSkills';
+import { Terminal } from '~/ui/components/Snippet';
+
+> **important** **EAS Simulator is a limited-access preview.** The CLI commands and service behavior are experimental and can change without notice. EAS Simulator uses your plan's compute allowance. See [Expo pricing](https://expo.dev/pricing) for current limits and pricing.
+
+**EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, interact with it, collect screenshots and recordings, and hand an iOS browser preview to another person without running the device locally.
+
+EAS Simulator is especially useful when:
+
+- Your development environment cannot run an iOS Simulator, such as Linux, CI, or a cloud coding agent
+- An AI agent needs to verify a change in a running app instead of only inspecting source code
+- You want a temporary, shareable iOS browser preview
+- You need to offload simulator compute or test on a remote platform
+
+EAS Simulator does not replace local Xcode or Android Studio workflows when you already have the required local simulator and do not need remote or shareable access.
+
+## How it works
+
+An EAS Simulator workflow has four stages:
+
+1. **Start a session** with EAS CLI. EAS boots a remote device and the selected controller.
+2. **Install your app.** The remote device starts blank, so install a local build or an EAS Build artifact.
+3. **Drive the device.** Use [agent-device](/agents/agent-device/), Argent, or the iOS browser preview.
+4. **Stop the session.** An unattended non-interactive session continues consuming usage until it stops.
+
+EAS CLI manages the session lifecycle and connection configuration. The controller provides device actions such as opening an app, pressing a button, entering text, inspecting the accessibility tree, and capturing a screenshot.
+
+## Available surfaces
+
+| Capability                                      | Availability |
+| ----------------------------------------------- | ------------ |
+| Remote iOS Simulator                            | <YesIcon />  |
+| Remote Android Emulator                         | <YesIcon />  |
+| Programmatic control with agent-device          | <YesIcon />  |
+| Programmatic control with Argent                | <YesIcon />  |
+| Live browser preview for iOS                    | <YesIcon />  |
+| Live browser preview for Android                | <NoIcon />   |
+| Physical device access                          | <NoIcon />   |
+| App Store signing or submission                 | <NoIcon />   |
+| Fast Refresh with a development build and Metro | <YesIcon />  |
+
+Use [EAS Build](/build/introduction/) for build and signing workflows, and use local device tooling for physical devices.
+
+## Quick start
+
+Run the commands from a linked Expo project:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:availability --json',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:get --json --non-interactive',
+  ]}
+/>
+
+The start command writes **.env.eas-simulator** with the session ID and controller credentials. Run device commands through `simulator:exec` so EAS CLI loads that configuration:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./shot.png',
+  ]}
+/>
+
+Always stop the session when you finish:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+
+### Expo Skills for AI agents
+
+If you use an AI coding agent, install [Expo Skills](/skills/) so it can choose the right build, control the remote device, and clean up the session:
+
+<RelatedSkills names={['eas-simulator']} />
+
+## Next steps
+
+<BoxLink
+  title="Get started"
+  description="Check access, start your first session, and open the dashboard and browser preview."
+  href="/preview/eas-simulator/get-started"
+  Icon={Cloud01Icon}
+/>
+
+<BoxLink
+  title="Run and control your app"
+  description="Install a local or EAS build, interact with the app, and capture evidence."
+  href="/preview/eas-simulator/run-and-control"
+  Icon={Cloud01Icon}
+/>
+
+<BoxLink
+  title="CLI reference"
+  description="Review the experimental simulator commands, flags, output, and managed environment file."
+  href="/preview/eas-simulator/cli-reference"
+  Icon={Cloud01Icon}
+/>
+
+<BoxLink
+  title="Troubleshooting"
+  description="Recover from unavailable accounts, stale sessions, dropped tunnels, and incorrect builds."
+  href="/preview/eas-simulator/troubleshooting"
+  Icon={Cloud01Icon}
+/>

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -46,7 +46,6 @@ EAS CLI manages the session lifecycle and connection configuration. The controll
 | Live browser preview for iOS                    | <YesIcon />  |
 | Live browser preview for Android                | <NoIcon />   |
 | Physical device access                          | <NoIcon />   |
-| App Store signing or submission                 | <NoIcon />   |
 | Fast Refresh with a development build and Metro | <YesIcon />  |
 
 Use [EAS Build](/build/introduction/) for build and signing workflows, and use local device tooling for physical devices.

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -11,7 +11,7 @@ import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **EAS Simulator is a limited-access preview.** The CLI commands and service behavior are experimental and can change without notice. EAS Simulator uses your plan's compute allowance. See [Expo pricing](https://expo.dev/pricing) for current limits and pricing.
+> **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
 **EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, interact with it, collect screenshots and recordings, and hand an iOS browser preview to another person without running the device locally.
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -51,7 +51,7 @@ An EAS Simulator workflow has four stages:
 
 1. **Start a session** with EAS CLI. EAS boots a remote device and the selected controller.
 2. **Install your app.** The remote device starts blank, so install a local build or an EAS Build artifact.
-3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](/agents/argent/) ([repository](https://github.com/software-mansion/argent)), or the iOS browser preview.
+3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](/agents/argent/), or the iOS browser preview.
 4. **Stop the session.** An unattended non-interactive session continues consuming usage until it stops.
 
 EAS CLI manages the session lifecycle and connection configuration. The controller provides device actions such as opening an app, pressing a button, entering text, inspecting the accessibility tree, and capturing a screenshot.

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -16,14 +16,40 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 **EAS Simulator** runs a remote iOS Simulator or Android Emulator on EAS infrastructure. You can install an app, inspect its user interface, interact with it, collect screenshots and recordings, and hand an iOS browser preview to another person without running the device locally.
 
+EAS Simulator is built for agentic development. It gives coding agents a real device runtime so they can verify agent-written code, fix issues they observe, and return evidence from the running app instead of stopping after a source-code change.
+
 EAS Simulator is especially useful when:
 
-- Your development environment cannot run an iOS Simulator, such as Linux, CI, or a cloud coding agent
+- A background or cloud coding agent needs device access that is not available in its sandbox
 - An AI agent needs to verify a change in a running app instead of only inspecting source code
 - You want a temporary, shareable iOS browser preview
 - You need to offload simulator compute or test on a remote platform
 
 EAS Simulator does not replace local Xcode or Android Studio workflows when you already have the required local simulator and do not need remote or shareable access.
+
+## Close the loop on agent-written code
+
+For agentic development, the recommended starting point is the official EAS Simulator skill. Ask your coding agent to use the skill instead of manually giving it individual EAS CLI and controller commands. The skill teaches the agent how to check access, prepare the appropriate build, start a remote device, drive the app with your selected controller, collect evidence, and stop the session.
+
+<RelatedSkills names={['eas-simulator']} />
+
+For example, give your agent a prompt like:
+
+```text
+Use the EAS Simulator skill to run this project on a remote iOS Simulator. Ask me whether to use agent-device or Argent, verify <flow>, and report what you observe with a screenshot.
+```
+
+The agent can then complete the runtime loop:
+
+1. Implement or fix the code.
+2. Check EAS Simulator access and prepare a compatible app build.
+3. Start a remote device and drive the app through agent-device or Argent.
+4. Inspect the result and iterate if needed.
+5. Return screenshots, recordings, logs, or other evidence and stop the session.
+
+### Typical setup: a Cursor cloud agent
+
+A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another background coding agent working in a cloud project checkout. The environment can edit and build the project but cannot launch a local iOS Simulator. With the EAS Simulator skill, the agent starts a remote device on EAS, controls it through agent-device or Argent, and returns the result to the task or pull request. Your computer does not need to host the simulator.
 
 ## How it works
 
@@ -52,6 +78,8 @@ EAS CLI manages the session lifecycle and connection configuration. The controll
 Use [EAS Build](/build/introduction/) for build and signing workflows, and use local device tooling for physical devices.
 
 ## Quick start
+
+The EAS Simulator skill can perform this sequence for your agent. Use the commands below when you want to operate a session manually or integrate it into custom automation.
 
 Run the availability check from a linked Expo project:
 
@@ -110,12 +138,6 @@ The start command writes **.env.eas-simulator** with the session ID and controll
 Always stop the session when you finish:
 
 <Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
-
-### Expo Skills for AI agents
-
-If you use an AI coding agent, install [Expo Skills](/skills/) so it can choose the right build, control the remote device, and clean up the session:
-
-<RelatedSkills names={['eas-simulator']} />
 
 ## Next steps
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -10,6 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { RelatedSkills } from '~/ui/components/RelatedSkills';
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 > **important** **EAS Simulator is a limited-access preview.** [Contact us](https://expo.dev/contact) if you are interested in trying it.
 
@@ -30,7 +31,7 @@ An EAS Simulator workflow has four stages:
 
 1. **Start a session** with EAS CLI. EAS boots a remote device and the selected controller.
 2. **Install your app.** The remote device starts blank, so install a local build or an EAS Build artifact.
-3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](https://github.com/software-mansion/argent), or the iOS browser preview.
+3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](/agents/argent/) ([repository](https://github.com/software-mansion/argent)), or the iOS browser preview.
 4. **Stop the session.** An unattended non-interactive session continues consuming usage until it stops.
 
 EAS CLI manages the session lifecycle and connection configuration. The controller provides device actions such as opening an app, pressing a button, entering text, inspecting the accessibility tree, and capturing a screenshot.
@@ -52,25 +53,59 @@ Use [EAS Build](/build/introduction/) for build and signing workflows, and use l
 
 ## Quick start
 
-Run the commands from a linked Expo project:
+Run the availability check from a linked Expo project:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+
+Choose the controller you want to use, then start the session with its type explicitly:
+
+<Tabs>
+
+<Tab label="agent-device">
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:availability --json',
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:get --json --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
   ]}
 />
 
-The start command writes **.env.eas-simulator** with the session ID and controller credentials. Run device commands through `simulator:exec` so EAS CLI loads that configuration:
+</Tab>
+
+<Tab label="Argent">
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./shot.png',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
   ]}
 />
+
+</Tab>
+
+</Tabs>
+
+Confirm that the session is active:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:get --json --non-interactive']} />
+
+The start command writes **.env.eas-simulator** with the session ID and controller credentials. `simulator:exec` loads that configuration and runs the command for the controller you selected:
+
+<Tabs>
+
+<Tab label="agent-device">
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
+/>
+
+</Tab>
+
+<Tab label="Argent">
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
+
+</Tab>
+
+</Tabs>
 
 Always stop the session when you finish:
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -33,12 +33,6 @@ For agentic development, the recommended starting point is the official EAS Simu
 
 <RelatedSkills names={['eas-simulator']} />
 
-For example, give your agent a prompt like:
-
-```text
-Use the EAS Simulator skill to run this project on a remote iOS Simulator. Ask me whether to use agent-device or Argent, verify <flow>, and report what you observe with a screenshot.
-```
-
 The agent can then complete the runtime loop:
 
 1. Implement or fix the code.

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -30,7 +30,7 @@ An EAS Simulator workflow has four stages:
 
 1. **Start a session** with EAS CLI. EAS boots a remote device and the selected controller.
 2. **Install your app.** The remote device starts blank, so install a local build or an EAS Build artifact.
-3. **Drive the device.** Use [agent-device](/agents/agent-device/), Argent, or the iOS browser preview.
+3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](https://github.com/software-mansion/argent), or the iOS browser preview.
 4. **Stop the session.** An unattended non-interactive session continues consuming usage until it stops.
 
 EAS CLI manages the session lifecycle and connection configuration. The controller provides device actions such as opening an app, pressing a button, entering text, inspecting the accessibility tree, and capturing a screenshot.

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -57,7 +57,7 @@ Run the commands from a linked Expo project:
 <Terminal
   cmd={[
     '$ npx --yes eas-cli@latest simulator:availability --json',
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive',
     '$ npx --yes eas-cli@latest simulator:get --json --non-interactive',
   ]}
 />

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -7,7 +7,7 @@ description: Install an app on EAS Simulator and control it with agent-device, A
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-The remote device starts blank. Install a Simulator- or Emulator-compatible build before opening and controlling the app.
+The remote device starts blank. Install a simulator- or emulator-compatible build before opening and controlling the app.
 
 > **info** For agentic development, ask your coding agent to use the [EAS Simulator skill](https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-simulator/SKILL.md). It can choose the appropriate build workflow, start the remote device, drive the app, collect evidence, and stop the session. The sections below document the same workflow for manual use.
 
@@ -17,7 +17,7 @@ Choose the build type based on what you need:
 | -------------------------------------------- | ------------------------------------------- |
 | Inspect a fixed build or capture evidence    | Local release build or EAS simulator build  |
 | See current source changes with Fast Refresh | Development build connected to Metro        |
-| Use an existing EAS artifact                 | Matching iOS Simulator build or Android APK |
+| Use an existing EAS artifact                 | Matching iOS simulator build or Android APK |
 
 > **warning** A release build contains the JavaScript from build time. Connecting it to Metro does not enable Fast Refresh. Use a development build for live iteration.
 
@@ -36,7 +36,7 @@ Read the resolved app configuration before installing a build:
 
 <Terminal cmd={['$ npx expo config --json']} />
 
-Use `ios.bundleIdentifier` for iOS commands and `android.package` for Android commands. Configure the missing value in **app.json** or your dynamic app config before creating the build.
+Use `ios.bundleIdentifier` for iOS commands and `android.package` for Android commands. Configure the missing value in the [app config](/workflow/configuration/) before creating the build.
 
 ## Install an EAS Build artifact
 
@@ -59,27 +59,21 @@ Create an installable artifact for each platform in an EAS Build profile. iOS re
 
 Build the app before starting EAS Simulator. A build can take long enough for an idle simulator session to lose its controller tunnel:
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest build --platform ios --profile remote-device --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ eas build --platform ios --profile remote-device --non-interactive']} />
 
 You can also find a completed simulator build:
 
 <Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest build:list --platform ios --simulator --status finished --json --non-interactive',
-  ]}
+  cmd={['$ eas build:list --platform ios --simulator --status finished --json --non-interactive']}
 />
 
-After the build is ready, start an agent-device session and use `install-from-source`. The remote VM downloads the artifact directly:
+After the build is ready, start an agent-device session and use `install-from-source`. The remote virtual machine (VM) downloads the artifact directly:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.tar.gz" --platform ios',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ eas simulator:start --platform ios --type agent-device --non-interactive',
+    '$ eas simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.tar.gz" --platform ios',
+    '$ eas simulator:exec npx agent-device@latest open com.example.app --platform ios',
   ]}
 />
 
@@ -89,10 +83,10 @@ For Android, create and install the APK from the same profile:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest build --platform android --profile remote-device --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:start --platform android --type agent-device --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.apk" --platform android',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform android',
+    '$ eas build --platform android --profile remote-device --non-interactive',
+    '$ eas simulator:start --platform android --type agent-device --non-interactive',
+    '$ eas simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.apk" --platform android',
+    '$ eas simulator:exec npx agent-device@latest open com.example.app --platform android',
   ]}
 />
 
@@ -100,12 +94,12 @@ Replace `com.example.app` with the app's Android package. Android sessions suppo
 
 ## Install a local build with agent-device
 
-For a local iOS Simulator `.app` bundle, `install` uploads the build through the controller:
+For a local iOS simulator `.app` bundle, `install` uploads the build through the controller:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install com.example.app ./path/to/MyApp.app --platform ios',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ eas simulator:exec npx agent-device@latest install com.example.app ./path/to/MyApp.app --platform ios',
+    '$ eas simulator:exec npx agent-device@latest open com.example.app --platform ios',
   ]}
 />
 
@@ -134,11 +128,7 @@ If the machine cannot create the native build locally, configure an EAS profile 
 
 Create the build before starting the simulator session:
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest build --platform ios --profile development-simulator --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ eas build --platform ios --profile development-simulator --non-interactive']} />
 
 The same profile produces an installable Android development build when you run the build command with `--platform android`.
 
@@ -158,15 +148,13 @@ For the complete tested development-client sequence, install the [EAS Simulator 
 
 <Tab label="agent-device">
 
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
-/>
+<Terminal cmd={['$ eas simulator:exec npx agent-device@latest <command> [args...]']} />
 
 </Tab>
 
 <Tab label="Argent">
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
+<Terminal cmd={['$ eas simulator:exec argent run <tool> [args...]']} />
 
 </Tab>
 
@@ -180,21 +168,21 @@ Use these commands with a session started with `--type agent-device`:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest apps --platform ios',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ eas simulator:exec npx agent-device@latest apps --platform ios',
+    '$ eas simulator:exec npx agent-device@latest open com.example.app --platform ios',
   ]}
 />
 
 Inspect the interactive accessibility tree:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i']} />
+<Terminal cmd={['$ eas simulator:exec npx agent-device@latest snapshot -i']} />
 
 The snapshot returns references such as `@e1` and `@e2`. Use `press` to activate an element:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press @e2',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press \'label="Continue"\'',
+    '$ eas simulator:exec npx agent-device@latest press @e2',
+    '$ eas simulator:exec npx agent-device@latest press \'label="Continue"\'',
   ]}
 />
 
@@ -204,8 +192,8 @@ Enter text and capture a screenshot:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest fill @e4 "hello@example.com"',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./artifacts/result.png',
+    '$ eas simulator:exec npx agent-device@latest fill @e4 "hello@example.com"',
+    '$ eas simulator:exec npx agent-device@latest screenshot ./artifacts/result.png',
   ]}
 />
 
@@ -215,9 +203,9 @@ Record a flow:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest record start',
+    '$ eas simulator:exec npx agent-device@latest record start',
     '# Interact with the app',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest record stop ./artifacts/flow.mp4',
+    '$ eas simulator:exec npx agent-device@latest record stop ./artifacts/flow.mp4',
   ]}
 />
 
@@ -225,8 +213,8 @@ Other useful controller commands include `scroll`, `gesture`, `logs`, `network`,
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest --help',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest help workflow',
+    '$ eas simulator:exec npx agent-device@latest --help',
+    '$ eas simulator:exec npx agent-device@latest help workflow',
   ]}
 />
 
@@ -240,18 +228,14 @@ Install the Argent CLI:
 
 Start an Argent-backed session with:
 
-<Terminal
-  cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
-  ]}
-/>
+<Terminal cmd={['$ eas simulator:start --platform ios --type argent --non-interactive']} />
 
 Use these commands with a session started with `--type argent`. `simulator:exec` supplies `ARGENT_TOOLS_URL` and `ARGENT_AUTH_TOKEN` from **.env.eas-simulator**, so `argent link` is not required for commands invoked this way:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec argent run reinstall-app --udid <udid> --bundleId com.example.app --appPath ./MyApp.app',
-    '$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]',
+    '$ eas simulator:exec argent run reinstall-app --udid <udid> --bundleId com.example.app --appPath ./MyApp.app',
+    '$ eas simulator:exec argent run <tool> [args...]',
   ]}
 />
 
@@ -259,10 +243,10 @@ Argent uses its own tools and app installation commands. An Argent session does 
 
 ## Use the iOS browser preview
 
-Supported iOS sessions return a `webPreviewUrl`. Open it in a desktop browser while the session is active. It is for the person viewing the simulator; do not open it inside the remote simulator.
+Supported iOS sessions return a `webPreviewUrl`. Open it in a desktop browser while the session is active.
 
 ## Stop when finished
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+<Terminal cmd={['$ eas simulator:stop']} />
 
 If you started Metro, stop that process too.

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -130,7 +130,7 @@ Create the build before starting the simulator session:
 
 <Terminal cmd={['$ eas build --platform ios --profile development-simulator --non-interactive']} />
 
-The same profile produces an installable Android development build when you run the build command with `--platform android`.
+For Android, the same profile produces an installable APK when you run the build command with `--platform android`. No additional Android configuration is required.
 
 Start Metro with a public tunnel that the remote development client can reach:
 

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -17,7 +17,7 @@ Choose the build type based on what you need:
 | -------------------------------------------- | ------------------------------------------- |
 | Inspect a fixed build or capture evidence    | Local release build or EAS simulator build  |
 | See current source changes with Fast Refresh | Development build connected to Metro        |
-| Use an existing EAS artifact                 | Matching iOS simulator build or Android APK |
+| Use an existing EAS artifact                 | Matching iOS Simulator build or Android APK |
 
 > **warning** A release build contains the JavaScript from build time. Connecting it to Metro does not enable Fast Refresh. Use a development build for live iteration.
 

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -5,6 +5,7 @@ description: Install an app on EAS Simulator and control it with agent-device, A
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 The remote device starts blank. Install a Simulator- or Emulator-compatible build before opening and controlling the app.
 
@@ -17,6 +18,15 @@ Choose the build type based on what you need:
 | Use an existing EAS artifact                 | Matching iOS Simulator build or Android APK |
 
 > **warning** A release build contains the JavaScript from build time. Connecting it to Metro does not enable Fast Refresh. Use a development build for live iteration.
+
+## Choose a controller
+
+Choose a controller before starting the session and pass its type explicitly. Use that controller's commands for the rest of the session.
+
+| Controller   | Start option          | Documentation                                  |
+| ------------ | --------------------- | ---------------------------------------------- |
+| agent-device | `--type agent-device` | [agent-device and Expo](/agents/agent-device/) |
+| Argent       | `--type argent`       | [Argent and Expo](/agents/argent/)             |
 
 ## Find the app identifier
 
@@ -61,11 +71,11 @@ You can also find a completed simulator build:
   ]}
 />
 
-After the build is ready, start the simulator session and use `install-from-source`. The remote VM downloads the artifact directly:
+After the build is ready, start an agent-device session and use `install-from-source`. The remote VM downloads the artifact directly:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.tar.gz" --platform ios',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
   ]}
@@ -78,7 +88,7 @@ For Android, create and install the APK from the same profile:
 <Terminal
   cmd={[
     '$ npx --yes eas-cli@latest build --platform android --profile remote-device --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:start --platform android --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform android --type agent-device --non-interactive',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.apk" --platform android',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform android',
   ]}
@@ -86,7 +96,7 @@ For Android, create and install the APK from the same profile:
 
 Replace `com.example.app` with the app's Android package. Android sessions support controller-driven interactions and screenshots, but not the live browser preview.
 
-## Install a local build
+## Install a local build with agent-device
 
 For a local iOS Simulator `.app` bundle, `install` uploads the build through the controller:
 
@@ -138,11 +148,33 @@ Install and open the development build, then enter the public Metro URL in the d
 
 For the complete tested development-client sequence, install the [EAS Simulator skill](https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-simulator/SKILL.md).
 
+## Run controller commands with `simulator:exec`
+
+`simulator:exec` is controller-neutral. It loads the active session's connection environment and runs the command that follows. Use the command pattern for the controller selected when the session started:
+
+<Tabs>
+
+<Tab label="agent-device">
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest <command> [args...]']}
+/>
+
+</Tab>
+
+<Tab label="Argent">
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]']} />
+
+</Tab>
+
+</Tabs>
+
 ## Control the app with agent-device
 
 For installation and broader controller guidance, see [agent-device and Expo](/agents/agent-device/).
 
-Every device command should run through `simulator:exec`. It loads the controller URL and token from **.env.eas-simulator**:
+Use these commands with a session started with `--type agent-device`:
 
 <Terminal
   cmd={[
@@ -196,13 +228,7 @@ Other useful controller commands include `scroll`, `gesture`, `logs`, `network`,
   ]}
 />
 
-## Use the iOS browser preview
-
-An iOS `agent-device` session also starts a browser preview. Open the `webPreviewUrl` printed by `simulator:start` in a desktop browser.
-
-The preview URL is temporary and works only while the session is active. It is for the person viewing the simulator; do not open it inside the remote simulator.
-
-## Use Argent instead
+## Control the app with Argent
 
 For installation and broader controller guidance, see [Argent and Expo](/agents/argent/).
 
@@ -218,7 +244,7 @@ Start an Argent-backed session with:
   ]}
 />
 
-Run Argent commands through `simulator:exec`, just like agent-device commands. The wrapper loads `ARGENT_TOOLS_URL` and `ARGENT_AUTH_TOKEN` from **.env.eas-simulator**, so `argent link` is not required for commands invoked this way:
+Use these commands with a session started with `--type argent`. `simulator:exec` supplies `ARGENT_TOOLS_URL` and `ARGENT_AUTH_TOKEN` from **.env.eas-simulator**, so `argent link` is not required for commands invoked this way:
 
 <Terminal
   cmd={[
@@ -228,6 +254,10 @@ Run Argent commands through `simulator:exec`, just like agent-device commands. T
 />
 
 Argent uses its own tools and app installation commands. An Argent session does not also provision an agent-device daemon, so do not run agent-device commands against it.
+
+## Use the iOS browser preview
+
+Supported iOS sessions return a `webPreviewUrl`. Open it in a desktop browser while the session is active. It is for the person viewing the simulator; do not open it inside the remote simulator.
 
 ## Stop when finished
 

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -9,6 +9,8 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 The remote device starts blank. Install a Simulator- or Emulator-compatible build before opening and controlling the app.
 
+> **info** For agentic development, ask your coding agent to use the [EAS Simulator skill](https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-simulator/SKILL.md). It can choose the appropriate build workflow, start the remote device, drive the app, collect evidence, and stop the session. The sections below document the same workflow for manual use.
+
 Choose the build type based on what you need:
 
 | Goal                                         | Build type                                  |

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -65,7 +65,7 @@ After the build is ready, start the simulator session and use `install-from-sour
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --non-interactive',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.tar.gz" --platform ios',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
   ]}
@@ -78,7 +78,7 @@ For Android, create and install the APK from the same profile:
 <Terminal
   cmd={[
     '$ npx --yes eas-cli@latest build --platform android --profile remote-device --non-interactive',
-    '$ npx --yes eas-cli@latest simulator:start --platform android --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform android --non-interactive',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.apk" --platform android',
     '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform android',
   ]}

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -1,0 +1,219 @@
+---
+title: Run and control an app
+sidebar_title: Run and control an app
+description: Install an app on EAS Simulator and control it with agent-device, Argent, or the iOS browser preview.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+The remote device starts blank. Install a Simulator- or Emulator-compatible build before opening and controlling the app.
+
+Choose the build type based on what you need:
+
+| Goal                                         | Build type                                  |
+| -------------------------------------------- | ------------------------------------------- |
+| Inspect a fixed build or capture evidence    | Local release build or EAS simulator build  |
+| See current source changes with Fast Refresh | Development build connected to Metro        |
+| Use an existing EAS artifact                 | Matching iOS Simulator build or Android APK |
+
+> **warning** A release build contains the JavaScript from build time. Connecting it to Metro does not enable Fast Refresh. Use a development build for live iteration.
+
+## Find the app identifier
+
+Read the resolved app configuration before installing a build:
+
+<Terminal cmd={['$ npx expo config --json']} />
+
+Use `ios.bundleIdentifier` for iOS commands and `android.package` for Android commands. Configure the missing value in **app.json** or your dynamic app config before creating the build.
+
+## Install an EAS Build artifact
+
+Create an installable artifact for each platform in an EAS Build profile. iOS requires `ios.simulator: true`, and Android requires an [APK build](/build-reference/apk/):
+
+```json eas.json
+{
+  "build": {
+    "remote-device": {
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    }
+  }
+}
+```
+
+Build the app before starting EAS Simulator. A build can take long enough for an idle simulator session to lose its controller tunnel:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest build --platform ios --profile remote-device --non-interactive',
+  ]}
+/>
+
+You can also find a completed simulator build:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest build:list --platform ios --simulator --status finished --json --non-interactive',
+  ]}
+/>
+
+After the build is ready, start the simulator session and use `install-from-source`. The remote VM downloads the artifact directly:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.tar.gz" --platform ios',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+  ]}
+/>
+
+Replace `com.example.app` with the app's iOS bundle identifier.
+
+For Android, create and install the APK from the same profile:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest build --platform android --profile remote-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:start --platform android --type agent-device --non-interactive',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install-from-source "https://expo.dev/artifacts/eas/<artifact>.apk" --platform android',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform android',
+  ]}
+/>
+
+Replace `com.example.app` with the app's Android package. Android sessions support controller-driven interactions and screenshots, but not the live browser preview.
+
+## Install a local build
+
+For a local iOS Simulator `.app` bundle, `install` uploads the build through the controller:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install com.example.app ./path/to/MyApp.app --platform ios',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+  ]}
+/>
+
+Large local builds take longer because the client uploads them from your machine. Prefer `install-from-source` when an EAS artifact URL is available.
+
+For a local Android APK, use the same command with the Android package, APK path, and `--platform android`.
+
+## Use a development build for live changes
+
+Live iteration requires a [development build](/develop/development-builds/introduction/) with `expo-dev-client`. The development build loads JavaScript from Metro instead of relying only on the bundle embedded at build time.
+
+If the machine cannot create the native build locally, configure an EAS profile with both `developmentClient: true` and `ios.simulator: true`:
+
+```json eas.json
+{
+  "build": {
+    "development-simulator": {
+      "developmentClient": true,
+      "ios": {
+        "simulator": true
+      }
+    }
+  }
+}
+```
+
+Create the build before starting the simulator session:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest build --platform ios --profile development-simulator --non-interactive',
+  ]}
+/>
+
+The same profile produces an installable Android development build when you run the build command with `--platform android`.
+
+Start Metro with a public tunnel that the remote development client can reach:
+
+<Terminal cmd={['$ EXPO_UNSTABLE_TUNNEL_V2=1 npx expo start --tunnel']} />
+
+Install and open the development build, then enter the public Metro URL in the development client's **Enter URL manually** flow. Keep exactly one Metro process running. After the first bundle loads, Fast Refresh sends source edits to the remote app.
+
+For the complete tested development-client sequence, install the [EAS Simulator skill](https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-simulator/SKILL.md).
+
+## Control the app with agent-device
+
+Every device command should run through `simulator:exec`. It loads the controller URL and token from **.env.eas-simulator**:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest apps --platform ios',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+  ]}
+/>
+
+Inspect the interactive accessibility tree:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i']} />
+
+The snapshot returns references such as `@e1` and `@e2`. Use `press` to activate an element:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press @e2',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press \'label="Continue"\'',
+  ]}
+/>
+
+The action is named `press`, not `tap` or `click`.
+
+Enter text and capture a screenshot:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest fill @e4 "hello@example.com"',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./artifacts/result.png',
+  ]}
+/>
+
+The screenshot is downloaded to the machine running the command.
+
+Record a flow:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest record start',
+    '# Interact with the app',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest record stop ./artifacts/flow.mp4',
+  ]}
+/>
+
+Other useful controller commands include `scroll`, `gesture`, `logs`, `network`, and `perf`. Read the version-matched help through the active session:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest --help',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest help workflow',
+  ]}
+/>
+
+## Use the iOS browser preview
+
+An iOS `agent-device` session also starts a browser preview. Open the `webPreviewUrl` printed by `simulator:start` in a desktop browser.
+
+The preview URL is temporary and works only while the session is active. It is for the person viewing the simulator; do not open it inside the remote simulator.
+
+## Use Argent instead
+
+Start an Argent-backed session with:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:start --platform ios --type argent --non-interactive',
+  ]}
+/>
+
+Argent uses its own connection variables and app installation commands. An Argent session does not also provision an agent-device daemon, so do not run agent-device commands against it. Follow the connection instructions printed by EAS CLI.
+
+## Stop when finished
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+
+If you started Metro, stop that process too.

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -202,6 +202,10 @@ The preview URL is temporary and works only while the session is active. It is f
 
 ## Use Argent instead
 
+Install the Argent CLI:
+
+<Terminal cmd={['$ npm install --global @swmansion/argent']} />
+
 Start an Argent-backed session with:
 
 <Terminal
@@ -210,7 +214,16 @@ Start an Argent-backed session with:
   ]}
 />
 
-Argent uses its own connection variables and app installation commands. An Argent session does not also provision an agent-device daemon, so do not run agent-device commands against it. Follow the connection instructions printed by EAS CLI.
+Run Argent commands through `simulator:exec`, just like agent-device commands. The wrapper loads `ARGENT_TOOLS_URL` and `ARGENT_AUTH_TOKEN` from **.env.eas-simulator**, so `argent link` is not required for commands invoked this way:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec argent run reinstall-app --udid <udid> --bundleId com.example.app --appPath ./MyApp.app',
+    '$ npx --yes eas-cli@latest simulator:exec argent run <tool> [args...]',
+  ]}
+/>
+
+Argent uses its own tools and app installation commands. An Argent session does not also provision an agent-device daemon, so do not run agent-device commands against it.
 
 ## Stop when finished
 

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -140,6 +140,8 @@ For the complete tested development-client sequence, install the [EAS Simulator 
 
 ## Control the app with agent-device
 
+For installation and broader controller guidance, see [agent-device and Expo](/agents/agent-device/).
+
 Every device command should run through `simulator:exec`. It loads the controller URL and token from **.env.eas-simulator**:
 
 <Terminal
@@ -201,6 +203,8 @@ An iOS `agent-device` session also starts a browser preview. Open the `webPrevie
 The preview URL is temporary and works only while the session is active. It is for the person viewing the simulator; do not open it inside the remote simulator.
 
 ## Use Argent instead
+
+For installation and broader controller guidance, see [Argent and Expo](/agents/argent/).
 
 Install the Argent CLI:
 

--- a/docs/pages/preview/eas-simulator/troubleshooting.mdx
+++ b/docs/pages/preview/eas-simulator/troubleshooting.mdx
@@ -10,9 +10,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ### `Command simulator:start not found`
 
-The installed EAS CLI is too old. Run the command with the latest version:
+The installed EAS CLI is too old. [Install or update EAS CLI](/eas/cli/), then inspect the command:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --help']} />
+<Terminal cmd={['$ eas simulator:start --help']} />
 
 The commands remain hidden because the API is experimental.
 
@@ -22,21 +22,21 @@ The commands remain hidden because the API is experimental.
 
 Check before starting:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+<Terminal cmd={['$ eas simulator:availability --json']} />
 
-If `available` is `false`, do not retry `simulator:start`. Use a local Simulator or Emulator, or wait for access to be enabled.
+If `available` is `false`, do not retry `simulator:start`. Use a local simulator or emulator, or wait for access to be enabled.
 
 ### EAS CLI reports that a user account is required
 
 Log in interactively or provide `EXPO_TOKEN` in a headless environment:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest whoami']} />
+<Terminal cmd={['$ eas whoami']} />
 
 ### EAS CLI reports that the project is not linked
 
 Run the command inside the Expo project and initialize EAS:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest init']} />
+<Terminal cmd={['$ eas init']} />
 
 ## Session lifecycle problems
 
@@ -44,29 +44,15 @@ Run the command inside the Expo project and initialize EAS:
 
 Boot time varies with device capacity. Do not start a second session to retry a slow boot. Poll the existing session:
 
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:get --id <session-id> --json --non-interactive']}
-/>
+<Terminal cmd={['$ eas simulator:get --id <session-id> --json --non-interactive']} />
 
 Continue when the status is `IN_PROGRESS` and `remoteConfig` is present. Stop and recreate the session only after it reaches `STOPPED` or `ERRORED`, or the start command reports a terminal failure.
-
-### Two sessions are running
-
-Starting another session replaces the ID in **.env.eas-simulator** but does not stop the old device. List active sessions:
-
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
-/>
-
-Stop each unwanted ID:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
 
 ### A non-interactive session did not stop automatically
 
 `--non-interactive` returns after the controller is ready. It does not stop the session. Run:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+<Terminal cmd={['$ eas simulator:stop']} />
 
 ## Controller and tunnel problems
 
@@ -80,7 +66,7 @@ Stop the session if it is still active, then start a fresh session and repeat in
 
 The agent-device action is named `press`:
 
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press @e2']} />
+<Terminal cmd={['$ eas simulator:exec npx agent-device@latest press @e2']} />
 
 ### A controller action hangs
 
@@ -92,7 +78,7 @@ Pass the platform:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install com.example.app ./MyApp.app --platform ios',
+    '$ eas simulator:exec npx agent-device@latest install com.example.app ./MyApp.app --platform ios',
   ]}
 />
 
@@ -102,8 +88,8 @@ Open an installed app before taking the screenshot:
 
 <Terminal
   cmd={[
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
-    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./shot.png',
+    '$ eas simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ eas simulator:exec npx agent-device@latest screenshot ./shot.png',
   ]}
 />
 
@@ -111,7 +97,7 @@ Open an installed app before taking the screenshot:
 
 ### The remote device does not contain the app
 
-This is expected. Each session starts with a blank device. Install a local Simulator or Emulator build, or use `install-from-source` with an EAS Build artifact.
+This is expected. Each session starts with a blank device. Install a local simulator or emulator build, or use `install-from-source` with an EAS Build artifact.
 
 ### The screenshot shows old source code
 
@@ -143,16 +129,6 @@ Android browser preview is not currently supported. Use agent-device or Argent a
 ### The preview appears inside the simulator
 
 The `webPreviewUrl` was opened as though it were an app URL. Open it in the desktop browser instead. It is a browser stream, not an application deep link.
-
-## Unexpected usage
-
-List all active sessions for the current project:
-
-<Terminal
-  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
-/>
-
-Stop every session that is no longer needed.
 
 ## Report feedback
 

--- a/docs/pages/preview/eas-simulator/troubleshooting.mdx
+++ b/docs/pages/preview/eas-simulator/troubleshooting.mdx
@@ -24,7 +24,7 @@ Check before starting:
 
 <Terminal cmd={['$ eas simulator:availability --json']} />
 
-If `available` is `false`, do not retry `simulator:start`. Use a local simulator or emulator, or wait for access to be enabled.
+If `available` is `false`, do not retry `simulator:start`. Use a local simulator or emulator, or [join the waitlist](https://expo.dev/services/simulator) for access.
 
 ### EAS CLI reports that a user account is required
 
@@ -42,11 +42,11 @@ Run the command inside the Expo project and initialize EAS:
 
 ### The session takes a long time to start
 
-Boot time varies with device capacity. Do not start a second session to retry a slow boot. Poll the existing session:
+Boot time varies with device capacity. While the device is starting, poll the existing session:
 
 <Terminal cmd={['$ eas simulator:get --id <session-id> --json --non-interactive']} />
 
-Continue when the status is `IN_PROGRESS` and `remoteConfig` is present. Stop and recreate the session only after it reaches `STOPPED` or `ERRORED`, or the start command reports a terminal failure.
+The session is ready when the status is `IN_PROGRESS` and `remoteConfig` is present. If it reaches `STOPPED` or `ERRORED`, or the start command reports a terminal failure, start a new session. Starting a second session while the first is still booting does not speed up the process.
 
 ### A non-interactive session did not stop automatically
 
@@ -70,7 +70,11 @@ The agent-device action is named `press`:
 
 ### A controller action hangs
 
-Some iOS snapshots and interactions can take tens of seconds. If an action times out, take a fresh `snapshot -i` before retrying. The original action may have reached the device even when the response was delayed, and blindly retrying can perform it twice.
+Some iOS snapshots and interactions can take tens of seconds. If an action times out, refresh the interactive accessibility tree before retrying:
+
+<Terminal cmd={['$ eas simulator:exec npx agent-device@latest snapshot -i']} />
+
+The original action may have reached the device even when the response was delayed, and blindly retrying can perform it twice.
 
 ### `install requires an active session or an explicit device selector`
 

--- a/docs/pages/preview/eas-simulator/troubleshooting.mdx
+++ b/docs/pages/preview/eas-simulator/troubleshooting.mdx
@@ -152,7 +152,7 @@ List all active sessions for the current project:
   cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
 />
 
-Stop every session that is no longer needed. For sessions kept open for another person, set `--max-duration-minutes` when the account supports it and tell the person when the session will stop.
+Stop every session that is no longer needed.
 
 ## Report feedback
 

--- a/docs/pages/preview/eas-simulator/troubleshooting.mdx
+++ b/docs/pages/preview/eas-simulator/troubleshooting.mdx
@@ -1,0 +1,175 @@
+---
+title: Troubleshoot EAS Simulator
+sidebar_title: Troubleshooting
+description: Diagnose access, session lifecycle, controller, installation, preview, and Fast Refresh issues in EAS Simulator.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+## Command not found
+
+### `Command simulator:start not found`
+
+The installed EAS CLI is too old. Run the command with the latest version:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:start --help']} />
+
+The commands remain hidden because the API is experimental.
+
+## Access and project errors
+
+### EAS Simulator is not enabled for the account
+
+Check before starting:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:availability --json']} />
+
+If `available` is `false`, do not retry `simulator:start`. Use a local Simulator or Emulator, or wait for access to be enabled.
+
+### EAS CLI reports that a user account is required
+
+Log in interactively or provide `EXPO_TOKEN` in a headless environment:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest whoami']} />
+
+### EAS CLI reports that the project is not linked
+
+Run the command inside the Expo project and initialize EAS:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest init']} />
+
+## Session lifecycle problems
+
+### The session takes a long time to start
+
+Boot time varies with device capacity. Do not start a second session to retry a slow boot. Poll the existing session:
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:get --id <session-id> --json --non-interactive']}
+/>
+
+Continue when the status is `IN_PROGRESS` and `remoteConfig` is present. Stop and recreate the session only after it reaches `STOPPED` or `ERRORED`, or the start command reports a terminal failure.
+
+### Two sessions are running
+
+Starting another session replaces the ID in **.env.eas-simulator** but does not stop the old device. List active sessions:
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
+/>
+
+Stop each unwanted ID:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
+
+### The dotenv file points to a stopped session
+
+Confirm that the session is stopped, then remove the stale file:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop', '$ rm -f .env.eas-simulator']} />
+
+Do not clear the file before stopping unless you saved the session ID elsewhere.
+
+### A non-interactive session did not stop automatically
+
+`--non-interactive` returns after the controller is ready. It does not stop the session. Run:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop']} />
+
+## Controller and tunnel problems
+
+### `Remote daemon is unavailable` or the tunnel endpoint is offline
+
+The controller tunnel has dropped or the remote VM has ended. A dropped controller invalidates the installed app state, accessibility references, and connection configuration.
+
+Stop the session if it is still active, remove **.env.eas-simulator**, then start a fresh session and repeat install → open → drive. Do not repeatedly retry a controller command against the dead endpoint.
+
+### `Unknown command: tap` or `Unknown command: click`
+
+The agent-device action is named `press`:
+
+<Terminal cmd={['$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest press @e2']} />
+
+### A controller action hangs
+
+Some iOS snapshots and interactions can take tens of seconds. If an action times out, take a fresh `snapshot -i` before retrying. The original action may have reached the device even when the response was delayed, and blindly retrying can perform it twice.
+
+### `install requires an active session or an explicit device selector`
+
+Pass the platform:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest install com.example.app ./MyApp.app --platform ios',
+  ]}
+/>
+
+### Screenshot reports that there is no active session
+
+Open an installed app before taking the screenshot:
+
+<Terminal
+  cmd={[
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest open com.example.app --platform ios',
+    '$ npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./shot.png',
+  ]}
+/>
+
+## App and build problems
+
+### The remote device does not contain the app
+
+This is expected. Each session starts with a blank device. Install a local Simulator or Emulator build, or use `install-from-source` with an EAS Build artifact.
+
+### The screenshot shows old source code
+
+A release build embeds JavaScript at build time. Rebuild it from the current source, confirm that an existing EAS Build has the matching fingerprint, or install a development build and connect it to Metro.
+
+Changing source files does not update an already-installed release build.
+
+### Fast Refresh does not work
+
+Confirm all of the following:
+
+- The installed binary is a development build with `expo-dev-client`, not a release build
+- Metro is running once, without another process occupying port 8081
+- The development client is connected to the public Metro tunnel URL
+- The simulator session and controller are still active
+
+Use tunnel v2 in remote or headless agent environments:
+
+<Terminal cmd={['$ EXPO_UNSTABLE_TUNNEL_V2=1 npx expo start --tunnel']} />
+
+If the first connection fails, reset the simulator session and Metro once, then repeat the documented development-build flow. Reconnecting a release build cannot enable Fast Refresh.
+
+## Browser preview problems
+
+### Android did not return a `webPreviewUrl`
+
+Android browser preview is not currently supported. Use agent-device or Argent and collect screenshots or recordings instead.
+
+### The preview appears inside the simulator
+
+The `webPreviewUrl` was opened as though it were an app URL. Open it in the desktop browser instead. It is a browser stream, not an application deep link.
+
+## Unexpected usage
+
+List all active sessions for the current project:
+
+<Terminal
+  cmd={['$ npx --yes eas-cli@latest simulator:list --status in-progress --json --non-interactive']}
+/>
+
+Stop every session that is no longer needed. For sessions kept open for another person, set `--max-duration-minutes` when the account supports it and tell the person when the session will stop.
+
+## Report feedback
+
+EAS Simulator and its CLI are experimental. Include the EAS CLI version, session ID, platform, controller type, and failing command when reporting a problem.
+
+For feedback about the official EAS Simulator skill:
+
+<Terminal
+  cmd={[
+    '$ npx --yes submit-expo-feedback@latest --category skills --subject "eas-simulator" "<actionable feedback>"',
+  ]}
+/>

--- a/docs/pages/preview/eas-simulator/troubleshooting.mdx
+++ b/docs/pages/preview/eas-simulator/troubleshooting.mdx
@@ -62,14 +62,6 @@ Stop each unwanted ID:
 
 <Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop --id <session-id>']} />
 
-### The dotenv file points to a stopped session
-
-Confirm that the session is stopped, then remove the stale file:
-
-<Terminal cmd={['$ npx --yes eas-cli@latest simulator:stop', '$ rm -f .env.eas-simulator']} />
-
-Do not clear the file before stopping unless you saved the session ID elsewhere.
-
 ### A non-interactive session did not stop automatically
 
 `--non-interactive` returns after the controller is ready. It does not stop the session. Run:
@@ -82,7 +74,7 @@ Do not clear the file before stopping unless you saved the session ID elsewhere.
 
 The controller tunnel has dropped or the remote VM has ended. A dropped controller invalidates the installed app state, accessibility references, and connection configuration.
 
-Stop the session if it is still active, remove **.env.eas-simulator**, then start a fresh session and repeat install → open → drive. Do not repeatedly retry a controller command against the dead endpoint.
+Stop the session if it is still active, then start a fresh session and repeat install → open → drive. Do not repeatedly retry a controller command against the dead endpoint.
 
 ### `Unknown command: tap` or `Unknown command: click`
 


### PR DESCRIPTION
## Summary

- add a hidden EAS Simulator documentation section under `/preview/eas-simulator/`
- document availability checks, session lifecycle, expo.dev session pages, and the iOS browser preview
- add copy-pasteable iOS Simulator and Android Emulator build, install, and control workflows
- add a CLI reference and troubleshooting guide for the experimental `simulator:*` commands
- expose the section only in preview navigation, which remains excluded from the public sitemap and search indexing

## Why

The existing EAS Simulator instructions predate the current CLI lifecycle, project session pages, managed `.env.eas-simulator` configuration, Android support, agent-device verbs, development-build workflow, and Expo skill. This gives limited-access users a current service-style documentation set without publishing it in the main docs navigation.

## Validation

- formatted all changed files with `oxfmt`
- compiled all five new pages with `@mdx-js/mdx`
- verified every new internal documentation link resolves
- ran `git diff --check`

A full Next.js docs build was not run because the checkout does not have the docs dependencies installed.