### PR TITLE
[expo-updates] Stop stacking native state change listeners on module re-evaluation

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [Android] Skip and repair updates that are missing their launch asset instead of selecting them for launch, which previously failed every cold start with "Launch asset not found for update". ([#49470](https://github.com/expo/expo/pull/49470) by [@alanjhughes](https://github.com/alanjhughes), based on [#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
 - [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49505](https://github.com/expo/expo/pull/49505) by [@alanjhughes](https://github.com/alanjhughes))
+- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#47938](https://github.com/expo/expo/issues/47938) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - Fix `isUpdatePending` incorrectly becoming `true` after a fetch or check that finds no new update to download. ([#47830](https://github.com/expo/expo/pull/47830) by [@kudo](https://github.com/kudo))
-- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#47938](https://github.com/expo/expo/issues/47938) by [@ahmdshrif](https://github.com/ahmdshrif))
+- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#48241](https://github.com/expo/expo/pull/48241) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -35,7 +35,7 @@
 - [Android] Skip and repair updates that are missing their launch asset instead of selecting them for launch, which previously failed every cold start with "Launch asset not found for update". ([#49470](https://github.com/expo/expo/pull/49470) by [@alanjhughes](https://github.com/alanjhughes), based on [#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
 - [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49505](https://github.com/expo/expo/pull/49505) by [@alanjhughes](https://github.com/alanjhughes))
-- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#47938](https://github.com/expo/expo/issues/47938) by [@ahmdshrif](https://github.com/ahmdshrif))
+- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#48241](https://github.com/expo/expo/pull/48241) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - Fix `isUpdatePending` incorrectly becoming `true` after a fetch or check that finds no new update to download. ([#47830](https://github.com/expo/expo/pull/47830) by [@kudo](https://github.com/kudo))
+- Drop the previous native state change listener before registering a new one, so re-evaluating `UpdatesEmitter` no longer stacks a subscription that retains the whole module scope — a leak that grew per request under server rendering until the dev server crashed with OOM. ([#47938](https://github.com/expo/expo/issues/47938) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-updates/src/UpdatesEmitter.ts
+++ b/packages/expo-updates/src/UpdatesEmitter.ts
@@ -6,6 +6,13 @@ import type {
 
 export let latestContext = transformNativeStateMachineContext(ExpoUpdatesModule.initialContext);
 
+// The native module instance lives on the global object and therefore outlives this module's
+// scope (see `requireNativeModule` and `registerWebModule`). Whenever this module is evaluated
+// again against the same global — which happens once per request when the server rendering
+// runtime recreates the module graph, and on Fast Refresh — adding another listener would stack
+// a subscription that keeps the entire previous module scope alive. Dropping the previous
+// listener first keeps exactly one live subscription at all times.
+ExpoUpdatesModule.removeAllListeners('Expo.nativeUpdatesStateChangeEvent');
 ExpoUpdatesModule.addListener('Expo.nativeUpdatesStateChangeEvent', _handleNativeStateChangeEvent);
 
 interface UpdatesStateChangeSubscription {

--- a/packages/expo-updates/src/__mocks__/ExpoUpdates.ts
+++ b/packages/expo-updates/src/__mocks__/ExpoUpdates.ts
@@ -4,7 +4,26 @@ const commitTime = new Date('2023-03-26T04:58:02.560Z');
 const checkForUpdateAsync = jest.fn();
 const fetchUpdateAsync = jest.fn();
 const reload = jest.fn();
-const addListener = jest.fn();
+
+// The real module is a singleton stored on the global object, so its listeners survive a
+// re-evaluation of the module graph. Keep the registry on the global here too, otherwise
+// `jest.resetModules()` would hand out a fresh set of listeners and hide that behavior.
+const listeners: Map<string, Set<Function>> = ((globalThis as any).__expoUpdatesMockListeners ??=
+  new Map());
+
+const addListener = jest.fn((eventName: string, listener: Function) => {
+  if (!listeners.has(eventName)) {
+    listeners.set(eventName, new Set());
+  }
+  listeners.get(eventName)?.add(listener);
+  return { remove: () => listeners.get(eventName)?.delete(listener) };
+});
+
+const removeAllListeners = jest.fn((eventName: string) => {
+  listeners.get(eventName)?.clear();
+});
+
+const listenerCount = jest.fn((eventName: string) => listeners.get(eventName)?.size ?? 0);
 
 export default {
   channel,
@@ -14,4 +33,6 @@ export default {
   fetchUpdateAsync,
   reload,
   addListener,
+  removeAllListeners,
+  listenerCount,
 };

--- a/packages/expo-updates/src/__mocks__/ExpoUpdates.web.ts
+++ b/packages/expo-updates/src/__mocks__/ExpoUpdates.web.ts
@@ -1,0 +1,38 @@
+const channel = 'main';
+const updateId = '0000-1111';
+const commitTime = new Date('2023-03-26T04:58:02.560Z');
+const checkForUpdateAsync = jest.fn();
+const fetchUpdateAsync = jest.fn();
+const reload = jest.fn();
+
+// The real module is a singleton stored on the global object, so its listeners survive a
+// re-evaluation of the module graph. Keep the registry on the global here too, otherwise
+// `jest.resetModules()` would hand out a fresh set of listeners and hide that behavior.
+const listeners: Map<string, Set<Function>> = ((globalThis as any).__expoUpdatesMockListeners ??=
+  new Map());
+
+const addListener = jest.fn((eventName: string, listener: Function) => {
+  if (!listeners.has(eventName)) {
+    listeners.set(eventName, new Set());
+  }
+  listeners.get(eventName)?.add(listener);
+  return { remove: () => listeners.get(eventName)?.delete(listener) };
+});
+
+const removeAllListeners = jest.fn((eventName: string) => {
+  listeners.get(eventName)?.clear();
+});
+
+const listenerCount = jest.fn((eventName: string) => listeners.get(eventName)?.size ?? 0);
+
+export default {
+  channel,
+  updateId,
+  commitTime,
+  checkForUpdateAsync,
+  fetchUpdateAsync,
+  reload,
+  addListener,
+  removeAllListeners,
+  listenerCount,
+};

--- a/packages/expo-updates/src/__tests__/UpdatesEmitter-test.node.ts
+++ b/packages/expo-updates/src/__tests__/UpdatesEmitter-test.node.ts
@@ -1,0 +1,21 @@
+import ExpoUpdatesModule from '../ExpoUpdates';
+
+jest.mock('../ExpoUpdates');
+
+const EVENT_NAME = 'Expo.nativeUpdatesStateChangeEvent';
+
+it('keeps a single native listener when the module graph is re-evaluated', () => {
+  require('../UpdatesEmitter');
+  expect(ExpoUpdatesModule.listenerCount(EVENT_NAME)).toBe(1);
+
+  // A server rendering runtime recreates the module graph for every request, while the native
+  // module instance persists on the global object. Without cleanup each evaluation stacked
+  // another listener that retained the whole previous module scope, leaking until the dev
+  // server ran out of heap. See https://github.com/expo/expo/issues/47938.
+  for (let i = 0; i < 5; i++) {
+    jest.resetModules();
+    require('../UpdatesEmitter');
+  }
+
+  expect(ExpoUpdatesModule.listenerCount(EVENT_NAME)).toBe(1);
+});


### PR DESCRIPTION
# Why

Fixes #47938.

`UpdatesEmitter.ts` registers a native state change listener as an import-time side effect:

```ts
ExpoUpdatesModule.addListener('Expo.nativeUpdatesStateChangeEvent', _handleNativeStateChangeEvent);
```

`ExpoUpdatesModule` is a singleton stored on the global object — `registerWebModule` returns the cached instance from `globalThis.expo.modules`, and `requireNativeModule` likewise hands back one instance per runtime. The listener therefore outlives the module scope that registered it.

Server rendering recreates the module graph for every request against that same global. Each request evaluated `UpdatesEmitter` again and stacked another listener, and because `_handleNativeStateChangeEvent` closes over that evaluation's `_updatesStateChangeListeners` set and `latestContext`, every stacked listener pinned an entire copy of the module graph. The dev server's heap grew per request until it thrashed GC and crashed with OOM. Fast Refresh has the same shape on a smaller scale.

The reporter's log shows the listener count climbing one per rendered request:

```
λ  LOG  expo-updates listener size: 4
λ  LOG  expo-updates listener size: 5
λ  LOG  expo-updates listener size: 6
```

# How

Drop the previous listener before registering a new one, so exactly one subscription is live at any time:

```ts
ExpoUpdatesModule.removeAllListeners('Expo.nativeUpdatesStateChangeEvent');
ExpoUpdatesModule.addListener('Expo.nativeUpdatesStateChangeEvent', _handleNativeStateChangeEvent);
```

`removeAllListeners` is a no-op when the count is already zero, so the first evaluation in a runtime — the only one that happens on device outside Fast Refresh — behaves exactly as before, and `OnStopObserving` is not triggered spuriously. On a re-evaluation the module ends up owning the single live listener, which is the desired outcome: the older module scope is dead and its listeners should not keep receiving events.

Alternatives considered and rejected:

- **Subscribe lazily / reference-count on `addUpdatesStateChangeListener`.** This would leave `latestContext` un-updated whenever no `useUpdates()` hook is mounted, so a later mount would read a stale sequence number as its initial state. That is a behavior change to the state machine, not a leak fix.
- **Guard the registration with a "is this the server?" check.** Narrower than the actual bug — it leaves the Fast Refresh case in place and encodes an environment assumption into a module that otherwise has none.

# Test Plan

Added `packages/expo-updates/src/__tests__/UpdatesEmitter-test.node.ts`, which evaluates `UpdatesEmitter` six times across `jest.resetModules()` and asserts the native listener count stays at 1.

`src/__mocks__/ExpoUpdates.ts` previously stubbed `addListener` with a bare `jest.fn()`, which could not observe this at all. It now keeps a real listener registry and implements `removeAllListeners` / `listenerCount`. The registry is stored on `globalThis` so that it survives `jest.resetModules()` — mirroring how the real singleton survives module graph re-evaluation. No existing test asserts against the mock's `addListener`.

Before/after, run against the changed files:

```
# with the fix
PASS src/__tests__/UpdatesEmitter-test.node.ts
  ✓ keeps a single native listener when the module graph is re-evaluated

# with the removeAllListeners line reverted
● keeps a single native listener when the module graph is re-evaluated
  expect(received).toBe(expected)
  Expected: 1
  Received: 6
```

# Checklist

- [x] Documentation is up to date to reflect any changes in this PR.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
