### PR TITLE
[ios][fetch] Fix text() / arrayBuffer() never settling after mid-response failure

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered.
+- [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered. ([#48230](https://github.com/expo/expo/pull/48230) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered.
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -72,14 +72,22 @@ public final class ExpoFetchModule: Module {
       Property("redirected", \.redirected)
 
       AsyncFunction("arrayBuffer") { (response: NativeResponse, promise: Promise) in
-        response.waitFor(states: [.bodyCompleted]) { _ in
+        response.waitFor(states: [.bodyCompleted, .errorReceived]) { state in
+          if state == .errorReceived {
+            promise.reject(response.error ?? FetchUnknownException())
+            return
+          }
           let data = response.sink.finalize()
           promise.resolve(NativeArrayBuffer.wrap(dataWithoutCopy: data))
         }
       }.runOnQueue(fetchRequestQueue)
 
       AsyncFunction("text") { (response: NativeResponse, promise: Promise) in
-        response.waitFor(states: [.bodyCompleted]) { _ in
+        response.waitFor(states: [.bodyCompleted, .errorReceived]) { state in
+          if state == .errorReceived {
+            promise.reject(response.error ?? FetchUnknownException())
+            return
+          }
           let data = response.sink.finalize()
           let text = String(decoding: data, as: UTF8.self)
           promise.resolve(text)


### PR DESCRIPTION
# Why

Fixes #48124. `Response.text()` and `Response.arrayBuffer()` in `expo/fetch` never settle when the request fails (dropped socket, `abort()`) after the response headers / first body bytes were already delivered. The promise is stranded forever, since `waitFor` only fires on a transition _into_ a listed state and `.errorReceived` is terminal.

# How

In `ios/Fetch/ExpoFetchModule.swift`, both `text` and `arrayBuffer` now `waitFor(states: [.bodyCompleted, .errorReceived])` instead of `.bodyCompleted` alone, and reject with `response.error` when the state is `.errorReceived`.

# Test Plan

Reproduced with the minimal repro app linked in #48124

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
