### PR TITLE
refactor(cli): Give the dev server port a single source

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Fix opening web from the Terminal UI when the dev server was started without `--web` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
 - Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
-- Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` and warn, instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
 - Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
-- Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` and warn, instead of failing to start the dev server (by [@ramonclaudio](https://github.com/ramonclaudio))
+- Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` and warn, instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 
@@ -50,7 +50,7 @@
 - [Internal] Migrate structured event logging to the `2g` package ([#46667](https://github.com/expo/expo/pull/46667) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
 - Preserve `watchFolders` external to `serverRoot` explicitly, when they've been manually added ([#48177](https://github.com/expo/expo/pull/48177) by [@kitten](https://github.com/kitten))
-- [Internal] Resolve the dev server port once instead of re-deriving it, and read the URL environment variables outside the `UrlCreator` (by [@ramonclaudio](https://github.com/ramonclaudio))
+- [Internal] Resolve the dev server port once instead of re-deriving it, and read the URL environment variables outside the `UrlCreator` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix GraphQL `data` results with all-null fields being treated as failed, obscuring underlying failure states ([#47860](https://github.com/expo/expo/pull/47860) by [@kitten](https://github.com/kitten))
 - Prevent `expo export` from corrupting server bundles that contain `//# sourceMappingURL=` inside a string literal ([#47981](https://github.com/expo/expo/pull/47981) by [@hassankhan](https://github.com/hassankhan))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
+- Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` and warn, instead of failing to start the dev server (by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 
@@ -49,6 +50,7 @@
 - [Internal] Migrate structured event logging to the `2g` package ([#46667](https://github.com/expo/expo/pull/46667) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
 - Preserve `watchFolders` external to `serverRoot` explicitly, when they've been manually added ([#48177](https://github.com/expo/expo/pull/48177) by [@kitten](https://github.com/kitten))
+- [Internal] Resolve the dev server port once instead of re-deriving it, and read the URL environment variables outside the `UrlCreator` (by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ## 56.1.12 — 2026-05-26
 

--- a/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
+++ b/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { resolvePortAsync } from '../../utils/port';
+import { resolveMetroPortAsync } from '../../utils/port';
 import { resolveBundlerPropsAsync } from '../resolveBundlerProps';
 
 jest.mock('../../utils/port');
@@ -14,7 +14,7 @@ describe(resolveBundlerPropsAsync, () => {
     );
   });
   it(`skips bundling if the port is busy`, async () => {
-    jest.mocked(resolvePortAsync).mockResolvedValueOnce(null);
+    jest.mocked(resolveMetroPortAsync).mockResolvedValueOnce(null);
 
     expect(await resolveBundlerPropsAsync('/', {})).toEqual({
       port: 8081,
@@ -32,7 +32,7 @@ describe(resolveBundlerPropsAsync, () => {
     });
   });
   it(`resolves default port`, async () => {
-    jest.mocked(resolvePortAsync).mockResolvedValueOnce(19006);
+    jest.mocked(resolveMetroPortAsync).mockResolvedValueOnce(19006);
 
     expect(
       await resolveBundlerPropsAsync('/', {

--- a/packages/@expo/cli/src/run/resolveBundlerProps.ts
+++ b/packages/@expo/cli/src/run/resolveBundlerProps.ts
@@ -1,6 +1,6 @@
 import { Log } from '../log';
 import { CommandError } from '../utils/errors';
-import { resolvePortAsync } from '../utils/port';
+import { resolveMetroPortAsync } from '../utils/port';
 
 export interface BundlerProps {
   /** Port to start the dev server on. */
@@ -28,7 +28,10 @@ export async function resolveBundlerPropsAsync(
 
   // Resolve the port if the bundler is used.
   let port = options.bundler
-    ? await resolvePortAsync(projectRoot, { reuseExistingPort: true, defaultPort: options.port })
+    ? await resolveMetroPortAsync(projectRoot, {
+        reuseExistingPort: true,
+        defaultPort: options.port,
+      })
     : null;
 
   // Skip bundling if the port is null -- meaning skip the bundler if the port is already running the app.

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -10,7 +10,7 @@ import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
-import { resolvePortAsync } from '../utils/port';
+import { resolveMetroPortAsync } from '../utils/port';
 import { applyStaticHeaders, loadStaticManifestAsync, resolveStaticHeaders } from './static';
 
 type Options = {
@@ -25,7 +25,7 @@ export async function serveAsync(inputDir: string, options: Options) {
   setNodeEnv('production');
   loadEnvFiles(projectRoot);
 
-  const port = await resolvePortAsync(projectRoot, {
+  const port = await resolveMetroPortAsync(projectRoot, {
     defaultPort: options.port,
     fallbackPort: 8081,
   });

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -1,5 +1,5 @@
 import { Log } from '../../log';
-import { choosePortAsync, resolvePortAsync } from '../../utils/port';
+import { choosePortAsync, resolveMetroPortAsync } from '../../utils/port';
 import { getOptionalDevClientSchemeAsync } from '../../utils/scheme';
 import { canResolveDevClient, hasDirectDevClientDependency } from '../detectDevClient';
 import {
@@ -12,7 +12,7 @@ import {
 jest.mock('../../log');
 jest.mock('../../utils/port', () => {
   return {
-    resolvePortAsync: jest.fn(),
+    resolveMetroPortAsync: jest.fn(),
     choosePortAsync: jest.fn(),
   };
 });
@@ -212,7 +212,7 @@ describe(resolveHostType, () => {
 describe(resolvePortsAsync, () => {
   beforeEach(() => {
     jest
-      .mocked(resolvePortAsync)
+      .mocked(resolveMetroPortAsync)
       .mockImplementation(async (root, { defaultPort, fallbackPort } = {}) => {
         if (typeof defaultPort === 'string' && defaultPort) {
           return parseInt(defaultPort, 10);
@@ -245,7 +245,7 @@ describe(resolvePortsAsync, () => {
     );
   });
   it(`does not abort when port resolves to 0`, async () => {
-    jest.mocked(resolvePortAsync).mockResolvedValueOnce(0);
+    jest.mocked(resolveMetroPortAsync).mockResolvedValueOnce(0);
     await expect(resolvePortsAsync('/noop', { port: 0 }, ['metro'])).resolves.toStrictEqual({
       metroPort: 0,
     });

--- a/packages/@expo/cli/src/start/__tests__/startAsync-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/startAsync-test.ts
@@ -1,0 +1,42 @@
+import { resolvePortsAsync } from '../resolveOptions';
+import type { PlatformBundlers } from '../server/platformBundlers';
+import { _getMultiBundlerStartOptions } from '../startAsync';
+
+jest.mock('../resolveOptions', () => ({
+  resolvePortsAsync: jest.fn(async () => ({ metroPort: 8081, webpackPort: 19006 })),
+}));
+
+const NATIVE_METRO_WEB_WEBPACK: PlatformBundlers = {
+  ios: 'metro',
+  android: 'metro',
+  tvos: 'metro',
+  macos: 'metro',
+  web: 'webpack',
+};
+
+describe(_getMultiBundlerStartOptions, () => {
+  it(`resolves the web port even when web isn't started`, async () => {
+    const [, startOptions, webPort] = await _getMultiBundlerStartOptions(
+      '/',
+      { web: false } as any,
+      { ...NATIVE_METRO_WEB_WEBPACK }
+    );
+
+    expect(resolvePortsAsync).toHaveBeenCalledWith('/', expect.anything(), ['metro', 'webpack']);
+    expect(startOptions).toEqual([
+      { type: 'metro', options: expect.objectContaining({ port: 8081 }) },
+    ]);
+    expect(webPort).toBe(19006);
+  });
+
+  it(`starts both bundlers with --web`, async () => {
+    const [, startOptions] = await _getMultiBundlerStartOptions('/', { web: true } as any, {
+      ...NATIVE_METRO_WEB_WEBPACK,
+    });
+
+    expect(startOptions).toEqual([
+      { type: 'metro', options: expect.objectContaining({ port: 8081 }) },
+      { type: 'webpack', options: expect.objectContaining({ port: 19006 }) },
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Log } from '../log';
 import { env, envIsWebcontainer } from '../utils/env';
 import { AbortCommandError, CommandError } from '../utils/errors';
-import { choosePortAsync, resolvePortAsync } from '../utils/port';
+import { choosePortAsync, resolveMetroPortAsync } from '../utils/port';
 import { canResolveDevClient, hasDirectDevClientDependency } from './detectDevClient';
 
 export type Options = {
@@ -162,9 +162,8 @@ export async function resolvePortsAsync(
   options: Partial<Pick<Options, 'port' | 'devClient'>>,
   bundlers: ('metro' | 'webpack')[]
 ): Promise<{ metroPort: number; webpackPort?: number }> {
-  const metroPort = await resolvePortAsync(projectRoot, {
+  const metroPort = await resolveMetroPortAsync(projectRoot, {
     defaultPort: options.port,
-    // resolvePortAsync already honors RCT_METRO_PORT, so we only pass the default
     fallbackPort: 8081,
   });
   if (metroPort == null) {

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -428,20 +428,14 @@ export abstract class BundlerDevServer {
   ) {
     assert(options?.port, 'Dev server instance not found');
     assert(!this.urlCreator, 'Dev server is already initialized');
+    this.resolvedPort = options.port;
     // TODO: Drop the undocumented REACT_NATIVE_PACKAGER_HOSTNAME
-    const hostnameOverride = env.REACT_NATIVE_PACKAGER_HOSTNAME;
-    if (hostnameOverride && !hostnameOverride.trim()) {
-      Log.warn(
-        `Ignoring REACT_NATIVE_PACKAGER_HOSTNAME because it is only whitespace. Set it to a hostname, or unset it to use the default host.`
-      );
-    }
     const urlCreator = await UrlCreator.init(options.location, {
       getPort: () => this.getPort(),
       getTunnelUrl: this.getTunnelUrl.bind(this),
       getHostnameOverride: () => env.REACT_NATIVE_PACKAGER_HOSTNAME,
       getProxyUrl: () => env.EXPO_PACKAGER_PROXY_URL,
     });
-    this.resolvedPort = options.port;
     this.urlCreator = urlCreator;
     return urlCreator;
   }

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -129,6 +129,8 @@ export abstract class BundlerDevServer {
     {};
   /** Manages the creation of dev server URLs. */
   protected urlCreator?: UrlCreator | null = null;
+  /** The resolved port every URL and `instance.location` is built from. */
+  private resolvedPort: number | null = null;
 
   private notifier: FileNotifier | null = null;
   protected readonly devToolsPluginManager: DevToolsPluginManager;
@@ -238,11 +240,11 @@ export abstract class BundlerDevServer {
       },
       location: {
         // The port is the main thing we want to send back.
-        port: options.port,
+        port: this.getPort(),
         // localhost isn't always correct.
         host: 'localhost',
         // http is the only supported protocol on native.
-        url: `http://localhost:${options.port}`,
+        url: `http://localhost:${this.getPort()}`,
         protocol: 'http',
       },
       middleware: {},
@@ -370,6 +372,7 @@ export abstract class BundlerDevServer {
     const stoppedAt = Date.now();
     // Reset url creator
     this.urlCreator = undefined;
+    // Keep `resolvedPort`: the manifest middleware still builds URLs until the server closes below.
 
     // Stop file watching.
     this.notifier?.stopObserving();
@@ -425,10 +428,20 @@ export abstract class BundlerDevServer {
   ) {
     assert(options?.port, 'Dev server instance not found');
     assert(!this.urlCreator, 'Dev server is already initialized');
+    // TODO: Drop the undocumented REACT_NATIVE_PACKAGER_HOSTNAME
+    const hostnameOverride = env.REACT_NATIVE_PACKAGER_HOSTNAME;
+    if (hostnameOverride && !hostnameOverride.trim()) {
+      Log.warn(
+        `Ignoring REACT_NATIVE_PACKAGER_HOSTNAME because it is only whitespace. Set it to a hostname, or unset it to use the default host.`
+      );
+    }
     const urlCreator = await UrlCreator.init(options.location, {
-      port: options.port,
+      getPort: () => this.getPort(),
       getTunnelUrl: this.getTunnelUrl.bind(this),
+      getHostnameOverride: () => env.REACT_NATIVE_PACKAGER_HOSTNAME,
+      getProxyUrl: () => env.EXPO_PACKAGER_PROXY_URL,
     });
+    this.resolvedPort = options.port;
     this.urlCreator = urlCreator;
     return urlCreator;
   }
@@ -436,6 +449,11 @@ export abstract class BundlerDevServer {
   public getUrlCreator() {
     assert(this.urlCreator, 'Dev server is uninitialized');
     return this.urlCreator;
+  }
+
+  protected getPort() {
+    assert(this.resolvedPort != null, 'Dev server port is unresolved');
+    return this.resolvedPort;
   }
 
   public getNativeRuntimeUrl(opts: Partial<CreateURLOptions> = {}) {

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -54,7 +54,9 @@ export class DevServerManager {
   constructor(
     public projectRoot: string,
     /** Keep track of the original CLI options for bundlers that are started interactively. */
-    public options: BundlerStartOptions
+    public options: BundlerStartOptions,
+    /** Port for the web dev server, resolved up front even when web starts interactively. */
+    private webPort?: number
   ) {
     if (!options.isExporting) {
       this.notifier = this.watchBabelConfig();
@@ -140,7 +142,7 @@ export class DevServerManager {
     return this.startAsync([
       {
         type: bundler,
-        options: this.options,
+        options: { ...this.options, port: this.webPort ?? this.options.port },
       },
     ]);
   }

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -25,7 +25,7 @@ interface BundlerInfo {
   getPort(): number;
   getTunnelUrl?(): string | null;
   /** Hostname that replaces the requested or LAN host. The proxy and tunnel URLs still win over it. */
-  getHostnameOverride?(): string;
+  getHostnameOverride?(): string | null;
   /** Proxy URL that replaces the host and port of every URL. Read before every other host. */
   getProxyUrl?(): string;
 }
@@ -177,9 +177,8 @@ const getDefaultHostname = (
   gateway: GatewayInfo,
   hostnameOverride?: string | null
 ) => {
-  const override = hostnameOverride?.trim();
-  if (override) {
-    return override;
+  if (hostnameOverride) {
+    return hostnameOverride;
   } else if (options.hostname === 'localhost') {
     // NOTE: We always convert "localhost" as a request to 127.0.0.1,
     // to normalize to an address that's consistent

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -1,4 +1,3 @@
-import { getOriginalEnvValue } from '@expo/env';
 import assert from 'assert';
 import { URL } from 'url';
 
@@ -23,8 +22,12 @@ interface UrlComponents {
 }
 
 interface BundlerInfo {
-  port: number;
+  getPort(): number;
   getTunnelUrl?(): string | null;
+  /** Hostname that replaces the requested or LAN host. The proxy and tunnel URLs still win over it. */
+  getHostnameOverride?(): string;
+  /** Proxy URL that replaces the host and port of every URL. Read before every other host. */
+  getProxyUrl?(): string;
 }
 
 export class UrlCreator {
@@ -120,7 +123,7 @@ export class UrlCreator {
 
   private getUrlComponents(options: CreateURLOptions): UrlComponents {
     // Proxy comes first.
-    const proxyURL = getProxyUrl();
+    const proxyURL = this.bundlerInfo.getProxyUrl?.();
     if (proxyURL) {
       return getUrlComponentsFromProxyUrl(options, proxyURL);
     }
@@ -137,8 +140,12 @@ export class UrlCreator {
     }
 
     return {
-      hostname: getDefaultHostname(options, this.gatewayInfo),
-      port: this.bundlerInfo.port.toString(),
+      hostname: getDefaultHostname(
+        options,
+        this.gatewayInfo,
+        this.bundlerInfo.getHostnameOverride?.()
+      ),
+      port: this.bundlerInfo.getPort().toString(),
       protocol: options.scheme ?? 'http',
     };
   }
@@ -165,10 +172,14 @@ function getUrlComponentsFromProxyUrl(
   };
 }
 
-const getDefaultHostname = (options: CreateURLOptions, gateway: GatewayInfo) => {
-  // TODO: Drop REACT_NATIVE_PACKAGER_HOSTNAME
-  if (process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {
-    return process.env.REACT_NATIVE_PACKAGER_HOSTNAME.trim();
+const getDefaultHostname = (
+  options: CreateURLOptions,
+  gateway: GatewayInfo,
+  hostnameOverride?: string | null
+) => {
+  const override = hostnameOverride?.trim();
+  if (override) {
+    return override;
   } else if (options.hostname === 'localhost') {
     // NOTE: We always convert "localhost" as a request to 127.0.0.1,
     // to normalize to an address that's consistent
@@ -191,14 +202,3 @@ function joinUrlComponents({ protocol, hostname, port }: Partial<UrlComponents>)
 
   return url;
 }
-
-/** @deprecated */
-function getProxyUrl(): string | undefined {
-  // Read from the pre-dotenv env — overriding this would redirect connected dev
-  // clients through an attacker-controlled URL.
-  return getOriginalEnvValue('EXPO_PACKAGER_PROXY_URL');
-}
-
-// TODO: Drop the undocumented env variables:
-// REACT_NATIVE_PACKAGER_HOSTNAME
-// EXPO_PACKAGER_PROXY_URL

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -1,6 +1,5 @@
 import { vol } from 'memfs';
 
-import * as Log from '../../../log';
 import { envIsWebcontainer } from '../../../utils/env';
 import { openBrowserAsync } from '../../../utils/open';
 import { AsyncNgrok } from '../AsyncNgrok';
@@ -50,7 +49,6 @@ const originalEnv = process.env;
 beforeEach(() => {
   vol.reset();
   jest.mocked(envIsWebcontainer).mockReset();
-  jest.mocked(Log.warn).mockClear();
   delete process.env.EXPO_NO_REDIRECT_PAGE;
   delete process.env.EXPO_UNSTABLE_TUNNEL_V2;
   delete process.env.EXPO_PACKAGER_PROXY_URL;
@@ -164,16 +162,10 @@ describe('initUrlCreator', () => {
     expect(urlCreator.constructUrl({})).toBe('http://proxy.dev');
   });
 
-  it(`warns once and ignores a whitespace-only hostname override from the environment`, async () => {
+  it(`ignores a whitespace-only hostname override from the environment`, async () => {
     process.env.REACT_NATIVE_PACKAGER_HOSTNAME = '\t';
     const urlCreator = await createDevServer()['initUrlCreator']({ port: 3000, location: {} });
-
     expect(urlCreator.constructUrl({})).toBe('http://100.100.1.100:3000');
-    expect(urlCreator.constructUrl({})).toBe('http://100.100.1.100:3000');
-    expect(Log.warn).toHaveBeenCalledTimes(1);
-    expect(Log.warn).toHaveBeenCalledWith(
-      expect.stringMatching(/REACT_NATIVE_PACKAGER_HOSTNAME because it is only whitespace/)
-    );
   });
 
   it(`keeps serving URLs from a creator that outlives the dev server`, async () => {

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -1,12 +1,12 @@
 import { vol } from 'memfs';
 
+import * as Log from '../../../log';
 import { envIsWebcontainer } from '../../../utils/env';
 import { openBrowserAsync } from '../../../utils/open';
 import { AsyncNgrok } from '../AsyncNgrok';
 import { AsyncWsTunnel } from '../AsyncWsTunnel';
 import type { BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import { BundlerDevServer } from '../BundlerDevServer';
-import { UrlCreator } from '../UrlCreator';
 import { getPlatformBundlers } from '../platformBundlers';
 
 jest.mock(`../../../utils/env`, () => ({
@@ -50,8 +50,11 @@ const originalEnv = process.env;
 beforeEach(() => {
   vol.reset();
   jest.mocked(envIsWebcontainer).mockReset();
+  jest.mocked(Log.warn).mockClear();
   delete process.env.EXPO_NO_REDIRECT_PAGE;
   delete process.env.EXPO_UNSTABLE_TUNNEL_V2;
+  delete process.env.EXPO_PACKAGER_PROXY_URL;
+  delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
 });
 
 afterAll(() => {
@@ -68,16 +71,14 @@ class MockBundlerDevServer extends BundlerDevServer {
     options: BundlerStartOptions
   ): Promise<DevServerInstance> {
     const port = options.port || 3000;
-    this.urlCreator = new UrlCreator(
-      {
+    await this.initUrlCreator({
+      ...options,
+      port,
+      location: {
         scheme: options.https ? 'https' : 'http',
         ...options.location,
       },
-      {
-        port,
-        getTunnelUrl: this.getTunnelUrl.bind(this),
-      }
-    );
+    });
 
     const protocol = 'http';
     const host = 'localhost';
@@ -86,8 +87,8 @@ class MockBundlerDevServer extends BundlerDevServer {
       server: { close: jest.fn((fn) => fn?.()), addListener() {} },
       // URL Info
       location: {
-        url: `${protocol}://${host}:${port}`,
-        port,
+        url: `${protocol}://${host}:${this.getPort()}`,
+        port: this.getPort(),
         protocol,
         host,
       },
@@ -143,6 +144,70 @@ describe('broadcastMessage', () => {
     expect(devServer.getInstance()!.messageSocket.broadcast).toHaveBeenCalledWith('reload', {
       foo: true,
     });
+  });
+});
+
+describe('initUrlCreator', () => {
+  function createDevServer() {
+    return new MockBundlerDevServer('/', getPlatformBundlers('/', { web: { bundler: 'metro' } }));
+  }
+
+  it(`passes the hostname override from the environment`, async () => {
+    process.env.REACT_NATIVE_PACKAGER_HOSTNAME = 'from-env.dev';
+    const urlCreator = await createDevServer()['initUrlCreator']({ port: 3000, location: {} });
+    expect(urlCreator.constructUrl({})).toBe('http://from-env.dev:3000');
+  });
+
+  it(`passes the proxy url from the environment`, async () => {
+    process.env.EXPO_PACKAGER_PROXY_URL = 'http://proxy.dev';
+    const urlCreator = await createDevServer()['initUrlCreator']({ port: 3000, location: {} });
+    expect(urlCreator.constructUrl({})).toBe('http://proxy.dev');
+  });
+
+  it(`warns once and ignores a whitespace-only hostname override from the environment`, async () => {
+    process.env.REACT_NATIVE_PACKAGER_HOSTNAME = '\t';
+    const urlCreator = await createDevServer()['initUrlCreator']({ port: 3000, location: {} });
+
+    expect(urlCreator.constructUrl({})).toBe('http://100.100.1.100:3000');
+    expect(urlCreator.constructUrl({})).toBe('http://100.100.1.100:3000');
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/REACT_NATIVE_PACKAGER_HOSTNAME because it is only whitespace/)
+    );
+  });
+
+  it(`keeps serving URLs from a creator that outlives the dev server`, async () => {
+    const devServer = createDevServer();
+    const urlCreator = await devServer['initUrlCreator']({ port: 3000, location: {} });
+    // The manifest middleware holds this bound function for the life of the server.
+    const constructUrl = urlCreator.constructUrl.bind(urlCreator);
+    expect(constructUrl({})).toBe('http://100.100.1.100:3000');
+
+    await devServer.stopAsync();
+
+    expect(constructUrl({})).toBe('http://100.100.1.100:3000');
+  });
+
+  it(`throws when the port is read before the dev server starts`, () => {
+    expect(() => createDevServer()['getPort']()).toThrow(/port is unresolved/);
+  });
+});
+
+describe('startHeadlessAsync', () => {
+  it(`reports the resolved port without a real server`, async () => {
+    const devServer = new MockBundlerDevServer(
+      '/',
+      getPlatformBundlers('/', { web: { bundler: 'metro' } })
+    );
+    const instance = await devServer.startAsync({ location: {}, port: 3000, headless: true });
+
+    expect(instance.location).toEqual({
+      url: 'http://localhost:3000',
+      port: 3000,
+      protocol: 'http',
+      host: 'localhost',
+    });
+    expect(devServer.getUrlCreator().constructUrl({})).toBe('http://100.100.1.100:3000');
   });
 });
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevServerManager-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevServerManager-test.ts
@@ -1,0 +1,47 @@
+import { getConfig } from '@expo/config';
+
+import type { BundlerStartOptions } from '../BundlerDevServer';
+import { DevServerManager } from '../DevServerManager';
+import { getPlatformBundlers } from '../platformBundlers';
+
+jest.mock('@expo/config');
+jest.mock('../platformBundlers');
+jest.mock('../DevToolsPluginManager');
+
+const asMock = <T extends (...args: any[]) => any>(fn: T) => fn as jest.MockedFunction<T>;
+
+function createManager(webPort?: number, port?: number) {
+  // `isExporting` skips the babel config watcher, which needs a real project on disk.
+  const options = { location: {}, isExporting: true, port } as BundlerStartOptions;
+  const manager = new DevServerManager('/', options, webPort);
+  jest.spyOn(manager, 'startAsync').mockResolvedValue({} as any);
+  return manager;
+}
+
+beforeEach(() => {
+  asMock(getConfig).mockReturnValue({ exp: {} } as any);
+  asMock(getPlatformBundlers).mockReturnValue({ web: 'webpack' } as any);
+});
+
+describe('ensureWebDevServerRunningAsync', () => {
+  it(`starts the web dev server with the port resolved up front`, async () => {
+    const manager = createManager(19006);
+
+    await manager.ensureWebDevServerRunningAsync();
+
+    expect(manager.startAsync).toHaveBeenCalledWith([
+      { type: 'webpack', options: expect.objectContaining({ port: 19006 }) },
+    ]);
+  });
+
+  it(`falls back to the start options port when no web port was resolved`, async () => {
+    // `expo run:*` builds the manager through `startMetroAsync`, which has no web port.
+    const manager = createManager(undefined, 8081);
+
+    await manager.ensureWebDevServerRunningAsync();
+
+    expect(manager.startAsync).toHaveBeenCalledWith([
+      { type: 'webpack', options: expect.objectContaining({ port: 8081 }) },
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -5,7 +5,7 @@ jest.mock('../../../log');
 
 function createDefaultCreator(overrides?: {
   getProxyUrl?: () => string;
-  getHostnameOverride?: () => string;
+  getHostnameOverride?: () => string | null;
 }) {
   return new UrlCreator(
     {},
@@ -157,9 +157,9 @@ describe('constructUrl', () => {
       })
     ).toMatchInlineSnapshot(`"http://override.dev:8081"`);
   });
-  it(`ignores a blank hostname override`, () => {
+  it(`ignores a missing hostname override`, () => {
     expect(
-      createDefaultCreator({ getHostnameOverride: () => '  ' }).constructUrl({})
+      createDefaultCreator({ getHostnameOverride: () => null }).constructUrl({})
     ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
   });
   it(`reads the hostname override on every url`, () => {

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -3,13 +3,14 @@ import { UrlCreator } from '../UrlCreator';
 
 jest.mock('../../../log');
 
-beforeEach(() => {
-  delete process.env.EXPO_PACKAGER_PROXY_URL;
-  delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
-});
-
-function createDefaultCreator() {
-  return new UrlCreator({}, { port: 8081, getTunnelUrl: () => `http://tunnel.dev/` });
+function createDefaultCreator(overrides?: {
+  getProxyUrl?: () => string;
+  getHostnameOverride?: () => string;
+}) {
+  return new UrlCreator(
+    {},
+    { getPort: () => 8081, getTunnelUrl: () => `http://tunnel.dev/`, ...overrides }
+  );
 }
 
 describe('constructLoadingUrl', () => {
@@ -76,9 +77,10 @@ describe('constructDevClientUrl', () => {
 });
 
 describe('constructUrl', () => {
-  it(`skips default port with environment variable`, () => {
-    process.env.EXPO_PACKAGER_PROXY_URL = 'http://expo.dev';
-    expect(createDefaultCreator().constructUrl({})).toMatchInlineSnapshot(`"http://expo.dev"`);
+  it(`skips default port with proxy url`, () => {
+    expect(
+      createDefaultCreator({ getProxyUrl: () => 'http://expo.dev' }).constructUrl({})
+    ).toMatchInlineSnapshot(`"http://expo.dev"`);
   });
 
   it(`creates default`, () => {
@@ -108,18 +110,20 @@ describe('constructUrl', () => {
   });
   it(`uses defaults`, () => {
     expect(
-      new UrlCreator({ scheme: 'foobar' }, { port: 8081 }).constructUrl({})
+      new UrlCreator({ scheme: 'foobar' }, { getPort: () => 8081 }).constructUrl({})
     ).toMatchInlineSnapshot(`"foobar://100.100.1.100:8081"`);
   });
   it(`uses function options over defaults`, () => {
     expect(
-      new UrlCreator({ scheme: 'foobar' }, { port: 8081 }).constructUrl({ scheme: 'newer' })
+      new UrlCreator({ scheme: 'foobar' }, { getPort: () => 8081 }).constructUrl({
+        scheme: 'newer',
+      })
     ).toMatchInlineSnapshot(`"newer://100.100.1.100:8081"`);
   });
   it(`warns when tunnel isn't available`, () => {
     jest.mocked(Log.warn).mockClear();
     expect(
-      new UrlCreator({}, { port: 8081, getTunnelUrl: () => null }).constructUrl({
+      new UrlCreator({}, { getPort: () => 8081, getTunnelUrl: () => null }).constructUrl({
         hostType: 'tunnel',
       })
     ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
@@ -136,15 +140,33 @@ describe('constructUrl', () => {
       `"http://foobar.dev:8081"`
     );
   });
-  it(`uses env variable as proxy`, () => {
-    process.env.EXPO_PACKAGER_PROXY_URL = 'http://localhost:9999';
+  it(`uses proxy url over every other host`, () => {
     expect(
-      createDefaultCreator().constructUrl({
+      createDefaultCreator({ getProxyUrl: () => 'http://localhost:9999' }).constructUrl({
         // scheme will be used, all others will be ignored...
         scheme: 'foobar',
         hostType: 'tunnel',
         hostname: 'foobar.dev',
       })
     ).toMatchInlineSnapshot(`"foobar://localhost:9999"`);
+  });
+  it(`uses hostname override over a custom hostname`, () => {
+    expect(
+      createDefaultCreator({ getHostnameOverride: () => 'override.dev' }).constructUrl({
+        hostname: 'foobar.dev',
+      })
+    ).toMatchInlineSnapshot(`"http://override.dev:8081"`);
+  });
+  it(`ignores a blank hostname override`, () => {
+    expect(
+      createDefaultCreator({ getHostnameOverride: () => '  ' }).constructUrl({})
+    ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
+  });
+  it(`reads the hostname override on every url`, () => {
+    let hostname = 'first.dev';
+    const urlCreator = createDefaultCreator({ getHostnameOverride: () => hostname });
+    expect(urlCreator.constructUrl({})).toBe('http://first.dev:8081');
+    hostname = 'second.dev';
+    expect(urlCreator.constructUrl({})).toBe('http://second.dev:8081');
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1303,7 +1303,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
     const parsedOptions = {
       host: options.location.hostType === 'localhost' ? 'localhost' : undefined,
-      port: options.port,
+      port: this.getPort(),
       maxWorkers: options.maxWorkers,
       resetCache: options.resetDevServer,
     };
@@ -1329,7 +1329,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       });
 
     // Required for symbolication:
-    const serverBaseUrl = `${address?.protocol ?? 'http'}://localhost:${address?.port ?? options.port}`;
+    const serverBaseUrl = `${address?.protocol ?? 'http'}://localhost:${this.getPort()}`;
     process.env.EXPO_DEV_SERVER_ORIGIN = serverBaseUrl;
 
     if (!options.isExporting) {
@@ -1603,7 +1603,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       server,
       location: {
         // The port is the main thing we want to send back.
-        port: address?.port ?? options.port,
+        port: this.getPort(),
         // localhost isn't always correct.
         host: 'localhost',
         url: serverBaseUrl,

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -47,6 +47,8 @@ jest.mock('../../../../log');
 
 beforeEach(() => {
   vol.reset();
+  delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
+  delete process.env.EXPO_PACKAGER_PROXY_URL;
 });
 
 const htmlRoute = {
@@ -104,9 +106,9 @@ describe('startAsync', () => {
     expect(devServer.getInstance()).toEqual({
       location: {
         host: 'localhost',
-        port: expect.any(Number),
+        port: 3000,
         protocol: 'http',
-        url: expect.stringMatching(/http:\/\/localhost:\d+/),
+        url: 'http://localhost:3000',
       },
       middleware: {
         use: expect.any(Function),
@@ -120,10 +122,27 @@ describe('startAsync', () => {
     expect(instantiateMetroAsync).toHaveBeenCalled();
     expect(instantiateMetroAsync).toHaveBeenCalledWith(
       devServer,
-      expect.any(Object),
+      expect.objectContaining({ port: 3000 }),
       expect.objectContaining({
         devToolsPluginManager: devServer['devToolsPluginManager'],
       })
+    );
+  });
+
+  it(`reports the resolved port, not the port the socket came back with`, async () => {
+    jest.mocked(instantiateMetroAsync).mockResolvedValueOnce({
+      metro: { _config: {}, _bundler: {} },
+      middleware: { use: jest.fn() },
+      server: { listen: jest.fn(), close: jest.fn() },
+      address: { protocol: 'http', address: 'localhost', family: 'ipv4', port: 9999 },
+    } as any);
+
+    const devServer = await getStartedDevServer({ port: 3000 });
+
+    expect(devServer.getInstance()!.location.port).toBe(3000);
+    expect(devServer.getInstance()!.location.url).toBe('http://localhost:3000');
+    expect(devServer.getUrlCreator().constructUrl({ hostType: 'localhost' })).toBe(
+      'http://127.0.0.1:3000'
     );
   });
 });

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/openHandlers-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/openHandlers-test.ts
@@ -7,15 +7,10 @@ jest.mock('../../../../log');
 const TUNNEL_URL = 'https://abc.ngrok-free.app';
 const LAN_ADDR = '192.168.7.42';
 
-beforeEach(() => {
-  delete process.env.EXPO_PACKAGER_PROXY_URL;
-  delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
-});
-
 function lanCreator(scheme: string | null = 'myapp') {
   return new UrlCreator(
     { scheme: scheme ?? undefined },
-    { port: 8081, getTunnelUrl: () => null },
+    { getPort: () => 8081, getTunnelUrl: () => null },
     { address: LAN_ADDR, iname: null, gateway: null, internal: false }
   );
 }
@@ -23,7 +18,7 @@ function lanCreator(scheme: string | null = 'myapp') {
 function tunnelCreator(scheme: string | null = 'myapp') {
   return new UrlCreator(
     { scheme: scheme ?? undefined, hostType: 'tunnel' },
-    { port: 8081, getTunnelUrl: () => TUNNEL_URL },
+    { getPort: () => 8081, getTunnelUrl: () => TUNNEL_URL },
     { address: LAN_ADDR, iname: null, gateway: null, internal: false }
   );
 }

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -163,7 +163,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
 
     const config = await this.loadConfigAsync(options);
 
-    Log.log(chalk`Starting Webpack on port ${port} in {underline ${mode}} mode.`);
+    Log.log(chalk`Starting Webpack on port ${this.getPort()} in {underline ${mode}} mode.`);
 
     // Create a webpack compiler that is configured with custom messages.
     const compiler = webpack(config);
@@ -173,7 +173,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       env.WEB_HOST ?? (options.location.hostType === 'localhost' ? 'localhost' : undefined);
 
     // Launch WebpackDevServer.
-    server.listen(port, host, function (this: http.Server, error) {
+    server.listen(this.getPort(), host, function (this: http.Server, error) {
       if (error) {
         Log.error(error.message);
       }
@@ -198,8 +198,8 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       // URL Info
       // TODO(@kitten): Why is this not using the URL creator?
       location: {
-        url: `${protocol}://${_host}:${port}`,
-        port,
+        url: `${protocol}://${_host}:${this.getPort()}`,
+        port: this.getPort(),
         protocol,
         host: _host,
       },

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -26,11 +26,12 @@ import { openPlatformsAsync } from './server/openPlatforms';
 import type { PlatformBundlers } from './server/platformBundlers';
 import { getPlatformBundlers } from './server/platformBundlers';
 
-async function getMultiBundlerStartOptions(
+/** Exported for testing. `startAsync` is the entry point. */
+export async function _getMultiBundlerStartOptions(
   projectRoot: string,
   options: Options,
   platformBundlers: PlatformBundlers
-): Promise<[BundlerStartOptions, MultiBundlerStartOptions]> {
+): Promise<[BundlerStartOptions, MultiBundlerStartOptions, number | undefined]> {
   const commonOptions: BundlerStartOptions = {
     mode: options.dev ? 'development' : 'production',
     devClient: options.devClient,
@@ -52,7 +53,10 @@ async function getMultiBundlerStartOptions(
   }
 
   const bundlers = [...new Set(Object.values(optionalBundlers))];
-  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options, bundlers);
+  // Resolve ports for every bundler, not just the ones starting now, so a bundler that
+  // starts interactively already has a port when it's asked for.
+  const allBundlers = [...new Set(Object.values(platformBundlers))];
+  const multiBundlerSettings = await resolvePortsAsync(projectRoot, options, allBundlers);
 
   const multiBundlerStartOptions = bundlers.map((bundler) => {
     const port =
@@ -66,7 +70,7 @@ async function getMultiBundlerStartOptions(
     };
   });
 
-  return [commonOptions, multiBundlerStartOptions];
+  return [commonOptions, multiBundlerStartOptions, multiBundlerSettings.webpackPort];
 }
 
 export async function startAsync(
@@ -98,13 +102,13 @@ export async function startAsync(
 
   const platformBundlers = getPlatformBundlers(projectRoot, exp);
 
-  const [defaultOptions, startOptions] = await getMultiBundlerStartOptions(
+  const [defaultOptions, startOptions, webPort] = await _getMultiBundlerStartOptions(
     projectRoot,
     options,
     platformBundlers
   );
 
-  const devServerManager = new DevServerManager(projectRoot, defaultOptions);
+  const devServerManager = new DevServerManager(projectRoot, defaultOptions, webPort);
 
   // Validations
 

--- a/packages/@expo/cli/src/utils/__mocks__/port.ts
+++ b/packages/@expo/cli/src/utils/__mocks__/port.ts
@@ -1,7 +1,7 @@
 export const resolveMetroPortAsync = jest.fn(
   async (root, { defaultPort, fallbackPort } = {}) => defaultPort ?? fallbackPort ?? 8081
 );
-export const resolvePortAsync = jest.fn(
+export const _resolvePortAsync = jest.fn(
   async (root, { defaultPort, preferredPort }) => defaultPort ?? preferredPort
 );
 export const ensurePortAvailabilityAsync = jest.fn(async () => true);

--- a/packages/@expo/cli/src/utils/__mocks__/port.ts
+++ b/packages/@expo/cli/src/utils/__mocks__/port.ts
@@ -1,4 +1,7 @@
+export const resolveMetroPortAsync = jest.fn(
+  async (root, { defaultPort, fallbackPort } = {}) => defaultPort ?? fallbackPort ?? 8081
+);
 export const resolvePortAsync = jest.fn(
-  async (root, { defaultPort, fallbackPort }) => defaultPort ?? fallbackPort ?? 8081
+  async (root, { defaultPort, preferredPort }) => defaultPort ?? preferredPort
 );
 export const ensurePortAvailabilityAsync = jest.fn(async () => true);

--- a/packages/@expo/cli/src/utils/__tests__/env-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/env-test.ts
@@ -1,8 +1,28 @@
 import * as process from 'node:process';
 
-import { envIsWebcontainer } from '../env';
+import { env, envIsWebcontainer } from '../env';
 
 jest.mock('node:process', () => jest.requireActual('node:process'));
+
+describe('REACT_NATIVE_PACKAGER_HOSTNAME', () => {
+  beforeEach(() => {
+    delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
+  });
+
+  it('returns null when unset', () => {
+    expect(env.REACT_NATIVE_PACKAGER_HOSTNAME).toBe(null);
+  });
+
+  it('returns null when only whitespace', () => {
+    process.env.REACT_NATIVE_PACKAGER_HOSTNAME = ' \t ';
+    expect(env.REACT_NATIVE_PACKAGER_HOSTNAME).toBe(null);
+  });
+
+  it('trims the hostname', () => {
+    process.env.REACT_NATIVE_PACKAGER_HOSTNAME = '  foobar.dev  ';
+    expect(env.REACT_NATIVE_PACKAGER_HOSTNAME).toBe('foobar.dev');
+  });
+});
 
 describe(envIsWebcontainer, () => {
   it('returns false without running in stackblitz', () => {

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -5,7 +5,7 @@ import {
   choosePortAsync,
   ensurePortAvailabilityAsync,
   resolveMetroPortAsync,
-  resolvePortAsync,
+  _resolvePortAsync,
 } from '../port';
 import { confirmAsync } from '../prompts';
 
@@ -140,17 +140,17 @@ describe(choosePortAsync, () => {
   });
 });
 
-describe(resolvePortAsync, () => {
+describe(_resolvePortAsync, () => {
   it(`finds the first available port from the preferred port when port is 0`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8081);
-    const port = await resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
+    const port = await _resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
     expect(port).toBe(8081);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null, 'localhost']);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`finds the next available port from the preferred port when port is 0 and it is busy`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    const port = await resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
+    const port = await _resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
     expect(port).toBe(8082);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null, 'localhost']);
     expect(confirmAsync).not.toHaveBeenCalled();
@@ -158,34 +158,34 @@ describe(resolvePortAsync, () => {
   it(`rolls over to the next free port when the preferred port is busy in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    const port = await resolvePortAsync('/', { preferredPort: 8081 });
+    const port = await _resolvePortAsync('/', { preferredPort: 8081 });
     expect(port).toBe(8082);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`hard-fails when an explicit --port is busy in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    await expect(resolvePortAsync('/', { defaultPort: 8081, preferredPort: 8081 })).rejects.toThrow(
-      /Port 8081 is unavailable/
-    );
+    await expect(
+      _resolvePortAsync('/', { defaultPort: 8081, preferredPort: 8081 })
+    ).rejects.toThrow(/Port 8081 is unavailable/);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`hard-fails when an explicitly requested preferred port is busy in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
     await expect(
-      resolvePortAsync('/', { preferredPort: 8081, isPreferredPortExplicit: true })
+      _resolvePortAsync('/', { preferredPort: 8081, isPreferredPortExplicit: true })
     ).rejects.toThrow(/Port 8081 is unavailable/);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`ignores RCT_METRO_PORT`, async () => {
     process.env.RCT_METRO_PORT = '9999';
-    const port = await resolvePortAsync('/', { preferredPort: 8081 });
+    const port = await _resolvePortAsync('/', { preferredPort: 8081 });
     expect(port).toBe(8081);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null]);
   });
   it(`leaves RCT_METRO_PORT alone`, async () => {
-    await resolvePortAsync('/', { preferredPort: 8081 });
+    await _resolvePortAsync('/', { preferredPort: 8081 });
     expect(process.env.RCT_METRO_PORT).toBeUndefined();
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,7 +1,12 @@
 import { freePortAsync, testPortAsync } from '../freeport';
 import { getRunningProcess } from '../getRunningProcess';
 import { isInteractive } from '../interactive';
-import { choosePortAsync, ensurePortAvailabilityAsync, resolvePortAsync } from '../port';
+import {
+  choosePortAsync,
+  ensurePortAvailabilityAsync,
+  resolveMetroPortAsync,
+  resolvePortAsync,
+} from '../port';
 import { confirmAsync } from '../prompts';
 
 jest.mock('../freeport', () => ({
@@ -17,6 +22,10 @@ jest.mock('../interactive', () => ({
 jest.mock('../getRunningProcess', () => ({
   getRunningProcess: jest.fn(() => null),
 }));
+
+beforeEach(() => {
+  delete process.env.RCT_METRO_PORT;
+});
 
 describe(ensurePortAvailabilityAsync, () => {
   it(`returns true if the port is available`, async () => {
@@ -132,51 +141,97 @@ describe(choosePortAsync, () => {
 });
 
 describe(resolvePortAsync, () => {
-  const originalRctMetroPort = process.env.RCT_METRO_PORT;
-  beforeEach(() => {
-    delete process.env.RCT_METRO_PORT;
-  });
-  afterEach(() => {
-    if (originalRctMetroPort == null) {
-      delete process.env.RCT_METRO_PORT;
-    } else {
-      process.env.RCT_METRO_PORT = originalRctMetroPort;
-    }
-  });
-  it(`finds the first available port from the fallback when port is 0`, async () => {
+  it(`finds the first available port from the preferred port when port is 0`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8081);
-    const port = await resolvePortAsync('/', { defaultPort: 0, fallbackPort: 8081 });
+    const port = await resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
     expect(port).toBe(8081);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null, 'localhost']);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
-  it(`finds the next available port from the fallback when port is 0 and fallback is busy`, async () => {
+  it(`finds the next available port from the preferred port when port is 0 and it is busy`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    const port = await resolvePortAsync('/', { defaultPort: 0, fallbackPort: 8081 });
+    const port = await resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
     expect(port).toBe(8082);
     expect(freePortAsync).toHaveBeenCalledWith(8081, [null, 'localhost']);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
-  it(`rolls over to the next free port when the default port is busy in non-interactive mode`, async () => {
+  it(`rolls over to the next free port when the preferred port is busy in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    const port = await resolvePortAsync('/', { fallbackPort: 8081 });
+    const port = await resolvePortAsync('/', { preferredPort: 8081 });
     expect(port).toBe(8082);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`hard-fails when an explicit --port is busy in non-interactive mode`, async () => {
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    await expect(resolvePortAsync('/', { defaultPort: 8081 })).rejects.toThrow(
+    await expect(resolvePortAsync('/', { defaultPort: 8081, preferredPort: 8081 })).rejects.toThrow(
       /Port 8081 is unavailable/
     );
     expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`hard-fails when an explicitly requested preferred port is busy in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    await expect(
+      resolvePortAsync('/', { preferredPort: 8081, isPreferredPortExplicit: true })
+    ).rejects.toThrow(/Port 8081 is unavailable/);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`ignores RCT_METRO_PORT`, async () => {
+    process.env.RCT_METRO_PORT = '9999';
+    const port = await resolvePortAsync('/', { preferredPort: 8081 });
+    expect(port).toBe(8081);
+    expect(freePortAsync).toHaveBeenCalledWith(8081, [null]);
+  });
+  it(`leaves RCT_METRO_PORT alone`, async () => {
+    await resolvePortAsync('/', { preferredPort: 8081 });
+    expect(process.env.RCT_METRO_PORT).toBeUndefined();
+  });
+});
+
+describe(resolveMetroPortAsync, () => {
+  it(`prefers RCT_METRO_PORT over the fallback`, async () => {
+    process.env.RCT_METRO_PORT = '9000';
+    const port = await resolveMetroPortAsync('/', { fallbackPort: 8081 });
+    expect(port).toBe(9000);
+  });
+  it(`scans from RCT_METRO_PORT when --port is 0`, async () => {
+    process.env.RCT_METRO_PORT = '9000';
+    jest.mocked(freePortAsync).mockResolvedValueOnce(9001);
+    const port = await resolveMetroPortAsync('/', { defaultPort: 0, fallbackPort: 8081 });
+    expect(port).toBe(9001);
+    expect(freePortAsync).toHaveBeenCalledWith(9000, [null, 'localhost']);
+  });
+  it(`writes the resolved port back to RCT_METRO_PORT`, async () => {
+    const port = await resolveMetroPortAsync('/', { defaultPort: 3000, fallbackPort: 8081 });
+    expect(port).toBe(3000);
+    expect(process.env.RCT_METRO_PORT).toBe('3000');
+  });
+  it(`falls back to 8081 when nothing requests a port`, async () => {
+    const port = await resolveMetroPortAsync('/');
+    expect(port).toBe(8081);
   });
   it(`hard-fails when a configured RCT_METRO_PORT is busy in non-interactive mode`, async () => {
     process.env.RCT_METRO_PORT = '8081';
     jest.mocked(isInteractive).mockReturnValueOnce(false);
     jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
-    await expect(resolvePortAsync('/', {})).rejects.toThrow(/Port 8081 is unavailable/);
-    expect(confirmAsync).not.toHaveBeenCalled();
+    await expect(resolveMetroPortAsync('/', { fallbackPort: 8081 })).rejects.toThrow(
+      /Port 8081 is unavailable/
+    );
+  });
+  it(`leaves RCT_METRO_PORT alone when the dev server is skipped`, async () => {
+    jest.mocked(getRunningProcess).mockResolvedValueOnce({
+      pid: 1,
+      directory: '/',
+      command: 'npx expo',
+    });
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    const port = await resolveMetroPortAsync('/', {
+      fallbackPort: 8081,
+      reuseExistingPort: true,
+    });
+    expect(port).toBe(null);
+    expect(process.env.RCT_METRO_PORT).toBeUndefined();
   });
 });

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -112,8 +112,8 @@ class Env {
   }
 
   /** Overwrite the hostname used in dev server URLs, disregarding the `--host`, `--lan` and `--localhost` arguments. */
-  get REACT_NATIVE_PACKAGER_HOSTNAME(): string {
-    return string('REACT_NATIVE_PACKAGER_HOSTNAME', '');
+  get REACT_NATIVE_PACKAGER_HOSTNAME(): string | null {
+    return string('REACT_NATIVE_PACKAGER_HOSTNAME', '')?.trim() || null;
   }
 
   /**

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -111,6 +111,11 @@ class Env {
     return string('EXPO_EDITOR', '');
   }
 
+  /** Overwrite the hostname used in dev server URLs, disregarding the `--host`, `--lan` and `--localhost` arguments. */
+  get REACT_NATIVE_PACKAGER_HOSTNAME(): string {
+    return string('REACT_NATIVE_PACKAGER_HOSTNAME', '');
+  }
+
   /**
    * Overwrite the dev server URL, disregarding the `--port`, `--host`, `--tunnel`, `--lan`, `--localhost` arguments.
    * This is useful for browser editors that require custom proxy URLs.

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -145,7 +145,7 @@ export async function choosePortAsync(
 
 // TODO(Bacon): Revisit after all start and run code is merged.
 /** Picks a port without reading the environment. `resolveMetroPortAsync` is the entry point every command uses. */
-export async function resolvePortAsync(
+export async function _resolvePortAsync(
   projectRoot: string,
   {
     /** Should opt to reuse a port that is running the same project in another window. */
@@ -210,7 +210,7 @@ export async function resolveMetroPortAsync(
 ): Promise<number | null> {
   // NOTE(@kitten): We treat `--port` and `RCT_METRO_PORT` as the fixed preferred ports
   const requestedMetroPort = env.RCT_METRO_PORT;
-  const resolvedPort = await resolvePortAsync(projectRoot, {
+  const resolvedPort = await _resolvePortAsync(projectRoot, {
     reuseExistingPort,
     defaultPort,
     preferredPort: requestedMetroPort || fallbackPort || 8081,

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -144,25 +144,25 @@ export async function choosePortAsync(
 }
 
 // TODO(Bacon): Revisit after all start and run code is merged.
+/** Picks a port without reading the environment. `resolveMetroPortAsync` is the entry point every command uses. */
 export async function resolvePortAsync(
   projectRoot: string,
   {
     /** Should opt to reuse a port that is running the same project in another window. */
     reuseExistingPort,
-    /** Preferred port. */
+    /** Requested port, e.g. from `--port`. */
     defaultPort,
-    /** Backup port for when the default isn't available. */
-    fallbackPort,
+    /** Port to use when none is requested, and the port to scan from when `--port 0` is used. */
+    preferredPort,
+    /** Whether the preferred port was requested rather than defaulted, making it a hard requirement. */
+    isPreferredPortExplicit,
   }: {
     reuseExistingPort?: boolean;
     defaultPort?: string | number;
-    fallbackPort?: number;
-  } = {}
+    preferredPort: number;
+    isPreferredPortExplicit?: boolean;
+  }
 ): Promise<number | null> {
-  // NOTE(@kitten): We treat `--port` and `RCT_METRO_PORT` as the fixed preferred ports
-  const requestedMetroPort = env.RCT_METRO_PORT;
-  const preferredPort = requestedMetroPort || fallbackPort || 8081;
-
   let port: number;
   if (typeof defaultPort === 'string') {
     port = parseInt(defaultPort, 10);
@@ -174,22 +174,50 @@ export async function resolvePortAsync(
 
   // Port 0 means "pick any available port"
   if (port === 0) {
-    const resolvedPort = await getFreePortAsync(preferredPort);
-    process.env.RCT_METRO_PORT = String(resolvedPort);
-    return resolvedPort;
+    return getFreePortAsync(preferredPort);
   }
 
   // Only check the port when the bundler is running.
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
     reuseExistingPort,
-    explicitPort: defaultPort != null || !!requestedMetroPort,
+    explicitPort: defaultPort != null || !!isPreferredPortExplicit,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');
-    // Skip bundling if the port is null
-  } else {
-    // Use the new or resolved port
+  }
+
+  return resolvedPort;
+}
+
+/**
+ * Resolve the Metro port, honoring `RCT_METRO_PORT` and writing the result back to it.
+ * The write-back matters: react-native's build scripts read `RCT_METRO_PORT`, and native
+ * builds started later in the command inherit it from this process.
+ */
+export async function resolveMetroPortAsync(
+  projectRoot: string,
+  {
+    reuseExistingPort,
+    defaultPort,
+    /** Backup port for when neither `--port` nor `RCT_METRO_PORT` is set. */
+    fallbackPort,
+  }: {
+    reuseExistingPort?: boolean;
+    defaultPort?: string | number;
+    fallbackPort?: number;
+  } = {}
+): Promise<number | null> {
+  // NOTE(@kitten): We treat `--port` and `RCT_METRO_PORT` as the fixed preferred ports
+  const requestedMetroPort = env.RCT_METRO_PORT;
+  const resolvedPort = await resolvePortAsync(projectRoot, {
+    reuseExistingPort,
+    defaultPort,
+    preferredPort: requestedMetroPort || fallbackPort || 8081,
+    isPreferredPortExplicit: !!requestedMetroPort,
+  });
+
+  if (resolvedPort != null) {
     process.env.RCT_METRO_PORT = String(resolvedPort);
   }
 


### PR DESCRIPTION
# Why

Follow-up to #47771.

The dev server port came from three places, `resolvePortAsync` picked it, `UrlCreator` kept its own copy from init, and Metro read it back off the socket after binding.

# How

I put the port on `BundlerDevServer` and everything reads it back with `getPort()`. The two env vars get passed into `UrlCreator` now instead of it reading them itself.

I also had to resolve the web port even when web isn't starting, otherwise there's no port to use when you open it later.

Two things change, a `REACT_NATIVE_PACKAGER_HOSTNAME` that's only whitespace used to stop the start, now it's ignored. And on a project using the `webpack` web bundler, pressing `w` used to quit with an error if you hadn't started with `--web`.

# Test Plan

build, typecheck, depscheck, lint, format, test.