### PR TITLE
[docs] add how to disable caches in workflows

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -15,7 +15,7 @@ The `cache` field on build profiles in [eas.json](/build/eas-json) can be used t
 
 EAS Build runs an npm cache server that can speed up downloading JavaScript dependencies for your build jobs. By default, projects using npm or Yarn 2+ will use the cache. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache in your project's **package.json**.
 
-To disable using our npm cache server for your builds set the `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in **eas.json**.
+To disable the npm cache server, set the `EAS_BUILD_DISABLE_NPM_CACHE` environment variable to `"1"` in **eas.json**. If you use EAS Workflows, set it in a job's [`env`](/eas/workflows/syntax/#jobsjob_idenv) instead.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -48,7 +48,7 @@ Currently, we are caching:
 - `google` - [https://maven.google.com/](https://maven.google.com/)
 - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
 
-To disable using our Maven cache server for your builds set the `EAS_BUILD_DISABLE_MAVEN_CACHE` env variable value to `"1"` in **eas.json**.
+To disable the Maven cache server, set the `EAS_BUILD_DISABLE_MAVEN_CACHE` environment variable to `"1"` in **eas.json**. If you use EAS Workflows, set it in a job's [`env`](/eas/workflows/syntax/#jobsjob_idenv) instead.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -236,7 +236,7 @@ jobs:
 
 EAS Build serves most CocoaPods artifacts from a cache server. This improves the consistency of `pod install` times and generally improves speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.
 
-To disable using our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+To disable the CocoaPods cache server, set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` environment variable to `"1"` in **eas.json**. If you use EAS Workflows, set it in a job's [`env`](/eas/workflows/syntax/#jobsjob_idenv) instead.
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/eas/environment-variables/usage.mdx
+++ b/docs/pages/eas/environment-variables/usage.mdx
@@ -70,6 +70,9 @@ The following environment variables are additional system environment variables 
 - `EAS_BUILD_USERNAME`: The username of the user initiating the build (it's undefined for bot users)
 - `EAS_BUILD_WORKINGDIR`: The remote directory path with your project
 - `EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP`: Set to `1` to skip the early JavaScript bundling check. By default, EAS Build runs the JavaScript bundler before the native build to surface JS errors earlier. Disabling this step means JavaScript errors won't be caught until the native build step.
+- `EAS_BUILD_DISABLE_NPM_CACHE`: Set to `1` to disable the npm cache server ([learn more about caching JavaScript dependencies](/build-reference/caching/#javascript-dependencies))
+- `EAS_BUILD_DISABLE_MAVEN_CACHE`: Set to `1` to disable the Maven cache server ([learn more about caching Android dependencies](/build-reference/caching/#android-dependencies))
+- `EAS_BUILD_DISABLE_COCOAPODS_CACHE`: Set to `1` to disable the CocoaPods cache server ([learn more about caching iOS dependencies](/build-reference/caching/#ios-dependencies))
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

The variables that turn off the npm, Maven, and CocoaPods cache servers were documented only as **eas.json** settings, and the EAS Workflows docs did not mention these caches at all. A custom job has no build profile, so **eas.json** is not a place it can set them.

# How

I did not add an `### EAS Workflows` section to the caching page. It already has a heading with that name under the ccache section, so a second one would get a duplicate-suffixed anchor whose value depends on heading order, and there is nothing to say about workflows beyond where the variable goes. The entries in the built-in variable list are what make these variables reachable from the EAS Workflows environment page, which already links to that list.

The "Currently, we are caching:" sentence just above the Maven edit still uses the first person. I left it alone to keep the diff focused.

# Test Plan

I verified that a job's `env` is where these three variables are read during a build, so the guidance holds for pre-packaged `build` jobs and for custom jobs. The new links point at `jobs.<job_id>.env` in the workflow syntax reference, an anchor other pages already link to.

CI passes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
