### PR TITLE
chore: Clean up `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,6 @@
 * text=auto eol=lf
 *.pbxproj merge=union -text diff linguist-generated
 
-packages/*/build/** -diff linguist-generated eol=lf
-packages/*/plugin/build/** -diff linguist-generated eol=lf
-packages/*/cli/build/** -diff linguist-generated eol=lf
-packages/*/utils/build/** -diff linguist-generated eol=lf
-packages/*/scripts/build/** -diff linguist-generated eol=lf
-
-packages/@*/*/build/** -diff linguist-generated eol=lf
-packages/@*/*/plugin/build/** -diff linguist-generated eol=lf
-packages/@*/*/cli/build/** -diff linguist-generated eol=lf
-packages/@*/*/utils/build/** -diff linguist-generated eol=lf
-packages/@*/*/scripts/build/** -diff linguist-generated eol=lf
-
 ios/vendored/** linguist-vendored
 ios/versioned/** linguist-vendored
 ios/versioned-react-native/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,2 @@
 * text=auto eol=lf
 *.pbxproj merge=union -text diff linguist-generated
-
-ios/vendored/** linguist-vendored
-ios/versioned/** linguist-vendored
-ios/versioned-react-native/** linguist-vendored
-android/vendored/** linguist-vendored
-android/versioned-abis/** linguist-vendored
-android/versioned-react-native/** linguist-vendored
-packages/expo-dev-menu/vendored/** linguist-vendored


### PR DESCRIPTION
# Why

I've noticed that most entries in here are unused or invalid now.
- `build` files aren't committed anymore on `main`
- the remaining `ios|android` rules seem unused

It seems to be more risky now to ignore files that correspond to a now unused pattern, and we should remove the obsolete entries, to prevent us from accidentally missing committed files that just happen to be matching these patterns.

There's a trade-off here for `@expo/log-box` bundles potentially that I didn't check, but if this does occur we should add a new rule. However, this is due a refactor anyway.

# How

- Remove `/build/` rules from `.gitattributes`
- Remove `/{ios,android}/` vendored rules from `.gitattributes`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
