### PR TITLE
Fix/hmr native reload

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix dev-only crash `Cannot read property 'reload' of undefined` on Android and iOS when an async bundle loads after Metro disconnects, by using the platform-split `reload()` helper instead of `window.location.reload()`. ([#00000](https://github.com/expo/expo/pull/00000) by [@chrisnojima](https://github.com/chrisnojima))
+- Fix dev-only crash `Cannot read property 'reload' of undefined` on Android and iOS when an async bundle loads after Metro disconnects, by using the platform-split `reload()` helper instead of `window.location.reload()`. ([#48238](https://github.com/expo/expo/pull/48238) by [@chrisnojima](https://github.com/chrisnojima))
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix dev-only crash `Cannot read property 'reload' of undefined` on Android and iOS when an async bundle loads after Metro disconnects, by using the platform-split `reload()` helper instead of `window.location.reload()`. ([#00000](https://github.com/expo/expo/pull/00000) by [@chrisnojima](https://github.com/chrisnojima))
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/src/async-require/hmr.ts
+++ b/packages/expo/src/async-require/hmr.ts
@@ -17,6 +17,7 @@ import {
   getFullBundlerUrl,
   handleCompileError,
   hideLoading,
+  reload,
   resetErrorOverlay,
   showLoading,
 } from './hmrUtils';
@@ -324,7 +325,8 @@ function setHMRUnavailableReason(reason: string) {
 function registerBundleEntryPoints(client: MetroHMRClient | null) {
   if (hmrUnavailableReason != null) {
     // "Bundle Splitting – Metro disconnected"
-    window.location.reload();
+    // `window.location` is undefined on native, use the platform-split helper.
+    reload();
     return;
   }
 


### PR DESCRIPTION
# Why

`registerBundleEntryPoints` calls `window.location.reload()` when `hmrUnavailableReason != null`:

https://github.com/expo/expo/blob/main/packages/expo/src/async-require/hmr.ts#L325-L329

`window.location` is undefined on Android and iOS, so on native this throws instead of reloading:

```
TypeError: Cannot read property 'reload' of undefined
```

Repro (development builds only):

1. Run an app that loads an async bundle (`asyncRoutes`, or any `import()`-split route).
2. Kill the Metro server, or let the socket drop / go out of sync so `setHMRUnavailableReason` runs.
3. Navigate to a route that pulls in an async chunk.

Instead of the intended "Metro disconnected, reload the app" recovery, you get a red box.

# How

`./hmrUtils` already has a platform-split `reload()` — `hmrUtils.ts` uses `window.location.reload()`
and `hmrUtils.native.ts` uses `DevSettings.reload()`. Every other platform-specific operation in
`hmr.ts` goes through that module; this one call site bypassed it. Import `reload` and call it.

No behavior change on web: the web implementation of `reload()` is `window.location.reload()`.

# Test Plan

- Web: HMR unavailable path still reloads the tab (unchanged code path).
- iOS + Android dev build: kill Metro, navigate to an async route. Before: red box
  `Cannot read property 'reload' of undefined`. After: the app reloads via `DevSettings.reload()`.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build.
