### PR TITLE
[docs] Update `eas/checkout` docs by informing about the `ref` input

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -930,7 +930,7 @@ build:
     # @end #
 ```
 
-The `ref` input only works when your project sources come from a Git repository. Place the step before [`eas/build`](#easbuild), which checks out the project internally.
+The `ref` input only works when your project sources come from a Git repository, for example, a build triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. A branch takes a bare name or a qualified ref such as `refs/heads/feature/add-icon`. A tag takes the qualified form, such as `refs/tags/v1.2.3`. A commit takes a full SHA. Place the step before [`eas/build`](#easbuild), which checks out the project internally.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -919,6 +919,8 @@ build:
         run: ls assets
 ```
 
+For builds with Git-based project sources, the step uses the build's recorded commit by default. Use `ref` to check out a different branch, tag, or commit:
+
 ```yaml example.yml
 build:
   name: Check out a specific ref
@@ -928,9 +930,16 @@ build:
         inputs:
           ref: feature/add-icon
     # @end #
+    - eas/build
 ```
 
-The `ref` input only works when your project sources come from a Git repository, for example, a build triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. A branch takes a bare name or a qualified ref such as `refs/heads/feature/add-icon`. A tag takes the qualified form, such as `refs/tags/v1.2.3`. A commit takes a full SHA. Place the step before [`eas/build`](#easbuild), which checks out the project internally.
+`ref` accepts:
+
+- A branch, as a bare name such as `feature/add-icon` or a qualified ref such as `refs/heads/feature/add-icon`. The repository ends up on that branch.
+- A tag, as a qualified ref such as `refs/tags/v1.2.3`. The repository ends up on a detached `HEAD`.
+- A full commit SHA. The repository ends up on a detached `HEAD`.
+
+The `ref` input only works when your project sources come from a Git repository, for example, a build triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Place the step before [`eas/build`](#easbuild), which checks out the project internally.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -930,7 +930,7 @@ build:
     # @end #
 ```
 
-The `ref` input requires Git-based project sources and must be set before [`eas/build`](#easbuild), which checks out the project internally.
+The `ref` input only works when your project sources come from a Git repository. Place the step before [`eas/build`](#easbuild), which checks out the project internally.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -919,6 +919,19 @@ build:
         run: ls assets
 ```
 
+```yaml example.yml
+build:
+  name: Check out a specific ref
+  steps:
+    # @info #
+    - eas/checkout:
+        inputs:
+          ref: feature/add-icon
+    # @end #
+```
+
+The `ref` input requires Git-based project sources and must be set before [`eas/build`](#easbuild), which checks out the project internally.
+
 <EASFunctionDescription name="checkout" />
 
 #### `eas/use_npm_token`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1855,7 +1855,7 @@ jobs:
 
 Branches accept a bare name or a qualified ref such as `refs/heads/feature/add-icon`. Tags need the qualified form, such as `refs/tags/v1.2.3`. A full commit SHA also works and leaves the repository on a detached `HEAD`. The step performs a shallow, depth-one fetch from the source repository's `origin`, so the ref must be reachable there.
 
-`ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Place the step before any other step that checks out the project. Setting `ref` after checkout fails the step.
+`ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Put `ref` on the first `eas/checkout` in the job. If the project was already checked out by an earlier `eas/checkout` or by [`eas/build`](/custom-builds/schema/#easbuild), setting `ref` fails the step.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1861,7 +1861,7 @@ jobs:
 
 The step runs a shallow fetch (`--depth 1`) from the source repository's `origin`, so the ref must be reachable there.
 
-`ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Put `ref` on the first `eas/checkout` in the job. If the project was already checked out by an earlier `eas/checkout` or by [`eas/build`](/custom-builds/schema/#easbuild), setting `ref` fails the step.
+`ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Set `ref` on the job's first `eas/checkout` step. Setting it on a later step fails, because the project is already checked out.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1840,7 +1840,7 @@ jobs:
         # @end #
 ```
 
-By default, the step checks out the ref that triggered the job. Use `ref` to check out a different branch, tag, or commit:
+For jobs with Git-based project sources, the step uses the job's recorded commit by default. Use `ref` to check out a different branch, tag, or commit:
 
 ```yaml
 jobs:
@@ -1853,7 +1853,13 @@ jobs:
         # @end #
 ```
 
-Branches accept a bare name or a qualified ref such as `refs/heads/feature/add-icon`. Tags need the qualified form, such as `refs/tags/v1.2.3`. A full commit SHA also works and leaves the repository on a detached `HEAD`. The step performs a shallow, depth-one fetch from the source repository's `origin`, so the ref must be reachable there.
+`ref` accepts:
+
+- A branch, as a bare name such as `feature/add-icon` or a qualified ref such as `refs/heads/feature/add-icon`. The repository ends up on that branch.
+- A tag, as a qualified ref such as `refs/tags/v1.2.3`. The repository ends up on a detached `HEAD`.
+- A full commit SHA. The repository ends up on a detached `HEAD`.
+
+The step runs a shallow fetch (`--depth 1`) from the source repository's `origin`, so the ref must be reachable there.
 
 `ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Put `ref` on the first `eas/checkout` in the job. If the project was already checked out by an earlier `eas/checkout` or by [`eas/build`](/custom-builds/schema/#easbuild), setting `ref` fails the step.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1840,6 +1840,23 @@ jobs:
         # @end #
 ```
 
+By default, the step checks out the ref that triggered the job. Use `ref` to check out a different branch, tag, or commit:
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      # @info #
+      - uses: eas/checkout
+        with:
+          ref: feature/add-icon
+        # @end #
+```
+
+Branches accept a bare name or a qualified ref such as `refs/heads/feature/add-icon`, tags require a qualified ref such as `refs/tags/v1.2.3`, and a full commit SHA leaves a detached `HEAD`. The ref is fetched from the source repository's `origin` with a depth-one fetch, so it must be reachable there.
+
+`ref` requires Git-based project sources, such as a job triggered through the GitHub integration, and is not supported for local builds or uploaded project tarballs. The step must also run before any other step that checks out the project, otherwise it fails.
+
 <EASFunctionDescription name="checkout" />
 
 #### `eas/install_node_modules`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1853,9 +1853,9 @@ jobs:
         # @end #
 ```
 
-Branches accept a bare name or a qualified ref such as `refs/heads/feature/add-icon`, tags require a qualified ref such as `refs/tags/v1.2.3`, and a full commit SHA leaves a detached `HEAD`. The ref is fetched from the source repository's `origin` with a depth-one fetch, so it must be reachable there.
+Branches accept a bare name or a qualified ref such as `refs/heads/feature/add-icon`. Tags need the qualified form, such as `refs/tags/v1.2.3`. A full commit SHA also works and leaves the repository on a detached `HEAD`. The step performs a shallow, depth-one fetch from the source repository's `origin`, so the ref must be reachable there.
 
-`ref` requires Git-based project sources, such as a job triggered through the GitHub integration, and is not supported for local builds or uploaded project tarballs. The step must also run before any other step that checks out the project, otherwise it fails.
+`ref` only works when your project sources come from a Git repository, for example a job triggered through the GitHub integration. Local builds and uploaded project tarballs do not support it. Place the step before any other step that checks out the project. Setting `ref` after checkout fails the step.
 
 <EASFunctionDescription name="checkout" />
 

--- a/docs/scenes/eas-functions/_checkout.mdx
+++ b/docs/scenes/eas-functions/_checkout.mdx
@@ -3,9 +3,9 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon } from '~/ui/components/DocIcons';
 
-| Property | Type     | Required   | Description                                                                                                                                                                                                           |
-| -------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ref`    | `string` | <NoIcon /> | Git branch, tag, or full commit SHA to check out instead of the ref that triggered the job. Requires project sources from a Git repository, and this step must run before any other step that checks out the project. |
+| Property | Type     | Required   | Description                                                                                                     |
+| -------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| `ref`    | `string` | <NoIcon /> | Git branch, tag, or full commit SHA to check out. Defaults to the ref that triggered the build or workflow job. |
 
 <BoxLink
   title="eas/checkout source code"

--- a/docs/scenes/eas-functions/_checkout.mdx
+++ b/docs/scenes/eas-functions/_checkout.mdx
@@ -1,6 +1,11 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { NoIcon } from '~/ui/components/DocIcons';
+
+| Property | Type     | Required   | Description                                                                                                                                                                                            |
+| -------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ref`    | `string` | <NoIcon /> | Git branch, tag, or full commit SHA to check out instead of the ref that triggered the job. Requires Git-based project sources, and this step must precede any other step that checks out the project. |
 
 <BoxLink
   title="eas/checkout source code"

--- a/docs/scenes/eas-functions/_checkout.mdx
+++ b/docs/scenes/eas-functions/_checkout.mdx
@@ -3,9 +3,9 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { NoIcon } from '~/ui/components/DocIcons';
 
-| Property | Type     | Required   | Description                                                                                                                                                                                            |
-| -------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ref`    | `string` | <NoIcon /> | Git branch, tag, or full commit SHA to check out instead of the ref that triggered the job. Requires Git-based project sources, and this step must precede any other step that checks out the project. |
+| Property | Type     | Required   | Description                                                                                                                                                                                                           |
+| -------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ref`    | `string` | <NoIcon /> | Git branch, tag, or full commit SHA to check out instead of the ref that triggered the job. Requires project sources from a Git repository, and this step must run before any other step that checks out the project. |
 
 <BoxLink
   title="eas/checkout source code"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added a `ref` input to `eas/checkout`: https://github.com/expo/eas-cli/pull/4035

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the EAS workflows sytnax and custom builds docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="700" height="647" alt="Screenshot 2026-07-28 at 16 39 24" src="https://github.com/user-attachments/assets/615dc4d8-9d0b-42d4-8107-3f15a7d2a388" />

<img width="680" height="313" alt="Screenshot 2026-07-28 at 16 39 43" src="https://github.com/user-attachments/assets/bc9f2817-7fb2-4561-997c-ad84954b25f6" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
