### PR TITLE
[docs] Update EAS Workflows App Store Connect build upload interpolation context fields documentation

### DIFF
--- a/docs/pages/eas/workflows/environment.mdx
+++ b/docs/pages/eas/workflows/environment.mdx
@@ -220,6 +220,10 @@ app_store_connect {
     id,
     state,             // 'awaiting_upload', 'processing', 'failed', or 'complete'
     cf_bundle_version,
+    cf_bundle_short_version_string,
+    platform,
+    uploaded_date,
+    created_date,
     build { id },
   },
   app_version { id, state },

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -901,6 +901,10 @@ type AppStoreConnectContext = {
     id: string;
     state: 'awaiting_upload' | 'processing' | 'failed' | 'complete';
     cf_bundle_version?: string;
+    cf_bundle_short_version_string?: string;
+    platform?: string;
+    uploaded_date?: string;
+    created_date?: string;
     build?: {
       id: string;
     };
@@ -941,6 +945,7 @@ jobs:
         Upload complete for App Store Connect app: ${{ app_store_connect.app.id }}
         Upload ID: ${{ app_store_connect.build_upload.id }}
         Upload state: ${{ app_store_connect.build_upload.state }}
+        Version: ${{ app_store_connect.build_upload.cf_bundle_short_version_string }} (${{ app_store_connect.build_upload.cf_bundle_version }})
 ```
 
 Use `build_upload.build.id` as the `asc_build_id` for a `testflight` job:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added more fields to the EAS workflows ASC `build_upload` interpolation context object.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add the missing fields to the ASC build upload interpolation context docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="855" height="998" alt="Screenshot 2026-07-28 at 17 02 16" src="https://github.com/user-attachments/assets/56504079-cfd0-45fd-bcd6-6c346e935396" />

<img width="860" height="538" alt="Screenshot 2026-07-28 at 17 02 30" src="https://github.com/user-attachments/assets/a40c812d-8acf-4274-b023-744c6bca8b31" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
